### PR TITLE
[VarDumper] Fix CliDumper coloration on light arrays

### DIFF
--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -268,7 +268,8 @@ class CliDumper extends AbstractDumper
         } elseif (Cursor::HASH_RESOURCE === $type) {
             $prefix = $this->style('note', $class.' resource').($hasChild ? ' {' : ' ');
         } else {
-            $prefix = $class && !(self::DUMP_LIGHT_ARRAY & $this->flags) ? $this->style('note', 'array:'.$class).' [' : '[';
+            $unstyledPrefix = $class && !(self::DUMP_LIGHT_ARRAY & $this->flags) ? 'array:'.$class : '';
+            $prefix = $this->style('note', $unstyledPrefix).($unstyledPrefix ? ' [' : '[');
         }
 
         if ($cursor->softRefCount || 0 < $cursor->softRefHandle) {

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/CliDumperTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\VarDumper\Tests\Dumper;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\AbstractDumper;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
 use Twig\Environment;
@@ -570,6 +571,57 @@ EOTXT
             ,
             $var
         );
+    }
+
+    public function provideDumpArrayWithColor()
+    {
+        yield [
+            ['foo' => 'bar'],
+            0,
+<<<EOTXT
+\e[0;38;5;208m\e[38;5;38marray:1\e[0;38;5;208m [\e[m
+  \e[0;38;5;208m"\e[38;5;113mfoo\e[0;38;5;208m" => "\e[1;38;5;113mbar\e[0;38;5;208m"\e[m
+\e[0;38;5;208m]\e[m
+
+EOTXT
+        ];
+
+        yield [[], AbstractDumper::DUMP_LIGHT_ARRAY, "\e[0;38;5;208m\e[38;5;38m\e[0;38;5;208m[]\e[m\n"];
+
+        yield [
+            ['foo' => 'bar'],
+            AbstractDumper::DUMP_LIGHT_ARRAY,
+            <<<EOTXT
+\e[0;38;5;208m\e[38;5;38m\e[0;38;5;208m[\e[m
+  \e[0;38;5;208m"\e[38;5;113mfoo\e[0;38;5;208m" => "\e[1;38;5;113mbar\e[0;38;5;208m"\e[m
+\e[0;38;5;208m]\e[m
+
+EOTXT
+        ];
+
+        yield [[], 0, "\e[0;38;5;208m\e[38;5;38m\e[0;38;5;208m[]\e[m\n"];
+    }
+
+    /**
+     * @dataProvider provideDumpArrayWithColor
+     */
+    public function testDumpArrayWithColor($value, $flags, $expectedOut)
+    {
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('Windows console does not support coloration');
+        }
+
+        $out = '';
+        $dumper = new CliDumper(function ($line, $depth) use (&$out) {
+            if ($depth >= 0) {
+                $out .= str_repeat('  ', $depth).$line."\n";
+            }
+        }, null, $flags);
+        $dumper->setColors(true);
+        $cloner = new VarCloner();
+        $dumper->dump($cloner->cloneVar($value));
+
+        $this->assertSame($expectedOut, $out);
     }
 
     private function getSpecialVars()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When `AbstractDumper::DUMP_LIGHT_ARRAY` is used with the `CliDumper`, the first line (opening bracket) is not colored. When an empty array is dumped (with or without  `AbstractDumper::DUMP_LIGHT_ARRAY`) the array is not colored too. This PR aims to fix that.
