### PR TITLE
[Uid] make Uuid::getTime() return subseconds info

### DIFF
--- a/src/Symfony/Component/Uid/InternalUtil.php
+++ b/src/Symfony/Component/Uid/InternalUtil.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Uid;
+
+/**
+ * @internal
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class InternalUtil
+{
+    public static function toBinary(string $digits): string
+    {
+        $bytes = '';
+        $len = \strlen($digits);
+
+        while ($len > $i = strspn($digits, '0')) {
+            for ($j = 2, $r = 0; $i < $len; $i += $j, $j = 0) {
+                do {
+                    $r *= 10;
+                    $d = (int) substr($digits, $i, ++$j);
+                } while ($i + $j < $len && $r + $d < 256);
+
+                $j = \strlen((string) $d);
+                $q = str_pad(($d += $r) >> 8, $j, '0', STR_PAD_LEFT);
+                $digits = substr_replace($digits, $q, $i, $j);
+                $r = $d % 256;
+            }
+
+            $bytes .= \chr($r);
+        }
+
+        return strrev($bytes);
+    }
+
+    public static function toDecimal(string $bytes): string
+    {
+        $digits = '';
+        $len = \strlen($bytes);
+
+        while ($len > $i = strspn($bytes, "\0")) {
+            for ($r = 0; $i < $len; $i += $j) {
+                $j = $d = 0;
+                do {
+                    $r <<= 8;
+                    $d = ($d << 8) + \ord($bytes[$i + $j]);
+                } while ($i + ++$j < $len && $r + $d < 10);
+
+                if (256 < $d) {
+                    $q = intdiv($d += $r, 10);
+                    $bytes[$i] = \chr($q >> 8);
+                    $bytes[1 + $i] = \chr($q & 0xFF);
+                } else {
+                    $bytes[$i] = \chr(intdiv($d += $r, 10));
+                }
+                $r = $d % 10;
+            }
+
+            $digits .= (string) $r;
+        }
+
+        return strrev($digits);
+    }
+
+    public static function binaryAdd(string $a, string $b): string
+    {
+        $sum = 0;
+        for ($i = 7; 0 <= $i; --$i) {
+            $sum += \ord($a[$i]) + \ord($b[$i]);
+            $a[$i] = \chr($sum & 0xFF);
+            $sum >>= 8;
+        }
+
+        return $a;
+    }
+}

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -117,7 +117,7 @@ class UuidTest extends TestCase
         $uuid = new Uuid(self::A_UUID_V1);
 
         $this->assertSame(Uuid::VARIANT_DCE, $uuid->getVariant());
-        $this->assertSame(1583245966, $uuid->getTime());
+        $this->assertSame(1583245966.746458, $uuid->getTime());
         $this->assertSame('3499710062d0', $uuid->getMac());
         $this->assertSame(self::A_UUID_V1, (string) $uuid);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

A UUID timestamp contains 60bit of data, but a timestamp barely contains 31bit.
Let's return a float instead.