### PR TITLE
[Validator][RecursiveContextualValidator] Prevent validated hash collisions

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -12,9 +12,12 @@
 namespace Symfony\Component\Validator\Tests\Validator;
 
 use Symfony\Component\Translation\IdentityTranslator;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\Constraints\IsFalse;
+use Symfony\Component\Validator\Constraints\IsNull;
 use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -22,6 +25,7 @@ use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Required;
 use Symfony\Component\Validator\Constraints\Valid;
+use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Context\ExecutionContextFactory;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -199,5 +203,48 @@ class RecursiveValidatorTest extends AbstractTest
         $violations = $this->validator->validate([], new Optional());
 
         $this->assertCount(0, $violations);
+    }
+
+    public function testValidatedConstraintsHashesDontCollide()
+    {
+        $metadata = new ClassMetadata(Entity::class);
+        $metadata->addPropertyConstraint('initialized', new NotNull(['groups' => 'should_pass']));
+        $metadata->addPropertyConstraint('initialized', new IsNull(['groups' => 'should_fail']));
+
+        $this->metadataFactory->addMetadata($metadata);
+
+        $entity = new Entity();
+        $entity->data = new \stdClass();
+
+        $this->assertCount(2, $this->validator->validate($entity, new TestConstraintHashesDontCollide()));
+    }
+}
+
+final class TestConstraintHashesDontCollide extends Constraint
+{
+}
+
+final class TestConstraintHashesDontCollideValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$value instanceof Entity) {
+            throw new \LogicException();
+        }
+
+        $this->context->getValidator()
+            ->inContext($this->context)
+            ->atPath('data')
+            ->validate($value, new NotNull())
+            ->validate($value, new NotNull())
+            ->validate($value, new IsFalse());
+
+        $this->context->getValidator()
+            ->inContext($this->context)
+            ->validate($value, null, new GroupSequence(['should_pass']))
+            ->validate($value, null, new GroupSequence(['should_fail']));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | -
| Deprecations? | -
| Tickets       | -
| License       | MIT
| Doc PR        | -

`RecursiveContextualValidator` uses `spl_object_hash` at different places to generate cache keys. The problem with this method is that there can be collisions (same hash for two different objects) since once an object is destroyed, `spl_object_hash` can return a previously used hash.

I encountered the problem on a project with constraints that are created on the fly. The first constraint is applied and is "cached". Then it is destroyed. Then another constraint happen to have the exact same `spl_object_hash`. It is skipped while it would cause violations. I was able to reproduce the problem consistently in the unit test.

The easy way to deal with this is to keep references to all objects (proposed solution). But I guess it could leak too much.

We could also try to "clean" the `ExecutionContext` stores at the end of the three validate methods. However, we would still need to keep references to the initialized objects since they must really be initialized one time, even on multiple calls