### PR TITLE
[DI] deprecate the `inline()` function from the PHP-DSL in favor of `service()`

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -24,6 +24,7 @@ DependencyInjection
    configure them explicitly instead.
  * Deprecated `Definition::getDeprecationMessage()`, use `Definition::getDeprecation()` instead.
  * Deprecated `Alias::getDeprecationMessage()`, use `Alias::getDeprecation()` instead.
+ * The `inline()` function from the PHP-DSL has been deprecated, use `service()` instead
 
 Dotenv
 ------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -24,6 +24,7 @@ DependencyInjection
    configure them explicitly instead.
  * Removed `Definition::getDeprecationMessage()`, use `Definition::getDeprecation()` instead.
  * Removed `Alias::getDeprecationMessage()`, use `Alias::getDeprecation()` instead.
+ * The `inline()` function from the PHP-DSL has been removed, use `service()` instead
 
 Dotenv
 ------

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * added tags `container.preload`/`.no_preload` to declare extra classes to preload/services to not preload
  * deprecated `Definition::getDeprecationMessage()`, use `Definition::getDeprecation()` instead
  * deprecated `Alias::getDeprecationMessage()`, use `Alias::getDeprecation()` instead
+ * deprecated PHP-DSL's `inline()` function, use `service()` instead
 
 5.0.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -92,8 +92,20 @@ function ref(string $id): ReferenceConfigurator
 
 /**
  * Creates an inline service.
+ *
+ * @deprecated since Symfony 5.1, use service() instead.
  */
 function inline(string $class = null): InlineServiceConfigurator
+{
+    trigger_deprecation('symfony/dependency-injection', '5.1', '"%s()" is deprecated, use "service()" instead.', __FUNCTION__);
+
+    return new InlineServiceConfigurator(new Definition($class));
+}
+
+/**
+ * Creates an inline service.
+ */
+function service(string $class = null): InlineServiceConfigurator
 {
     return new InlineServiceConfigurator(new Definition($class));
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/InlineServiceConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/InlineServiceConfigurator.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Definition;
  */
 class InlineServiceConfigurator extends AbstractConfigurator
 {
-    const FACTORY = 'inline';
+    const FACTORY = 'service';
 
     use Traits\ArgumentTrait;
     use Traits\AutowireTrait;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/basic.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/basic.php
@@ -7,5 +7,5 @@ use App\BarService;
 return function (ContainerConfigurator $c) {
     $s = $c->services();
     $s->set(BarService::class)
-        ->args([inline('FooClass')]);
+        ->args([service('FooClass')]);
 };

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object.php
@@ -9,6 +9,6 @@ return new class() {
     {
         $s = $c->services();
         $s->set(BarService::class)
-            ->args([inline('FooClass')]);
+            ->args([service('FooClass')]);
     }
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

In the PHP-DSL, the `inline()` function helps declaring ... inline services.

I'm proposing to rename it to `service()`, for consistency with yaml tags. All other helpers but this one have the same name as the yaml tag.

Let's do this while "nobody" uses this format yet :)