### PR TITLE
[Notifier][WebProfilerBundle][FrameworkBundle] Add notifier section to profiler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_debug.php
@@ -17,5 +17,6 @@ return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('notifier.data_collector', NotificationDataCollector::class)
             ->args([service('notifier.logger_notification_listener')])
+            ->tag('data_collector', ['template' => '@WebProfiler/Collector/notifier.html.twig', 'id' => 'notifier'])
     ;
 };

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/notifier.html.twig
@@ -1,0 +1,168 @@
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% block toolbar %}
+    {% set events = collector.events %}
+
+    {% if events.messages|length %}
+        {% set icon %}
+            {% include('@WebProfiler/Icon/mailer.svg') %}
+            <span class="sf-toolbar-value">{{ events.messages|length }}</span>
+        {% endset %}
+
+        {% set text %}
+            <div class="sf-toolbar-info-piece">
+                <b>Sent notifications</b>
+                <span class="sf-toolbar-status">{{ events.messages|length }}</span>
+            </div>
+
+            {% for transport in events.transports %}
+                <div class="sf-toolbar-info-piece">
+                    <b>{{ transport }}</b>
+                    <span class="sf-toolbar-status">{{ events.messages(transport)|length }}</span>
+                </div>
+            {% endfor %}
+        {% endset %}
+
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { 'link': profiler_url }) }}
+    {% endif %}
+{% endblock %}
+
+{% block head %}
+    {{ parent() }}
+    <style type="text/css">
+        /* utility classes */
+        .m-t-0 { margin-top: 0 !important; }
+        .m-t-10 { margin-top: 10px !important; }
+
+        /* basic grid */
+        .row {
+            display: flex;
+            flex-wrap: wrap;
+            margin-right: -15px;
+            margin-left: -15px;
+        }
+        .col {
+            flex-basis: 0;
+            flex-grow: 1;
+            max-width: 100%;
+            position: relative;
+            width: 100%;
+            min-height: 1px;
+            padding-right: 15px;
+            padding-left: 15px;
+        }
+        .col-4 {
+            flex: 0 0 33.333333%;
+            max-width: 33.333333%;
+        }
+
+        /* small tabs */
+        .sf-tabs-sm .tab-navigation li {
+            font-size: 14px;
+            padding: .3em .5em;
+        }
+    </style>
+{% endblock %}
+
+{% block menu %}
+    {% set events = collector.events %}
+
+    <span class="label {{ events.messages|length ? '' : 'disabled' }}">
+        <span class="icon">{{ include('@WebProfiler/Icon/mailer.svg') }}</span>
+
+        <strong>Notifications</strong>
+        {% if events.messages|length > 0 %}
+            <span class="count">
+                <span>{{ events.messages|length }}</span>
+            </span>
+        {% endif %}
+    </span>
+{% endblock %}
+
+{% block panel %}
+    {% set events = collector.events %}
+
+    <h2>Notifications</h2>
+
+    {% if not events.messages|length %}
+        <div class="empty">
+            <p>No notifications were sent.</p>
+        </div>
+    {% endif %}
+
+    <div class="metrics">
+        {% for transport in events.transports %}
+            <div class="metric">
+                <span class="value">{{ events.messages(transport)|length }}</span>
+                <span class="label">{{ transport }}</span>
+            </div>
+        {% endfor %}
+    </div>
+
+    {% for transport in events.transports %}
+        <h3>{{ transport }}</h3>
+
+        <div class="card-block">
+            <div class="sf-tabs sf-tabs-sm">
+                {% for event in events.events(transport) %}
+                    {% set message = event.message %}
+                    <div class="tab">
+                        <h3 class="tab-title">Message #{{ loop.index }} <small>({{ event.isQueued() ? 'queued' : 'sent' }})</small></h3>
+                        <div class="tab-content">
+                            <div class="card">
+                                <div class="card-block">
+                                    <span class="label">Subject</span>
+                                    <h2 class="m-t-10">{{ message.getSubject() ?? '(empty)' }}</h2>
+                                </div>
+                                {% if message.getNotification is defined %}
+                                    <div class="card-block">
+                                        <div class="row">
+                                            <div class="col">
+                                                <span class="label">Content</span>
+                                                <pre class="prewrap">{{ message.getNotification().getContent() ?? '(empty)' }}</pre>
+                                                <span class="label">Importance</span>
+                                                <pre class="prewrap">{{ message.getNotification().getImportance() }}</pre>
+                                            </div>
+                                        </div>
+                                    </div>
+                                {% endif %}
+                                    <div class="card-block">
+                                        <div class="sf-tabs sf-tabs-sm">
+                                            {% if message.getNotification is defined %}
+                                                <div class="tab">
+                                                    <h3 class="tab-title">Notification</h3>
+                                                    {% set notification = event.message.getNotification() %}
+                                                    <div class="tab-content">
+                                                        <pre class="prewrap" style="max-height: 600px">
+                                                            {{- 'Subject: ' ~ notification.getSubject() }}<br/>
+                                                            {{- 'Content: ' ~ notification.getContent() }}<br/>
+                                                            {{- 'Importance: ' ~ notification.getImportance() }}<br/>
+                                                            {{- 'Emoji: ' ~ (notification.getEmoji() is empty ? '(empty)' : notification.getEmoji()) }}<br/>
+                                                            {{- 'Exception: ' ~ notification.getException() ?? '(empty)' }}<br/>
+                                                            {{- 'ExceptionAsString: ' ~ (notification.getExceptionAsString() is empty ? '(empty)' : notification.getExceptionAsString()) }}
+                                                        </pre>
+                                                    </div>
+                                                </div>
+                                            {% endif %}
+                                                <div class="tab">
+                                                    <h3 class="tab-title">Message Options</h3>
+                                                    <div class="tab-content">
+                                                        <pre class="prewrap" style="max-height: 600px">
+                                                            {%- if message.getOptions() is null %}
+                                                                {{- '(empty)' }}
+                                                            {%- else %}
+                                                                {{- message.getOptions()|json_encode(constant('JSON_PRETTY_PRINT')) }}
+                                                            {%- endif %}
+                                                        </pre>
+                                                    </div>
+                                                </div>
+                                        </div>
+                                    </div>
+                            </div>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+    {% endfor %}
+{% endblock %}

