### PR TITLE
[BrowserKit] fixed missing post request parameters in file uploads

### DIFF
--- a/src/Symfony/Component/BrowserKit/HttpBrowser.php
+++ b/src/Symfony/Component/BrowserKit/HttpBrowser.php
@@ -75,7 +75,7 @@ class HttpBrowser extends AbstractBrowser
         $fields = $request->getParameters();
 
         if ($uploadedFiles = $this->getUploadedFiles($request->getFiles())) {
-            $part = new FormDataPart($uploadedFiles);
+            $part = new FormDataPart(array_merge($fields, $uploadedFiles));
 
             return [$part->bodyToIterable(), $part->getPreparedHeaders()->toArray()];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Pull Request #35827 "[BrowserKit] Nested file array prevents uploading file" introduced a bug that had not been previously covered by unit tests for the component. Requests that include additional parameters with a file upload are not being included

