### PR TITLE
[DependencyInjection] Deprecate ContainerInterface aliases

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -12,6 +12,8 @@ DependencyInjection
  * The signature of method `Definition::setDeprecated()` has been updated to `Definition::setDeprecation(string $package, string $version, string $message)`.
  * The signature of method `Alias::setDeprecated()` has been updated to `Alias::setDeprecation(string $package, string $version, string $message)`.
  * The signature of method `DeprecateTrait::deprecate()` has been updated to `DeprecateTrait::deprecation(string $package, string $version, string $message)`.
+ * Deprecated the `Psr\Container\ContainerInterface` and `Symfony\Component\DependencyInjection\ContainerInterface` aliases of the `service_container` service,
+   configure them explicitly instead.
 
 Dotenv
 ------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -12,6 +12,8 @@ DependencyInjection
  * The signature of method `Definition::setDeprecated()` has been updated to `Definition::setDeprecation(string $package, string $version, string $message)`.
  * The signature of method `Alias::setDeprecated()` has been updated to `Alias::setDeprecation(string $package, string $version, string $message)`.
  * The signature of method `DeprecateTrait::deprecate()` has been updated to `DeprecateTrait::deprecation(string $package, string $version, string $message)`.
+ * Removed the `Psr\Container\ContainerInterface` and `Symfony\Component\DependencyInjection\ContainerInterface` aliases of the `service_container` service,
+   configure them explicitly instead.
 
 Dotenv
 ------

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/AddSessionDomainConstraintPassTest.php
@@ -12,10 +12,14 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSessionDomainConstraintPass;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\HttpFoundation\Request;
 
 class AddSessionDomainConstraintPassTest extends TestCase
@@ -147,6 +151,9 @@ class AddSessionDomainConstraintPassTest extends TestCase
 
         $pass = new AddSessionDomainConstraintPass();
         $pass->process($container);
+
+        $container->setDefinition('.service_subscriber.fallback_container', new Definition(Container::class));
+        $container->setAlias(ContainerInterface::class, new Alias('.service_subscriber.fallback_container', false));
 
         return $container;
     }

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -10,6 +10,8 @@ CHANGELOG
  * updated the signature of method `Definition::setDeprecated()` to `Definition::setDeprecation(string $package, string $version, string $message)`
  * updated the signature of method `Alias::setDeprecated()` to `Alias::setDeprecation(string $package, string $version, string $message)`
  * updated the signature of method `DeprecateTrait::deprecate()` to `DeprecateTrait::deprecation(string $package, string $version, string $message)`
+ * deprecated the `Psr\Container\ContainerInterface` and `Symfony\Component\DependencyInjection\ContainerInterface` aliases of the `service_container` service,
+   configure them explicitly instead
 
 5.0.0
 -----

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -147,8 +147,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
         $this->trackResources = interface_exists('Symfony\Component\Config\Resource\ResourceInterface');
         $this->setDefinition('service_container', (new Definition(ContainerInterface::class))->setSynthetic(true)->setPublic(true));
-        $this->setAlias(PsrContainerInterface::class, new Alias('service_container', false));
-        $this->setAlias(ContainerInterface::class, new Alias('service_container', false));
+        $this->setAlias(PsrContainerInterface::class, new Alias('service_container', false))->setDeprecated('symfony/dependency-injection', '5.1', $deprecationMessage = 'The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.');
+        $this->setAlias(ContainerInterface::class, new Alias('service_container', false))->setDeprecated('symfony/dependency-injection', '5.1', $deprecationMessage);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -88,8 +88,12 @@ class XmlDumperTest extends TestCase
         </service>
       </argument>
     </service>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
+    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
   </services>
 </container>
 ', $dumper->dump());
@@ -107,8 +111,12 @@ class XmlDumperTest extends TestCase
       <tag name=\"foo&quot;bar\bar\" foo=\"foo&quot;barřž€\"/>
       <argument>foo&lt;&gt;&amp;bar</argument>
     </service>
-    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
-    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
+    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\">
+      <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
+    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\">
+      <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
   </services>
 </container>
 ", $dumper->dump());
@@ -133,8 +141,12 @@ class XmlDumperTest extends TestCase
   <services>
     <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" public=\"true\" synthetic=\"true\"/>
     <service id=\"foo\" class=\"FooClass\Foo\" public=\"true\" decorates=\"bar\" decoration-inner-name=\"bar.woozy\"/>
-    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
-    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
+    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\">
+      <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
+    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\">
+      <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
   </services>
 </container>
 ", include $fixturesPath.'/containers/container15.php'],
