### PR TITLE
[Validator] Assert Valid with many groups

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Validator/AbstractTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/AbstractTest.php
@@ -701,4 +701,25 @@ abstract class AbstractTest extends AbstractValidatorTest
 
         $this->assertCount(2, $violations);
     }
+
+    public function testNestedObjectIsValidatedInMultipleGroupsIfGroupInValidConstraintIsValidated()
+    {
+        $entity = new Entity();
+        $entity->firstName = null;
+
+        $reference = new Reference();
+        $reference->value = null;
+
+        $entity->childA = $reference;
+
+        $this->metadata->addPropertyConstraint('firstName', new NotBlank());
+        $this->metadata->addPropertyConstraint('childA', new Valid(['groups' => ['group1', 'group2']]));
+
+        $this->referenceMetadata->addPropertyConstraint('value', new NotBlank(['groups' => 'group1']));
+        $this->referenceMetadata->addPropertyConstraint('value', new NotNull(['groups' => 'group2']));
+
+        $violations = $this->validator->validate($entity, null, ['Default', 'group1', 'group2']);
+
+        $this->assertCount(3, $violations);
+    }
 }

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Validator\Validator;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Composite;
 use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
 use Symfony\Component\Validator\Context\ExecutionContext;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
@@ -782,8 +783,9 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
             // that constraints belong to multiple validated groups
             if (null !== $cacheKey) {
                 $constraintHash = spl_object_hash($constraint);
-
-                if ($constraint instanceof Composite) {
+                // instanceof Valid: In case of using a Valid constraint with many groups
+                // it makes a reference object get validated by each group
+                if ($constraint instanceof Composite || $constraint instanceof Valid) {
                     $constraintHash .= $group;
                 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/36157
| License       | MIT

Make a reference object get validated by each group when using the Valid constraint with many groups
