### PR TITLE
Fix the reporting of deprecations in twig:lint

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -110,7 +110,7 @@ EOF
             $prevErrorHandler = set_error_handler(static function ($level, $message, $file, $line) use (&$prevErrorHandler) {
                 if (E_USER_DEPRECATED === $level) {
                     $templateLine = 0;
-                    if (preg_match('/ at line (\d+) /', $message, $matches)) {
+                    if (preg_match('/ at line (\d+)[ .]/', $message, $matches)) {
                         $templateLine = $matches[1];
                     }
 
@@ -234,6 +234,14 @@ EOF
             $output->text(sprintf('<error> ERROR </error> in %s (line %s)', $file, $line));
         } else {
             $output->text(sprintf('<error> ERROR </error> (line %s)', $line));
+        }
+
+        // If the line is not known (this might happen for deprecations if we fail at detecting the line for instance),
+        // we render the message without context, to ensure the message is displayed.
+        if ($line <= 0) {
+            $output->text(sprintf('<error> >> %s</error> ', $exception->getRawMessage()));
+
+            return;
         }
 
         foreach ($this->getContext($template, $line) as $lineNumber => $code) {

--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
+use Twig\TwigFilter;
 
 class LintCommandTest extends TestCase
 {
@@ -67,6 +68,34 @@ class LintCommandTest extends TestCase
     }
 
     /**
+     * When deprecations are not reported by the command, the testsuite reporter will catch them so we need to mark the test as legacy.
+     *
+     * @group legacy
+     */
+    public function testLintFileWithNotReportedDeprecation()
+    {
+        $tester = $this->createCommandTester();
+        $filename = $this->createFile('{{ foo|deprecated_filter }}');
+
+        $ret = $tester->execute(['filename' => [$filename]], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false]);
+
+        $this->assertEquals(0, $ret, 'Returns 0 in case of success');
+        $this->assertStringContainsString('OK in', trim($tester->getDisplay()));
+    }
+
+    public function testLintFileWithReportedDeprecation()
+    {
+        $tester = $this->createCommandTester();
+        $filename = $this->createFile('{{ foo|deprecated_filter }}');
+
+        $ret = $tester->execute(['filename' => [$filename], '--show-deprecations' => true], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false]);
+
+        $this->assertEquals(1, $ret, 'Returns 1 in case of error');
+        $this->assertRegExp('/ERROR  in \S+ \(line 1\)/', trim($tester->getDisplay()));
+        $this->assertStringContainsString('Filter "deprecated_filter" is deprecated', trim($tester->getDisplay()));
+    }
+
+    /**
      * @group tty
      */
     public function testLintDefaultPaths()
@@ -80,7 +109,12 @@ class LintCommandTest extends TestCase
 
     private function createCommandTester(): CommandTester
     {
-        $command = new LintCommand(new Environment(new FilesystemLoader(\dirname(__DIR__).'/Fixtures/templates/')));
+        $environment = new Environment(new FilesystemLoader(\dirname(__DIR__).'/Fixtures/templates/'));
+        $environment->addFilter(new TwigFilter('deprecated_filter', function ($v) {
+            return $v;
+        }, ['deprecated' => true]));
+
+        $command = new LintCommand($environment);
 
         $application = new Application();
         $application->add($command);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 (the `--show-deprecations` option does not exist in 3.4)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

- ensure that the message is rendered when the line detection fails and we end up with 0 as line number (the implementation also deals with -1 which is sometimes used by Twig for errors when it does not know the line, even though this should not happen for compile-time errors).
- fix the detection of the line number when the number is at the end of the sentence, which happens for the deprecation of filters for instance.
