### PR TITLE
[Form] Deprecated `choice_attr` as nested arrays mapped by indexes

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -24,6 +24,49 @@ Form
  * Implementing the `FormConfigBuilderInterface` without implementing the `setIsEmptyCallback()` method
    is deprecated. The method will be added to the interface in 6.0.
  * Added argument `callable|null $filter` to `ChoiceListFactoryInterface::createListFromChoices()` and `createListFromLoader()` - not defining them is deprecated.
+ * Usage of `choice_attr` option as an array of nested arrays has been deprecated and indexes will be considered as attributes in 6.0. Use a unique array for all choices or a `callable` instead.
+
+   Before:
+   ```php
+   // Single array for all choices using callable
+   'choice_attr' => function () {
+       return ['class' => 'choice-options'];
+   },
+
+   // Different arrays per choice using array
+   'choices' => [
+       'Yes' => true,
+       'No' => false,
+       'Maybe' => null,
+   ],
+   'choice_attr' => [
+       'Yes' => ['class' => 'option-green'],
+       'No' => ['class' => 'option-red'],
+   ],
+   ```
+
+   After:
+   ```php
+   // Single array for all choices using array
+   'choice_attr' => ['class' => 'choice-options'],
+
+   // Different arrays per choice using callable
+   'choices' => [
+       'Yes' => true,
+       'No' => false,
+       'Maybe' => null,
+   ],
+   'choice_attr' => function ($choice, $index, $value) {
+       if ('Yes' === $index) {
+           return ['class' => 'option-green'];
+       }
+       if ('No' === $index) {
+           return ['class' => 'option-red'];
+       }
+
+       return [];
+   },
+   ```
 
 FrameworkBundle
 ---------------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -22,6 +22,50 @@ Form
  * Added the `getIsEmptyCallback()` method to the `FormConfigInterface`.
  * Added the `setIsEmptyCallback()` method to the `FormConfigBuilderInterface`.
  * Added argument `callable|null $filter` to `ChoiceListFactoryInterface::createListFromChoices()` and `createListFromLoader()`.
+ * Usage of `choice_attr` option as an array of nested arrays has been removed
+   and indexes are considered as attributes. Use a unique array for all choices or a `callable` instead.
+
+   Before:
+   ```php
+   // Single array for all choices using callable
+   'choice_attr' => function () {
+       return ['class' => 'choice-options'];
+   },
+
+   // Different arrays per choice using array
+   'choices' => [
+       'Yes' => true,
+       'No' => false,
+       'Maybe' => null,
+   ],
+   'choice_attr' => [
+       'Yes' => ['class' => 'option-green'],
+       'No' => ['class' => 'option-red'],
+   ],
+   ```
+
+   After:
+   ```php
+   // Single array for all choices using array
+   'choice_attr' => ['class' => 'choice-options'],
+
+   // Different arrays per choice using callable
+   'choices' => [
+       'Yes' => true,
+       'No' => false,
+       'Maybe' => null,
+   ],
+   'choice_attr' => function ($choice, $index, $value) {
+       if ('Yes' === $index) {
+           return ['class' => 'option-green'];
+       }
+       if ('No' === $index) {
+           return ['class' => 'option-red'];
+       }
+
+       return [];
+   },
+   ```
 
 FrameworkBundle
 ---------------

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3HorizontalLayoutTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
 abstract class AbstractBootstrap3HorizontalLayoutTest extends AbstractBootstrap3LayoutTest
 {
     public function testLabelOnForm()
@@ -211,6 +213,42 @@ abstract class AbstractBootstrap3HorizontalLayoutTest extends AbstractBootstrap3
         [
             ./span[text() = "[trans]really helpful text[/trans]"]
         ]
+    ]
+'
+        );
+    }
+
+    public function testSingleChoiceExpandedAttributes()
+    {
+        $form = $this->factory->createNamed('name', ChoiceType::class, '&a', [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
+            'choice_attr' => ['class' => 'foo&bar'],
+            'multiple' => false,
+            'expanded' => true,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), [],
+            '/div
+    [
+        ./div
+            [@class="radio"]
+            [
+                ./label
+                    [.=" [trans]Choice&A[/trans]"]
+                    [
+                        input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked][@class="foo&bar"]
+                    ]
+            ]
+        /following-sibling::div
+            [@class="radio"]
+            [
+                ./label
+                    [.=" [trans]Choice&B[/trans]"]
+                    [
+                        input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)][@class="foo&bar"]
+                    ]
+            ]
+        /following-sibling::input[@type="hidden"][@id="name__token"]
     ]
 '
         );

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Tests\AbstractLayoutTest;
@@ -531,11 +532,64 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         );
     }
 
