### PR TITLE
[Console] cursor tweaks

### DIFF
--- a/src/Symfony/Component/Console/Cursor.php
+++ b/src/Symfony/Component/Console/Cursor.php
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @author Pierre du Plessis <pdples@gmail.com>
  */
-class Cursor
+final class Cursor
 {
     private $output;
     private $input;

--- a/src/Symfony/Component/Console/Cursor.php
+++ b/src/Symfony/Component/Console/Cursor.php
@@ -19,7 +19,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Cursor
 {
     private $output;
-
     private $input;
 
     public function __construct(OutputInterface $output, $input = STDIN)
@@ -28,86 +27,114 @@ class Cursor
         $this->input = $input;
     }
 
-    public function moveUp(int $lines = 1)
+    public function moveUp(int $lines = 1): self
     {
         $this->output->write(sprintf("\x1b[%dA", $lines));
+
+        return $this;
     }
 
-    public function moveDown(int $lines = 1)
+    public function moveDown(int $lines = 1): self
     {
         $this->output->write(sprintf("\x1b[%dB", $lines));
+
+        return $this;
     }
 
-    public function moveRight(int $columns = 1)
+    public function moveRight(int $columns = 1): self
     {
         $this->output->write(sprintf("\x1b[%dC", $columns));
+
+        return $this;
     }
 
-    public function moveLeft(int $columns = 1)
+    public function moveLeft(int $columns = 1): self
     {
         $this->output->write(sprintf("\x1b[%dD", $columns));
+
+        return $this;
     }
 
-    public function moveToColumn(int $column)
+    public function moveToColumn(int $column): self
     {
         $this->output->write(sprintf("\x1b[%dG", $column));
+
+        return $this;
     }
 
-    public function moveToPosition(int $column, int $row)
+    public function moveToPosition(int $column, int $row): self
     {
         $this->output->write(sprintf("\x1b[%d;%dH", $row + 1, $column));
+
+        return $this;
     }
 
-    public function savePosition()
+    public function savePosition(): self
     {
         $this->output->write("\x1b7");
+
+        return $this;
     }
 
-    public function restorePosition()
+    public function restorePosition(): self
     {
         $this->output->write("\x1b8");
+
+        return $this;
     }
 
-    public function hide()
+    public function hide(): self
     {
         $this->output->write("\x1b[?25l");
+
+        return $this;
     }
 
-    public function show()
+    public function show(): self
     {
         $this->output->write("\x1b[?25h\x1b[?0c");
+
+        return $this;
     }
 
     /**
      * Clears all the output from the current line.
      */
-    public function clearLine()
+    public function clearLine(): self
     {
         $this->output->write("\x1b[2K");
+
+        return $this;
     }
 
     /**
      * Clears all the output from the current line after the current position.
      */
-    public function clearLineAfter()
+    public function clearLineAfter(): self
     {
         $this->output->write("\x1b[K");
+
+        return $this;
     }
 
     /**
      * Clears all the output from the cursors' current position to the end of the screen.
      */
-    public function clearOutput()
+    public function clearOutput(): self
     {
         $this->output->write("\x1b[0J");
+
+        return $this;
     }
 
     /**
      * Clears the entire screen.
      */
-    public function clearScreen()
+    public function clearScreen(): self
     {
         $this->output->write("\x1b[2J");
+
+        return $this;
     }
 
     /**

--- a/src/Symfony/Component/Console/Cursor.php
+++ b/src/Symfony/Component/Console/Cursor.php
@@ -81,13 +81,17 @@ class Cursor
     /**
      * Clears all the output from the current line.
      */
-    public function clearLine(bool $fromCurrentPosition = false)
+    public function clearLine()
     {
-        if (true === $fromCurrentPosition) {
-            $this->output->write("\x1b[K");
-        } else {
-            $this->output->write("\x1b[2K");
-        }
+        $this->output->write("\x1b[2K");
+    }
+
+    /**
+     * Clears all the output from the current line after the current position.
+     */
+    public function clearLineAfter()
+    {
+        $this->output->write("\x1b[K");
     }
 
     /**

--- a/src/Symfony/Component/Console/Cursor.php
+++ b/src/Symfony/Component/Console/Cursor.php
@@ -95,7 +95,7 @@ class Cursor
      */
     public function clearOutput()
     {
-        $this->output->write("\x1b[0J", false);
+        $this->output->write("\x1b[0J");
     }
 
     /**
@@ -103,7 +103,7 @@ class Cursor
      */
     public function clearScreen()
     {
-        $this->output->write("\x1b[2J", false);
+        $this->output->write("\x1b[2J");
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -353,7 +353,7 @@ class QuestionHelper extends Helper
                 }
             }
 
-            $cursor->clearLine(true);
+            $cursor->clearLineAfter();
 
             if ($numMatches > 0 && -1 !== $ofs) {
                 $cursor->savePosition();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Refs #27444
| License       | MIT
| Doc PR        | n/a

While playing with the new cursor class, I realized that I would like to make some changes. Mainly having a fluent interface: `$cursor->moveUp(10)->clearOutput()` for instance.

I have also separater the `clearLine()` method in two method to avoid the bool arg.

/cc @pierredup 
