### PR TITLE
Check whether path is file in DataPart::fromPath()

### DIFF
--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -56,6 +56,10 @@ class DataPart extends TextPart
             $contentType = self::$mimeTypes->getMimeTypes($ext)[0] ?? 'application/octet-stream';
         }
 
+        if (false === is_readable($path)) {
+            throw new InvalidArgumentException(sprintf('Path "%s" is not readable.', $path));
+        }
+        
         if (false === $handle = @fopen($path, 'r', false)) {
             throw new InvalidArgumentException(sprintf('Unable to open path "%s".', $path));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no

Method `getBody()` uses stream_get_contents() to retrieve the body, however it fails to do so when the stream is a directory.