### PR TITLE
Update EsmtpTransport.php

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -106,7 +106,7 @@ class EsmtpTransport extends SmtpTransport
 
         /** @var SocketStream $stream */
         $stream = $this->getStream();
-        if (!$stream->isTLS() && \defined('OPENSSL_VERSION_NUMBER') && \array_key_exists('STARTTLS', $capabilities)) {
+        if ($stream->isTLS() && \defined('OPENSSL_VERSION_NUMBER') && \array_key_exists('STARTTLS', $capabilities)) {
             $this->executeCommand("STARTTLS\r\n", [220]);
 
             if (!$stream->startTLS()) {


### PR DESCRIPTION
I thinks that this condition is false. We should not call startTLS if we are not in TLS.
see symfony/symfony#36005

That's my first PR on symfony, so please say me if it's not the right way to do.

| Q             | A
| ------------- | ---
| Branch?       | 5.0 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yno
| Tickets       | Fix #36005 
| License       | MIT

I thinks that this condition is false. We should not call startTLS if we are not in TLS.
see symfony/symfony#36005

That's my first PR on symfony, so please say me if it's not the right way to do.
