### PR TITLE
[FrameworkBundle][Routing] Add link to source to router:match

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.1.0
 -----
 
+ * Added link to source on controller on `router:match`/`debug:router` (when `framework.ide` is configured)
  * Added `Routing\Loader` and `Routing\Loader\Configurator` namespaces to ease defining routes with default controllers
  * Added the `framework.router.context` configuration node to configure the `RequestContext`
  * Made `MicroKernelTrait::configureContainer()` compatible with `ContainerConfigurator`

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -82,6 +82,11 @@ class TextDescriptor extends Descriptor
 
     protected function describeRoute(Route $route, array $options = [])
     {
+        $defaults = $route->getDefaults();
+        if (isset($defaults['_controller'])) {
+            $defaults['_controller'] = $this->formatControllerLink($defaults['_controller'], $this->formatCallable($defaults['_controller']));
+        }
+
         $tableHeaders = ['Property', 'Value'];
         $tableRows = [
             ['Route Name', isset($options['name']) ? $options['name'] : ''],
@@ -93,7 +98,7 @@ class TextDescriptor extends Descriptor
             ['Method', ($route->getMethods() ? implode('|', $route->getMethods()) : 'ANY')],
             ['Requirements', ($route->getRequirements() ? $this->formatRouterConfig($route->getRequirements()) : 'NO CUSTOM')],
             ['Class', \get_class($route)],
-            ['Defaults', $this->formatRouterConfig($route->getDefaults())],
+            ['Defaults', $this->formatRouterConfig($defaults)],
             ['Options', $this->formatRouterConfig($route->getOptions())],
         ];
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/TextDescriptorTest.php
@@ -12,9 +12,13 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor;
 
 use Symfony\Bundle\FrameworkBundle\Console\Descriptor\TextDescriptor;
+use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
+use Symfony\Component\Routing\Route;
 
 class TextDescriptorTest extends AbstractDescriptorTest
 {
+    private $fileLinkFormatter = null;
+
     protected function setUp(): void
     {
         putenv('COLUMNS=121');
@@ -27,11 +31,41 @@ class TextDescriptorTest extends AbstractDescriptorTest
 
     protected function getDescriptor()
     {
-        return new TextDescriptor();
+        return new TextDescriptor($this->fileLinkFormatter);
     }
 
     protected function getFormat()
     {
         return 'txt';
+    }
+
+    public function getDescribeRouteWithControllerLinkTestData()
+    {
+        $getDescribeData = $this->getDescribeRouteTestData();
+
+        foreach ($getDescribeData as $key => &$data) {
+            $routeStub = $data[0];
+            $routeStub->setDefault('_controller', sprintf('%s::%s', MyController::class, '__invoke'));
+            $file = $data[2];
+            $file = preg_replace('#(\..*?)$#', '_link$1', $file);
+            $data = file_get_contents(__DIR__.'/../../Fixtures/Descriptor/'.$file);
+            $data = [$routeStub, $data, $file];
+        }
+
+        return $getDescribeData;
+    }
+
+    /** @dataProvider getDescribeRouteWithControllerLinkTestData */
+    public function testDescribeRouteWithControllerLink(Route $route, $expectedDescription)
+    {
+        $this->fileLinkFormatter = new FileLinkFormatter('myeditor://open?file=%f&line=%l');
+        parent::testDescribeRoute($route, str_replace('[:file:]', __FILE__, $expectedDescription));
+    }
+}
+
+class MyController
+{
+    public function __invoke()
+    {
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_1_link.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_1_link.txt
@@ -1,0 +1,18 @@
++--------------+-----------------------------------------------------------------------------------------------+
+|[32m Property     [39m|[32m Value                                                                                         [39m|
++--------------+-----------------------------------------------------------------------------------------------+
+| Route Name   |                                                                                               |
+| Path         | /hello/{name}                                                                                 |
+| Path Regex   | #PATH_REGEX#                                                                                  |
+| Host         | localhost                                                                                     |
+| Host Regex   | #HOST_REGEX#                                                                                  |
+| Scheme       | http|https                                                                                    |
+| Method       | GET|HEAD                                                                                      |
+| Requirements | name: [a-z]+                                                                                  |
+| Class        | Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\RouteStub                             |
+[39;49m| Defaults     | _controller: [39;49m]8;;myeditor://open?file=[:file:]&line=68\Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\MyController::__invoke()]8;;\[39;49m |[39;49m
+[39;49m|              | [39;49mname: Joseph                                                                                  |
+[39;49m| Options      | compiler_class: Symfony\Component\Routing\RouteCompiler[39;49m[39;49m                                       |[39;49m
+[39;49m|              | [39;49m[39;49mopt1: val1[39;49m[39;49m                                                                                    |[39;49m
+[39;49m|              | [39;49mopt2: val2                                                                                    |
++--------------+-----------------------------------------------------------------------------------------------+

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_2_link.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/route_2_link.txt
@@ -1,0 +1,18 @@
++--------------+-----------------------------------------------------------------------------------------------+
+|[32m Property     [39m|[32m Value                                                                                         [39m|
++--------------+-----------------------------------------------------------------------------------------------+
+| Route Name   |                                                                                               |
+| Path         | /name/add                                                                                     |
+| Path Regex   | #PATH_REGEX#                                                                                  |
+| Host         | localhost                                                                                     |
+| Host Regex   | #HOST_REGEX#                                                                                  |
+| Scheme       | http|https                                                                                    |
+| Method       | PUT|POST                                                                                      |
+| Requirements | NO CUSTOM                                                                                     |
+| Class        | Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\RouteStub                             |
+| Defaults     | _controller: ]8;;myeditor://open?file=[:file:]&line=68\Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor\MyController::__invoke()]8;;\ |
+[39;49m| Options      | compiler_class: Symfony\Component\Routing\RouteCompiler[39;49m[39;49m                                       |[39;49m
+[39;49m|              | [39;49m[39;49mopt1: val1[39;49m[39;49m                                                                                    |[39;49m
+[39;49m|              | [39;49mopt2: val2                                                                                    |
+| Condition    | context.getMethod() in ['GET', 'HEAD', 'POST']                                                |
++--------------+-----------------------------------------------------------------------------------------------+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/orgs/symfony/projects/1#card-30505860
| License       | MIT
| Doc PR        | 

Add link to source on `debug:router`/`router:match` when `framework.ide` is configured