### PR TITLE
[Serializer] Catch \Throwable in getCacheKey()

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -401,6 +401,20 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     private function getCacheKey($format, array $context)
     {
         unset($context['cache_key']); // avoid artificially different keys
+
+        if (interface_exists(\Throwable::class)) {
+            try {
+                return md5($format.serialize([
+                        'context' => $context,
+                        'ignored' => $this->ignoredAttributes,
+                        'camelized' => $this->camelizedAttributes,
+                    ]));
+            } catch (\Throwable $exception) {
+                // The context cannot be serialized, skip the cache
+                return false;
+            }
+        }
+
         try {
             return md5($format.serialize([
                 'context' => $context,

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -401,28 +401,17 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     private function getCacheKey($format, array $context)
     {
         unset($context['cache_key']); // avoid artificially different keys
-
-        if (interface_exists(\Throwable::class)) {
-            try {
-                return md5($format.serialize([
-                        'context' => $context,
-                        'ignored' => $this->ignoredAttributes,
-                        'camelized' => $this->camelizedAttributes,
-                    ]));
-            } catch (\Throwable $exception) {
-                // The context cannot be serialized, skip the cache
-                return false;
-            }
-        }
-
         try {
             return md5($format.serialize([
                 'context' => $context,
                 'ignored' => $this->ignoredAttributes,
                 'camelized' => $this->camelizedAttributes,
             ]));
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             // The context cannot be serialized, skip the cache
+            return false;
+        } catch (\Exception $exception) {
+            // compatibility layer for PHP 5
             return false;
         }
     }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -565,8 +565,7 @@ class ObjectNormalizerTest extends TestCase
             'bar' => null,
         ];
 
-        $this->assertEquals($expected, $this->normalizer->normalize($objectDummy, null, ['not_serializable' => function () {
-        }]));
+        $this->assertEquals($expected, $this->normalizer->normalize($objectDummy, null, ['not_serializable' => new NotSerializable()]));
     }
 
     public function testMaxDepth()
@@ -1100,5 +1099,17 @@ class ObjectWithUpperCaseAttributeNames
     public function getFoo()
     {
         return $this->Foo;
+    }
+}
+
+class NotSerializable
+{
+    public function __sleep()
+    {
+        if (class_exists(\Error::class)) {
+            throw new \Error('not serializable');
+        }
+
+        throw new \Exception('not serializable');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/symfony/symfony/pull/36332#issuecomment-608424596
| License       | MIT
| Doc PR        | n/a

`serialize()` can throw `\Throwable` with PHP 7+, and it will if you try to serialize a Doctrine entity. As the serialization context will likely contain Doctrine entity, this must be caught.