### PR TITLE
[Cache] CacheItem with tag is never a hit after expired

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/FilesystemTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/FilesystemTagAwareAdapter.php
@@ -107,7 +107,7 @@ class FilesystemTagAwareAdapter extends AbstractTagAwareAdapter implements Prune
 
                 $file = $this->getFile($id);
 
-                if (!@symlink($file, $this->getFile($id, true, $tagFolder))) {
+                if (!@symlink($file, $tagLink = $this->getFile($id, true, $tagFolder)) && !is_link($tagLink)) {
                     @unlink($file);
                     $failed[] = $id;
                 }

--- a/src/Symfony/Component/Cache/Tests/Traits/TagAwareTestTrait.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/TagAwareTestTrait.php
@@ -155,4 +155,42 @@ trait TagAwareTestTrait
         $i = $pool->getItem('k');
         $this->assertSame(['foo' => 'foo'], $i->getMetadata()[CacheItem::METADATA_TAGS]);
     }
+
+    public function testRefreshAfterExpires()
+    {
+        $pool = $this->createCachePool();
+        $pool->clear();
+
+        $cacheItem = $pool->getItem('test');
+
+        $this->assertFalse($cacheItem->isHit());
+
+        // write cache with expires
+        $cacheItem->set('test');
+        $cacheItem->tag('1234');
+        $cacheItem->expiresAfter(1);
+
+        $pool->save($cacheItem);
+
+        $cacheItem = $pool->getItem('test');
+        $this->assertTrue($cacheItem->isHit());
+
+        // wait until expired
+        sleep(2);
+
+        // item should not longer be a hit
+        $cacheItem = $pool->getItem('test');
+        $this->assertFalse($cacheItem->isHit());
+
+        // update expired item
+        $cacheItem->set('test');
+        $cacheItem->tag('1234');
+        $cacheItem->expiresAfter(1);
+
+        $pool->save($cacheItem);
+
+        // item should be again a hit
+        $cacheItem = $pool->getItem('test');
+        $this->assertTrue($cacheItem->isHit());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes/no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36458
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


It seems like a tag cacheItem is never a hit again. Not sure how fix this but the cache component is really hard to debug 🙈 .

It need to be somewhere generally as all TagAware caches are effected:

```
1) Symfony\Component\Cache\Tests\Adapter\FilesystemTagAwareAdapterTest::testRefreshAfterExpires

Failed asserting that false is true.

/home/travis/build/symfony/symfony/src/Symfony/Component/Cache/Tests/Traits/TagAwareTestTrait.php:194

2) Symfony\Component\Cache\Tests\Adapter\PredisTagAwareClusterAdapterTest::testRefreshAfterExpires

Failed asserting that true is false.

/home/travis/build/symfony/symfony/src/Symfony/Component/Cache/Tests/Traits/TagAwareTestTrait.php:183

3) Symfony\Component\Cache\Tests\Adapter\RedisTagAwareAdapterTest::testRefreshAfterExpires

Failed asserting that true is false.

/home/travis/build/symfony/symfony/src/Symfony/Component/Cache/Tests/Traits/TagAwareTestTrait.php:183

4) Symfony\Component\Cache\Tests\Adapter\RedisTagAwareClusterAdapterTest::testRefreshAfterExpires

Failed asserting that true is false.

/home/travis/build/symfony/symfony/src/Symfony/Component/Cache/Tests/Traits/TagAwareTestTrait.php:183
```
