### PR TITLE
[Profiler] Fix profiler nullable string type

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -101,7 +101,7 @@ class Profile
         return $this->ip;
     }
 
-    public function setIp(string $ip)
+    public function setIp(?string $ip)
     {
         $this->ip = $ip;
     }
@@ -131,7 +131,7 @@ class Profile
         return $this->url;
     }
 
-    public function setUrl(string $url)
+    public function setUrl(?string $url)
     {
         $this->url = $url;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets | n/a
| License | MIT
| Doc PR | -


This PR fixes nullable string types in setter for the Profile class.

The detected issue comes from [the Profiler class](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/Profiler/Profiler.php#L149) :

```php
$profile->setIp($request->getClientIp()); // string or null
```

The corresponding return types for the Profile getters are allready good:
```php
    /**
     * Returns the IP.
     *
     * @return string|null The IP
     */
    public function getIp()
    {
        return $this->ip;
    }
```
