### PR TITLE
[Messenger] Add possibility to route delayed messages to the origin queue directly

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpStampTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpStampTest.php
@@ -70,4 +70,13 @@ class AmqpStampTest extends TestCase
         $this->assertSame($amqpEnvelope->getAppId(), $stamp->getAttributes()['app_id']);
         $this->assertSame(\AMQP_MANDATORY, $stamp->getFlags());
     }
+
+    public function testCreateFromAmqpEnvelopeWithOriginQueueName()
+    {
+        $amqpEnvelope = $this->createMock(\AMQPEnvelope::class);
+
+        $stamp = AmqpStamp::createFromAmqpEnvelope($amqpEnvelope, null, 'origin_queue');
+
+        $this->assertSame('origin_queue', $stamp->getOriginQueueName());
+    }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -535,7 +535,12 @@ class ConnectionTest extends TestCase
         $delayQueue->expects($this->once())->method('declareQueue');
         $delayQueue->expects($this->never())->method('bind');
 
-        $delayExchange->expects($this->once())->method('publish')->with('{}', 'delay_messages__5000', AMQP_NOPARAM, ['headers' => [], 'delivery_mode' => 2]);
+        $delayExchange->expects($this->once())->method('publish')->with(
+            '{}',
+            'delay_messages__5000',
+            AMQP_NOPARAM,
+            ['headers' => [], 'delivery_mode' => 2, 'timestamp' => time()]
+        );
 
         $connection = Connection::fromDsn('amqp://localhost', ['delay' => ['exchange_name' => '']], $factory);
         $connection->publish('{}', [], 5000);
@@ -570,7 +575,12 @@ class ConnectionTest extends TestCase
         $delayQueue->expects($this->once())->method('declareQueue');
         $delayQueue->expects($this->once())->method('bind')->with('delays', 'delay__origin_queue_name_5000');
 
-        $delayExchange->expects($this->once())->method('publish')->with('{}', 'delay__origin_queue_name_5000', AMQP_NOPARAM, ['headers' => [], 'delivery_mode' => 2]);
+        $delayExchange->expects($this->once())->method('publish')->with(
+            '{}',
+            'delay__origin_queue_name_5000',
+            AMQP_NOPARAM,
+            ['headers' => [], 'delivery_mode' => 2, 'timestamp' => time()]
+        );
 
         $amqpStamp = new AmqpStamp(null, AMQP_NOPARAM, [], 'origin_queue_name');
         $connection = Connection::fromDsn('amqp://localhost', [], $factory);
@@ -606,7 +616,12 @@ class ConnectionTest extends TestCase
         $delayQueue->expects($this->once())->method('declareQueue');
         $delayQueue->expects($this->never())->method('bind');
 
-        $delayExchange->expects($this->once())->method('publish')->with('{}', 'delay__origin_queue_name_5000', AMQP_NOPARAM, ['headers' => [], 'delivery_mode' => 2]);
+        $delayExchange->expects($this->once())->method('publish')->with(
+            '{}',
+            'delay__origin_queue_name_5000',
+            AMQP_NOPARAM,
+            ['headers' => [], 'delivery_mode' => 2, 'timestamp' => time()]
+        );
 
         $amqpStamp = new AmqpStamp(null, AMQP_NOPARAM, [], 'origin_queue_name');
         $connection = Connection::fromDsn('amqp://localhost', ['delay' => ['exchange_name' => '']], $factory);

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -608,8 +608,8 @@ class ConnectionTest extends TestCase
         $delayExchange->expects($this->once())->method('publish')->with('{}', 'delay__origin_queue_name_5000', AMQP_NOPARAM, ['headers' => [], 'delivery_mode' => 2]);
 
         $amqpStamp = new AmqpStamp(null, AMQP_NOPARAM, [], 'origin_queue_name');
-        $connection = Connection::fromDsn('amqp://localhost', [], $factory);
-        $connection->publish('{}', ['delay' => ['exchange_name' => '']], 5000, $amqpStamp);
+        $connection = Connection::fromDsn('amqp://localhost', ['delay' => ['exchange_name' => '']], $factory);
+        $connection->publish('{}', [], 5000, $amqpStamp);
     }
 
     public function testItDelaysTheMessageWithADifferentRoutingKeyAndTTLs()

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -470,7 +470,7 @@ class ConnectionTest extends TestCase
         $connection->publish('{}', ['x-some-headers' => 'foo'], 5000);
     }
 
