### PR TITLE
Add symfony/polyfill-php80 as requirement

### DIFF
--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -20,6 +20,7 @@
         "symfony/event-dispatcher-contracts": "^1.1|^2",
         "symfony/http-foundation": "^3.4.40|^4.4.7|^5.0.7",
         "symfony/http-kernel": "^4.4",
+        "symfony/polyfill-php80": "^1.15",
         "symfony/property-access": "^3.4|^4.0|^5.0",
         "symfony/service-contracts": "^1.1|^2"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Symfony uses the `Stringable` interface in the [`TokenInterface`](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php#L57) class in Symfony 4.4, however it does not require `symfony/polyfill-php80` before Symfony 5.1 (see [composer.json@4.4](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Security/Core/composer.json) and [composer.json@master](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Security/Core/composer.json#L21)), therefore the class is undefined in PHP 7 + Symfony 4.

Thanks to @leofeyer for debugging it (see https://github.com/contao/contao/pull/1647).