### PR TITLE
[UID] Added the component + Added support for UUID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ before_install:
       sudo wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | sudo apt-key add -
       echo "deb http://packages.couchbase.com/ubuntu xenial xenial/main" | sudo tee /etc/apt/sources.list.d/couchbase.list
       sudo apt update
-      sudo apt install -y librabbitmq-dev libsodium-dev libcouchbase-dev zlib1g-dev
+      sudo apt install -y libcouchbase-dev librabbitmq-dev libsodium-dev php-uuid zlib1g-dev
 
     - |
       # Start Couchbase

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "symfony/polyfill-intl-idn": "^1.10",
         "symfony/polyfill-intl-normalizer": "~1.0",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/polyfill-php73": "^1.11"
+        "symfony/polyfill-php73": "^1.11",
+        "symfony/polyfill-uuid": "^1.15"
     },
     "replace": {
         "symfony/asset": "self.version",
@@ -90,6 +91,7 @@
         "symfony/translation": "self.version",
         "symfony/twig-bridge": "self.version",
         "symfony/twig-bundle": "self.version",
+        "symfony/uid": "self.version",
         "symfony/validator": "self.version",
         "symfony/var-dumper": "self.version",
         "symfony/var-exporter": "self.version",

--- a/src/Symfony/Component/Uid/.gitattributes
+++ b/src/Symfony/Component/Uid/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/Uid/.gitignore
+++ b/src/Symfony/Component/Uid/.gitignore
@@ -1,0 +1,3 @@
+composer.lock
+phpunit.xml
+vendor/

--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -1,0 +1,8 @@
+CHANGELOG
+=========
+
+5.1.0
+-----
+
+ * added support for UUID
+ * added the component

--- a/src/Symfony/Component/Uid/LICENSE
+++ b/src/Symfony/Component/Uid/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Uid/README.md
+++ b/src/Symfony/Component/Uid/README.md
@@ -1,0 +1,18 @@
+Uid Component
+=============
+
+The UID component provides an object-oriented API to generate and represent UIDs.
+
+**This Component is experimental**.
+[Experimental features](https://symfony.com/doc/current/contributing/code/experimental.html)
+are not covered by Symfony's
+[Backward Compatibility Promise](https://symfony.com/doc/current/contributing/code/bc.html).
+
+Resources
+---------
+
+  * [Documentation](https://symfony.com/doc/current/components/uid.html)
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Uid;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+class UuidTest extends TestCase
+{
+    private const A_UUID_V1 = 'd9e7a184-5d5b-11ea-a62a-3499710062d0';
+    private const A_UUID_V4 = 'd6b3345b-2905-4048-a83c-b5988e765d98';
+
+    public function testConstructorWithInvalidUuid()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid UUID: "this is not a uuid".');
+
+        new Uuid('this is not a uuid');
+    }
+
+    public function testConstructorWithValidUuid()
+    {
+        $uuid = new Uuid(self::A_UUID_V4);
+
+        $this->assertSame(self::A_UUID_V4, (string) $uuid);
+        $this->assertSame('"'.self::A_UUID_V4.'"', json_encode($uuid));
+    }
+
+    public function testV1()
+    {
+        $uuid = Uuid::v1();
+
+        $this->assertSame(Uuid::TYPE_1, $uuid->getType());
+    }
+
+    public function testV3()
+    {
+        $uuid = Uuid::v3(new Uuid(self::A_UUID_V4), 'the name');
+
+        $this->assertSame(Uuid::TYPE_3, $uuid->getType());
+    }
+
+    public function testV4()
+    {
+        $uuid = Uuid::v4();
+
+        $this->assertSame(Uuid::TYPE_4, $uuid->getType());
+    }
+
+    public function testV5()
+    {
+        $uuid = Uuid::v5(new Uuid(self::A_UUID_V4), 'the name');
+
+        $this->assertSame(Uuid::TYPE_5, $uuid->getType());
+    }
+
+    public function testBinary()
+    {
+        $uuid = new Uuid(self::A_UUID_V4);
+
+        $this->assertSame(self::A_UUID_V4, (string) Uuid::fromBinary($uuid->toBinary()));
+    }
+
+    public function testIsValid()
+    {
+        $this->assertFalse(Uuid::isValid('not a uuid'));
+        $this->assertTrue(Uuid::isValid(self::A_UUID_V4));
+    }
+
+    public function testIsNull()
+    {
+        $uuid = new Uuid(self::A_UUID_V1);
+        $this->assertFalse($uuid->isNull());
+
+        $uuid = new Uuid('00000000-0000-0000-0000-000000000000');
+        $this->assertTrue($uuid->isNull());
+    }
+
+    public function testEquals()
+    {
+        $uuid1 = new Uuid(self::A_UUID_V1);
+        $uuid2 = new Uuid(self::A_UUID_V4);
+
+        $this->assertTrue($uuid1->equals($uuid1));
+        $this->assertFalse($uuid1->equals($uuid2));
+    }
+
+    public function testCompare()
+    {
+        $uuids = [];
+
+        $uuids[] = $b = new Uuid('00000000-0000-0000-0000-00000000000b');
+        $uuids[] = $a = new Uuid('00000000-0000-0000-0000-00000000000a');
+        $uuids[] = $d = new Uuid('00000000-0000-0000-0000-00000000000d');
+        $uuids[] = $c = new Uuid('00000000-0000-0000-0000-00000000000c');
+
+        $this->assertNotSame([$a, $b, $c, $d], $uuids);
+
+        usort($uuids, static function (Uuid $a, Uuid $b): int {
+            return $a->compare($b);
+        });
+
+        $this->assertSame([$a, $b, $c, $d], $uuids);
+    }
+
+    public function testExtraMethods()
+    {
+        $uuid = new Uuid(self::A_UUID_V1);
+
+        $this->assertSame(Uuid::VARIANT_DCE, $uuid->getVariant());
+        $this->assertSame(1583245966, $uuid->getTime());
+        $this->assertSame('3499710062d0', $uuid->getMac());
+        $this->assertSame(self::A_UUID_V1, (string) $uuid);
+    }
+}

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Uid;
+
+/**
+ * @experimental in 5.1
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class Uuid implements \JsonSerializable
+{
+    public const TYPE_1 = UUID_TYPE_TIME;
+    public const TYPE_3 = UUID_TYPE_MD5;
+    public const TYPE_4 = UUID_TYPE_RANDOM;
+    public const TYPE_5 = UUID_TYPE_SHA1;
+
+    public const VARIANT_NCS = UUID_VARIANT_NCS;
+    public const VARIANT_DCE = UUID_VARIANT_DCE;
+    public const VARIANT_MICROSOFT = UUID_VARIANT_MICROSOFT;
+    public const VARIANT_OTHER = UUID_VARIANT_OTHER;
+
+    private $uuid;
+
+    public function __construct(string $uuid = null)
+    {
+        if (null === $uuid) {
+            $this->uuid = uuid_create(self::TYPE_4);
+
+            return;
+        }
+
+        if (!uuid_is_valid($uuid)) {
+            throw new \InvalidArgumentException(sprintf('Invalid UUID: "%s".', $uuid));
+        }
+
+        $this->uuid = $uuid;
+    }
+
+    public static function v1(): self
+    {
+        return new self(uuid_create(self::TYPE_1));
+    }
+
+    public static function v3(self $uuidNamespace, string $name): self
+    {
+        return new self(uuid_generate_md5($uuidNamespace->uuid, $name));
+    }
+
+    public static function v4(): self
+    {
+        return new self(uuid_create(self::TYPE_4));
+    }
+
+    public static function v5(self $uuidNamespace, string $name): self
+    {
+        return new self(uuid_generate_sha1($uuidNamespace->uuid, $name));
+    }
+
+    public static function fromBinary(string $uuidAsBinary): self
+    {
+        return new self(uuid_unparse($uuidAsBinary));
+    }
+
+    public static function isValid(string $uuid): bool
+    {
+        return uuid_is_valid($uuid);
+    }
+
+    public function toBinary(): string
+    {
+        return uuid_parse($this->uuid);
+    }
+
+    public function isNull(): bool
+    {
+        return uuid_is_null($this->uuid);
+    }
+
+    public function equals(self $other): bool
+    {
+        return 0 === uuid_compare($this->uuid, $other->uuid);
+    }
+
+    public function compare(self $other): int
+    {
+        return uuid_compare($this->uuid, $other->uuid);
+    }
+
+    public function getType(): int
+    {
+        return uuid_type($this->uuid);
+    }
+
+    public function getVariant(): int
+    {
+        return uuid_variant($this->uuid);
+    }
+
+    public function getTime(): int
+    {
+        if (self::TYPE_1 !== $t = uuid_type($this->uuid)) {
+            throw new \LogicException("UUID of type $t doesn't contain a time.");
+        }
+
+        return uuid_time($this->uuid);
+    }
+
+    public function getMac(): string
+    {
+        if (self::TYPE_1 !== $t = uuid_type($this->uuid)) {
+            throw new \LogicException("UUID of type $t doesn't contain a MAC.");
+        }
+
+        return uuid_mac($this->uuid);
+    }
+
+    public function __toString(): string
+    {
+        return $this->uuid;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->uuid;
+    }
+}

--- a/src/Symfony/Component/Uid/composer.json
+++ b/src/Symfony/Component/Uid/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "symfony/uid",
+    "type": "library",
+    "description": "Symfony Uid component",
+    "keywords": ["uid", "uuid"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Grégoire Pineau",
+            "email": "lyrixx@lyrixx.info"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": "^7.2.5",
+        "symfony/polyfill-uuid": "^1.15"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Uid\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "5.1-dev"
+        }
+    }
+}

--- a/src/Symfony/Component/Uid/phpunit.xml.dist
+++ b/src/Symfony/Component/Uid/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony UID Component Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests/</directory>
+                <directory>./vendor/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |


---

```php
<?php

require __DIR__.'/vendor/autoload.php';

use Symfony\Component\Uid\Uuid;

$u = Uuid::v1();
dump($u);
dump($u->isNull());
dump($u->getType());
dump($u->getVariant());
dump($u->getTime());
dump($u->getMac());
dump($u->isEqualsTo($u));
dump($u->compare($u));
dump(Uuid::fromBinary($u->toBinary()));
```