### PR TITLE
Fix form/data mapping for typehinted properties

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
@@ -47,7 +47,11 @@ class PropertyPathMapper implements DataMapperInterface
             $config = $form->getConfig();
 
             if (!$empty && null !== $propertyPath && $config->getMapped()) {
-                $form->setData($this->propertyAccessor->getValue($data, $propertyPath));
+                try {
+                    $form->setData($this->propertyAccessor->getValue($data, $propertyPath));
+                } catch (AccessException $e) {
+                    // Skip unitialized properties on $data
+                }
             } else {
                 $form->setData($config->getData());
             }

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Extension\Core\DataMapper;
 use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\Exception\AccessException;
+use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
@@ -51,6 +52,12 @@ class PropertyPathMapper implements DataMapperInterface
                     $form->setData($this->propertyAccessor->getValue($data, $propertyPath));
                 } catch (AccessException $e) {
                     // Skip unitialized properties on $data
+                    if (!$e instanceof UninitializedPropertyException
+                        // For versions without UninitializedPropertyException check the exception message
+                        && (class_exists(UninitializedPropertyException::class) || false === strpos($e->getMessage(), 'You should initialize it'))
+                    ) {
+                        throw $e;
+                    }
                 }
             } else {
                 $form->setData($config->getData());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -115,7 +115,7 @@ class PropertyPathMapperTest extends TestCase
     }
 
     /**
-     * @requires PHP >= 7.4
+     * @requires PHP 7.4
      */
     public function testMapDataToFormsIgnoresUninitializedProperties()
     {
@@ -322,7 +322,7 @@ class PropertyPathMapperTest extends TestCase
     }
 
     /**
-     * @requires PHP >= 7.4
+     * @requires PHP 7.4
      */
     public function testMapFormsToUninitializedProperties()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormConfigBuilder;
+use Symfony\Component\Form\Tests\Fixtures\TypehintedPropertiesCar;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyPath;
@@ -298,6 +299,22 @@ class PropertyPathMapperTest extends TestCase
         $this->mapper->mapFormsToData([$form], $car);
 
         $this->assertSame($initialEngine, $car->engine);
+    }
+
+    /**
+     * @requires PHP >= 7.4
+     */
+    public function testMapFormsToUninitializedProperties()
+    {
+        $engine = new \stdClass();
+        $car = new TypehintedPropertiesCar();
+        $config = new FormConfigBuilder('engine', \stdClass::class, $this->dispatcher);
+        $config->setData($engine);
+        $form = new SubmittedForm($config);
+
+        $this->mapper->mapFormsToData([$form], $car);
+
+        $this->assertSame($engine, $car->engine);
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -120,10 +120,7 @@ class PropertyPathMapperTest extends TestCase
     public function testMapDataToFormsIgnoresUninitializedProperties()
     {
         $engineForm = new Form(new FormConfigBuilder('engine', \stdClass::class, $this->dispatcher));
-        $colorConfig = new FormConfigBuilder('color', \stdClass::class, $this->dispatcher);
-        $color = new \stdClass();
-        $colorConfig->setData($color);
-        $colorForm = new Form($colorConfig);
+        $colorForm = new Form(new FormConfigBuilder('color', \stdClass::class, $this->dispatcher));
 
         $car = new TypehintedPropertiesCar();
         $car->engine = new \stdClass();
@@ -131,7 +128,6 @@ class PropertyPathMapperTest extends TestCase
         $this->mapper->mapDataToForms($car, [$engineForm, $colorForm]);
 
         $this->assertSame($car->engine, $engineForm->getData());
-        $this->assertSame($color, $colorForm->getData());
     }
 
     public function testMapDataToFormsSetsDefaultDataIfPassedDataIsNull()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -114,6 +114,26 @@ class PropertyPathMapperTest extends TestCase
         $this->assertNull($form->getData());
     }
 
+    /**
+     * @requires PHP >= 7.4
+     */
+    public function testMapDataToFormsIgnoresUninitializedProperties()
+    {
+        $engineForm = new Form(new FormConfigBuilder('engine', \stdClass::class, $this->dispatcher));
+        $colorConfig = new FormConfigBuilder('color', \stdClass::class, $this->dispatcher);
+        $color = new \stdClass();
+        $colorConfig->setData($color);
+        $colorForm = new Form($colorConfig);
+
+        $car = new TypehintedPropertiesCar();
+        $car->engine = new \stdClass();
+
+        $this->mapper->mapDataToForms($car, [$engineForm, $colorForm]);
+
+        $this->assertSame($car->engine, $engineForm->getData());
+        $this->assertSame($color, $colorForm->getData());
+    }
+
     public function testMapDataToFormsSetsDefaultDataIfPassedDataIsNull()
     {
         $default = new \stdClass();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -314,7 +314,7 @@ class PropertyPathMapperTest extends TestCase
         $config->setPropertyPath($propertyPath);
         $config->setData($engine);
         $config->setDisabled(true);
-        $form = new Form($config);
+        $form = new SubmittedForm($config);
 
         $this->mapper->mapFormsToData([$form], $car);
 
@@ -376,7 +376,7 @@ class SubmittedForm extends Form
     }
 }
 
-class NotSynchronizedForm extends Form
+class NotSynchronizedForm extends SubmittedForm
 {
     public function isSynchronized()
     {

--- a/src/Symfony/Component/Form/Tests/Fixtures/TypehintedPropertiesCar.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/TypehintedPropertiesCar.php
@@ -1,0 +1,8 @@
+<?php
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+class TypehintedPropertiesCar
+{
+    public ?\stdClass $engine;
+    public ?\stdClass $color;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |  --
| License       | MIT
| Doc PR        | --


## Mapping to unitialized properties

`PropertyPathMapper` uses `PropertyAccessor` to retrieve a property value for comparison before setting that property.
This led to `AccessException` for getting an unitialized property when setting such property per `PropertyPathMapper::mapFormsToData()`.

The proposed changes fix that by treating those unitialized properties as null for comparison.


## Mapping from unitialized properties

When mapping objects to a form `PropertyPathMapper` is flexible to deal with different strategies (getter, hasser, ...) for providing entity properties.
For typehinted properties however mapping fails with `AccessException` for providing partial data per entity class.

```php
class Foo {
    public string $bar;
    public string $baz;
}

class FooController extends AbstractController {
    //...
        $foo = new Foo();
        $foo->bar = 'thisValueIsSet';
        $form = $this->createForm(FooType::class, $foo);
    //...
}
```

This one is not necessarily to be considered a bug, but I would expect a flexible implementation to only map `bar` even if `baz` is part of `FooType`.

The proposed changes lead to ignoring those uninitialized properties like non-existing keys in an array.


## Fix tests

The modified tests provided false negatives.
The implementation did not check for the tested features.
