### PR TITLE
[Ldap] Feature/force lowercase attributes

### DIFF
--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Added the "extra_fields" option, an array of custom fields to pull from the LDAP server
+ * Added option to allow consumers to force attribute keys to be lowercase when utilizing the Entry class.
 
 4.3.0
 -----

--- a/src/Symfony/Component/Ldap/Entry.php
+++ b/src/Symfony/Component/Ldap/Entry.php
@@ -18,11 +18,16 @@ class Entry
 {
     private $dn;
     private $attributes;
+    private $force_lowercase_attributes;
 
-    public function __construct(string $dn, array $attributes = [])
+    public function __construct(string $dn, array $attributes = [], bool $force_lowercase_attributes = false)
     {
         $this->dn = $dn;
         $this->attributes = $attributes;
+
+        if ($force_lowercase_attributes) {
+          $this->attributes = array_change_key_case($attributes);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Ldap/Entry.php
+++ b/src/Symfony/Component/Ldap/Entry.php
@@ -26,7 +26,7 @@ class Entry
         $this->attributes = $attributes;
 
         if ($force_lowercase_attributes) {
-          $this->attributes = array_change_key_case($attributes);
+            $this->attributes = array_change_key_case($attributes);
         }
     }
 


### PR DESCRIPTION
…e all lowercase, to force case insensitivity and enforce a standard (if desired) for the consumer software.

| Q             | A
| ------------- | ---
| Branch?       | 4.4 (I'll create another PR for 5.0)
| Bug fix?      | no
| New feature?  | no, Changelog updated
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Why? Companies have different AD setups, some force certain naming conventions, that developers may not know what and why. Coding around these pseudo standards introduces complex code that isn't necessary.  Allowing the SE to force all lowercase attributes will ease their utilization of symfony/ldap and overall (I think) have better quality code.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
