### PR TITLE
[DoctrineBridge][DoctrineExtractor] Fix wrong guessed type for "json" type

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -178,7 +178,6 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
                     switch ($typeOfField) {
                         case self::$useDeprecatedConstants ? DBALType::TARRAY : 'array':
                         case 'json_array':
-                        case self::$useDeprecatedConstants ? false : Types::JSON:
                             return [new Type(Type::BUILTIN_TYPE_ARRAY, $nullable, null, true)];
 
                         case self::$useDeprecatedConstants ? DBALType::SIMPLE_ARRAY : Types::SIMPLE_ARRAY:
@@ -266,7 +265,6 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
             case self::$useDeprecatedConstants ? DBALType::TARRAY : 'array':
             case self::$useDeprecatedConstants ? DBALType::SIMPLE_ARRAY : Types::SIMPLE_ARRAY:
             case 'json_array':
-            case self::$useDeprecatedConstants ? false : Types::JSON:
                 return Type::BUILTIN_TYPE_ARRAY;
         }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -182,7 +182,7 @@ class DoctrineExtractorTest extends TestCase
         ];
 
         if (class_exists(Types::class)) {
-            $provider[] = ['json', [new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true)]];
+            $provider[] = ['json', null];
         }
 
         return $provider;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/35968
| License       | MIT
| Doc PR        | -

After checking the code, it appears that `json` have a different behavior than `json_array`.

> In json_array doctrine was converting null or empty value to array, but json type doesn't do that

@norkunas is right about this. Consequently, we cannot safely guess a built in type for the `json` Doctrine type.