--- a/src/Symfony/Component/Notifier/Message/ChatMessage.php
+++ b/src/Symfony/Component/Notifier/Message/ChatMessage.php
@@ -77,7 +77,7 @@ final class ChatMessage implements MessageInterface
     /**
      * @return $this
      */
-    public function transport(?string $transport): self
+    public function transport(?string $transport): MessageInterface
     {
         $this->transport = $transport;
 

--- a/src/Symfony/Component/Notifier/Message/EmailMessage.php
+++ b/src/Symfony/Component/Notifier/Message/EmailMessage.php
@@ -102,7 +102,7 @@ final class EmailMessage implements MessageInterface
     /**
      * @return $this
      */
-    public function transport(string $transport): self
+    public function transport(string $transport): MessageInterface
     {
         if (!$this->message instanceof Email) {
             throw new LogicException('Cannot set a Transport on a RawMessage instance.');

--- a/src/Symfony/Component/Notifier/Message/MessageInterface.php
+++ b/src/Symfony/Component/Notifier/Message/MessageInterface.php
@@ -25,4 +25,6 @@ interface MessageInterface
     public function getOptions(): ?MessageOptionsInterface;
 
     public function getTransport(): ?string;
+
+    public function transport(string $transport): self;
 }

--- a/src/Symfony/Component/Notifier/Message/SmsMessage.php
+++ b/src/Symfony/Component/Notifier/Message/SmsMessage.php
@@ -83,7 +83,7 @@ final class SmsMessage implements MessageInterface
     /**
      * @return $this
      */
-    public function transport(string $transport): self
+    public function transport(string $transport): MessageInterface
     {
         $this->transport = $transport;
 

--- a/src/Symfony/Component/Notifier/Transport/NullTransport.php
+++ b/src/Symfony/Component/Notifier/Transport/NullTransport.php
@@ -34,6 +34,10 @@ class NullTransport implements TransportInterface
 
     public function send(MessageInterface $message): SentMessage
     {
+        if (null === $message->getTransport()) {
+            $message->transport((string) $this);
+        }
+
         if (null !== $this->dispatcher) {
             $this->dispatcher->dispatch(new MessageEvent($message));
         }

--- a/src/Symfony/Component/Notifier/Transport/Transports.php
+++ b/src/Symfony/Component/Notifier/Transport/Transports.php
@@ -55,8 +55,10 @@ final class Transports implements TransportInterface
     public function send(MessageInterface $message): SentMessage
     {
         if (!$transport = $message->getTransport()) {
-            foreach ($this->transports as $transport) {
+            foreach ($this->transports as $transportName => $transport) {
                 if ($transport->supports($message)) {
+                    $message->transport($transportName);
+
                     return $transport->send($message);
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

This is the first iteration of adding a profiler panel for the new Notifier component:

WebProfiler Toolbar:
![Screenshot 2020-10-02 at 10 26 35](https://user-images.githubusercontent.com/1880467/94903474-28bece00-049a-11eb-945c-d6ce047b35e8.png)

WebProfiler Notifier Panel:

![Screenshot 2020-10-02 at 10 28 19](https://user-images.githubusercontent.com/1880467/94903594-5277f500-049a-11eb-8c1e-27e6ec87a51c.png)
![Screenshot 2020-10-02 at 10 28 29](https://user-images.githubusercontent.com/1880467/94903591-51df5e80-049a-11eb-935a-9ba130ef69f0.png)
![Screenshot 2020-10-02 at 10 28 35](https://user-images.githubusercontent.com/1880467/94903589-5146c800-049a-11eb-8a69-28d362ef6640.png)
![Screenshot 2020-10-02 at 10 28 42](https://user-images.githubusercontent.com/1880467/94903586-50159b00-049a-11eb-97bd-382a823087a6.png)

An example project can to test the new profiler panel can be found here: https://github.com/jschaedl/notifier-profiler-integration




