### PR TITLE
[Mailer][Mailgun] Support more headers

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -39,6 +39,11 @@ HttpFoundation
    `__construct()` instead)
  * Made the Mime component an optional dependency
 
+Mailer
+------
+
+ * Deprecated passing Mailgun headers without their "h:" prefix.
+
 Messenger
 ---------
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+5.1.0
+
+ * Not prefixing headers with "h:" is deprecated.
+
 4.4.0
 -----
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -58,8 +58,17 @@ class MailgunApiTransportTest extends TestCase
     public function testCustomHeader()
     {
         $json = json_encode(['foo' => 'bar']);
+        $deliveryTime = (new \DateTimeImmutable('2020-03-20 13:01:00'))->format(\DateTimeImmutable::RFC2822);
+
         $email = new Email();
         $email->getHeaders()->addTextHeader('X-Mailgun-Variables', $json);
+        $email->getHeaders()->addTextHeader('h:foo', 'foo-value');
+        $email->getHeaders()->addTextHeader('t:text', 'text-value');
+        $email->getHeaders()->addTextHeader('o:deliverytime', $deliveryTime);
+        $email->getHeaders()->addTextHeader('v:version', 'version-value');
+        $email->getHeaders()->addTextHeader('template', 'template-value');
+        $email->getHeaders()->addTextHeader('recipient-variables', 'recipient-variables-value');
+        $email->getHeaders()->addTextHeader('amp-html', 'amp-html-value');
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
         $transport = new MailgunApiTransport('ACCESS_KEY', 'DOMAIN');
@@ -69,6 +78,43 @@ class MailgunApiTransportTest extends TestCase
 
         $this->assertArrayHasKey('h:x-mailgun-variables', $payload);
         $this->assertEquals($json, $payload['h:x-mailgun-variables']);
+
+        $this->assertArrayHasKey('h:foo', $payload);
+        $this->assertEquals('foo-value', $payload['h:foo']);
+        $this->assertArrayHasKey('t:text', $payload);
+        $this->assertEquals('text-value', $payload['t:text']);
+        $this->assertArrayHasKey('o:deliverytime', $payload);
+        $this->assertEquals($deliveryTime, $payload['o:deliverytime']);
+        $this->assertArrayHasKey('v:version', $payload);
+        $this->assertEquals('version-value', $payload['v:version']);
+        $this->assertArrayHasKey('template', $payload);
+        $this->assertEquals('template-value', $payload['template']);
+        $this->assertArrayHasKey('recipient-variables', $payload);
+        $this->assertEquals('recipient-variables-value', $payload['recipient-variables']);
+        $this->assertArrayHasKey('amp-html', $payload);
+        $this->assertEquals('amp-html-value', $payload['amp-html']);
+    }
+
+    /**
+     * @legacy
+     */
+    public function testPrefixHeaderWithH()
+    {
+        $json = json_encode(['foo' => 'bar']);
+        $deliveryTime = (new \DateTimeImmutable('2020-03-20 13:01:00'))->format(\DateTimeImmutable::RFC2822);
+
+        $email = new Email();
+        $email->getHeaders()->addTextHeader('bar', 'bar-value');
+
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new MailgunApiTransport('ACCESS_KEY', 'DOMAIN');
+        $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
+        $method->setAccessible(true);
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('h:bar', $payload, 'We should prefix headers with "h:" to keep BC');
+        $this->assertEquals('bar-value', $payload['h:bar']);
     }
 
     public function testSend()
@@ -130,7 +176,7 @@ class MailgunApiTransportTest extends TestCase
             ->text('Hello There!');
 
         $this->expectException(HttpTransportException::class);
-        $this->expectExceptionMessage('Unable to send an email: i\'m a teapot (code 418).');
+        $this->expectExceptionMessage('Unable to send an email: "i\'m a teapot" (code 418).');
         $transport->send($mail);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #35776
| License       | MIT
| Doc PR        | 

Im not sure if this should be classified as a bug since "setting headers are broken". Ie, you cannot use some Mailgun API features. 

Or, this may be a feature because now you may specify any supported custom header you want. 
