### PR TITLE
Fix constant accessor

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -949,7 +949,7 @@ class Response
      */
     public function setCache(array $options): object
     {
-        if ($diff = array_diff(array_keys($options), array_keys(static::HTTP_RESPONSE_CACHE_CONTROL_DIRECTIVES))) {
+        if ($diff = array_diff(array_keys($options), array_keys(self::HTTP_RESPONSE_CACHE_CONTROL_DIRECTIVES))) {
             throw new \InvalidArgumentException(sprintf('Response does not support the following options: "%s".', implode('", "', $diff)));
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -672,6 +672,12 @@ class ResponseTest extends ResponseTestCase
 
             $this->assertFalse($response->headers->hasCacheControlDirective(str_replace('_', '-', $directive)));
         }
+
+        $response = new DefaultResponse();
+
+        $options = ['etag' => '"whatever"'];
+        $response->setCache($options);
+        $this->assertSame($response->getEtag(), '"whatever"');
     }
 
     public function testSendContent()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Because HTTP_RESPONSE_CACHE_CONTROL_DIRECTIVES is private, using static will fail for any classes extending the Response class. HTTP_RESPONSE_CACHE_CONTROL_DIRECTIVES is already properly using self a bit lower so we should do the same thing here.

Introduced in https://github.com/symfony/symfony/pull/35748