### PR TITLE
[Mime] Fix header boundary

### DIFF
--- a/link
+++ b/link
@@ -38,7 +38,7 @@ if (!is_dir("$pathToProject/vendor/symfony")) {
 $sfPackages = array('symfony/symfony' => __DIR__);
 
 $filesystem = new Filesystem();
-$braces = array('Bundle', 'Bridge', 'Component', 'Component/Security', 'Contracts');
+$braces = array('Bundle', 'Bridge', 'Component', 'Component/Security', 'Component/Mailer/Bridge', 'Component/Messenger/Bridge', 'Component/Notifier/Bridge', 'Contracts');
 $directories = array_merge(...array_values(array_map(function ($part) {
     return glob(__DIR__.'/src/Symfony/'.$part.'/*', GLOB_ONLYDIR | GLOB_NOSORT);
 }, $braces)));

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -794,20 +794,26 @@ EOF;
 EOF;
         }
 
-        $this->serviceCalls = [];
-        $this->inlinedDefinitions = $this->getDefinitionsFromArguments([$definition], null, $this->serviceCalls);
+        if ($definition->hasErrors() && $e = $definition->getErrors()) {
+            $this->addThrow = true;
 
-        if ($definition->isDeprecated()) {
-            $code .= sprintf("        @trigger_error(%s, E_USER_DEPRECATED);\n\n", $this->export($definition->getDeprecationMessage($id)));
+            $code .= sprintf("        \$this->throw(%s);\n", $this->export(reset($e)));
+        } else {
+            $this->serviceCalls = [];
+            $this->inlinedDefinitions = $this->getDefinitionsFromArguments([$definition], null, $this->serviceCalls);
+
+            if ($definition->isDeprecated()) {
+                $code .= sprintf("        @trigger_error(%s, E_USER_DEPRECATED);\n\n", $this->export($definition->getDeprecationMessage($id)));
+            }
+
+            if ($this->getProxyDumper()->isProxyCandidate($definition)) {
+                $factoryCode = $asFile ? ($definition->isShared() ? "\$this->load('%s.php', false)" : '$this->factories[%2$s](false)') : '$this->%s(false)';
+                $code .= $this->getProxyDumper()->getProxyFactoryCode($definition, $id, sprintf($factoryCode, $methodName, $this->doExport($id)));
+            }
+
+            $code .= $this->addServiceInclude($id, $definition);
+            $code .= $this->addInlineService($id, $definition);
         }
-
-        if ($this->getProxyDumper()->isProxyCandidate($definition)) {
-            $factoryCode = $asFile ? ($definition->isShared() ? "\$this->load('%s.php', false)" : '$this->factories[%2$s](false)') : '$this->%s(false)';
-            $code .= $this->getProxyDumper()->getProxyFactoryCode($definition, $id, sprintf($factoryCode, $methodName, $this->doExport($id)));
-        }
-
-        $code .= $this->addServiceInclude($id, $definition);
-        $code .= $this->addInlineService($id, $definition);
 
         if ($asFile) {
             $code = implode("\n", array_map(function ($line) { return $line ? substr($line, 8) : $line; }, explode("\n", $code)));

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
@@ -105,7 +105,7 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
     public function testNulledEnvInConfig()
     {
         $this->expectException('Symfony\Component\Config\Definition\Exception\InvalidTypeException');
-        $this->expectExceptionMessage('Invalid type for path "env_extension.int_node". Expected int, but got NULL.');
+        $this->expectExceptionMessageRegexp('/^Invalid type for path "env_extension\.int_node"\. Expected "?int"?, but got (NULL|"null")\.$/');
         $container = new ContainerBuilder();
         $container->setParameter('env(NULLED)', null);
         $container->registerExtension(new EnvExtension());

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_service_locator_argument.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_service_locator_argument.php
@@ -120,6 +120,11 @@ class Symfony_DI_PhpDumper_Service_Locator_Argument extends Container
      */
     protected function getFoo4Service()
     {
-        return $this->privates['foo4'] = new \stdClass();
+        $this->throw('BOOM');
+    }
+
+    protected function throw($message)
+    {
+        throw new RuntimeException($message);
     }
 }

--- a/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
@@ -206,7 +206,7 @@ class FlattenException extends LegacyFlattenException
         return $this;
     }
 
-    public function getCode(): int
+    public function getCode()
     {
         return $this->code;
     }

--- a/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
@@ -206,6 +206,9 @@ class FlattenException extends LegacyFlattenException
         return $this;
     }
 
