### PR TITLE
[HttpClient] Fix curl warning when resource body is closed

### DIFF
--- a/src/Symfony/Component/HttpClient/Internal/ClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/ClientState.php
@@ -22,4 +22,5 @@ class ClientState
 {
     public $handlesActivity = [];
     public $openHandles = [];
+    public $openResources = [];
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #35859
| License       | MIT
| Doc PR        | NA

Fixes `PHP Warning: curl_multi_exec(): CURLOPT_INFILE resource has gone away, resetting to default` when the request body contains a closed resource.

I'm not sure that the best way to fix it ping @nicolas-grekas. Maybe a temporary error_handler?

I also think that this could be improved: When we the request has been sent, curl may ignore that option, and user may be free to close the resource (even if the response is not fully downloaded)
```php
foreach ($this->client($response) as $chunk) {
  if ($chunk->isFirst()) {
    fclose($body); // that should be allowed.
  }
}

```