### PR TITLE
[Notifier ] Add Discord notifier

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -96,6 +96,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\MimeTypeGuesserInterface;
 use Symfony\Component\Mime\MimeTypes;
+use Symfony\Component\Notifier\Bridge\Discord\DiscordTransportFactory;
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransportFactory;
 use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransportFactory;
@@ -2142,6 +2143,7 @@ class FrameworkExtension extends Extension
             MobytTransportFactory::class => 'notifier.transport_factory.mobyt',
             SmsapiTransportFactory::class => 'notifier.transport_factory.smsapi',
             EsendexTransportFactory::class => 'notifier.transport_factory.esendex',
+            DiscordTransportFactory::class => 'notifier.transport_factory.discord',
         ];
 
         foreach ($classToServices as $class => $service) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\Notifier\Bridge\Discord\DiscordTransportFactory;
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransportFactory;
 use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransportFactory;
@@ -104,6 +105,10 @@ return static function (ContainerConfigurator $container) {
         ->set('notifier.transport_factory.esendex', EsendexTransportFactory::class)
             ->parent('notifier.transport_factory.abstract')
             ->tag('texter.transport_factory')
+
+        ->set('notifier.transport_factory.discord', DiscordTransportFactory::class)
+            ->parent('notifier.transport_factory.abstract')
+            ->tag('chatter.transport_factory')
 
         ->set('notifier.transport_factory.null', NullTransportFactory::class)
             ->parent('notifier.transport_factory.abstract')

--- a/src/Symfony/Component/Notifier/Bridge/Discord/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Discord/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.1.0
+-----
+
+ * Added the bridge

--- a/src/Symfony/Component/Notifier/Bridge/Discord/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-5.1.0
+5.2.0
 -----
 
  * Added the bridge

--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
@@ -20,7 +20,6 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
- * DiscordTransport.
  *
  * @author Mathieu Piot <math.piot@gmail.com>
  *

--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
@@ -15,21 +15,21 @@ use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Transport\AbstractTransport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
- *
  * @author Mathieu Piot <math.piot@gmail.com>
  *
  * @internal
  *
- * @experimental in 5.0
+ * @experimental in 5.2
  */
 final class DiscordTransport extends AbstractTransport
 {
-    protected const HOST = 'discordapp.com';
+    protected const HOST = 'discord.com';
 
     private $token;
     private $chatChannel;
@@ -54,9 +54,9 @@ final class DiscordTransport extends AbstractTransport
     }
 
     /**
-     * @see https://discordapp.com/developers/docs/resources/webhook
+     * @see https://discord.com/developers/docs/resources/webhook
      */
-    protected function doSend(MessageInterface $message): void
+    protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof ChatMessage) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, get_debug_type($message)));

