### PR TITLE
[Debug] Allow setting any level

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -283,7 +283,7 @@ class ErrorHandler
     public function throwAt($levels, $replace = false)
     {
         $prev = $this->thrownErrors;
-        $this->thrownErrors = ($levels | E_RECOVERABLE_ERROR | E_USER_ERROR) & ~E_USER_DEPRECATED & ~E_DEPRECATED;
+        $this->thrownErrors = $levels;
         if (!$replace) {
             $this->thrownErrors |= $prev;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | possible #36009 and others
| License       | MIT

I know this is a BC break but I'm happy to follow up with a better fix based on suggestions.
Use case; I do a typically setup like;

index.php
```php
if ($_SERVER['APP_DEBUG']) {
    umask(0000);

    Debug::enable();
}
```

This causes PHP level deprecations like `$b = implode($a, '');` to be not converted into errors/exceptions (these don't even show up in the logs). Currently this means that when I enable debugging I get less reporting than without it, which is not intended :)

Using;
```php
if ($_SERVER['APP_DEBUG']) {
    umask(0000);

    $handler = Debug::enable();
    $handler->throwAt(E_DEPRECATED, true);
}
```

Is not helping either in any form, as the method will always disable the flags again by;
```php
$this->thrownErrors = ($levels | E_RECOVERABLE_ERROR | E_USER_ERROR) & ~E_USER_DEPRECATED & ~E_DEPRECATED;
```

Any help getting any level of deprecation errors in the logs is welcome as well, currently I'm logging using the following without luck;
```yaml
monolog:
    handlers:
        main:
            type: stream
            path: "%kernel.logs_dir%/%kernel.environment%.log"
            level: DEBUG
            include_stacktraces: true
```

updated:
forgot a word making my issue not correct