### PR TITLE
[HttpClient] Issue notice when NativeHttpClient is used

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClient.php
+++ b/src/Symfony/Component/HttpClient/HttpClient.php
@@ -61,6 +61,8 @@ final class HttpClient
             return new AmpHttpClient($defaultOptions, null, $maxHostConnections, $maxPendingPushes);
         }
 
+        @trigger_error((\extension_loaded('curl') ? 'Upgrade' : 'Install').' the curl extension or run "composer require amphp/http-client" to perform async HTTP operations, including full HTTP/2 support', E_USER_NOTICE);
+
         return new NativeHttpClient($defaultOptions, $maxHostConnections);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Simple PR to issue a notice to notify the user that `ext-curl` or `amphp/http-client` should be installed to use an HTTP/2 capable HTTP client. Not sure on the notice wording.