### PR TITLE
[String] move symfony/translation-contracts to require-dev

### DIFF
--- a/src/Symfony/Component/String/composer.json
+++ b/src/Symfony/Component/String/composer.json
@@ -19,12 +19,12 @@
         "php": "^7.2.5",
         "symfony/polyfill-intl-grapheme": "~1.0",
         "symfony/polyfill-intl-normalizer": "~1.0",
-        "symfony/polyfill-mbstring": "~1.0",
-        "symfony/translation-contracts": "^1.1|^2"
+        "symfony/polyfill-mbstring": "~1.0"
     },
     "require-dev": {
         "symfony/error-handler": "^4.4|^5.0",
         "symfony/http-client": "^4.4|^5.0",
+        "symfony/translation-contracts": "^1.1|^2",
         "symfony/var-exporter": "^4.4|^5.0"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Since it's needed only if `AsciiSlugger` is used.
Surprisingly, the code in `FrameworkExtension` deals with this as if the dep was already optional:
https://github.com/symfony/symfony/blob/210ea2202b7384ac5e5793ae64f9bfe561c857e5/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L217-L220