### PR TITLE
Updated name for BYN and BYR currencies for Latvian language in Intl …

### DIFF
--- a/src/Symfony/Component/Intl/Resources/data/currencies/lv.json
+++ b/src/Symfony/Component/Intl/Resources/data/currencies/lv.json
@@ -107,11 +107,11 @@
         ],
         "BYN": [
             "BYN",
-            "Baltkrievijas rubelis"
+            "Baltkrievijas rublis"
         ],
         "BYR": [
             "BYR",
-            "Baltkrievijas rubelis (2000–2016)"
+            "Baltkrievijas rublis (2000–2016)"
         ],
         "BZD": [
             "BZD",


### PR DESCRIPTION
`Symfony\Component\Intl` component

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Updated currency name in Latvian language, see https://translate.google.com/#view=home&op=translate&sl=en&tl=lv&text=belarussian%20ruble for reference