### PR TITLE
[Framework-Bundle] fixed kernel.secret not being overridden when loaded from extension using MicroKernelTrait

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -88,6 +88,7 @@ trait MicroKernelTrait
     {
         $loader->load(function (ContainerBuilder $container) use ($loader) {
             $container->loadFromExtension('framework', [
+                'secret' => '%env(APP_SECRET)%',
                 'router' => [
                     'resource' => 'kernel::loadRoutes',
                     'type' => 'service',
@@ -108,7 +109,6 @@ trait MicroKernelTrait
 
             $container->addObjectResource($this);
             $container->fileExists($this->getProjectDir().'/config/bundles.php');
-            $container->setParameter('kernel.secret', '%env(APP_SECRET)%');
 
             try {
                 $this->configureContainer($container, $loader);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/MicroKernelTraitTest.php
@@ -69,4 +69,12 @@ class MicroKernelTraitTest extends TestCase
 
         $this->assertEquals('Have a great day!', $response->getContent());
     }
+
+    public function testSecretLoadedFromExtension()
+    {
+        $kernel = new ConcreteMicroKernel('test', false);
+        $kernel->boot();
+
+        self::assertSame('$ecret', $kernel->getContainer()->getParameter('kernel.secret'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

Previously, when extending `Kernel::class` and using the `MicroKernelTrait::class` setting the `secret` like
```
protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
    {
        $container->loadFromExtension('framework', [ 'secret' => 'foo',]);
```
would not replace the `kernel.secret` parameter set by `$container->setParameter('kernel.secret', '%env(APP_SECRET)%');`  in the `MicroKernelTrait`.

Initiating a service with a secret argument without a `APP_ENV` value set in `.env` would throw:
`Symfony\Component\DependencyInjection\Exception\EnvNotFoundException : Environment variable not found: "APP_SECRET".` 

This PR allows the `kernel.secret`  set in the `MicroKernelTrait::registerContainerConfiguration()` to be overridden in a class extending `Kernel` while using the trait.

Thanks @nicolas-grekas for the help on this one. 
