### PR TITLE
[ErrorHandler] Remove trigger_deprecation frame from trace

### DIFF
--- a/src/Symfony/Component/ErrorHandler/composer.json
+++ b/src/Symfony/Component/ErrorHandler/composer.json
@@ -23,7 +23,8 @@
     },
     "require-dev": {
         "symfony/http-kernel": "^4.4|^5.0",
-        "symfony/serializer": "^4.4|^5.0"
+        "symfony/serializer": "^4.4|^5.0",
+        "symfony/deprecation-contracts": "^2.1"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\ErrorHandler\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I did not modify the `cleanTrace` method because it is also used for silenced errors. However, deprecations cannot be silenced. So it seems better to me to create a new method and use it when it is needed. Also we need to know the modified line and file before creating the exception. So we cannot use the exception trace, unless we create the exception twice. I don't know what is better performance wise: let me know!