### PR TITLE
Force ping after transport exception

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -206,12 +206,11 @@ class SmtpTransport extends AbstractTransport
             $this->stream->flush();
             $this->executeCommand("\r\n.\r\n", [250]);
             $message->appendDebug($this->stream->getDebug());
+            $this->lastMessageTime = microtime(true);
         } catch (TransportExceptionInterface $e) {
             $e->appendDebug($this->stream->getDebug());
-
+            $this->lastMessageTime = 0;
             throw $e;
-        } finally {
-            $this->lastMessageTime = microtime(true);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36301 
| License       | MIT
| Doc PR        | 

SMTP transport fails for long running processes after tranport exception, if stream is closed all messages will throw a transport exception until $lastMessageTime exceds $pingThreshold.

With this PR, after transport expception the transport will ping the server to check if the connection is still alive.
