### PR TITLE
[Mime] remove phpdoc mentioning Utf8AddressEncoder

### DIFF
--- a/src/Symfony/Component/Mime/Encoder/IdnAddressEncoder.php
+++ b/src/Symfony/Component/Mime/Encoder/IdnAddressEncoder.php
@@ -20,9 +20,7 @@ use Symfony\Component\Mime\Exception\AddressEncoderException;
  * SMTP servers.
  *
  * This encoder does not support email addresses with non-ASCII characters in
- * local-part (the substring before @). To send to such addresses, use
- * Utf8AddressEncoder together with SmtpUtf8Handler. Your outbound SMTP server must support
- * the SMTPUTF8 extension.
+ * local-part (the substring before @).
  *
  * @author Christian Schmidt
  */


### PR DESCRIPTION
This class does not exist

| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I'm currently migrating from Swiftmailer fo Symfony mailer and stumbled upon this exception:

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Mime/Encoder/IdnAddressEncoder.php#L44

The phpdoc of the class is a bit confusing/wrong. Seems to be a copy&paste leftover from Swiftmailer:

https://github.com/swiftmailer/swiftmailer/blob/master/lib/classes/Swift/AddressEncoder/IdnAddressEncoder.php#L19
