### PR TITLE
[DX][Testing] Added a loginUser() method to test protected resources

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle;
 
+use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\BrowserKit\History;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -19,6 +20,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\Profiler\Profile as HttpProfile;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Simulates a browser and makes requests to a Kernel object.
@@ -202,5 +205,18 @@ $profilerCode
 EOF;
 
         return $code.$this->getHandleScript();
+    }
+
+    public function loginUser(UserInterface $user, string $firewallContext = 'main'): self
+    {
+        $token = new UsernamePasswordToken($user, null, $firewallContext, $user->getRoles());
+        $session = $this->getContainer()->get('session');
+        $session->set('_security_'.$firewallContext, serialize($token));
+        $session->save();
+
+        $cookie = new Cookie($session->getName(), $session->getId());
+        $this->getCookieJar()->set($cookie);
+
+        return $this;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/TestBrowserToken.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/TestBrowserToken.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * A very limited token that is used to login in tests using the KernelBrowser.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class TestBrowserToken extends AbstractToken
+{
+    public function __construct(array $roles = [], UserInterface $user = null)
+    {
+        parent::__construct($roles);
+
+        if (null !== $user) {
+            $this->setUser($user);
+        }
+    }
+
+    public function getCredentials()
+    {
+        return null;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SecurityController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SecurityController.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
+
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityController implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function profileAction()
+    {
+        return new Response('Welcome '.$this->container->get('security.token_storage')->getToken()->getUsername().'!');
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SecurityTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SecurityTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\User;
+
+class SecurityTest extends AbstractWebTestCase
+{
+    /**
+     * @dataProvider getUsers
+     */
+    public function testLoginUser(string $username, ?string $password, array $roles, ?string $firewallContext, string $expectedProviderKey)
+    {
+        $user = new User($username, $password, $roles);
+        $client = $this->createClient(['test_case' => 'Security', 'root_config' => 'config.yml']);
+
+        if (null === $firewallContext) {
+            $client->loginUser($user);
+        } else {
+            $client->loginUser($user, $firewallContext);
+        }
+
+        /** @var SessionInterface $session */
+        $session = $client->getContainer()->get('session');
+        /** @var UsernamePasswordToken $userToken */
+        $userToken = unserialize($session->get('_security_'.$expectedProviderKey));
+
+        $this->assertSame('_security_'.$expectedProviderKey, array_keys($session->all())[0]);
+        $this->assertSame($expectedProviderKey, $userToken->getProviderKey());
+        $this->assertSame($username, $userToken->getUsername());
+        $this->assertSame($password, $userToken->getUser()->getPassword());
+        $this->assertSame($roles, $userToken->getUser()->getRoles());
+
+        $this->assertNotNull($client->getCookieJar()->get('MOCKSESSID'));
+    }
+
+    public function getUsers()
+    {
+        yield ['the-username', 'the-password', ['ROLE_FOO'], null, 'main'];
+        yield ['the-username', 'the-password', ['ROLE_FOO'], 'main', 'main'];
+        yield ['the-username', 'the-password', ['ROLE_FOO'], 'custom_firewall_context', 'custom_firewall_context'];
+
+        yield ['the-username', null, ['ROLE_FOO'], null, 'main'];
+        yield ['the-username', 'the-password', [], null, 'main'];
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/bundles.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+
+return [
+    new FrameworkBundle(),
+    new SecurityBundle(),
+    new TestBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/config.yml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: ./../config/default.yml }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/config.yml
@@ -1,2 +1,26 @@
 imports:
     - { resource: ./../config/default.yml }
+
+security:
+    providers:
+        main:
+            memory:
+                users:
+                    the-username: { password: the-password, roles: ['ROLE_FOO'] }
+                    no-role-username: { password: the-password, roles: [] }
+        custom:
+            memory:
+                users:
+                    other-username: { password: the-password, roles: ['ROLE_FOO'] }
+
+    firewalls:
+        main:
+            pattern: ^/main
+            form_login:
+                check_path: /main/login/check
+            provider: main
+        custom:
+            pattern: ^/custom
+            form_login:
+                check_path: /custom/login/check
+            provider: custom

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/routing.yml
@@ -1,0 +1,2 @@
+_sessiontest_bundle:
+    resource: '@TestBundle/Resources/config/routing.yml'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/routing.yml
@@ -1,2 +1,7 @@
-_sessiontest_bundle:
-    resource: '@TestBundle/Resources/config/routing.yml'
+security_profile:
+    path:     /main/user_profile
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\SecurityController::profileAction }
+
+security_custom_profile:
+    path:     /custom/user_profile
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\SecurityController::profileAction }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -47,6 +47,7 @@
         "symfony/messenger": "^4.4|^5.0",
         "symfony/mime": "^4.4|^5.0",
         "symfony/process": "^4.4|^5.0",
+        "symfony/security-bundle": "^4.0|^5.0",
         "symfony/security-csrf": "^4.4|^5.0",
         "symfony/security-http": "^4.4|^5.0",
         "symfony/serializer": "^4.4|^5.0",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -47,7 +47,7 @@
         "symfony/messenger": "^4.4|^5.0",
         "symfony/mime": "^4.4|^5.0",
         "symfony/process": "^4.4|^5.0",
-        "symfony/security-bundle": "^4.0|^5.0",
+        "symfony/security-bundle": "^5.1",
         "symfony/security-csrf": "^4.4|^5.0",
         "symfony/security-http": "^4.4|^5.0",
         "symfony/serializer": "^4.4|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #26839
| License       | MIT
| Doc PR        | tbd

This finishes https://github.com/symfony/symfony/pull/32850 original description:

> I know this won't work for 100% of our users ... but the goal is to make life easier to *most* of them. Thanks!

A custom `ConcreteToken` test-object is created as suggested by @linaori, to not bind this token to any specific implementation (as other implementations aren't fully compatible with eachother).