### PR TITLE
[DI] fix detecting short service syntax in yaml

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -299,7 +299,7 @@ class YamlFileLoader extends FileLoader
     private function isUsingShortSyntax(array $service): bool
     {
         foreach ($service as $key => $value) {
-            if (\is_string($key) && ('' === $key || '$' !== $key[0])) {
+            if (\is_string($key) && ('' === $key || ('$' !== $key[0] && false === strpos($key, '\\')))) {
                 return false;
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_short_syntax.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_short_syntax.yml
@@ -1,0 +1,6 @@
+services:
+    foo_bar: [1, 2]
+
+    bar_foo:
+        $a: 'a'
+        App\Foo: 'foo'

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -205,6 +205,17 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals(['decorated', 'decorated.pif-pouf', 5, ContainerInterface::IGNORE_ON_INVALID_REFERENCE], $services['decorator_service_with_name_and_priority_and_on_invalid']->getDecoratedService());
     }
 
+    public function testLoadShortSyntax()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services_short_syntax.yml');
+        $services = $container->getDefinitions();
+
+        $this->assertSame([1, 2], $services['foo_bar']->getArguments());
+        $this->assertSame(['$a' => 'a', 'App\Foo' => 'foo'], $services['bar_foo']->getArguments());
+    }
+
     public function testDeprecatedAliases()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

We do allow interfaces/classes as keys in arguments, yet the short syntax fails to know about those.

This fixes it, allowing one to use:
```
services:
    App\Foo:
        App\BarInterface: '@App\BarClass'
```

As a reminder, by-name is also allowed:
```
services:
    App\Foo: {
        $bar: '@App\BarClass'
    }
```
