### PR TITLE
Allowing empty secrets to be set

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsSetCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsSetCommand.php
@@ -96,6 +96,11 @@ EOF
             $value = strtr(substr(base64_encode(random_bytes($random)), 0, $random), '+/', '-_');
         } elseif (!$file = $input->getArgument('file')) {
             $value = $io->askHidden('Please type the secret value');
+
+            if (null === $value) {
+                $io->warning('No value provided: using empty string');
+                $value = '';
+            }
         } elseif ('-' === $file) {
             $value = file_get_contents('php://stdin');
         } elseif (is_file($file) && is_readable($file)) {
@@ -104,12 +109,6 @@ EOF
             throw new \InvalidArgumentException(sprintf('File not found: "%s".', $file));
         } elseif (!is_readable($file)) {
             throw new \InvalidArgumentException(sprintf('File is not readable: "%s".', $file));
-        }
-
-        if (null === $value) {
-            $io->warning('No value provided, aborting.');
-
-            return 1;
         }
 
         if ($vault->generateKeys()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Not needed

Setting secrets to an empty string is a valid value - you can already do this by consuming from an empty file or `stdin` with no input. But it's *not* currently possible to use the interactive prompt to set a secret to an empty string. This fixes that.