### PR TITLE
[String] fix failing test on PHP 8

### DIFF
--- a/src/Symfony/Component/String/Tests/LazyStringTest.php
+++ b/src/Symfony/Component/String/Tests/LazyStringTest.php
@@ -107,6 +107,8 @@ class LazyStringTest extends TestCase
         $this->assertFalse(LazyString::isStringable([]));
         $this->assertFalse(LazyString::isStringable(STDIN));
         $this->assertFalse(LazyString::isStringable(new \StdClass()));
-        $this->assertFalse(LazyString::isStringable(@eval('return new class() {private function __toString() {}};')));
+        if (\PHP_VERSION_ID < 80000) {
+            $this->assertFalse(LazyString::isStringable(@eval('return new class() {private function __toString() {}};')));
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`__toString()` must be public in PHP 8.