### PR TITLE
[Security/Http] Allow setting cookie security settings for delete_cookies

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -273,6 +273,8 @@ class MainConfiguration implements ConfigurationInterface
                             ->children()
                                 ->scalarNode('path')->defaultNull()->end()
                                 ->scalarNode('domain')->defaultNull()->end()
+                                ->scalarNode('secure')->defaultFalse()->end()
+                                ->scalarNode('samesite')->defaultNull()->end()
                             ->end()
                         ->end()
                     ->end()

--- a/src/Symfony/Component/Security/Http/Logout/CookieClearingLogoutHandler.php
+++ b/src/Symfony/Component/Security/Http/Logout/CookieClearingLogoutHandler.php
@@ -38,7 +38,7 @@ class CookieClearingLogoutHandler implements LogoutHandlerInterface
     public function logout(Request $request, Response $response, TokenInterface $token)
     {
         foreach ($this->cookies as $cookieName => $cookieData) {
-            $response->headers->clearCookie($cookieName, $cookieData['path'], $cookieData['domain']);
+            $response->headers->clearCookie($cookieName, $cookieData['path'], $cookieData['domain'], isset($cookieData['secure']) ? $cookieData['secure'] : false, true, isset($cookieData['samesite']) ? $cookieData['samesite'] : null);
         }
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Logout/CookieClearingLogoutHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/CookieClearingLogoutHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Tests\Logout;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
@@ -25,7 +26,7 @@ class CookieClearingLogoutHandlerTest extends TestCase
         $response = new Response();
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
 
-        $handler = new CookieClearingLogoutHandler(['foo' => ['path' => '/foo', 'domain' => 'foo.foo'], 'foo2' => ['path' => null, 'domain' => null]]);
+        $handler = new CookieClearingLogoutHandler(['foo' => ['path' => '/foo', 'domain' => 'foo.foo', 'secure' => true, 'samesite' => Cookie::SAMESITE_STRICT], 'foo2' => ['path' => null, 'domain' => null]]);
 
         $cookies = $response->headers->getCookies();
         $this->assertCount(0, $cookies);
@@ -39,12 +40,16 @@ class CookieClearingLogoutHandlerTest extends TestCase
         $this->assertEquals('foo', $cookie->getName());
         $this->assertEquals('/foo', $cookie->getPath());
         $this->assertEquals('foo.foo', $cookie->getDomain());
+        $this->assertEquals(Cookie::SAMESITE_STRICT, $cookie->getSameSite());
+        $this->assertTrue($cookie->isSecure());
         $this->assertTrue($cookie->isCleared());
 
         $cookie = $cookies['']['/']['foo2'];
         $this->assertStringStartsWith('foo2', $cookie->getName());
         $this->assertEquals('/', $cookie->getPath());
         $this->assertNull($cookie->getDomain());
+        $this->assertNull($cookie->getSameSite());
+        $this->assertFalse($cookie->isSecure());
         $this->assertTrue($cookie->isCleared());
     }
 }

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -19,7 +19,7 @@
         "php": "^5.5.9|>=7.0.8",
         "symfony/security-core": "~3.2|~4.0",
         "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-        "symfony/http-foundation": "~2.8|~3.0|~4.0",
+        "symfony/http-foundation": "~3.4.39|^4.4.6",
         "symfony/http-kernel": "~3.3|~4.0",
         "symfony/polyfill-php56": "~1.0",
         "symfony/polyfill-php70": "~1.0",

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^5.5.9|>=7.0.8",
         "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-        "symfony/http-foundation": "^2.8.31|~3.3.13|~3.4|~4.0",
+        "symfony/http-foundation": "~3.4.39|^4.4.6",
         "symfony/http-kernel": "~3.3|~4.0",
         "symfony/polyfill-php56": "~1.0",
         "symfony/polyfill-php70": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/pull/36243#discussion_r399646893
| License       | MIT
| Doc PR        | tbd

Similar to #36173 and #36175. This is needed for Chrome 80 compatibility.

My only question is whether we should introduce these specific settings, or somehow fetch them from `framework.session`?