### PR TITLE
Added ROLE_PREVIOUS_ADMIN deprecation to UPGRADE guide

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -61,6 +61,25 @@ Routing
  * Added argument `$priority` to `RouteCollection::add()`
  * Deprecated the `RouteCompiler::REGEX_DELIMITER` constant
 
+Security
+--------
+
+ * Deprecated `ROLE_PREVIOUS_ADMIN` role in favor of `IS_IMPERSONATOR` attribute.
+
+   *before*
+   ```twig
+   {% if is_granted('ROLE_PREVIOUS_ADMIN') %}
+       <a href="">Exit impersonation</a>
+   {% endif %}
+   ```
+
+   *after*
+   ```twig
+   {% if is_granted('IS_IMPERSONATOR') %}
+       <a href="">Exit impersonation</a>
+   {% endif %}
+   ```
+
 Yaml
 ----
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -49,3 +49,8 @@ Routing
  * Removed `RouteCollectionBuilder`.
  * Added argument `$priority` to `RouteCollection::add()`
  * Removed the `RouteCompiler::REGEX_DELIMITER` constant
+
+Security
+--------
+
+ * Removed `ROLE_PREVIOUS_ADMIN` role in favor of `IS_IMPERSONATOR` attribute


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

I forgot to update the UPGRADE guides in https://github.com/symfony/symfony/pull/35858