### PR TITLE
[Serializer] snake properties loose values

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -168,7 +168,7 @@ class SwitchUserListener extends AbstractListener implements ListenerInterface
 
             try {
                 $this->provider->loadUserByUsername($nonExistentUsername);
-            } catch (AuthenticationException $e) {
+            } catch (\Exception $e) {
             }
         } catch (AuthenticationException $e) {
             $this->provider->loadUserByUsername($currentUsername);

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -168,7 +168,7 @@ class SwitchUserListener extends AbstractListener implements ListenerInterface
 
             try {
                 $this->provider->loadUserByUsername($nonExistentUsername);
-            } catch (\Exception $e) {
+            } catch (AuthenticationException $e) {
             }
         } catch (AuthenticationException $e) {
             $this->provider->loadUserByUsername($currentUsername);

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
-use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;/**
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter; /**
  * Converts between objects with getter and setter methods and arrays.
  * The normalization process looks at all public methods and calls the ones
  * which have a name starting with get and take no parameters. The result is a
@@ -26,6 +26,7 @@ use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter
  * setter method exists for any of the properties. If a setter exists it is
  * called with the property value. No automatic denormalization of the value
  * takes place.
+ *
  * @author Nils Adermann <naderman@naderman.de>
  * @author Kévin Dunglas <dunglas@gmail.com>
  */

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -11,15 +11,13 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
-/**
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;/**
  * Converts between objects with getter and setter methods and arrays.
- *
  * The normalization process looks at all public methods and calls the ones
  * which have a name starting with get and take no parameters. The result is a
  * map from property names (method name stripped of the get prefix and converted
  * to lower case) to property values. Property values are normalized through the
  * serializer.
- *
  * The denormalization first looks at the constructor of the given class to see
  * if any of the parameters have the same name as one of the properties. The
  * constructor is then called with all parameters or an exception is thrown if
@@ -28,7 +26,6 @@ namespace Symfony\Component\Serializer\Normalizer;
  * setter method exists for any of the properties. If a setter exists it is
  * called with the property value. No automatic denormalization of the value
  * takes place.
- *
  * @author Nils Adermann <naderman@naderman.de>
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
@@ -138,6 +135,14 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
         $haser = 'has'.$ucfirsted;
         if (\is_callable([$object, $haser])) {
             return $object->$haser();
+        }
+
+        $camelCaseToSnakeCaseConverter = new CamelCaseToSnakeCaseNameConverter();
+        $camelCaseAttribute = $camelCaseToSnakeCaseConverter->denormalize($ucfirsted);
+        $getter = 'get'.ucfirst($camelCaseAttribute);
+
+        if (\is_callable([$object, $getter])) {
+            return $object->$getter();
         }
 
         return null;

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -139,7 +139,7 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
         }
 
         $camelCaseToSnakeCaseConverter = new CamelCaseToSnakeCaseNameConverter();
-        $camelCaseAttribute = $camelCaseToSnakeCaseConverter->denormalize($ucfirsted);
+        $camelCaseAttribute = $camelCaseToSnakeCaseConverter->denormalize($attribute);
         $getter = 'get'.ucfirst($camelCaseAttribute);
 
         if (\is_callable([$object, $getter])) {

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
-use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter; /**
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+
+/**
  * Converts between objects with getter and setter methods and arrays.
  * The normalization process looks at all public methods and calls the ones
  * which have a name starting with get and take no parameters. The result is a

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/GroupDummySnakeCase.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/GroupDummySnakeCase.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+
+class GroupDummySnakeCase
+{
+    /**
+     * @Groups({"b", "c", "name_converter"})
+     */
+    protected $snake_case;
+
+    public function getSnakeCase()
+    {
+        return $this->snake_case;
+    }
+
+    public function setSnakeCase($snake_case): void
+    {
+        $this->snake_case = $snake_case;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/GroupDummySnakeCase.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/GroupDummySnakeCase.php
@@ -7,7 +7,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 class GroupDummySnakeCase
 {
     /**
-     * @Groups({"b", "c", "name_converter"})
+     * @Groups({"name_converter"})
      */
     protected $snake_case;
 

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/GroupDummySnakeCase.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/GroupDummySnakeCase.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Serializer\Tests\Fixtures;
 
 use Symfony\Component\Serializer\Annotation\Groups;

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/GroupDummySnakeCase.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/GroupDummySnakeCase.php
@@ -4,6 +4,9 @@ namespace Symfony\Component\Serializer\Tests\Fixtures;
 
 use Symfony\Component\Serializer\Annotation\Groups;
 
+/**
+ * @author Laurent Masforné <l.masforne@gmail.com>
+ */
 class GroupDummySnakeCase
 {
     /**

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\GroupDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\GroupDummySnakeCase;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CallbacksObject;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CallbacksTestTrait;
@@ -328,6 +329,23 @@ class GetSetMethodNormalizerTest extends TestCase
                 'bar' => null,
                 'foo_bar' => '@dunglas',
                 'symfony' => '@coopTilleuls',
+            ],
+            $this->normalizer->normalize($obj, null, [GetSetMethodNormalizer::GROUPS => ['name_converter']])
+        );
+    }
+
+    public function testGroupsNormalizeWithNameConverterSnakeCaseProperty()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $this->normalizer = new GetSetMethodNormalizer($classMetadataFactory, new CamelCaseToSnakeCaseNameConverter());
+        $this->normalizer->setSerializer($this->serializer);
+
+        $obj = new GroupDummySnakeCase();
+        $obj->setSnakeCase('snake_case_value');
+
+        $this->assertEquals(
+            [
+                'snake_case' => 'snake_case_value',
             ],
             $this->normalizer->normalize($obj, null, [GetSetMethodNormalizer::GROUPS => ['name_converter']])
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36288 
| License       | MIT

Fix bug when a snake property value is lost in serialization. 
We try to guess name method on GetSetMethodNormalizer but not we have the good name 'getSnake_case' when in general it's 'getSnakeCase'
