### PR TITLE
[DI] Fix container lint command when a synthetic service is used in an expression

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -191,7 +191,12 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
         } elseif ($value instanceof Parameter) {
             $value = $this->container->getParameter($value);
         } elseif ($value instanceof Expression) {
-            $value = $this->getExpressionLanguage()->evaluate($value, ['container' => $this->container]);
+            try {
+                $value = $this->getExpressionLanguage()->evaluate($value, ['container' => $this->container]);
+            } catch (\Exception $e) {
+                // If a service from the expression cannot be fetched from the container, we skip the validation.
+                return;
+            }
         } elseif (\is_string($value)) {
             if ('%' === ($value[0] ?? '') && preg_match('/^%([^%]+)%$/', $value, $match)) {
                 // Only array parameters are not inlined when dumped.

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -739,4 +739,20 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
         $this->addToAssertionCount(1);
     }
+
+    public function testExpressionLanguageWithSyntheticService()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('synthetic')
+            ->setSynthetic(true);
+        $container->register('baz', \stdClass::class)
+            ->addArgument(new Reference('synthetic'));
+        $container->register('bar', Bar::class)
+            ->addArgument(new Expression('service("baz").getStdClass()'));
+
+        (new CheckTypeDeclarationsPass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
 }


### PR DESCRIPTION
Fix container lint command when a synthetic service is used in combination with the expression language.

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35691
| License       | MIT
| Doc PR        | -