-    public function testItDelaysTheMessage()
+    public function testItDelaysTheMessageUsingDefaultExchange()
     {
         $amqpConnection = $this->createMock(\AMQPConnection::class);
         $amqpChannel = $this->createMock(\AMQPChannel::class);
@@ -505,7 +505,78 @@ class ConnectionTest extends TestCase
         $connection->publish('{}', ['x-some-headers' => 'foo'], 5000);
     }
 
-    public function testItRetriesTheMessage()
+    public function testItDelaysTheMessageUsingEmptyExchange()
+    {
+        $amqpConnection = $this->createMock(\AMQPConnection::class);
+        $amqpChannel = $this->createMock(\AMQPChannel::class);
+
+        $factory = $this->createMock(AmqpFactory::class);
+        $factory->method('createConnection')->willReturn($amqpConnection);
+        $factory->method('createChannel')->willReturn($amqpChannel);
+        $factory->method('createQueue')->will($this->onConsecutiveCalls(
+            $this->createMock(\AMQPQueue::class),
+            $delayQueue = $this->createMock(\AMQPQueue::class)
+        ));
+        $factory->method('createExchange')->will($this->onConsecutiveCalls(
+            $this->createMock(\AMQPExchange::class),
+            $delayExchange = $this->createMock(\AMQPExchange::class)
+        ));
+        $delayQueue->method('getName')->willReturn('delay_messages__5000');
+
+        $delayQueue->expects($this->once())->method('setName')->with('delay_messages__5000');
+        $delayQueue->expects($this->once())->method('setArguments')->with([
+            'x-message-ttl' => 5000,
+            'x-expires' => 5000 + 10000,
+            'x-dead-letter-exchange' => self::DEFAULT_EXCHANGE_NAME,
+            'x-dead-letter-routing-key' => '',
+        ]);
+
+        $delayQueue->expects($this->once())->method('declareQueue');
+        $delayQueue->expects($this->never())->method('bind');
+
+        $delayExchange->expects($this->once())->method('publish')->with('{}', 'delay_messages__5000', AMQP_NOPARAM, ['headers' => [], 'delivery_mode' => 2]);
+
+        $connection = Connection::fromDsn('amqp://localhost', ['delay' => ['exchange_name' => '']], $factory);
+        $connection->publish('{}', [], 5000);
+    }
+
+    public function testItRetriesTheMessageUsingDefaultExchange()
+    {
+        $amqpConnection = $this->createMock(\AMQPConnection::class);
+        $amqpChannel = $this->createMock(\AMQPChannel::class);
+
+        $factory = $this->createMock(AmqpFactory::class);
+        $factory->method('createConnection')->willReturn($amqpConnection);
+        $factory->method('createChannel')->willReturn($amqpChannel);
+        $factory->method('createQueue')->will($this->onConsecutiveCalls(
+            $this->createMock(\AMQPQueue::class),
+            $delayQueue = $this->createMock(\AMQPQueue::class)
+        ));
+        $factory->method('createExchange')->will($this->onConsecutiveCalls(
+            $this->createMock(\AMQPExchange::class),
+            $delayExchange = $this->createMock(\AMQPExchange::class)
+        ));
+
+        $delayQueue->method('getName')->willReturn('delay__origin_queue_name_5000');
+        $delayQueue->expects($this->once())->method('setName')->with('delay__origin_queue_name_5000');
+        $delayQueue->expects($this->once())->method('setArguments')->with([
+            'x-message-ttl' => 5000,
+            'x-expires' => 5000 + 10000,
+            'x-dead-letter-exchange' => '',
+            'x-dead-letter-routing-key' => 'origin_queue_name',
+        ]);
+
+        $delayQueue->expects($this->once())->method('declareQueue');
+        $delayQueue->expects($this->once())->method('bind')->with('delays', 'delay__origin_queue_name_5000');
+
+        $delayExchange->expects($this->once())->method('publish')->with('{}', 'delay__origin_queue_name_5000', AMQP_NOPARAM, ['headers' => [], 'delivery_mode' => 2]);
+
+        $amqpStamp = new AmqpStamp(null, AMQP_NOPARAM, [], 'origin_queue_name');
+        $connection = Connection::fromDsn('amqp://localhost', [], $factory);
+        $connection->publish('{}', [], 5000, $amqpStamp);
+    }
+
+    public function testItRetriesTheMessageUsingEmptyExchange()
     {
         $amqpConnection = $this->createMock(\AMQPConnection::class);
         $amqpChannel = $this->createMock(\AMQPChannel::class);
@@ -534,11 +605,11 @@ class ConnectionTest extends TestCase
         $delayQueue->expects($this->once())->method('declareQueue');
         $delayQueue->expects($this->never())->method('bind');
 
-        $delayExchange->expects($this->once())->method('publish')->with('{}', 'delay_messages__5000', AMQP_NOPARAM, ['headers' => ['x-some-headers' => 'foo'], 'delivery_mode' => 2]);
+        $delayExchange->expects($this->once())->method('publish')->with('{}', 'delay__origin_queue_name_5000', AMQP_NOPARAM, ['headers' => [], 'delivery_mode' => 2]);
 
         $amqpStamp = new AmqpStamp(null, AMQP_NOPARAM, [], 'origin_queue_name');
         $connection = Connection::fromDsn('amqp://localhost', [], $factory);
-        $connection->publish('{}', [], 5000, $amqpStamp);
+        $connection->publish('{}', ['delay' => ['exchange_name' => '']], 5000, $amqpStamp);
     }
 
     public function testItDelaysTheMessageWithADifferentRoutingKeyAndTTLs()

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -486,6 +486,7 @@ class ConnectionTest extends TestCase
             $this->createMock(\AMQPExchange::class),
             $delayExchange = $this->createMock(\AMQPExchange::class)
         ));
