### PR TITLE
[Notifier][Slack] Add fields on Slack Section block

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackSectionBlock.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackSectionBlock.php
@@ -37,6 +37,19 @@ final class SlackSectionBlock extends AbstractSlackBlock
     /**
      * @return $this
      */
+    public function field(string $text, bool $markdown = true): self
+    {
+        $this->options['fields'][] = [
+            'type' => $markdown ? 'mrkdwn' : 'plain_text',
+            'text' => $text,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
     public function accessory(SlackBlockElementInterface $element): self
     {
         $this->options['accessory'] = $element->toArray();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
Added `fields` field on section block.
> An array of text objects. Any text objects included with fields will be rendered in a compact format that allows for 2 columns of side-by-side text. Maximum number of items is 10. Maximum length for the text in each item is 2000 characters.

Example of use:
```php
$slackOptions = (new SlackOptions())
            ->block((new SlackSectionBlock())->text('My message'))
            ->block(new SlackDividerBlock())
            ->block(
                (new SlackSectionBlock())
                    ->field('*Max Rating*')
                    ->field('5.0')
                    ->field('*Min Rating*')
                    ->field('1.0')
            );
```

Expected output:

<img width="677" alt="Screen Shot 2020-03-21 at 09 57 36" src="https://user-images.githubusercontent.com/65848/77222314-b8360c80-6b5a-11ea-874c-2cfb1829f839.png">
