### PR TITLE
[Process] Fixed input/output error on PHP 7.4

### DIFF
--- a/src/Symfony/Component/Process/Pipes/UnixPipes.php
+++ b/src/Symfony/Component/Process/Pipes/UnixPipes.php
@@ -118,7 +118,7 @@ class UnixPipes extends AbstractPipes
             $read[$type = array_search($pipe, $this->pipes, true)] = '';
 
             do {
-                $data = fread($pipe, self::CHUNK_SIZE);
+                $data = @fread($pipe, self::CHUNK_SIZE);
                 $read[$type] .= $data;
             } while (isset($data[0]) && ($close || isset($data[self::CHUNK_SIZE - 1])));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34945
| License       | MIT
| Doc PR        | 

This PR aims to fix the error from #34945, but i'm unsure if this is the best solution. The issue is that on PHP 7.4 the input/output error may come up. 

php.net/manual/en/migration74.incompatible.php#migration74.incompatible.core.fread-fwrite

> fread() and fwrite() will now return FALSE if the operation failed. Previously an empty string or 0 was returned. EAGAIN/EWOULDBLOCK are not considered failures. These functions now also raise a notice on failure, such as when trying to write to a read only file resource.
