### PR TITLE
Fix a docblock in console application

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -450,6 +450,8 @@ class Application implements ResetInterface
      * If the command is not enabled it will not be added.
      *
      * @return Command|null The registered command if enabled or null
+     *
+     * @throws LogicException When command name is not defined
      */
     public function add(Command $command)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR adds missing @throws tag to the add function of the Console Application