### PR TITLE
[Security] Refactor logout listener to dispatch an event instead

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -91,6 +91,9 @@ Security
    {% endif %}
    ```
 
+ * Deprecated `LogoutSuccessHandlerInterface` and `LogoutHandlerInterface`, register a listener on the `LogoutEvent` event instead.
+ * Deprecated `DefaultLogoutSuccessHandler` in favor of `DefaultLogoutListener`.
+
 Yaml
 ----
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -60,3 +60,5 @@ Security
 --------
 
  * Removed `ROLE_PREVIOUS_ADMIN` role in favor of `IS_IMPERSONATOR` attribute
+ * Removed `LogoutSuccessHandlerInterface` and `LogoutHandlerInterface`, register a listener on the `LogoutEvent` event instead.
+ * Removed `DefaultLogoutSuccessHandler` in favor of `DefaultLogoutListener`.

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterCsrfTokenClearingLogoutHandlerPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterCsrfTokenClearingLogoutHandlerPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Http\EventListener\CsrfTokenClearingLogoutListener;
 
 /**
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
@@ -33,10 +34,9 @@ class RegisterCsrfTokenClearingLogoutHandlerPass implements CompilerPassInterfac
             return;
         }
 
-        $container->register('security.logout.handler.csrf_token_clearing', 'Symfony\Component\Security\Http\Logout\CsrfTokenClearingLogoutHandler')
+        $container->register('security.logout.listener.csrf_token_clearing', CsrfTokenClearingLogoutListener::class)
             ->addArgument(new Reference('security.csrf.token_storage'))
+            ->addTag('kernel.event_subscriber')
             ->setPublic(false);
-
-        $container->findDefinition('security.logout_listener')->addMethodCall('addHandler', [new Reference('security.logout.handler.csrf_token_clearing')]);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -16,6 +16,7 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy;
 
 /**
@@ -205,7 +206,7 @@ class MainConfiguration implements ConfigurationInterface
                     ->scalarNode('csrf_token_id')->defaultValue('logout')->end()
                     ->scalarNode('path')->defaultValue('/logout')->end()
                     ->scalarNode('target')->defaultValue('/')->end()
-                    ->scalarNode('success_handler')->end()
+                    ->scalarNode('success_handler')->setDeprecated(sprintf('The "%%node%%" at path "%%path%%" is deprecated, register a listener on the "%s" event instead.', LogoutEvent::class))->end()
                     ->booleanNode('invalidate_session')->defaultTrue()->end()
                 ->end()
                 ->fixXmlConfig('delete_cookie')
@@ -228,7 +229,7 @@ class MainConfiguration implements ConfigurationInterface
                 ->fixXmlConfig('handler')
                 ->children()
                     ->arrayNode('handlers')
-                        ->prototype('scalar')->end()
+                        ->prototype('scalar')->setDeprecated(sprintf('The "%%node%%" at path "%%path%%" is deprecated, register a listener on the "%s" event instead.', LogoutEvent::class))->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/SecurityBundle/EventListener/FirewallEventBubblingListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/EventListener/FirewallEventBubblingListener.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * A listener that dispatches all security events from the firewall-specific
+ * dispatcher on the global event dispatcher.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class FirewallEventBubblingListener implements EventSubscriberInterface
+{
+    private $eventDispatcher;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            LogoutEvent::class => 'bubbleEvent',
+        ];
+    }
+
+    public function bubbleEvent($event): void
+    {
+        $this->eventDispatcher->dispatch($event);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -90,6 +90,10 @@
         </service>
         <service id="Symfony\Component\Security\Http\Authentication\AuthenticationUtils" alias="security.authentication_utils" />
 
+        <service id="security.event_dispatcher.event_bubbling_listener" class="Symfony\Bundle\SecurityBundle\EventListener\FirewallEventBubblingListener" abstract="true">
+            <argument type="service" id="event_dispatcher" />
+        </service>
+
         <!-- Authorization related services -->
         <service id="security.access.decision_manager" class="Symfony\Component\Security\Core\Authorization\AccessDecisionManager">
             <argument type="collection" />

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -48,17 +48,17 @@
         <service id="security.logout_listener" class="Symfony\Component\Security\Http\Firewall\LogoutListener" abstract="true">
             <argument type="service" id="security.token_storage" />
             <argument type="service" id="security.http_utils" />
-            <argument type="service" id="security.logout.success_handler" />
+            <argument /> <!-- event dispatcher -->
             <argument /> <!-- Options -->
         </service>
 
-        <service id="security.logout.handler.session" class="Symfony\Component\Security\Http\Logout\SessionLogoutHandler" />
+        <service id="security.logout.listener.session" class="Symfony\Component\Security\Http\EventListener\SessionLogoutListener" abstract="true" />
 
-        <service id="security.logout.handler.cookie_clearing" class="Symfony\Component\Security\Http\Logout\CookieClearingLogoutHandler" abstract="true" />
+        <service id="security.logout.listener.cookie_clearing" class="Symfony\Component\Security\Http\Logout\CookieClearingLogoutHandler" abstract="true" />
 
-        <service id="security.logout.success_handler" class="Symfony\Component\Security\Http\Logout\DefaultLogoutSuccessHandler" abstract="true">
+        <service id="security.logout.listener.default" class="Symfony\Component\Security\Http\EventListener\DefaultLogoutListener" abstract="true">
             <argument type="service" id="security.http_utils" />
-            <argument>/</argument>
+            <argument>/</argument> <!-- target url -->
         </service>
 
         <service id="security.authentication.form_entry_point" class="Symfony\Component\Security\Http\EntryPoint\FormAuthenticationEntryPoint" abstract="true">

--- a/src/Symfony/Bundle/SecurityBundle/Security/LegacyLogoutHandlerListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/LegacyLogoutHandlerListener.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Security;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
+use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
+
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ *
+ * @internal
+ */
+class LegacyLogoutHandlerListener implements EventSubscriberInterface
+{
+    private $logoutHandler;
+
+    public function __construct(object $logoutHandler)
+    {
+        if (!$logoutHandler instanceof LogoutSuccessHandlerInterface && !$logoutHandler instanceof LogoutHandlerInterface) {
+            throw new \InvalidArgumentException(sprintf('An instance of "%s" or "%s" must be passed to "%s", "%s" given.', LogoutHandlerInterface::class, LogoutSuccessHandlerInterface::class, __METHOD__, get_debug_type($logoutHandler)));
+        }
+
+        $this->logoutHandler = $logoutHandler;
+    }
+
+    public function onLogout(LogoutEvent $event): void
+    {
+        if ($this->logoutHandler instanceof LogoutSuccessHandlerInterface) {
+            $event->setResponse($this->logoutHandler->onLogoutSuccess($event->getRequest()));
+        } elseif ($this->logoutHandler instanceof LogoutHandlerInterface) {
+            $this->logoutHandler->logout($event->getRequest(), $event->getResponse(), $event->getToken());
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            LogoutEvent::class => 'onLogout',
+        ];
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -20,6 +20,7 @@
         "ext-xml": "*",
         "symfony/config": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
+        "symfony/event-dispatcher": "^5.1",
         "symfony/http-kernel": "^5.0",
         "symfony/polyfill-php80": "^1.15",
         "symfony/security-core": "^4.4|^5.0",

--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * The `LegacyEventDispatcherProxy` class has been deprecated.
+ * Added an optional `dispatcher` attribute to the listener and subscriber tags in `RegisterListenerPass`.
 
 5.0.0
 -----

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * Added access decision strategy to override access decisions by voter service priority
  * Added `IS_ANONYMOUS`, `IS_REMEMBERED`, `IS_IMPERSONATOR`
  * Hash the persistent RememberMe token value in database.
+ * Added `LogoutEvent` to allow custom logout listeners.
+ * Deprecated `LogoutSuccessHandlerInterface` and `LogoutHandlerInterface` in favor of listening on the `LogoutEvent`.
 
 5.0.0
 -----

--- a/src/Symfony/Component/Security/Http/Event/LogoutEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/LogoutEvent.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Event;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class LogoutEvent extends Event
+{
+    private $request;
+    private $response;
+    private $token;
+
+    public function __construct(Request $request, ?TokenInterface $token)
+    {
+        $this->request = $request;
+        $this->token = $token;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+    public function getToken(): ?TokenInterface
+    {
+        return $this->token;
+    }
+
+    public function setResponse(Response $response): void
+    {
+        $this->response = $response;
+    }
+
+    public function getResponse(): ?Response
+    {
+        return $this->response;
+    }
+}

--- a/src/Symfony/Component/Security/Http/EventListener/CookieClearingLogoutListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/CookieClearingLogoutListener.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+
+/**
+ * This listener clears the passed cookies when a user logs out.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @final
+ */
+class CookieClearingLogoutListener implements EventSubscriberInterface
+{
+    private $cookies;
+
+    /**
+     * @param array $cookies An array of cookies (keys are names, values contain path and domain) to unset
+     */
+    public function __construct(array $cookies)
+    {
+        $this->cookies = $cookies;
+    }
+
+    public function onLogout(LogoutEvent $event): void
+    {
+        if (!$response = $event->getResponse()) {
+            return;
+        }
+
+        foreach ($this->cookies as $cookieName => $cookieData) {
+            $response->headers->clearCookie($cookieName, $cookieData['path'], $cookieData['domain']);
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            LogoutEvent::class => ['onLogout', -255],
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/Http/EventListener/CsrfTokenClearingLogoutListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/CsrfTokenClearingLogoutListener.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Csrf\TokenStorage\ClearableTokenStorageInterface;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+
+/**
+ * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
+ *
+ * @final
+ */
+class CsrfTokenClearingLogoutListener implements EventSubscriberInterface
+{
+    private $csrfTokenStorage;
+
+    public function __construct(ClearableTokenStorageInterface $csrfTokenStorage)
+    {
+        $this->csrfTokenStorage = $csrfTokenStorage;
+    }
+
+    public function onLogout(LogoutEvent $event): void
+    {
+        $this->csrfTokenStorage->clear();
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            LogoutEvent::class => 'onLogout',
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/Http/EventListener/DefaultLogoutListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/DefaultLogoutListener.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+use Symfony\Component\Security\Http\HttpUtils;
+
+/**
+ * Default logout listener will redirect users to a configured path.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander <iam.asm89@gmail.com>
+ *
+ * @final
+ */
+class DefaultLogoutListener implements EventSubscriberInterface
+{
+    private $httpUtils;
+    private $targetUrl;
+
+    public function __construct(HttpUtils $httpUtils, string $targetUrl = '/')
+    {
+        $this->httpUtils = $httpUtils;
+        $this->targetUrl = $targetUrl;
+    }
+
+    public function onLogout(LogoutEvent $event): void
+    {
+        if (null !== $event->getResponse()) {
+            return;
+        }
+
+        $event->setResponse($this->httpUtils->createRedirectResponse($event->getRequest(), $this->targetUrl));
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            LogoutEvent::class => ['onLogout', 64],
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/Http/EventListener/RememberMeLogoutListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/RememberMeLogoutListener.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Exception\LogicException;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+use Symfony\Component\Security\Http\RememberMe\AbstractRememberMeServices;
+
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ *
+ * @final
+ */
+class RememberMeLogoutListener implements EventSubscriberInterface
+{
+    private $rememberMeServices;
+
+    public function __construct(AbstractRememberMeServices $rememberMeServices)
+    {
+        $this->rememberMeServices = $rememberMeServices;
+    }
+
+    public function onLogout(LogoutEvent $event): void
+    {
+        if (null === $event->getResponse()) {
+            throw new LogicException(sprintf('No response was set for this logout action. Make sure the DefaultLogoutListener or another listener has set the response before "%s" is called.', __CLASS__));
+        }
+
+        $this->rememberMeServices->logout($event->getRequest(), $event->getResponse(), $event->getToken());
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            LogoutEvent::class => 'onLogout',
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/Http/EventListener/SessionLogoutListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/SessionLogoutListener.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+
+/**
+ * Handler for clearing invalidating the current session.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @final
+ */
+class SessionLogoutListener implements EventSubscriberInterface
+{
+    public function onLogout(LogoutEvent $event): void
+    {
+        $event->getRequest()->getSession()->invalidate();
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            LogoutEvent::class => 'onLogout',
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -11,17 +11,21 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\LogicException;
 use Symfony\Component\Security\Core\Exception\LogoutException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
 use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
 use Symfony\Component\Security\Http\ParameterBagUtils;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * LogoutListener logout users.
@@ -34,16 +38,30 @@ class LogoutListener extends AbstractListener
 {
     private $tokenStorage;
     private $options;
-    private $handlers;
-    private $successHandler;
     private $httpUtils;
     private $csrfTokenManager;
+    private $eventDispatcher;
 
     /**
-     * @param array $options An array of options to process a logout attempt
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param array                    $options         An array of options to process a logout attempt
      */
-    public function __construct(TokenStorageInterface $tokenStorage, HttpUtils $httpUtils, LogoutSuccessHandlerInterface $successHandler, array $options = [], CsrfTokenManagerInterface $csrfTokenManager = null)
+    public function __construct(TokenStorageInterface $tokenStorage, HttpUtils $httpUtils, /* EventDispatcherInterface */$eventDispatcher, array $options = [], CsrfTokenManagerInterface $csrfTokenManager = null)
     {
+        if (!$eventDispatcher instanceof EventDispatcherInterface) {
+            trigger_deprecation('symfony/security-http', '5.1', 'Passing a logout success handler to "%s" is deprecated, pass an instance of "%s" instead.', __METHOD__, EventDispatcherInterface::class);
+
+            if (!$eventDispatcher instanceof LogoutSuccessHandlerInterface) {
+                throw new \TypeError(sprintf('Argument 3 of "%s" must be instance of "%s" or "%s", "%s" given.', __METHOD__, EventDispatcherInterface::class, LogoutSuccessHandlerInterface::class, get_debug_type($eventDispatcher)));
+            }
+
+            $successHandler = $eventDispatcher;
+            $eventDispatcher = new EventDispatcher();
+            $eventDispatcher->addListener(LogoutEvent::class, function (LogoutEvent $event) use ($successHandler) {
+                $event->setResponse($r = $successHandler->onLogoutSuccess($event->getRequest()));
+            });
+        }
+
         $this->tokenStorage = $tokenStorage;
         $this->httpUtils = $httpUtils;
         $this->options = array_merge([
@@ -51,14 +69,24 @@ class LogoutListener extends AbstractListener
             'csrf_token_id' => 'logout',
             'logout_path' => '/logout',
         ], $options);
-        $this->successHandler = $successHandler;
         $this->csrfTokenManager = $csrfTokenManager;
-        $this->handlers = [];
+        $this->eventDispatcher = $eventDispatcher;
     }
 
+    /**
+     * @deprecated since version 5.1
+     */
     public function addHandler(LogoutHandlerInterface $handler)
     {
-        $this->handlers[] = $handler;
+        trigger_deprecation('symfony/security-http', '5.1', 'Calling "%s" is deprecated, register a listener on the "%s" event instead.', __METHOD__, LogoutEvent::class);
+
+        $this->eventDispatcher->addListener(LogoutEvent::class, function (LogoutEvent $event) use ($handler) {
+            if (null === $event->getResponse()) {
+                throw new LogicException(sprintf('No response was set for this logout action. Make sure the DefaultLogoutListener or another listener has set the response before "%s" is called.', __CLASS__));
+            }
+
+            $handler->logout($event->getRequest(), $event->getResponse(), $event->getToken());
+        });
     }
 
     /**
@@ -90,16 +118,12 @@ class LogoutListener extends AbstractListener
             }
         }
 
-        $response = $this->successHandler->onLogoutSuccess($request);
-        if (!$response instanceof Response) {
-            throw new \RuntimeException('Logout Success Handler did not return a Response.');
-        }
+        $logoutEvent = new LogoutEvent($request, $this->tokenStorage->getToken());
+        $this->eventDispatcher->dispatch($logoutEvent);
 
-        // handle multiple logout attempts gracefully
-        if ($token = $this->tokenStorage->getToken()) {
-            foreach ($this->handlers as $handler) {
-                $handler->logout($request, $response, $token);
-            }
+        $response = $logoutEvent->getResponse();
+        if (!$response instanceof Response) {
+            throw new \RuntimeException('No logout listener set the Response, make sure at least the DefaultLogoutListener is registered.');
         }
 
         $this->tokenStorage->setToken(null);

--- a/src/Symfony/Component/Security/Http/Logout/DefaultLogoutSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Logout/DefaultLogoutSuccessHandler.php
@@ -12,13 +12,18 @@
 namespace Symfony\Component\Security\Http\Logout;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\EventListener\DefaultLogoutListener;
 use Symfony\Component\Security\Http\HttpUtils;
+
+trigger_deprecation('symfony/security-http', '5.1', 'The "%s" class is deprecated, use "%s" instead.', DefaultLogoutSuccessHandler::class, DefaultLogoutListener::class);
 
 /**
  * Default logout success handler will redirect users to a configured path.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Alexander <iam.asm89@gmail.com>
+ *
+ * @deprecated since version 5.1
  */
 class DefaultLogoutSuccessHandler implements LogoutSuccessHandlerInterface
 {

--- a/src/Symfony/Component/Security/Http/Logout/LogoutHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutHandlerInterface.php
@@ -19,6 +19,8 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  * Interface that needs to be implemented by LogoutHandlers.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated since Symfony 5.1
  */
 interface LogoutHandlerInterface
 {

--- a/src/Symfony/Component/Security/Http/Logout/LogoutSuccessHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutSuccessHandlerInterface.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Security\Http\Logout;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+
+trigger_deprecation('symfony/security-http', '5.1', 'The "%s" interface is deprecated, create a listener for the "%s" event instead.', LogoutSuccessHandlerInterface::class, LogoutEvent::class);
 
 /**
  * LogoutSuccesshandlerInterface.
@@ -24,6 +27,8 @@ use Symfony\Component\HttpFoundation\Response;
  * LogoutHandlerInterface instead.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated since Symfony 5.1.
  */
 interface LogoutSuccessHandlerInterface
 {

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
@@ -12,21 +12,30 @@
 namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
 use Symfony\Component\Security\Http\Firewall\LogoutListener;
+use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
 
 class LogoutListenerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testHandleUnmatchedPath()
     {
-        list($listener, , $httpUtils, $options) = $this->getListener();
+        $dispatcher = $this->getEventDispatcher();
+        list($listener, , $httpUtils, $options) = $this->getListener($dispatcher);
 
         list($event, $request) = $this->getGetResponseEvent();
 
-        $event->expects($this->never())
-            ->method('setResponse');
+        $logoutEventDispatched = false;
+        $dispatcher->addListener(LogoutEvent::class, function (LogoutEvent $event) use (&$logoutEventDispatched) {
+            $logoutEventDispatched = true;
+        });
 
         $httpUtils->expects($this->once())
             ->method('checkRequestPath')
@@ -34,14 +43,16 @@ class LogoutListenerTest extends TestCase
             ->willReturn(false);
 
         $listener($event);
+
+        $this->assertFalse($logoutEventDispatched, 'LogoutEvent should not have been dispatched.');
     }
 
-    public function testHandleMatchedPathWithSuccessHandlerAndCsrfValidation()
+    public function testHandleMatchedPathWithCsrfValidation()
     {
-        $successHandler = $this->getSuccessHandler();
         $tokenManager = $this->getTokenManager();
+        $dispatcher = $this->getEventDispatcher();
 
-        list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener($successHandler, $tokenManager);
+        list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener($dispatcher, $tokenManager);
 
         list($event, $request) = $this->getGetResponseEvent();
 
@@ -56,19 +67,14 @@ class LogoutListenerTest extends TestCase
             ->method('isTokenValid')
             ->willReturn(true);
 
-        $successHandler->expects($this->once())
-            ->method('onLogoutSuccess')
-            ->with($request)
-            ->willReturn($response = new Response());
+        $response = new Response();
+        $dispatcher->addListener(LogoutEvent::class, function (LogoutEvent $event) use ($response) {
+            $event->setResponse($response);
+        });
 
         $tokenStorage->expects($this->once())
             ->method('getToken')
             ->willReturn($token = $this->getToken());
-
-        $handler = $this->getHandler();
-        $handler->expects($this->once())
-            ->method('logout')
-            ->with($request, $response, $token);
 
         $tokenStorage->expects($this->once())
             ->method('setToken')
@@ -78,16 +84,13 @@ class LogoutListenerTest extends TestCase
             ->method('setResponse')
             ->with($response);
 
-        $listener->addHandler($handler);
-
         $listener($event);
     }
 
-    public function testHandleMatchedPathWithoutSuccessHandlerAndCsrfValidation()
+    public function testHandleMatchedPathWithoutCsrfValidation()
     {
-        $successHandler = $this->getSuccessHandler();
-
-        list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener($successHandler);
+        $dispatcher = $this->getEventDispatcher();
+        list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener($dispatcher);
 
         list($event, $request) = $this->getGetResponseEvent();
 
@@ -96,19 +99,14 @@ class LogoutListenerTest extends TestCase
             ->with($request, $options['logout_path'])
             ->willReturn(true);
 
-        $successHandler->expects($this->once())
-            ->method('onLogoutSuccess')
-            ->with($request)
-            ->willReturn($response = new Response());
+        $response = new Response();
+        $dispatcher->addListener(LogoutEvent::class, function (LogoutEvent $event) use ($response) {
+            $event->setResponse($response);
+        });
 
         $tokenStorage->expects($this->once())
             ->method('getToken')
             ->willReturn($token = $this->getToken());
-
-        $handler = $this->getHandler();
-        $handler->expects($this->once())
-            ->method('logout')
-            ->with($request, $response, $token);
 
         $tokenStorage->expects($this->once())
             ->method('setToken')
@@ -118,17 +116,14 @@ class LogoutListenerTest extends TestCase
             ->method('setResponse')
             ->with($response);
 
-        $listener->addHandler($handler);
-
         $listener($event);
     }
 
-    public function testSuccessHandlerReturnsNonResponse()
+    public function testNoResponseSet()
     {
         $this->expectException('RuntimeException');
-        $successHandler = $this->getSuccessHandler();
 
-        list($listener, , $httpUtils, $options) = $this->getListener($successHandler);
+        list($listener, , $httpUtils, $options) = $this->getListener();
 
         list($event, $request) = $this->getGetResponseEvent();
 
@@ -136,11 +131,6 @@ class LogoutListenerTest extends TestCase
             ->method('checkRequestPath')
             ->with($request, $options['logout_path'])
             ->willReturn(true);
-
-        $successHandler->expects($this->once())
-            ->method('onLogoutSuccess')
-            ->with($request)
-            ->willReturn(null);
 
         $listener($event);
     }
@@ -168,6 +158,40 @@ class LogoutListenerTest extends TestCase
         $listener($event);
     }
 
+    /**
+     * @group legacy
+     */
+    public function testLegacyLogoutHandlers()
+    {
+        $this->expectDeprecation('Since symfony/security-http 5.1: The "%s\LogoutSuccessHandlerInterface" interface is deprecated, create a listener for the "%s" event instead.');
+        $this->expectDeprecation('Since symfony/security-http 5.1: Passing a logout success handler to "%s\LogoutListener::__construct" is deprecated, pass an instance of "%s" instead.');
+        $this->expectDeprecation('Since symfony/security-http 5.1: Calling "%s::addHandler" is deprecated, register a listener on the "%s" event instead.');
+
+        $logoutSuccessHandler = $this->createMock(LogoutSuccessHandlerInterface::class);
+        list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener($logoutSuccessHandler);
+
+        $token = $this->getToken();
+        $tokenStorage->expects($this->any())->method('getToken')->willReturn($token);
+
+        list($event, $request) = $this->getGetResponseEvent();
+
+        $httpUtils->expects($this->once())
+            ->method('checkRequestPath')
+            ->with($request, $options['logout_path'])
+            ->willReturn(true);
+
+        $response = new Response();
+        $logoutSuccessHandler->expects($this->any())->method('onLogoutSuccess')->willReturn($response);
+
+        $handler = $this->createMock('Symfony\Component\Security\Http\Logout\LogoutHandlerInterface');
+        $handler->expects($this->once())->method('logout')->with($request, $response, $token);
+        $listener->addHandler($handler);
+
+        $event->expects($this->once())->method('setResponse')->with($this->identicalTo($response));
+
+        $listener($event);
+    }
+
     private function getTokenManager()
     {
         return $this->getMockBuilder('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface')->getMock();
@@ -191,11 +215,6 @@ class LogoutListenerTest extends TestCase
         return [$event, $request];
     }
 
-    private function getHandler()
-    {
-        return $this->getMockBuilder('Symfony\Component\Security\Http\Logout\LogoutHandlerInterface')->getMock();
-    }
-
     private function getHttpUtils()
     {
         return $this->getMockBuilder('Symfony\Component\Security\Http\HttpUtils')
@@ -203,12 +222,12 @@ class LogoutListenerTest extends TestCase
             ->getMock();
     }
 
-    private function getListener($successHandler = null, $tokenManager = null)
+    private function getListener($eventDispatcher = null, $tokenManager = null)
     {
         $listener = new LogoutListener(
             $tokenStorage = $this->getTokenStorage(),
             $httpUtils = $this->getHttpUtils(),
-            $successHandler ?: $this->getSuccessHandler(),
+            $eventDispatcher ?? $this->getEventDispatcher(),
             $options = [
                 'csrf_parameter' => '_csrf_token',
                 'csrf_token_id' => 'logout',
@@ -221,9 +240,9 @@ class LogoutListenerTest extends TestCase
         return [$listener, $tokenStorage, $httpUtils, $options];
     }
 
-    private function getSuccessHandler()
+    private function getEventDispatcher()
     {
-        return $this->getMockBuilder('Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface')->getMock();
+        return new EventDispatcher();
     }
 
     private function getToken()

--- a/src/Symfony/Component/Security/Http/Tests/Logout/DefaultLogoutSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/DefaultLogoutSuccessHandlerTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Security\Http\Logout\DefaultLogoutSuccessHandler;
 
+/**
+ * @group legacy
+ */
 class DefaultLogoutSuccessHandlerTest extends TestCase
 {
     public function testLogout()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes (sort of...)
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #25212, Fix #22473
| License       | MIT
| Doc PR        | tbd

The current `LogoutListener` has some extension points, but they are not really DX-friendly (ref #25212). It requires hacking a `addMethodCall('addHandler')` in the container builder to register a custom logout handler.  
Also, it is impossible to overwrite the default logout functionality from a bundle (ref #22473).

This PR introduces a `LogoutEvent` that replaces both the `LogoutSuccessHandlerInterface` and `LogoutHandlerInterface`. This provides a DX-friendly extension point and also cleans up the authentication factories (no more `addMethodCall()`'s).

In order to allow different logout handlers for different firewalls, I created a specific event dispatcher for each firewall (as also shortly discussed in #33558). The `dispatcher` tag attribute allows you to specify which dispatcher it should be registered to (defaulting to the global dispatcher). The `EventBubblingLogoutListener` also dispatches logout events on the global dispatcher, to be used for listeners that should run on all firewalls.

_@weaverryan and I discussed this feature while working on #33558, but figured it was unrelated and could be done while preservering BC. So that's why a separate PR is created._