### PR TITLE
[String] Add AbstractString::containsAny()

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -255,6 +255,14 @@ abstract class AbstractString implements \JsonSerializable
     }
 
     /**
+     * @param string|string[] $needle
+     */
+    public function containsAny($needle): bool
+    {
+        return null !== $this->indexOf($needle);
+    }
+
+    /**
      * @param string|string[] $suffix
      */
     public function endsWith($suffix): bool

--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * added the `s()` helper method to get either an `UnicodeString` or `ByteString` instance,
    depending of the input string UTF-8 compliancy
  * added `$cut` parameter to `Symfony\Component\String\AbstractString::truncate()`
+ * added `AbstractString::containsAny()`
 
 5.0.0
 -----

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -55,6 +55,26 @@ abstract class AbstractAsciiTestCase extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider provideIndexOf
+     */
+    public function testContainsAny(?int $result, string $string, $needle)
+    {
+        $instance = static::createFromString($string);
+
+        $this->assertSame(null !== $instance->indexOf($needle), $instance->containsAny($needle));
+    }
+
+    /**
+     * @dataProvider provideIndexOfIgnoreCase
+     */
+    public function testContainsAnyIgnoreCase(?int $result, string $string, $needle)
+    {
+        $instance = static::createFromString($string);
+
+        $this->assertSame(null !== $instance->ignoreCase()->indexOf($needle), $instance->ignoreCase()->containsAny($needle));
+    }
+
     public function testUnwrap()
     {
         $expected = ['hello', 'world'];
@@ -161,7 +181,7 @@ abstract class AbstractAsciiTestCase extends TestCase
     /**
      * @dataProvider provideIndexOf
      */
-    public function testIndexOf(?int $result, string $string, string $needle, int $offset)
+    public function testIndexOf(?int $result, string $string, $needle, int $offset)
     {
         $instance = static::createFromString($string);
 
@@ -180,6 +200,7 @@ abstract class AbstractAsciiTestCase extends TestCase
             [null, 'abc', 'a', -1],
             [null, '123abc', 'B', -3],
             [null, '123abc', 'b', 6],
+            [0, 'abc', ['a', 'e'], 0],
             [0, 'abc', 'a', 0],
             [1, 'abc', 'b', 1],
             [2, 'abc', 'c', 1],
@@ -191,7 +212,7 @@ abstract class AbstractAsciiTestCase extends TestCase
     /**
      * @dataProvider provideIndexOfIgnoreCase
      */
-    public function testIndexOfIgnoreCase(?int $result, string $string, string $needle, int $offset)
+    public function testIndexOfIgnoreCase(?int $result, string $string, $needle, int $offset)
     {
         $instance = static::createFromString($string);
 
@@ -208,6 +229,7 @@ abstract class AbstractAsciiTestCase extends TestCase
             [null, 'abc', 'a', -1],
             [null, 'abc', 'A', -1],
             [null, '123abc', 'B', 6],
+            [0, 'ABC', ['a', 'e'], 0],
             [0, 'ABC', 'a', 0],
             [0, 'ABC', 'A', 0],
             [1, 'ABC', 'b', 0],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

We decided to not have a `contains()` method because we didn't know how to handle the case where several needles are passed. But https://wiki.php.net/rfc/str_contains made me reconsider this idea and I think `containsAny()` works great. WDYT?