### PR TITLE
JsonResponse::create() should be compatible with Response::create()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -66,7 +66,7 @@ class JsonResponse extends Response
      *
      * @deprecated since Symfony 5.1, use __construct() instead.
      */
-    public static function create($data = null, int $status = 200, array $headers = [])
+    public static function create(?string $data = null, int $status = 200, array $headers = [])
     {
         trigger_deprecation('symfony/http-foundation', '5.1', 'The "%s()" method is deprecated, use "new %s()" instead.', __METHOD__, \get_called_class());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations | yes
