### PR TITLE
[Routing] Fix some wrong localized routes tests

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/CompiledUrlGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/CompiledUrlGeneratorDumperTest.php
@@ -87,8 +87,8 @@ class CompiledUrlGeneratorDumperTest extends TestCase
     public function testDumpWithSimpleLocalizedRoutes()
     {
         $this->routeCollection->add('test', (new Route('/foo')));
-        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test'));
-        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test'));
+        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'nl'));
 
         $code = $this->generatorDumper->dump();
         file_put_contents($this->testTmpFilepath, $code);
@@ -120,7 +120,7 @@ class CompiledUrlGeneratorDumperTest extends TestCase
     {
         $this->expectException('Symfony\Component\Routing\Exception\RouteNotFoundException');
         $this->expectExceptionMessage('Unable to generate a URL for the named route "test" as such route does not exist.');
-        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test'));
+        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'en'));
 
         $code = $this->generatorDumper->dump();
         file_put_contents($this->testTmpFilepath, $code);
@@ -131,9 +131,9 @@ class CompiledUrlGeneratorDumperTest extends TestCase
 
     public function testDumpWithFallbackLocaleLocalizedRoutes()
     {
-        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test'));
-        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test'));
-        $this->routeCollection->add('test.fr', (new Route('/tester/est/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'test'));
+        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'nl'));
+        $this->routeCollection->add('test.fr', (new Route('/tester/est/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'fr'));
 
         $code = $this->generatorDumper->dump();
         file_put_contents($this->testTmpFilepath, $code);
@@ -234,10 +234,10 @@ class CompiledUrlGeneratorDumperTest extends TestCase
 
     public function testDumpWithLocalizedRoutesPreserveTheGoodLocaleInTheUrl()
     {
-        $this->routeCollection->add('foo.en', (new Route('/{_locale}/foo'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo'));
-        $this->routeCollection->add('foo.fr', (new Route('/{_locale}/foo'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'foo'));
-        $this->routeCollection->add('fun.en', (new Route('/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'fun'));
-        $this->routeCollection->add('fun.fr', (new Route('/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'fun'));
+        $this->routeCollection->add('foo.en', (new Route('/{_locale}/fork'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('foo.fr', (new Route('/{_locale}/fourchette'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'foo')->setRequirement('_locale', 'fr'));
+        $this->routeCollection->add('fun.en', (new Route('/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'fun')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('fun.fr', (new Route('/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'fun')->setRequirement('_locale', 'fr'));
 
         file_put_contents($this->testTmpFilepath, $this->generatorDumper->dump());
 
@@ -246,10 +246,10 @@ class CompiledUrlGeneratorDumperTest extends TestCase
 
         $compiledUrlGenerator = new CompiledUrlGenerator(require $this->testTmpFilepath, $requestContext, null, null);
 
-        $this->assertSame('/fr/foo', $compiledUrlGenerator->generate('foo'));
-        $this->assertSame('/en/foo', $compiledUrlGenerator->generate('foo.en'));
-        $this->assertSame('/en/foo', $compiledUrlGenerator->generate('foo', ['_locale' => 'en']));
-        $this->assertSame('/en/foo', $compiledUrlGenerator->generate('foo.fr', ['_locale' => 'en']));
+        $this->assertSame('/fr/fourchette', $compiledUrlGenerator->generate('foo'));
+        $this->assertSame('/en/fork', $compiledUrlGenerator->generate('foo.en'));
+        $this->assertSame('/en/fork', $compiledUrlGenerator->generate('foo', ['_locale' => 'en']));
+        $this->assertSame('/fr/fourchette', $compiledUrlGenerator->generate('foo.fr', ['_locale' => 'en']));
 
         $this->assertSame('/amusant', $compiledUrlGenerator->generate('fun'));
         $this->assertSame('/fun', $compiledUrlGenerator->generate('fun.en'));

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -90,8 +90,8 @@ class PhpGeneratorDumperTest extends TestCase
     public function testDumpWithSimpleLocalizedRoutes()
     {
         $this->routeCollection->add('test', (new Route('/foo')));
-        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test'));
-        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test'));
+        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'nl'));
 
         $code = $this->generatorDumper->dump([
             'class' => 'SimpleLocalizedProjectUrlGenerator',
@@ -126,7 +126,7 @@ class PhpGeneratorDumperTest extends TestCase
     {
         $this->expectException('Symfony\Component\Routing\Exception\RouteNotFoundException');
         $this->expectExceptionMessage('Unable to generate a URL for the named route "test" as such route does not exist.');
-        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test'));
+        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'en'));
 
         $code = $this->generatorDumper->dump([
             'class' => 'RouteNotFoundLocalizedProjectUrlGenerator',
@@ -140,9 +140,9 @@ class PhpGeneratorDumperTest extends TestCase
 
     public function testDumpWithFallbackLocaleLocalizedRoutes()
     {
-        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test'));
-        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test'));
-        $this->routeCollection->add('test.fr', (new Route('/tester/est/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'test'));
+        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'nl'));
+        $this->routeCollection->add('test.fr', (new Route('/tester/est/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'fr'));
 
         $code = $this->generatorDumper->dump([
             'class' => 'FallbackLocaleLocalizedProjectUrlGenerator',
@@ -253,10 +253,10 @@ class PhpGeneratorDumperTest extends TestCase
 
     public function testDumpWithLocalizedRoutesPreserveTheGoodLocaleInTheUrl()
     {
-        $this->routeCollection->add('foo.en', (new Route('/{_locale}/foo'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo'));
-        $this->routeCollection->add('foo.fr', (new Route('/{_locale}/foo'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'foo'));
-        $this->routeCollection->add('fun.en', (new Route('/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'fun'));
-        $this->routeCollection->add('fun.fr', (new Route('/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'fun'));
+        $this->routeCollection->add('foo.en', (new Route('/{_locale}/fork'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('foo.fr', (new Route('/{_locale}/fourchette'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'foo')->setRequirement('_locale', 'fr'));
+        $this->routeCollection->add('fun.en', (new Route('/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'fun')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('fun.fr', (new Route('/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'fun')->setRequirement('_locale', 'fr'));
 
         file_put_contents($this->testTmpFilepath, $this->generatorDumper->dump([
             'class' => 'PreserveTheGoodLocaleInTheUrlGenerator',
@@ -268,10 +268,10 @@ class PhpGeneratorDumperTest extends TestCase
 
         $phpGenerator = new \PreserveTheGoodLocaleInTheUrlGenerator($requestContext);
 
-        $this->assertSame('/fr/foo', $phpGenerator->generate('foo'));
-        $this->assertSame('/en/foo', $phpGenerator->generate('foo.en'));
-        $this->assertSame('/en/foo', $phpGenerator->generate('foo', ['_locale' => 'en']));
-        $this->assertSame('/en/foo', $phpGenerator->generate('foo.fr', ['_locale' => 'en']));
+        $this->assertSame('/fr/fourchette', $phpGenerator->generate('foo'));
+        $this->assertSame('/en/fork', $phpGenerator->generate('foo.en'));
+        $this->assertSame('/en/fork', $phpGenerator->generate('foo', ['_locale' => 'en']));
+        $this->assertSame('/fr/fourchette', $phpGenerator->generate('foo.fr', ['_locale' => 'en']));
 
         $this->assertSame('/amusant', $phpGenerator->generate('fun'));
         $this->assertSame('/fun', $phpGenerator->generate('fun.en'));

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -171,6 +171,7 @@ class UrlGeneratorTest extends TestCase
         foreach (['hr' => '/foo', 'en' => '/bar'] as $locale => $path) {
             $localizedRoute = clone $route;
             $localizedRoute->setDefault('_locale', $locale);
+            $localizedRoute->setRequirement('_locale', $locale);
             $localizedRoute->setDefault('_canonical_route', $name);
             $localizedRoute->setPath($path);
             $routes->add($name.'.'.$locale, $localizedRoute);
@@ -195,6 +196,7 @@ class UrlGeneratorTest extends TestCase
         foreach (['hr' => '/foo', 'en' => '/bar'] as $locale => $path) {
             $localizedRoute = clone $route;
             $localizedRoute->setDefault('_locale', $locale);
+            $localizedRoute->setRequirement('_locale', $locale);
             $localizedRoute->setDefault('_canonical_route', $name);
             $localizedRoute->setPath($path);
             $routes->add($name.'.'.$locale, $localizedRoute);
@@ -219,6 +221,7 @@ class UrlGeneratorTest extends TestCase
         foreach (['hr' => '/foo', 'en' => '/bar'] as $locale => $path) {
             $localizedRoute = clone $route;
             $localizedRoute->setDefault('_locale', $locale);
+            $localizedRoute->setRequirement('_locale', $locale);
             $localizedRoute->setDefault('_canonical_route', $name);
             $localizedRoute->setPath($path);
             $routes->add($name.'.'.$locale, $localizedRoute);
@@ -240,18 +243,18 @@ class UrlGeneratorTest extends TestCase
     {
         $routeCollection = new RouteCollection();
 
-        $routeCollection->add('foo.en', (new Route('/{_locale}/foo'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo'));
-        $routeCollection->add('foo.fr', (new Route('/{_locale}/foo'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'foo'));
-        $routeCollection->add('fun.en', (new Route('/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'fun'));
-        $routeCollection->add('fun.fr', (new Route('/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'fun'));
+        $routeCollection->add('foo.en', (new Route('/{_locale}/fork'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo')->setRequirement('_locale', 'en'));
+        $routeCollection->add('foo.fr', (new Route('/{_locale}/fourchette'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'foo')->setRequirement('_locale', 'fr'));
+        $routeCollection->add('fun.en', (new Route('/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'fun')->setRequirement('_locale', 'en'));
+        $routeCollection->add('fun.fr', (new Route('/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'fun')->setRequirement('_locale', 'fr'));
 
         $urlGenerator = $this->getGenerator($routeCollection);
         $urlGenerator->getContext()->setParameter('_locale', 'fr');
 
-        $this->assertSame('/app.php/fr/foo', $urlGenerator->generate('foo'));
-        $this->assertSame('/app.php/en/foo', $urlGenerator->generate('foo.en'));
-        $this->assertSame('/app.php/en/foo', $urlGenerator->generate('foo', ['_locale' => 'en']));
-        $this->assertSame('/app.php/en/foo', $urlGenerator->generate('foo.fr', ['_locale' => 'en']));
+        $this->assertSame('/app.php/fr/fourchette', $urlGenerator->generate('foo'));
+        $this->assertSame('/app.php/en/fork', $urlGenerator->generate('foo.en'));
+        $this->assertSame('/app.php/en/fork', $urlGenerator->generate('foo', ['_locale' => 'en']));
+        $this->assertSame('/app.php/fr/fourchette', $urlGenerator->generate('foo.fr', ['_locale' => 'en']));
 
         $this->assertSame('/app.php/amusant', $urlGenerator->generate('fun'));
         $this->assertSame('/app.php/fun', $urlGenerator->generate('fun.en'));
@@ -278,6 +281,7 @@ class UrlGeneratorTest extends TestCase
         foreach (['hr' => '/foo', 'en' => '/bar'] as $locale => $path) {
             $localizedRoute = clone $route;
             $localizedRoute->setDefault('_locale', $locale);
+            $localizedRoute->setRequirement('_locale', $locale);
             $localizedRoute->setDefault('_canonical_route', $name);
             $localizedRoute->setPath($path);
             $routes->add($name.'.'.$locale, $localizedRoute);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

~~Since https://github.com/symfony/symfony/pull/35855, the `_locale` path param is directly substituted so those tests are not valid cases anymore. Instead, the path directly contain the right locale.~~ Actually, the compilation is done after, so instead we need to set the new requirement in all tests to reflect the "reality".

https://github.com/symfony/symfony/pull/35855 also causes a BC break on one case:
```php
$compiledUrlGenerator->generate('foo.fr', ['_locale' => 'en']))
```

Previously, the generated route would be the `/en/fourchette`. Now that the locale is hardcoded in the route path, it will always be `/fr/fourchette`. I changed `foo` to relevant words because it is easier to understand like that.