### PR TITLE
[DI] add syntax to stack decorators

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -38,6 +38,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'container.service_locator',
         'container.service_locator_context',
         'container.service_subscriber',
+        'container.stack',
         'controller.argument_value_resolver',
         'controller.service_arguments',
         'data_collector',

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -51,6 +51,7 @@ class PassConfig
         $this->optimizationPasses = [[
             new AutoAliasServicePass(),
             new ValidateEnvPlaceholdersPass(),
+            new ResolveDecoratorStackPass(),
             new ResolveChildDefinitionsPass(),
             new RegisterServiceSubscribersPass(),
             new ResolveParameterPlaceHoldersPass(false, false),

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDecoratorStackPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDecoratorStackPass.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class ResolveDecoratorStackPass implements CompilerPassInterface
+{
+    private $tag;
+
+    public function __construct(string $tag = 'container.stack')
+    {
+        $this->tag = $tag;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        $stacks = [];
+
+        foreach ($container->findTaggedServiceIds($this->tag) as $id => $tags) {
+            $definition = $container->getDefinition($id);
+
+            if (!$definition instanceof ChildDefinition) {
+                throw new InvalidArgumentException(sprintf('Invalid service "%s": only definitions with a "parent" can have the "%s" tag.', $id, $this->tag));
+            }
+
+            if (!$stack = $definition->getArguments()) {
+                throw new InvalidArgumentException(sprintf('Invalid service "%s": the stack of decorators is empty.', $id));
+            }
+
+            $stacks[$id] = $stack;
+        }
+
+        if (!$stacks) {
+            return;
+        }
+
+        $resolvedDefinitions = [];
+
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (!isset($stacks[$id])) {
+                $resolvedDefinitions[$id] = $definition;
+                continue;
+            }
+
+            foreach (array_reverse($this->resolveStack($stacks, [$id]), true) as $k => $v) {
+                $resolvedDefinitions[$k] = $v;
+            }
+
+            $alias = $container->setAlias($id, $k);
+
+            if ($definition->getChanges()['public'] ?? false) {
+                $alias->setPublic($definition->isPublic());
+            }
+
+            if ($definition->isDeprecated()) {
+                $alias->setDeprecated(...array_values($definition->getDeprecation('%alias_id%')));
+            }
+        }
+
+        $container->setDefinitions($resolvedDefinitions);
+    }
+
+    private function resolveStack(array $stacks, array $path): array
+    {
+        $definitions = [];
+        $id = end($path);
+        $prefix = '.'.$id.'.';
+
+        if (!isset($stacks[$id])) {
+            return [$id => new ChildDefinition($id)];
+        }
+
+        if (key($path) !== $searchKey = array_search($id, $path)) {
+            throw new ServiceCircularReferenceException($id, \array_slice($path, $searchKey));
+        }
+
+        foreach ($stacks[$id] as $k => $definition) {
+            if ($definition instanceof ChildDefinition && isset($stacks[$definition->getParent()])) {
+                $path[] = $definition->getParent();
+                $definition = unserialize(serialize($definition)); // deep clone
+            } elseif ($definition instanceof Definition) {
+                $definitions[$decoratedId = $prefix.$k] = $definition;
+                continue;
+            } elseif ($definition instanceof Reference || $definition instanceof Alias) {
+                $path[] = (string) $definition;
+            } else {
+                throw new InvalidArgumentException(sprintf('Invalid service "%s": unexpected value of type "%s" found in the stack of decorators.', $id, get_debug_type($definition)));
+            }
+
+            $p = $prefix.$k;
+
+            foreach ($this->resolveStack($stacks, $path) as $k => $v) {
+                $definitions[$decoratedId = $p.$k] = $definition instanceof ChildDefinition ? $definition->setParent($k) : new ChildDefinition($k);
+                $definition = null;
+            }
+            array_pop($path);
+        }
+
+        if (1 === \count($path)) {
+            foreach ($definitions as $k => $definition) {
+                $definition->setPublic(false)->setTags([])->setDecoratedService($decoratedId);
+            }
+            $definition->setDecoratedService(null);
+        }
+
+        return $definitions;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractServiceConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractServiceConfigurator.php
@@ -82,6 +82,18 @@ abstract class AbstractServiceConfigurator extends AbstractConfigurator
     }
 
     /**
+     * Registers a stack of decorator services.
+     *
+     * @param InlineServiceConfigurator[]|ReferenceConfigurator[] $services
+     */
+    final public function stack(string $id, array $services): AliasConfigurator
+    {
+        $this->__destruct();
+
+        return $this->parent->stack($id, $services);
+    }
+
+    /**
      * Registers a service.
      */
     final public function __invoke(string $id, string $class = null): ServiceConfigurator

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -57,6 +57,7 @@
       <xsd:element name="prototype" type="prototype" minOccurs="0" />
       <xsd:element name="defaults" type="defaults" minOccurs="0" maxOccurs="1" />
       <xsd:element name="instanceof" type="instanceof" minOccurs="0" />
+      <xsd:element name="stack" type="stack" minOccurs="0" />
     </xsd:choice>
   </xsd:complexType>
 
@@ -174,6 +175,15 @@
     <xsd:attribute name="parent" type="xsd:string" />
     <xsd:attribute name="autowire" type="boolean" />
     <xsd:attribute name="autoconfigure" type="boolean" />
+  </xsd:complexType>
+
+  <xsd:complexType name="stack">
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="service" type="service" minOccurs="1" />
+      <xsd:element name="deprecated" type="deprecated" minOccurs="0" maxOccurs="1" />
+    </xsd:choice>
+    <xsd:attribute name="id" type="xsd:string" use="required" />
+    <xsd:attribute name="public" type="boolean" />
   </xsd:complexType>
 
   <xsd:complexType name="tag">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/stack.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/stack.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo;
+
+return function (ContainerConfigurator $c) {
+    $services = $c->services();
+
+    $services->stack('stack_a', [
+        service('stdClass')
+            ->property('label', 'A')
+            ->property('inner', ref('.inner')),
+        service('stdClass')
+            ->property('label', 'B')
+            ->property('inner', ref('.inner')),
+        service('stdClass')
+            ->property('label', 'C'),
+    ])->public();
+
+    $services->stack('stack_abstract', [
+        service('stdClass')
+            ->property('label', 'A')
+            ->property('inner', ref('.inner')),
+        service('stdClass')
+            ->property('label', 'B')
+            ->property('inner', ref('.inner')),
+    ]);
+
+    $services->stack('stack_b', [
+        ref('stack_abstract'),
+        service('stdClass')
+            ->property('label', 'C'),
+    ])->public();
+
+    $services->stack('stack_c', [
+        service('stdClass')
+            ->property('label', 'Z')
+            ->property('inner', ref('.inner')),
+        ref('stack_a'),
+    ])->public();
+
+    $services->stack('stack_d', [
+        service()
+            ->parent('stack_abstract')
+            ->property('label', 'Z'),
+        service('stdClass')
+            ->property('label', 'C'),
+    ])->public();
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/stack.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/stack.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <stack id="stack_a" public="true">
+            <service class="stdClass">
+                <property name="label">A</property>
+                <property name="inner" type="service" id=".inner" />
+            </service>
+            <service class="stdClass">
+                <property name="label">B</property>
+                <property name="inner" type="service" id=".inner" />
+            </service>
+            <service class="stdClass">
+                <property name="label">C</property>
+            </service>
+        </stack>
+
+        <stack id="stack_abstract">
+            <service class="stdClass" abstract="true">
+                <property name="label">A</property>
+                <property name="inner" type="service" id=".inner" />
+            </service>
+            <service class="stdClass">
+                <property name="label">B</property>
+                <property name="inner" type="service" id=".inner" />
+            </service>
+        </stack>
+
+        <stack id="stack_b" public="true">
+            <service alias="stack_abstract" />
+            <service class="stdClass">
+                <property name="label">C</property>
+            </service>
+        </stack>
+
+        <stack id="stack_c" public="true">
+            <service class="stdClass">
+                <property name="label">Z</property>
+                <property name="inner" type="service" id=".inner" />
+            </service>
+            <service alias="stack_a" />
+        </stack>
+
+        <stack id="stack_d" public="true">
+            <service parent="stack_abstract">
+                <property name="label">Z</property>
+            </service>
+            <service class="stdClass">
+                <property name="label">C</property>
+            </service>
+        </stack>
+    </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/stack.yaml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/stack.yaml
@@ -1,0 +1,67 @@
+services:
+    stack_short:
+        stack:
+            - stdClass: [1, 2]
+
+    stack_a:
+        public: true
+        stack:
+            - class: stdClass
+              properties:
+                  label: A
+                  inner: '@.inner'
+            - class: stdClass
+              properties:
+                  label: B
+                  inner: '@.inner'
+            - class: stdClass
+              properties:
+                  label: C
+
+    stack_abstract:
+        stack:
+            - class: stdClass
+              abstract: true
+              properties:
+                  label: A
+                  inner: '@.inner'
+            - class: stdClass
+              properties:
+                  label: B
+                  inner: '@.inner'
+
+    stack_b:
+        public: true
+        stack:
+            - alias: 'stack_abstract'
+            - class: stdClass
+              properties:
+                  label: C
+
+    stack_c:
+        public: true
+        stack:
+            - class: stdClass
+              properties:
+                  label: Z
+                  inner: '@.inner'
+            - '@stack_a'
+
+    stack_d:
+        public: true
+        stack:
+            - parent: 'stack_abstract'
+              properties:
+                  label: 'Z'
+            - class: stdClass
+              properties:
+                  label: C
+
+    stack_e:
+        public: true
+        stack:
+            - class: stdClass
+              properties:
+                  label: Y
+                  inner: '@.inner'
+            - '@stack_d'

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -101,6 +101,38 @@ class PhpFileLoaderTest extends TestCase
         $container->compile();
     }
 
+    public function testStack()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new PhpFileLoader($container, new FileLocator(realpath(__DIR__.'/../Fixtures').'/config'));
+        $loader->load('stack.php');
+
+        $container->compile();
+
+        $expected = (object) [
+            'label' => 'A',
+            'inner' => (object) [
+                'label' => 'B',
+                'inner' => (object) [
+                    'label' => 'C',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $container->get('stack_a'));
+        $this->assertEquals($expected, $container->get('stack_b'));
+
+        $expected = (object) [
+            'label' => 'Z',
+            'inner' => $expected,
+        ];
+        $this->assertEquals($expected, $container->get('stack_c'));
+
+        $expected = $expected->inner;
+        $expected->label = 'Z';
+        $this->assertEquals($expected, $container->get('stack_d'));
+    }
+
     /**
      * @group legacy
      * @expectedDeprecation Since symfony/dependency-injection 5.1: The signature of method "Symfony\Component\DependencyInjection\Loader\Configurator\Traits\DeprecateTrait::deprecate()" requires 3 arguments: "string $package, string $version, string $message", not defining them is deprecated.

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -1039,4 +1039,36 @@ class XmlFileLoaderTest extends TestCase
         $arguments = $container->getDefinition(FooWithAbstractArgument::class)->getArguments();
         $this->assertInstanceOf(AbstractArgument::class, $arguments['$baz']);
     }
+
+    public function testStack()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('stack.xml');
+
+        $container->compile();
+
+        $expected = (object) [
+            'label' => 'A',
+            'inner' => (object) [
+                'label' => 'B',
+                'inner' => (object) [
+                    'label' => 'C',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $container->get('stack_a'));
+        $this->assertEquals($expected, $container->get('stack_b'));
+
+        $expected = (object) [
+            'label' => 'Z',
+            'inner' => $expected,
+        ];
+        $this->assertEquals($expected, $container->get('stack_c'));
+
+        $expected = $expected->inner;
+        $expected->label = 'Z';
+        $this->assertEquals($expected, $container->get('stack_d'));
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -958,4 +958,44 @@ class YamlFileLoaderTest extends TestCase
 
         $this->assertSame($expected, $container->getDefinition('foo')->getMethodCalls());
     }
+
+    public function testStack()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('stack.yaml');
+
+        $this->assertSame([1, 2], $container->getDefinition('stack_short')->getArguments()[0]->getArguments());
+
+        $container->compile();
+
+        $expected = (object) [
+            'label' => 'A',
+            'inner' => (object) [
+                'label' => 'B',
+                'inner' => (object) [
+                    'label' => 'C',
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $container->get('stack_a'));
+        $this->assertEquals($expected, $container->get('stack_b'));
+
+        $expected = (object) [
+            'label' => 'Z',
+            'inner' => $expected,
+        ];
+        $this->assertEquals($expected, $container->get('stack_c'));
+
+        $expected = $expected->inner;
+        $expected->label = 'Z';
+        $this->assertEquals($expected, $container->get('stack_d'));
+
+        $expected = (object) [
+            'label' => 'Y',
+            'inner' => $expected,
+        ];
+        $this->assertEquals($expected, $container->get('stack_e'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #30599
| License       | MIT
| Doc PR        | -

Declare this:
```yaml
services:
    my_stack_of_decorators:
        stack:
            - class: App\ExternalDecorator
            - class: App\InternalDecorator
            - class: App\DecoratoredClass
```

And get this:
![image](https://user-images.githubusercontent.com/243674/78615803-b8c8e580-7872-11ea-95c2-22cb78f88ca8.png)

The PR is now ready with support for Yaml, XML and the PHP-DSL. It needs #36388, #36392 and #36389 to pass, and relates to #36390 to be DX-friendly.

The new syntax now supports composable stacks - i.e stack you can reuse in the middle of another stack.

RIP middleware, simple decorators FTW :)

From the test cases:
```yaml
services:
    reusable_stack:
        stack:
            - class: stdClass
              properties:
                  label: A
                  inner: '@.inner'
            - class: stdClass
              properties:
                  label: B
                  inner: '@.inner'

    concrete_stack:
        stack:
            - parent: reusable_stack
            - class: stdClass
              properties:
                  label: C
```

This will create a service similar to:
```php
(object) [
    'label' => 'A',
    'inner' => (object) [
        'label' => 'B',
        'inner' => (object) [
             'label' => 'C',
        ]
    ],
];
```

When used together with autowiring, this is enough to declare a stack of decorators:
```yaml
services:
    my_processing_stack:
        stack:
            - App\ExternalDecorator: ~
            - App\InternalDecorator: ~
            - App\TheDecoratedClass: ~
```

See fixtures for the other configuration formats.

See also https://twitter.com/nicolasgrekas/status/1248198573998604288

Todo:
- [x] rebase on top of #36388, #36392 and #36389 once they are merged
- [x] test declaring deeper nested stacks