### PR TITLE
[MonologBridge] Fix $level type

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/MailerHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/MailerHandler.php
@@ -30,8 +30,9 @@ class MailerHandler extends AbstractProcessingHandler
 
     /**
      * @param callable|Email $messageTemplate
+     * @param string|int     $level           The minimum logging level at which this handler will be triggered
      */
-    public function __construct(MailerInterface $mailer, $messageTemplate, int $level = Logger::DEBUG, bool $bubble = true)
+    public function __construct(MailerInterface $mailer, $messageTemplate, $level = Logger::DEBUG, bool $bubble = true)
     {
         parent::__construct($level, $bubble);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

Monolog accepts both level names like 'info' or int constants. The parent constructor will normalize it to an int. https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/AbstractHandler.php#L53

Note that this may need to be applied on more handlers here I did not check, if someone feels like going over them all please feel free.