### PR TITLE
[PhpUnitBridge] Deprecate @expectedDeprecation annotation

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -54,6 +54,11 @@ Notifier
  * [BC BREAK] The `EmailMessage::fromNotification()` and `SmsMessage::fromNotification()`
    methods' `$transport` argument was removed.
 
+PhpUnitBridge
+-------------
+
+ * Deprecated the `@expectedDeprecation` annotation, use the `ExpectDeprecationTrait::expectDeprecation()` method instead.
+
 Routing
 -------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -43,6 +43,11 @@ Messenger
  * Removed RedisExt transport. Run `composer require symfony/redis-messenger` to keep the transport in your application.
  * Use of invalid options in Redis and AMQP connections now throws an error.
 
+PhpUnitBridge
+-------------
+
+ * Removed support for `@expectedDeprecation` annotations, use the `ExpectDeprecationTrait::expectDeprecation()` method instead.
+
 Routing
 -------
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/ChoiceList/DoctrineChoiceLoaderTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityLoaderInterface;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\IdReader;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
 use Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface;
 
@@ -27,6 +28,8 @@ use Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface;
  */
 class DoctrineChoiceLoaderTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var ChoiceListFactoryInterface|MockObject
      */
@@ -192,11 +195,10 @@ class DoctrineChoiceLoaderTest extends TestCase
 
     /**
      * @group legacy
-     *
-     * @expectedDeprecation Since symfony/doctrine-bridge 5.1: Not defining explicitly the IdReader as value callback when query can be optimized is deprecated. Don't pass the IdReader to "Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader" or define the "choice_value" option instead.
      */
     public function testLoadValuesForChoicesDoesNotLoadIfSingleIntId()
     {
+        $this->expectDeprecation('Since symfony/doctrine-bridge 5.1: Not defining explicitly the IdReader as value callback when query can be optimized is deprecated. Don\'t pass the IdReader to "Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader" or define the "choice_value" option instead.');
         $loader = new DoctrineChoiceLoader(
             $this->om,
             $this->class,
@@ -295,11 +297,10 @@ class DoctrineChoiceLoaderTest extends TestCase
 
     /**
      * @group legacy
-     *
-     * @expectedDeprecation Not defining explicitly the IdReader as value callback when query can be optimized has been deprecated in 5.1. Don't pass the IdReader to "Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader" or define the choice_value instead.
      */
     public function legacyTestLoadChoicesForValuesLoadsOnlyChoicesIfValueUseIdReader()
     {
+        $this->expectDeprecation('Not defining explicitly the IdReader as value callback when query can be optimized has been deprecated in 5.1. Don\'t pass the IdReader to "Symfony\Bridge\Doctrine\Form\ChoiceList\DoctrineChoiceLoader" or define the choice_value instead.');
         $loader = new DoctrineChoiceLoader(
             $this->om,
             $this->class,

--- a/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
+++ b/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * ignore verbosity settings when the build fails because of deprecations
  * added per-group verbosity
  * added `ExpectDeprecationTrait` to be able to define an expected deprecation from inside a test
+ * deprecated the `@expectedDeprecation` annotation, use the `ExpectDeprecationTrait::expectDeprecation()` method instead
 
 5.0.0
 -----

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -226,6 +226,7 @@ class SymfonyTestsListenerTrait
                 if (isset($annotations['method']['expectedDeprecation'])) {
                     self::$expectedDeprecations = $annotations['method']['expectedDeprecation'];
                     self::$previousErrorHandler = set_error_handler([self::class, 'handleError']);
+                    @trigger_error('Since symfony/phpunit-bridge 5.1: Using "@expectedDeprecation" annotations in tests is deprecated, use the "ExpectDeprecationTrait::expectDeprecation()" method instead.', E_USER_DEPRECATED);
                 }
 
                 if ($this->checkNumAssertions) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveReferencesToAliasesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveReferencesToAliasesPassTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Compiler\ResolveReferencesToAliasesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -20,6 +21,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class ResolveReferencesToAliasesPassTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testProcess()
     {
         $container = new ContainerBuilder();
@@ -83,10 +86,10 @@ class ResolveReferencesToAliasesPassTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The "deprecated_foo_alias" service alias is deprecated. You should stop using it, as it will be removed in the future. It is being referenced by the "alias" alias.
      */
     public function testDeprecationNoticeWhenReferencedByAlias()
     {
+        $this->expectDeprecation('The "deprecated_foo_alias" service alias is deprecated. You should stop using it, as it will be removed in the future. It is being referenced by the "alias" alias.');
         $container = new ContainerBuilder();
 
         $container->register('foo', 'stdClass');
@@ -103,10 +106,10 @@ class ResolveReferencesToAliasesPassTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The "foo_aliased" service alias is deprecated. You should stop using it, as it will be removed in the future. It is being referenced by the "definition" service.
      */
     public function testDeprecationNoticeWhenReferencedByDefinition()
     {
+        $this->expectDeprecation('The "foo_aliased" service alias is deprecated. You should stop using it, as it will be removed in the future. It is being referenced by the "definition" service.');
         $container = new ContainerBuilder();
 
         $container->register('foo', 'stdClass');

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
@@ -49,6 +50,8 @@ require_once __DIR__.'/../Fixtures/includes/foo_lazy.php';
 
 class PhpDumperTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     protected static $fixturesPath;
 
     public static function setUpBeforeClass(): void
@@ -410,10 +413,10 @@ class PhpDumperTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The "alias_for_foo_deprecated" service alias is deprecated. You should stop using it, as it will be removed in the future.
      */
     public function testAliasesDeprecation()
     {
+        $this->expectDeprecation('The "alias_for_foo_deprecated" service alias is deprecated. You should stop using it, as it will be removed in the future.');
         $container = include self::$fixturesPath.'/containers/container_alias_deprecation.php';
         $container->compile();
         $dumper = new PhpDumper($container);
@@ -1192,10 +1195,10 @@ class PhpDumperTest extends TestCase
      * This test checks the trigger of a deprecation note and should not be removed in major releases.
      *
      * @group legacy
-     * @expectedDeprecation The "foo" service is deprecated. You should stop using it, as it will be removed in the future.
      */
     public function testPrivateServiceTriggersDeprecation()
     {
+        $this->expectDeprecation('The "foo" service is deprecated. You should stop using it, as it will be removed in the future.');
         $container = new ContainerBuilder();
         $container->register('foo', 'stdClass')
             ->setPublic(false)
@@ -1344,11 +1347,11 @@ class PhpDumperTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The "deprecated1" service alias is deprecated. You should stop using it, as it will be removed in the future.
-     * @expectedDeprecation The "deprecated2" service alias is deprecated. You should stop using it, as it will be removed in the future.
      */
     public function testMultipleDeprecatedAliasesWorking()
     {
+        $this->expectDeprecation('The "deprecated1" service alias is deprecated. You should stop using it, as it will be removed in the future.');
+        $this->expectDeprecation('The "deprecated2" service alias is deprecated. You should stop using it, as it will be removed in the future.');
         $container = new ContainerBuilder();
         $container->setDefinition('bar', new Definition('stdClass'))->setPublic(true);
         $container->setAlias('deprecated1', 'bar')->setPublic(true)->setDeprecated('%alias_id% is deprecated');

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Bridge\Amqp\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Messenger\Bridge\Amqp\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpFactory;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpStamp;
@@ -23,6 +24,8 @@ use Symfony\Component\Messenger\Exception\InvalidArgumentException;
  */
 class ConnectionTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private const DEFAULT_EXCHANGE_NAME = 'messages';
 
     public function testItCannotBeConstructedWithAWrongDsn()
@@ -104,37 +107,37 @@ class ConnectionTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Since symfony/messenger 5.1: Invalid option(s) "foo" passed to the AMQP Messenger transport. Passing invalid options is deprecated.
      */
     public function testDeprecationIfInvalidOptionIsPassedWithDsn()
     {
+        $this->expectDeprecation('Since symfony/messenger 5.1: Invalid option(s) "foo" passed to the AMQP Messenger transport. Passing invalid options is deprecated.');
         Connection::fromDsn('amqp://host?foo=bar');
     }
 
     /**
      * @group legacy
-     * @expectedDeprecation Since symfony/messenger 5.1: Invalid option(s) "foo" passed to the AMQP Messenger transport. Passing invalid options is deprecated.
      */
     public function testDeprecationIfInvalidOptionIsPassedAsArgument()
     {
+        $this->expectDeprecation('Since symfony/messenger 5.1: Invalid option(s) "foo" passed to the AMQP Messenger transport. Passing invalid options is deprecated.');
         Connection::fromDsn('amqp://host', ['foo' => 'bar']);
     }
 
     /**
      * @group legacy
-     * @expectedDeprecation Since symfony/messenger 5.1: Invalid queue option(s) "foo" passed to the AMQP Messenger transport. Passing invalid queue options is deprecated.
      */
     public function testDeprecationIfInvalidQueueOptionIsPassed()
     {
+        $this->expectDeprecation('Since symfony/messenger 5.1: Invalid queue option(s) "foo" passed to the AMQP Messenger transport. Passing invalid queue options is deprecated.');
         Connection::fromDsn('amqp://host', ['queues' => ['queueName' => ['foo' => 'bar']]]);
     }
 
     /**
      * @group legacy
-     * @expectedDeprecation Since symfony/messenger 5.1: Invalid exchange option(s) "foo" passed to the AMQP Messenger transport. Passing invalid exchange options is deprecated.
      */
     public function testDeprecationIfInvalidExchangeOptionIsPassed()
     {
+        $this->expectDeprecation('Since symfony/messenger 5.1: Invalid exchange option(s) "foo" passed to the AMQP Messenger transport. Passing invalid exchange options is deprecated.');
         Connection::fromDsn('amqp://host', ['exchange' => ['foo' => 'bar']]);
     }
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Bridge\Redis\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\Connection;
 use Symfony\Component\Messenger\Exception\TransportException;
 
@@ -20,6 +21,8 @@ use Symfony\Component\Messenger\Exception\TransportException;
  */
 class ConnectionTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public static function setUpBeforeClass(): void
     {
         $redis = Connection::fromDsn('redis://localhost/queue');
@@ -109,11 +112,11 @@ class ConnectionTest extends TestCase
     }
 
     /**
-     * @expectedDeprecation Since symfony/messenger 5.1: Invalid option(s) "foo" passed to the Redis Messenger transport. Passing invalid options is deprecated.
      * @group legacy
      */
     public function testDeprecationIfInvalidOptionIsPassedWithDsn()
     {
+        $this->expectDeprecation('Since symfony/messenger 5.1: Invalid option(s) "foo" passed to the Redis Messenger transport. Passing invalid options is deprecated.');
         Connection::fromDsn('redis://localhost/queue?foo=bar');
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleVoterTest.php
@@ -12,12 +12,15 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization\Voter;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Authorization\Voter\RoleVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class RoleVoterTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @dataProvider getVoteTests
      */
@@ -46,10 +49,10 @@ class RoleVoterTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Since symfony/security-core 5.1: The ROLE_PREVIOUS_ADMIN role is deprecated and will be removed in version 6.0, use the IS_IMPERSONATOR attribute instead.
      */
     public function testDeprecatedRolePreviousAdmin()
     {
+        $this->expectDeprecation('Since symfony/security-core 5.1: The ROLE_PREVIOUS_ADMIN role is deprecated and will be removed in version 6.0, use the IS_IMPERSONATOR attribute instead.');
         $voter = new RoleVoter();
 
         $voter->vote($this->getTokenWithRoleNames(['ROLE_USER', 'ROLE_PREVIOUS_ADMIN']), null, ['ROLE_PREVIOUS_ADMIN']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes<!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Addresses https://github.com/orgs/symfony/projects/1#card-32934769 as a follow-up to #35192.

Deprecating `@expectedDeprecation` annotation on tests in favour of the `expectDeprecation()` method similar to other PHPUnit deprecations of annotations in favour of methods.