### PR TITLE
[Mailer][Messenger] add return statement for MessageHandler

### DIFF
--- a/src/Symfony/Component/Mailer/Messenger/MessageHandler.php
+++ b/src/Symfony/Component/Mailer/Messenger/MessageHandler.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Mailer\Messenger;
 
+use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 
 /**
@@ -25,8 +26,8 @@ class MessageHandler
         $this->transport = $transport;
     }
 
-    public function __invoke(SendEmailMessage $message)
+    public function __invoke(SendEmailMessage $message): ?SentMessage
     {
-        $this->transport->send($message->getMessage(), $message->getEnvelope());
+        return $this->transport->send($message->getMessage(), $message->getEnvelope());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 

By returning the result of the transporter in `MessageHandler` we can get hold of `SentMessage` from `HandledStamp::getResult()`.
![image](https://user-images.githubusercontent.com/4582866/79046122-3bed9100-7c0f-11ea-878f-65a6eb610758.png)


