### PR TITLE
[Uid] add AbstractUid and interop with base-58/32/RFC4122 encodings

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Uid;
+
+/**
+ * @experimental in 5.1
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+abstract class AbstractUid implements \JsonSerializable
+{
+    /**
+     * The identifier in its canonic representation.
+     */
+    protected $uid;
+
+    /**
+     * Whether the passed value is valid for the constructor of the current class.
+     */
+    abstract public static function isValid(string $uid): bool;
+
+    /**
+     * Creates an AbstractUid from an identifier represented in any of the supported formats.
+     *
+     * @return static
+     *
+     * @throws \InvalidArgumentException When the passed value is not valid
+     */
+    abstract public static function fromString(string $uid): self;
+
+    /**
+     * Returns the identifier as a raw binary string.
+     */
+    abstract public function toBinary(): string;
+
+    /**
+     * Returns the identifier as a base-58 case sensitive string.
+     */
+    public function toBase58(): string
+    {
+        return strtr(sprintf('%022s', BinaryUtil::toBase($this->toBinary(), BinaryUtil::BASE58)), '0', '1');
+    }
+
+    /**
+     * Returns the identifier as a base-32 case insensitive string.
+     */
+    public function toBase32(): string
+    {
+        $uid = bin2hex($this->toBinary());
+        $uid = sprintf('%02s%04s%04s%04s%04s%04s%04s',
+            base_convert(substr($uid, 0, 2), 16, 32),
+            base_convert(substr($uid, 2, 5), 16, 32),
+            base_convert(substr($uid, 7, 5), 16, 32),
+            base_convert(substr($uid, 12, 5), 16, 32),
+            base_convert(substr($uid, 17, 5), 16, 32),
+            base_convert(substr($uid, 22, 5), 16, 32),
+            base_convert(substr($uid, 27, 5), 16, 32)
+        );
+
+        return strtr($uid, 'abcdefghijklmnopqrstuv', 'ABCDEFGHJKMNPQRSTVWXYZ');
+    }
+
+    /**
+     * Returns the identifier as a RFC4122 case insensitive string.
+     */
+    public function toRfc4122(): string
+    {
+        return uuid_unparse($this->toBinary());
+    }
+
+    /**
+     * Returns whether the argument is an AbstractUid and contains the same value as the current instance.
+     */
+    public function equals($other): bool
+    {
+        if (!$other instanceof self) {
+            return false;
+        }
+
+        return $this->uid === $other->uid;
+    }
+
+    public function compare(self $other): int
+    {
+        return (\strlen($this->uid) - \strlen($other->uid)) ?: ($this->uid <=> $other->uid);
+    }
+
+    public function __toString(): string
+    {
+        return $this->uid;
+    }
+
+    public function jsonSerialize(): string
+    {
+        return $this->uid;
+    }
+}

--- a/src/Symfony/Component/Uid/BinaryUtil.php
+++ b/src/Symfony/Component/Uid/BinaryUtil.php
@@ -23,6 +23,19 @@ class BinaryUtil
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
     ];
 
+    public const BASE58 = [
+        '' => '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz',
+        1 => 0, 1, 2, 3, 4, 5, 6, 7, 8, 'A' => 9,
+        'B' => 10, 'C' => 11, 'D' => 12, 'E' => 13, 'F' => 14, 'G' => 15,
+        'H' => 16, 'J' => 17, 'K' => 18, 'L' => 19, 'M' => 20, 'N' => 21,
+        'P' => 22, 'Q' => 23, 'R' => 24, 'S' => 25, 'T' => 26, 'U' => 27,
+        'V' => 28, 'W' => 29, 'X' => 30, 'Y' => 31, 'Z' => 32, 'a' => 33,
+        'b' => 34, 'c' => 35, 'd' => 36, 'e' => 37, 'f' => 38, 'g' => 39,
+        'h' => 40, 'i' => 41, 'j' => 42, 'k' => 43, 'm' => 44, 'n' => 45,
+        'o' => 46, 'p' => 47, 'q' => 48, 'r' => 49, 's' => 50, 't' => 51,
+        'u' => 52, 'v' => 53, 'w' => 54, 'x' => 55, 'y' => 56, 'z' => 57,
+    ];
+
     public static function toBase(string $bytes, array $map): string
     {
         $base = \strlen($alphabet = $map['']);

--- a/src/Symfony/Component/Uid/NilUuid.php
+++ b/src/Symfony/Component/Uid/NilUuid.php
@@ -22,6 +22,6 @@ class NilUuid extends Uuid
 
     public function __construct()
     {
-        $this->uuid = '00000000-0000-0000-0000-000000000000';
+        $this->uid = '00000000-0000-0000-0000-000000000000';
     }
 }

