### PR TITLE
improve PlaintextPasswordEncoder docBlock summary

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
@@ -14,7 +14,9 @@ namespace Symfony\Component\Security\Core\Encoder;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
 /**
- * PlaintextPasswordEncoder does not do any encoding.
+ * PlaintextPasswordEncoder does not do any encoding but is useful in testing environments.
+ *
+ * As this encoder is not cryptographically secure, usage of it in production environments is not recommended.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */

--- a/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
@@ -16,7 +16,7 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 /**
  * PlaintextPasswordEncoder does not do any encoding but is useful in testing environments.
  *
- * As this encoder is not cryptographically secure, usage of it in production environments is not recommended.
+ * As this encoder is not cryptographically secure, usage of it in production environments is discouraged.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Updates class summary as suggested in tkt #35927 & pr #35929 to suggest the encoder is for test usage. 