--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Discord;
+
+use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * DiscordTransport.
+ *
+ * @author Mathieu Piot <math.piot@gmail.com>
+ *
+ * @internal
+ *
+ * @experimental in 5.0
+ */
+final class DiscordTransport extends AbstractTransport
+{
+    protected const HOST = 'discordapp.com';
+
+    private $token;
+    private $chatChannel;
+
+    public function __construct(string $token, string $channel = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    {
+        $this->token = $token;
+        $this->chatChannel = $channel;
+        $this->client = $client;
+
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('discord://%s?channel=%s', $this->getEndpoint(), $this->chatChannel);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof ChatMessage;
+    }
+
+    /**
+     * @see https://discordapp.com/developers/docs/resources/webhook
+     */
+    protected function doSend(MessageInterface $message): void
+    {
+        if (!$message instanceof ChatMessage) {
+            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, get_debug_type($message)));
+        }
+
+        $endpoint = sprintf('https://%s/api/webhooks/%s/%s', $this->getEndpoint(), $this->token, $this->chatChannel);
+        $options['content'] = $message->getSubject();
+        $response = $this->client->request('POST', $endpoint, [
+            'json' => array_filter($options),
+        ]);
+
+        if (204 !== $response->getStatusCode()) {
+            $result = $response->toArray(false);
+
+            throw new TransportException(sprintf('Unable to post the Discord message: "%s" (%s).', $result['message'], $result['code']), $response);
+        }
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransportFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Discord;
+
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+
+/**
+ * @author Mathieu Piot <math.piot@gmail.com>
+ *
+ * @experimental in 5.0
+ */
+final class DiscordTransportFactory extends AbstractTransportFactory
+{
+    /**
+     * @return DiscordTransport
+     */
+    public function create(Dsn $dsn): TransportInterface
+    {
+        $scheme = $dsn->getScheme();
+        $token = $this->getUser($dsn);
+        $channel = $dsn->getOption('channel');
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        if ('discord' === $scheme) {
+            return (new DiscordTransport($token, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        }
+
+        throw new UnsupportedSchemeException($dsn, 'discord', $this->getSupportedSchemes());
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['discord'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransportFactory.php
@@ -19,7 +19,7 @@ use Symfony\Component\Notifier\Transport\TransportInterface;
 /**
  * @author Mathieu Piot <math.piot@gmail.com>
  *
- * @experimental in 5.0
+ * @experimental in 5.2
  */
 final class DiscordTransportFactory extends AbstractTransportFactory
 {

--- a/src/Symfony/Component/Notifier/Bridge/Discord/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2019-2020 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/Discord/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/README.md
@@ -1,0 +1,12 @@
+Discord Notifier
+================
+
+Provides Discord integration for Symfony Notifier.
+
+Resources
+---------
+
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Notifier/Bridge/Discord/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/README.md
@@ -3,6 +3,19 @@ Discord Notifier
 
 Provides Discord integration for Symfony Notifier.
 
+DSN example
+-----------
+
+```
+// .env file
+DISCORD_DSN=discord://TOKEN@default?channel=ID
+```
+
+where:
+ - `TOKEN` the secure token of the webhook (returned for Incoming Webhooks)
+ - `ID` the id of the webhook
+
+
 Resources
 ---------
 

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportFactoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Discord\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\Discord\DiscordTransportFactory;
+use Symfony\Component\Notifier\Exception\IncompleteDsnException;
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\Dsn;
+
+final class DiscordTransportFactoryTest extends TestCase
+{
+    public function testCreateWithDsn(): void
+    {
+        $factory = new DiscordTransportFactory();
+
+        $host = 'testHost';
+        $channel = 'testChannel';
+
+        $transport = $factory->create(Dsn::fromString(sprintf('discord://%s@%s/?channel=%s', 'token', $host, $channel)));
+
+        $this->assertSame(sprintf('discord://%s?channel=%s', $host, $channel), (string) $transport);
+    }
+
+    public function testCreateWithNoTokenThrowsMalformed(): void
+    {
+        $factory = new DiscordTransportFactory();
+
+        $this->expectException(IncompleteDsnException::class);
+        $factory->create(Dsn::fromString(sprintf('discord://%s/?channel=%s', 'testHost', 'testChannel')));
+    }
+
+    public function testSupportsDiscordScheme(): void
+    {
+        $factory = new DiscordTransportFactory();
+
+        $this->assertTrue($factory->supports(Dsn::fromString('discord://host/?channel=testChannel')));
+        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://host/?channel=testChannel')));
+    }
+
+    public function testNonDiscordSchemeThrows(): void
+    {
+        $factory = new DiscordTransportFactory();
+
+        $this->expectException(UnsupportedSchemeException::class);
+        $factory->create(Dsn::fromString('somethingElse://token@host/?channel=testChannel'));
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Discord\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Notifier\Bridge\Discord\DiscordTransport;
+use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class DiscordTransportTest extends TestCase
+{
+    public function testToStringContainsProperties(): void
+    {
+        $channel = 'testChannel';
+
+        $transport = new DiscordTransport('testToken', $channel, $this->createMock(HttpClientInterface::class));
+        $transport->setHost('testHost');
+
+        $this->assertSame(sprintf('discord://%s?channel=%s', 'testHost', $channel), (string) $transport);
+    }
+
+    public function testSupportsChatMessage(): void
+    {
+        $transport = new DiscordTransport('testToken', 'testChannel', $this->createMock(HttpClientInterface::class));
+
+        $this->assertTrue($transport->supports(new ChatMessage('testChatMessage')));
+        $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
+    }
+
+    public function testSendNonChatMessageThrows(): void
+    {
+        $this->expectException(LogicException::class);
+        $transport = new DiscordTransport('testToken', 'testChannel', $this->createMock(HttpClientInterface::class));
+
+        $transport->send($this->createMock(MessageInterface::class));
+    }
+
+    public function testSendWithErrorResponseThrows(): void
+    {
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessageMatches('/testDescription.+testErrorCode/');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->exactly(2))
+            ->method('getStatusCode')
+            ->willReturn(400);
+        $response->expects($this->once())
+            ->method('getContent')
+            ->willReturn(json_encode(['message' => 'testDescription', 'code' => 'testErrorCode']));
+
+        $client = new MockHttpClient(static function () use ($response): ResponseInterface {
+            return $response;
+        });
+
+        $transport = new DiscordTransport('testToken', 'testChannel', $client);
+
+        $transport->send(new ChatMessage('testMessage'));
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.1"
+        "symfony/notifier": "^5.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^4.3|^5.0"
@@ -32,7 +32,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "5.1-dev"
+            "dev-master": "5.2-dev"
         }
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
@@ -1,0 +1,38 @@
+{
+    "name": "symfony/discord-notifier",
+    "type": "symfony-bridge",
+    "description": "Symfony Discord Notifier Bridge",
+    "keywords": ["discord", "notifier"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Fabien Potencier",
+            "email": "fabien@symfony.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": "^7.2.5",
+        "symfony/http-client": "^4.3|^5.0",
+        "symfony/notifier": "^5.1"
+    },
+    "require-dev": {
+        "symfony/event-dispatcher": "^4.3|^5.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Discord\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "5.1-dev"
+        }
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Discord/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Discord Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -82,6 +82,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Esendex\EsendexTransportFactory::class,
             'package' => 'symfony/esendex-notifier',
         ],
+        'discord' => [
+            'class' => Bridge\Discord\DiscordTransportFactory::class,
+            'package' => 'symfony/discord-notifier',
+        ],
     ];
 
     /**

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier;
 
+use Symfony\Component\Notifier\Bridge\Discord\DiscordTransportFactory;
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransportFactory;
 use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransportFactory;
@@ -60,6 +61,7 @@ class Transport
         MobytTransportFactory::class,
         SmsapiTransportFactory::class,
         EsendexTransportFactory::class,
+        DiscordTransportFactory::class,
     ];
 
     private $factories;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#13558

Add a basic Discord notifier via webhook (https://discordapp.com/developers/docs/resources/webhook).

![Capture d’écran de 2020-04-17 15-27-42](https://user-images.githubusercontent.com/10453508/79574359-510b6980-80c0-11ea-8c82-8dc8f512a286.png)

Actually I've just a Message from the notification displayed (on the image the simple line: "My notification subject").

It's also possible to have an embed message (https://discordapp.com/developers/docs/resources/channel#embed-object) as exemple I've done one with a title (message subject), description (message content), and a color (on the importance)

![Capture d’écran de 2020-04-17 15-27-54](https://user-images.githubusercontent.com/10453508/79574427-66809380-80c0-11ea-89a3-527fff6a0063.png)

At the moment it's not implemented yet in this PR, 2 possibilities:
 - the embed type by default (never the simple type)
 - add a DiscordConfigurationMessage object  to enable the embed format ? (only on ChatMessage, not Notification)

In my case, I prefer embded by default, like Email notification (subject, content and border color).

We also can add a configuration file (only for ChatMessage) to the Bot name, bot image.