@@ -143,8 +155,12 @@ class XmlDumperTest extends TestCase
   <services>
     <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" public=\"true\" synthetic=\"true\"/>
     <service id=\"foo\" class=\"FooClass\Foo\" public=\"true\" decorates=\"bar\"/>
-    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
-    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
+    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\">
+      <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
+    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\">
+      <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
   </services>
 </container>
 ", include $fixturesPath.'/containers/container16.php'],
@@ -153,8 +169,12 @@ class XmlDumperTest extends TestCase
   <services>
     <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" public=\"true\" synthetic=\"true\"/>
     <service id=\"decorator\" decorates=\"decorated\" decoration-on-invalid=\"null\" decoration-inner-name=\"decorated.inner\" decoration-priority=\"1\"/>
-    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
-    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\"/>
+    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\">
+      <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
+    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\">
+      <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
   </services>
 </container>
 ", include $fixturesPath.'/containers/container34.php'],

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services1.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services1.xml
@@ -2,7 +2,11 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service class="Symfony\Component\DependencyInjection\ContainerInterface" id="service_container" public="true" synthetic="true"/>
-        <service alias="service_container" id="Psr\Container\ContainerInterface" public="false"/>
-        <service alias="service_container" id="Symfony\Component\DependencyInjection\ContainerInterface" public="false"/>
+        <service alias="service_container" id="Psr\Container\ContainerInterface" public="false">
+          <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+        </service>
+        <service alias="service_container" id="Symfony\Component\DependencyInjection\ContainerInterface" public="false">
+          <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+        </service>
     </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services21.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services21.xml
@@ -18,7 +18,11 @@
         </service>
       </configurator>
     </service>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
+    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services24.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services24.xml
@@ -3,7 +3,11 @@
   <services>
     <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
     <service id="foo" class="Foo" public="true" autowire="true"/>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
+    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services8.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services8.xml
@@ -34,7 +34,11 @@
   </parameters>
   <services>
     <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
+    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -148,8 +148,12 @@
       <argument type="service" id="errored_definition"/>
     </service>
     <service id="errored_definition" class="stdClass"/>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
+    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
     <service id="alias_for_foo" alias="foo" public="true"/>
     <service id="alias_for_alias" alias="foo" public="true"/>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_abstract.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_abstract.xml
@@ -3,7 +3,11 @@
   <services>
     <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
     <service id="foo" class="Foo" public="true" abstract="true"/>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
+    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_dump_load.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_dump_load.xml
@@ -5,7 +5,11 @@
     <service id="foo" autoconfigure="true" abstract="true">
       <argument type="service" id="bar" on-invalid="ignore_uninitialized"/>
     </service>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
+    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_abstract_argument.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_abstract_argument.xml
@@ -6,7 +6,11 @@
       <argument key="$baz" type="abstract">should be defined by Pass</argument>
       <argument key="$bar">test</argument>
     </service>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
+    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_arguments.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_arguments.xml
@@ -11,7 +11,11 @@
     <service id="foo_tagged_locator" class="Bar" public="true">
       <argument type="tagged_locator" tag="foo_tag" index-by="barfoo" default-index-method="foobar" default-priority-method="getPriority"/>
     </service>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false"/>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false"/>
+    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+      <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
+    </service>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services1.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services1.yml
@@ -6,6 +6,14 @@ services:
     Psr\Container\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services24.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services24.yml
@@ -11,6 +11,14 @@ services:
     Psr\Container\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services34.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services34.yml
@@ -12,6 +12,14 @@ services:
     Psr\Container\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services8.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services8.yml
@@ -26,6 +26,14 @@ services:
     Psr\Container\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -168,9 +168,17 @@ services:
     Psr\Container\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     alias_for_foo:
         alias: 'foo'
         public: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_dump_load.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_dump_load.yml
@@ -11,6 +11,14 @@ services:
     Psr\Container\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_inline.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_inline.yml
@@ -11,6 +11,14 @@ services:
     Psr\Container\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_abstract_argument.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_abstract_argument.yml
@@ -10,6 +10,14 @@ services:
     Psr\Container\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_argument.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_argument.yml
@@ -20,6 +20,14 @@ services:
     Psr\Container\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
         public: false
+        deprecated:
+            package: symfony/dependency-injection
+            version: 5.1
+            message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Defining those aliases makes it harder to detect problems when you use `!tagged_locator` or any service locator with autowiring since the global service container is always injected. Moreover, should we encourage passing the global service container easily? Shouldn't it be more "explicit"? I think that by default, those aliases should not exist.

However, that means we will have to reintroduce code to hook the global service container in our own code base since some part rely on it (~~eg: FWB AbstractController::setContainer~~). WDYT? 🤷‍♂ 