### PR TITLE
[Security] Cast user to string before calling loadUserByUsername()

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProvider.php
@@ -54,7 +54,7 @@ class PreAuthenticatedAuthenticationProvider implements AuthenticationProviderIn
             throw new BadCredentialsException('No pre-authenticated principal found in request.');
         }
 
-        $user = $this->userProvider->loadUserByUsername($user);
+        $user = $this->userProvider->loadUserByUsername($user instanceof UserInterface ? $user->getUsername() : (string) $user);
 
         $this->userChecker->checkPostAuth($user);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36054 
| License       | MIT
| Doc PR        | -
