### PR TITLE
Prevent warning in proc_open()

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -336,7 +336,7 @@ class Process implements \IteratorAggregate
             @trigger_error('The provided cwd does not exist. Command is currently ran against getcwd(). This behavior is deprecated since Symfony 3.4 and will be removed in 4.0.', E_USER_DEPRECATED);
         }
 
-        $this->process = proc_open($commandline, $descriptors, $this->processPipes->pipes, $this->cwd, $envPairs, $this->options);
+        $this->process = @proc_open($commandline, $descriptors, $this->processPipes->pipes, $this->cwd, $envPairs, $this->options);
 
         if (!\is_resource($this->process)) {
             throw new RuntimeException('Unable to launch a new process.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | none

In addition to returning `false`, `proc_open()` triggers a warning when it fails. For example:

>  Warning: proc_open(): fork failed - Cannot allocate memory

When using the `ErrorHandler`, the warning gets promoted to an exception, and the next line, `if (! is_resource(...`, is not executed. This mutes the warning and ensures that the next line is always executed and the proper exception is thrown.