### PR TITLE
[String] Remove single letters in slug

### DIFF
--- a/src/Symfony/Component/String/Slugger/AsciiSlugger.php
+++ b/src/Symfony/Component/String/Slugger/AsciiSlugger.php
@@ -100,6 +100,7 @@ class AsciiSlugger implements SluggerInterface, LocaleAwareInterface
             ->replace('@', $separator.'at'.$separator)
             ->replace('&', $separator.'and'.$separator)
             ->replaceMatches('/[^A-Za-z0-9]++/', $separator)
+            ->replaceMatches("/$separator\w{1}$separator/", $separator)
             ->trim($separator)
         ;
     }

--- a/src/Symfony/Component/String/Tests/SluggerTest.php
+++ b/src/Symfony/Component/String/Tests/SluggerTest.php
@@ -35,10 +35,11 @@ class SluggerTest extends TestCase
             ['symfony@symfony.com', 'en', 'symfony-at-symfony-com'],
             ['Dieser Wert sollte größer oder gleich', 'de', 'Dieser-Wert-sollte-groesser-oder-gleich'],
             ['Dieser Wert sollte größer oder gleich', 'de_AT', 'Dieser-Wert-sollte-groesser-oder-gleich'],
-            ['Αυτή η τιμή πρέπει να είναι ψευδής', 'el', 'Avti-i-timi-prepi-na-inai-psevdhis'],
+            ['Αυτή η τιμή πρέπει να είναι ψευδής', 'el', 'Avti-timi-prepi-na-inai-psevdhis'],
             ['该变量的值应为', 'zh', 'gai-bian-liang-de-zhi-ying-wei'],
             ['該變數的值應為', 'zh_TW', 'gai-bian-shu-de-zhi-ying-wei'],
             ['Wôrķšƥáçè ~~sèťtïñğš~~', 'C', 'Workspace-settings'],
+            ['Pantalon d\'été', 'fr', 'Pantalon-ete'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | 

Avoid single letters lost in a slug:
`Pantalon d'été` will be "slugified" to `pantalon-ete` instead of `pantalon-d-ete`.

WDYT ?


