### PR TITLE
[Dotenv] Documentation improvement

### DIFF
--- a/src/Symfony/Component/Dotenv/README.md
+++ b/src/Symfony/Component/Dotenv/README.md
@@ -2,7 +2,7 @@ Dotenv Component
 ================
 
 Symfony Dotenv parses `.env` files to make environment variables stored in them
-accessible via `$_SERVER`, `$_ENV` and optionally `getenv()`.
+accessible via `$_SERVER` or `$_ENV`.
 
 Resources
 ---------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->

Equalization with the component description in the [documentation](https://symfony.com/doc/current/components/dotenv.html). 
My suggestion is to remove `getenv()` from this description. [Since Symfony 4.3](https://github.com/symfony/symfony/blob/master/UPGRADE-4.3.md), `$usePutenv = false` by default in `Dotenv::__construct()`. Because of this, `getenv()` is not usable by default.