### PR TITLE
[Routing] Deal with hosts per locale

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * deprecated the `RouteCompiler::REGEX_DELIMITER` constant
  * added `ExpressionLanguageProvider` to expose extra functions to route conditions
  * added support for a `stateless` keyword for configuring route stateless in PHP, YAML and XML configurations.
+ * added the "hosts" option to be able to configure the host per locale.
 
 5.0.0
 -----

--- a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
@@ -20,11 +20,13 @@ use Symfony\Component\Routing\RouteCollection;
 class CollectionConfigurator
 {
     use Traits\AddTrait;
+    use Traits\HostTrait;
     use Traits\RouteTrait;
 
     private $parent;
     private $parentConfigurator;
     private $parentPrefixes;
+    private $host;
 
     public function __construct(RouteCollection $parent, string $name, self $parentConfigurator = null, array $parentPrefixes = null)
     {
@@ -40,6 +42,9 @@ class CollectionConfigurator
     {
         if (null === $this->prefixes) {
             $this->collection->addPrefix($this->route->getPath());
+        }
+        if (null !== $this->host) {
+            $this->addHost($this->collection, $this->host);
         }
 
         $this->parent->addCollection($this->collection);
@@ -82,6 +87,20 @@ class CollectionConfigurator
             $this->prefixes = null;
             $this->route->setPath($prefix);
         }
+
+        return $this;
+    }
+
+    /**
+     * Sets the host to use for all child routes.
+     *
+     * @param string|array $host the host, or the localized hosts
+     *
+     * @return $this
+     */
+    final public function host($host): self
+    {
+        $this->host = $host;
 
         return $this;
     }

--- a/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
@@ -18,6 +18,7 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class ImportConfigurator
 {
+    use Traits\HostTrait;
     use Traits\PrefixTrait;
     use Traits\RouteTrait;
 
@@ -56,6 +57,20 @@ class ImportConfigurator
     final public function namePrefix(string $namePrefix): self
     {
         $this->route->addNamePrefix($namePrefix);
+
+        return $this;
+    }
+
+    /**
+     * Sets the host to use for all child routes.
+     *
+     * @param string|array $host the host, or the localized hosts
+     *
+     * @return $this
+     */
+    final public function host($host): self
+    {
+        $this->addHost($this->route, $host);
 
         return $this;
     }

--- a/src/Symfony/Component/Routing/Loader/Configurator/RouteConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/RouteConfigurator.php
@@ -19,6 +19,7 @@ use Symfony\Component\Routing\RouteCollection;
 class RouteConfigurator
 {
     use Traits\AddTrait;
+    use Traits\HostTrait;
     use Traits\RouteTrait;
 
     protected $parentConfigurator;
@@ -30,5 +31,19 @@ class RouteConfigurator
         $this->name = $name;
         $this->parentConfigurator = $parentConfigurator; // for GC control
         $this->prefixes = $prefixes;
+    }
+
+    /**
+     * Sets the host to use for all child routes.
+     *
+     * @param string|array $host the host, or the localized hosts
+     *
+     * @return $this
+     */
+    final public function host($host): self
+    {
+        $this->addHost($this->route, $host);
+
+        return $this;
     }
 }

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/HostTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/HostTrait.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Loader\Configurator\Traits;
+
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @internal
+ */
+trait HostTrait
+{
+    final protected function addHost(RouteCollection $routes, $hosts)
+    {
+        if (!$hosts || !\is_array($hosts)) {
+            $routes->setHost($hosts ?: '');
+
+            return;
+        }
+
+        foreach ($routes->all() as $name => $route) {
+            if (null === $locale = $route->getDefault('_locale')) {
+                $routes->remove($name);
+                foreach ($hosts as $locale => $host) {
+                    $localizedRoute = clone $route;
+                    $localizedRoute->setDefault('_locale', $locale);
+                    $localizedRoute->setRequirement('_locale', preg_quote($locale));
+                    $localizedRoute->setDefault('_canonical_route', $name);
+                    $localizedRoute->setHost($host);
+                    $routes->add($name.'.'.$locale, $localizedRoute);
+                }
+            } elseif (!isset($hosts[$locale])) {
+                throw new \InvalidArgumentException(sprintf('Route "%s" with locale "%s" is missing a corresponding host in its parent collection.', $name, $locale));
+            } else {
+                $route->setHost($hosts[$locale]);
+                $route->setRequirement('_locale', preg_quote($locale));
+                $routes->add($name, $route);
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/LocalizedRouteTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/LocalizedRouteTrait.php
@@ -26,12 +26,12 @@ trait LocalizedRouteTrait
      * Creates one or many routes.
      *
      * @param string|array $path the path, or the localized paths of the route
-     *
-     * @return Route|RouteCollection
      */
-    final protected function createLocalizedRoute(RouteCollection $collection, string $name, $path, string $namePrefix = '', array $prefixes = null)
+    final protected function createLocalizedRoute(RouteCollection $collection, string $name, $path, string $namePrefix = '', array $prefixes = null): RouteCollection
     {
         $paths = [];
+
+        $routes = new RouteCollection();
 
         if (\is_array($path)) {
             if (null === $prefixes) {
@@ -52,12 +52,11 @@ trait LocalizedRouteTrait
                 $paths[$locale] = $prefix.$path;
             }
         } else {
-            $collection->add($namePrefix.$name, $route = $this->createRoute($path));
+            $routes->add($namePrefix.$name, $route = $this->createRoute($path));
+            $collection->add($namePrefix.$name, $route);
 
-            return $route;
+            return $routes;
         }
-
-        $routes = new RouteCollection();
 
         foreach ($paths as $locale => $path) {
             $routes->add($name.'.'.$locale, $route = $this->createRoute($path));

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Routing\Loader;
 
 use Symfony\Component\Config\Loader\FileLoader;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\Loader\Configurator\Traits\HostTrait;
 use Symfony\Component\Routing\Loader\Configurator\Traits\LocalizedRouteTrait;
 use Symfony\Component\Routing\Loader\Configurator\Traits\PrefixTrait;
 use Symfony\Component\Routing\RouteCollection;
@@ -28,6 +29,7 @@ use Symfony\Component\Yaml\Yaml;
  */
 class YamlFileLoader extends FileLoader
 {
+    use HostTrait;
     use LocalizedRouteTrait;
     use PrefixTrait;
 
@@ -137,14 +139,17 @@ class YamlFileLoader extends FileLoader
             $defaults['_stateless'] = $config['stateless'];
         }
 
-        $route = $this->createLocalizedRoute($collection, $name, $config['path']);
-        $route->addDefaults($defaults);
-        $route->addRequirements($requirements);
-        $route->addOptions($options);
-        $route->setHost($config['host'] ?? '');
-        $route->setSchemes($config['schemes'] ?? []);
-        $route->setMethods($config['methods'] ?? []);
-        $route->setCondition($config['condition'] ?? null);
+        $routes = $this->createLocalizedRoute($collection, $name, $config['path']);
+        $routes->addDefaults($defaults);
+        $routes->addRequirements($requirements);
+        $routes->addOptions($options);
+        $routes->setSchemes($config['schemes'] ?? []);
+        $routes->setMethods($config['methods'] ?? []);
+        $routes->setCondition($config['condition'] ?? null);
+
+        if (isset($config['host'])) {
+            $this->addHost($routes, $config['host']);
+        }
     }
 
     /**
@@ -198,7 +203,7 @@ class YamlFileLoader extends FileLoader
             $this->addPrefix($subCollection, $prefix, $trailingSlashOnRoot);
 
             if (null !== $host) {
-                $subCollection->setHost($host);
+                $this->addHost($subCollection, $host);
             }
             if (null !== $condition) {
                 $subCollection->setCondition($condition);

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -45,6 +45,7 @@
     <xsd:sequence>
       <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="path" type="localized-path" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="host" type="localized-path" minOccurs="0" maxOccurs="unbounded" />
     </xsd:sequence>
     <xsd:attribute name="id" type="xsd:string" use="required" />
     <xsd:attribute name="path" type="xsd:string" />
@@ -63,6 +64,7 @@
       <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="prefix" type="localized-path" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="exclude" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="host" type="localized-path" minOccurs="0" maxOccurs="unbounded" />
     </xsd:sequence>
     <xsd:attribute name="resource" type="xsd:string" use="required" />
     <xsd:attribute name="type" type="xsd:string" />

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/import-with-host-expected-collection.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/import-with-host-expected-collection.php
@@ -1,0 +1,50 @@
+<?php
+
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+return function (string $format) {
+    $expectedRoutes = new RouteCollection();
+    $expectedRoutes->add('imported.en', $route = new Route('/example'));
+    $route->setHost('www.example.com');
+    $route->setRequirement('_locale', 'en');
+    $route->setDefault('_locale', 'en');
+    $route->setDefault('_canonical_route', 'imported');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported.nl', $route = new Route('/voorbeeld'));
+    $route->setHost('www.example.nl');
+    $route->setRequirement('_locale', 'nl');
+    $route->setDefault('_locale', 'nl');
+    $route->setDefault('_canonical_route', 'imported');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported_not_localized.en', $route = new Route('/here'));
+    $route->setHost('www.example.com');
+    $route->setRequirement('_locale', 'en');
+    $route->setDefault('_locale', 'en');
+    $route->setDefault('_canonical_route', 'imported_not_localized');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported_not_localized.nl', $route = new Route('/here'));
+    $route->setHost('www.example.nl');
+    $route->setRequirement('_locale', 'nl');
+    $route->setDefault('_locale', 'nl');
+    $route->setDefault('_canonical_route', 'imported_not_localized');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported_single_host.en', $route = new Route('/here_again'));
+    $route->setHost('www.example.com');
+    $route->setRequirement('_locale', 'en');
+    $route->setDefault('_locale', 'en');
+    $route->setDefault('_canonical_route', 'imported_single_host');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported_single_host.nl', $route = new Route('/here_again'));
+    $route->setHost('www.example.nl');
+    $route->setRequirement('_locale', 'nl');
+    $route->setDefault('_locale', 'nl');
+    $route->setDefault('_canonical_route', 'imported_single_host');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+
+    $expectedRoutes->addResource(new FileResource(__DIR__."/imported.$format"));
+    $expectedRoutes->addResource(new FileResource(__DIR__."/importer-with-host.$format"));
+
+    return $expectedRoutes;
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/import-with-locale-and-host-expected-collection.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/import-with-locale-and-host-expected-collection.php
@@ -1,0 +1,50 @@
+<?php
+
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+return function (string $format) {
+    $expectedRoutes = new RouteCollection();
+    $expectedRoutes->add('imported.en', $route = new Route('/en/example'));
+    $route->setHost('www.example.com');
+    $route->setRequirement('_locale', 'en');
+    $route->setDefault('_locale', 'en');
+    $route->setDefault('_canonical_route', 'imported');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported.nl', $route = new Route('/nl/voorbeeld'));
+    $route->setHost('www.example.nl');
+    $route->setRequirement('_locale', 'nl');
+    $route->setDefault('_locale', 'nl');
+    $route->setDefault('_canonical_route', 'imported');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported_not_localized.en', $route = new Route('/en/here'));
+    $route->setHost('www.example.com');
+    $route->setRequirement('_locale', 'en');
+    $route->setDefault('_locale', 'en');
+    $route->setDefault('_canonical_route', 'imported_not_localized');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported_not_localized.nl', $route = new Route('/nl/here'));
+    $route->setHost('www.example.nl');
+    $route->setRequirement('_locale', 'nl');
+    $route->setDefault('_locale', 'nl');
+    $route->setDefault('_canonical_route', 'imported_not_localized');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported_single_host.en', $route = new Route('/en/here_again'));
+    $route->setHost('www.example.com');
+    $route->setRequirement('_locale', 'en');
+    $route->setDefault('_locale', 'en');
+    $route->setDefault('_canonical_route', 'imported_single_host');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported_single_host.nl', $route = new Route('/nl/here_again'));
+    $route->setHost('www.example.nl');
+    $route->setRequirement('_locale', 'nl');
+    $route->setDefault('_locale', 'nl');
+    $route->setDefault('_canonical_route', 'imported_single_host');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+
+    $expectedRoutes->addResource(new FileResource(__DIR__."/imported.$format"));
+    $expectedRoutes->addResource(new FileResource(__DIR__."/importer-with-locale-and-host.$format"));
+
+    return $expectedRoutes;
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/import-with-single-host-expected-collection.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/import-with-single-host-expected-collection.php
@@ -1,0 +1,32 @@
+<?php
+
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+return function (string $format) {
+    $expectedRoutes = new RouteCollection();
+    $expectedRoutes->add('imported.en', $route = new Route('/example'));
+    $route->setHost('www.example.com');
+    $route->setRequirement('_locale', 'en');
+    $route->setDefault('_locale', 'en');
+    $route->setDefault('_canonical_route', 'imported');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported.nl', $route = new Route('/voorbeeld'));
+    $route->setHost('www.example.com');
+    $route->setRequirement('_locale', 'nl');
+    $route->setDefault('_locale', 'nl');
+    $route->setDefault('_canonical_route', 'imported');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported_not_localized', $route = new Route('/here'));
+    $route->setHost('www.example.com');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported_single_host', $route = new Route('/here_again'));
+    $route->setHost('www.example.com');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+
+    $expectedRoutes->addResource(new FileResource(__DIR__."/imported.$format"));
+    $expectedRoutes->addResource(new FileResource(__DIR__."/importer-with-single-host.$format"));
+
+    return $expectedRoutes;
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/import-without-host-expected-collection.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/import-without-host-expected-collection.php
@@ -1,0 +1,31 @@
+<?php
+
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+return function (string $format) {
+    $expectedRoutes = new RouteCollection();
+    $expectedRoutes->add('imported.en', $route = new Route('/example'));
+    $route->setHost('www.custom.com');
+    $route->setRequirement('_locale', 'en');
+    $route->setDefault('_locale', 'en');
+    $route->setDefault('_canonical_route', 'imported');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported.nl', $route = new Route('/voorbeeld'));
+    $route->setHost('www.custom.nl');
+    $route->setRequirement('_locale', 'nl');
+    $route->setDefault('_locale', 'nl');
+    $route->setDefault('_canonical_route', 'imported');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported_not_localized', $route = new Route('/here'));
+    $route->setDefault('_controller', 'ImportedController::someAction');
+    $expectedRoutes->add('imported_single_host', $route = new Route('/here_again'));
+    $route->setHost('www.custom.com');
+    $route->setDefault('_controller', 'ImportedController::someAction');
+
+    $expectedRoutes->addResource(new FileResource(__DIR__."/imported.$format"));
+    $expectedRoutes->addResource(new FileResource(__DIR__."/importer-without-host.$format"));
+
+    return $expectedRoutes;
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/imported.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/imported.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes
+        ->add('imported', ['nl' => '/voorbeeld', 'en' => '/example'])
+            ->controller('ImportedController::someAction')
+            ->host([
+                'nl' => 'www.custom.nl',
+                'en' => 'www.custom.com',
+            ])
+        ->add('imported_not_localized', '/here')
+            ->controller('ImportedController::someAction')
+        ->add('imported_single_host', '/here_again')
+            ->controller('ImportedController::someAction')
+            ->host('www.custom.com')
+    ;
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/imported.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/imported.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+    <route id="imported">
+        <default key="_controller">ImportedController::someAction</default>
+        <path locale="nl">/voorbeeld</path>
+        <path locale="en">/example</path>
+        <host locale="nl">www.custom.nl</host>
+        <host locale="en">www.custom.com</host>
+    </route>
+    <route id="imported_not_localized" path="/here">
+        <default key="_controller">ImportedController::someAction</default>
+    </route>
+    <route id="imported_single_host" path="/here_again" host="www.custom.com">
+        <default key="_controller">ImportedController::someAction</default>
+    </route>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/imported.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/imported.yml
@@ -1,0 +1,18 @@
+---
+imported:
+    controller: ImportedController::someAction
+    path:
+        nl: /voorbeeld
+        en: /example
+    host:
+        nl: www.custom.nl
+        en: www.custom.com
+
+imported_not_localized:
+    controller: ImportedController::someAction
+    path: /here
+
+imported_single_host:
+    controller: ImportedController::someAction
+    path: /here_again
+    host: www.custom.com

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-host.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-host.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes->import('imported.php')->host([
+        'nl' => 'www.example.nl',
+        'en' => 'www.example.com',
+    ]);
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-host.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-host.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+    <import resource="./imported.xml">
+        <host locale="nl">www.example.nl</host>
+        <host locale="en">www.example.com</host>
+    </import>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-host.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-host.yml
@@ -1,0 +1,6 @@
+---
+i_need:
+    resource: ./imported.yml
+    host:
+        nl: www.example.nl
+        en: www.example.com

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-locale-and-host.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-locale-and-host.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes->import('imported.php')->host([
+        'nl' => 'www.example.nl',
+        'en' => 'www.example.com',
+    ])->prefix([
+        'nl' => '/nl',
+        'en' => '/en',
+    ]);
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-locale-and-host.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-locale-and-host.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+    <import resource="./imported.xml">
+        <prefix locale="nl">/nl</prefix>
+        <prefix locale="en">/en</prefix>
+        <host locale="nl">www.example.nl</host>
+        <host locale="en">www.example.com</host>
+    </import>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-locale-and-host.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-locale-and-host.yml
@@ -1,0 +1,9 @@
+---
+i_need:
+    resource: ./imported.yml
+    prefix:
+        nl: /nl
+        en: /en
+    host:
+        nl: www.example.nl
+        en: www.example.com

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-single-host.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-single-host.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes->import('imported.php')->host('www.example.com');
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-single-host.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-single-host.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+    <import resource="./imported.xml" host="www.example.com">
+    </import>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-single-host.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-with-single-host.yml
@@ -1,0 +1,4 @@
+---
+i_need:
+    resource: ./imported.yml
+    host: www.example.com

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-without-host.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-without-host.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Routing\Loader\Configurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes->import('imported.php');
+};

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-without-host.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-without-host.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+    <import resource="./imported.xml">
+    </import>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-without-host.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/locale_and_host/importer-without-host.yml
@@ -1,0 +1,3 @@
+---
+i_need:
+    resource: ./imported.yml

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -243,4 +243,44 @@ class PhpFileLoaderTest extends TestCase
 
         $this->assertEquals($expectedCollection, $routeCollection);
     }
+
+    public function testImportingRoutesWithHostsInImporter()
+    {
+        $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('importer-with-host.php');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/import-with-host-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('php'), $routes);
+    }
+
+    public function testImportingRoutesWithLocalesAndHostInImporter()
+    {
+        $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('importer-with-locale-and-host.php');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/import-with-locale-and-host-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('php'), $routes);
+    }
+
+    public function testImportingRoutesWithoutHostInImporter()
+    {
+        $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('importer-without-host.php');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/import-without-host-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('php'), $routes);
+    }
+
+    public function testImportingRoutesWithSingleHostInImporter()
+    {
+        $loader = new PhpFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('importer-with-single-host.php');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/import-with-single-host-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('php'), $routes);
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -520,4 +520,44 @@ class XmlFileLoaderTest extends TestCase
         $this->assertEquals('/slash/', $routeCollection->get('a_app_homepage')->getPath());
         $this->assertEquals('/no-slash', $routeCollection->get('b_app_homepage')->getPath());
     }
+
+    public function testImportingRoutesWithHostsInImporter()
+    {
+        $loader = new XmlFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('importer-with-host.xml');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/import-with-host-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('xml'), $routes);
+    }
+
+    public function testImportingRoutesWithLocalesAndHostInImporter()
+    {
+        $loader = new XmlFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('importer-with-locale-and-host.xml');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/import-with-locale-and-host-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('xml'), $routes);
+    }
+
+    public function testImportingRoutesWithoutHostsInImporter()
+    {
+        $loader = new XmlFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('importer-without-host.xml');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/import-without-host-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('xml'), $routes);
+    }
+
+    public function testImportingRoutesWithSingleHostsInImporter()
+    {
+        $loader = new XmlFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('importer-with-single-host.xml');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/import-with-single-host-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('xml'), $routes);
+    }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -392,4 +392,44 @@ class YamlFileLoaderTest extends TestCase
         $loader = new YamlFileLoader(new FileLocator([__DIR__.'/../Fixtures']));
         $loader->load('requirements_without_placeholder_name.yml');
     }
+
+    public function testImportingRoutesWithHostsInImporter()
+    {
+        $loader = new YamlFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('importer-with-host.yml');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/import-with-host-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('yml'), $routes);
+    }
+
+    public function testImportingRoutesWithLocalesAndHostInImporter()
+    {
+        $loader = new YamlFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('importer-with-locale-and-host.yml');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/import-with-locale-and-host-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('yml'), $routes);
+    }
+
+    public function testImportingRoutesWithoutHostInImporter()
+    {
+        $loader = new YamlFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('importer-without-host.yml');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/import-without-host-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('yml'), $routes);
+    }
+
+    public function testImportingRoutesWithSingleHostInImporter()
+    {
+        $loader = new YamlFileLoader(new FileLocator([__DIR__.'/../Fixtures/locale_and_host']));
+        $routes = $loader->load('importer-with-single-host.yml');
+
+        $expectedRoutes = require __DIR__.'/../Fixtures/locale_and_host/import-with-single-host-expected-collection.php';
+
+        $this->assertEquals($expectedRoutes('yml'), $routes);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #30617
| License       | MIT
| Doc PR        | TODO

Allow to define a different host for each locale in routing.

It's now possible to define this kind of configuration:
```yaml
controllers:
    resource: ../../src/Controller/
    type: annotation
    host:
        fr: www.example.fr
        en: www.example.com
```

It's still possible to define an unique host (`host: wwww.example.com`) and if a host is defined for a given route directly, it's not overridden.

To be done:
- [x] YamlLoader
- [x] XmlLoader
- [x] PhpLoader?
- [x] Documentation
- [x] Changelog