### PR TITLE
[HttpFoundation] workaround PHP bug in the session module

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/AbstractSessionHandler.php
@@ -71,6 +71,15 @@ abstract class AbstractSessionHandler implements \SessionHandlerInterface, \Sess
         $this->prefetchData = $this->read($sessionId);
         $this->prefetchId = $sessionId;
 
+        if (\PHP_VERSION_ID < 70317 || (70400 <= \PHP_VERSION_ID && \PHP_VERSION_ID < 70405)) {
+            // work around https://bugs.php.net/79413
+            foreach (debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
+                if (!isset($frame['class']) && isset($frame['function']) && \in_array($frame['function'], ['session_regenerate_id', 'session_create_id'], true)) {
+                    return '' === $this->prefetchData;
+                }
+            }
+        }
+
         return '' !== $this->prefetchData;
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/regenerate.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/Fixtures/regenerate.expected
@@ -11,6 +11,7 @@ validateId
 read
 doRead: abc|i:123;
 read
+doRead: abc|i:123;
 
 write
 doWrite: abc|i:123;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Current tests fail after https://github.com/php/php-src/pull/5305
Which itself is a patch for a bug in the session module.

This PR works around the issue in older versions of PHP and fixes the tests.