### PR TITLE
[Routing] Add installation and minimal example to README

### DIFF
--- a/src/Symfony/Component/Routing/README.md
+++ b/src/Symfony/Component/Routing/README.md
@@ -3,10 +3,48 @@ Routing Component
 
 The Routing component maps an HTTP request to a set of configuration variables.
 
+Getting Started
+---------------
+
+```
+$ composer require symfony/routing
+```
+
+```php
+use App\Controller\BlogController;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\Matcher\UrlMatcher;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+$route = new Route('/blog/{slug}', ['_controller' => BlogController::class]);
+$routes = new RouteCollection();
+$routes->add('blog_show', $route);
+
+$context = new RequestContext();
+
+// Routing can match routes with incoming requests
+$matcher = new UrlMatcher($routes, $context);
+$parameters = $matcher->match('/blog/lorem-ipsum');
+// $parameters = [
+//     '_controller' => 'App\Controller\BlogController',
+//     'slug' => 'lorem-ipsum',
+//     '_route' => 'blog_show'
+// ]
+
+// Routing can also generate URLs for a given route
+$generator = new UrlGenerator($routes, $context);
+$url = $generator->generate('blog_show', [
+    'slug' => 'my-blog-post',
+]);
+// $url = '/blog/my-blog-post'
+```
+
 Resources
 ---------
 
-  * [Documentation](https://symfony.com/doc/current/components/routing.html)
+  * [Documentation](https://symfony.com/doc/current/routing.html)
   * [Contributing](https://symfony.com/doc/current/contributing/index.html)
   * [Report issues](https://github.com/symfony/symfony/issues) and
     [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | symfony/symfony-docs#13431

Similair to what I did in #35552, this PR updates the README of the Routing component to include a minimal example and installation command.