### PR TITLE
[Form] Added `choice_entry`, `checkbox_entry` and `radio_entry` to `ChoiceType` entries

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.1.0
 -----
 
+ * Added `choice_entry`, `checkbox_entry` and `radio_entry` block prefixes to `ChoiceType` entries
  * Added `collection_entry` block prefix to `CollectionType` entries
  * Added a `choice_filter` option to `ChoiceType`
  * Added argument `callable|null $filter` to `ChoiceListFactoryInterface::createListFromChoices()` and `createListFromLoader()` - not defining them is deprecated.

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -39,6 +39,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\Util\FormUtil;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyPath;
@@ -260,6 +261,7 @@ class ChoiceType extends AbstractType
 
             foreach ($view as $childView) {
                 $childView->vars['full_name'] = $childName;
+                FormUtil::appendStaticBlockPrefix($childView, 'choice_entry', true);
             }
         }
     }
@@ -399,8 +401,10 @@ class ChoiceType extends AbstractType
             // The user can check 0 or more checkboxes. If required
             // is true, they are required to check all of them.
             $choiceOpts['required'] = false;
+            $choiceOpts['block_prefix'] = 'checkbox_entry';
         } else {
             $choiceType = RadioType::class;
+            $choiceOpts['block_prefix'] = 'radio_entry';
         }
 
         $builder->add($name, $choiceType, $choiceOpts);

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\Util\FormUtil;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -72,19 +73,19 @@ class CollectionType extends AbstractType
      */
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
-        $prefixOffset = -1;
+        $decreaseOffset = false;
         // check if the entry type also defines a block prefix
         /** @var FormInterface $entry */
         foreach ($form as $entry) {
             if ($entry->getConfig()->getOption('block_prefix')) {
-                --$prefixOffset;
+                $decreaseOffset = true;
             }
 
             break;
         }
 
         foreach ($view as $entryView) {
-            array_splice($entryView->vars['block_prefixes'], $prefixOffset, 0, 'collection_entry');
+            FormUtil::appendStaticBlockPrefix($entryView, 'collection_entry', $decreaseOffset);
         }
 
         /** @var FormInterface $prototype */
@@ -93,11 +94,11 @@ class CollectionType extends AbstractType
                 $view->vars['multipart'] = true;
             }
 
-            if ($prefixOffset > -2 && $prototype->getConfig()->getOption('block_prefix')) {
-                --$prefixOffset;
+            if (!$decreaseOffset && $prototype->getConfig()->getOption('block_prefix')) {
+                $decreaseOffset = true;
             }
 
-            array_splice($view->vars['prototype']->vars['block_prefixes'], $prefixOffset, 0, 'collection_entry');
+            FormUtil::appendStaticBlockPrefix($view->vars['prototype'], 'collection_entry', $decreaseOffset);
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -418,6 +418,50 @@ class ChoiceTypeTest extends BaseTypeTest
         }
     }
 
+    public function testCheckboxBlockPrefixes()
+    {
+        $choiceView = $this->factory->createNamed('choices', static::TESTED_TYPE, [''], [
+            'choices' => ['foo' => 'bar'],
+            'expanded' => true,
+            'multiple' => true,
+        ])
+            ->createView()
+        ;
+
+        $expectedBlockPrefixes = [
+            'form',
+            'checkbox',
+            'choice_entry',
+            'checkbox_entry',
+            '_choices_entry',
+        ];
+
+        $this->assertCount(1, $choiceView);
+        $this->assertSame($expectedBlockPrefixes, $choiceView[0]->vars['block_prefixes']);
+    }
+
+    public function testRadioBlockPrefixes()
+    {
+        $choiceView = $this->factory->createNamed('choices', static::TESTED_TYPE, '', [
+            'choices' => ['foo' => 'bar'],
+            'expanded' => true,
+        ])
+            ->createView()
+        ;
+
+        $expectedBlockPrefixes = [
+            'form',
+            'checkbox',
+            'radio',
+            'choice_entry',
+            'radio_entry',
+            '_choices_entry',
+        ];
+
+        $this->assertCount(1, $choiceView);
+        $this->assertSame($expectedBlockPrefixes, $choiceView[0]->vars['block_prefixes']);
+    }
+
     public function testSubmitSingleNonExpanded()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [

--- a/src/Symfony/Component/Form/Util/FormUtil.php
+++ b/src/Symfony/Component/Form/Util/FormUtil.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Util;
 
+use Symfony\Component\Form\FormView;
+
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
@@ -40,5 +42,14 @@ class FormUtil
         // This method is used in occurrences where arrays are
         // not considered to be empty, ever.
         return null === $data || '' === $data;
+    }
+
+    /**
+     * Appends a block prefix after the static defaults and before dynamic ones.
+     */
+    public static function appendStaticBlockPrefix(FormView $view, string $prefix, bool $decreaseOffset): void
+    {
+        // the offset is decreased if more than one dynamic prefix exists, i.e. using the "block_prefix" option
+        array_splice($view->vars['block_prefixes'], $decreaseOffset ? -2 : -1, 0, $prefix);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | TODO

I had the idea when I started working on #36088, but #36484 lit the fire (ping @ThomasLandauer :)).

Allows to use `choice_entry_*` blocks to customize all choice entries (whether radio or checkbox) for all types, in addition (and with precedence) of the dynamic `_form_name_choice_field_name_entry_*`.

Plus specific type of entries with `checkbox_entry_*` and `radio_entry_*` blocks.

So the order is now looked up like this (from last to first):
```php
$choiceCheckBoxPrefixes = [
    'form', // as before
    'checkbox', // all checkboxes and radios, as before
    'choice_entry', // all fields (radio and checkbox) nested in choice lists
    'checkbox_entry', // all checkboxes nested in choice lists
    '_form_name_choice_field_name_entry',  // as before
];

$choiceRadioPrefixes = [
    'form', // as before
    'checkbox', // all checkboxes and radios, as before
    'radio', // all radios, as before
    'choice_entry', // all fields (radio and checkbox) nested in choice lists
    'radio_entry', // all radios nested in choice lists
    '_form_name_choice_field_name_entry',  // as before
];
```