--- a/src/Symfony/Component/Uid/Tests/UlidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UlidTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Tests\Component\Uid;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\UuidV4;
 
 class UlidTest extends TestCase
 {
@@ -47,6 +48,28 @@ class UlidTest extends TestCase
         $this->assertSame('7fffffffffffffffffffffffffffffff', bin2hex($ulid->toBinary()));
 
         $this->assertTrue($ulid->equals(Ulid::fromString(hex2bin('7fffffffffffffffffffffffffffffff'))));
+    }
+
+    public function testFromUuid()
+    {
+        $uuid = new UuidV4();
+
+        $ulid = Ulid::fromString($uuid);
+
+        $this->assertSame($uuid->toBase32(), (string) $ulid);
+        $this->assertSame($ulid->toBase32(), (string) $ulid);
+        $this->assertSame((string) $uuid, $ulid->toRfc4122());
+        $this->assertTrue($ulid->equals(Ulid::fromString($uuid)));
+    }
+
+    public function testBase58()
+    {
+        $ulid = new Ulid('00000000000000000000000000');
+        $this->assertSame('1111111111111111111111', $ulid->toBase58());
+
+        $ulid = Ulid::fromString("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF");
+        $this->assertSame('YcVfxkQb6JRzqk5kF2tNLv', $ulid->toBase58());
+        $this->assertTrue($ulid->equals(Ulid::fromString('YcVfxkQb6JRzqk5kF2tNLv')));
     }
 
     /**

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Tests\Component\Uid;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\NilUuid;
+use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Uid\UuidV1;
 use Symfony\Component\Uid\UuidV3;
@@ -93,6 +94,26 @@ class UuidTest extends TestCase
 
         $this->assertInstanceOf(UuidV4::class, $uuid);
         $this->assertSame(self::A_UUID_V4, (string) $uuid);
+    }
+
+    public function testFromUlid()
+    {
+        $ulid = new Ulid();
+        $uuid = Uuid::fromString($ulid);
+
+        $this->assertSame((string) $ulid, $uuid->toBase32());
+        $this->assertSame((string) $uuid, $uuid->toRfc4122());
+        $this->assertTrue($uuid->equals(Uuid::fromString($ulid)));
+    }
+
+    public function testBase58()
+    {
+        $uuid = new NilUuid();
+        $this->assertSame('1111111111111111111111', $uuid->toBase58());
+
+        $uuid = Uuid::fromString("\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF");
+        $this->assertSame('YcVfxkQb6JRzqk5kF2tNLv', $uuid->toBase58());
+        $this->assertTrue($uuid->equals(Uuid::fromString('YcVfxkQb6JRzqk5kF2tNLv')));
     }
 
     public function testIsValid()

--- a/src/Symfony/Component/Uid/UuidV1.php
+++ b/src/Symfony/Component/Uid/UuidV1.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Uid;
 
 /**
- * A v1 UUID contains a 60-bit timestamp and 63 extra unique bits.
+ * A v1 UUID contains a 60-bit timestamp and 62 extra unique bits.
  *
  * @experimental in 5.1
  *
@@ -31,7 +31,7 @@ class UuidV1 extends Uuid
     public function __construct(string $uuid = null)
     {
         if (null === $uuid) {
-            $this->uuid = uuid_create(static::TYPE);
+            $this->uid = uuid_create(static::TYPE);
         } else {
             parent::__construct($uuid);
         }
@@ -39,7 +39,7 @@ class UuidV1 extends Uuid
 
     public function getTime(): float
     {
-        $time = '0'.substr($this->uuid, 15, 3).substr($this->uuid, 9, 4).substr($this->uuid, 0, 8);
+        $time = '0'.substr($this->uid, 15, 3).substr($this->uid, 9, 4).substr($this->uid, 0, 8);
 
         if (\PHP_INT_SIZE >= 8) {
             return (hexdec($time) - self::TIME_OFFSET_INT) / 10000000;
@@ -54,6 +54,6 @@ class UuidV1 extends Uuid
 
     public function getNode(): string
     {
-        return uuid_mac($this->uuid);
+        return uuid_mac($this->uid);
     }
 }

--- a/src/Symfony/Component/Uid/UuidV4.php
+++ b/src/Symfony/Component/Uid/UuidV4.php
@@ -30,7 +30,7 @@ class UuidV4 extends Uuid
             $uuid[8] = $uuid[8] & "\x3F" | "\x80";
             $uuid = bin2hex($uuid);
 
-            $this->uuid = substr($uuid, 0, 8).'-'.substr($uuid, 8, 4).'-'.substr($uuid, 12, 4).'-'.substr($uuid, 16, 4).'-'.substr($uuid, 20, 12);
+            $this->uid = substr($uuid, 0, 8).'-'.substr($uuid, 8, 4).'-'.substr($uuid, 12, 4).'-'.substr($uuid, 16, 4).'-'.substr($uuid, 20, 12);
         } else {
             parent::__construct($uuid);
         }

--- a/src/Symfony/Component/Uid/UuidV6.php
+++ b/src/Symfony/Component/Uid/UuidV6.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Uid;
 
 /**
- * A v6 UUID is lexicographically sortable and contains a 60-bit timestamp and 63 extra unique bits.
+ * A v6 UUID is lexicographically sortable and contains a 60-bit timestamp and 62 extra unique bits.
  *
  * @experimental in 5.1
  *
@@ -32,7 +32,7 @@ class UuidV6 extends Uuid
     {
         if (null === $uuid) {
             $uuid = uuid_create(UUID_TYPE_TIME);
-            $this->uuid = substr($uuid, 15, 3).substr($uuid, 9, 4).$uuid[0].'-'.substr($uuid, 1, 4).'-6'.substr($uuid, 5, 3).substr($uuid, 18);
+            $this->uid = substr($uuid, 15, 3).substr($uuid, 9, 4).$uuid[0].'-'.substr($uuid, 1, 4).'-6'.substr($uuid, 5, 3).substr($uuid, 18);
         } else {
             parent::__construct($uuid);
         }
@@ -40,7 +40,7 @@ class UuidV6 extends Uuid
 
     public function getTime(): float
     {
-        $time = '0'.substr($this->uuid, 0, 8).substr($this->uuid, 9, 4).substr($this->uuid, 15, 3);
+        $time = '0'.substr($this->uid, 0, 8).substr($this->uid, 9, 4).substr($this->uid, 15, 3);
 
         if (\PHP_INT_SIZE >= 8) {
             return (hexdec($time) - self::TIME_OFFSET_INT) / 10000000;
@@ -55,6 +55,6 @@ class UuidV6 extends Uuid
 
     public function getNode(): string
     {
-        return substr($this->uuid, 24);
+        return substr($this->uid, 24);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR provides a base `AbstractUid` class that is shared by `Uuid` and `Ulid`.

It adds new methods that provide interoperability between all types of UIDs but also between different encodings of UIDs:
- `toBase58()` using the [bitcoin alphabet](https://en.wikipedia.org/wiki/Base58) - that's 22 chars aka "short-ids" - case sensitive
- `toBase32()` using [Crockford's alphabet](https://www.crockford.com/base32.html) - 26 chars ids - case insensitive
- `toRfc4122()` to represent as a UUID-formatted string - 36 chars

This adds to `toBinary()` and to `fromString()`, the latter being able to cope with any of the 4 representations to create any kind of UIDs.