### PR TITLE
[Validator] Added support for cascade validation on typed properties

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -32,6 +32,7 @@ CHANGELOG
 5.1.0
 -----
 
+ * added a `Cascade` constraint to ease validating typed nested objects
  * added the `Hostname` constraint and validator
  * added the `alpha3` option to the `Country` and `Language` constraints
  * allow to define a reusable set of constraints by extending the `Compound` constraint

--- a/src/Symfony/Component/Validator/Constraints/Cascade.php
+++ b/src/Symfony/Component/Validator/Constraints/Cascade.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * @Annotation
+ * @Target({"CLASS"})
+ *
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+class Cascade extends Constraint
+{
+    public function __construct($options = null)
+    {
+        if (\is_array($options) && \array_key_exists('groups', $options)) {
+            throw new ConstraintDefinitionException(sprintf('The option "groups" is not supported by the constraint "%s".', __CLASS__));
+        }
+
+        parent::__construct($options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -12,8 +12,10 @@
 namespace Symfony\Component\Validator\Mapping;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Cascade;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\Traverse;
+use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\GroupDefinitionException;
 
@@ -170,6 +172,17 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
 
     /**
      * {@inheritdoc}
+     *
+     * If the constraint {@link Cascade} is added, the cascading strategy will be
+     * changed to {@link CascadingStrategy::CASCADE}.
+     *
+     * If the constraint {@link Traverse} is added, the traversal strategy will be
+     * changed. Depending on the $traverse property of that constraint,
+     * the traversal strategy will be set to one of the following:
+     *
+     *  - {@link TraversalStrategy::IMPLICIT} by default
+     *  - {@link TraversalStrategy::NONE} if $traverse is disabled
+     *  - {@link TraversalStrategy::TRAVERSE} if $traverse is enabled
      */
     public function addConstraint(Constraint $constraint)
     {
@@ -184,6 +197,23 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
             } else {
                 // If traverse is false, traversal should be explicitly disabled
                 $this->traversalStrategy = TraversalStrategy::NONE;
+            }
+
+            // The constraint is not added
+            return $this;
+        }
+
+        if ($constraint instanceof Cascade) {
+            if (\PHP_VERSION_ID < 70400) {
+                throw new ConstraintDefinitionException(sprintf('The constraint "%s" requires PHP 7.4.', Cascade::class));
+            }
+
+            $this->cascadingStrategy = CascadingStrategy::CASCADE;
+
+            foreach ($this->getReflectionClass()->getProperties() as $property) {
+                if ($property->hasType() && (('array' === $type = $property->getType()->getName()) || class_exists(($type)))) {
+                    $this->addPropertyConstraint($property->getName(), new Valid());
+                }
             }
 
             // The constraint is not added
@@ -459,13 +489,11 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
     }
 
     /**
-     * Class nodes are never cascaded.
-     *
      * {@inheritdoc}
      */
     public function getCascadingStrategy()
     {
-        return CascadingStrategy::NONE;
+        return $this->cascadingStrategy;
     }
 
     private function addPropertyMetadata(PropertyMetadataInterface $metadata)

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Mapping;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Cascade;
 use Symfony\Component\Validator\Constraints\DisableAutoMapping;
 use Symfony\Component\Validator\Constraints\EnableAutoMapping;
 use Symfony\Component\Validator\Constraints\Traverse;
@@ -132,12 +133,12 @@ class GenericMetadata implements MetadataInterface
      *
      * @return $this
      *
-     * @throws ConstraintDefinitionException When trying to add the
-     *                                       {@link Traverse} constraint
+     * @throws ConstraintDefinitionException When trying to add the {@link Cascade}
+     *                                       or {@link Traverse} constraint
      */
     public function addConstraint(Constraint $constraint)
     {
-        if ($constraint instanceof Traverse) {
+        if ($constraint instanceof Traverse || $constraint instanceof Cascade) {
             throw new ConstraintDefinitionException(sprintf('The constraint "%s" can only be put on classes. Please use "Symfony\Component\Validator\Constraints\Valid" instead.', get_debug_type($constraint)));
         }
 

--- a/src/Symfony/Component/Validator/Tests/Fixtures/CascadedChild.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/CascadedChild.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class CascadedChild
+{
+    public $name;
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/CascadingEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/CascadingEntity.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class CascadingEntity
+{
+    public string $scalar;
+
+    public CascadedChild $requiredChild;
+
+    public ?CascadedChild $optionalChild;
+
+    public static ?CascadedChild $staticChild;
+
+    /**
+     * @var CascadedChild[]
+     */
+    public array $children;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | TODO

This PR leverages PHP 7.4 property types to "guess" typed object members and enable default cascade validation on nested objects.

Before:
```php
use Symfony\Component\Validator\Constraints as Assert;

class Composite
{
    /**
     * @var self[]
     *
     * @Assert\Valid
     */
    public array $children;

    /**
     * @Assert\Valid
     */
    public ?self $parent;

    /**
     * @Assert\Valid
     */
    public static ?self $root;
}
```

After:
```php
use Symfony\Component\Validator\Constraints as Assert;

/**
 * @Assert\Cascade
 */
class Composite
{
    /*
     * @var self[]
     */
    public array $children;
    public ?self $parent;
    public static ?self $root;
}
```

The constraint can also be used in xml, yaml, and of course raw PHP.
___________ 
Question: is the naming ok, maybe we could use `CascadeValid` to be more explicit?