### PR TITLE
[Security/Http] Hash Persistent RememberMe token

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Added access decision strategy to override access decisions by voter service priority
  * Added `IS_ANONYMOUS`, `IS_REMEMBERED`, `IS_IMPERSONATOR`
+ * Hash the persistent RememberMe token value in database.
 
 5.0.0
 -----

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
+use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentTokenInterface;
 use Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -29,6 +30,8 @@ use Symfony\Component\Security\Core\Exception\CookieTheftException;
  */
 class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
 {
+    private const HASHED_TOKEN_PREFIX = 'sha256_';
+
     /** @var TokenProviderInterface */
     private $tokenProvider;
 
@@ -66,7 +69,7 @@ class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
         list($series, $tokenValue) = $cookieParts;
         $persistentToken = $this->tokenProvider->loadTokenBySeries($series);
 
-        if (!hash_equals($persistentToken->getTokenValue(), $tokenValue)) {
+        if (!$this->isTokenValueValid($persistentToken, $tokenValue)) {
             throw new CookieTheftException('This token was already used. The account is possibly compromised.');
         }
 
@@ -75,7 +78,7 @@ class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
         }
 
         $tokenValue = base64_encode(random_bytes(64));
-        $this->tokenProvider->updateToken($series, $tokenValue, new \DateTime());
+        $this->tokenProvider->updateToken($series, $this->generateHash($tokenValue), new \DateTime());
         $request->attributes->set(self::COOKIE_ATTR_NAME,
             new Cookie(
                 $this->options['name'],
@@ -106,7 +109,7 @@ class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
                 \get_class($user = $token->getUser()),
                 $user->getUsername(),
                 $series,
-                $tokenValue,
+                $this->generateHash($tokenValue),
                 new \DateTime()
             )
         );
@@ -124,5 +127,19 @@ class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
                 $this->options['samesite'] ?? null
             )
         );
+    }
+
+    private function generateHash(string $tokenValue): string
+    {
+        return self::HASHED_TOKEN_PREFIX.hash_hmac('sha256', $tokenValue, $this->getSecret());
+    }
+
+    private function isTokenValueValid(PersistentTokenInterface $persistentToken, string $tokenValue): bool
+    {
+        if (0 === strpos($persistentToken->getTokenValue(), self::HASHED_TOKEN_PREFIX)) {
+            return hash_equals($persistentToken->getTokenValue(), $this->generateHash($tokenValue));
+        }
+
+        return hash_equals($persistentToken->getTokenValue(), $tokenValue);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #27910
| License       | MIT
| Doc PR        | Not sure this enhancement needs documentation

The purpose of this PR is to enhance the Remember Me persistent token feature: instead of storing cleared token value in DB, the values will be hashed. 
To make sure that existing remember me cookies will keep being valid after this change, we prefix the new token values with 'hash_'. In case the token value doesn't match this prefix, we keep validating it the old way.

