### PR TITLE
[DI] Clarified deprecation for TypedReference in 4.4

### DIFF
--- a/src/Symfony/Component/DependencyInjection/TypedReference.php
+++ b/src/Symfony/Component/DependencyInjection/TypedReference.php
@@ -31,7 +31,7 @@ class TypedReference extends Reference
     public function __construct(string $id, string $type, $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $name = null)
     {
         if (\is_string($invalidBehavior ?? '') || \is_int($name)) {
-            @trigger_error(sprintf('The $requiringClass argument of "%s()" is deprecated since Symfony 4.1.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Passing the $requiringClass as 3rd argument for "%s()" is deprecated since Symfony 4.1. It should be removed, moving all following arguments 1 to the left.', __METHOD__), E_USER_DEPRECATED);
 
             $this->requiringClass = $invalidBehavior;
             $invalidBehavior = 3 < \func_num_args() ? func_get_arg(3) : ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #35752 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        |~ <!-- required for new features -->

Changes the deprecation message to indicate the argument has been removed and how to fix it.