### PR TITLE
[Console] Fix OutputStream for PHP 7.4

### DIFF
--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Console\Output;
 
 use Symfony\Component\Console\Exception\InvalidArgumentException;
-use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 
 /**
@@ -74,10 +73,7 @@ class StreamOutput extends Output
             $message .= PHP_EOL;
         }
 
-        if (false === @fwrite($this->stream, $message)) {
-            // should never happen
-            throw new RuntimeException('Unable to write output.');
-        }
+        @fwrite($this->stream, $message);
 
         fflush($this->stream);
     }

--- a/src/Symfony/Component/Console/Tests/Output/StreamOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/StreamOutputTest.php
@@ -56,4 +56,12 @@ class StreamOutputTest extends TestCase
         rewind($output->getStream());
         $this->assertEquals('foo'.PHP_EOL, stream_get_contents($output->getStream()), '->doWrite() writes to the stream');
     }
+
+    public function testDoWriteOnFailure()
+    {
+        $resource = fopen(__DIR__.'/../Fixtures/stream_output_file.txt', 'r', false);
+        $output = new StreamOutput($resource);
+        rewind($output->getStream());
+        $this->assertEquals('', stream_get_contents($output->getStream()));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36166
| License       | MIT

From PHP 7.4, `fwrite` function now returns false for any failure: https://www.php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.fread-fwrite

Actually, the note in the PHP documentation is not exact: for PHP 7.3 and lower, `fwrite` function did return false when arguments passed in to the function were invalid, and 0 for other failures. From PHP 7.4, it returns false for any failure.
We can see it in the source code: for PHP 7.3: https://github.com/php/php-src/blob/a1a8d144854acb1c891cf0c21abb0f612b1d8de7/ext/standard/file.c#L1140
Compare to PHP 7.4: https://github.com/php/php-src/blob/master/ext/standard/file.c#L1136

I update `OutputStream::doWrite()` to keep the same behavior as before.

