### PR TITLE
[FrameworkBundle][HttpKernel] Restrict stateless reporting to exception only

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
  * Made `BrowserKitAssertionsTrait` report the original error message in case of a failure
  * Added ability for `config:dump-reference` and `debug:config` to dump and debug kernel container extension configuration.
  * Deprecated `session.attribute_bag` service and `session.flash_bag` service.
+ * Added `session.strict_statless` option to configure the strictness of stateless reporting
 
 5.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -540,6 +540,7 @@ class Configuration implements ConfigurationInterface
                             ->min(4)
                             ->max(6)
                         ->end()
+                        ->booleanNode('strict_stateless')->defaultValue('%kernel.debug%')->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -972,6 +972,8 @@ class FrameworkExtension extends Extension
         $container->setParameter('session.save_path', $config['save_path']);
 
         $container->setParameter('session.metadata.update_threshold', $config['metadata_update_threshold']);
+
+        $container->setParameter('session.strict_stateless', $config['strict_stateless']);
     }
 
     private function registerRequestConfiguration(array $config, ContainerBuilder $container, XmlFileLoader $loader)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -117,6 +117,7 @@
         <xsd:attribute name="metadata-update-threshold" type="xsd:nonNegativeInteger" />
         <xsd:attribute name="sid-length" type="sid_length" />
         <xsd:attribute name="sid-bits-per-character" type="sid_bits_per_character" />
+        <xsd:attribute name="strict-stateless" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:complexType name="request">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -78,7 +78,7 @@
                 <argument key="initialized_session" type="service" id="session" on-invalid="ignore_uninitialized" />
                 <argument key="logger" type="service" id="logger" on-invalid="ignore" />
             </argument>
-            <argument>%kernel.debug%</argument>
+            <argument>%session.strict_stateless%</argument>
         </service>
 
         <!-- for BC -->

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -429,6 +429,7 @@ class ConfigurationTest extends TestCase
                 'gc_probability' => 1,
                 'save_path' => '%kernel.cache_dir%/sessions',
                 'metadata_update_threshold' => 0,
