### PR TITLE
[FrameworkBundle] add missing Messenger options to XML schema definition

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -427,6 +427,7 @@
         </xsd:sequence>
         <xsd:attribute name="default-bus" type="xsd:string" />
         <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="failure-transport" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="messenger_serializer">
@@ -457,10 +458,19 @@
     <xsd:complexType name="messenger_transport">
         <xsd:sequence>
             <xsd:element name="options" type="metadata" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="retry-strategy" type="messenger_retry_strategy" minOccurs="0" maxOccurs="1" />
         </xsd:sequence>
         <xsd:attribute name="name" type="xsd:string" />
         <xsd:attribute name="serializer" type="xsd:string" />
         <xsd:attribute name="dsn" type="xsd:string" />
+    </xsd:complexType>
+
+    <xsd:complexType name="messenger_retry_strategy">
+        <xsd:attribute name="service" type="xsd:string" />
+        <xsd:attribute name="max-retries" type="xsd:integer" />
+        <xsd:attribute name="delay" type="xsd:integer" />
+        <xsd:attribute name="multiplier" type="xsd:float" />
+        <xsd:attribute name="max-delay" type="xsd:float" />
     </xsd:complexType>
 
     <xsd:complexType name="messenger_bus">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transports.php
@@ -3,6 +3,7 @@
 $container->loadFromExtension('framework', [
     'serializer' => true,
     'messenger' => [
+        'failure_transport' => 'failed',
         'serializer' => [
             'default_serializer' => 'messenger.transport.symfony_serializer',
         ],
@@ -12,7 +13,14 @@ $container->loadFromExtension('framework', [
                 'dsn' => 'amqp://localhost/%2f/messages?exchange_name=exchange_name',
                 'options' => ['queue' => ['name' => 'Queue']],
                 'serializer' => 'messenger.transport.native_php_serializer',
+                'retry_strategy' => [
+                    'max_retries' => 10,
+                    'delay' => 7,
+                    'multiplier' => 3,
+                    'max_delay' => 100,
+                ],
             ],
+            'failed' => 'in-memory:///',
             'redis' => 'redis://127.0.0.1:6379/messages',
         ],
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transports.xml
@@ -7,7 +7,7 @@
 
     <framework:config>
         <framework:serializer enabled="true" />
-        <framework:messenger>
+        <framework:messenger failure-transport="failed">
             <framework:serializer default-serializer="messenger.transport.symfony_serializer" />
             <framework:transport name="default" dsn="amqp://localhost/%2f/messages" />
             <framework:transport name="customised" dsn="amqp://localhost/%2f/messages?exchange_name=exchange_name" serializer="messenger.transport.native_php_serializer">
@@ -16,7 +16,9 @@
                         <framework:name>Queue</framework:name>
                     </framework:queue>
                 </framework:options>
+                <framework:retry-strategy max-retries="10" delay="7" multiplier="3" max-delay="100"/>
             </framework:transport>
+            <framework:transport name="failed" dsn="in-memory:///" />
             <framework:transport name="redis" dsn="redis://127.0.0.1:6379/messages" />
         </framework:messenger>
     </framework:config>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transports.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transports.yml
@@ -1,6 +1,7 @@
 framework:
     serializer: true
     messenger:
+        failure_transport: failed
         serializer:
             default_serializer: messenger.transport.symfony_serializer
         transports:
@@ -11,4 +12,10 @@ framework:
                     queue:
                         name: Queue
                 serializer: 'messenger.transport.native_php_serializer'
+                retry_strategy:
+                    max_retries: 10
+                    delay: 7
+                    multiplier: 3
+                    max_delay: 100
+            failed: 'in-memory:///'
             redis: 'redis://127.0.0.1:6379/messages'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -725,6 +725,13 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame('redis://127.0.0.1:6379/messages', $transportArguments[0]);
 
         $this->assertTrue($container->hasDefinition('messenger.transport.redis.factory'));
+
+        $this->assertSame(10, $container->getDefinition('messenger.retry.multiplier_retry_strategy.customised')->getArgument(0));
+        $this->assertSame(7, $container->getDefinition('messenger.retry.multiplier_retry_strategy.customised')->getArgument(1));
+        $this->assertSame(3, $container->getDefinition('messenger.retry.multiplier_retry_strategy.customised')->getArgument(2));
+        $this->assertSame(100, $container->getDefinition('messenger.retry.multiplier_retry_strategy.customised')->getArgument(3));
+
+        $this->assertEquals(new Reference('messenger.transport.failed'), $container->getDefinition('messenger.failure.send_failed_message_to_failure_transport_listener')->getArgument(0));
     }
 
     public function testMessengerRouting()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix symfony/symfony-docs#13010
| License       | MIT
| Doc PR        | symfony/symfony-docs#13277