### PR TITLE
Add bridges in linked dependencies

### DIFF
--- a/link
+++ b/link
@@ -38,7 +38,7 @@ if (!is_dir("$pathToProject/vendor/symfony")) {
 $sfPackages = array('symfony/symfony' => __DIR__);
 
 $filesystem = new Filesystem();
-$braces = array('Bundle', 'Bridge', 'Component', 'Component/Security', 'Contracts');
+$braces = array('Bundle', 'Bridge', 'Component', 'Component/Security', 'Component/*/Bridge', 'Contracts');
 $directories = array_merge(...array_values(array_map(function ($part) {
     return glob(__DIR__.'/src/Symfony/'.$part.'/*', GLOB_ONLYDIR | GLOB_NOSORT);
 }, $braces)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

when running the `./link` tool, the bridges (mailer, notifier, messenger) were not linked.