### PR TITLE
[DI] Allow class created via eval to work in container

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * added support to autowire public typed properties in php 7.4
  * added support for defining method calls, a configurator, and property setters in `InlineServiceConfigurator`
  * added possibility to define abstract service arguments
+ * allow classes created via eval to be used in the container
 
 5.0.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -470,6 +470,10 @@ EOF;
             return;
         }
         $file = $r->getFileName();
+        if (') : eval()\'d code' === substr($file, -17)) {
+            // Remove "eval()'d" part of the filename when the class is defined via eval()
+            $file = substr($file, 0, strrpos($file, '(', -17));
+        }
         if (!$file || $this->doExport($file) === $exportedFile = $this->export($file)) {
             return;
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/MyEvalClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/MyEvalClass.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+eval('namespace '.__NAMESPACE__.'; class MyEvalClass { function foo() { return "bar"; } }');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Most of the time for bundles, classes must be created via eval to allow compatibility with several versions of php/symfony (for instance [here](https://github.com/Exercise/HTMLPurifierBundle/blob/2.0/src/Form/TypeExtension/ForwardCompatTypeExtensionTrait.php)). In some cases, the container try to determine in which file the class is instantiated and this fails due to the `eval()'d` string after the class path. 

This PR aims to remove this string to be able to load classes created via eval.