-    public function testSingleChoiceAttributes()
+    /**
+     * @group legacy
+     */
+    public function testLegacySingleChoiceAttributes()
     {
+        $this->expectDeprecation('Since symfony/form 5.1: Using an array of arrays mapped by choice indexes to define the "choice_attr" option is deprecated. Use a callable or a unique array for all choices instead.');
+
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
             'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
             'choice_attr' => ['Choice&B' => ['class' => 'foo&bar']],
+            'multiple' => false,
+            'expanded' => false,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
+'/select
+    [@name="name"]
+    [@class="my&class form-control"]
+    [not(@required)]
+    [
+        ./option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
+        /following-sibling::option[@value="&b"][@class="foo&bar"][not(@selected)][.="[trans]Choice&B[/trans]"]
+    ]
+    [count(./option)=2]
+'
+        );
+    }
+
+    public function testSingleChoiceAttributes()
+    {
+        $form = $this->factory->createNamed('name', ChoiceType::class, '&a', [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
+            'choice_attr' => ['class' => 'foo&bar'],
+            'multiple' => false,
+            'expanded' => false,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
+'/select
+    [@name="name"]
+    [@class="my&class form-control"]
+    [not(@required)]
+    [
+        ./option[@value="&a"][@class="foo&bar"][@selected="selected"][.="[trans]Choice&A[/trans]"]
+        /following-sibling::option[@value="&b"][@class="foo&bar"][not(@selected)][.="[trans]Choice&B[/trans]"]
+    ]
+    [count(./option)=2]
+'
+        );
+    }
+
+    public function testSingleChoiceAttributesSetByCallable()
+    {
+        $form = $this->factory->createNamed('name', ChoiceType::class, '&a', [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
+            'choice_attr' => function ($choice, $key, $value) {
+                return '&b' === $choice ? ['class' => 'foo&bar'] : [];
+            },
             'multiple' => false,
             'expanded' => false,
         ]);
@@ -847,11 +901,68 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         );
     }
 
