### PR TITLE
[Draft] [Profiler] [Twig] Add Twig variables in profiler

### DIFF
--- a/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
+++ b/src/Symfony/Bridge/Twig/DataCollector/TwigDataCollector.php
@@ -64,6 +64,8 @@ class TwigDataCollector extends DataCollector implements LateDataCollectorInterf
     {
         $this->data['profile'] = serialize($this->profile);
         $this->data['template_paths'] = [];
+        $this->data['global_variables'] = [];
+        $this->data['template_variables'] = [];
 
         if (null === $this->twig) {
             return;
@@ -87,6 +89,10 @@ class TwigDataCollector extends DataCollector implements LateDataCollectorInterf
             }
         };
         $templateFinder($this->profile);
+
+        foreach ($this->twig->mergeGlobals() as $twigGlobalKey => $twigGlobalValue) {
+            $this->data['global_variables'][$twigGlobalKey] = $this->cloneVar($twigGlobalValue);
+        }
     }
 
     public function getTime()
@@ -102,6 +108,16 @@ class TwigDataCollector extends DataCollector implements LateDataCollectorInterf
     public function getTemplatePaths()
     {
         return $this->data['template_paths'];
+    }
+
+    public function getGlobalVariables()
+    {
+        return $this->data['global_variables'];
+    }
+
+    public function getTemplateVariables()
+    {
+        return $this->data['template_variables'];
     }
 
     public function getTemplates()

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/twig.html.twig
@@ -45,71 +45,145 @@
             <p>No Twig templates were rendered for this request.</p>
         </div>
     {% else %}
-        <h2>Twig Metrics</h2>
+        <div class="sf-tabs">
+            <div class="tab">
+                <h3 class="tab-title">Twig Metrics</h3>
 
-        <div class="metrics">
-            <div class="metric">
-                <span class="value">{{ '%0.0f'|format(collector.time) }} <span class="unit">ms</span></span>
-                <span class="label">Render time</span>
+                <div class="tab-content">
+                    <h2>Metrics</h2>
+
+                    <div class="metrics">
+                        <div class="metric">
+                            <span class="value">{{ '%0.0f'|format(collector.time) }} <span class="unit">ms</span></span>
+                            <span class="label">Render time</span>
+                        </div>
+
+                        <div class="metric">
+                            <span class="value">{{ collector.templatecount }}</span>
+                            <span class="label">Template calls</span>
+                        </div>
+
+                        <div class="metric">
+                            <span class="value">{{ collector.blockcount }}</span>
+                            <span class="label">Block calls</span>
+                        </div>
+
+                        <div class="metric">
+                            <span class="value">{{ collector.macrocount }}</span>
+                            <span class="label">Macro calls</span>
+                        </div>
+                    </div>
+
+                    <p class="help">
+                        Render time includes sub-requests rendering time (if any).
+                    </p>
+
+                    <h2>Rendered Templates</h2>
+
+                    <table id="twig-table">
+                        <thead>
+                        <tr>
+                            <th scope="col">Template Name &amp; Path</th>
+                            <th class="num-col" scope="col">Render Count</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for template, count in collector.templates %}
+                            <tr>
+                                {%- set file = collector.templatePaths[template]|default(false) -%}
+                                {%- set link = file ? file|file_link(1) : false -%}
+                                <td>
+                                    <span class="sf-icon icon-twig">{{ include('@WebProfiler/Icon/twig.svg') }}</span>
+                                    {% if link %}
+                                        <a href="{{ link }}" title="{{ file }}">{{ template }}</a>
+                                        <div>
+                                            <a class="text-muted" href="{{ link }}" title="{{ file }}">
+                                                {{ file|file_relative|default(file) }}
+                                            </a>
+                                        </div>
+                                    {% else %}
+                                        {{ template }}
+                                    {% endif %}
+                                </td>
+                                <td class="font-normal num-col">{{ count }}</td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+
+                    <h2>Rendering Call Graph</h2>
+
+                    <div id="twig-dump">
+                        {{ collector.htmlcallgraph }}
+                    </div>
+                </div>
             </div>
 
