### PR TITLE
[Mailer] Add a transport that uses php.ini settings for configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_transports.php
@@ -18,6 +18,7 @@ use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunTransportFactory;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
 use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
+use Symfony\Component\Mailer\Transport\NativeTransportFactory;
 use Symfony\Component\Mailer\Transport\NullTransportFactory;
 use Symfony\Component\Mailer\Transport\SendmailTransportFactory;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransportFactory;
@@ -67,5 +68,8 @@ return static function (ContainerConfigurator $container) {
         ->set('mailer.transport_factory.smtp', EsmtpTransportFactory::class)
             ->parent('mailer.transport_factory.abstract')
             ->tag('mailer.transport_factory', ['priority' => -100])
-    ;
+
+        ->set('mailer.transport_factory.native', NativeTransportFactory::class)
+            ->parent('mailer.transport_factory.abstract')
+            ->tag('mailer.transport_factory');
 };

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * added `NativeTransportFactory` to configure a transport based on php.ini settings
+
 4.4.0
 -----
 

--- a/src/Symfony/Component/Mailer/Tests/Transport/NativeTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/NativeTransportFactoryTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Symfony\Component\Mailer\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\NativeTransportFactory;
+use Symfony\Component\Mailer\Transport\SendmailTransport;
+use Symfony\Component\Mailer\Transport\Smtp\SmtpTransport;
+use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+
+final class NativeTransportFactoryTest extends TestCase
+{
+    public static $fakeConfiguration = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $namespace = str_replace('\\Tests\\', '\\', __NAMESPACE__);
+
+        $current = static::class;
+
+        $eval = <<<EOT
+namespace $namespace;
+
+function ini_get(\$key)
+{
+    \$vals = \\$current::\$fakeConfiguration;
+    return \$vals[\$key] ?? '';
+}
+EOT;
+        eval($eval);
+    }
+
+    public function testCreateWithNotSupportedScheme()
+    {
+        $this->expectException(UnsupportedSchemeException::class);
+        $this->expectExceptionMessageRegExp('#The ".*" scheme is not supported#');
+
+        $sut = new NativeTransportFactory();
+        $sut->create(Dsn::fromString('sendmail://default'));
+    }
+
+    public function testCreateSendmailWithNoSendmailPath()
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('This test cannot run on Windows.');
+        }
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('sendmail_path is not configured');
+
+        $sut = new NativeTransportFactory();
+        $sut->create(Dsn::fromString('native://default'));
+    }
+
+    public function provideCreateSendmailWithNoHostOrNoPort(): \Generator
+    {
+        yield ['native://default', '', '', ''];
+        yield ['native://default', '', 'localhost', ''];
+        yield ['native://default', '', '', '25'];
+    }
+
+    /**
+     * @dataProvider provideCreateSendmailWithNoHostOrNoPort
+     */
+    public function testCreateSendmailWithNoHostOrNoPort(string $dsn, string $sendmaiPath, string $smtp, string $smtpPort)
+    {
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('This test only run on Windows.');
+        }
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('smtp or smtp_port is not configured');
+
+        self::$fakeConfiguration = [
+            'sendmail_path' => $sendmaiPath,
+            'smtp' => $smtp,
+            'smtp_port' => $smtpPort,
+        ];
+
+        $sut = new NativeTransportFactory();
+        $sut->create(Dsn::fromString($dsn));
+    }
+
+    public function provideCreate(): \Generator
+    {
+        yield ['native://default', '/usr/sbin/sendmail -t -i', '', '', new SendmailTransport('/usr/sbin/sendmail -t -i')];
+
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $socketStream = new SocketStream();
+            $socketStream->setHost('myhost.tld');
+            $socketStream->setPort(25);
+            $socketStream->disableTls();
+            yield ['native://default', '', 'myhost.tld', '25', new SmtpTransport($socketStream)];
+
+            $socketStreamTls = new SocketStream();
+            $socketStreamTls->setHost('myhost.tld');
+            $socketStreamTls->setPort(465);
+            yield ['native://default', '', 'myhost.tld', '465', new SmtpTransport($socketStreamTls)];
+        }
+    }
+
+    /**
+     * @dataProvider provideCreate
+     */
+    public function testCreate(string $dsn, string $sendmailPath, string $smtp, string $smtpPort, TransportInterface $expectedTransport)
+    {
+        self::$fakeConfiguration = [
+            'sendmail_path' => $sendmailPath,
+            'smtp' => $smtp,
+            'smtp_port' => $smtpPort,
+        ];
+
+        $sut = new NativeTransportFactory();
+        $transport = $sut->create(Dsn::fromString($dsn));
+
+        $this->assertEquals($expectedTransport, $transport);
+    }
+}

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -22,6 +22,7 @@ use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
 use Symfony\Component\Mailer\Transport\Dsn;
 use Symfony\Component\Mailer\Transport\FailoverTransport;
+use Symfony\Component\Mailer\Transport\NativeTransportFactory;
 use Symfony\Component\Mailer\Transport\NullTransportFactory;
 use Symfony\Component\Mailer\Transport\RoundRobinTransport;
 use Symfony\Component\Mailer\Transport\SendmailTransportFactory;
@@ -162,5 +163,7 @@ class Transport
         yield new SendmailTransportFactory($dispatcher, $client, $logger);
 
         yield new EsmtpTransportFactory($dispatcher, $client, $logger);
+
+        yield new NativeTransportFactory($dispatcher, $client, $logger);
     }
 }

--- a/src/Symfony/Component/Mailer/Transport/NativeTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/NativeTransportFactory.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Transport;
+
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+use Symfony\Component\Mailer\Transport\Smtp\SmtpTransport;
+use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
+
+/**
+ * Factory that configures a transport (sendmail or SMTP) based on php.ini settings.
+ *
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ */
+final class NativeTransportFactory extends AbstractTransportFactory
+{
+    public function create(Dsn $dsn): TransportInterface
+    {
+        if (!\in_array($dsn->getScheme(), $this->getSupportedSchemes(), true)) {
+            throw new UnsupportedSchemeException($dsn, 'native', $this->getSupportedSchemes());
+        }
+
+        if ($sendMailPath = ini_get('sendmail_path')) {
+            return new SendmailTransport($sendMailPath, $this->dispatcher, $this->logger);
+        }
+
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            throw new TransportException('sendmail_path is not configured in php.ini.');
+        }
+
+        // Only for windows hosts; at this point non-windows
+        // host have already thrown an exception or returned a transport
+        $host = ini_get('smtp');
+        $port = (int) ini_get('smtp_port');
+
+        if (!$host || !$port) {
+            throw new TransportException('smtp or smtp_port is not configured in php.ini.');
+        }
+
+        $socketStream = new SocketStream();
+        $socketStream->setHost($host);
+        $socketStream->setPort($port);
+        if (465 !== $port) {
+            $socketStream->disableTls();
+        }
+
+        return new SmtpTransport($socketStream, $this->dispatcher, $this->logger);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['native'];
+    }
+}

--- a/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
@@ -27,6 +27,11 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  * It is advised to use -bs mode since error reporting with -t mode is not
  * possible.
  *
+ * Transport can be instanciated through SendmailTransportFactory or NativeTransportFactory:
+ *
+ * - SendmailTransportFactory to use most common sendmail path and recommanded options
+ * - NativeTransportFactory when configuration is set via php.ini
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Chris Corbyn
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#14083

This PR aims to allow to use the mailer when sendmail is not on the `/usr/sbin` directory or when the `-bs` option is not supported.