-    public function testMultipleChoiceAttributes()
+    /**
+     * @group legacy
+     */
+    public function testLegacyMultipleChoiceAttributes()
     {
+        $this->expectDeprecation('Since symfony/form 5.1: Using an array of arrays mapped by choice indexes to define the "choice_attr" option is deprecated. Use a callable or a unique array for all choices instead.');
+
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', ['&a'], [
             'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
             'choice_attr' => ['Choice&B' => ['class' => 'foo&bar']],
+            'required' => true,
+            'multiple' => true,
+            'expanded' => false,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
+'/select
+    [@name="name[]"]
+    [@class="my&class form-control"]
+    [@required="required"]
+    [@multiple="multiple"]
+    [
+        ./option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
+        /following-sibling::option[@value="&b"][@class="foo&bar"][not(@selected)][.="[trans]Choice&B[/trans]"]
+    ]
+    [count(./option)=2]
+'
+        );
+    }
+
+    public function testMultipleChoiceAttributes()
+    {
+        $form = $this->factory->createNamed('name', ChoiceType::class, ['&a'], [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
+            'choice_attr' => ['class' => 'foo&bar'],
+            'required' => true,
+            'multiple' => true,
+            'expanded' => false,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
+'/select
+    [@name="name[]"]
+    [@class="my&class form-control"]
+    [@required="required"]
+    [@multiple="multiple"]
+    [
+        ./option[@value="&a"][@class="foo&bar"][@selected="selected"][.="[trans]Choice&A[/trans]"]
+        /following-sibling::option[@value="&b"][@class="foo&bar"][not(@selected)][.="[trans]Choice&B[/trans]"]
+    ]
+    [count(./option)=2]
+'
+        );
+    }
+
+    public function testMultipleChoiceAttributesSetByCallable()
+    {
+        $form = $this->factory->createNamed('name', ChoiceType::class, ['&a'], [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
+            'choice_attr' => function ($choice, $key, $value) {
+                return '&b' === $choice ? ['class' => 'foo&bar'] : [];
+            },
             'required' => true,
             'multiple' => true,
             'expanded' => false,
@@ -1109,11 +1220,89 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         );
     }
 
-    public function testSingleChoiceExpandedAttributes()
+    /**
+     * @group legacy
+     */
+    public function testLegacySingleChoiceExpandedAttributes()
     {
+        $this->expectDeprecation('Since symfony/form 5.1: Using an array of arrays mapped by choice indexes to define the "choice_attr" option is deprecated. Use a callable or a unique array for all choices instead.');
+
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', '&a', [
             'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
             'choice_attr' => ['Choice&B' => ['class' => 'foo&bar']],
+            'multiple' => false,
+            'expanded' => true,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), [],
+'/div
+    [
+        ./div
+            [@class="radio"]
+            [
+                ./label
+                    [.=" [trans]Choice&A[/trans]"]
+                    [
+                        ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
+                    ]
+            ]
+        /following-sibling::div
+            [
+                ./label
+                    [.=" [trans]Choice&B[/trans]"]
+                    [
+                        ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)][@class="foo&bar"]
+                    ]
+            ]
+        /following-sibling::input[@type="hidden"][@id="name__token"]
+    ]
+'
+        );
+    }
+
+    public function testSingleChoiceExpandedAttributes()
+    {
+        $form = $this->factory->createNamed('name', ChoiceType::class, '&a', [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
+            'choice_attr' => ['class' => 'foo&bar'],
+            'multiple' => false,
+            'expanded' => true,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), [],
+'/div
+    [
+        ./div
+            [@class="radio"]
+            [
+                ./label
+                    [.=" [trans]Choice&A[/trans]"]
+                    [
+                        input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked][@class="foo&bar"]
+                    ]
+            ]
+        /following-sibling::div
+            [@class="radio"]
+            [
+                ./label
+                    [.=" [trans]Choice&B[/trans]"]
+                    [
+                        input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)][@class="foo&bar"]
+                    ]
+            ]
+        /following-sibling::input[@type="hidden"][@id="name__token"]
+    ]
+'
+        );
+    }
+
+    public function testSingleChoiceExpandedAttributesSetByCallable()
+    {
+        $form = $this->factory->createNamed('name', ChoiceType::class, '&a', [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
+            'choice_attr' => function ($choice, $key, $value) {
+                return '&b' == $choice ? ['class' => 'foo&bar'] : [];
+            },
             'multiple' => false,
             'expanded' => true,
         ]);
@@ -1484,11 +1673,110 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         );
     }
 
