### PR TITLE
[Lock] Fix StoreFactory to accept same DSN syntax as AbstractAdapter

### DIFF
--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -66,13 +66,13 @@ class StoreFactory
             case 'semaphore' === $connection:
                 return new SemaphoreStore();
 
-            case 0 === strpos($connection, 'redis://'):
-            case 0 === strpos($connection, 'rediss://'):
-            case 0 === strpos($connection, 'memcached://'):
+            case 0 === strpos($connection, 'redis:'):
+            case 0 === strpos($connection, 'rediss:'):
+            case 0 === strpos($connection, 'memcached:'):
                 if (!class_exists(AbstractAdapter::class)) {
                     throw new InvalidArgumentException(sprintf('Unsupported DSN "%s". Try running "composer require symfony/cache".', $connection));
                 }
-                $storeClass = 0 === strpos($connection, 'memcached://') ? MemcachedStore::class : RedisStore::class;
+                $storeClass = 0 === strpos($connection, 'memcached:') ? MemcachedStore::class : RedisStore::class;
                 $connection = AbstractAdapter::createConnection($connection, ['lazy' => true]);
 
                 return new $storeClass($connection);

--- a/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
@@ -58,12 +58,14 @@ class StoreFactoryTest extends TestCase
         }
         if (class_exists(\Memcached::class) && class_exists(AbstractAdapter::class)) {
             yield ['memcached://server.com', MemcachedStore::class];
+            yield ['memcached:?host[localhost]&host[localhost:12345]', MemcachedStore::class];
         }
-        if (class_exists(\Redis::class) && class_exists(AbstractAdapter::class)) {
+        if ((class_exists(\Redis::class) || class_exists(\Predis\Client::class)) && class_exists(AbstractAdapter::class)) {
             yield ['redis://localhost', RedisStore::class];
             yield ['redis://localhost?lazy=1', RedisStore::class];
             yield ['redis://localhost?redis_cluster=1', RedisStore::class];
             yield ['redis://localhost?redis_cluster=1&lazy=1', RedisStore::class];
+            yield ['redis:?host[localhost]&host[localhost:6379]&redis_cluster=1', RedisStore::class];
         }
         if (class_exists(\PDO::class)) {
             yield ['sqlite:/tmp/sqlite.db', PdoStore::class];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35350
| License       | MIT
| Doc PR        |

Updates `Symfony\Component\Lock\Store\StoreFactory` to accept same DSN syntax as `Symfony\Component\Cache\Adapter\AbstractAdapter` which is used to create Redis class instance.