### PR TITLE
[DomCrawler] Added nextUntil and previousUntil sibling navigation functions.

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+* Added `Crawler::previousUntil()` function for sibling navigation
+* Added `Crawler::nextUntil()` function for sibling navigation
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -519,6 +519,41 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
+     * Returns the previous siblings nodes of the current selection
+     * until a provided node. Excluding current and final node.
+     *
+     * @param \DOMNode $finalNode
+     * @return static
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function previousUntil(\DOMNode $finalNode): self
+    {
+        if (!$this->nodes) {
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        $siblings = $this->previousAll();
+        $siblingCount = $siblings->count();
+
+        $nodes = [];
+        $siblingIndex = 0;
+
+        while($siblingIndex < $siblingCount){
+            $siblingNode = $siblings->eq($siblingIndex)->getNode(0);
+
+            if ($siblingNode === $finalNode) {
+                break;
+            }
+
+            $nodes[] = $siblingNode;
+            $siblingIndex++;
+        }
+
+        return $this->createSubCrawler($nodes);
+    }
+
+    /**
      * Returns the parents nodes of the current selection.
      *
      * @return static

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -471,13 +471,13 @@ class Crawler implements \Countable, \IteratorAggregate
      * Returns the next siblings nodes of the current selection
      * until a provided node. Excluding current and final node.
      *
-     * @param \DOMNode $finalNode Final sibling node.
+     * @param \DOMNode $finalNode Final sibling node
+     *
      * @return static
      *
      * @throws \InvalidArgumentException
      */
-    public function nextUntil(\DOMNode $finalNode): self
-    {
+    public function nextUntil(\DOMNode $finalNode){
         if (!$this->nodes) {
             throw new \InvalidArgumentException('The current node list is empty.');
         }
@@ -522,12 +522,13 @@ class Crawler implements \Countable, \IteratorAggregate
      * Returns the previous siblings nodes of the current selection
      * until a provided node. Excluding current and final node.
      *
-     * @param \DOMNode $finalNode Final sibling node.
+     * @param \DOMNode $finalNode Final sibling node
+     *
      * @return static
      *
      * @throws \InvalidArgumentException
      */
-    public function previousUntil(\DOMNode $finalNode): self
+    public function previousUntil(\DOMNode $finalNode)
     {
         if (!$this->nodes) {
             throw new \InvalidArgumentException('The current node list is empty.');

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -471,7 +471,7 @@ class Crawler implements \Countable, \IteratorAggregate
      * Returns the next siblings nodes of the current selection
      * until a provided node. Excluding current and final node.
      *
-     * @param \DOMNode $finalNode
+     * @param \DOMNode $finalNode Final sibling node.
      * @return static
      *
      * @throws \InvalidArgumentException
@@ -488,7 +488,7 @@ class Crawler implements \Countable, \IteratorAggregate
         $nodes = [];
         $siblingIndex = 0;
 
-        while($siblingIndex < $siblingCount){
+        while ($siblingIndex < $siblingCount) {
             $siblingNode = $siblings->eq($siblingIndex)->getNode(0);
 
             if ($siblingNode === $finalNode) {
@@ -496,7 +496,7 @@ class Crawler implements \Countable, \IteratorAggregate
             }
 
             $nodes[] = $siblingNode;
-            $siblingIndex++;
+            ++$siblingIndex;
         }
 
         return $this->createSubCrawler($nodes);
@@ -522,7 +522,7 @@ class Crawler implements \Countable, \IteratorAggregate
      * Returns the previous siblings nodes of the current selection
      * until a provided node. Excluding current and final node.
      *
-     * @param \DOMNode $finalNode
+     * @param \DOMNode $finalNode Final sibling node.
      * @return static
      *
      * @throws \InvalidArgumentException
@@ -539,7 +539,7 @@ class Crawler implements \Countable, \IteratorAggregate
         $nodes = [];
         $siblingIndex = 0;
 
-        while($siblingIndex < $siblingCount){
+        while ($siblingIndex < $siblingCount) {
             $siblingNode = $siblings->eq($siblingIndex)->getNode(0);
 
             if ($siblingNode === $finalNode) {
@@ -547,7 +547,7 @@ class Crawler implements \Countable, \IteratorAggregate
             }
 
             $nodes[] = $siblingNode;
-            $siblingIndex++;
+            ++$siblingIndex;
         }
 
         return $this->createSubCrawler($nodes);

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -477,7 +477,8 @@ class Crawler implements \Countable, \IteratorAggregate
      *
      * @throws \InvalidArgumentException
      */
-    public function nextUntil(\DOMNode $finalNode){
+    public function nextUntil(\DOMNode $finalNode)
+    {
         if (!$this->nodes) {
             throw new \InvalidArgumentException('The current node list is empty.');
         }

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -468,6 +468,41 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
+     * Returns the next siblings nodes of the current selection
+     * until a provided node. Excluding current and final node.
+     *
+     * @param \DOMNode $finalNode
+     * @return static
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function nextUntil(\DOMNode $finalNode): self
+    {
+        if (!$this->nodes) {
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        $siblings = $this->nextAll();
+        $siblingCount = $siblings->count();
+
+        $nodes = [];
+        $siblingIndex = 0;
+
+        while($siblingIndex < $siblingCount){
+            $siblingNode = $siblings->eq($siblingIndex)->getNode(0);
+
+            if ($siblingNode === $finalNode) {
+                break;
+            }
+
+            $nodes[] = $siblingNode;
+            $siblingIndex++;
+        }
+
+        return $this->createSubCrawler($nodes);
+    }
+
+    /**
      * Returns the previous sibling nodes of the current selection.
      *
      * @return static

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
@@ -1004,6 +1004,38 @@ HTML;
         }
     }
 
+    public function testNextUntil()
+    {
+        $html = <<<"HTML"
+        <html>
+            <body>
+                <ul id='list'>
+                    <li id='one'>1</li>
+                    <li id='two'>2</li>
+                    <li id='three'>3</li>
+                    <li id='four'>4</li>
+                    <li id='five'>5</li>
+                </ul>
+            </body>
+        </div>
+        HTML;
+
+        $crawler = $this->createCrawler($this->getDoctype().$html);
+        $startElement = $crawler->filter('#one');
+        $finalElement = $crawler->filter('#five')->getNode(0);
+        $elementsInBetween = $startElement->nextUntil($finalElement);
+        $this->assertEquals(3, $elementsInBetween->count());
+        $this->assertEquals('2', $elementsInBetween->eq(0)->text());
+
+        /**
+         * Using last element as stating point
+         */
+        $startElement = $crawler->filter('#five');
+        $finalElement = $crawler->filter('#three')->getNode(0);
+        $elementsInBetween = $startElement->nextUntil($finalElement);
+        $this->assertEquals(0, $elementsInBetween->count());
+    }
+
     public function testPreviousAll()
     {
         $crawler = $this->createTestCrawler()->filterXPath('//li')->eq(2);

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
@@ -1054,6 +1054,38 @@ HTML;
         }
     }
 
+    public function testPreviousUntil()
+    {
+        $html = <<<"HTML"
+        <html>
+            <body>
+                <ul id='list'>
+                    <li id='one'>1</li>
+                    <li id='two'>2</li>
+                    <li id='three'>3</li>
+                    <li id='four'>4</li>
+                    <li id='five'>5</li>
+                </ul>
+            </body>
+        </div>
+        HTML;
+
+        $crawler = $this->createCrawler($this->getDoctype().$html);
+        $startElement = $crawler->filter('#five');
+        $finalElement = $crawler->filter('#one')->getNode(0);
+        $elementsInBetween = $startElement->previousUntil($finalElement);
+        $this->assertEquals(3, $elementsInBetween->count());
+        $this->assertEquals('4', $elementsInBetween->eq(0)->text());
+
+        /**
+         * Using first element as stating point
+         */
+        $startElement = $crawler->filter('#one');
+        $finalElement = $crawler->filter('#three')->getNode(0);
+        $elementsInBetween = $startElement->previousUntil($finalElement);
+        $this->assertEquals(0, $elementsInBetween->count());
+    }
+
     public function testChildren()
     {
         $crawler = $this->createTestCrawler()->filterXPath('//ul');

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
@@ -1028,7 +1028,7 @@ HTML;
         $this->assertEquals('2', $elementsInBetween->eq(0)->text());
 
         /**
-         * Using last element as stating point
+         * Using last element as stating point.
          */
         $startElement = $crawler->filter('#five');
         $finalElement = $crawler->filter('#three')->getNode(0);
@@ -1078,7 +1078,7 @@ HTML;
         $this->assertEquals('4', $elementsInBetween->eq(0)->text());
 
         /**
-         * Using first element as stating point
+         * Using first element as stating point.
          */
         $startElement = $crawler->filter('#one');
         $finalElement = $crawler->filter('#three')->getNode(0);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / 5.0 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/13267

Crawler::nextUntil($finalNode) & Crawler::previousUntil($finalNode) returns siblings within the range of current and $finalNode.