+    /**
+     * @group legacy
+     */
+    public function testLegacyMultipleChoiceExpandedAttributes()
+    {
+        $this->expectDeprecation('Since symfony/form 5.1: Using an array of arrays mapped by choice indexes to define the "choice_attr" option is deprecated. Use a callable or a unique array for all choices instead.');
+
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', ['&a', '&c'], [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b', 'Choice&C' => '&c'],
+            'choice_attr' => ['Choice&B' => ['class' => 'foo&bar']],
+            'multiple' => true,
+            'expanded' => true,
+            'required' => true,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), [],
+'/div
+    [
+        ./div
+            [@class="checkbox"]
+            [
+                ./label
+                    [.=" [trans]Choice&A[/trans]"]
+                    [
+                        ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@checked][not(@required)]
+                    ]
+            ]
+        /following-sibling::div
+            [@class="checkbox"]
+            [
+                ./label
+                    [.=" [trans]Choice&B[/trans]"]
+                    [
+                        ./input[@type="checkbox"][@name="name[]"][@id="name_1"][not(@checked)][not(@required)][@class="foo&bar"]
+                    ]
+            ]
+        /following-sibling::div
+            [@class="checkbox"]
+            [
+                ./label
+                    [.=" [trans]Choice&C[/trans]"]
+                    [
+                        ./input[@type="checkbox"][@name="name[]"][@id="name_2"][@checked][not(@required)]
+                    ]
+            ]
+        /following-sibling::input[@type="hidden"][@id="name__token"]
+    ]
+'
+        );
+    }
+
     public function testMultipleChoiceExpandedAttributes()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', ['&a', '&c'], [
             'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b', 'Choice&C' => '&c'],
-            'choice_attr' => ['Choice&B' => ['class' => 'foo&bar']],
+            'choice_attr' => ['class' => 'foo&bar'],
+            'multiple' => true,
+            'expanded' => true,
+            'required' => true,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), [],
+'/div
+    [
+        ./div
+            [@class="checkbox"]
+            [
+                ./label
+                    [.=" [trans]Choice&A[/trans]"]
+                    [
+                        ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@checked][not(@required)][@class="foo&bar"]
+                    ]
+            ]
+        /following-sibling::div
+            [@class="checkbox"]
+            [
+                ./label
+                    [.=" [trans]Choice&B[/trans]"]
+                    [
+                        ./input[@type="checkbox"][@name="name[]"][@id="name_1"][not(@checked)][not(@required)][@class="foo&bar"]
+                    ]
+            ]
+        /following-sibling::div
+            [@class="checkbox"]
+            [
+                ./label
+                    [.=" [trans]Choice&C[/trans]"]
+                    [
+                        ./input[@type="checkbox"][@name="name[]"][@id="name_2"][@checked][not(@required)][@class="foo&bar"]
+                    ]
+            ]
+        /following-sibling::input[@type="hidden"][@id="name__token"]
+    ]
+'
+        );
+    }
+
+    public function testMultipleChoiceExpandedAttributesSetByCallable()
+    {
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', ['&a', '&c'], [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b', 'Choice&C' => '&c'],
+            'choice_attr' => function ($choice, $key, $value) {
+                return '&b' === $choice ? ['class' => 'foo&bar'] : [];
+            },
             'multiple' => true,
             'expanded' => true,
             'required' => true,

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTest.php
@@ -639,11 +639,48 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         );
     }
 
