### PR TITLE
[HttpKernel] Improve performance of the logger collector

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -85,7 +85,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
         }
 
         if (false === $this->data['logs_are_processed']) {
-            $this->sanitizeLogs(array_merge($this->data['logs'], $this->data['deprecation_logs']));
+            $this->data['logs'] = $this->sanitizeLogs(array_merge($this->data['logs'], $this->data['deprecation_logs']));
             $this->data['logs_are_processed'] = true;
             $this->data = $this->cloneVar($this->data);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The current logic of the LoggerDataCollector is:

* Let's collect everything
* And let's process everything

This PR proposes this other logic instead:

* Let's collect everything
* Don't process anything
* If user accesses to the profiler, then process the data on demand.

-----

If this logic is not flawed, it will save us lots of processing for all the times you don't access the profiler after making a request. I've tested successfully in the Symfony Demo app, where I got a 10% performance improvement for a non-trivial page:

![profiler-log-performance](https://user-images.githubusercontent.com/73419/78788565-49efa780-79ac-11ea-8484-2f57aee5d215.png)

[View full profiling details](https://blackfire.io/profiles/compare/b8625170-937a-4055-9d33-6682b68069b5/graph)

