### PR TITLE
[Uid] work around slow generation of v4 UUIDs

### DIFF
--- a/src/Symfony/Component/Uid/UuidV4.php
+++ b/src/Symfony/Component/Uid/UuidV4.php
@@ -25,7 +25,12 @@ class UuidV4 extends Uuid
     public function __construct(string $uuid = null)
     {
         if (null === $uuid) {
-            $this->uuid = uuid_create(static::TYPE);
+            $uuid = random_bytes(16);
+            $uuid[6] = $uuid[6] & "\x0F" | "\x4F";
+            $uuid[8] = $uuid[8] & "\x3F" | "\x80";
+            $uuid = bin2hex($uuid);
+
+            $this->uuid = substr($uuid, 0, 8).'-'.substr($uuid, 8, 4).'-'.substr($uuid, 12, 4).'-'.substr($uuid, 16, 4).'-'.substr($uuid, 20, 12);
         } else {
             parent::__construct($uuid);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This is more than 4 times faster than `uuid_create()` for v4.
As described in https://jolicode.com/blog/uuid-generation-in-php