### PR TITLE
Remove int return type from FlattenException::getCode

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
@@ -206,7 +206,7 @@ class FlattenException extends LegacyFlattenException
         return $this;
     }
 
-    public function getCode(): int
+    public function getCode()
     {
         return $this->code;
     }

--- a/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\ErrorHandler\Tests\Exception;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
+use Symfony\Component\ErrorHandler\Tests\Fixtures\StringErrorCodeException;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -198,6 +199,15 @@ class FlattenExceptionTest extends TestCase
     }
 
     /**
+     * @dataProvider stringAndIntDataProvider
+     */
+    public function testCode(\Throwable $exception)
+    {
+        $flattened = FlattenException::createFromThrowable($exception);
+        $this->assertSame($exception->getCode(), $flattened->getCode());
+    }
+
+    /**
      * @dataProvider flattenDataProvider
      */
     public function testToArray(\Throwable $exception, string $expectedClass)
@@ -235,6 +245,14 @@ class FlattenExceptionTest extends TestCase
         return [
             [new \Exception('test', 123), 'Exception'],
             [new \Error('test', 123), 'Error'],
+        ];
+    }
+
+    public function stringAndIntDataProvider(): array
+    {
+        return [
+            [new \Exception('test1', 123)],
+            [new StringErrorCodeException('test2', '42S02')],
         ];
     }
 

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/StringErrorCodeException.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/StringErrorCodeException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
+
+class StringErrorCodeException extends \Exception
+{
+
+    public function __construct(string $message, string $code) {
+        parent::__construct($message);
+        $this->code = $code;
+    }
+
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

Heya,

So my project died with `Return value of Symfony\Component\ErrorHandler\Exception\FlattenException::getCode() must be of the type int, string returned` symfony error page. Quite unexpected.

Turns out it's a `Doctrine\DBAL\Driver\PDOException` with code `42S02` and message `SQLSTATE[42S02]: Base table or view not found: 1146 Table 'some_db.some_table' doesn't exist`.

This is because I use the `FlattenException` class to serialize errors and store elsewhere, just more convenient to quickly check for any errors. I guess noone has stumbled upon a PDOException /  `FlattenException::getCode` before.

https://www.php.net/manual/en/throwable.getcode.php

`Returns the exception code as integer in Exception but possibly as other type in Exception descendants (for example as string in PDOException).`
