### PR TITLE
[Form] Fixed handling groups sequence validation

### DIFF
--- a/src/Symfony/Component/Form/Resources/config/validation.xml
+++ b/src/Symfony/Component/Form/Resources/config/validation.xml
@@ -7,7 +7,7 @@
   <class name="Symfony\Component\Form\Form">
     <constraint name="Symfony\Component\Form\Extension\Validator\Constraints\Form" />
     <property name="children">
-        <constraint name="Valid" />
+      <constraint name="Valid" />
     </property>
   </class>
 </constraint-mapping>

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -12,15 +12,19 @@
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\Forms;
 use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 use Symfony\Component\Form\Tests\Extension\Core\Type\FormTypeTest;
 use Symfony\Component\Form\Tests\Extension\Core\Type\TextTypeTest;
-use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Form\Tests\Fixtures\Author;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 use Symfony\Component\Validator\Validation;
 
 class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
@@ -64,14 +68,69 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
             ->add('field', TextTypeTest::TESTED_TYPE, [
                 'constraints' => [
                     new Length(['min' => 10, 'groups' => ['First']]),
-                    new Email(['groups' => ['Second']]),
+                    new NotBlank(['groups' => ['Second']]),
                 ],
             ])
         ;
 
         $form->submit(['field' => 'wrong']);
 
-        $this->assertCount(1, $form->getErrors(true));
+        $errors = $form->getErrors(true);
+
+        $this->assertCount(1, $errors);
+        $this->assertInstanceOf(Length::class, $errors[0]->getCause()->getConstraint());
+    }
+
+    public function testManyFieldsGroupSequenceWithConstraintsOption()
+    {
+        $formMetadata = new ClassMetadata(Form::class);
+        $authorMetadata = (new ClassMetadata(Author::class))
+            ->addPropertyConstraint('firstName', new NotBlank(['groups' => 'Second']))
+        ;
+        $metadataFactory = $this->createMock(MetadataFactoryInterface::class);
+        $metadataFactory->expects($this->any())
+            ->method('getMetadataFor')
+            ->willReturnCallback(static function ($classOrObject) use ($formMetadata, $authorMetadata) {
+                if (Author::class === $classOrObject || $classOrObject instanceof Author) {
+                    return $authorMetadata;
+                }
+
+                if (Form::class === $classOrObject || $classOrObject instanceof Form) {
+                    return $formMetadata;
+                }
+
+                return new ClassMetadata(\is_string($classOrObject) ? $classOrObject : \get_class($classOrObject));
+            })
+        ;
+
+        $validator = Validation::createValidatorBuilder()
+            ->setMetadataFactory($metadataFactory)
+            ->getValidator()
+        ;
+        $form = Forms::createFormFactoryBuilder()
+            ->addExtension(new ValidatorExtension($validator))
+            ->getFormFactory()
+            ->create(FormTypeTest::TESTED_TYPE, new Author(), (['validation_groups' => new GroupSequence(['First', 'Second'])]))
+            ->add('firstName', TextTypeTest::TESTED_TYPE)
+            ->add('lastName', TextTypeTest::TESTED_TYPE, [
+                'constraints' => [
+                    new Length(['min' => 10, 'groups' => ['First']]),
+                ],
+            ])
+            ->add('australian', TextTypeTest::TESTED_TYPE, [
+                'constraints' => [
+                    new NotBlank(['groups' => ['Second']]),
+                ],
+            ])
+        ;
+
+        $form->submit(['firstName' => '', 'lastName' => 'wrong_1', 'australian' => '']);
+
+        $errors = $form->getErrors(true);
+
+        $this->assertCount(1, $errors);
+        $this->assertInstanceOf(Length::class, $errors[0]->getCause()->getConstraint());
+        $this->assertSame('children[lastName].data', $errors[0]->getCause()->getPropertyPath());
     }
 
     protected function createForm(array $options = [])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | FIx https://github.com/symfony/symfony/issues/9939#issuecomment-607459505, Fix #35556
| License       | MIT
| Doc PR        | ~

This is not the same as the original issue fixed by #36245, that was reported in https://github.com/symfony/symfony/issues/9939#issuecomment-607459505.

The form also fails to cascade sequence validation properly because each nested field is validated against the sequence, and one can fail at a step independently from another which could failed in another step. I've added a lot of tests to ensure this is working properly and tested in a website skeleton too.

This PR aims to close #35556 which tries to fix the same issue but afterwards in its implementation as said in https://github.com/symfony/symfony/pull/35556#discussion_r379289230.