### PR TITLE
Add Spanish translation

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
@@ -364,7 +364,15 @@
             </trans-unit>
             <trans-unit id="94">
                 <source>This value should be between {{ min }} and {{ max }}.</source>
-                <target>Este valor debe estar entre {{ min }} y {{ max }}.</target>
+                <target>Este valor debería estar entre {{ min }} y {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>Este valor no es un nombre de host válido.</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>El número de elementos en esta colección debería ser múltiplo de {{ compared_value }}.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

@javiereguiluz I know it's not very significant, but in order to make distinction between `must be` and `should be`, shouldn't translation no. 94 be changed to `Este valor debería estar entre...`?