-            <div class="metric">
-                <span class="value">{{ collector.templatecount }}</span>
-                <span class="label">Template calls</span>
-            </div>
+            <div class="tab">
+                <h3 class="tab-title">Twig Variables</h3>
 
-            <div class="metric">
-                <span class="value">{{ collector.blockcount }}</span>
-                <span class="label">Block calls</span>
-            </div>
+                <div class="tab-content">
+                    <h2>Globals</h2>
 
-            <div class="metric">
-                <span class="value">{{ collector.macrocount }}</span>
-                <span class="label">Macro calls</span>
-            </div>
-        </div>
-
-        <p class="help">
-            Render time includes sub-requests rendering time (if any).
-        </p>
-
-        <h2>Rendered Templates</h2>
-
-        <table id="twig-table">
-            <thead>
-            <tr>
-                <th scope="col">Template Name &amp; Path</th>
-                <th class="num-col" scope="col">Render Count</th>
-            </tr>
-            </thead>
-            <tbody>
-            {% for template, count in collector.templates %}
-                <tr>
-                    {%- set file = collector.templatePaths[template]|default(false) -%}
-                    {%- set link = file ? file|file_link(1) : false -%}
-                    <td>
-                        <span class="sf-icon icon-twig">{{ include('@WebProfiler/Icon/twig.svg') }}</span>
-                        {% if link %}
-                            <a href="{{ link }}" title="{{ file }}">{{ template }}</a>
-                            <div>
-                                <a class="text-muted" href="{{ link }}" title="{{ file }}">
-                                    {{ file|file_relative|default(file) }}
-                                </a>
-                            </div>
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Value</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for key, value in collector.globalVariables %}
+                            <tr>
+                                <th class="key">{{ key }}</th>
+                                <td>{{ profiler_dump(value) }}</td>
+                            </tr>
                         {% else %}
-                            {{ template }}
-                        {% endif %}
-                    </td>
-                    <td class="font-normal num-col">{{ count }}</td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
+                            <tr>
+                                <th>No global variables</th>
+                                <td>-</td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
 
-        <h2>Rendering Call Graph</h2>
+                    <h2>Templates</h2>
 
-        <div id="twig-dump">
-            {{ collector.htmlcallgraph }}
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Template</th>
+                            <th>Name</th>
+                            <th>Value</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for template, variables in collector.templateVariables %}
+                            {% for key, value in variables %}
+                                <tr>
+                                    <th class="key">{{ template }}</th>
+                                    <dt>{{ key }}</dt>
+                                    <td>{{ profiler_dump(value) }}</td>
+                                </tr>
+                            {% else %}
+                                <tr>
+                                    <th>No templates variables</th>
+                                    <td>-</td>
+                                    <td>-</td>
+                                </tr>
+                            {% endfor %}
+                        {% else %}
+                            <tr>
+                                <th>No templates variables</th>
+                                <td>-</td>
+                                <td>-</td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+
+                </div>
+            </div>
         </div>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Implement https://github.com/symfony/symfony/issues/36247
| License       | MIT
| Doc PR        | TODO if accepted/merged

-----

# Draft PR

Hi,

Here is my attempt to implement the https://github.com/symfony/symfony/issues/36247 feature

- [x] global vars (Twig config)
- [ ] templates vars (passed form the controller)

On dev env, where and how is it smart to hook on the `Twig\Environment` `render` calls so that we can cache the template name and its context? via a TraceableTwigEnvironment?

Review & help appreciated

Thank you

-----

**before**

![before](https://user-images.githubusercontent.com/1358361/77826347-193b8280-710f-11ea-9d2b-ca2c7377fe45.jpg)

**after**

![after_1](https://user-images.githubusercontent.com/1358361/77826351-20fb2700-710f-11ea-9dae-b02691b3ded1.jpg)
![after_2](https://user-images.githubusercontent.com/1358361/77828188-2d38b180-711a-11ea-8243-d06c9217a5bf.jpg)

with this twig config:
```yaml
# config/packages/twig.yaml
twig:
    default_path: '%kernel.project_dir%/templates'
    form_themes: ['bootstrap_4_layout.html.twig']
    globals:
        is_beta: true
        app_version: 1.2.3
        emails: {'sales': 'sales@app.com', 'contact': 'contact@app.com'}
```
