### PR TITLE
[Translation][Feature] Return cached translation resources

### DIFF
--- a/src/Symfony/Component/Translation/CachedMessageCatalog.php
+++ b/src/Symfony/Component/Translation/CachedMessageCatalog.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation;
+
+/**
+ * @author Jannik Zschiesche <hi@jannik.io>
+ */
+class CachedMessageCatalog extends MessageCatalogue
+{
+    private $cachedResourcesGenerator;
+    private $cachedResourcesLoaded = [];
+
+    /**
+     * @internal
+     */
+    public function setCachedResources(callable $resourcesGenerator): void
+    {
+        $this->cachedResourcesGenerator = $resourcesGenerator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResources()
+    {
+        if (!$this->cachedResourcesLoaded) {
+            if ($this->cachedResourcesGenerator) {
+                foreach (($this->cachedResourcesGenerator)() as $resource) {
+                    parent::addResource($resource);
+                }
+            }
+
+            $this->cachedResourcesLoaded = true;
+        }
+
+        return parent::getResources();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #36161 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | ? *) see below

This is my first draft to implement the feature requested in #36161. 

@nicolas-grekas is this going in the right direction or would you implement it differently?
Also.. how would I best write tests for this feature?

*) do we need a docs PR? This is "fixing" the behaviour of a user-facing feature, so that it always works, instead of just with an empty cache. Nothing "new" here, just "now it should always work".