### PR TITLE
[Form] action allows only strings

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -203,6 +203,7 @@ class FormType extends BaseType
         ]);
 
         $resolver->setAllowedTypes('label_attr', 'array');
+        $resolver->setAllowedTypes('action', 'string');
         $resolver->setAllowedTypes('upload_max_size_message', ['callable']);
         $resolver->setAllowedTypes('help', ['string', 'null']);
         $resolver->setAllowedTypes('help_attr', 'array');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -341,6 +341,12 @@ class FormTypeTest extends BaseTypeTest
         $this->factory->create(static::TESTED_TYPE, null, ['attr' => '']);
     }
 
+    public function testActionCannotBeNull()
+    {
+        $this->expectException('Symfony\Component\OptionsResolver\Exception\InvalidOptionsException');
+        $this->factory->create(static::TESTED_TYPE, null, ['action' => null]);
+    }
+
     public function testNameCanBeEmptyString()
     {
         $form = $this->factory->createNamed('', static::TESTED_TYPE);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Tickets       | ... 
| License       | MIT
| Doc PR        | ... 

On updating an old project that had actions to null it's caused me a type-hint error. With that, we can quickly identify where the problem is