### PR TITLE
[MonologBridge] Require symfony/console because ConsoleHandler depends on it

### DIFF
--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -18,11 +18,11 @@
     "require": {
         "php": "^7.1.3",
         "monolog/monolog": "^1.25.1",
+        "symfony/console": "^3.4|^4.0|^5.0",
         "symfony/service-contracts": "^1.1|^2",
         "symfony/http-kernel": "^4.3"
     },
     "require-dev": {
-        "symfony/console": "^3.4|^4.0|^5.0",
         "symfony/http-client": "^4.4|^5.0",
         "symfony/security-core": "^3.4|^4.0|^5.0",
         "symfony/var-dumper": "^3.4|^4.0|^5.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4, 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->

**Description**  

`ConsoleHandler` class [actually depends on symfony/console](https://github.com/symfony/monolog-bridge/blob/fd9750c732596742ee4f890a0a236881aad26c11/Handler/ConsoleHandler.php#L19-L23) but [symfony/monolog-bridge depends on symfony/console **only as "require-dev"**](https://github.com/symfony/monolog-bridge/blob/fd9750c732596742ee4f890a0a236881aad26c11/composer.json#L25).
So in some Symfony projects **only require-dev** symfony/console (e.g. ones have started with very old symfony/skeleton) we cannot use `console` handler in `prod/monolog.yaml`.
(And nevertheless [the default `prod/monolog.yaml` uses `console` handler](https://github.com/symfony/recipes/blob/2de05e19f916c8841102f2a35f0dc08dbac219ed/symfony/monolog-bundle/3.3/config/packages/prod/monolog.yaml#L14).)

**How to reproduce**  

```bash
$ composer create-project symfony/skeleton:^4.4 
$ composer remove symfony/console
$ composer require --dev symfony/console
$ composer require symfony/monolog-bundle
$ rm -rf vendor
$ composer install --no-dev
$ symfony server:start
```

Open `http://localhost:8000` and you can see following ClassNotFoundError.

```
Attempted to load class "ConsoleEvents" from namespace "Symfony\Component\Console".
Did you forget a "use" statement for another namespace?
```

Quick reproducer is [here](https://github.com/ttskch/symfony-monolog-bridge-dependency-problem-reproducer).

**Additional context**  

refs. https://github.com/symfony/recipes/issues/752