### PR TITLE
[RedisMessengerBridge] Add a delete_after_ack option

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -9,3 +9,5 @@ CHANGELOG
  * Deprecated use of invalid options
  * Added ability to receive of old pending messages with new `redeliver_timeout`
    and `claim_interval` options.
+ * Added a `delete_after_ack` option to the DSN as an alternative to
+   `stream_max_entries` to avoid leaking memory.

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -307,6 +307,21 @@ class ConnectionTest extends TestCase
         $connection->add('1', []);
     }
 
+    public function testDeleteAfterAck()
+    {
+        $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();
+
+        $redis->expects($this->exactly(1))->method('xack')
+            ->with('queue', 'symfony', ['1'])
+            ->willReturn(1);
+        $redis->expects($this->exactly(1))->method('xdel')
+            ->with('queue', ['1'])
+            ->willReturn(1);
+
+        $connection = Connection::fromDsn('redis://localhost/queue?delete_after_ack=true', [], $redis); // 1 = always
+        $connection->ack('1');
+    }
+
     public function testLastErrorGetsCleared()
     {
         $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
This allows Messenger to clean up processed messages from memory, avoiding a mem "leak" in redis

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/33715
| License       | MIT
| Doc PR        | symfony/symfony-docs#... TODO - will pile it on to https://github.com/symfony/symfony-docs/pull/11869 as it kinda binds together and a bigger refactor of the docs here is much needed to avoid all these gotchas

Right now by default a redis transport for messenger will leak memory as all messages stay in redis forever. You can configure `stream_max_entries` to automatically trim to a max of X entries, but that means if you have big peaks in messages you might start losing messages which have not been processed. 

This PR provides an alternative to that, by deleting message as they are processed. This is ideal as it avoids having to find the right number for `stream_max_entries` (do you want to risk losing data or use more memory than needed on average?). The only catch is that if you have multiple groups consuming the same stream, the first one processing a message will delete it, so other groups will not see it. For that reason `setup()` attempts to detect this and fails hard if it is misconfigured to prevent data loss.