### PR TITLE
[Http Foundation] Fix clear cookie samesite

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -244,10 +244,13 @@ class ResponseHeaderBag extends HeaderBag
      * @param string $domain
      * @param bool   $secure
      * @param bool   $httpOnly
+     * @param string $sameSite
      */
-    public function clearCookie($name, $path = '/', $domain = null, $secure = false, $httpOnly = true)
+    public function clearCookie($name, $path = '/', $domain = null, $secure = false, $httpOnly = true/*, $sameSite = null*/)
     {
-        $this->setCookie(new Cookie($name, null, 1, $path, $domain, $secure, $httpOnly));
+        $sameSite = \func_num_args() > 5 ? func_get_arg(5) : null;
+
+        $this->setCookie(new Cookie($name, null, 1, $path, $domain, $secure, $httpOnly, false, $sameSite));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -128,6 +128,14 @@ class ResponseHeaderBagTest extends TestCase
         $this->assertSetCookieHeader('foo=deleted; expires='.gmdate('D, d-M-Y H:i:s T', time() - 31536001).'; Max-Age=0; path=/; secure', $bag);
     }
 
+    public function testClearCookieSamesite()
+    {
+        $bag = new ResponseHeaderBag([]);
+
+        $bag->clearCookie('foo', '/', null, true, false, 'none');
+        $this->assertSetCookieHeader('foo=deleted; expires='.gmdate('D, d-M-Y H:i:s T', time() - 31536001).'; Max-Age=0; path=/; secure; samesite=none', $bag);
+    }
+
     public function testReplace()
     {
         $bag = new ResponseHeaderBag([]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36107
| License       | MIT

With Chrome Update 80, Cookies are required to be `secure` and `samesite=none` for cross site requests. However they are defaulted to `samesite=lax` if the samesite attribute is not set. In other words: developer has to explicitely opt-in for `samesite=none` in the case of a cross site request.

More details: https://chromestatus.com/feature/5088147346030592

We add the `samesite` argument to `clearCookie` method to allow developer to explicitely set this value.