### PR TITLE
[DI] allow decorators to reference their decorated service using the special `.inner` id

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.1.0
 -----
 
+ * allow decorators to reference their decorated service using the special `.inner` id
  * added support to autowire public typed properties in php 7.4
  * added support for defining method calls, a configurator, and property setters in `InlineServiceConfigurator`
  * added possibility to define abstract service arguments

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Reference;
 
 class DecoratorServicePassTest extends TestCase
 {
@@ -240,6 +241,20 @@ class DecoratorServicePassTest extends TestCase
 
         $this->assertEquals(['container.service_locator' => [0 => []]], $container->getDefinition('baz.inner')->getTags());
         $this->assertEquals(['bar' => ['attr' => 'baz'], 'foobar' => ['attr' => 'bar']], $container->getDefinition('baz')->getTags());
+    }
+
+    public function testGenericInnerReference()
+    {
+        $container = new ContainerBuilder();
+        $container->register('foo');
+
+        $container->register('bar')
+            ->setDecoratedService('foo')
+            ->setProperty('prop', new Reference('.inner'));
+
+        $this->process($container);
+
+        $this->assertEquals(['prop' => new Reference('bar.inner')], $container->getDefinition('bar')->getProperties());
     }
 
     protected function process(ContainerBuilder $container)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Right now, when one wants to decorate a service, one needs to reference the decorated service using `foo.inner`, where `foo` is the id of the decorating service.

There are two issues with this IMHO:
- it's weird to have to repeat the name of declaring service inside of it;
- it doesn't play well with child definitions.

In this PR, I propose to use `.inner` to fix both issues.

Before:
```yaml
services:
  decorating_service:
    arguments: [@decorating_service.inner]
    decorates: decorated_service
```

After:
```yaml
services:
  decorating_service:
    arguments: [@.inner]
    decorates: decorated_service
```