### PR TITLE
[SecurityBundle] fix accepting env vars in remember-me configurations

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -146,8 +146,6 @@ class RememberMeFactory implements SecurityFactoryInterface
         foreach ($this->options as $name => $value) {
             if (\is_bool($value)) {
                 $builder->booleanNode($name)->defaultValue($value);
-            } elseif (\is_int($value)) {
-                $builder->integerNode($name)->defaultValue($value);
             } else {
                 $builder->scalarNode($name)->defaultValue($value);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36271
| License       | MIT
| Doc PR        | -

As @wouterj explained we cannot use env variables after #35910 merged. 

> Hmm, so I'm guessing this is what happens:
> 
> * `lifetime` is now an `integerNode()`
> * For the Config component (which IIRC doesn't know anything about env variables), you're passing a string: `"%env(int:REMEMBER_ME_COOKIE_LIFETIME)%"`
> * This throws an error, although if it wouldn't, the DI component would sucessfully process the string into a integer before it's used by any PHP class.
> 
> So we either make Config aware of environment variables (that's probably a huge feature) or we revert the `integerNode()` changes (as you suggested).
> 
> @HeahDude am I mislooking something, or would reverting these 2 lines not result in much harm? (only a little less strict config processor)

