### PR TITLE
[Security] Fixed broken master build

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -97,9 +97,10 @@ class ContextListener extends AbstractListener
         if (null !== $session) {
             $usageIndexValue = $session instanceof Session ? $usageIndexReference = &$session->getUsageIndex() : 0;
             $usageIndexReference = PHP_INT_MIN;
-            $sessionId = $request->cookies->get($session->getName());
+            $sessionId = $request->cookies->all()[$session->getName()] ?? null;
             $token = $session->get($this->sessionKey);
 
+            // sessionId = true is used in the tests
             if ($this->sessionTrackerEnabler && \in_array($sessionId, [true, $session->getId()], true)) {
                 $usageIndexReference = $usageIndexValue;
             } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | n/a

The build failures are caused by these lines (line 100 specically):

https://github.com/symfony/symfony/blob/2460ca59af71e0ce610a3f807ab092436850b487/src/Symfony/Component/Security/Http/Firewall/ContextListener.php#L97-L108

Since #34363, `$request->cookies->get()` is typehinted as `string|null`. On Travis with PHP=7.4, this doc typehint is transformed into PHP return type: `get(): ?string`.

On tests, the session cookie is set to `true`. See #36118 for some background on why this is necessary.

There are a couple possible solutions:

1. Update the `InputBag::get()` PHPdoc to use `@return scalar|null`
2. Use `$request->cookie->all()[$session->getName()]` in `ContextListener`
3. Allow pre-configuring the session ID in `MockArraySessionStorage`.

I've implemented solution (1). The method is actually using `is_scalar()` to check if a deprecation notice should be triggered, so it is expected to return a scalar in Symfony 6.

_I've had to update the `DebugClassLoader` to not convert this to `get(): ?scalar`, as that doesn't exists in PHP. I'm not sure if my changes are correct (but they work)._