### PR TITLE
Remove return type for Twig function workflow_metadata()

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
@@ -117,7 +117,7 @@ class WorkflowExtension extends AbstractExtension
      *                                                Use a string (the place name) to get place metadata
      *                                                Use a Transition instance to get transition metadata
      */
-    public function getMetadata($subject, string $key, $metadataSubject = null, string $name = null): ?string
+    public function getMetadata($subject, string $key, $metadataSubject = null, string $name = null)
     {
         return $this
             ->workflowRegistry


### PR DESCRIPTION
Technically it is allowed to have metadata other than string, even data that does not cast to string, like an array.

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36391
| License       | MIT
| Doc PR        | n/a

The workflow metadata store can contain not only strings, but setting nested metadata results in an error when workflow_metadata() is used in Twig.
Also see #36391 