### PR TITLE
[VarDumper] Add VAR_DUMPER_FORMAT=server format

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * added `VAR_DUMPER_FORMAT=server` env var value support
+ * prevent replacing the handler when the `VAR_DUMPER_FORMAT` env var is set
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -11,12 +11,18 @@
 
 namespace Symfony\Component\VarDumper;
 
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
 use Symfony\Component\VarDumper\Caster\ReflectionCaster;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\CliContextProvider;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\RequestContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextualizedDumper;
 use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+use Symfony\Component\VarDumper\Dumper\ServerDumper;
 
 // Load the global dump() function
 require_once __DIR__.'/Resources/functions/dump.php';
@@ -31,20 +37,7 @@ class VarDumper
     public static function dump($var)
     {
         if (null === self::$handler) {
-            $cloner = new VarCloner();
-            $cloner->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
-
-            if (isset($_SERVER['VAR_DUMPER_FORMAT'])) {
-                $dumper = 'html' === $_SERVER['VAR_DUMPER_FORMAT'] ? new HtmlDumper() : new CliDumper();
-            } else {
-                $dumper = \in_array(\PHP_SAPI, ['cli', 'phpdbg']) ? new CliDumper() : new HtmlDumper();
-            }
-
-            $dumper = new ContextualizedDumper($dumper, [new SourceContextProvider()]);
-
-            self::$handler = function ($var) use ($cloner, $dumper) {
-                $dumper->dump($cloner->cloneVar($var));
-            };
+            self::register();
         }
 
         return (self::$handler)($var);
@@ -53,8 +46,64 @@ class VarDumper
     public static function setHandler(callable $callable = null)
     {
         $prevHandler = self::$handler;
+
+        // Prevent replacing the handler with expected format as soon as the env var was set:
+        if (isset($_SERVER['VAR_DUMPER_FORMAT'])) {
+            return $prevHandler;
+        }
+
         self::$handler = $callable;
 
         return $prevHandler;
+    }
+
+    private static function register(): void
+    {
+        $cloner = new VarCloner();
+        $cloner->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
+
+        $format = $_SERVER['VAR_DUMPER_FORMAT'] ?? null;
+        switch (true) {
+            case 'html' === $format:
+                $dumper = new HtmlDumper();
+                break;
+            case 'cli' === $format:
+                $dumper = new CliDumper();
+                break;
+            case 'server' === $format:
+            case 'tcp' === parse_url($format, PHP_URL_SCHEME):
+                $host = 'server' === $format ? $_SERVER['VAR_DUMPER_SERVER'] ?? '127.0.0.1:9912' : $format;
+                $dumper = \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) ? new CliDumper() : new HtmlDumper();
+                $dumper = new ServerDumper($host, $dumper, self::getDefaultContextProviders());
+                break;
+            default:
+                $dumper = \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) ? new CliDumper() : new HtmlDumper();
+        }
+
+        if (!$dumper instanceof ServerDumper) {
+            $dumper = new ContextualizedDumper($dumper, [new SourceContextProvider()]);
+        }
+
+        self::$handler = function ($var) use ($cloner, $dumper) {
+            $dumper->dump($cloner->cloneVar($var));
+        };
+    }
+
+    private static function getDefaultContextProviders(): array
+    {
+        $contextProviders = [];
+
+        if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && (class_exists(Request::class))) {
+            $requestStack = new RequestStack();
+            $requestStack->push(Request::createFromGlobals());
+            $contextProviders['request'] = new RequestContextProvider($requestStack);
+        }
+
+        $fileLinkFormatter = class_exists(FileLinkFormatter::class) ? new FileLinkFormatter(null, $requestStack ?? null) : null;
+
+        return $contextProviders + [
+            'cli' => new CliContextProvider(),
+            'source' => new SourceContextProvider(null, null, $fileLinkFormatter),
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master<!-- see below -->
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #35801 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/14067 <!-- required for new features -->

This PR follows discussion in #35801 and adds support for a `server` value for the existing `VAR_DUMPER_FORMAT` env var.

It comes as well with two more things:
- ~~the handler is registered as soon as the `VAR_DUMPER_FORMAT` env var is detected~~ we prevent registering another handler as soon as the `VAR_DUMPER_FORMAT` env var is set, instead of checking if there was a previous handler (which could make this env var useless in some conditions where the handler was already set by another "process")
- the handler registered this way cannot be replaced. This prevents another "process" to takeover dump handling while undesired. E.g: a phpunit functional test booting the kernel to call an endpoint => the handler is replaced. It's (in a sense) a satisfying alternative to #26696

This PR means anyone can use dump with a server in any context, without changing a single line of code in the project by:
- starting the server using `./vendor/bin/var-dump-server --format=html > dumps.html`
- using the env var: `VAR_DUMPER_FORMAT=server [your-cli-command]`

---
Previous related PRs:
- https://github.com/symfony/symfony/pull/26695
- https://github.com/symfony/symfony/pull/26696