### PR TITLE
[HttpKernel] Fix support for single-colon syntax for controllers

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
@@ -51,6 +51,9 @@ class RemoveEmptyControllerArgumentLocatorsPass implements CompilerPassInterface
                     }
                 }
                 if (!$reason) {
+                    // see Symfony\Component\HttpKernel\Controller\ContainerControllerResolver
+                    $controllers[$id.':'.$action] = $argumentRef;
+
                     if ('__invoke' === $action) {
                         $controllers[$id] = $argumentRef;
                     }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPassTest.php
@@ -49,7 +49,7 @@ class RemoveEmptyControllerArgumentLocatorsPassTest extends TestCase
 
         $controllers = $container->getDefinition((string) $resolver->getArgument(0))->getArgument(0);
 
-        $this->assertSame(['c1::fooAction'], array_keys($controllers));
+        $this->assertSame(['c1::fooAction', 'c1:fooAction'], array_keys($controllers));
         $this->assertSame(['bar'], array_keys($container->getDefinition((string) $controllers['c1::fooAction']->getValues()[0])->getArgument(0)));
 
         $expectedLog = [
@@ -73,7 +73,7 @@ class RemoveEmptyControllerArgumentLocatorsPassTest extends TestCase
         (new RemoveEmptyControllerArgumentLocatorsPass())->process($container);
 
         $this->assertEquals(
-            ['invokable::__invoke', 'invokable'],
+            ['invokable::__invoke', 'invokable:__invoke', 'invokable'],
             array_keys($container->getDefinition((string) $resolver->getArgument(0))->getArgument(0))
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / 3.4, 4.4 or 5.0 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35983
| License       | MIT
| Doc PR        | -

This reverts commit 6bb64734894fe1a37f51ef499fdac37f101352b2, reversing
changes made to 4cce23d9ca20e447239a42e57137e744a78f65f9.

As spotted by @stof in https://github.com/symfony/symfony/issues/35983#issuecomment-597163526