### PR TITLE
[Messenger] Add ext-redis min version req to tests

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisTransportFactoryTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Messenger\Transport\RedisExt\RedisTransportFactory;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
- * @requires extension redis
+ * @requires extension redis >= 4.3.0
  */
 class RedisTransportFactoryTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | N/A

Properly skip the test instead of:

```
Testing src/Symfony/Component/Messenger
E                                                                   1 / 1 (100%)

Time: 597 ms, Memory: 16.00 MB

There was 1 error:

1) Symfony\Component\Messenger\Tests\Transport\RedisExt\RedisTransportFactoryTest::testCreateTransport
Symfony\Component\Messenger\Exception\LogicException: The redis transport requires php-redis 4.3.0 or higher.
```