### PR TITLE
[MIME] generateMessageId fix

### DIFF
--- a/src/Symfony/Component/Mime/Tests/MessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/MessageTest.php
@@ -147,4 +147,12 @@ EOF;
         $this->assertStringMatchesFormat($expected, str_replace("\r\n", "\n", $message->toString()));
         $this->assertStringMatchesFormat($expected, str_replace("\r\n", "\n", implode('', iterator_to_array($message->toIterable(), false))));
     }
+
+    public function testMessageIdShouldBeSame()
+    {
+        $message = new Message();
+        $message->getHeaders()->addMailboxListHeader('From', [new Address('fabien@symfony.com', 'Fabien')]);
+
+        $this->assertEquals($message->generateMessageId(), $message->generateMessageId());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

In my opinion, the message ID should be the same regardless of its generation.

The situation occurs when we queue a message and when the message is intercepted from the queue.

Although the two messages are the same, they are not entirely specific because their identifiers are different from each other.

This PR fix it.