### PR TITLE
[String] Add locale-sensitive map for slugging symbols

### DIFF
--- a/src/Symfony/Component/String/Tests/SluggerTest.php
+++ b/src/Symfony/Component/String/Tests/SluggerTest.php
@@ -49,4 +49,19 @@ class SluggerTest extends TestCase
         $this->assertSame('hello-world', (string) $slugger->slug('hello world'));
         $this->assertSame('hello_world', (string) $slugger->slug('hello world', '_'));
     }
+
+    public function testSlugCharReplacementLocaleConstruct()
+    {
+        $slugger = new AsciiSlugger('fr', ['fr' => ['&' => 'et', '@' => 'chez']]);
+        $slug = (string) $slugger->slug('toi & moi avec cette adresse slug@test.fr', '_');
+
+        $this->assertSame('toi_et_moi_avec_cette_adresse_slug_chez_test_fr', $slug);
+    }
+
+    public function testSlugCharReplacementLocaleMethod()
+    {
+        $slugger = new AsciiSlugger(null, ['es' => ['&' => 'y', '@' => 'en senal']]);
+        $slug = (string) $slugger->slug('yo & tu a esta dirección slug@test.es', '_', 'es');
+        $this->assertSame('yo_y_tu_a_esta_direccion_slug_en_senal_test_es', $slug);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Fix #36383 
| License       | MIT

By default chars '@' and '&' are respectively replaced by 'at' and 'and' (so limited by enlgish language).
I had an $options arguments to 'slug' method to replace chars with your own logic. 
 