### PR TITLE
[Validator] Add NotInRange constraint and validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/NotInRange.php
+++ b/src/Symfony/Component/Validator/Constraints/NotInRange.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\LogicException;
+use Symfony\Component\Validator\Exception\MissingOptionsException;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ *
+ * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
+ */
+class NotInRange extends Constraint
+{
+    const INVALID_CHARACTERS_ERROR = '88dea871-e57a-4836-9b55-11b7dcd73dc6';
+    const IN_RANGE_ERROR = '36b1a3ef-effe-4be4-b153-715c40ebce16';
+
+    protected static $errorNames = [
+        self::INVALID_CHARACTERS_ERROR => 'INVALID_CHARACTERS_ERROR',
+        self::IN_RANGE_ERROR => 'IN_RANGE_ERROR',
+    ];
+
+    public $inRangeMessage = 'This value should not be between {{ min }} and {{ max }}.';
+    public $invalidMessage = 'This value should be a valid number or a valid datetime.';
+    public $min;
+    public $minPropertyPath;
+    public $max;
+    public $maxPropertyPath;
+
+    public function __construct($options = null)
+    {
+        if (\is_array($options)) {
+            if (isset($options['min']) && isset($options['minPropertyPath'])) {
+                throw new ConstraintDefinitionException(sprintf('The "%s" constraint requires only one of the "min" or "minPropertyPath" options to be set, not both.', static::class));
+            }
+
+            if (isset($options['max']) && isset($options['maxPropertyPath'])) {
+                throw new ConstraintDefinitionException(sprintf('The "%s" constraint requires only one of the "max" or "maxPropertyPath" options to be set, not both.', static::class));
+            }
+
+            if ((isset($options['minPropertyPath']) || isset($options['maxPropertyPath'])) && !class_exists(PropertyAccess::class)) {
+                throw new LogicException(sprintf('The "%s" constraint requires the Symfony PropertyAccess component to use the "minPropertyPath" or "maxPropertyPath" option.', static::class));
+            }
+        }
+
+        parent::__construct($options);
+
+        if (null === $this->min && null === $this->minPropertyPath) {
+            throw new MissingOptionsException(sprintf('Either option "min" or "minPropertyPath" must be given for constraint %s', static::class), ['min', 'minPropertyPath']);
+        }
+
+        if (null === $this->max && null === $this->maxPropertyPath) {
+            throw new MissingOptionsException(sprintf('Either option "max" or "maxPropertyPath" must be given for constraint %s', static::class), ['max', 'maxPropertyPath']);
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/NotInRangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotInRangeValidator.php
@@ -43,7 +43,7 @@ class NotInRangeValidator extends ConstraintValidator
         if (null === $value) {
             return;
         }
-        
+
         if (!is_numeric($value) && !$value instanceof \DateTimeInterface) {
             $this->context->buildViolation($constraint->invalidMessage)
                 ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
@@ -52,7 +52,7 @@ class NotInRangeValidator extends ConstraintValidator
 
             return;
         }
-        
+
         if (null === $min = $this->getLimit($constraint->minPropertyPath, $constraint->min, $constraint)) {
             throw new ConstraintDefinitionException(sprintf('The min value cannot be null in the "%s" constraint.', \get_class($constraint)));
         }

--- a/src/Symfony/Component/Validator/Constraints/NotInRangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotInRangeValidator.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
+ */
+class NotInRangeValidator extends ConstraintValidator
+{
+    private $propertyAccessor;
+
+    public function __construct(PropertyAccessorInterface $propertyAccessor = null)
+    {
+        $this->propertyAccessor = $propertyAccessor;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof NotInRange) {
+            throw new UnexpectedTypeException($constraint, NotInRange::class);
+        }
+
+        if (null === $value) {
+            return;
+        }
+        
+        if (!is_numeric($value) && !$value instanceof \DateTimeInterface) {
+            $this->context->buildViolation($constraint->invalidMessage)
+                ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
+                ->setCode(NotInRange::INVALID_CHARACTERS_ERROR)
+                ->addViolation();
+
+            return;
+        }
+        
+        if (null === $min = $this->getLimit($constraint->minPropertyPath, $constraint->min, $constraint)) {
+            throw new ConstraintDefinitionException(sprintf('The min value cannot be null in the "%s" constraint.', \get_class($constraint)));
+        }
+
+        if (null === $max = $this->getLimit($constraint->maxPropertyPath, $constraint->max, $constraint)) {
+            throw new ConstraintDefinitionException(sprintf('The max value cannot be null in the "%s" constraint.', \get_class($constraint)));
+        }
+
+        // Convert strings to DateTimes if comparing another DateTime
+        // This allows to compare with any date/time value supported by
+        // the DateTime constructor:
+        // https://php.net/datetime.formats
+        if ($value instanceof \DateTimeInterface) {
+            $dateTimeClass = null;
+
+            if (\is_string($min)) {
+                $dateTimeClass = $value instanceof \DateTimeImmutable ? \DateTimeImmutable::class : \DateTime::class;
+
+                try {
+                    $min = new $dateTimeClass($min);
+                } catch (\Exception $e) {
+                    throw new ConstraintDefinitionException(sprintf('The min value "%s" could not be converted to a "%s" instance in the "%s" constraint.', $min, $dateTimeClass, \get_class($constraint)));
+                }
+            }
+
+            if (\is_string($max)) {
+                $dateTimeClass = $dateTimeClass ?: ($value instanceof \DateTimeImmutable ? \DateTimeImmutable::class : \DateTime::class);
+
+                try {
+                    $max = new $dateTimeClass($max);
+                } catch (\Exception $e) {
+                    throw new ConstraintDefinitionException(sprintf('The max value "%s" could not be converted to a "%s" instance in the "%s" constraint.', $max, $dateTimeClass, \get_class($constraint)));
+                }
+            }
+        }
+
+        if ($value >= $min && $value <= $max) {
+            $violationBuilder = $this->context->buildViolation($constraint->inRangeMessage)
+                ->setParameter('{{ value }}', $this->formatValue($value, self::PRETTY_DATE))
+                ->setParameter('{{ min }}', $this->formatValue($min, self::PRETTY_DATE))
+                ->setParameter('{{ max }}', $this->formatValue($max, self::PRETTY_DATE))
+                ->setCode(NotInRange::IN_RANGE_ERROR);
+
+            if (null !== $constraint->maxPropertyPath) {
+                $violationBuilder->setParameter('{{ max_limit_path }}', $constraint->maxPropertyPath);
+            }
+
+            if (null !== $constraint->minPropertyPath) {
+                $violationBuilder->setParameter('{{ min_limit_path }}', $constraint->minPropertyPath);
+            }
+
+            $violationBuilder->addViolation();
+
+            return;
+        }
+    }
+
+    private function getLimit($propertyPath, $default, Constraint $constraint)
+    {
+        if (null === $propertyPath) {
+            return $default;
+        }
+
+        if (null === $object = $this->context->getObject()) {
+            return $default;
+        }
+
+        try {
+            return $this->getPropertyAccessor()->getValue($object, $propertyPath);
+        } catch (NoSuchPropertyException $e) {
+            throw new ConstraintDefinitionException(sprintf('Invalid property path "%s" provided to "%s" constraint: %s', $propertyPath, \get_class($constraint), $e->getMessage()), 0, $e);
+        }
+    }
+
+    private function getPropertyAccessor(): PropertyAccessorInterface
+    {
+        if (null === $this->propertyAccessor) {
+            $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+        }
+
+        return $this->propertyAccessor;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotInRangeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotInRangeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\NotInRange;
+
+/**
+ * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
+ */
+class NotInRangeTest extends TestCase
+{
+    public function testThrowsConstraintExceptionIfBothMinLimitAndPropertyPath()
+    {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
+        $this->expectExceptionMessage('requires only one of the "min" or "minPropertyPath" options to be set, not both.');
+        new NotInRange([
+            'min' => 'min',
+            'minPropertyPath' => 'minPropertyPath',
+        ]);
+    }
+
+    public function testThrowsConstraintExceptionIfBothMaxLimitAndPropertyPath()
+    {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
+        $this->expectExceptionMessage('requires only one of the "max" or "maxPropertyPath" options to be set, not both.');
+        new NotInRange([
+            'max' => 'max',
+            'maxPropertyPath' => 'maxPropertyPath',
+        ]);
+    }
+
+    public function testThrowsConstraintExceptionIfNoMinNorMinPropertyPath()
+    {
+        $this->expectException('Symfony\Component\Validator\Exception\MissingOptionsException');
+        $this->expectExceptionMessage('Either option "min" or "minPropertyPath" must be given');
+        new NotInRange([
+            'max' => 'max',
+        ]);
+    }
+
+    public function testThrowsConstraintExceptionIfNoMaxNorMaxPropertyPath()
+    {
+        $this->expectException('Symfony\Component\Validator\Exception\MissingOptionsException');
+        $this->expectExceptionMessage('Either option "max" or "maxPropertyPath" must be given');
+        new NotInRange([
+            'min' => 'min',
+        ]);
+    }
+
+    public function testThrowsNoDefaultOptionConfiguredException()
+    {
+        $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
+        $this->expectExceptionMessage('No default option is configured');
+        new NotInRange('value');
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotInRangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotInRangeValidatorTest.php
@@ -1,0 +1,355 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Intl\Util\IntlTestHelper;
+use Symfony\Component\Validator\Constraints\NotInRange;
+use Symfony\Component\Validator\Constraints\NotInRangeValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
+ */
+class NotInRangeValidatorTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new NotInRangeValidator();
+    }
+
+    public function testNullIsValid()
+    {
+        $this->validator->validate(null, new NotInRange(['min' => 10, 'max' => 20]));
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getLessThanTenAndMoreThanTwenty
+     */
+    public function testValidNumericValues($value)
+    {
+        $constraint = new NotInRange(['min' => 10, 'max' => 20]);
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function getLessThanTenAndMoreThanTwenty()
+    {
+        return [
+            [9.99999],
+            ['9.99999'],
+            [5],
+            [1.0],
+            [20.000001],
+            ['20.000001'],
+            [21],
+            [30.0],
+        ];
+    }
+
+    /**
+     * @dataProvider getTenToTwenty
+     */
+    public function testInvalidNumericValues($value, $formattedValue)
+    {
+        $constraint = new NotInRange([
+            'min' => 10,
+            'max' => 20,
+            'inRangeMessage' => 'myMessage',
+        ]);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', $formattedValue)
+            ->setParameter('{{ min }}', 10)
+            ->setParameter('{{ max }}', 20)
+            ->setCode(NotInRange::IN_RANGE_ERROR)
+            ->assertRaised();
+    }
+
+    public function getTenToTwenty()
+    {
+        return [
+            [10.00001, '10.00001'],
+            [19.99999, '19.99999'],
+            ['10.00001', '"10.00001"'],
+            ['19.99999', '"19.99999"'],
+            [10, '10'],
+            [20, '20'],
+            [10.0, '10'],
+            [20.0, '20'],
+        ];
+    }
+
+    /**
+     * @dataProvider getValidDates
+     */
+    public function testValidDates($value)
+    {
+        $constraint = new NotInRange(['min' => 'March 10, 2014', 'max' => 'March 20, 2014']);
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function getValidDates()
+    {
+        // The provider runs before setUp(), so we need to manually fix
+        // the default timezone
+        $this->setDefaultTimezone('UTC');
+
+        $tests = [
+            [new \DateTime('March 20, 2013')],
+            [new \DateTime('March 9, 2014')],
+            [new \DateTime('March 21, 2014')],
+            [new \DateTime('March 9, 2015')],
+        ];
+
+        $tests[] = [new \DateTimeImmutable('March 20, 2013')];
+        $tests[] = [new \DateTimeImmutable('March 9, 2014')];
+        $tests[] = [new \DateTimeImmutable('March 21, 2014')];
+        $tests[] = [new \DateTimeImmutable('March 9, 2015')];
+
+        $this->restoreDefaultTimezone();
+
+        return $tests;
+    }
+
+    /**
+     * @dataProvider getInvalidDates
+     */
+    public function testInvalidDates($value, $dateTimeAsString)
+    {
+        // Conversion of dates to string differs between ICU versions
+        // Make sure we have the correct version loaded
+        IntlTestHelper::requireIntl($this, '57.1');
+
+        $constraint = new NotInRange([
+            'min' => 'March 10, 2014',
+            'max' => 'March 20, 2014',
+            'inRangeMessage' => 'myMessage',
+        ]);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', $dateTimeAsString)
+            ->setParameter('{{ min }}', 'Mar 10, 2014, 12:00 AM')
+            ->setParameter('{{ max }}', 'Mar 20, 2014, 12:00 AM')
+            ->setCode(NotInRange::IN_RANGE_ERROR)
+            ->assertRaised();
+    }
+
+    public function getInvalidDates()
+    {
+        // The provider runs before setUp(), so we need to manually fix
+        // the default timezone
+        $this->setDefaultTimezone('UTC');
+
+        $tests = [
+            [new \DateTime('March 10, 2014'), 'Mar 10, 2014, 12:00 AM'],
+            [new \DateTime('March 15, 2014'), 'Mar 15, 2014, 12:00 AM'],
+            [new \DateTime('March 20, 2014'), 'Mar 20, 2014, 12:00 AM'],
+        ];
+
+        $tests[] = [new \DateTimeImmutable('March 10, 2014'), 'Mar 10, 2014, 12:00 AM'];
+        $tests[] = [new \DateTimeImmutable('March 15, 2014'), 'Mar 15, 2014, 12:00 AM'];
+        $tests[] = [new \DateTimeImmutable('March 20, 2014'), 'Mar 20, 2014, 12:00 AM'];
+
+        $this->restoreDefaultTimezone();
+
+        return $tests;
+    }
+    
+    public function testNonNumeric()
+    {
+        $this->validator->validate('abcd', new NotInRange([
+            'min' => 10,
+            'max' => 20,
+            'invalidMessage' => 'myMessage',
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', '"abcd"')
+            ->setCode(NotInRange::INVALID_CHARACTERS_ERROR)
+            ->assertRaised();
+    }
+
+    /**
+     * @dataProvider throwsOnInvalidStringDatesProvider
+     */
+    public function testThrowsOnInvalidStringDates($expectedMessage, $value, $min, $max)
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $this->validator->validate($value, new NotInRange([
+            'min' => $min,
+            'max' => $max,
+        ]));
+    }
+
+    public function throwsOnInvalidStringDatesProvider(): array
+    {
+        return [
+            ['The max value "foo" could not be converted to a "DateTime" instance in the "Symfony\Component\Validator\Constraints\NotInRange" constraint.', new \DateTime(), 'first day of January', 'foo'],
+            ['The min value "bar" could not be converted to a "DateTimeImmutable" instance in the "Symfony\Component\Validator\Constraints\NotInRange" constraint.', new \DateTimeImmutable(), 'bar', 'ccc'],
+        ];
+    }
+
+    /**
+     * @dataProvider getLessThanTenAndMoreThanTwenty
+     */
+    public function testValidValuesPropertyPath($value)
+    {
+        $this->setObject(new MinMax(10, 20));
+
+        $this->validator->validate($value, new NotInRange([
+            'minPropertyPath' => 'min',
+            'maxPropertyPath' => 'max',
+        ]));
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getTenToTwenty
+     */
+    public function testInvalidValuesPropertyPath($value, $formattedValue)
+    {
+        $this->setObject(new MinMax(10, 20));
+
+        $constraint = new NotInRange([
+            'minPropertyPath' => 'min',
+            'maxPropertyPath' => 'max',
+            'inRangeMessage' => 'myMessage',
+        ]);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', $formattedValue)
+            ->setParameter('{{ min_limit_path }}', 'min')
+            ->setParameter('{{ min }}', 10)
+            ->setParameter('{{ max_limit_path }}', 'max')
+            ->setParameter('{{ max }}', 20)
+            ->setCode(NotInRange::IN_RANGE_ERROR)
+            ->assertRaised();
+    }
+
+    public function testThrowsOnNullObjectWithPropertyPaths()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The min value cannot be null in the "Symfony\Component\Validator\Constraints\NotInRange" constraint.');
+
+        $this->setObject(null);
+
+        $this->validator->validate(1, new NotInRange([
+            'minPropertyPath' => 'minPropertyPath',
+            'maxPropertyPath' => 'maxPropertyPath',
+        ]));
+    }
+    
+    public function testThrowsOnNullObjectWithDefinedMin()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The max value cannot be null in the "Symfony\Component\Validator\Constraints\NotInRange" constraint.');
+        
+        $this->setObject(null);
+
+        $this->validator->validate(1, new NotInRange([
+            'min' => 10,
+            'maxPropertyPath' => 'max',
+        ]));
+    }
+
+    public function testThrowsOnNullObjectWithDefinedMax()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The min value cannot be null in the "Symfony\Component\Validator\Constraints\NotInRange" constraint.');
+
+        $this->setObject(null);
+
+        $this->validator->validate(1, new NotInRange([
+            'minPropertyPath' => 'min',
+            'max' => 5,
+        ]));
+    }
+
+    /**
+     * @dataProvider getValidDates
+     */
+    public function testValidDatesPropertyPath($value)
+    {
+        $this->setObject(new MinMax('March 10, 2014', 'March 20, 2014'));
+
+        $constraint = new NotInRange(['minPropertyPath' => 'min', 'maxPropertyPath' => 'max']);
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+    
+    /**
+     * @dataProvider getInvalidDates
+     */
+    public function testInvalidDatesPropertyPath($value, $dateTimeAsString)
+    {
+        // Conversion of dates to string differs between ICU versions
+        // Make sure we have the correct version loaded
+        IntlTestHelper::requireIntl($this, '57.1');
+
+        $this->setObject(new MinMax('March 10, 2014', 'March 20, 2014'));
+
+        $constraint = new NotInRange([
+            'minPropertyPath' => 'min',
+            'maxPropertyPath' => 'max',
+            'inRangeMessage' => 'myMessage',
+        ]);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', $dateTimeAsString)
+            ->setParameter('{{ min }}', 'Mar 10, 2014, 12:00 AM')
+            ->setParameter('{{ max }}', 'Mar 20, 2014, 12:00 AM')
+            ->setParameter('{{ max_limit_path }}', 'max')
+            ->setParameter('{{ min_limit_path }}', 'min')
+            ->setCode(NotInRange::IN_RANGE_ERROR)
+            ->assertRaised();
+    }
+}
+
+final class MinMax
+{
+    private $min;
+    private $max;
+
+    public function __construct($min, $max)
+    {
+        $this->min = $min;
+        $this->max = $max;
+    }
+
+    public function getMin()
+    {
+        return $this->min;
+    }
+
+    public function getMax()
+    {
+        return $this->max;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotInRangeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotInRangeValidatorTest.php
@@ -173,7 +173,7 @@ class NotInRangeValidatorTest extends ConstraintValidatorTestCase
 
         return $tests;
     }
-    
+
     public function testNonNumeric()
     {
         $this->validator->validate('abcd', new NotInRange([
@@ -262,12 +262,12 @@ class NotInRangeValidatorTest extends ConstraintValidatorTestCase
             'maxPropertyPath' => 'maxPropertyPath',
         ]));
     }
-    
+
     public function testThrowsOnNullObjectWithDefinedMin()
     {
         $this->expectException(ConstraintDefinitionException::class);
         $this->expectExceptionMessage('The max value cannot be null in the "Symfony\Component\Validator\Constraints\NotInRange" constraint.');
-        
+
         $this->setObject(null);
 
         $this->validator->validate(1, new NotInRange([
@@ -301,7 +301,7 @@ class NotInRangeValidatorTest extends ConstraintValidatorTestCase
 
         $this->assertNoViolation();
     }
-    
+
     /**
      * @dataProvider getInvalidDates
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | TODO

Since many constraints come in pairs, e.g. `EqualTo` and `NotEqualTo`, `LessThan` and `GreaterThan`, I thought it might be a good idea to create the `NotInRange`, which could be used, if you wanted to make sure, that a given value **is not** between some minimum and maximum. In order to avoid making a mirror copy of the `Range` constraint, this one requires minimum and maximum not to be null.