### PR TITLE
[Uid] Add support for UUIDv6

### DIFF
--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Uid\UuidV1;
 use Symfony\Component\Uid\UuidV3;
 use Symfony\Component\Uid\UuidV4;
 use Symfony\Component\Uid\UuidV5;
+use Symfony\Component\Uid\UuidV6;
 
 class UuidTest extends TestCase
 {
@@ -71,6 +72,18 @@ class UuidTest extends TestCase
         $uuid = Uuid::v5(new UuidV4(self::A_UUID_V4), 'the name');
 
         $this->assertInstanceOf(UuidV5::class, $uuid);
+    }
+
+    public function testV6()
+    {
+        $uuid = Uuid::v6();
+
+        $this->assertInstanceOf(UuidV6::class, $uuid);
+
+        $uuid = new UuidV6(substr_replace(self::A_UUID_V1, '6', 14, 1));
+
+        $this->assertSame(85916308548.27832, $uuid->getTime());
+        $this->assertSame('3499710062d0', $uuid->getNode());
     }
 
     public function testBinary()

--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Uid;
 
 /**
+ * A ULID is lexicographically sortable and contains a 48-bit timestamp and 80-bit of crypto-random entropy.
+ *
  * @see https://github.com/ulid/spec
  *
  * @experimental in 5.1

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -49,6 +49,7 @@ class Uuid implements \JsonSerializable
             case UuidV3::TYPE: return new UuidV3($uuid);
             case UuidV4::TYPE: return new UuidV4($uuid);
             case UuidV5::TYPE: return new UuidV5($uuid);
+            case UuidV6::TYPE: return new UuidV6($uuid);
             case NullUuid::TYPE: return new NullUuid();
             case self::TYPE: return new self($uuid);
         }
@@ -74,6 +75,11 @@ class Uuid implements \JsonSerializable
     final public static function v5(self $namespace, string $name): UuidV5
     {
         return new UuidV5(uuid_generate_sha1($namespace->uuid, $name));
+    }
+
+    final public static function v6(): UuidV6
+    {
+        return new UuidV6();
     }
 
     public static function isValid(string $uuid): bool

--- a/src/Symfony/Component/Uid/UuidV6.php
+++ b/src/Symfony/Component/Uid/UuidV6.php
@@ -12,15 +12,15 @@
 namespace Symfony\Component\Uid;
 
 /**
- * A v1 UUID contains a 60-bit timestamp and 63 extra unique bits.
+ * A v6 UUID is lexicographically sortable and contains a 60-bit timestamp and 63 extra unique bits.
  *
  * @experimental in 5.1
  *
- * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ * @author Nicolas Grekas <p@tchwork.com>
  */
-class UuidV1 extends Uuid
+class UuidV6 extends Uuid
 {
-    protected const TYPE = UUID_TYPE_TIME;
+    protected const TYPE = 6;
 
     // https://tools.ietf.org/html/rfc4122#section-4.1.4
     // 0x01b21dd213814000 is the number of 100-ns intervals between the
@@ -31,7 +31,8 @@ class UuidV1 extends Uuid
     public function __construct(string $uuid = null)
     {
         if (null === $uuid) {
-            $this->uuid = uuid_create(static::TYPE);
+            $uuid = uuid_create(UUID_TYPE_TIME);
+            $this->uuid = substr($uuid, 15, 3).substr($uuid, 9, 4).$uuid[0].'-'.substr($uuid, 1, 4).'-6'.substr($uuid, 5, 3).substr($uuid, 18);
         } else {
             parent::__construct($uuid);
         }
@@ -39,7 +40,7 @@ class UuidV1 extends Uuid
 
     public function getTime(): float
     {
-        $time = '0'.substr($this->uuid, 15, 3).substr($this->uuid, 9, 4).substr($this->uuid, 0, 8);
+        $time = '0'.substr($this->uuid, 0, 8).substr($this->uuid, 9, 4).substr($this->uuid, 15, 3);
 
         if (\PHP_INT_SIZE >= 8) {
             return (hexdec($time) - self::TIME_OFFSET_INT) / 10000000;
@@ -54,6 +55,6 @@ class UuidV1 extends Uuid
 
     public function getNode(): string
     {
-        return uuid_mac($this->uuid);
+        return substr($this->uuid, 24);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

See https://github.com/uuid6/uuid6-ietf-draft/blob/master/draft-peabody-dispatch-new-uuid-format-00.txt

A v6 UUID is a lexicographically-sortable-v1.
This makes it db-index friendly (same as ULIDs).

For reference:
- v1 has no benefits over v6 except being in the current official RFC
- v6 is order-friendly and leaks time data + stable entropy (potentially bound to a MAC address or equivalent)
- ULID is also order-friendly and leaks time data, with high entropy (crypto random source)
- v4 is pure crypto random source, aka no order and no leak of anything.

