### PR TITLE
[DomCrawler] Check all matching elements in test assertions instead of only the first

### DIFF
--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextContains.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextContains.php
@@ -45,7 +45,13 @@ final class CrawlerSelectorTextContains extends Constraint
             return false;
         }
 
-        return false !== mb_strpos($crawler->text(null, false), $this->expectedText);
+        foreach ($crawler as $node) {
+            if (false !== mb_strpos($node->textContent, $this->expectedText)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextSame.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextSame.php
@@ -45,7 +45,13 @@ final class CrawlerSelectorTextSame extends Constraint
             return false;
         }
 
-        return $this->expectedText === trim($crawler->text(null, false));
+        foreach ($crawler as $node) {
+            if ($this->expectedText === trim($node->textContent)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/AbstractConstraintTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/AbstractConstraintTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Tests\Test\Constraint;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DomCrawler\Crawler;
+
+abstract class AbstractConstraintTest extends TestCase
+{
+    protected $errorMessage;
+    protected $constraint;
+
+    /**
+     * @dataProvider provideConstraintData
+     */
+    public function testConstraint(string $html, bool $result)
+    {
+        if (!$result) {
+            $this->expectException(ExpectationFailedException::class);
+            $this->expectExceptionMessage($this->errorMessage);
+
+            $this->constraint->evaluate(new Crawler($html));
+        } else {
+            $this->assertTrue($this->constraint->evaluate(new Crawler($html), '', true));
+        }
+    }
+
+    abstract public function provideConstraintData();
+}

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorAttributeValueSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorAttributeValueSameTest.php
@@ -11,28 +11,22 @@
 
 namespace Symfony\Component\DomCrawler\Tests\Test\Constraint;
 
-use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
-use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorAttributeValueSame;
 
-class CrawlerSelectorAttributeValueSameTest extends TestCase
+class CrawlerSelectorAttributeValueSameTest extends AbstractConstraintTest
 {
-    public function testConstraint(): void
+    protected $errorMessage = 'Failed asserting that the Crawler has a node matching selector "input[name="username"]" with attribute "value" of value "Fabien".';
+
+    protected function setUp(): void
     {
-        $constraint = new CrawlerSelectorAttributeValueSame('input[name="username"]', 'value', 'Fabien');
-        $this->assertTrue($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username" value="Fabien">'), '', true));
-        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
+        $this->constraint = new CrawlerSelectorAttributeValueSame('input[name="username"]', 'value', 'Fabien');
+    }
 
-        try {
-            $constraint->evaluate(new Crawler('<html><head><title>Bar'));
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Crawler has a node matching selector \"input[name=\"username\"]\" with attribute \"value\" of value \"Fabien\".\n", TestFailure::exceptionToString($e));
+    public function provideConstraintData()
+    {
+        yield ['<input type="text" name="username" value="Fabien">', true];
 
-            return;
-        }
-
-        $this->fail();
+        yield ['<input type="text" name="username" value="Wouter">', false];
+        yield ['<h1>Bar</h1>', false];
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorExistsTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorExistsTest.php
@@ -11,29 +11,21 @@
 
 namespace Symfony\Component\DomCrawler\Tests\Test\Constraint;
 
-use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
-use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorExists;
 
-class CrawlerSelectorExistsTest extends TestCase
+class CrawlerSelectorExistsTest extends AbstractConstraintTest
 {
-    public function testConstraint(): void
+    protected $errorMessage = 'Failed asserting that the Crawler matches selector "p".';
+
+    protected function setUp(): void
     {
-        $constraint = new CrawlerSelectorExists('title');
-        $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>'), '', true));
-        $constraint = new CrawlerSelectorExists('h1');
-        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>'), '', true));
+        $this->constraint = new CrawlerSelectorExists('p');
+    }
 
-        try {
-            $constraint->evaluate(new Crawler('<html><head><title>'));
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Crawler matches selector \"h1\".\n", TestFailure::exceptionToString($e));
-
-            return;
-        }
-
-        $this->fail();
+    public function provideConstraintData()
+    {
+        yield ['<p/>', true];
+        yield ['<p>Foo</p>', true];
+        yield ['<h1>Foo</h1>', false];
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
@@ -26,6 +26,7 @@ class CrawlerSelectorTextContainsTest extends AbstractConstraintTest
     {
         yield ['<p>Foo</p>', true];
         yield ['<p>Foobar</p>', true];
+        yield ['<p>Bar</p><p>Foo</p>', true];
 
         yield ['<p>Bar</p>', false];
         yield ['<h1>Foo</h1>', false];

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
@@ -11,28 +11,23 @@
 
 namespace Symfony\Component\DomCrawler\Tests\Test\Constraint;
 
-use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
-use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorTextContains;
 
-class CrawlerSelectorTextContainsTest extends TestCase
+class CrawlerSelectorTextContainsTest extends AbstractConstraintTest
 {
-    public function testConstraint(): void
+    protected $errorMessage = 'Failed asserting that the Crawler has a node matching selector "p" with content containing "Foo".';
+
+    protected function setUp(): void
     {
-        $constraint = new CrawlerSelectorTextContains('title', 'Foo');
-        $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>Foobar'), '', true));
-        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
+        $this->constraint = new CrawlerSelectorTextContains('p', 'Foo');
+    }
 
-        try {
-            $constraint->evaluate(new Crawler('<html><head><title>Bar'));
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Crawler has a node matching selector \"title\" with content containing \"Foo\".\n", TestFailure::exceptionToString($e));
+    public function provideConstraintData()
+    {
+        yield ['<p>Foo</p>', true];
+        yield ['<p>Foobar</p>', true];
 
-            return;
-        }
-
-        $this->fail();
+        yield ['<p>Bar</p>', false];
+        yield ['<h1>Foo</h1>', false];
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextSameTest.php
@@ -11,28 +11,21 @@
 
 namespace Symfony\Component\DomCrawler\Tests\Test\Constraint;
 
-use PHPUnit\Framework\ExpectationFailedException;
-use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestFailure;
-use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorTextSame;
 
-class CrawlerSelectorTextSameTest extends TestCase
+class CrawlerSelectorTextSameTest extends AbstractConstraintTest
 {
-    public function testConstraint(): void
+    protected $errorMessage = 'Failed asserting that the Crawler has a node matching selector "p" with content "Foo".';
+
+    protected function setUp(): void
     {
-        $constraint = new CrawlerSelectorTextSame('title', 'Foo');
-        $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>Foo'), '', true));
-        $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
+        $this->constraint = new CrawlerSelectorTextSame('p', 'Foo');
+    }
 
-        try {
-            $constraint->evaluate(new Crawler('<html><head><title>Bar'));
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Crawler has a node matching selector \"title\" with content \"Foo\".\n", TestFailure::exceptionToString($e));
+    public function provideConstraintData()
+    {
+        yield ['<p>Foo</p>', true];
 
-            return;
-        }
-
-        $this->fail();
+        yield ['<p>Bar</p>', false];
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextSameTest.php
@@ -25,6 +25,7 @@ class CrawlerSelectorTextSameTest extends AbstractConstraintTest
     public function provideConstraintData()
     {
         yield ['<p>Foo</p>', true];
+        yield ['<p>Bar</p><p>Foo</p>', true];
 
         yield ['<p>Bar</p>', false];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix symfony/symfony-docs#13385
| License       | MIT
| Doc PR        | -

@arneee reported in the docs repository that the `assertSelectorTextContains()` and `assertSelectorTextSame()` are only checking the first matching element. To me, this seems to be a bug (it's not what I would expect).

Meanwhile, I couldn't resist updating the tests a bit to use a data provider, instead of testing 3 things within one single test method.