### PR TITLE
[WebProfilerBundle] Make a difference between queued and sent emails

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -11,16 +11,13 @@
 
         {% set text %}
             <div class="sf-toolbar-info-piece">
-                <b>Sent messages</b>
-                <span class="sf-toolbar-status">{{ events.messages|length }}</span>
+                <b>Queued messages</b>
+                <span class="sf-toolbar-status">{{ events.events|filter(e => e.isQueued())|length }}</span>
             </div>
-
-            {% for transport in events.transports %}
-                <div class="sf-toolbar-info-piece">
-                    <b>{{ transport }}</b>
-                    <span class="sf-toolbar-status">{{ events.messages(transport)|length }}</span>
-                </div>
-            {% endfor %}
+            <div class="sf-toolbar-info-piece">
+                <b>Sent messages</b>
+                <span class="sf-toolbar-status">{{ events.events|filter(e => not e.isQueued())|length }}</span>
+            </div>
         {% endset %}
 
         {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { 'link': profiler_url }) }}
@@ -91,23 +88,24 @@
     {% endif %}
 
     <div class="metrics">
-        {% for transport in events.transports %}
-            <div class="metric">
-                <span class="value">{{ events.messages(transport)|length }}</span>
-                <span class="label">{{ events.messages(transport)|length == 1 ? 'message' : 'messages' }}</span>
-            </div>
-        {% endfor %}
+        <div class="metric">
+            <span class="value">{{ events.events|filter(e => e.isQueued())|length }}</span>
+            <span class="label">Queued</span>
+        </div>
+
+        <div class="metric">
+            <span class="value">{{ events.events|filter(e => not e.isQueued())|length }}</span>
+            <span class="label">Sent</span>
+        </div>
     </div>
 
     {% for transport in events.transports %}
-        <h3>{{ transport }}</h3>
-
         <div class="card-block">
             <div class="sf-tabs sf-tabs-sm">
                 {% for event in events.events(transport) %}
                     {% set message = event.message %}
                     <div class="tab">
-                        <h3 class="tab-title">Email #{{ loop.index }} <small>({{ event.isQueued() ? 'queued' : 'sent' }})</small></h3>
+                        <h3 class="tab-title">Email {{ event.isQueued() ? 'queued' : 'sent via ' ~ transport }}</h3>
                         <div class="tab-content">
                             <div class="card">
                                 {% if message.headers is not defined %}
@@ -118,32 +116,31 @@
                                 {% else %}
                                     {# Message instance #}
                                     <div class="card-block">
-                                        <span class="label">Subject</span>
-                                        <h2 class="m-t-10">{{ message.headers.get('subject').bodyAsString() ?? '(empty)' }}</h2>
-                                    </div>
+                                        <div class="sf-tabs sf-tabs-sm">
+                                            <div class="tab">
+                                                <h3 class="tab-title">Headers</h3>
+                                                <div class="tab-content">
+                                                    <span class="label">Subject</span>
+                                                    <h2 class="m-t-10">{{ message.headers.get('subject').bodyAsString() ?? '(empty)' }}</h2>
+                                                    <div class="row">
+                                                        <div class="col col-4">
+                                                            <span class="label">From</span>
+                                                            <pre class="prewrap">{{ (message.headers.get('from').bodyAsString() ?? '(empty)')|replace({'From:': ''}) }}</pre>
 
-                                    <div class="card-block">
-                                        <div class="row">
-                                            <div class="col col-4">
-                                                <span class="label">From</span>
-                                                <pre class="prewrap">{{ (message.headers.get('from').bodyAsString() ?? '(empty)')|replace({'From:': ''}) }}</pre>
-
-                                                <span class="label">To</span>
-                                                <pre class="prewrap">{{ (message.headers.get('to').bodyAsString() ?? '(empty)')|replace({'To:': ''}) }}</pre>
+                                                            <span class="label">To</span>
+                                                            <pre class="prewrap">{{ (message.headers.get('to').bodyAsString() ?? '(empty)')|replace({'To:': ''}) }}</pre>
+                                                        </div>
+                                                        <div class="col">
+                                                            <span class="label">Headers</span>
+                                                            <pre class="prewrap">{% for header in message.headers.all|filter(header => (header.name ?? '') not in ['Subject', 'From', 'To']) %}
+                                                                {{- header.toString }}
+                                                            {%~ endfor %}</pre>
+                                                        </div>
+                                                    </div>
+                                                </div>
                                             </div>
-                                            <div class="col">
-                                                <span class="label">Headers</span>
-                                                <pre class="prewrap">{% for header in message.headers.all|filter(header => (header.name ?? '') not in ['Subject', 'From', 'To']) %}
-                                                    {{- header.toString }}
-                                                {%~ endfor %}</pre>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <div class="card-block">
-                                        {% if message.htmlBody is defined %}
-                                            {# Email instance #}
-                                            <div class="sf-tabs sf-tabs-sm">
+                                            {% if message.htmlBody is defined %}
+                                                {# Email instance #}
                                                 <div class="tab">
                                                     <h3 class="tab-title">HTML Content</h3>
                                                     <div class="tab-content">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes-ish
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Refs #34972 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | n/a

The current profiler panel for Mailer is confusing when emails are sent synchronously.

Before:

![image](https://user-images.githubusercontent.com/47313/79122064-19867f80-7d97-11ea-9371-672f1b6f2998.png)

After:

![image](https://user-images.githubusercontent.com/47313/79121986-e8a64a80-7d96-11ea-8a41-b50f1d160f5f.png)

The new version makes a difference between queued and sent messages. The goes goes for the web debug toolbar.

I've also fixed an HTML markup issue and made the display more compact.
