### PR TITLE
[DI] add missing property declarations in InlineServiceConfigurator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AliasConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AliasConfigurator.php
@@ -20,6 +20,7 @@ class AliasConfigurator extends AbstractServiceConfigurator
 {
     const FACTORY = 'alias';
 
+    use Traits\DeprecateTrait;
     use Traits\PublicTrait;
 
     public function __construct(ServicesConfigurator $parent, Alias $alias)

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/InlineServiceConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/InlineServiceConfigurator.php
@@ -29,6 +29,10 @@ class InlineServiceConfigurator extends AbstractConfigurator
     use Traits\ParentTrait;
     use Traits\TagTrait;
 
+    private $id = '[inline]';
+    private $allowParent = true;
+    private $path = null;
+
     public function __construct(Definition $definition)
     {
         $this->definition = $definition;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

These are accessed by the traits used by the class.