### PR TITLE
Add get status text method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -476,6 +476,16 @@ class Response
     }
 
     /**
+     * Sets the response status code.
+     *
+     * @final
+     */
+    public function getStatusText(int $code): ?string
+    {
+        return self::$statusTexts[$code] ?? null;
+    }
+
+    /**
      * Sets the response charset.
      *
      * @return $this

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -1033,6 +1033,14 @@ class ResponseTest extends ResponseTestCase
         $this->assertEquals($reasonPhrase, Response::$statusTexts[$code]);
     }
 
+    public function testGetStatusText()
+    {
+        $response = new Response('foo');
+
+        $this->assertSame('Continue', $response->getStatusText(Response::HTTP_CONTINUE));
+        $this->assertNull($response->getStatusText(0));
+    }
+
     public function testSetContentSafe()
     {
         $response = new Response();

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -1037,7 +1037,11 @@ class ResponseTest extends ResponseTestCase
     {
         $response = new Response('foo');
 
-        $this->assertSame('Continue', $response->getStatusText(Response::HTTP_CONTINUE));
+        $this->assertSame(
+            Response::$statusTexts[Response::HTTP_CONTINUE],
+            $response->getStatusText(Response::HTTP_CONTINUE)
+        );
+
         $this->assertNull($response->getStatusText(0));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

This PR adds a simple Comenius way to pull out given `response status codes` within the `HTT Foundation Response` class.

By having this method in the core, we will reduce the noise in userland by accessing the public `status text` contained within this class. Furthermore, we will have an explicit contract to access these values.  
