### PR TITLE
[HttpClient] Add MockResponse::getRequestMethod() and getRequestUrl() to allow inspecting which request has been sent

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * added `AsyncDecoratorTrait` to ease processing responses without breaking async
  * added support for pausing responses with a new `pause_handler` callable exposed as an info item
  * added `StreamableInterface` to ease turning responses into PHP streams
+ * added `MockResponse::getRequestMethod()` and `getRequestUrl()` to allow inspecting which request has been sent
 
 5.1.0
 -----

--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -32,6 +32,8 @@ class MockResponse implements ResponseInterface, StreamableInterface
 
     private $body;
     private $requestOptions = [];
+    private $requestUrl;
+    private $requestMethod;
 
     private static $mainMulti;
     private static $idSequence = 0;
@@ -70,6 +72,22 @@ class MockResponse implements ResponseInterface, StreamableInterface
     public function getRequestOptions(): array
     {
         return $this->requestOptions;
+    }
+
+    /**
+     * Returns the URL used when doing the request.
+     */
+    public function getRequestUrl(): string
+    {
+        return $this->requestUrl;
+    }
+
+    /**
+     * Returns the method used when doing the request.
+     */
+    public function getRequestMethod(): string
+    {
+        return $this->requestMethod;
     }
 
     /**
@@ -122,6 +140,8 @@ class MockResponse implements ResponseInterface, StreamableInterface
 
         if ($mock instanceof self) {
             $mock->requestOptions = $response->requestOptions;
+            $mock->requestMethod = $method;
+            $mock->requestUrl = $url;
         }
 
         self::writeRequest($response, $options, $mock);

--- a/src/Symfony/Component/HttpClient/Tests/Response/MockResponseTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Response/MockResponseTest.php
@@ -33,6 +33,19 @@ class MockResponseTest extends TestCase
         $response->toArray();
     }
 
+    public function testUrlHttpMethodMockResponse(): void
+    {
+        $responseMock = new MockResponse(json_encode(['foo' => 'bar']));
+        $url = 'https://example.com/some-endpoint';
+        $response = MockResponse::fromRequest('GET', $url, [], $responseMock);
+
+        $this->assertSame('GET', $response->getInfo('http_method'));
+        $this->assertSame('GET', $responseMock->getRequestMethod());
+
+        $this->assertSame($url, $response->getInfo('url'));
+        $this->assertSame($url, $responseMock->getRequestUrl());
+    }
+
     public function toArrayErrors()
     {
         yield [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | -  <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->

---

As same as the `MockResponse` class has `getRequestOptions()` when doing a request; I've added:
* `getRequestUrl()` - returns the URL used when doing the request
* `getRequestMethod()` - returns the HTTP method used when doing the request

With these two getters, we would be able to assert that the method and URL passed to the `HttpClient` were well generated. I've tried to assert the URL generated in a unit test of a class with a `SymfonyHttpClient` injected and it wasn't possible. Calling `$mock->getInfo('url')` returns `null`.

Example, if we have a class with `HttpClientInterface` injected like this:

```php
final class SymfonyHttpUserClient
{
    private HttpClientInterface $httpClient;
    private string $baseUri;

    public function __construct(
        HttpClientInterface $httpClient,
        string $baseUri
    ) {
        $this->httpClient = $httpClient;
        $this->baseUri = $baseUri;
    }

    public function getById(string $userId): void
    {
        $this->httpClient->request(
            'GET',
            $this->baseUri . $customerId
        );
    }
}
```

And if we want to do a unit test of `SymfonyHttpUserClient` right now we are not able to check if the URL of the request was well-formed passing a `MockResponse`. Also, we weren't able to assert the HTTP method (maybe this piece is not so critical to assert in the unit test).

```php
class SymfonyHttpUserClientTests extends TestCase
{
    public function testGetById(): void
    {
        $baseUri = 'https://user-api.test/api/v1/users/';
        $mockResponse = new MockResponse();
        $symfonyHttpUserClient = new SymfonyHttpUserClient(
            new MockHttpClient(
                [$mockResponse],
                $baseUri
            ),
            $baseUri
        );    

        // test get by id:
        $symfonyHttpUserClient->getById('some-user-id');

        // cannot be asserted right now:
        $this->assertSame($mockResponse->getInfo('url'), $baseUri . 'some-user-id'); // fail
        $this->assertSame($mockResponse->getInfo('http_method'), 'GET'); // fail

        // it could be with the new getters:
        $this->assertSame($mockResponse->getRequestUrl(), $baseUri . 'some-user-id');
        $this->assertSame($mockResponse->getRequestMethod(), 'GET');
    }
}
```

This only happens if the class has injected the HttpClient and if it is used inside void methods with no being able to return the response. If the class returns the response, `url` and `http_method` are available with `$response->getInfo()` call. But this response object is a new one, is not the mock passed by argument when you instance the MockHttpClient. 

Var dumps of `getInfo` array:

```
$response->getInfo() from MockClient:

..array(10) {
  ["start_time"]=>
  float(1587109014.7985)
  ["user_data"]=>
  NULL
  ["http_code"]=>
  int(200)
  ["response_headers"]=>
  array(0) {
  }
  ["error"]=>
  NULL
  ["canceled"]=>
  bool(false)
  ["redirect_count"]=>
  int(0)
  ["redirect_url"]=>
  NULL
  ["http_method"]=>
  string(3) "GET"
  ["url"]=>
  string(47) "https://user-api.test/api/v1/users/some-user-id"
}

$mock->getInfo()

array(4) {
  ["http_code"]=>
  int(200)
  ["response_headers"]=>
  array(0) {
  }
  ["error"]=>
  NULL
  ["canceled"]=>
  bool(false)
}
```

This is a minor change, I opened the PR with `4.4` as base branch; but not sure if it should be opened with `5.0` as base branch or even `master` taking account is a feature (add two new getters in MockResponse class). Let me know if I didn't follow right the instructions (first PR on Symfony project :smiley:)

Thanks!
