### PR TITLE
[EventDispatcher] service-contracts is prod dependency in 4.4

### DIFF
--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "symfony/event-dispatcher-contracts": "^1.1"
+        "symfony/event-dispatcher-contracts": "^1.1",
+        "symfony/service-contracts": "^1.1|^2"
     },
     "require-dev": {
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",
         "symfony/expression-language": "^3.4|^4.0|^5.0",
         "symfony/config": "^3.4|^4.0|^5.0",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",
-        "symfony/service-contracts": "^1.1|^2",
         "symfony/stopwatch": "^3.4|^4.0|^5.0",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

service-contracts is production dependency of symfony/event dispatcher 4.3 and 4.4 because TraceableEventDispatcherInterface uses Symfony\Contracts\Service\ResetInterface

Relates to https://github.com/symfony/event-dispatcher/commit/c71314cd3b9420b732e1526f33a24eff5430b5b3

If TraceableEventDispatcherInterface is loaded, it causes fatal error:

> PHP Fatal error:  Interface 'Symfony\Contracts\Service\ResetInterface' not found in /var/www/html/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcherInterface.php on line 23

Reported in https://github.com/Codeception/Codeception/issues/5860

Links to code:
https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcherInterface.php
https://github.com/symfony/service-contracts/blob/master/ResetInterface.php