### PR TITLE
Allow 'Name <email@address.com>' pattern in `framework.mailer.envelop.sender` config

### DIFF
--- a/src/Symfony/Component/Mailer/EventListener/EnvelopeListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/EnvelopeListener.php
@@ -32,7 +32,7 @@ class EnvelopeListener implements EventSubscriberInterface
     public function __construct($sender = null, array $recipients = null)
     {
         if (null !== $sender) {
-            $this->sender = Address::create($sender);
+            $this->sender = Address::fromString($sender);
         }
         if (null !== $recipients) {
             $this->recipients = Address::createArray($recipients);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/33091
| License       | MIT
| Doc PR        | /

```diff
# config/packages/mailer.yaml
framework:
    mailer:
        dsn: '%env(MAILER_DSN)%'
        envelope:
-            sender: 'email@address.com'
+            sender: 'Name <email@address.com>'
```