### PR TITLE
[Uid] add autowirable UidFactory

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -124,6 +124,7 @@ use Symfony\Component\String\LazyString;
 use Symfony\Component\String\Slugger\SluggerInterface;
 use Symfony\Component\Translation\Command\XliffLintCommand as BaseXliffLintCommand;
 use Symfony\Component\Translation\Translator;
+use Symfony\Component\Uid\UidFactory;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Mapping\Loader\PropertyInfoLoader;
 use Symfony\Component\Validator\ObjectInitializerInterface;
@@ -174,6 +175,11 @@ class FrameworkExtension extends Extension
 
         if (interface_exists(PsrEventDispatcherInterface::class)) {
             $container->setAlias(PsrEventDispatcherInterface::class, 'event_dispatcher');
+        }
+
+        if (!class_exists(UidFactory::class)) {
+            $container->getDefinition('uid.factory')
+                ->addError('You cannot use the "uid.factory" service since the Uid component is not installed. Try running "composer require symfony/uid".');
         }
 
         $container->registerAliasForArgument('parameter_bag', PsrContainerInterface::class);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -144,5 +144,8 @@
             <factory class="Symfony\Component\String\LazyString" method="fromCallable" />
             <argument type="service" id="container.getenv" />
         </service>
+
+        <service id="uid.factory" class="Symfony\Component\Uid\UidFactory" />
+        <service id="Symfony\Component\Uid\UidFactory" alias="uid.factory" />
     </services>
 </container>

--- a/src/Symfony/Component/Uid/Tests/UidFactoryTest.php
+++ b/src/Symfony/Component/Uid/Tests/UidFactoryTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Uid;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\UidFactory;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\UuidV1;
+use Symfony\Component\Uid\UuidV3;
+use Symfony\Component\Uid\UuidV4;
+use Symfony\Component\Uid\UuidV5;
+use Symfony\Component\Uid\UuidV6;
+
+class UidFactoryTest extends TestCase
+{
+    public function testDefaults()
+    {
+        $factory = new UidFactory();
+
+        $this->assertInstanceOf(Ulid::class, $factory->ulid());
+        $this->assertInstanceOf(UuidV1::class, $factory->uuidV1());
+        $this->assertInstanceOf(UuidV3::class, $factory->uuidV3($factory->uuidV1(), 'foo'));
+        $this->assertInstanceOf(UuidV4::class, $factory->uuidV4());
+        $this->assertInstanceOf(UuidV5::class, $factory->uuidV5($factory->uuidV1(), 'foo'));
+        $this->assertInstanceOf(UuidV6::class, $factory->uuidV6());
+    }
+
+    public function testV1()
+    {
+        $v1 = 'caa9884e-105e-11b6-8101-010101010101';
+        $entropySource = function (int $bytes) use (&$called) {
+            $this->assertSame(8, $bytes);
+
+            return "\1\1\1\1\1\1\1\1";
+        };
+        $factory = new UidFactory($entropySource);
+        $uuid = (string) $factory->uuidV1();
+        $this->assertSame('-8101-010101010101', substr($uuid, -18));
+        $this->assertNotSame($v1, $uuid);
+
+        $timeSource = function () {
+            return '1111111112345678';
+        };
+        $factory = new UidFactory(null, $timeSource);
+        $uuid = (string) $factory->uuidV1();
+        $this->assertSame('caa9884e-105e-11b6', substr($uuid, 0, 18));
+        $this->assertNotSame($v1, $uuid);
+
+        $factory = new UidFactory($entropySource, $timeSource);
+        $this->assertSame($v1, (string) $factory->uuidV1());
+    }
+
+    public function testV6()
+    {
+        $v6 = '1b6105ec-aa98-684e-8102-030405060708';
+        $entropySource = function (int $bytes) use (&$called) {
+            $this->assertSame(8, $bytes);
+
+            return "\1\2\3\4\5\6\7\x08";
+        };
+        $factory = new UidFactory($entropySource);
+        $uuid = (string) $factory->uuidV6();
+        $this->assertSame('-8102-030405060708', substr($uuid, -18));
+        $this->assertNotSame($v6, $uuid);
+
+        $timeSource = function () {
+            return '1111111112345678';
+        };
+        $factory = new UidFactory(null, $timeSource);
+        $uuid = (string) $factory->uuidV6();
+        $this->assertSame('1b6105ec-aa98-684e', substr($uuid, 0, 18));
+        $this->assertNotSame($v6, $uuid);
+
+        $factory = new UidFactory($entropySource, $timeSource);
+        $this->assertSame($v6, (string) $factory->uuidV6());
+    }
+
+    public function testUlid()
+    {
+        $randomSource = function (int $bytes) use (&$called) {
+            $this->assertSame(10, $bytes);
+
+            return "\0\1\2\3\4\5\6\7\x08\0";
+        };
+        $timeSource = function () {
+            return '1111111111112345678';
+        };
+        $factory = new UidFactory(null, $timeSource, $randomSource);
+
+        $this->assertSame('351R94XWJ20001G0G3010501G7', (string) $factory->ulid());
+        $this->assertSame('351R94XWJ20001G0G3010501G8', (string) $factory->ulid());
+
+        $timeSource = function () {
+            return '1011111111112345678';
+        };
+        $factory = new UidFactory(null, $timeSource, $randomSource);
+        $this->assertSame('2VYQ1XRMJ20001G0G3010501G9', (string) $factory->ulid());
+    }
+
+    public function testV4()
+    {
+        $randomSource = function (int $bytes) use (&$called) {
+            $this->assertSame(16, $bytes);
+
+            return "\0\1\2\3\4\5\6\7\x08\x70\x60\x50\x40\x30\x20\x10";
+        };
+        $factory = new UidFactory(null, null, $randomSource);
+
+        $this->assertSame('00010203-0405-4607-8870-605040302010', (string) $factory->uuidV4());
+    }
+}

