### PR TITLE
[HttpKernel] decouple ArgumentResolverInterface and ArgumentValueReso…

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\Controller;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\DefaultValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestAttributeValueResolver;
 use Symfony\Component\HttpKernel\Controller\ArgumentResolver\RequestValueResolver;
@@ -43,17 +42,17 @@ final class ArgumentResolver implements ArgumentResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function getArguments(Request $request, callable $controller): array
+    public function getArguments($context, callable $controller): array
     {
         $arguments = [];
 
         foreach ($this->argumentMetadataFactory->createArgumentMetadata($controller) as $metadata) {
             foreach ($this->argumentValueResolvers as $resolver) {
-                if (!$resolver->supports($request, $metadata)) {
+                if (!$resolver->supports($context, $metadata)) {
                     continue;
                 }
 
-                $resolved = $resolver->resolve($request, $metadata);
+                $resolved = $resolver->resolve($context, $metadata);
 
                 $atLeastOne = false;
                 foreach ($resolved as $append) {

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DefaultValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/DefaultValueResolver.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
@@ -25,7 +24,7 @@ final class DefaultValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument): bool
+    public function supports($context, ArgumentMetadata $argument): bool
     {
         return $argument->hasDefaultValue() || (null !== $argument->getType() && $argument->isNullable() && !$argument->isVariadic());
     }
@@ -33,7 +32,7 @@ final class DefaultValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    public function resolve($context, ArgumentMetadata $argument): iterable
     {
         yield $argument->hasDefaultValue() ? $argument->getDefaultValue() : null;
     }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/NotTaggedControllerValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/NotTaggedControllerValueResolver.php
@@ -34,8 +34,12 @@ final class NotTaggedControllerValueResolver implements ArgumentValueResolverInt
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument): bool
+    public function supports($request, ArgumentMetadata $argument): bool
     {
+        if (!$request instanceof Request) {
+            return false;
+        }
+
         $controller = $request->attributes->get('_controller');
 
         if (\is_array($controller) && \is_callable($controller, true) && \is_string($controller[0])) {
@@ -57,8 +61,10 @@ final class NotTaggedControllerValueResolver implements ArgumentValueResolverInt
 
     /**
      * {@inheritdoc}
+     *
+     * @param Request $request
      */
-    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    public function resolve($request, ArgumentMetadata $argument): iterable
     {
         if (\is_array($controller = $request->attributes->get('_controller'))) {
             $controller = $controller[0].'::'.$controller[1];

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributeValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestAttributeValueResolver.php
@@ -25,15 +25,21 @@ final class RequestAttributeValueResolver implements ArgumentValueResolverInterf
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument): bool
+    public function supports($request, ArgumentMetadata $argument): bool
     {
+        if (!$request instanceof Request) {
+            return false;
+        }
+
         return !$argument->isVariadic() && $request->attributes->has($argument->getName());
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @param Request $request
      */
-    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    public function resolve($request, ArgumentMetadata $argument): iterable
     {
         yield $request->attributes->get($argument->getName());
     }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/RequestValueResolver.php
@@ -25,15 +25,19 @@ final class RequestValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument): bool
+    public function supports($request, ArgumentMetadata $argument): bool
     {
+        if (!$request instanceof Request) {
+            return false;
+        }
+
         return Request::class === $argument->getType() || is_subclass_of($argument->getType(), Request::class);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    public function resolve($request, ArgumentMetadata $argument): iterable
     {
         yield $request;
     }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/ServiceValueResolver.php
@@ -34,8 +34,12 @@ final class ServiceValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument): bool
+    public function supports($request, ArgumentMetadata $argument): bool
     {
+        if (!$request instanceof Request) {
+            return false;
+        }
+
         $controller = $request->attributes->get('_controller');
 
         if (\is_array($controller) && \is_callable($controller, true) && \is_string($controller[0])) {
@@ -57,8 +61,10 @@ final class ServiceValueResolver implements ArgumentValueResolverInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param Request $request
      */
-    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    public function resolve($request, ArgumentMetadata $argument): iterable
     {
         if (\is_array($controller = $request->attributes->get('_controller'))) {
             $controller = $controller[0].'::'.$controller[1];

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/SessionValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/SessionValueResolver.php
@@ -26,9 +26,9 @@ final class SessionValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument): bool
+    public function supports($request, ArgumentMetadata $argument): bool
     {
-        if (!$request->hasSession()) {
+        if (!$request instanceof Request || !$request->hasSession()) {
             return false;
         }
 
@@ -42,8 +42,10 @@ final class SessionValueResolver implements ArgumentValueResolverInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param Request $request
      */
-    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    public function resolve($request, ArgumentMetadata $argument): iterable
     {
         yield $request->getSession();
     }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/TraceableValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/TraceableValueResolver.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\Controller\ArgumentResolver;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -35,12 +34,12 @@ final class TraceableValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument): bool
+    public function supports($context, ArgumentMetadata $argument): bool
     {
         $method = \get_class($this->inner).'::'.__FUNCTION__;
         $this->stopwatch->start($method, 'controller.argument_value_resolver');
 
-        $return = $this->inner->supports($request, $argument);
+        $return = $this->inner->supports($context, $argument);
 
         $this->stopwatch->stop($method);
 
@@ -50,12 +49,12 @@ final class TraceableValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    public function resolve($context, ArgumentMetadata $argument): iterable
     {
         $method = \get_class($this->inner).'::'.__FUNCTION__;
         $this->stopwatch->start($method, 'controller.argument_value_resolver');
 
-        yield from $this->inner->resolve($request, $argument);
+        yield from $this->inner->resolve($context, $argument);
 
         $this->stopwatch->stop($method);
     }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/VariadicValueResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver/VariadicValueResolver.php
@@ -25,15 +25,21 @@ final class VariadicValueResolver implements ArgumentValueResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function supports(Request $request, ArgumentMetadata $argument): bool
+    public function supports($request, ArgumentMetadata $argument): bool
     {
+        if (!$request instanceof Request) {
+            return false;
+        }
+
         return $argument->isVariadic() && $request->attributes->has($argument->getName());
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @param Request $request
      */
-    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    public function resolve($request, ArgumentMetadata $argument): iterable
     {
         $values = $request->attributes->get($argument->getName());
 

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolverInterface.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\Controller;
 
-use Symfony\Component\HttpFoundation\Request;
-
 /**
  * An ArgumentResolverInterface instance knows how to determine the
  * arguments for a specific action.
@@ -22,11 +20,13 @@ use Symfony\Component\HttpFoundation\Request;
 interface ArgumentResolverInterface
 {
     /**
-     * Returns the arguments to pass to the controller.
+     * Returns the arguments to pass to the action.
      *
-     * @return array An array of arguments to pass to the controller
+     * @param mixed $context
+     *
+     * @return array An array of arguments to pass to the action
      *
      * @throws \RuntimeException When no value could be provided for a required argument
      */
-    public function getArguments(Request $request, callable $controller);
+    public function getArguments($context, callable $controller);
 }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentValueResolverInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentValueResolverInterface.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\Controller;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
 /**
@@ -24,14 +23,18 @@ interface ArgumentValueResolverInterface
     /**
      * Whether this resolver can resolve the value for the given ArgumentMetadata.
      *
+     * @param mixed $context
+     *
      * @return bool
      */
-    public function supports(Request $request, ArgumentMetadata $argument);
+    public function supports($context, ArgumentMetadata $argument);
 
     /**
      * Returns the possible value(s).
      *
+     * @param mixed $context
+     *
      * @return iterable
      */
-    public function resolve(Request $request, ArgumentMetadata $argument);
+    public function resolve($context, ArgumentMetadata $argument);
 }

--- a/src/Symfony/Component/HttpKernel/Controller/TraceableArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/TraceableArgumentResolver.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\Controller;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 /**
@@ -31,7 +30,7 @@ class TraceableArgumentResolver implements ArgumentResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function getArguments(Request $request, callable $controller)
+    public function getArguments($request, callable $controller)
     {
         $e = $this->stopwatch->start('controller.get_arguments');
 

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/TraceableValueResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ArgumentResolver/TraceableValueResolverTest.php
@@ -63,12 +63,12 @@ class TraceableValueResolverTest extends TestCase
 
 class ResolverStub implements ArgumentValueResolverInterface
 {
-    public function supports(Request $request, ArgumentMetadata $argument): bool
+    public function supports($request, ArgumentMetadata $argument): bool
     {
         return true;
     }
 
-    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    public function resolve($request, ArgumentMetadata $argument): iterable
     {
         yield 'first';
         yield 'second';

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
@@ -72,7 +72,7 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface, 
         return [$this, 'callController'];
     }
 
-    public function getArguments(Request $request, callable $controller): array
+    public function getArguments($request, callable $controller): array
     {
         return [$request];
     }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestMultipleHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestMultipleHttpKernel.php
@@ -55,7 +55,7 @@ class TestMultipleHttpKernel extends HttpKernel implements ControllerResolverInt
         return [$this, 'callController'];
     }
 
-    public function getArguments(Request $request, callable $controller): array
+    public function getArguments($request, callable $controller): array
     {
         return [$request];
     }

--- a/src/Symfony/Component/HttpKernel/Tests/TestHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/TestHttpKernel.php
@@ -30,7 +30,7 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface, 
         return [$this, 'callController'];
     }
 
-    public function getArguments(Request $request, callable $controller): array
+    public function getArguments($request, callable $controller): array
     {
         return [$request];
     }

--- a/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php
+++ b/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Http\Controller;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -32,7 +31,7 @@ final class UserValueResolver implements ArgumentValueResolverInterface
         $this->tokenStorage = $tokenStorage;
     }
 
-    public function supports(Request $request, ArgumentMetadata $argument): bool
+    public function supports($context, ArgumentMetadata $argument): bool
     {
         // only security user implementations are supported
         if (UserInterface::class !== $argument->getType()) {
@@ -50,7 +49,7 @@ final class UserValueResolver implements ArgumentValueResolverInterface
         return $user instanceof UserInterface;
     }
 
-    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    public function resolve($context, ArgumentMetadata $argument): iterable
     {
         yield $this->tokenStorage->getToken()->getUser();
     }


### PR DESCRIPTION
…lverInterface from the request

Fix https://github.com/symfony/symfony/issues/36290

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes **TODO changelog**
| Deprecations? | maybe **TODO BC break layer**
| Tickets       | Fix #36290
| License       | MIT
| Doc PR        | **TODO**

Remove the typing `Request` on `$request` argument passed to
- `ArgumentResolverInterface::getArguments`
- `ArgumentValueResolverInterface::supports`
- `ArgumentValueResolverInterface::resolve`

All the tests for HttpKernel and Security components are OK.

I rename the argument `$request` to `$context` when it's not necessarily a Request but I let the name `$request` where it works only with a Request. I'm not sure if a should rename it everywhere regardless of the type.

### Concrete example

As requested by @nicolas-grekas during our discussion, here is a concrete example of its usage in a JSON-RPC context with a naïve implementation. I chose this case because it is one of the example given by the initial issue author @grachevko 

```php
/**
 * The main entrypoint for this exemple.
 */
class JsonRpcEndpoint
{
    private $methodToServiceMapping;
    private $argumentResolver;

    public function __construct(ArgumentResolverInterface $argumentResolver, array $methodToServiceMapping)
    {
        $this->methodToServiceMapping = $methodToServiceMapping;
        $this->argumentResolver = $argumentResolver;
    }

    public function handle(JsonRpcRequest $request): JsonRpcResponse
    {
        // Use the mapping to get the correct handler for this method.
        if (!isset($this->methodToServiceMapping[$request->getMethod()])) {
            return JsonRpcResponse::methodNotFound($request->getId());
        }
        $methodHandler = $this->methodToServiceMapping[$request->getMethod()];

        // Resolve the arguments of the handler with the argument resolver.
        $arguments = $this->argumentResolver->getArguments($request, $methodHandler);

        // Actually call the handler with its arguments.
        $result = $methodHandler(...$arguments);

        return new JsonRpcResponse('2.0', $result, null, $request->getId());
    }
}
```
```php
/**
 * The action whose arguments are resolved using the new ArgumentResolver capabilities.
 */
class UpdatePostMethod
{
    private $entityManager;

    public function __construct(EntityManagerInterface $entityManager)
    {
        $this->entityManager = $entityManager;
    }

    public function __invoke(Post $post, string $title, string $summary)
    {
        $post->setTitle($title);
        $post->setSummary($summary);
        $this->entityManager->flush();

        return $post;
    }
}
```
```php
/**
 * Naïve resolver that try to find an Entity when the argument type is known by Doctrine.
 */
class EntityArgumentValueResolver implements ArgumentValueResolverInterface
{
    private $entityManager;

    public function __construct(EntityManagerInterface $entityManager)
    {
        $this->entityManager = $entityManager;
    }

    public function supports($context, ArgumentMetadata $argument)
    {
        return $context instanceof JsonRpcRequest && !$this->entityManager->getMetadataFactory()->isTransient($argument->getType());
    }

    /**
     * @param JsonRpcRequest $context
     */
    public function resolve($context, ArgumentMetadata $argument)
    {
        $entity = $this->entityManager->find($argument->getType(), $context->getId());
        if (null !== $entity) {
            yield $entity;
        } else {
            throw EntityNotFoundException::fromClassNameAndIdentifier($argument->getType(), ['id' => $context->getId()]);
        }
    }
}
```

```php
/**
 * Simple resolver that resolve a params by its name.
 */
class ParamsArgumentValueResolver implements ArgumentValueResolverInterface
{
    public function supports($context, ArgumentMetadata $argument)
    {
        return $context instanceof JsonRpcRequest && \array_key_exists($argument->getName(), $context->getParams());
    }

    /**
     * @param JsonRpcRequest $context
     */
    public function resolve($context, ArgumentMetadata $argument)
    {
        yield $context->getParams()[$argument->getName()];
    }
}
```
```yaml
services:
    App\JsonRpc\JsonRpcEndpoint:
        $argumentResolver: '@json_rpc.argument_resolver'
        $methodToServiceMapping:
            update_post: '@App\JsonRpc\Method\UpdatePostMethod'

    json_rpc.argument_resolver:
        class: Symfony\Component\HttpKernel\Controller\ArgumentResolver
        arguments:
            $argumentValueResolvers:
                - '@App\JsonRpc\ArgumentResolver\EntityArgumentValueResolver'
                - '@App\JsonRpc\ArgumentResolver\ParamsArgumentValueResolver'
```

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
