### PR TITLE
[Notifier][Slack] Error trown when having more than 10 fields specified #36346 

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackSectionBlock.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackSectionBlock.php
@@ -44,6 +44,11 @@ final class SlackSectionBlock extends AbstractSlackBlock
             'text' => $text,
         ];
 
+        // Maximum number of items is 10
+        if (10 <= \count($this->options['fields'])) {
+            throw new \LogicException('Maximum number of fields should not exceed 10.');
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #36346 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

As written in [docs](https://api.slack.com/reference/block-kit/blocks#section) of Section block, for fields we have to had maximum 10 items specified.
