### PR TITLE
[Form] Added "html5" option to both MoneyType and PercentType

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Added support for using the `{{ label }}` placeholder in constraint messages, which is replaced in the `ViolationMapper` by the corresponding field form label.
  * Added `DataMapper`, `ChainAccessor`, `PropertyPathAccessor` and `CallbackAccessor` with new callable `getter` and `setter` options for each form type
  * Deprecated `PropertyPathMapper` in favor of `DataMapper` and `PropertyPathAccessor`
+ * Added a `html5` option to `MoneyType` and `PercentType`, to use `<input type="number" />`
 
 5.1.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -23,7 +23,7 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
 {
     private $divisor;
 
-    public function __construct(?int $scale = 2, ?bool $grouping = true, ?int $roundingMode = \NumberFormatter::ROUND_HALFUP, ?int $divisor = 1)
+    public function __construct(?int $scale = 2, ?bool $grouping = true, ?int $roundingMode = \NumberFormatter::ROUND_HALFUP, ?int $divisor = 1, string $locale = null)
     {
         if (null === $grouping) {
             $grouping = true;
@@ -33,7 +33,7 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
             $scale = 2;
         }
 
-        parent::__construct($scale, $grouping, $roundingMode);
+        parent::__construct($scale, $grouping, $roundingMode, $locale);
 
         if (null === $divisor) {
             $divisor = 1;

--- a/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\Extension\Core\DataTransformer\MoneyToLocalizedStringTransformer;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -28,12 +29,15 @@ class MoneyType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        // Values used in HTML5 number inputs should be formatted as in "1234.5", ie. 'en' format without grouping,
+        // according to https://www.w3.org/TR/html51/sec-forms.html#date-time-and-number-formats
         $builder
             ->addViewTransformer(new MoneyToLocalizedStringTransformer(
                 $options['scale'],
                 $options['grouping'],
                 $options['rounding_mode'],
-                $options['divisor']
+                $options['divisor'],
+                $options['html5'] ? 'en' : null
             ))
         ;
     }
@@ -44,6 +48,10 @@ class MoneyType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['money_pattern'] = self::getPattern($options['currency']);
+
+        if ($options['html5']) {
+            $view->vars['type'] = 'number';
+        }
     }
 
     /**
@@ -58,6 +66,7 @@ class MoneyType extends AbstractType
             'divisor' => 1,
             'currency' => 'EUR',
             'compound' => false,
+            'html5' => false,
             'invalid_message' => function (Options $options, $previousValue) {
                 return ($options['legacy_error_messages'] ?? true)
                     ? $previousValue
@@ -76,6 +85,16 @@ class MoneyType extends AbstractType
         ]);
 
         $resolver->setAllowedTypes('scale', 'int');
+
+        $resolver->setAllowedTypes('html5', 'bool');
+
+        $resolver->setNormalizer('grouping', function (Options $options, $value) {
+            if ($value && $options['html5']) {
+                throw new LogicException('Cannot use the "grouping" option when the "html5" option is enabled.');
+            }
+
+            return $value;
+        });
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/PercentType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PercentType.php
@@ -30,7 +30,7 @@ class PercentType extends AbstractType
             $options['scale'],
             $options['type'],
             $options['rounding_mode'],
-            false
+            $options['html5']
         ));
     }
 
@@ -40,6 +40,10 @@ class PercentType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['symbol'] = $options['symbol'];
+
+        if ($options['html5']) {
+            $view->vars['type'] = 'number';
+        }
     }
 
     /**
@@ -57,6 +61,7 @@ class PercentType extends AbstractType
             'symbol' => '%',
             'type' => 'fractional',
             'compound' => false,
+            'html5' => false,
             'invalid_message' => function (Options $options, $previousValue) {
                 return ($options['legacy_error_messages'] ?? true)
                     ? $previousValue
@@ -87,6 +92,7 @@ class PercentType extends AbstractType
 
             return '';
         });
+        $resolver->setAllowedTypes('html5', 'bool');
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
@@ -412,4 +412,84 @@ class PercentToLocalizedStringTransformerTest extends TestCase
 
         $transformer->reverseTransform("12\xc2\xa0345,678foo");
     }
+
+    public function testTransformForHtml5Format()
+    {
+        $transformer = new PercentToLocalizedStringTransformer(null, null, \NumberFormatter::ROUND_HALFUP, true);
+
+        // Since we test against "de_CH", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_CH');
+
+        $this->assertEquals('10', $transformer->transform(0.104));
+        $this->assertEquals('11', $transformer->transform(0.105));
+        $this->assertEquals('200000', $transformer->transform(2000));
+    }
+
+    public function testTransformForHtml5FormatWithInteger()
+    {
+        $transformer = new PercentToLocalizedStringTransformer(null, 'integer', \NumberFormatter::ROUND_HALFUP, true);
+
+        // Since we test against "de_CH", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_CH');
+
+        $this->assertEquals('0', $transformer->transform(0.1));
+        $this->assertEquals('1234', $transformer->transform(1234));
+    }
+
+    public function testTransformForHtml5FormatWithScale()
+    {
+        // Since we test against "de_CH", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_CH');
+
+        $transformer = new PercentToLocalizedStringTransformer(2, null, \NumberFormatter::ROUND_HALFUP, true);
+
+        $this->assertEquals('12.34', $transformer->transform(0.1234));
+    }
+
+    public function testReverseTransformForHtml5Format()
+    {
+        // Since we test against "de_CH", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_CH');
+
+        $transformer = new PercentToLocalizedStringTransformer(null, null, \NumberFormatter::ROUND_HALFUP, true);
+
+        $this->assertEquals(0.02, $transformer->reverseTransform('1.5')); // rounded up, for 2 decimals
+        $this->assertEquals(0.15, $transformer->reverseTransform('15'));
+        $this->assertEquals(2000, $transformer->reverseTransform('200000'));
+    }
+
+    public function testReverseTransformForHtml5FormatWithInteger()
+    {
+        // Since we test against "de_CH", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_CH');
+
+        $transformer = new PercentToLocalizedStringTransformer(null, 'integer', \NumberFormatter::ROUND_HALFUP, true);
+
+        $this->assertEquals(10, $transformer->reverseTransform('10'));
+        $this->assertEquals(15, $transformer->reverseTransform('15'));
+        $this->assertEquals(12, $transformer->reverseTransform('12'));
+        $this->assertEquals(200, $transformer->reverseTransform('200'));
+    }
+
+    public function testReverseTransformForHtml5FormatWithScale()
+    {
+        // Since we test against "de_CH", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_CH');
+
+        $transformer = new PercentToLocalizedStringTransformer(2, null, \NumberFormatter::ROUND_HALFUP, true);
+
+        $this->assertEquals(0.1234, $transformer->reverseTransform('12.34'));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -109,4 +109,18 @@ class MoneyTypeTest extends BaseTypeTest
 
         $this->assertSame('12345', $form->createView()->vars['value']);
     }
+
+    public function testHtml5EnablesSpecificFormatting()
+    {
+        // Since we test against "de_CH", we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_CH');
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['html5' => true, 'scale' => 2]);
+        $form->setData('12345.6');
+
+        $this->assertSame('12345.60', $form->createView()->vars['value']);
+        $this->assertSame('number', $form->createView()->vars['type']);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PercentTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PercentTypeTest.php
@@ -14,12 +14,33 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class PercentTypeTest extends TypeTestCase
 {
     use ExpectDeprecationTrait;
 
     const TESTED_TYPE = PercentType::class;
+
+    private $defaultLocale;
+
+    protected function setUp(): void
+    {
+        // we test against different locales, so we need the full
+        // implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        parent::setUp();
+
+        $this->defaultLocale = \Locale::getDefault();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        \Locale::setDefault($this->defaultLocale);
+    }
 
     public function testSubmitWithRoundingMode()
     {
@@ -31,6 +52,35 @@ class PercentTypeTest extends TypeTestCase
         $form->submit('1.23456');
 
         $this->assertEquals(0.0124, $form->getData());
+    }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = '10', $expectedData = 0.1)
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'empty_data' => $emptyData,
+            'rounding_mode' => \NumberFormatter::ROUND_UP,
+        ]);
+        $form->submit(null);
+
+        $this->assertSame($emptyData, $form->getViewData());
+        $this->assertSame($expectedData, $form->getNormData());
+        $this->assertSame($expectedData, $form->getData());
+    }
+
+    public function testHtml5EnablesSpecificFormatting()
+    {
+        \Locale::setDefault('de_CH');
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'html5' => true,
+            'rounding_mode' => \NumberFormatter::ROUND_UP,
+            'scale' => 2,
+            'type' => 'integer',
+        ]);
+        $form->setData('1234.56');
+
+        $this->assertSame('1234.56', $form->createView()->vars['value']);
+        $this->assertSame('number', $form->createView()->vars['type']);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |  -
| License       | MIT
| Doc PR        | TBD

Hello,

In the same way that [NumberType](https://symfony.com/doc/current/reference/forms/types/number.html) offers a `html5` option to render a `number` input instead of a `text` input, this PR adds the same option to both `MoneyType` and `PercentType`. Number inputs offer a better UI, especially on mobile (specific keyboard), and they accept extra HTML attributes, such as `max=100`, which are quite useful.

The challenge is that `number` inputs need a "raw" value, nor formatted nor localized.
Format is described here https://www.w3.org/TR/html51/sec-forms.html#date-time-and-number-formats (non-normative, but tested on a few browsers). It matches number formatting for `en` locale (which is great, since it is the one provided by Symfony Intl polyflil), without grouping. 

Implementation was done in a manner similar to `NumberType` for `MoneyType`.
`PercentType` required to modify `PercentToLocalizedStringTransformer` too.

As a bonus, `PercentType` had no tests at all, I added a few.

I wanted to get some feedback on the idea first, remaining steps:
 - update `CHANGELOG.md`
 - update the doc