### PR TITLE
[Messenger] Added UniqueStamp to help ensure ExactlyOnce semantics

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/UniqueStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/UniqueStamp.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * Added by the user to signify this message is meant to be only one of this unique message inside
+ * of the message queue. This can be used to prevent enqueueing the same message awaiting to be processed.
+ * If no id is provided, the transport should generate a unique identifier based off of the content of the message.
+ *
+ * @author RJ Garcia <ragboyjr@icloud.com>
+ */
+final class UniqueStamp implements StampInterface
+{
+    private $id;
+
+    public function __construct(?string $id = null)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Stamp/UniqueStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/UniqueStampTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Stamp;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Stamp\UniqueStamp;
+
+/**
+ * @author RJ Garcia <ragboyjr@icloud.com>
+ */
+class UniqueStampTest extends TestCase
+{
+    public function testStampCreation()
+    {
+        $stamp = new UniqueStamp('1234');
+        $this->assertEquals('1234', $stamp->getId());
+    }
+
+    /** @dataProvider provideStampsForSerialization */
+    public function testStampIsSerializable(UniqueStamp $stamp)
+    {
+        $this->assertEquals($stamp, unserialize(serialize($stamp)));
+    }
+
+    public function provideStampsForSerialization()
+    {
+        yield 'Stamp without id' => [new UniqueStamp()];
+        yield 'Stamp with id' => [new UniqueStamp('12345')];
+    }
+}


### PR DESCRIPTION
The unique stamp can be used to declare that a given message
should be unique inside of a queue awaiting processing. This
stamp should allow ensuring that certain messages don't get
double processed if they are already awaiting in the queue.

Example:

- You have a queue for syncing product updates to an external
  service
- On every product save, you enqueue an UpdatedProductMessage
- The unique stamp would make sure that saving the same product
  multiple times will result in only one message in the queue
  preventing duplicated messages.

Signed-off-by: RJ Garcia <ragboyjr@icloud.com>

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | TKTK
