### PR TITLE
[Mime] Fix boundary header

### DIFF
--- a/src/Symfony/Component/Mime/Part/AbstractMultipartPart.php
+++ b/src/Symfony/Component/Mime/Part/AbstractMultipartPart.php
@@ -91,7 +91,7 @@ abstract class AbstractMultipartPart extends AbstractPart
     private function getBoundary(): string
     {
         if (null === $this->boundary) {
-            $this->boundary = '_=_symfony_'.time().'_'.bin2hex(random_bytes(16)).'_=_';
+            $this->boundary = strtr(base64_encode(random_bytes(6)), '+/', '-_');
         }
 
         return $this->boundary;

--- a/src/Symfony/Component/Mime/Tests/Part/Multipart/FormDataPartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/Multipart/FormDataPartTest.php
@@ -91,4 +91,16 @@ class FormDataPartTest extends TestCase
         $this->assertEquals($foo, $parts[0]->bodyToString());
         $this->assertEquals($bar, $parts[1]->bodyToString());
     }
+
+    public function testBoundaryContentTypeHeader()
+    {
+        $f = new FormDataPart([
+            'file' => new DataPart('data.csv', 'data.csv', 'text/csv'),
+        ]);
+        $headers = $f->getPreparedHeaders()->toArray();
+        $this->assertRegExp(
+            '/^Content-Type: multipart\/form-data; boundary=[a-zA-Z0-9\-_]{8}$/',
+            $headers[0]
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35443 (fixes the second problem described in this ticket)
| License       | MIT

The boundary value of Content-Type header was enclosed in quotes, cause of the "=" symbol.