+        $delayQueue->method('getName')->willReturn('delay_messages__5000');
 
         $delayQueue->expects($this->once())->method('setName')->with('delay_messages__5000');
         $delayQueue->expects($this->once())->method('setArguments')->with([
@@ -520,6 +521,7 @@ class ConnectionTest extends TestCase
             $this->createMock(\AMQPExchange::class),
             $delayExchange = $this->createMock(\AMQPExchange::class)
         ));
+        $delayQueue->method('getName')->willReturn('delay_messages__120000');
 
         $connectionOptions = [
             'retry' => [
@@ -660,6 +662,7 @@ class ConnectionTest extends TestCase
             $this->createMock(\AMQPExchange::class),
             $delayExchange = $this->createMock(\AMQPExchange::class)
         ));
+        $delayQueue->method('getName')->willReturn('delay_messages_routing_key_120000');
 
         $connectionOptions = [
             'retry' => [

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -505,6 +505,42 @@ class ConnectionTest extends TestCase
         $connection->publish('{}', ['x-some-headers' => 'foo'], 5000);
     }
 
+    public function testItRetriesTheMessage()
+    {
+        $amqpConnection = $this->createMock(\AMQPConnection::class);
+        $amqpChannel = $this->createMock(\AMQPChannel::class);
+
+        $factory = $this->createMock(AmqpFactory::class);
+        $factory->method('createConnection')->willReturn($amqpConnection);
+        $factory->method('createChannel')->willReturn($amqpChannel);
+        $factory->method('createQueue')->will($this->onConsecutiveCalls(
+            $this->createMock(\AMQPQueue::class),
+            $delayQueue = $this->createMock(\AMQPQueue::class)
+        ));
+        $factory->method('createExchange')->will($this->onConsecutiveCalls(
+            $this->createMock(\AMQPExchange::class),
+            $delayExchange = $this->createMock(\AMQPExchange::class)
+        ));
+
+        $delayQueue->method('getName')->willReturn('delay__origin_queue_name_5000');
+        $delayQueue->expects($this->once())->method('setName')->with('delay__origin_queue_name_5000');
+        $delayQueue->expects($this->once())->method('setArguments')->with([
+            'x-message-ttl' => 5000,
+            'x-expires' => 5000 + 10000,
+            'x-dead-letter-exchange' => '',
+            'x-dead-letter-routing-key' => 'origin_queue_name',
+        ]);
+
+        $delayQueue->expects($this->once())->method('declareQueue');
+        $delayQueue->expects($this->never())->method('bind');
+
+        $delayExchange->expects($this->once())->method('publish')->with('{}', 'delay_messages__5000', AMQP_NOPARAM, ['headers' => ['x-some-headers' => 'foo'], 'delivery_mode' => 2]);
+
+        $amqpStamp = new AmqpStamp(null, AMQP_NOPARAM, [], 'origin_queue_name');
+        $connection = Connection::fromDsn('amqp://localhost', [], $factory);
+        $connection->publish('{}', [], 5000, $amqpStamp);
+    }
+
     public function testItDelaysTheMessageWithADifferentRoutingKeyAndTTLs()
     {
         $amqpConnection = $this->createMock(\AMQPConnection::class);

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -456,6 +456,7 @@ class ConnectionTest extends TestCase
             $amqpExchange = $this->createMock(\AMQPExchange::class),
             $delayExchange = $this->createMock(\AMQPExchange::class)
         ));
