### PR TITLE
[FrameworkBundle] Deprecate flashbag and attributebag services

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -37,6 +37,7 @@ FrameworkBundle
 
  * Deprecated passing a `RouteCollectionBuilder` to `MicroKernelTrait::configureRoutes()`, type-hint `RoutingConfigurator` instead
  * Deprecated *not* setting the "framework.router.utf8" configuration option as it will default to `true` in Symfony 6.0
+ * Deprecated `session.attribute_bag` service and `session.flash_bag` service.
 
 HttpFoundation
 --------------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -35,6 +35,7 @@ FrameworkBundle
 
  * `MicroKernelTrait::configureRoutes()` is now always called with a `RoutingConfigurator`
  * The "framework.router.utf8" configuration option defaults to `true`
+ * Removed `session.attribute_bag` service and `session.flash_bag` service.
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * Added `debug:container --deprecations` option to see compile-time deprecations.
  * Made `BrowserKitAssertionsTrait` report the original error message in case of a failure
  * Added ability for `config:dump-reference` and `debug:config` to dump and debug kernel container extension configuration.
+ * Deprecated `session.attribute_bag` service and `session.flash_bag` service.
 
 5.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -43,11 +43,13 @@
 
         <service id="session.flash_bag" class="Symfony\Component\HttpFoundation\Session\Flash\FlashBag">
             <factory service="session" method="getFlashBag" />
+            <deprecated package="symfony/framework-bundle" version="5.1">The "%service_id%" service is deprecated, use "$session->getFlashBag()" instead.</deprecated>
         </service>
         <service id="Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface" alias="session.flash_bag" />
 
         <service id="session.attribute_bag" class="Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag">
             <factory service="session" method="getAttributeBag" />
+            <deprecated package="symfony/framework-bundle" version="5.1">The "%service_id%" service is deprecated, use "$session->getAttributeBag()" instead.</deprecated>
         </service>
 
         <service id="session.storage.mock_file" class="Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+
 class SessionTest extends AbstractWebTestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * Tests session attributes persist.
      *
@@ -72,10 +76,13 @@ class SessionTest extends AbstractWebTestCase
     /**
      * Tests flash messages work when flashbag service is injected to the constructor.
      *
+     * @group legacy
      * @dataProvider getConfigs
      */
     public function testFlashOnInjectedFlashbag($config, $insulate)
     {
+        $this->expectDeprecation('Since symfony/framework-bundle 5.1: The "session.flash_bag" service is deprecated, use "$session->getFlashBag()" instead.');
+
         $client = $this->createClient(['test_case' => 'Session', 'root_config' => $config]);
         if ($insulate) {
             $client->insulate();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Related to [#10557](https://github.com/symfony/symfony/issues/10557)
| Related to PR | #36063 
| License       | MIT

FlashBag and AttributeBag are data objects and so should not be available via the service container. The preferred method for accessing these objects is via
`$session->getFlashBag()` or `$session->getAttributeBag()`