+    /**
+     * @group legacy
+     */
+    public function testLegacySingleChoiceExpandedAttributes()
+    {
+        $this->expectDeprecation('Since symfony/form 5.1: Using an array of arrays mapped by choice indexes to define the "choice_attr" option is deprecated. Use a callable or a unique array for all choices instead.');
+
+        $form = $this->factory->createNamed('name', ChoiceType::class, '&a', [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
+            'choice_attr' => ['Choice&B' => ['class' => 'foo&bar']],
+            'multiple' => false,
+            'expanded' => true,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), [],
+            '/div
+    [
+        ./div
+            [@class="form-check"]
+            [
+                ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked][@class="form-check-input"]
+                /following-sibling::label
+                    [.="[trans]Choice&A[/trans]"]
+            ]
+        /following-sibling::div
+            [@class="form-check"]
+            [
+                ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)][@class="foo&bar form-check-input"]
+                /following-sibling::label
+                    [.="[trans]Choice&B[/trans]"]
+            ]
+        /following-sibling::input[@type="hidden"][@id="name__token"]
+    ]
+'
+        );
+    }
+
     public function testSingleChoiceExpandedAttributes()
     {
         $form = $this->factory->createNamed('name', ChoiceType::class, '&a', [
             'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
-            'choice_attr' => ['Choice&B' => ['class' => 'foo&bar']],
+            'choice_attr' => ['class' => 'foo&bar'],
             'multiple' => false,
             'expanded' => true,
         ]);
@@ -654,7 +691,41 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked]
+                ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked][@class="foo&bar form-check-input"]
+                /following-sibling::label
+                    [.="[trans]Choice&A[/trans]"]
+            ]
+        /following-sibling::div
+            [@class="form-check"]
+            [
+                ./input[@type="radio"][@name="name"][@id="name_1"][@value="&b"][not(@checked)][@class="foo&bar form-check-input"]
+                /following-sibling::label
+                    [.="[trans]Choice&B[/trans]"]
+            ]
+        /following-sibling::input[@type="hidden"][@id="name__token"]
+    ]
+'
+        );
+    }
+
+    public function testSingleChoiceExpandedAttributesSetByCallable()
+    {
+        $form = $this->factory->createNamed('name', ChoiceType::class, '&a', [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b'],
+            'choice_attr' => function ($choice, $key, $value) {
+                return '&b' == $choice ? ['class' => 'foo&bar'] : [];
+            },
+            'multiple' => false,
+            'expanded' => true,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), [],
+            '/div
+    [
+        ./div
+            [@class="form-check"]
+            [
+                ./input[@type="radio"][@name="name"][@id="name_0"][@value="&a"][@checked][@class="form-check-input"]
                 /following-sibling::label
                     [.="[trans]Choice&A[/trans]"]
             ]
@@ -968,8 +1039,13 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         );
     }
 
-    public function testMultipleChoiceExpandedAttributes()
+    /**
+     * @group legacy
+     */
+    public function testLegacyMultipleChoiceExpandedAttributes()
     {
+        $this->expectDeprecation('Since symfony/form 5.1: Using an array of arrays mapped by choice indexes to define the "choice_attr" option is deprecated. Use a callable or a unique array for all choices instead.');
+
         $form = $this->factory->createNamed('name', ChoiceType::class, ['&a', '&c'], [
             'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b', 'Choice&C' => '&c'],
             'choice_attr' => ['Choice&B' => ['class' => 'foo&bar']],
@@ -984,7 +1060,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
         ./div
             [@class="form-check"]
             [
-                ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@checked][not(@required)]
+                ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@checked][not(@required)][@class="form-check-input"]
                 /following-sibling::label
                     [.="[trans]Choice&A[/trans]"]
             ]
@@ -999,6 +1075,88 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
             [@class="form-check"]
             [
                 ./input[@type="checkbox"][@name="name[]"][@id="name_2"][@checked][not(@required)]
+                /following-sibling::label
+                    [.="[trans]Choice&C[/trans]"]
+            ]
+        /following-sibling::input[@type="hidden"][@id="name__token"]
+    ]
+'
+        );
+    }
+
+    public function testMultipleChoiceExpandedAttributes()
+    {
+        $form = $this->factory->createNamed('name', ChoiceType::class, ['&a', '&c'], [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b', 'Choice&C' => '&c'],
+            'choice_attr' => ['class' => 'foo&bar'],
+            'multiple' => true,
+            'expanded' => true,
+            'required' => true,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), [],
+'/div
+    [
+        ./div
+            [@class="form-check"]
+            [
+                ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@checked][not(@required)][@class="foo&bar form-check-input"]
+                /following-sibling::label
+                    [.="[trans]Choice&A[/trans]"]
+            ]
+        /following-sibling::div
+            [@class="form-check"]
+            [
+                ./input[@type="checkbox"][@name="name[]"][@id="name_1"][not(@checked)][not(@required)][@class="foo&bar form-check-input"]
+                /following-sibling::label
+                    [.="[trans]Choice&B[/trans]"]
+            ]
+        /following-sibling::div
+            [@class="form-check"]
+            [
+                ./input[@type="checkbox"][@name="name[]"][@id="name_2"][@checked][not(@required)][@class="foo&bar form-check-input"]
+                /following-sibling::label
+                    [.="[trans]Choice&C[/trans]"]
+            ]
+        /following-sibling::input[@type="hidden"][@id="name__token"]
+    ]
+'
+        );
+    }
+
+    public function testMultipleChoiceExpandedAttributesSetByCallable()
+    {
+        $form = $this->factory->createNamed('name', ChoiceType::class, ['&a', '&c'], [
+            'choices' => ['Choice&A' => '&a', 'Choice&B' => '&b', 'Choice&C' => '&c'],
+            'choice_attr' => function ($choice, $key, $value) {
+                return '&b' === $choice ? ['class' => 'foo&bar'] : [];
+            },
+            'multiple' => true,
+            'expanded' => true,
+            'required' => true,
+        ]);
+
+        $this->assertWidgetMatchesXpath($form->createView(), [],
+            '/div
+    [
+        ./div
+            [@class="form-check"]
+            [
+                ./input[@type="checkbox"][@name="name[]"][@id="name_0"][@checked][not(@required)][@class="form-check-input"]
+                /following-sibling::label
+                    [.="[trans]Choice&A[/trans]"]
+            ]
+        /following-sibling::div
+            [@class="form-check"]
+            [
+                ./input[@type="checkbox"][@name="name[]"][@id="name_1"][not(@checked)][not(@required)][@class="foo&bar form-check-input"]
+                /following-sibling::label
+                    [.="[trans]Choice&B[/trans]"]
+            ]
+        /following-sibling::div
+            [@class="form-check"]
+            [
+                ./input[@type="checkbox"][@name="name[]"][@id="name_2"][@checked][not(@required)][@class="form-check-input"]
                 /following-sibling::label
                     [.="[trans]Choice&C[/trans]"]
             ]

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.1.0
 -----
 
+ * Deprecated `choice_attr` option as array of nested arrays mapped by indexes
  * Added `collection_entry` block prefix to `CollectionType` entries
  * Added a `choice_filter` option to `ChoiceType`
  * Added argument `callable|null $filter` to `ChoiceListFactoryInterface::createListFromChoices()` and `createListFromLoader()` - not defining them is deprecated.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Part of #18318
| License       | MIT
| Doc PR        | TODO

Extracted from #16834, which I'll split in 3 to ease the review/merge process, hopefully in time for 5.1.
This PR deprecates using the `choice_attr` option as array of arrays of attributes per choice index, in favor of a new (more intuitive) support for a global array of attributes for all choices, or already implemented callable usage to define attributes per choice (or index or value).

Before:
```php
// Single array for all choices using callable
'choice_attr' => function ($choice, $index, $value) {
    return ['class' => 'choice-options'];
},

// Different arrays per choice using array
'choices' => [
    'Yes' => true,
    'No' => false,
    'Maybe' => null,
],
'choice_attr' => [
    'Yes' => ['class' => 'option-green'],
    'No' => ['class' => 'option-red'],
],
```

After:
```php
// Single array for all choices using array
'choice_attr' => ['class' => 'choice-options'],

// Different arrays per choice using callable
'choices' => [
    'Yes' => true,
    'No' => false,
    'Maybe' => null,
],
'choice_attr' => function ($choice, $index, $value) {
    if ('Yes' === $index) {
        return ['class' => 'option-green'];
    }
    if ('No' === $index) {
        return ['class' => 'option-red'];
    }

    return [];
},
```

There has been many issues in the past on the docs and Stack Overflow (ref #symfony/symfony-docs#6443), because the choice indexes are not always known, and with both using a callable to define global attributes, current ways are error prone. In consequence, this will also simplify the documentation of the option.

This PR also have a side effect on a potential new choice_label_attr (branch pending), because its behavior (and doc) should be the same.