### PR TITLE
[Security][Http][SwitchUserListener] Ignore all non existent username protection errors

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -168,7 +168,7 @@ class SwitchUserListener extends AbstractListener implements ListenerInterface
 
             try {
                 $this->provider->loadUserByUsername($nonExistentUsername);
-            } catch (AuthenticationException $e) {
+            } catch (\Exception $e) {
             }
         } catch (AuthenticationException $e) {
             $this->provider->loadUserByUsername($currentUsername);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/36174
| License       | MIT
| Doc PR        | -

Since we generate the non existent username blindly, it can lead to Doctrine exceptions or any other exception.

We can catch all exceptions here but I guess it reduces the protection since the SQL query was not executed?

Alternative: we can only catch Doctrine DriverException (in addition to the existing AuthenticationException) and only silent the reported error codes?