### PR TITLE
[DependencyInjection] Fix alias deprecations with package and version

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
@@ -63,7 +63,7 @@ class ResolveReferencesToAliasesPass extends AbstractRecursivePass
 
         if ($alias->isDeprecated()) {
             $deprecation = $alias->getDeprecation($id);
-            trigger_deprecation($deprecation['package'], $deprecation['version'], rtrim($deprecation['message'], '. ').'. It is being referenced by the "%s" '.($container->hasDefinition($this->currentId) ? 'service.' : 'alias.'), rtrim($deprecation['message'], '. '), $this->currentId);
+            trigger_deprecation($deprecation['package'], $deprecation['version'], rtrim($deprecation['message'], '. ').'. It is being referenced by the "%s" '.($container->hasDefinition($this->currentId) ? 'service.' : 'alias.'), $this->currentId);
         }
 
         $seen = [];

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -230,7 +230,7 @@ class XmlDumper extends Dumper
         if ($id->isDeprecated()) {
             $deprecation = $id->getDeprecation('%alias_id%');
             $deprecated = $this->document->createElement('deprecated');
-            $deprecated->setAttribute('message', $deprecation['message']);
+            $deprecated->appendChild($this->document->createTextNode($deprecation['message']));
             $deprecated->setAttribute('package', $deprecation['package']);
             $deprecated->setAttribute('version', $deprecation['version']);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveReferencesToAliasesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveReferencesToAliasesPassTest.php
@@ -89,13 +89,13 @@ class ResolveReferencesToAliasesPassTest extends TestCase
      */
     public function testDeprecationNoticeWhenReferencedByAlias()
     {
-        $this->expectDeprecation('The "deprecated_foo_alias" service alias is deprecated. You should stop using it, as it will be removed in the future. It is being referenced by the "alias" alias.');
+        $this->expectDeprecation('Since foobar 1.2.3.4: The "deprecated_foo_alias" service alias is deprecated. You should stop using it, as it will be removed in the future. It is being referenced by the "alias" alias.');
         $container = new ContainerBuilder();
 
         $container->register('foo', 'stdClass');
 
         $aliasDeprecated = new Alias('foo');
-        $aliasDeprecated->setDeprecated(true);
+        $aliasDeprecated->setDeprecated('foobar', '1.2.3.4', '');
         $container->setAlias('deprecated_foo_alias', $aliasDeprecated);
 
         $alias = new Alias('deprecated_foo_alias');
@@ -109,13 +109,13 @@ class ResolveReferencesToAliasesPassTest extends TestCase
      */
     public function testDeprecationNoticeWhenReferencedByDefinition()
     {
-        $this->expectDeprecation('The "foo_aliased" service alias is deprecated. You should stop using it, as it will be removed in the future. It is being referenced by the "definition" service.');
+        $this->expectDeprecation('Since foobar 1.2.3.4: The "foo_aliased" service alias is deprecated. You should stop using it, as it will be removed in the future. It is being referenced by the "definition" service.');
         $container = new ContainerBuilder();
 
         $container->register('foo', 'stdClass');
 
         $aliasDeprecated = new Alias('foo');
-        $aliasDeprecated->setDeprecated(true);
+        $aliasDeprecated->setDeprecated('foobar', '1.2.3.4', '');
         $container->setAlias('foo_aliased', $aliasDeprecated);
 
         $container


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Firstly, this PR fixes the alias dump by the XmlDumper to be consistent with stof comment in the inital PR (the message is the node content) - it is the case for deprecated services. Otherwise, we need to add the "message" attribute in the XSD.

Secondly, it fixes the arguments when the deprecation is actually triggered as well as two related tests.