### PR TITLE
[Uid] make `Uuid::equals()` accept any types of argument for more flexibility

### DIFF
--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -94,6 +94,22 @@ class UuidTest extends TestCase
         $this->assertFalse($uuid1->equals($uuid2));
     }
 
+    /**
+     * @dataProvider provideInvalidEqualType
+     */
+    public function testEqualsAgainstOtherType($other)
+    {
+        $this->assertFalse((new Uuid(self::A_UUID_V4))->equals($other));
+    }
+
+    public function provideInvalidEqualType()
+    {
+        yield [null];
+        yield [self::A_UUID_V1];
+        yield [self::A_UUID_V4];
+        yield [new \stdClass()];
+    }
+
     public function testCompare()
     {
         $uuids = [];

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -42,7 +42,7 @@ class Uuid implements \JsonSerializable
             throw new \InvalidArgumentException(sprintf('Invalid UUID: "%s".', $uuid));
         }
 
-        $this->uuid = $uuid;
+        $this->uuid = strtr($uuid, 'ABCDEF', 'abcdef');
     }
 
     public static function v1(): self
@@ -85,8 +85,15 @@ class Uuid implements \JsonSerializable
         return uuid_is_null($this->uuid);
     }
 
-    public function equals(self $other): bool
+    /**
+     * Returns whether the argument is of class Uuid and contains the same value as the current instance.
+     */
+    public function equals($other): bool
     {
+        if (!$other instanceof self) {
+            return false;
+        }
+
         return 0 === uuid_compare($this->uuid, $other->uuid);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

I suggest to weaken the `Uuid:equals` method argument type to accept any types of value to compare against. This makes one able to compare the `Uuid` instance with any values.
