### PR TITLE
[Validator] Added `StrictTypes` as class constraint with not nullable typed properties

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.1.0
 -----
 
+ * added a `StrictTypes` constraint to ease validating non nullable typed properties
  * added a `Cascade` constraint to ease validating typed nested objects
  * added the `Hostname` constraint and validator
  * added the `alpha3` option to the `Country` and `Language` constraints

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.1.0
 -----
 
+ * added a `Cascade` constraint to ease validating typed nested objects
  * added the `Hostname` constraint and validator
  * added the `alpha3` option to the `Country` and `Language` constraints
  * allow to define a reusable set of constraints by extending the `Compound` constraint

--- a/src/Symfony/Component/Validator/Constraints/Cascade.php
+++ b/src/Symfony/Component/Validator/Constraints/Cascade.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * @Annotation
+ * @Target({"CLASS"})
+ *
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+class Cascade extends Constraint
+{
+    public function __construct($options = null)
+    {
+        if (\is_array($options) && \array_key_exists('groups', $options)) {
+            throw new ConstraintDefinitionException(sprintf('The option "groups" is not supported by the constraint "%s".', __CLASS__));
+        }
+
+        parent::__construct($options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/StrictTypes.php
+++ b/src/Symfony/Component/Validator/Constraints/StrictTypes.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * @Annotation
+ * @Target({"CLASS"})
+ *
+ * @author Jules Pietri <jules@heahprod.com>
+ */
+class StrictTypes extends Constraint
+{
+    public function __construct($options = null)
+    {
+        if (\is_array($options) && \array_key_exists('groups', $options)) {
+            throw new ConstraintDefinitionException(sprintf('The option "groups" is not supported by the constraint "%s".', __CLASS__));
+        }
+
+        parent::__construct($options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTargets()
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -12,8 +12,10 @@
 namespace Symfony\Component\Validator\Mapping;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Cascade;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\Traverse;
+use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\GroupDefinitionException;
 
@@ -170,6 +172,17 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
 
     /**
      * {@inheritdoc}
+     *
+     * If the constraint {@link Cascade} is added, the cascading strategy will be
+     * changed to {@link CascadingStrategy::CASCADE}.
+     *
+     * If the constraint {@link Traverse} is added, the traversal strategy will be
+     * changed. Depending on the $traverse property of that constraint,
+     * the traversal strategy will be set to one of the following:
+     *
+     *  - {@link TraversalStrategy::IMPLICIT} by default
+     *  - {@link TraversalStrategy::NONE} if $traverse is disabled
+     *  - {@link TraversalStrategy::TRAVERSE} if $traverse is enabled
      */
     public function addConstraint(Constraint $constraint)
     {
@@ -184,6 +197,23 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
             } else {
                 // If traverse is false, traversal should be explicitly disabled
                 $this->traversalStrategy = TraversalStrategy::NONE;
+            }
+
+            // The constraint is not added
+            return $this;
+        }
+
+        if ($constraint instanceof Cascade) {
+            if (\PHP_VERSION_ID < 70400) {
+                throw new ConstraintDefinitionException(sprintf('The constraint "%s" requires PHP 7.4.', Cascade::class));
+            }
+
+            $this->cascadingStrategy = CascadingStrategy::CASCADE;
+
+            foreach ($this->getReflectionClass()->getProperties() as $property) {
+                if ($property->hasType() && (('array' === $type = $property->getType()->getName()) || class_exists(($type)))) {
+                    $this->addPropertyConstraint($property->getName(), new Valid());
+                }
             }
 
             // The constraint is not added
@@ -459,13 +489,11 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
     }
 
     /**
-     * Class nodes are never cascaded.
-     *
      * {@inheritdoc}
      */
     public function getCascadingStrategy()
     {
-        return CascadingStrategy::NONE;
+        return $this->cascadingStrategy;
     }
 
     private function addPropertyMetadata(PropertyMetadataInterface $metadata)

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Validator\Mapping;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Cascade;
 use Symfony\Component\Validator\Constraints\GroupSequence;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\StrictTypes;
 use Symfony\Component\Validator\Constraints\Traverse;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
@@ -213,6 +215,21 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
             foreach ($this->getReflectionClass()->getProperties() as $property) {
                 if ($property->hasType() && (('array' === $type = $property->getType()->getName()) || class_exists(($type)))) {
                     $this->addPropertyConstraint($property->getName(), new Valid());
+                }
+            }
+
+            // The constraint is not added
+            return $this;
+        }
+
+        if ($constraint instanceof StrictTypes) {
+            if (\PHP_VERSION_ID < 70400) {
+                throw new ConstraintDefinitionException(sprintf('The constraint "%s" requires PHP 7.4.', StrictTypes::class));
+            }
+
+            foreach ($this->getReflectionClass()->getProperties() as $property) {
+                if ($property->hasType() && !$property->getType()->allowsNull()) {
+                    $this->addPropertyConstraint($property->getName(), new NotNull());
                 }
             }
 

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Mapping;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Cascade;
 use Symfony\Component\Validator\Constraints\DisableAutoMapping;
 use Symfony\Component\Validator\Constraints\EnableAutoMapping;
 use Symfony\Component\Validator\Constraints\Traverse;
@@ -132,12 +133,12 @@ class GenericMetadata implements MetadataInterface
      *
      * @return $this
      *
-     * @throws ConstraintDefinitionException When trying to add the
-     *                                       {@link Traverse} constraint
+     * @throws ConstraintDefinitionException When trying to add the {@link Cascade}
+     *                                       or {@link Traverse} constraint
      */
     public function addConstraint(Constraint $constraint)
     {
-        if ($constraint instanceof Traverse) {
+        if ($constraint instanceof Traverse || $constraint instanceof Cascade) {
             throw new ConstraintDefinitionException(sprintf('The constraint "%s" can only be put on classes. Please use "Symfony\Component\Validator\Constraints\Valid" instead.', get_debug_type($constraint)));
         }
 

--- a/src/Symfony/Component/Validator/Tests/Fixtures/CascadedChild.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/CascadedChild.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class CascadedChild
+{
+    public $name;
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/CascadingEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/CascadingEntity.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+class CascadingEntity
+{
+    public string $scalar;
+
+    public CascadedChild $requiredChild;
+
+    public ?CascadedChild $optionalChild;
+
+    public static ?CascadedChild $staticChild;
+
+    /**
+     * @var CascadedChild[]
+     */
+    public array $children;
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Validator\Tests\Mapping;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Cascade;
+use Symfony\Component\Validator\Constraints\StrictTypes;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Mapping\CascadingStrategy;
@@ -343,6 +344,36 @@ class ClassMetadataTest extends TestCase
             'requiredChild',
             'optionalChild',
             'staticChild',
+            'children',
+        ], $metadata->getConstrainedProperties());
+    }
+
+    /**
+     * @requires PHP < 7.4
+     */
+    public function testStrictTypesConstraintIsNotAvailable()
+    {
+        $metadata = new ClassMetadata(CascadingEntity::class);
+
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The constraint "Symfony\Component\Validator\Constraints\StrictTypes" requires PHP 7.4.');
+
+        $metadata->addConstraint(new StrictTypes());
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testStrictTypesConstraint()
+    {
+        $metadata = new ClassMetadata(CascadingEntity::class);
+
+        $metadata->addConstraint(new StrictTypes());
+
+        $this->assertCount(3, $metadata->properties);
+        $this->assertSame([
+            'scalar',
+            'requiredChild',
             'children',
         ], $metadata->getConstrainedProperties());
     }

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -13,18 +13,23 @@ namespace Symfony\Component\Validator\Tests\Validator;
 
 use Symfony\Component\Translation\IdentityTranslator;
 use Symfony\Component\Validator\Constraints\All;
+use Symfony\Component\Validator\Constraints\Cascade;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Type;
+use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Context\ExecutionContextFactory;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface;
 use Symfony\Component\Validator\Tests\Constraints\Fixtures\ChildA;
 use Symfony\Component\Validator\Tests\Constraints\Fixtures\ChildB;
+use Symfony\Component\Validator\Tests\Fixtures\CascadedChild;
+use Symfony\Component\Validator\Tests\Fixtures\CascadingEntity;
 use Symfony\Component\Validator\Tests\Fixtures\Entity;
 use Symfony\Component\Validator\Tests\Fixtures\EntityWithGroupedConstraintOnMethods;
 use Symfony\Component\Validator\Validator\RecursiveValidator;
@@ -158,5 +163,117 @@ class RecursiveValidatorTest extends AbstractTest
         $this->assertInstanceOf(NotBlank::class, $violations->get(0)->getConstraint());
         $this->assertInstanceOf(Length::class, $violations->get(1)->getConstraint());
         $this->assertInstanceOf(Length::class, $violations->get(2)->getConstraint());
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testValidateDoNotCascadeNestedObjectsAndArraysByDefault()
+    {
+        $this->metadataFactory->addMetadata(new ClassMetadata(CascadingEntity::class));
+        $this->metadataFactory->addMetadata((new ClassMetadata(CascadedChild::class))
+            ->addPropertyConstraint('name', new NotNull())
+        );
+
+        $entity = new CascadingEntity();
+        $entity->requiredChild = new CascadedChild();
+        $entity->optionalChild = new CascadedChild();
+        $entity->children[] = new CascadedChild();
+        CascadingEntity::$staticChild = new CascadedChild();
+
+        $violations = $this->validator->validate($entity);
+
+        $this->assertCount(0, $violations);
+
+        CascadingEntity::$staticChild = null;
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testValidateTraverseNestedArrayByDefaultIfConstrainedWithoutCascading()
+    {
+        $this->metadataFactory->addMetadata((new ClassMetadata(CascadingEntity::class))
+            ->addPropertyConstraint('children', new All([
+                new Type(CascadedChild::class),
+            ]))
+        );
+        $this->metadataFactory->addMetadata((new ClassMetadata(CascadedChild::class))
+            ->addPropertyConstraint('name', new NotNull())
+        );
+
+        $entity = new CascadingEntity();
+        $entity->children[] = new \stdClass();
+        $entity->children[] = new CascadedChild();
+
+        $violations = $this->validator->validate($entity);
+
+        $this->assertCount(1, $violations);
+        $this->assertInstanceOf(Type::class, $violations->get(0)->getConstraint());
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testValidateCascadeWithValid()
+    {
+        $this->metadataFactory->addMetadata((new ClassMetadata(CascadingEntity::class))
+            ->addPropertyConstraint('requiredChild', new Valid())
+            ->addPropertyConstraint('optionalChild', new Valid())
+            ->addPropertyConstraint('staticChild', new Valid())
+            ->addPropertyConstraint('children', new Valid())
+        );
+        $this->metadataFactory->addMetadata((new ClassMetadata(CascadedChild::class))
+            ->addPropertyConstraint('name', new NotNull())
+        );
+
+        $entity = new CascadingEntity();
+        $entity->requiredChild = new CascadedChild();
+        $entity->children[] = new CascadedChild();
+        $entity->children[] = null;
+        CascadingEntity::$staticChild = new CascadedChild();
+
+        $violations = $this->validator->validate($entity);
+
+        $this->assertCount(3, $violations);
+        $this->assertInstanceOf(NotNull::class, $violations->get(0)->getConstraint());
+        $this->assertInstanceOf(NotNull::class, $violations->get(1)->getConstraint());
+        $this->assertInstanceOf(NotNull::class, $violations->get(2)->getConstraint());
+        $this->assertSame('requiredChild.name', $violations->get(0)->getPropertyPath());
+        $this->assertSame('staticChild.name', $violations->get(1)->getPropertyPath());
+        $this->assertSame('children[0].name', $violations->get(2)->getPropertyPath());
+
+        CascadingEntity::$staticChild = null;
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testValidateWithExplicitCascade()
+    {
+        $this->metadataFactory->addMetadata((new ClassMetadata(CascadingEntity::class))
+            ->addConstraint(new Cascade())
+        );
+        $this->metadataFactory->addMetadata((new ClassMetadata(CascadedChild::class))
+            ->addPropertyConstraint('name', new NotNull())
+        );
+
+        $entity = new CascadingEntity();
+        $entity->requiredChild = new CascadedChild();
+        $entity->children[] = new CascadedChild();
+        $entity->children[] = null;
+        CascadingEntity::$staticChild = new CascadedChild();
+
+        $violations = $this->validator->validate($entity);
+
+        $this->assertCount(3, $violations);
+        $this->assertInstanceOf(NotNull::class, $violations->get(0)->getConstraint());
+        $this->assertInstanceOf(NotNull::class, $violations->get(1)->getConstraint());
+        $this->assertInstanceOf(NotNull::class, $violations->get(2)->getConstraint());
+        $this->assertSame('requiredChild.name', $violations->get(0)->getPropertyPath());
+        $this->assertSame('staticChild.name', $violations->get(1)->getPropertyPath());
+        $this->assertSame('children[0].name', $violations->get(2)->getPropertyPath());
+
+        CascadingEntity::$staticChild = null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | TODO

After I commented https://github.com/symfony/symfony/pull/36352#issuecomment-612410767, I started to work on a proper constraint instead. Following #35532, #36492 and #36352, this PR enables the following short example:

- Before:
  ```php
  /**
   * @Assert\Cascade
   */
  class User
  {
      /**
       * @Assert\NotNull
       * @Assert\Regex("some pattern")
       */
      public string $username;

      /**
       * @Assert\NotNull
       * @AssertEmail
       */
      public string $email;

      /**
       * @AssertEmail
       */
      public ?string $secondaryEmail;

      /**
       * @Assert\NotNull
       */
      public Address $address;

      public ?Address $secondaryAddress;
  }
  ```
 - After:
   ```php
   /**
    * @Assert\Cascade
    * @Assert\StrictTypes
    */
   class User
   {
       /**
        * @Assert\Regex("some pattern")
        */
       public string $username;

       /**
        * @AssertEmail
        */
       public string $email;

       /**
        * @AssertEmail
        */
       public ?string $secondaryEmail;

       public Address $address;

       public ?Address $secondaryAddress;
   }
   ```

Until #36352 is merged or close, only the second commit should be reviewed here.

_______
Side note: unlike `AutoMapping`, this feature require PHP 7.4, but do not rely on complexity or other components to achieve a simple non nullable check.
This remains explicit and works for simple VO which do not require PHP annotations anymore, nor ORM mapping.