### PR TITLE
[DomCrawler] compare CrawlerSelector constraints against all matches

### DIFF
--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorAttributeValueSame.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorAttributeValueSame.php
@@ -47,12 +47,13 @@ final class CrawlerSelectorAttributeValueSame extends Constraint
             return false;
         }
 
-        foreach($crawler->getIterator() as $node){
+        foreach ($crawler->getIterator() as $node) {
             $attrValue = $node->hasAttribute($this->attribute) ? trim($node->getAttribute($this->attribute)) : null;
-            if ($this->expectedText === $attrValue){
+            if ($this->expectedText === $attrValue) {
                 return true;
             }
         }
+
         return false;
     }
 

--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorAttributeValueSame.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorAttributeValueSame.php
@@ -47,7 +47,13 @@ final class CrawlerSelectorAttributeValueSame extends Constraint
             return false;
         }
 
-        return $this->expectedText === trim($crawler->attr($this->attribute));
+        foreach($crawler->getIterator() as $node){
+            $attrValue = $node->hasAttribute($this->attribute) ? trim($node->getAttribute($this->attribute)) : null;
+            if ($this->expectedText === $attrValue){
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextContains.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextContains.php
@@ -45,11 +45,12 @@ final class CrawlerSelectorTextContains extends Constraint
             return false;
         }
 
-        foreach($crawler->getIterator() as $node){
-            if(false !== mb_strpos($node->nodeValue, $this->expectedText)) {
+        foreach ($crawler->getIterator() as $node) {
+            if (false !== mb_strpos($node->nodeValue, $this->expectedText)) {
                 return true;
             }
         }
+
         return false;
     }
 

--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextContains.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextContains.php
@@ -45,7 +45,12 @@ final class CrawlerSelectorTextContains extends Constraint
             return false;
         }
 
-        return false !== mb_strpos($crawler->text(null, false), $this->expectedText);
+        foreach($crawler->getIterator() as $node){
+            if(false !== mb_strpos($node->nodeValue, $this->expectedText)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextSame.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextSame.php
@@ -45,11 +45,12 @@ final class CrawlerSelectorTextSame extends Constraint
             return false;
         }
 
-        foreach($crawler->getIterator() as $node){
-            if($this->expectedText === trim($node->nodeValue)) {
+        foreach ($crawler->getIterator() as $node) {
+            if ($this->expectedText === trim($node->nodeValue)) {
                 return true;
             }
         }
+
         return false;
     }
 

--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextSame.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextSame.php
@@ -45,7 +45,12 @@ final class CrawlerSelectorTextSame extends Constraint
             return false;
         }
 
-        return $this->expectedText === trim($crawler->text(null, false));
+        foreach($crawler->getIterator() as $node){
+            if($this->expectedText === trim($node->nodeValue)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorAttributeValueSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorAttributeValueSameTest.php
@@ -24,7 +24,7 @@ class CrawlerSelectorAttributeValueSameTest extends TestCase
         $constraint = new CrawlerSelectorAttributeValueSame('input[name^="username"]', 'value', 'Fabien');
         $this->assertTrue($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username1" value="Fabien"><input type="text" name="username2" value="Kim">'), '', true));
         $this->assertTrue($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username1" value="Kim"><input type="text" name="username2" value="Fabien">'), '', true));
-        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
+        $this->assertFalse($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username1" value="Kim"><input type="text" name="username2" value="Jean">'), '', true));
 
         try {
             $constraint->evaluate(new Crawler('<html><head><title>Bar'));

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorAttributeValueSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorAttributeValueSameTest.php
@@ -21,14 +21,15 @@ class CrawlerSelectorAttributeValueSameTest extends TestCase
 {
     public function testConstraint(): void
     {
-        $constraint = new CrawlerSelectorAttributeValueSame('input[name="username"]', 'value', 'Fabien');
-        $this->assertTrue($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username" value="Fabien">'), '', true));
+        $constraint = new CrawlerSelectorAttributeValueSame('input[name^="username"]', 'value', 'Fabien');
+        $this->assertTrue($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username1" value="Fabien"><input type="text" name="username2" value="Kim">'), '', true));
+        $this->assertTrue($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username1" value="Kim"><input type="text" name="username2" value="Fabien">'), '', true));
         $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
 
         try {
             $constraint->evaluate(new Crawler('<html><head><title>Bar'));
         } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Crawler has a node matching selector \"input[name=\"username\"]\" with attribute \"value\" of value \"Fabien\".\n", TestFailure::exceptionToString($e));
+            $this->assertEquals("Failed asserting that the Crawler has a node matching selector \"input[name^=\"username\"]\" with attribute \"value\" of value \"Fabien\".\n", TestFailure::exceptionToString($e));
 
             return;
         }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
@@ -21,14 +21,15 @@ class CrawlerSelectorTextContainsTest extends TestCase
 {
     public function testConstraint(): void
     {
-        $constraint = new CrawlerSelectorTextContains('title', 'Foo');
-        $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>Foobar'), '', true));
+        $constraint = new CrawlerSelectorTextContains('table td', 'Foo');
+        $this->assertTrue($constraint->evaluate(new Crawler('<html><body><table><tr><td>Bar</td></tr><tr><td>Foobar</td></tr>'), '', true));
+        $this->assertTrue($constraint->evaluate(new Crawler('<html><body><table><tr><td>Foobar</td></tr><tr><td>Bar</td></tr>'), '', true));
         $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
 
         try {
             $constraint->evaluate(new Crawler('<html><head><title>Bar'));
         } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Crawler has a node matching selector \"title\" with content containing \"Foo\".\n", TestFailure::exceptionToString($e));
+            $this->assertEquals("Failed asserting that the Crawler has a node matching selector \"table td\" with content containing \"Foo\".\n", TestFailure::exceptionToString($e));
 
             return;
         }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
@@ -24,7 +24,7 @@ class CrawlerSelectorTextContainsTest extends TestCase
         $constraint = new CrawlerSelectorTextContains('table td', 'Foo');
         $this->assertTrue($constraint->evaluate(new Crawler('<html><body><table><tr><td>Bar</td></tr><tr><td>Foobar</td></tr>'), '', true));
         $this->assertTrue($constraint->evaluate(new Crawler('<html><body><table><tr><td>Foobar</td></tr><tr><td>Bar</td></tr>'), '', true));
-        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
+        $this->assertFalse($constraint->evaluate(new Crawler('<html><body><table><tr><td>Fuubar</td></tr><tr><td>Bar</td></tr>'), '', true));
 
         try {
             $constraint->evaluate(new Crawler('<html><head><title>Bar'));

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextSameTest.php
@@ -24,7 +24,7 @@ class CrawlerSelectorTextSameTest extends TestCase
         $constraint = new CrawlerSelectorTextSame('table td', 'Foo');
         $this->assertTrue($constraint->evaluate(new Crawler('<html><body><table><tr><td>Foo</td></tr><tr><td>Foobar</td></tr>'), '', true));
         $this->assertTrue($constraint->evaluate(new Crawler('<html><body><table><tr><td>Foobar</td></tr><tr><td>Foo</td></tr>'), '', true));
-        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
+        $this->assertFalse($constraint->evaluate(new Crawler('<html><body><table><tr><td>Foobar</td></tr><tr><td>Bar</td></tr>'), '', true));
 
         try {
             $constraint->evaluate(new Crawler('<html><head><title>Bar'));

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextSameTest.php
@@ -21,14 +21,15 @@ class CrawlerSelectorTextSameTest extends TestCase
 {
     public function testConstraint(): void
     {
-        $constraint = new CrawlerSelectorTextSame('title', 'Foo');
-        $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>Foo'), '', true));
+        $constraint = new CrawlerSelectorTextSame('table td', 'Foo');
+        $this->assertTrue($constraint->evaluate(new Crawler('<html><body><table><tr><td>Foo</td></tr><tr><td>Foobar</td></tr>'), '', true));
+        $this->assertTrue($constraint->evaluate(new Crawler('<html><body><table><tr><td>Foobar</td></tr><tr><td>Foo</td></tr>'), '', true));
         $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
 
         try {
             $constraint->evaluate(new Crawler('<html><head><title>Bar'));
         } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Crawler has a node matching selector \"title\" with content \"Foo\".\n", TestFailure::exceptionToString($e));
+            $this->assertEquals("Failed asserting that the Crawler has a node matching selector \"table td\" with content \"Foo\".\n", TestFailure::exceptionToString($e));
 
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4+
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

The Symfony [documentation](https://symfony.com/doc/current/testing.html) explains that...

>  To assert that the phrase "Hello World" is present in the page's main title, you can use this assertion:

`$this->assertSelectorTextContains('html h1.title', 'Hello World');`

> Using native PHPUnit methods, the same assertion would look like this:

`
$this->assertGreaterThan(
    0,
    $crawler->filter('html h1.title:contains("Hello World")')->count()
);
`

**..this is ONLY true if the selector has only one match.**

This pull requests changes the constraint behaviour to compare all matches against the provided criteria. If this is not the desired behaviour, please fix the documentation.
