### PR TITLE
[Config] fix import from config file using type: glob

### DIFF
--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -76,7 +76,7 @@ abstract class FileLoader extends Loader
             $ret = [];
             $isSubpath = 0 !== $i && false !== strpos(substr($resource, 0, $i), '/');
             foreach ($this->glob($resource, false, $_, $ignoreErrors || !$isSubpath) as $path => $info) {
-                if (null !== $res = $this->doImport($path, $type, $ignoreErrors, $sourceResource)) {
+                if (null !== $res = $this->doImport($path, 'glob' === $type ? null : $type, $ignoreErrors, $sourceResource)) {
                     $ret[] = $res;
                 }
                 $isSubpath = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 

If you try to import configs with glob using
```
imports:
    - { resource: '../dev/*.{php,xml,yaml,yml}', type: 'glob' }
```
it didn't work because the FileLoader resolves the glob pattern but forwards the glob type. This meant the resolver then choses the GlobFilerLoader again for each already resolved file which does not find the files. So in the end the glob was resolved but the files never imported.
The workaround is to remove the `type: glob` from the import above. But the real fix should be to not forward the glob type when it's already resolved.
