### PR TITLE
[Cache] Avoid memory leak in TraceableAdapter::reset()

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TraceableAdapter.php
@@ -191,15 +191,11 @@ class TraceableAdapter implements AdapterInterface, PruneableInterface, Resettab
      */
     public function reset()
     {
-        if (!$this->pool instanceof ResettableInterface) {
-            return;
-        }
-        $event = $this->start(__FUNCTION__);
-        try {
+        if ($this->pool instanceof ResettableInterface) {
             $this->pool->reset();
-        } finally {
-            $event->end = microtime(true);
         }
+
+        $this->clearCalls();
     }
 
     public function getCalls()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

When we call `ServicesResetter::reset()`, we want to reset the
application to its initial states. We don't want a memory leak :p