### PR TITLE
[Workflow] Use a strict comparison when retrieving raw marking in MarkingStore

### DIFF
--- a/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
+++ b/src/Symfony/Component/Workflow/MarkingStore/MethodMarkingStore.php
@@ -56,7 +56,7 @@ final class MethodMarkingStore implements MarkingStoreInterface
 
         $marking = $subject->{$method}();
 
-        if (!$marking) {
+        if (null === $marking) {
             return new Marking();
         }
 

--- a/src/Symfony/Component/Workflow/Tests/MarkingStore/MethodMarkingStoreTest.php
+++ b/src/Symfony/Component/Workflow/Tests/MarkingStore/MethodMarkingStoreTest.php
@@ -53,6 +53,18 @@ class MethodMarkingStoreTest extends TestCase
         $this->assertEquals($marking, $marking2);
     }
 
+    public function testGetSetMarkingWithSingleStateAndAlmostEmptyPlaceName()
+    {
+        $subject = new Subject(0);
+
+        $markingStore = new MethodMarkingStore(true);
+
+        $marking = $markingStore->getMarking($subject);
+
+        $this->assertInstanceOf(Marking::class, $marking);
+        $this->assertCount(1, $marking->getPlaces());
+    }
+
     public function testGetMarkingWithValueObject()
     {
         $subject = new Subject($this->createValueObject('first_place'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/36358
| License       | MIT
| Doc PR        |