### PR TITLE
[VarDumper] fix side-effect by not using mt_rand()

### DIFF
--- a/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/VarCloner.php
@@ -48,8 +48,8 @@ class VarCloner extends AbstractCloner
                                         // or null if the original value is used directly
 
         if (!self::$hashMask) {
-            self::$gid = uniqid(mt_rand(), true); // Unique string used to detect the special $GLOBALS variable
             self::initHashMask();
+            self::$gid = md5(dechex(self::$hashMask)); // Unique string used to detect the special $GLOBALS variable
         }
         $gid = self::$gid;
         $hashMask = self::$hashMask;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Reported by @bobthecow on Twitter: using `mt_rand()` breaks inspecting seeded calls to `mt_rand()`.

Should be replaced by a call to `md5(random_bytes(6))` on 4.4.