### PR TITLE
[DomCrawler] Fix BC break in assertions breaking Panther

### DIFF
--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextContains.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextContains.php
@@ -45,7 +45,7 @@ final class CrawlerSelectorTextContains extends Constraint
             return false;
         }
 
-        return false !== mb_strpos($crawler->text(null, false), $this->expectedText);
+        return false !== mb_strpos($crawler->text(null, true), $this->expectedText);
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextSame.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextSame.php
@@ -45,7 +45,7 @@ final class CrawlerSelectorTextSame extends Constraint
             return false;
         }
 
-        return $this->expectedText === trim($crawler->text(null, false));
+        return $this->expectedText === trim($crawler->text(null, true));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

#35899 introduces a BC break: browsers aren't able to retrieve the non-normalized version of a text. According to the HTML spec, whitespaces are always normalized. Because of this patch, these assertions doesn't work with Panther anymore.

Also, this change probably hurts other users because getting the non-normalized version is almost never expected. (I'm in favor of **not** supporting retrieving the non-normalized version at all, for consistency with browsers and the spec, but it's another topic).