### PR TITLE
Use some PHP 5.4 constants unconditionally

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -243,9 +243,9 @@ class FormHelper extends Helper
     public function formEncodeCurrency($text, $widget = '')
     {
         if ('UTF-8' === $charset = $this->getCharset()) {
-            $text = htmlspecialchars($text, ENT_QUOTES | (\defined('ENT_SUBSTITUTE') ? ENT_SUBSTITUTE : 0), 'UTF-8');
+            $text = htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
         } else {
-            $text = htmlentities($text, ENT_QUOTES | (\defined('ENT_SUBSTITUTE') ? ENT_SUBSTITUTE : 0), 'UTF-8');
+            $text = htmlentities($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
             $text = iconv('UTF-8', $charset, $text);
             $widget = iconv('UTF-8', $charset, $widget);
         }

--- a/src/Symfony/Component/Form/FormRenderer.php
+++ b/src/Symfony/Component/Form/FormRenderer.php
@@ -291,9 +291,9 @@ class FormRenderer implements FormRendererInterface
     public function encodeCurrency(Environment $environment, $text, $widget = '')
     {
         if ('UTF-8' === $charset = $environment->getCharset()) {
-            $text = htmlspecialchars($text, ENT_QUOTES | (\defined('ENT_SUBSTITUTE') ? ENT_SUBSTITUTE : 0), 'UTF-8');
+            $text = htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
         } else {
-            $text = htmlentities($text, ENT_QUOTES | (\defined('ENT_SUBSTITUTE') ? ENT_SUBSTITUTE : 0), 'UTF-8');
+            $text = htmlentities($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
             $text = iconv('UTF-8', $charset, $text);
             $widget = iconv('UTF-8', $charset, $widget);
         }

--- a/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/JsonFileDumper.php
@@ -28,7 +28,7 @@ class JsonFileDumper extends FileDumper
         if (isset($options['json_encoding'])) {
             $flags = $options['json_encoding'];
         } else {
-            $flags = \defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0;
+            $flags = JSON_PRETTY_PRINT;
         }
 
         return json_encode($messages->all($domain), $flags);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Since we are PHP >= 5.5.9 only, we can use those constants unconditionally.