### PR TITLE
[Validator] Add option to override property constraints in child class

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/DisableOverridingPropertyConstraints.php
+++ b/src/Symfony/Component/Validator/Constraints/DisableOverridingPropertyConstraints.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * Disables overriding property constraints of parent class.
+ *
+ * Using the annotations on a property has higher precedence than using it on a class.
+ *
+ * @Annotation
+ *
+ * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
+ */
+class DisableOverridingPropertyConstraints extends Constraint
+{
+    public function __construct($options = null)
+    {
+        if (\is_array($options) && \array_key_exists('groups', $options)) {
+            throw new ConstraintDefinitionException(sprintf('The option "groups" is not supported by the constraint "%s".', __CLASS__));
+        }
+
+        parent::__construct($options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return [self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT];
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/EnableOverridingPropertyConstraints.php
+++ b/src/Symfony/Component/Validator/Constraints/EnableOverridingPropertyConstraints.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * Enables overriding property constraints of parent class.
+ *
+ * Using the annotations on a property has higher precedence than using it on a class.
+ *
+ * @Annotation
+ *
+ * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
+ */
+class EnableOverridingPropertyConstraints extends Constraint
+{
+    public function __construct($options = null)
+    {
+        if (\is_array($options) && \array_key_exists('groups', $options)) {
+            throw new ConstraintDefinitionException(sprintf('The option "groups" is not supported by the constraint "%s".', __CLASS__));
+        }
+
+        parent::__construct($options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return [self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT];
+    }
+}

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -310,7 +310,7 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
         if ($source->isGroupSequenceProvider()) {
             $this->setGroupSequenceProvider(true);
         }
-        
+
         if (OverridingPropertyConstraintsStrategy::NONE === $this->getOverridingPropertyConstraintsStrategy()) {
             $this->overridingPropertyConstraintsStrategy = $source->getOverridingPropertyConstraintsStrategy();
         }
@@ -321,14 +321,14 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
 
         foreach ($source->getConstrainedProperties() as $property) {
             $strategy = null;
-            
+
             foreach ($this->getPropertyMetadata($property) as $childMember) {
                 // overriding is enabled in property
                 if (OverridingPropertyConstraintsStrategy::ENABLED === $strategy = $childMember->getOverridingPropertyConstraintsStrategy()) {
                     continue 2;
                 }
             }
-            
+
             foreach ($source->getPropertyMetadata($property) as $member) {
                 // property is overridden, but property constraints strategy is not set explicitly in property
                 if (OverridingPropertyConstraintsStrategy::NONE === $strategy) {
@@ -345,7 +345,7 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
                         continue 2;
                     }
                 }
-                
+
                 $member = clone $member;
 
                 foreach ($member->getConstraints() as $constraint) {

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Validator\Mapping;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\DisableAutoMapping;
 use Symfony\Component\Validator\Constraints\EnableAutoMapping;
+use Symfony\Component\Validator\Constraints\DisableOverridingPropertyConstraints;
+use Symfony\Component\Validator\Constraints\EnableOverridingPropertyConstraints;
 use Symfony\Component\Validator\Constraints\Traverse;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
@@ -89,6 +91,21 @@ class GenericMetadata implements MetadataInterface
     public $autoMappingStrategy = AutoMappingStrategy::NONE;
 
     /**
+     * The strategy for merging/overriding property constraints, when extending class that has property constraints.
+     *
+     * By default, property constraints in a child class are merged with property constraints of a parent class.
+     *
+     * @var int
+     *
+     * @see OverridingPropertyConstraintsStrategy
+     *
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link getOverridingPropertyConstraintsStrategy()} instead.
+     */
+    public $overridingPropertyConstraintsStrategy = OverridingPropertyConstraintsStrategy::NONE;
+
+    /**
      * Returns the names of the properties that should be serialized.
      *
      * @return string[]
@@ -101,6 +118,7 @@ class GenericMetadata implements MetadataInterface
             'cascadingStrategy',
             'traversalStrategy',
             'autoMappingStrategy',
+            'overridingPropertyConstraintsStrategy'
         ];
     }
 
@@ -155,6 +173,13 @@ class GenericMetadata implements MetadataInterface
 
         if ($constraint instanceof DisableAutoMapping || $constraint instanceof EnableAutoMapping) {
             $this->autoMappingStrategy = $constraint instanceof EnableAutoMapping ? AutoMappingStrategy::ENABLED : AutoMappingStrategy::DISABLED;
+
+            // The constraint is not added
+            return $this;
+        }
+
+        if ($constraint instanceof EnableOverridingPropertyConstraints || $constraint instanceof DisableOverridingPropertyConstraints) {
+            $this->overridingPropertyConstraintsStrategy = $constraint instanceof EnableOverridingPropertyConstraints ? OverridingPropertyConstraintsStrategy::ENABLED : OverridingPropertyConstraintsStrategy::DISABLED;
 
             // The constraint is not added
             return $this;
@@ -235,5 +260,13 @@ class GenericMetadata implements MetadataInterface
     public function getAutoMappingStrategy(): int
     {
         return $this->autoMappingStrategy;
+    }
+
+    /**
+     * @see OverridingPropertyConstraintsStrategy
+     */
+    public function getOverridingPropertyConstraintsStrategy(): int
+    {
+        return $this->overridingPropertyConstraintsStrategy;
     }
 }

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -13,8 +13,8 @@ namespace Symfony\Component\Validator\Mapping;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\DisableAutoMapping;
-use Symfony\Component\Validator\Constraints\EnableAutoMapping;
 use Symfony\Component\Validator\Constraints\DisableOverridingPropertyConstraints;
+use Symfony\Component\Validator\Constraints\EnableAutoMapping;
 use Symfony\Component\Validator\Constraints\EnableOverridingPropertyConstraints;
 use Symfony\Component\Validator\Constraints\Traverse;
 use Symfony\Component\Validator\Constraints\Valid;
@@ -118,7 +118,7 @@ class GenericMetadata implements MetadataInterface
             'cascadingStrategy',
             'traversalStrategy',
             'autoMappingStrategy',
-            'overridingPropertyConstraintsStrategy'
+            'overridingPropertyConstraintsStrategy',
         ];
     }
 

--- a/src/Symfony/Component/Validator/Mapping/OverridingPropertyConstraintsStrategy.php
+++ b/src/Symfony/Component/Validator/Mapping/OverridingPropertyConstraintsStrategy.php
@@ -27,7 +27,7 @@ final class OverridingPropertyConstraintsStrategy
      * In case of class, inherit strategy from parent class.
      */
     public const NONE = 0;
-    
+
     /**
      * Specifies that class' property constraints should be merged with constraints of a parent class.
      */

--- a/src/Symfony/Component/Validator/Mapping/OverridingPropertyConstraintsStrategy.php
+++ b/src/Symfony/Component/Validator/Mapping/OverridingPropertyConstraintsStrategy.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Mapping;
+
+/**
+ * Specifies whether class' property constraints should be merged with
+ * or override property constraints of a parent class.
+ *
+ * Overriding property constraints works for properties that override parent property of same name.
+ *
+ * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
+ */
+final class OverridingPropertyConstraintsStrategy
+{
+    /**
+     * Nothing explicitly set.
+     * In case of property, rely on class strategy.
+     * In case of class, inherit strategy from parent class.
+     */
+    public const NONE = 0;
+    
+    /**
+     * Specifies that class' property constraints should be merged with constraints of a parent class.
+     */
+    public const DISABLED = 1;
+
+    /**
+     * Specifies that class' property constraints should override constraints of a parent class.
+     */
+    public const ENABLED = 2;
+
+    /**
+     * Not instantiable.
+     */
+    private function __construct()
+    {
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/AtLeastOneOfValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AtLeastOneOfValidatorTest.php
@@ -37,7 +37,6 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
     protected function createValidator()
     {
         return new AtLeastOneOfValidator();
-        
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/AtLeastOneOfValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AtLeastOneOfValidatorTest.php
@@ -37,6 +37,7 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
     protected function createValidator()
     {
         return new AtLeastOneOfValidator();
+        
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/DisableOverridingPropertyConstraintsTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DisableOverridingPropertyConstraintsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\DisableOverridingPropertyConstraints;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
+ */
+class DisableOverridingPropertyConstraintsTest extends TestCase
+{
+    public function testGroups()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage(sprintf('The option "groups" is not supported by the constraint "%s".', DisableOverridingPropertyConstraints::class));
+
+        new DisableOverridingPropertyConstraints(['groups' => 'foo']);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/EnableOverridingPropertyConstraintsTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EnableOverridingPropertyConstraintsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\EnableOverridingPropertyConstraints;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
+ */
+class EnableOverridingPropertyConstraintsTest extends TestCase
+{
+    public function testGroups()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage(sprintf('The option "groups" is not supported by the constraint "%s".', EnableOverridingPropertyConstraints::class));
+
+        new EnableOverridingPropertyConstraints(['groups' => 'foo']);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -13,9 +13,9 @@ namespace Symfony\Component\Validator\Tests\Mapping;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\DisableOverridingPropertyConstraints;
 use Symfony\Component\Validator\Constraints\EnableOverridingPropertyConstraints;
+use Symfony\Component\Validator\Constraints\GreaterThan;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\OverridingPropertyConstraintsStrategy;
@@ -314,17 +314,17 @@ class ClassMetadataTest extends TestCase
     {
         $this->assertCount(0, $this->metadata->getPropertyMetadata('foo'), '->getPropertyMetadata() returns an empty collection if no metadata is configured for the given property');
     }
-    
+
     public function testOverrideConstraintsIfOverridingEnabledInProperty()
     {
         $parentMetadata = new ClassMetadata('\Symfony\Component\Validator\Tests\Mapping\ParentClass');
         $parentMetadata->addPropertyConstraint('example', new GreaterThan(0));
-        
+
         $childMetadata = new ClassMetadata('\Symfony\Component\Validator\Tests\Mapping\ChildClass');
         $childMetadata->addPropertyConstraint('example', new EnableOverridingPropertyConstraints());
         $childMetadata->addPropertyConstraint('example', new GreaterThan(1));
         $childMetadata->mergeConstraints($parentMetadata);
-        
+
         $expectedMetadata = new ClassMetadata('\Symfony\Component\Validator\Tests\Mapping\ChildClass');
         $expectedMetadata->addPropertyConstraint('example', new EnableOverridingPropertyConstraints());
         $expectedMetadata->addPropertyConstraint('example', new GreaterThan(1));
@@ -438,7 +438,7 @@ class ClassMetadataTest extends TestCase
         foreach ($childMetadata->getPropertyMetadata('example') as $member) {
             $childConstraints[] = $member->getConstraints()[0];
         }
-        
+
         $expectedConstraints = [
             new GreaterThan(['value' => 1, 'groups' => ['Default', 'ChildClass']]),
             new GreaterThan(['value' => 0, 'groups' => ['Default', 'ParentClass', 'ChildClass']]),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| BC breaks? | no
| Deprecations? | no
| Tests pass? | yes
| Fixed tickets | #15950
| License       | MIT
| Doc PR        | TODO

Currently, property constraints defined in a child class are merged with property constraints of parent class. I believe it's sometimes necessary to override them instead. This PR allows this option to be configurable.

Example
```php
class ParentClass
{
    /**
     * @Assert\GreaterThanOrEqual(1)
     */
    public $example = 1;
}

class ChildClass extends ParentClass
{
    /**
     * @Assert\GreaterThanOrEqual(0)
     * @Assert\EnableOverridingPropertyConstraints()
     */
    public $example = 0;
}
```