### PR TITLE
[Security] deprecate plaintext password encoder in symfony 5.1

### DIFF
--- a/CHANGELOG-5.1.md
+++ b/CHANGELOG-5.1.md
@@ -9,4 +9,4 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 
 * 5.1.0 (TBD)
 
- * feature # [Security] deprecate plaintext password encoder (jrushlow)
+ * feature #35929 [Security] deprecate plaintext password encoder (jrushlow)

--- a/CHANGELOG-5.1.md
+++ b/CHANGELOG-5.1.md
@@ -1,0 +1,12 @@
+CHANGELOG for 5.1.x
+===================
+
+This changelog references the relevant changes (bug and security fixes) done
+in 5.1 minor versions.
+
+To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
+To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v5.0.0...v5.0.1
+
+* 5.1.0 (TBD)
+
+ * feature # [Security] deprecate plaintext password encoder (jrushlow)

--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -80,6 +80,8 @@ Security
    {% endif %}
    ```
 
+ * Deprecated `PlaintextPasswordEncoder`. Using the `UserPasswordEncoder` or any other the provided `Symfony\Component\Security\Core\Encoder`'s is highly recommended.
+
 Yaml
 ----
 

--- a/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
@@ -13,10 +13,14 @@ namespace Symfony\Component\Security\Core\Encoder;
 
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
+@trigger_error(sprintf('The "%s" class is deprecated since Symfony 5.1, use "%s" instead.', PlaintextPasswordEncoder::class, UserPasswordEncoder::class), E_USER_DEPRECATED);
+
 /**
  * PlaintextPasswordEncoder does not do any encoding.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 5.1, use another included encoder instead. I.e. Symfony\Component\Security\Core\Encoder\UserPasswordEncoder.
  */
 class PlaintextPasswordEncoder extends BasePasswordEncoder
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | #35927
| License       | MIT
| Doc PR        | n/a

The `PlaintextPasswordEncoder` included with Symfony core was introduced back in 2010ish. This encoder was de-referenced from the Symfony Docs back in 2018. This PR deprecates the encoder in Symfony 5.1 and recommends using the `UserPasswordEncoder` or any one of the other included `Symfony\Component\Security\Core\Encoder`'s.

The intent is to move the framework forward and encourage current best practices in regards to password security techniques.
