### PR TITLE
[Validator] Fixed default group for nested composite constraints

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Composite.php
+++ b/src/Symfony/Component/Validator/Constraints/Composite.php
@@ -88,7 +88,8 @@ abstract class Composite extends Constraint
                 }
             }
 
-            $this->groups = array_keys($mergedGroups);
+            // prevent empty composite constraint to have empty groups
+            $this->groups = array_keys($mergedGroups) ?: [self::DEFAULT_GROUP];
             $this->$compositeOption = $nestedConstraints;
 
             return;

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionTest.php
@@ -100,4 +100,16 @@ class CollectionTest extends TestCase
 
         $this->assertEquals($collection1, $collection2);
     }
+
+    public function testConstraintHasDefaultGroupWithOptionalValues()
+    {
+        $constraint = new Collection([
+            'foo' => new Required(),
+            'bar' => new Optional(),
+        ]);
+
+        $this->assertEquals(['Default'], $constraint->groups);
+        $this->assertEquals(['Default'], $constraint->fields['foo']->groups);
+        $this->assertEquals(['Default'], $constraint->fields['bar']->groups);
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
@@ -143,6 +143,29 @@ abstract class CollectionValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    public function testExtraFieldsDisallowedWithOptionalValues()
+    {
+        $constraint = new Optional();
+
+        $data = $this->prepareTestData([
+            'baz' => 6,
+        ]);
+
+        $this->validator->validate($data, new Collection([
+            'fields' => [
+                'foo' => $constraint,
+            ],
+            'extraFieldsMessage' => 'myMessage',
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ field }}', '"baz"')
+            ->atPath('property.path[baz]')
+            ->setInvalidValue(6)
+            ->setCode(Collection::NO_SUCH_FIELD_ERROR)
+            ->assertRaised();
+    }
+
     // bug fix
     public function testNullNotConsideredExtraField()
     {

--- a/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CompositeTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Constraints\Valid;
 
 class ConcreteComposite extends Composite
 {
-    public $constraints;
+    public $constraints = [];
 
     protected function getCompositeOption()
     {
@@ -37,6 +37,30 @@ class ConcreteComposite extends Composite
  */
 class CompositeTest extends TestCase
 {
+    public function testConstraintHasDefaultGroup()
+    {
+        $constraint = new ConcreteComposite([
+            new NotNull(),
+            new NotBlank(),
+        ]);
+
+        $this->assertEquals(['Default'], $constraint->groups);
+        $this->assertEquals(['Default'], $constraint->constraints[0]->groups);
+        $this->assertEquals(['Default'], $constraint->constraints[1]->groups);
+    }
+
+    public function testNestedCompositeConstraintHasDefaultGroup()
+    {
+        $constraint = new ConcreteComposite([
+            new ConcreteComposite(),
+            new ConcreteComposite(),
+        ]);
+
+        $this->assertEquals(['Default'], $constraint->groups);
+        $this->assertEquals(['Default'], $constraint->constraints[0]->groups);
+        $this->assertEquals(['Default'], $constraint->constraints[1]->groups);
+    }
+
     public function testMergeNestedGroupsIfNoExplicitParentGroup()
     {
         $constraint = new ConcreteComposite([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33986
| License       | MIT
| Doc PR        | ~

Take a breath: when composite constraints are nested in a parent composite constraint without having non composite nested constraints (i.e empty), then the default group is not added, making the validator failing to validate in any group (including default), because there is no group at all, which should never happen.