### PR TITLE
[Typo] Rename occurence to occurrence

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/DeprecationGroup.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/DeprecationGroup.php
@@ -30,7 +30,7 @@ final class DeprecationGroup
      */
     public function addNoticeFromObject($message, $class, $method)
     {
-        $this->deprecationNotice($message)->addObjectOccurence($class, $method);
+        $this->deprecationNotice($message)->addObjectOccurrence($class, $method);
         $this->addNotice();
     }
 
@@ -39,7 +39,7 @@ final class DeprecationGroup
      */
     public function addNoticeFromProceduralCode($message)
     {
-        $this->deprecationNotice($message)->addProceduralOccurence();
+        $this->deprecationNotice($message)->addProceduralOccurrence();
         $this->addNotice();
     }
 

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/DeprecationNotice.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/DeprecationNotice.php
@@ -23,7 +23,7 @@ final class DeprecationNotice
      */
     private $countsByCaller = [];
 
-    public function addObjectOccurence($class, $method)
+    public function addObjectOccurrence($class, $method)
     {
         if (!isset($this->countsByCaller["$class::$method"])) {
             $this->countsByCaller["$class::$method"] = 0;
@@ -32,7 +32,7 @@ final class DeprecationNotice
         ++$this->count;
     }
 
-    public function addProceduralOccurence()
+    public function addProceduralOccurrence()
     {
         ++$this->count;
     }

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationNoticeTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationNoticeTest.php
@@ -10,9 +10,9 @@ final class DeprecationNoticeTest extends TestCase
     public function testItGroupsByCaller()
     {
         $notice = new DeprecationNotice();
-        $notice->addObjectOccurence('MyAction', '__invoke');
-        $notice->addObjectOccurence('MyAction', '__invoke');
-        $notice->addObjectOccurence('MyOtherAction', '__invoke');
+        $notice->addObjectOccurrence('MyAction', '__invoke');
+        $notice->addObjectOccurrence('MyAction', '__invoke');
+        $notice->addObjectOccurrence('MyOtherAction', '__invoke');
 
         $countsByCaller = $notice->getCountsByCaller();
 
@@ -23,13 +23,13 @@ final class DeprecationNoticeTest extends TestCase
         $this->assertSame(1, $countsByCaller['MyOtherAction::__invoke']);
     }
 
-    public function testItCountsBothTypesOfOccurences()
+    public function testItCountsBothTypesOfOccurrences()
     {
         $notice = new DeprecationNotice();
-        $notice->addObjectOccurence('MyAction', '__invoke');
+        $notice->addObjectOccurrence('MyAction', '__invoke');
         $this->assertSame(1, $notice->count());
 
-        $notice->addProceduralOccurence();
+        $notice->addProceduralOccurrence();
         $this->assertSame(2, $notice->count());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master (5.1)
| Bug fix?      | yes (typo)
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36242
| License       | MIT
| Doc PR        | Not needed

This PR will fix correct spelling of methods containing the word occurrence implemented with PR : 
- [PHPUnitBridge] Improved deprecations display #35271

This changes are on master branch, because the original PR is a new feature for Symfony 5.1.