+        $delayQueue->method('getName')->willReturn('delay_messages__5000');
 
         $amqpExchange->expects($this->once())->method('setName')->with(self::DEFAULT_EXCHANGE_NAME);
         $amqpExchange->expects($this->once())->method('declareExchange');

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpSender.php
@@ -58,8 +58,11 @@ class AmqpSender implements SenderInterface
 
         $amqpReceivedStamp = $envelope->last(AmqpReceivedStamp::class);
         if ($amqpReceivedStamp instanceof AmqpReceivedStamp) {
-            $amqpStamp = AmqpStamp::createFromAmqpEnvelope($amqpReceivedStamp->getAmqpEnvelope(), $amqpStamp);
-            $encodedMessage['headers']['X-Origin-Queue'] = $amqpReceivedStamp->getQueueName();
+            $amqpStamp = AmqpStamp::createFromAmqpEnvelope(
+                $amqpReceivedStamp->getAmqpEnvelope(),
+                $amqpStamp,
+                $amqpReceivedStamp->getQueueName()
+            );
         }
 
         try {

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpSender.php
@@ -59,6 +59,7 @@ class AmqpSender implements SenderInterface
         $amqpReceivedStamp = $envelope->last(AmqpReceivedStamp::class);
         if ($amqpReceivedStamp instanceof AmqpReceivedStamp) {
             $amqpStamp = AmqpStamp::createFromAmqpEnvelope($amqpReceivedStamp->getAmqpEnvelope(), $amqpStamp);
+            $encodedMessage['headers']['X-Origin-Queue'] = $amqpReceivedStamp->getQueueName();
         }
 
         try {

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpSender.php
@@ -58,11 +58,7 @@ class AmqpSender implements SenderInterface
 
         $amqpReceivedStamp = $envelope->last(AmqpReceivedStamp::class);
         if ($amqpReceivedStamp instanceof AmqpReceivedStamp) {
-            $amqpStamp = AmqpStamp::createFromAmqpEnvelope(
-                $amqpReceivedStamp->getAmqpEnvelope(),
-                $amqpStamp,
-                $amqpReceivedStamp->getQueueName()
-            );
+            $amqpStamp = AmqpStamp::createFromAmqpEnvelope($amqpReceivedStamp->getAmqpEnvelope(), $amqpStamp, $amqpReceivedStamp->getQueueName());
         }
 
         try {

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpStamp.php
@@ -52,7 +52,7 @@ final class AmqpStamp implements NonSendableStampInterface
         return $this->originQueueName;
     }
 
-    public static function createFromAmqpEnvelope(\AMQPEnvelope $amqpEnvelope, self $previousStamp = null, string $originQueue = null): self
+    public static function createFromAmqpEnvelope(\AMQPEnvelope $amqpEnvelope, self $previousStamp = null, string $originQueueName = null): self
     {
         $attr = $previousStamp->attributes ?? [];
 
@@ -69,16 +69,21 @@ final class AmqpStamp implements NonSendableStampInterface
         $attr['type'] = $attr['type'] ?? $amqpEnvelope->getType();
         $attr['reply_to'] = $attr['reply_to'] ?? $amqpEnvelope->getReplyTo();
 
-        return new self($previousStamp->routingKey ?? $amqpEnvelope->getRoutingKey(), $previousStamp->flags ?? \AMQP_NOPARAM, $attr, $originQueue);
+        return new self(
+            $previousStamp->routingKey ?? $amqpEnvelope->getRoutingKey(),
+            $previousStamp->flags ?? \AMQP_NOPARAM,
+            $attr,
+            $originQueueName
+        );
     }
 
-    public static function createWithAttributes(array $attributes, self $previousStamp = null, string $originQueue = null): self
+    public static function createWithAttributes(array $attributes, self $previousStamp = null, string $originQueueName = null): self
     {
         return new self(
             $previousStamp->routingKey ?? null,
             $previousStamp->flags ?? \AMQP_NOPARAM,
             array_merge($previousStamp->attributes ?? [], $attributes),
-            $originQueue
+            $originQueueName
         );
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpStamp.php
@@ -69,12 +69,7 @@ final class AmqpStamp implements NonSendableStampInterface
         $attr['type'] = $attr['type'] ?? $amqpEnvelope->getType();
         $attr['reply_to'] = $attr['reply_to'] ?? $amqpEnvelope->getReplyTo();
 
-        return new self(
-            $previousStamp->routingKey ?? $amqpEnvelope->getRoutingKey(),
-            $previousStamp->flags ?? \AMQP_NOPARAM,
-            $attr,
-            $originQueueName
-        );
+        return new self($previousStamp->routingKey ?? $amqpEnvelope->getRoutingKey(), $previousStamp->flags ?? \AMQP_NOPARAM, $attr, $originQueueName);
     }
 
     public static function createWithAttributes(array $attributes, self $previousStamp = null, string $originQueueName = null): self

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -382,7 +382,7 @@ class Connection
     {
         $queue = $this->amqpFactory->createQueue($this->channel());
 
-        if ($originQueue === null) {
+        if (null === $originQueue) {
             $dlExchange = $this->exchangeOptions['name'];
             $dlRoutingKey = $routingKey ?? '';
             $dlQueueName = $this->getRoutingKeyForDelay($delay, $routingKey);
@@ -598,7 +598,7 @@ class Connection
 
     private function useDefaultExchangeForDelay(): bool
     {
-        return $this->connectionOptions['delay']['exchange_name'] === self::DEFAULT_EXCHANGE;
+        return self::DEFAULT_EXCHANGE === $this->connectionOptions['delay']['exchange_name'];
     }
 }
 class_alias(Connection::class, \Symfony\Component\Messenger\Transport\AmqpExt\Connection::class);

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -381,7 +381,7 @@ class Connection
      */
     private function createDelayQueue(int $delay, string $finalExchange, string $finalRoutingKey = null): \AMQPQueue
     {
-        $queueName = $this->buildDelayQueueName($finalExchange, $delay, $finalRoutingKey);
+        $queueName = $this->buildDelayQueueName($delay, $finalExchange, $finalRoutingKey);
 
         $queue = $this->amqpFactory->createQueue($this->channel());
         $queue->setName($queueName);
@@ -399,11 +399,11 @@ class Connection
         return $queue;
     }
 
-    private function buildDelayQueueName(string $exchangeName, int $delay, ?string $routingKey): string
+    private function buildDelayQueueName(int $delay, string $finalExchangeName, ?string $finalRoutingKey): string
     {
         return str_replace(
             ['%delay%', '%exchange_name%', '%routing_key%'],
-            [$delay, $exchangeName, $routingKey ?? ''],
+            [$delay, $finalExchangeName, $finalRoutingKey ?? ''],
             $this->connectionOptions['delay']['queue_name_pattern']
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #36196
| License       | MIT

Allows messenger to delay/retry messages more safely on topic exchange using amqp transport