+    /**
+     * @return int|string int most of the time (might be a string with PDOException)
+     */
     public function getCode()
     {
         return $this->code;

--- a/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\ErrorHandler\Tests\Exception;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Debug\Exception\FatalThrowableError;
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
+use Symfony\Component\ErrorHandler\Tests\Fixtures\StringErrorCodeException;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -198,6 +199,15 @@ class FlattenExceptionTest extends TestCase
     }
 
     /**
+     * @dataProvider stringAndIntDataProvider
+     */
+    public function testCode(\Throwable $exception)
+    {
+        $flattened = FlattenException::createFromThrowable($exception);
+        $this->assertSame($exception->getCode(), $flattened->getCode());
+    }
+
+    /**
      * @dataProvider flattenDataProvider
      */
     public function testToArray(\Throwable $exception, string $expectedClass)
@@ -235,6 +245,14 @@ class FlattenExceptionTest extends TestCase
         return [
             [new \Exception('test', 123), 'Exception'],
             [new \Error('test', 123), 'Error'],
+        ];
+    }
+
+    public function stringAndIntDataProvider(): array
+    {
+        return [
+            [new \Exception('test1', 123)],
+            [new StringErrorCodeException('test2', '42S02')],
         ];
     }
 

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/StringErrorCodeException.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/StringErrorCodeException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
+
+class StringErrorCodeException extends \Exception
+{
+
+    public function __construct(string $message, string $code) {
+        parent::__construct($message);
+        $this->code = $code;
+    }
+
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisTransportFactoryTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Messenger\Transport\RedisExt\RedisTransportFactory;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
- * @requires extension redis
+ * @requires extension redis >= 4.3.0
  */
 class RedisTransportFactoryTest extends TestCase
 {

--- a/src/Symfony/Component/Mime/Encoder/IdnAddressEncoder.php
+++ b/src/Symfony/Component/Mime/Encoder/IdnAddressEncoder.php
@@ -20,9 +20,7 @@ use Symfony\Component\Mime\Exception\AddressEncoderException;
  * SMTP servers.
  *
  * This encoder does not support email addresses with non-ASCII characters in
- * local-part (the substring before @). To send to such addresses, use
- * Utf8AddressEncoder together with SmtpUtf8Handler. Your outbound SMTP server must support
- * the SMTPUTF8 extension.
+ * local-part (the substring before @).
  *
  * @author Christian Schmidt
  */

--- a/src/Symfony/Component/Mime/Part/AbstractMultipartPart.php
+++ b/src/Symfony/Component/Mime/Part/AbstractMultipartPart.php
@@ -91,7 +91,7 @@ abstract class AbstractMultipartPart extends AbstractPart
     private function getBoundary(): string
     {
         if (null === $this->boundary) {
-            $this->boundary = '_=_symfony_'.time().'_'.bin2hex(random_bytes(16)).'_=_';
+            $this->boundary = '_symfony_'.time().'_'.bin2hex(random_bytes(16)).'_';
         }
 
         return $this->boundary;

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -376,6 +376,10 @@ class Route implements \Serializable
      */
     public function addDefaults(array $defaults)
     {
+        if (isset($defaults['_locale']) && $this->isLocalized()) {
+            unset($defaults['_locale']);
+        }
+
         foreach ($defaults as $name => $default) {
             $this->defaults[$name] = $default;
         }
@@ -418,6 +422,10 @@ class Route implements \Serializable
      */
     public function setDefault($name, $default)
     {
+        if ('_locale' === $name && $this->isLocalized()) {
+            return $this;
+        }
+
         $this->defaults[$name] = $default;
         $this->compiled = null;
 
@@ -461,6 +469,10 @@ class Route implements \Serializable
      */
     public function addRequirements(array $requirements)
     {
+        if (isset($requirements['_locale']) && $this->isLocalized()) {
+            unset($requirements['_locale']);
+        }
+
         foreach ($requirements as $key => $regex) {
             $this->requirements[$key] = $this->sanitizeRequirement($key, $regex);
         }
@@ -503,6 +515,10 @@ class Route implements \Serializable
      */
     public function setRequirement($key, $regex)
     {
+        if ('_locale' === $key && $this->isLocalized()) {
+            return $this;
+        }
+
         $this->requirements[$key] = $this->sanitizeRequirement($key, $regex);
         $this->compiled = null;
 
@@ -576,5 +592,10 @@ class Route implements \Serializable
         }
 
         return $regex;
+    }
+
+    private function isLocalized(): bool
+    {
+        return isset($this->defaults['_locale']) && isset($this->defaults['_canonical_route']) && ($this->requirements['_locale'] ?? null) === preg_quote($this->defaults['_locale'], RouteCompiler::REGEX_DELIMITER);
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/CompiledUrlGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/CompiledUrlGeneratorDumperTest.php
@@ -87,8 +87,8 @@ class CompiledUrlGeneratorDumperTest extends TestCase
     public function testDumpWithSimpleLocalizedRoutes()
     {
         $this->routeCollection->add('test', (new Route('/foo')));
-        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test'));
-        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test'));
+        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'nl'));
 
         $code = $this->generatorDumper->dump();
         file_put_contents($this->testTmpFilepath, $code);
@@ -120,7 +120,7 @@ class CompiledUrlGeneratorDumperTest extends TestCase
     {
         $this->expectException('Symfony\Component\Routing\Exception\RouteNotFoundException');
         $this->expectExceptionMessage('Unable to generate a URL for the named route "test" as such route does not exist.');
-        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test'));
+        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'en'));
 
         $code = $this->generatorDumper->dump();
         file_put_contents($this->testTmpFilepath, $code);
@@ -131,9 +131,9 @@ class CompiledUrlGeneratorDumperTest extends TestCase
 
     public function testDumpWithFallbackLocaleLocalizedRoutes()
     {
-        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test'));
-        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test'));
-        $this->routeCollection->add('test.fr', (new Route('/tester/est/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'test'));
+        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'nl'));
+        $this->routeCollection->add('test.fr', (new Route('/tester/est/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'fr'));
 
         $code = $this->generatorDumper->dump();
         file_put_contents($this->testTmpFilepath, $code);
@@ -234,10 +234,10 @@ class CompiledUrlGeneratorDumperTest extends TestCase
 
     public function testDumpWithLocalizedRoutesPreserveTheGoodLocaleInTheUrl()
     {
-        $this->routeCollection->add('foo.en', (new Route('/{_locale}/foo'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo'));
-        $this->routeCollection->add('foo.fr', (new Route('/{_locale}/foo'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'foo'));
-        $this->routeCollection->add('fun.en', (new Route('/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'fun'));
-        $this->routeCollection->add('fun.fr', (new Route('/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'fun'));
+        $this->routeCollection->add('foo.en', (new Route('/{_locale}/fork'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('foo.fr', (new Route('/{_locale}/fourchette'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'foo')->setRequirement('_locale', 'fr'));
+        $this->routeCollection->add('fun.en', (new Route('/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'fun')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('fun.fr', (new Route('/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'fun')->setRequirement('_locale', 'fr'));
 
         file_put_contents($this->testTmpFilepath, $this->generatorDumper->dump());
 
@@ -246,10 +246,10 @@ class CompiledUrlGeneratorDumperTest extends TestCase
 
         $compiledUrlGenerator = new CompiledUrlGenerator(require $this->testTmpFilepath, $requestContext, null, null);
 
-        $this->assertSame('/fr/foo', $compiledUrlGenerator->generate('foo'));
-        $this->assertSame('/en/foo', $compiledUrlGenerator->generate('foo.en'));
-        $this->assertSame('/en/foo', $compiledUrlGenerator->generate('foo', ['_locale' => 'en']));
-        $this->assertSame('/en/foo', $compiledUrlGenerator->generate('foo.fr', ['_locale' => 'en']));
+        $this->assertSame('/fr/fourchette', $compiledUrlGenerator->generate('foo'));
+        $this->assertSame('/en/fork', $compiledUrlGenerator->generate('foo.en'));
+        $this->assertSame('/en/fork', $compiledUrlGenerator->generate('foo', ['_locale' => 'en']));
+        $this->assertSame('/fr/fourchette', $compiledUrlGenerator->generate('foo.fr', ['_locale' => 'en']));
 
         $this->assertSame('/amusant', $compiledUrlGenerator->generate('fun'));
         $this->assertSame('/fun', $compiledUrlGenerator->generate('fun.en'));

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -90,8 +90,8 @@ class PhpGeneratorDumperTest extends TestCase
     public function testDumpWithSimpleLocalizedRoutes()
     {
         $this->routeCollection->add('test', (new Route('/foo')));
-        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test'));
-        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test'));
+        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'nl'));
 
         $code = $this->generatorDumper->dump([
             'class' => 'SimpleLocalizedProjectUrlGenerator',
@@ -126,7 +126,7 @@ class PhpGeneratorDumperTest extends TestCase
     {
         $this->expectException('Symfony\Component\Routing\Exception\RouteNotFoundException');
         $this->expectExceptionMessage('Unable to generate a URL for the named route "test" as such route does not exist.');
-        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test'));
+        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'en'));
 
         $code = $this->generatorDumper->dump([
             'class' => 'RouteNotFoundLocalizedProjectUrlGenerator',
@@ -140,9 +140,9 @@ class PhpGeneratorDumperTest extends TestCase
 
     public function testDumpWithFallbackLocaleLocalizedRoutes()
     {
-        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test'));
-        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test'));
-        $this->routeCollection->add('test.fr', (new Route('/tester/est/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'test'));
+        $this->routeCollection->add('test.en', (new Route('/testing/is/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('test.nl', (new Route('/testen/is/leuk'))->setDefault('_locale', 'nl')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'nl'));
+        $this->routeCollection->add('test.fr', (new Route('/tester/est/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'test')->setRequirement('_locale', 'fr'));
 
         $code = $this->generatorDumper->dump([
             'class' => 'FallbackLocaleLocalizedProjectUrlGenerator',
@@ -253,10 +253,10 @@ class PhpGeneratorDumperTest extends TestCase
 
     public function testDumpWithLocalizedRoutesPreserveTheGoodLocaleInTheUrl()
     {
-        $this->routeCollection->add('foo.en', (new Route('/{_locale}/foo'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo'));
-        $this->routeCollection->add('foo.fr', (new Route('/{_locale}/foo'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'foo'));
-        $this->routeCollection->add('fun.en', (new Route('/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'fun'));
-        $this->routeCollection->add('fun.fr', (new Route('/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'fun'));
+        $this->routeCollection->add('foo.en', (new Route('/{_locale}/fork'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('foo.fr', (new Route('/{_locale}/fourchette'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'foo')->setRequirement('_locale', 'fr'));
+        $this->routeCollection->add('fun.en', (new Route('/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'fun')->setRequirement('_locale', 'en'));
+        $this->routeCollection->add('fun.fr', (new Route('/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'fun')->setRequirement('_locale', 'fr'));
 
         file_put_contents($this->testTmpFilepath, $this->generatorDumper->dump([
             'class' => 'PreserveTheGoodLocaleInTheUrlGenerator',
@@ -268,10 +268,10 @@ class PhpGeneratorDumperTest extends TestCase
 
         $phpGenerator = new \PreserveTheGoodLocaleInTheUrlGenerator($requestContext);
 
-        $this->assertSame('/fr/foo', $phpGenerator->generate('foo'));
-        $this->assertSame('/en/foo', $phpGenerator->generate('foo.en'));
-        $this->assertSame('/en/foo', $phpGenerator->generate('foo', ['_locale' => 'en']));
-        $this->assertSame('/en/foo', $phpGenerator->generate('foo.fr', ['_locale' => 'en']));
+        $this->assertSame('/fr/fourchette', $phpGenerator->generate('foo'));
+        $this->assertSame('/en/fork', $phpGenerator->generate('foo.en'));
+        $this->assertSame('/en/fork', $phpGenerator->generate('foo', ['_locale' => 'en']));
+        $this->assertSame('/fr/fourchette', $phpGenerator->generate('foo.fr', ['_locale' => 'en']));
 
         $this->assertSame('/amusant', $phpGenerator->generate('fun'));
         $this->assertSame('/fun', $phpGenerator->generate('fun.en'));

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -171,6 +171,7 @@ class UrlGeneratorTest extends TestCase
         foreach (['hr' => '/foo', 'en' => '/bar'] as $locale => $path) {
             $localizedRoute = clone $route;
             $localizedRoute->setDefault('_locale', $locale);
+            $localizedRoute->setRequirement('_locale', $locale);
             $localizedRoute->setDefault('_canonical_route', $name);
             $localizedRoute->setPath($path);
             $routes->add($name.'.'.$locale, $localizedRoute);
@@ -195,6 +196,7 @@ class UrlGeneratorTest extends TestCase
         foreach (['hr' => '/foo', 'en' => '/bar'] as $locale => $path) {
             $localizedRoute = clone $route;
             $localizedRoute->setDefault('_locale', $locale);
+            $localizedRoute->setRequirement('_locale', $locale);
             $localizedRoute->setDefault('_canonical_route', $name);
             $localizedRoute->setPath($path);
             $routes->add($name.'.'.$locale, $localizedRoute);
@@ -219,6 +221,7 @@ class UrlGeneratorTest extends TestCase
         foreach (['hr' => '/foo', 'en' => '/bar'] as $locale => $path) {
             $localizedRoute = clone $route;
             $localizedRoute->setDefault('_locale', $locale);
+            $localizedRoute->setRequirement('_locale', $locale);
             $localizedRoute->setDefault('_canonical_route', $name);
             $localizedRoute->setPath($path);
             $routes->add($name.'.'.$locale, $localizedRoute);
@@ -240,18 +243,18 @@ class UrlGeneratorTest extends TestCase
     {
         $routeCollection = new RouteCollection();
 
-        $routeCollection->add('foo.en', (new Route('/{_locale}/foo'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo'));
-        $routeCollection->add('foo.fr', (new Route('/{_locale}/foo'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'foo'));
-        $routeCollection->add('fun.en', (new Route('/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'fun'));
-        $routeCollection->add('fun.fr', (new Route('/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'fun'));
+        $routeCollection->add('foo.en', (new Route('/{_locale}/fork'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo')->setRequirement('_locale', 'en'));
+        $routeCollection->add('foo.fr', (new Route('/{_locale}/fourchette'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'foo')->setRequirement('_locale', 'fr'));
+        $routeCollection->add('fun.en', (new Route('/fun'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'fun')->setRequirement('_locale', 'en'));
+        $routeCollection->add('fun.fr', (new Route('/amusant'))->setDefault('_locale', 'fr')->setDefault('_canonical_route', 'fun')->setRequirement('_locale', 'fr'));
 
         $urlGenerator = $this->getGenerator($routeCollection);
         $urlGenerator->getContext()->setParameter('_locale', 'fr');
 
-        $this->assertSame('/app.php/fr/foo', $urlGenerator->generate('foo'));
-        $this->assertSame('/app.php/en/foo', $urlGenerator->generate('foo.en'));
-        $this->assertSame('/app.php/en/foo', $urlGenerator->generate('foo', ['_locale' => 'en']));
-        $this->assertSame('/app.php/en/foo', $urlGenerator->generate('foo.fr', ['_locale' => 'en']));
+        $this->assertSame('/app.php/fr/fourchette', $urlGenerator->generate('foo'));
+        $this->assertSame('/app.php/en/fork', $urlGenerator->generate('foo.en'));
+        $this->assertSame('/app.php/en/fork', $urlGenerator->generate('foo', ['_locale' => 'en']));
+        $this->assertSame('/app.php/fr/fourchette', $urlGenerator->generate('foo.fr', ['_locale' => 'en']));
 
         $this->assertSame('/app.php/amusant', $urlGenerator->generate('fun'));
         $this->assertSame('/app.php/fun', $urlGenerator->generate('fun.en'));
@@ -278,6 +281,7 @@ class UrlGeneratorTest extends TestCase
         foreach (['hr' => '/foo', 'en' => '/bar'] as $locale => $path) {
             $localizedRoute = clone $route;
             $localizedRoute->setDefault('_locale', $locale);
+            $localizedRoute->setRequirement('_locale', $locale);
             $localizedRoute->setDefault('_canonical_route', $name);
             $localizedRoute->setPath($path);
             $routes->add($name.'.'.$locale, $localizedRoute);

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -271,4 +271,65 @@ class RouteTest extends TestCase
         $this->assertEquals($route, $unserialized);
         $this->assertNotSame($route, $unserialized);
     }
+
+    /**
+     * @dataProvider provideNonLocalizedRoutes
+     */
+    public function testLocaleDefaultWithNonLocalizedRoutes(Route $route)
+    {
+        $this->assertNotSame('fr', $route->getDefault('_locale'));
+        $route->setDefault('_locale', 'fr');
+        $this->assertSame('fr', $route->getDefault('_locale'));
+    }
+
+    /**
+     * @dataProvider provideLocalizedRoutes
+     */
+    public function testLocaleDefaultWithLocalizedRoutes(Route $route)
+    {
+        $expected = $route->getDefault('_locale');
+        $this->assertIsString($expected);
+        $this->assertNotSame('fr', $expected);
+        $route->setDefault('_locale', 'fr');
+        $this->assertSame($expected, $route->getDefault('_locale'));
+    }
+
+    /**
+     * @dataProvider provideNonLocalizedRoutes
+     */
+    public function testLocaleRequirementWithNonLocalizedRoutes(Route $route)
+    {
+        $this->assertNotSame('fr', $route->getRequirement('_locale'));
+        $route->setRequirement('_locale', 'fr');
+        $this->assertSame('fr', $route->getRequirement('_locale'));
+    }
+
+    /**
+     * @dataProvider provideLocalizedRoutes
+     */
+    public function testLocaleRequirementWithLocalizedRoutes(Route $route)
+    {
+        $expected = $route->getRequirement('_locale');
+        $this->assertIsString($expected);
+        $this->assertNotSame('fr', $expected);
+        $route->setRequirement('_locale', 'fr');
+        $this->assertSame($expected, $route->getRequirement('_locale'));
+    }
+
+    public function provideNonLocalizedRoutes()
+    {
+        return [
+            [(new Route('/foo'))],
+            [(new Route('/foo'))->setDefault('_locale', 'en')],
+            [(new Route('/foo'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo')],
+            [(new Route('/foo'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo')->setRequirement('_locale', 'foobar')],
+        ];
+    }
+
+    public function provideLocalizedRoutes()
+    {
+        return [
+            [(new Route('/foo'))->setDefault('_locale', 'en')->setDefault('_canonical_route', 'foo')->setRequirement('_locale', 'en')],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35443
| License       | MIT

The boundary attribute of Content-Type header was enclosed in quotes, cause of the "=" symbol. That caused some issues, because it was enclosed in quotes only in the request header, but not in the multipart/form-data headers.