### PR TITLE
[HttpKernel] add deprecation for controller:method syntax in ServiceValueResolver

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
@@ -73,6 +73,16 @@ final class ServiceValueResolver implements ArgumentValueResolverInterface
             $controller = substr($controller, 0, $i).strtolower(substr($controller, $i));
         }
 
+        if (false !== strpos($controller, ':') && false === strpos($controller, '::')) {
+            $i = strrpos($controller, ':');
+            $controllerName = substr($controller, 0, $i);
+            $methodName = substr($controller, $i + 1);
+            @trigger_error(
+                sprintf('Referencing a controller as "%1$s:%2$s" is deprecated since Symfony 4.1, use "%1$s::%2$s" instead.', $controllerName, $methodName),
+                E_USER_DEPRECATED
+            );
+        }
+
         try {
             yield $this->container->get($controller)->get($argument->getName());
         } catch (RuntimeException $e) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/ServiceValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/ServiceValueResolverTest.php
@@ -105,6 +105,29 @@ class ServiceValueResolverTest extends TestCase
         $this->assertYieldEquals([new DummyService()], $resolver->resolve($request, $argument));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Referencing a controller as "App\Controller\Mine:method" is deprecated since Symfony 4.1, use "App\Controller\Mine::method" instead.
+     */
+    public function testExistingControllerWithSingleColonTriggersDeprecation()
+    {
+        $resolver = new ServiceValueResolver(new ServiceLocator([
+            'App\\Controller\\Mine:method' => function () {
+                return new ServiceLocator([
+                    'dummy' => function () {
+                        return new DummyService();
+                    },
+                ]);
+            },
+        ]));
+
+        $request = $this->requestWithAttributes(['_controller' => '\\App\\Controller\\Mine:method']);
+        $argument = new ArgumentMetadata('dummy', DummyService::class, false, false, null);
+
+        $this->assertTrue($resolver->supports($request, $argument));
+        $this->assertYieldEquals([new DummyService()], $resolver->resolve($request, $argument));
+    }
+
     public function testErrorIsTruncated()
     {
         $this->expectException('Symfony\Component\DependencyInjection\Exception\RuntimeException');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.1
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | See #35909 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->

_I apologize in advance, I am not fluent in English_

Single colon syntax when referencing a controller as a service is deprecated since Symfony 4.1 but there was no deprecations trigger on runtime.

I found the problem trying to understand the issue #35909 

By using Symfony, people have become accustomed to having all the deprecations reported in runtime.

The problem only affects controllers who need to have a service injected as a method argument.

It looks like the deprecation for the controller without injected service argument will be deprecate on v5.1. It seems weird not to deprecate these 2 cases at the same time.

In Symfony\Component\HttpKernel\Controller\ContainerControllerResolver, line 35
```php
    protected function createController($controller)
    {
        if (1 === substr_count($controller, ':')) {
            $controller = str_replace(':', '::', $controller);
            // TODO deprecate this in 5.1
        }

        return parent::createController($controller);
    }
```

## TODO
- I don't know if I should target v4.1 (the start of the deprecation) or v4.4 as suggested by the Q/A
- I didn't add an entry in the CHANGELOG.md as this deprecation is already referenced in https://github.com/symfony/symfony/blob/master/UPGRADE-4.1.md#frameworkbundle

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