--- a/src/Symfony/Component/Uid/Tests/UlidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UlidTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Tests\Component\Uid;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\UidFactory;
 use Symfony\Component\Uid\Ulid;
-use Symfony\Component\Uid\UuidV4;
 
 class UlidTest extends TestCase
 {
@@ -22,8 +22,8 @@ class UlidTest extends TestCase
      */
     public function testGenerate()
     {
-        $a = new Ulid();
-        $b = new Ulid();
+        $a = (new UidFactory())->ulid();
+        $b = (new UidFactory())->ulid();
 
         $this->assertSame(0, strncmp($a, $b, 20));
         $a = base_convert(strtr(substr($a, -6), 'ABCDEFGHJKMNPQRSTVWXYZ', 'abcdefghijklmnopqrstuv'), 32, 10);
@@ -52,7 +52,7 @@ class UlidTest extends TestCase
 
     public function testFromUuid()
     {
-        $uuid = new UuidV4();
+        $uuid = (new UidFactory())->uuidV4();
 
         $ulid = Ulid::fromString($uuid);
 
@@ -78,7 +78,7 @@ class UlidTest extends TestCase
     public function testGetTime()
     {
         $time = microtime(false);
-        $ulid = new Ulid();
+        $ulid = (new UidFactory())->ulid();
         $time = substr($time, 11).substr($time, 1, 4);
 
         $this->assertSame((float) $time, $ulid->getTime());
@@ -92,8 +92,8 @@ class UlidTest extends TestCase
 
     public function testEquals()
     {
-        $a = new Ulid();
-        $b = new Ulid();
+        $a = (new UidFactory())->ulid();
+        $b = (new UidFactory())->ulid();
 
         $this->assertTrue($a->equals($a));
         $this->assertFalse($a->equals($b));
@@ -105,15 +105,15 @@ class UlidTest extends TestCase
      */
     public function testCompare()
     {
-        $a = new Ulid();
-        $b = new Ulid();
+        $a = (new UidFactory())->ulid();
+        $b = (new UidFactory())->ulid();
 
         $this->assertSame(0, $a->compare($a));
         $this->assertLessThan(0, $a->compare($b));
         $this->assertGreaterThan(0, $b->compare($a));
 
         usleep(1001);
-        $c = new Ulid();
+        $c = (new UidFactory())->ulid();
 
         $this->assertLessThan(0, $b->compare($c));
         $this->assertGreaterThan(0, $c->compare($b));

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Tests\Component\Uid;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\NilUuid;
-use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\UidFactory;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Uid\UuidV1;
 use Symfony\Component\Uid\UuidV3;
@@ -44,7 +44,7 @@ class UuidTest extends TestCase
 
     public function testV1()
     {
-        $uuid = Uuid::v1();
+        $uuid = (new UidFactory())->uuidV1();
 
         $this->assertInstanceOf(UuidV1::class, $uuid);
 
@@ -56,28 +56,28 @@ class UuidTest extends TestCase
 
     public function testV3()
     {
-        $uuid = Uuid::v3(new UuidV4(self::A_UUID_V4), 'the name');
+        $uuid = (new UidFactory())->uuidV3(Uuid::fromString(self::A_UUID_V4), 'the name');
 
         $this->assertInstanceOf(UuidV3::class, $uuid);
     }
 
     public function testV4()
     {
-        $uuid = Uuid::v4();
+        $uuid = (new UidFactory())->uuidV4();
 
         $this->assertInstanceOf(UuidV4::class, $uuid);
     }
 
     public function testV5()
     {
-        $uuid = Uuid::v5(new UuidV4(self::A_UUID_V4), 'the name');
+        $uuid = (new UidFactory())->uuidV5(Uuid::fromString(self::A_UUID_V4), 'the name');
 
         $this->assertInstanceOf(UuidV5::class, $uuid);
     }
 
     public function testV6()
     {
-        $uuid = Uuid::v6();
+        $uuid = (new UidFactory())->uuidV6();
 
         $this->assertInstanceOf(UuidV6::class, $uuid);
 
@@ -98,7 +98,7 @@ class UuidTest extends TestCase
 
     public function testFromUlid()
     {
-        $ulid = new Ulid();
+        $ulid = (new UidFactory())->ulid();
         $uuid = Uuid::fromString($ulid);
 
         $this->assertSame((string) $ulid, $uuid->toBase32());

--- a/src/Symfony/Component/Uid/UidFactory.php
+++ b/src/Symfony/Component/Uid/UidFactory.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Uid;
+
+/**
+ * A factory to create several kind of unique identifiers.
+ *
+ * @experimental in 5.1
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class UidFactory
+{
+    private $entropySource;
+    private $timeSource;
+    private $randomSource;
+
+    public function __construct(callable $entropySource = null, callable $timeSource = null, callable $randomSource = null)
+    {
+        $this->entropySource = $entropySource;
+        $this->timeSource = $timeSource;
+        $this->randomSource = $randomSource;
+    }
+
+    public function ulid(): Ulid
+    {
+        return new Ulid(Ulid::generate($this->timeSource, $this->randomSource));
+    }
+
+    public function uuidV1(): UuidV1
+    {
+        return new UuidV1(UuidV1::generate($this->entropySource, $this->timeSource));
+    }
+
+    public function uuidV3(Uuid $namespace, string $name): UuidV3
+    {
+        return new UuidV3(uuid_generate_md5($namespace, $name));
+    }
+
+    public function uuidV4(): UuidV4
+    {
+        if (!$this->randomSource) {
+            $uuid = random_bytes(16);
+        } elseif (!\is_string($uuid = ($this->randomSource)(16)) || 16 !== \strlen($uuid)) {
+            throw new \LogicException('The random source must return 8 bytes.');
+        }
+
+        $uuid[6] = $uuid[6] & "\x0F" | "\x40";
+        $uuid[8] = $uuid[8] & "\x3F" | "\x80";
+        $uuid = bin2hex($uuid);
+        $uuid = substr($uuid, 0, 8).'-'.substr($uuid, 8, 4).'-'.substr($uuid, 12, 4).'-'.substr($uuid, 16, 4).'-'.substr($uuid, 20, 12);
+
+        return new UuidV4($uuid);
+    }
+
+    public function uuidV5(Uuid $namespace, string $name): UuidV5
+    {
+        return new UuidV5(uuid_generate_sha1($namespace, $name));
+    }
+
+    public function uuidV6(): UuidV6
+    {
+        $uuid = UuidV1::generate($this->entropySource, $this->timeSource);
+        $uuid = substr($uuid, 15, 3).substr($uuid, 9, 4).$uuid[0].'-'.substr($uuid, 1, 4).'-6'.substr($uuid, 5, 3).substr($uuid, 18);
+
+        return new UuidV6($uuid);
+    }
+}

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -67,31 +67,6 @@ class Uuid extends AbstractUid
         return new self($uuid);
     }
 
-    final public static function v1(): UuidV1
-    {
-        return new UuidV1();
-    }
-
-    final public static function v3(self $namespace, string $name): UuidV3
-    {
-        return new UuidV3(uuid_generate_md5($namespace->uid, $name));
-    }
-
-    final public static function v4(): UuidV4
-    {
-        return new UuidV4();
-    }
-
-    final public static function v5(self $namespace, string $name): UuidV5
-    {
-        return new UuidV5(uuid_generate_sha1($namespace->uid, $name));
-    }
-
-    final public static function v6(): UuidV6
-    {
-        return new UuidV6();
-    }
-
     public static function isValid(string $uuid): bool
     {
         if (__CLASS__ === static::class) {

--- a/src/Symfony/Component/Uid/UuidV1.php
+++ b/src/Symfony/Component/Uid/UuidV1.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Uid;
 /**
  * A v1 UUID contains a 60-bit timestamp and 62 extra unique bits.
  *
+ * Use UidFactory::uuidV1() to compute one.
+ *
  * @experimental in 5.1
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
@@ -26,16 +28,8 @@ class UuidV1 extends Uuid
     // 0x01b21dd213814000 is the number of 100-ns intervals between the
     // UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
     private const TIME_OFFSET_INT = 0x01b21dd213814000;
+    private const TIME_OFFSET_BIN = "\x01\xb2\x1d\xd2\x13\x81\x40\x00";
     private const TIME_OFFSET_COM = "\xfe\x4d\xe2\x2d\xec\x7e\xc0\x00";
-
-    public function __construct(string $uuid = null)
-    {
-        if (null === $uuid) {
-            $this->uid = uuid_create(static::TYPE);
-        } else {
-            parent::__construct($uuid);
-        }
-    }
 
     public function getTime(): float
     {
@@ -55,5 +49,45 @@ class UuidV1 extends Uuid
     public function getNode(): string
     {
         return uuid_mac($this->uid);
+    }
+
+    /**
+     * @internal
+     */
+    public static function generate(callable $entropySource = null, callable $timeSource = null): string
+    {
+        if (!$timeSource || !$entropySource) {
+            $uuid = uuid_create(self::TYPE);
+        } else {
+            $uuid = '00000000-0000-0000-0000-000000000000';
+        }
+
+        if ($timeSource) {
+            if (!is_numeric($time = $timeSource()) || 8 > \strlen($time)) {
+                throw new \LogicException('The time source must return the time as a decimal string of tenth of microseconds.');
+            }
+
+            if (\PHP_INT_SIZE >= 8) {
+                $time = str_pad(dechex($time + self::TIME_OFFSET_INT), 16, '0', STR_PAD_LEFT);
+            } else {
+                $time = str_pad(BinaryUtil::fromBase($time, BinaryUtil::BASE10), 8, "\0", STR_PAD_LEFT);
+                $time = BinaryUtil::add($time, self::TIME_OFFSET_BIN);
+                $time = bin2hex($time);
+            }
+
+            $uuid = substr($time, 8).'-'.substr($time, 4, 4).'-1'.substr($time, 1, 3).substr($uuid, 18);
+        }
+
+        if ($entropySource) {
+            if (!\is_string($entropy = $entropySource(8)) || 8 !== \strlen($entropy)) {
+                throw new \LogicException('The entropy source must return 8 bytes.');
+            }
+
+            $entropy[0] = $entropy[0] & "\x3F" | "\x80";
+            $entropy = bin2hex($entropy);
+            $uuid = substr($uuid, 0, 19).substr($entropy, 0, 4).'-'.substr($entropy, 4);
+        }
+
+        return $uuid;
     }
 }

--- a/src/Symfony/Component/Uid/UuidV3.php
+++ b/src/Symfony/Component/Uid/UuidV3.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Uid;
 /**
  * A v3 UUID contains an MD5 hash of another UUID and a name.
  *
- * Use Uuid::v3() to compute one.
+ * Use UidFactory::uuidV3() to compute one.
  *
  * @experimental in 5.1
  *

--- a/src/Symfony/Component/Uid/UuidV4.php
+++ b/src/Symfony/Component/Uid/UuidV4.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Uid;
 /**
  * A v4 UUID contains a 122-bit random number.
  *
+ * Use UidFactory::uuidV4() to compute one.
+ *
  * @experimental in 5.1
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
@@ -21,18 +23,4 @@ namespace Symfony\Component\Uid;
 class UuidV4 extends Uuid
 {
     protected const TYPE = UUID_TYPE_RANDOM;
-
-    public function __construct(string $uuid = null)
-    {
-        if (null === $uuid) {
-            $uuid = random_bytes(16);
-            $uuid[6] = $uuid[6] & "\x0F" | "\x4F";
-            $uuid[8] = $uuid[8] & "\x3F" | "\x80";
-            $uuid = bin2hex($uuid);
-
-            $this->uid = substr($uuid, 0, 8).'-'.substr($uuid, 8, 4).'-'.substr($uuid, 12, 4).'-'.substr($uuid, 16, 4).'-'.substr($uuid, 20, 12);
-        } else {
-            parent::__construct($uuid);
-        }
-    }
 }

--- a/src/Symfony/Component/Uid/UuidV5.php
+++ b/src/Symfony/Component/Uid/UuidV5.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Uid;
 /**
  * A v5 UUID contains a SHA1 hash of another UUID and a name.
  *
- * Use Uuid::v5() to compute one.
+ * Use UidFactory::uuidV5() to compute one.
  *
  * @experimental in 5.1
  *

--- a/src/Symfony/Component/Uid/UuidV6.php
+++ b/src/Symfony/Component/Uid/UuidV6.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Uid;
 /**
  * A v6 UUID is lexicographically sortable and contains a 60-bit timestamp and 62 extra unique bits.
  *
+ * Use UidFactory::uuidV6() to compute one.
+ *
  * @experimental in 5.1
  *
  * @author Nicolas Grekas <p@tchwork.com>
@@ -27,16 +29,6 @@ class UuidV6 extends Uuid
     // UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
     private const TIME_OFFSET_INT = 0x01b21dd213814000;
     private const TIME_OFFSET_COM = "\xfe\x4d\xe2\x2d\xec\x7e\xc0\x00";
-
-    public function __construct(string $uuid = null)
-    {
-        if (null === $uuid) {
-            $uuid = uuid_create(UUID_TYPE_TIME);
-            $this->uid = substr($uuid, 15, 3).substr($uuid, 9, 4).$uuid[0].'-'.substr($uuid, 1, 4).'-6'.substr($uuid, 5, 3).substr($uuid, 18);
-        } else {
-            parent::__construct($uuid);
-        }
-    }
 
     public function getTime(): float
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While reviewing https://github.com/ulid/javascript/, I noticed that they define a way to change the source of random and the source of time, at least for testing purposes. UUIDv1 also has the same concept, as the RFC explains that the "node" part can be sourced from a MAC or from randomness.

This PR introduces the `UidFactory` factory class.
It's meant to be used as a service.
For this reason, this PR also defines a corresponding autowiring alias.

```php
$factory = new UidFactory();

$ulid = $factory->ulid();
$v1 = $factory->uuidV1();
$v3 = $factory->uuidV3($v1, 'foo');
$v4 = $factory->uuidV4();
$v5 = $factory->uuidV5($v1, 'foo'));
$v6 = $factory->uuidV6();
```

This replaces the current static factories and empty constructors.