### PR TITLE
[Form] Deprecated unused old `ServerParams` util

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -43,6 +43,7 @@ Form
  * Implementing the `FormConfigBuilderInterface` without implementing the `setIsEmptyCallback()` method
    is deprecated. The method will be added to the interface in 6.0.
  * Added argument `callable|null $filter` to `ChoiceListFactoryInterface::createListFromChoices()` and `createListFromLoader()` - not defining them is deprecated.
+ * Using `Symfony\Component\Form\Extension\Validator\Util\ServerParams` class is deprecated, use its parent `Symfony\Component\Form\Util\ServerParams` instead.
 
 FrameworkBundle
 ---------------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -41,6 +41,7 @@ Form
  * Added the `getIsEmptyCallback()` method to the `FormConfigInterface`.
  * Added the `setIsEmptyCallback()` method to the `FormConfigBuilderInterface`.
  * Added argument `callable|null $filter` to `ChoiceListFactoryInterface::createListFromChoices()` and `createListFromLoader()`.
+ * The `Symfony\Component\Form\Extension\Validator\Util\ServerParams` class has been removed, use its parent `Symfony\Component\Form\Util\ServerParams` instead.
 
 FrameworkBundle
 ---------------

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * Implementing the `FormConfigBuilderInterface` without implementing the `setIsEmptyCallback()` method
    is deprecated. The method will be added to the interface in 6.0.
  * Added a `rounding_mode` option for the PercentType and correctly round the value when submitted
+ * Deprecated `Symfony\Component\Form\Extension\Validator\Util\ServerParams` in favor of its parent class `Symfony\Component\Form\Util\ServerParams`
 
 5.0.0
 -----

--- a/src/Symfony/Component/Form/Extension/Validator/Util/ServerParams.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Util/ServerParams.php
@@ -13,8 +13,12 @@ namespace Symfony\Component\Form\Extension\Validator\Util;
 
 use Symfony\Component\Form\Util\ServerParams as BaseServerParams;
 
+trigger_deprecation('symfony/form', '5.1', 'The "%s" class is deprecated. Use "%s" instead.', ServerParams::class, BaseServerParams::class);
+
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @deprecated since Symfony 5.1. Use {@see BaseServerParams} instead.
  */
 class ServerParams extends BaseServerParams
 {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Util/LegacyServerParamsTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Util/LegacyServerParamsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Util;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Form\Extension\Validator\Util\ServerParams;
+
+class LegacyServerParamsTest extends TestCase
+{
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
+    public function testClassIsDeprecated()
+    {
+        $this->expectDeprecation('Since symfony/form 5.1: The "Symfony\Component\Form\Extension\Validator\Util\ServerParams" class is deprecated. Use "Symfony\Component\Form\Util\ServerParams" instead.');
+
+        new ServerParams();
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Util/ServerParamsTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/ServerParamsTest.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Form\Tests\Extension\Validator\Util;
+namespace Symfony\Component\Form\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Form\Extension\Validator\Util\ServerParams;
+use Symfony\Component\Form\Util\ServerParams;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

A left over after https://github.com/symfony/symfony/pull/11924#issuecomment-56511557, this class is unused since Symfony 2.3 ^^'. I've noticed it before but never took the time to submit a PR because this is very minor IMHO. But since this deprecation should not impact anyone, let's keep the codebase clean and remove it in 6.0.