### PR TITLE
[ExpressionLanguage] Added safe navigation operator

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Parser.php
+++ b/src/Symfony/Component/ExpressionLanguage/Parser.php
@@ -337,6 +337,15 @@ class Parser
                 $token = $this->stream->current;
                 $this->stream->next();
 
+                $safeNavigation = false;
+
+                // Check for safe navigation operator
+                if ('?' === $token->value) {
+                    $safeNavigation = true;
+                    $token = $this->stream->current;
+                    $this->stream->next();
+                }
+
                 if (
                     Token::NAME_TYPE !== $token->type
                     &&
@@ -368,7 +377,11 @@ class Parser
                     $type = Node\GetAttrNode::PROPERTY_CALL;
                 }
 
-                $node = new Node\GetAttrNode($node, $arg, $arguments, $type);
+                if ($node instanceof Node\GetAttrNode && $node->isSafeNavigationEnabled()) {
+                    $safeNavigation = true;
+                }
+
+                $node = new Node\GetAttrNode($node, $arg, $arguments, $type, $safeNavigation);
             } elseif ('[' === $token->value) {
                 $this->stream->next();
                 $arg = $this->parseExpression();

--- a/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/Node/GetAttrNodeTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\ExpressionLanguage\Tests\Node;
 
+use Symfony\Component\ExpressionLanguage\Node\ArgumentsNode;
 use Symfony\Component\ExpressionLanguage\Node\ArrayNode;
 use Symfony\Component\ExpressionLanguage\Node\ConstantNode;
 use Symfony\Component\ExpressionLanguage\Node\GetAttrNode;
@@ -41,6 +42,8 @@ class GetAttrNodeTest extends AbstractNodeTest
 
             ['$foo->foo(["b" => "a", 0 => "b"])', new GetAttrNode(new NameNode('foo'), new ConstantNode('foo'), $this->getArrayNode(), GetAttrNode::METHOD_CALL), ['foo' => new Obj()]],
             ['$foo[$index]', new GetAttrNode(new NameNode('foo'), new NameNode('index'), $this->getArrayNode(), GetAttrNode::ARRAY_CALL)],
+            ['(\is_object($foo) ? $foo->bar : null)', new GetAttrNode(new NameNode('foo'), new ConstantNode('bar'), new ArgumentsNode(), GetAttrNode::PROPERTY_CALL, true), ['foo' => new Obj()]],
+            ['(\is_object($foo) && \is_callable([$foo, "bar"])) ? $foo->bar() : null', new GetAttrNode(new NameNode('foo'), new ConstantNode('bar'), new ArgumentsNode(), GetAttrNode::METHOD_CALL, true), ['foo' => new Obj()]]
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | TODO

The aim of this PR is to propose adding the [safe navigation operator](https://en.wikipedia.org/wiki/Safe_navigation_operator) to the expression language, which is a convenient way to guard against runtime exception when trying to access to a property or calling a method on a `null` object.

For example, if we have an expression like this:
```php
$expressionLanguage->evaluate('person.birthday.format("d/m/Y")', ['person' => $person]);
```

If one of `person` or `birthday` are `null`, a runtime exception will be thrown (`Unable to get a property on a non-object`), which could be what went, but if we want to avoid that, we need to add more tests in our expression:

```php
$expressionLanguage->evaluate('person ? (person.birthday ? person.birthday.format("d/m/Y") : null) : null', ['person' => $person]);
```

The safe navigation operator will replace the previous expression by:
```diff
- $expressionLanguage->evaluate('person ? (person.birthday ? person.birthday.format("d/m/Y") : null) : null', ['person' => $person]);
+ $expressionLanguage->evaluate('person.?birthday.format("d/m/Y")', ['person' => $person])
```

TODO:
- [x] update the compiler
- [x] add tests