+                'strict_stateless' => '%kernel.debug%',
             ],
             'request' => [
                 'enabled' => false,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -41,6 +41,7 @@ $container->loadFromExtension('framework', [
         'sid_length' => 22,
         'sid_bits_per_character' => 4,
         'save_path' => '/path/to/sessions',
+        'strict_stateless' => true,
     ],
     'assets' => [
         'version' => 'v1',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -15,7 +15,7 @@
         <framework:ssi enabled="true" />
         <framework:profiler only-exceptions="true" enabled="false" />
         <framework:router resource="%kernel.project_dir%/config/routing.xml" type="xml" utf8="true" />
-        <framework:session gc-maxlifetime="90000" gc-probability="1" gc-divisor="108" storage-id="session.storage.native" handler-id="session.handler.native_file" name="_SYMFONY" cookie-lifetime="86400" cookie-path="/" cookie-domain="example.com" cookie-secure="true" cookie-httponly="false" use-cookies="true" save-path="/path/to/sessions" sid-length="22" sid-bits-per-character="4" />
+        <framework:session gc-maxlifetime="90000" gc-probability="1" gc-divisor="108" storage-id="session.storage.native" handler-id="session.handler.native_file" name="_SYMFONY" cookie-lifetime="86400" cookie-path="/" cookie-domain="example.com" cookie-secure="true" cookie-httponly="false" use-cookies="true" save-path="/path/to/sessions" sid-length="22" sid-bits-per-character="4" strict-stateless="true" />
         <framework:request>
             <framework:format name="csv">
                 <framework:mime-type>text/csv</framework:mime-type>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -33,6 +33,7 @@ framework:
         sid_length:      22
         sid_bits_per_character: 4
         save_path:       /path/to/sessions
+        strict_stateless: true
     assets:
         version: v1
     translator:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -478,6 +478,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals('fr', $container->getParameter('kernel.default_locale'));
         $this->assertEquals('session.storage.native', (string) $container->getAlias('session.storage'));
         $this->assertEquals('session.handler.native_file', (string) $container->getAlias('session.handler'));
+        $this->assertTrue($container->getParameter('session.strict_stateless'));
 
         $options = $container->getParameter('session.storage.options');
         $this->assertEquals('_SYMFONY', $options['name']);

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -42,12 +42,12 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
 
     protected $container;
     private $sessionUsageStack = [];
-    private $debug;
+    private $strictStatelessReport;
 
-    public function __construct(ContainerInterface $container = null, bool $debug = false)
+    public function __construct(ContainerInterface $container = null, bool $strictStatelessReport = false)
     {
         $this->container = $container;
-        $this->debug = $debug;
+        $this->strictStatelessReport = $strictStatelessReport;
     }
 
     public function onKernelRequest(RequestEvent $event)
@@ -130,7 +130,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
             return;
         }
 
-        if ($this->debug) {
+        if ($this->strictStatelessReport) {
             throw new UnexpectedSessionUsageException('Session was used while the request was declared stateless.');
         }
 
@@ -148,7 +148,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
 
     public function onSessionUsage(): void
     {
-        if (!$this->debug) {
+        if (!$this->strictStatelessReport) {
             return;
         }
 

--- a/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
@@ -28,9 +28,9 @@ use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
  */
 class SessionListener extends AbstractSessionListener
 {
-    public function __construct(ContainerInterface $container, bool $debug = false)
+    public function __construct(ContainerInterface $container, bool $strictStatelessReport = false)
     {
-        parent::__construct($container, $debug);
+        parent::__construct($container, $strictStatelessReport);
     }
 
     protected function getSession(): ?SessionInterface

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -181,7 +181,7 @@ class SessionListenerTest extends TestCase
         $this->assertLessThanOrEqual((new \DateTime('now', new \DateTimeZone('UTC'))), (new \DateTime($response->headers->get('Expires'))));
     }
 
-    public function testSessionUsageExceptionIfStatelessAndSessionUsed()
+    public function testSessionUsageExceptionWhenStrictStatelessAndSessionUsed()
     {
         $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
         $session->expects($this->exactly(2))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1));
@@ -200,7 +200,7 @@ class SessionListenerTest extends TestCase
         $listener->onKernelResponse(new ResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, new Response()));
     }
 
-    public function testSessionUsageLogIfStatelessAndSessionUsed()
+    public function testSessionUsageLogWhenNotStrictStatelessAndSessionUsed()
     {
         $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
         $session->expects($this->exactly(2))->method('getUsageIndex')->will($this->onConsecutiveCalls(0, 1));
@@ -245,7 +245,7 @@ class SessionListenerTest extends TestCase
         $listener->onKernelResponse(new ResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response));
     }
 
-    public function testSessionUsageCallbackWhenDebugAndStateless()
+    public function testSessionUsageCallbackWhenStrictAndStateless()
     {
         $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
         $session->method('isStarted')->willReturn(true);
@@ -268,7 +268,7 @@ class SessionListenerTest extends TestCase
         (new SessionListener($container, true))->onSessionUsage();
     }
 
-    public function testSessionUsageCallbackWhenNoDebug()
+    public function testSessionUsageCallbackWhenNotStrict()
     {
         $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
         $session->method('isStarted')->willReturn(true);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

This PR is related to https://github.com/symfony/symfony/pull/35732 which is reporting session usage when stateless is specified.
In debug mode, it throws an `UnexpectedSessionUsageException` whereas in "no debug mode", it only logs that session is unexpectedly used.

The current PR proposes to replace the log by an exception in the "no debug mode".
In that way, if session is unexpectedly used in production mode, it will throw an exception and prevent more serious problems such as serving a cached page with personal data.

WDYT ?