### PR TITLE
[PropertyAccess] Improve message of unitialized property in php 7.4

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -505,7 +505,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             if (\PHP_VERSION_ID >= 70400 && preg_match('/^Typed property ([\w\\\]+)::\$(\w+) must not be accessed before initialization$/', $e->getMessage(), $matches)) {
                 $r = new \ReflectionProperty($matches[1], $matches[2]);
 
-                throw new AccessException(sprintf('The property "%s::$%s" is not readable because it is typed "%3$s". You should either initialize it or make it nullable using "?%3$s" instead.', $r->getDeclaringClass()->getName(), $r->getName(), $r->getType()->getName()), 0, $e);
+                throw new AccessException(sprintf('The property "%s::$%s" is not readable because it is typed "%2$s". You should initialize it or declare a default value instead.', $r->getDeclaringClass()->getName(), $r->getType()->getName()), 0, $e);
             }
 
             throw $e;

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -126,7 +126,7 @@ class PropertyAccessorTest extends TestCase
     public function testGetValueThrowsExceptionIfUninitializedProperty()
     {
         $this->expectException('Symfony\Component\PropertyAccess\Exception\AccessException');
-        $this->expectExceptionMessage('The property "Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedProperty::$uninitialized" is not readable because it is typed "string". You should either initialize it or make it nullable using "?string" instead.');
+        $this->expectExceptionMessage('The property "Symfony\Component\PropertyAccess\Tests\Fixtures\UninitializedProperty::$uninitialized" is not readable because it is typed "string". You should initialize it or declare a default value instead.');
 
         $this->propertyAccessor->getValue(new UninitializedProperty(), 'uninitialized');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36277 
| License       | MIT

Improve message of unitialized property in php 7.4 ; 
Before 
You should either initialize it or make it nullable using "?string" instead.
After 
You should either initialize it or make it nullable using "?string $var = null" instead.
