### PR TITLE
Revert "bug symfony#28179 [DomCrawler] Skip disabled fields processing in Form"

### DIFF
--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -89,6 +89,10 @@ class Form extends Link implements \ArrayAccess
     {
         $values = [];
         foreach ($this->fields->all() as $name => $field) {
+            if ($field->isDisabled()) {
+                continue;
+            }
+
             if (!$field instanceof Field\FileFormField && $field->hasValue()) {
                 $values[$name] = $field->getValue();
             }
@@ -111,6 +115,10 @@ class Form extends Link implements \ArrayAccess
         $files = [];
 
         foreach ($this->fields->all() as $name => $field) {
+            if ($field->isDisabled()) {
+                continue;
+            }
+
             if ($field instanceof Field\FileFormField) {
                 $files[$name] = $field->getValue();
             }
@@ -455,7 +463,7 @@ class Form extends Link implements \ArrayAccess
 
     private function addField(\DOMElement $node)
     {
-        if (!$node->hasAttribute('name') || !$node->getAttribute('name') || $node->hasAttribute('disabled')) {
+        if (!$node->hasAttribute('name') || !$node->getAttribute('name')) {
             return;
         }
 

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -159,12 +159,12 @@ class FormTest extends TestCase
     public function testMultiValuedFields()
     {
         $form = $this->createForm('<form>
-            <input type="text" name="foo[4]" value="foo" />
-            <input type="text" name="foo" value="foo" />
-            <input type="text" name="foo[2]" value="foo" />
-            <input type="text" name="foo[]" value="foo" />
-            <input type="text" name="bar[foo][]" value="foo" />
-            <input type="text" name="bar[foo][foobar]" value="foo" />
+            <input type="text" name="foo[4]" value="foo" disabled="disabled" />
+            <input type="text" name="foo" value="foo" disabled="disabled" />
+            <input type="text" name="foo[2]" value="foo" disabled="disabled" />
+            <input type="text" name="foo[]" value="foo" disabled="disabled" />
+            <input type="text" name="bar[foo][]" value="foo" disabled="disabled" />
+            <input type="text" name="bar[foo][foobar]" value="foo" disabled="disabled" />
             <input type="submit" />
         </form>
         ');
@@ -227,10 +227,10 @@ class FormTest extends TestCase
                 [],
             ],
             [
-                'skips disabled input fields',
+                'takes into account disabled input fields',
                 '<input type="text" name="foo" value="foo" disabled="disabled" />
                  <input type="submit" />',
-                [],
+                ['foo' => ['InputFormField', 'foo']],
             ],
             [
                 'appends the submitted button value',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/35923
| License       | MIT
| Doc PR        | -

Reverts https://github.com/symfony/symfony/pull/34059

See https://github.com/symfony/symfony/issues/35923