### PR TITLE
[Notifier] added telegram options

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/AbstractTelegramReplyMarkup.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/AbstractTelegramReplyMarkup.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup;
+
+/**
+ * @author Mihail Krasilnikov <mihail.krasilnikov.j@gmail.com>
+ *
+ * @experimental in 5.2
+ */
+abstract class AbstractTelegramReplyMarkup
+{
+    protected $options = [];
+
+    public function toArray(): array
+    {
+        return $this->options;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/Button/AbstractKeyboardButton.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/Button/AbstractKeyboardButton.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\Button;
+
+/**
+ * @author Mihail Krasilnikov <mihail.krasilnikov.j@gmail.com>
+ *
+ * @experimental in 5.2
+ */
+abstract class AbstractKeyboardButton
+{
+    protected $options = [];
+
+    public function toArray(): array
+    {
+        return $this->options;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/Button/InlineKeyboardButton.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/Button/InlineKeyboardButton.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\Button;
+
+/**
+ * @author Mihail Krasilnikov <mihail.krasilnikov.j@gmail.com>
+ *
+ * @see https://core.telegram.org/bots/api#inlinekeyboardbutton
+ *
+ * @experimental in 5.2
+ */
+final class InlineKeyboardButton extends AbstractKeyboardButton
+{
+    public function __construct(string $text = '')
+    {
+        $this->options['text'] = $text;
+    }
+
+    public function url(string $url): self
+    {
+        $this->options['url'] = $url;
+
+        return $this;
+    }
+
+    public function loginUrl(string $url): self
+    {
+        $this->options['login_url']['url'] = $url;
+
+        return $this;
+    }
+
+    public function loginUrlForwardText(string $text): self
+    {
+        $this->options['login_url']['forward_text'] = $text;
+
+        return $this;
+    }
+
+    public function requestWriteAccess(bool $bool): self
+    {
+        $this->options['login_url']['request_write_access'] = $bool;
+
+        return $this;
+    }
+
+    public function callbackData(string $data): self
+    {
+        $this->options['callback_data'] = $data;
+
+        return $this;
+    }
+
+    public function switchInlineQuery(string $query): self
+    {
+        $this->options['switch_inline_query'] = $query;
+
+        return $this;
+    }
+
+    public function payButton(bool $bool): self
+    {
+        $this->options['pay'] = $bool;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/Button/KeyboardButton.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/Button/KeyboardButton.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\Button;
+
+/**
+ * @author Mihail Krasilnikov <mihail.krasilnikov.j@gmail.com>
+ *
+ * @see https://core.telegram.org/bots/api#keyboardbutton
+ *
+ * @experimental in 5.2
+ */
+final class KeyboardButton extends AbstractKeyboardButton
+{
+    public function __construct(string $text)
+    {
+        $this->options['text'] = $text;
+    }
+
+    public function requestContact(bool $bool): self
+    {
+        $this->options['request_contact'] = $bool;
+
+        return $this;
+    }
+
+    public function requestLocation(bool $bool): self
+    {
+        $this->options['request_location'] = $bool;
+
+        return $this;
+    }
+
+    public function requestPollType(string $type): self
+    {
+        $this->options['request_contact']['type'] = $type;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/ForceReply.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/ForceReply.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup;
+
+/**
+ * @author Mihail Krasilnikov <mihail.krasilnikov.j@gmail.com>
+ *
+ * @see https://core.telegram.org/bots/api#forcereply
+ *
+ * @experimental in 5.2
+ */
+final class ForceReply extends AbstractTelegramReplyMarkup
+{
+    public function __construct(bool $forceReply = false, bool $selective = false)
+    {
+        $this->options['force_reply'] = $forceReply;
+        $this->options['selective'] = $selective;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/InlineKeyboardMarkup.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/InlineKeyboardMarkup.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup;
+
+use Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\Button\InlineKeyboardButton;
+
+/**
+ * @author Mihail Krasilnikov <mihail.krasilnikov.j@gmail.com>
+ *
+ * @see https://core.telegram.org/bots/api#inlinekeyboardmarkup
+ *
+ * @experimental in 5.2
+ */
+final class InlineKeyboardMarkup extends AbstractTelegramReplyMarkup
+{
+    public function __construct()
+    {
+        $this->options['inline_keyboard'] = [];
+    }
+
+    /**
+     * @param array|InlineKeyboardButton[] $buttons
+     */
+    public function inlineKeyboard(array $buttons): self
+    {
+        $buttons = array_map(static function (InlineKeyboardButton $button) {
+            return $button->toArray();
+        }, $buttons);
+
+        $this->options['inline_keyboard'][] = $buttons;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/ReplyKeyboardMarkup.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/ReplyKeyboardMarkup.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup;
+
+use Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\Button\KeyboardButton;
+
+/**
+ * @author Mihail Krasilnikov <mihail.krasilnikov.j@gmail.com>
+ *
+ * @see https://core.telegram.org/bots/api#replykeyboardmarkup
+ *
+ * @experimental in 5.2
+ */
+final class ReplyKeyboardMarkup extends AbstractTelegramReplyMarkup
+{
+    public function __construct()
+    {
+        $this->options['keyboard'] = [];
+    }
+
+    /**
+     * @param array|KeyboardButton[] $buttons
+     *
+     * @return $this
+     */
+    public function keyboard(array $buttons): self
+    {
+        $buttons = array_map(static function (KeyboardButton $button) {
+            return $button->toArray();
+        }, $buttons);
+
+        $this->options['keyboard'][] = $buttons;
+
+        return $this;
+    }
+
+    public function resizeKeyboard(bool $bool): self
+    {
+        $this->options['resize_keyboard'] = $bool;
+
+        return $this;
+    }
+
+    public function oneTimeKeyboard(bool $bool): self
+    {
+        $this->options['one_time_keyboard'] = $bool;
+
+        return $this;
+    }
+
+    public function selective(bool $bool): self
+    {
+        $this->options['selective'] = $bool;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/ReplyKeyboardRemove.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/ReplyKeyboardRemove.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup;
+
+/**
+ * @author Mihail Krasilnikov <mihail.krasilnikov.j@gmail.com>
+ *
+ * @see https://core.telegram.org/bots/api#replykeyboardremove
+ *
+ * @experimental in 5.2
+ */
+final class ReplyKeyboardRemove extends AbstractTelegramReplyMarkup
+{
+    public function __construct(bool $removeKeyboard = false, bool $selective = false)
+    {
+        $this->options['remove_keyboard'] = $removeKeyboard;
+        $this->options['selective'] = $selective;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramOptions.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Telegram;
+
+use Symfony\Component\Notifier\Bridge\Telegram\Reply\Markup\AbstractTelegramReplyMarkup;
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+/**
+ * @author Mihail Krasilnikov <mihail.krasilnikov.j@gmail.com>
+ *
+ * @experimental in 5.2
+ */
+final class TelegramOptions implements MessageOptionsInterface
+{
+    public const PARSE_MODE_HTML = 'HTML';
+    public const PARSE_MODE_MARKDOWN = 'Markdown';
+    public const PARSE_MODE_MARKDOWN_V2 = 'MarkdownV2';
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+    }
+
+    public function toArray(): array
+    {
+        return $this->options;
+    }
+
+    public function getRecipientId(): ?string
+    {
+        return $this->options['chat_id'] ?? null;
+    }
+
+    public function chatId(string $id): self
+    {
+        $this->options['chat_id'] = $id;
+
+        return $this;
+    }
+
+    public function parseMode(string $mode): self
+    {
+        $this->options['parse_mode'] = $mode;
+
+        return $this;
+    }
+
+    public function disableWebPagePreview(bool $bool): self
+    {
+        $this->options['disable_web_page_preview'] = $bool;
+
+        return $this;
+    }
+
+    public function disableNotification(bool $bool): self
+    {
+        $this->options['disable_notification'] = $bool;
+
+        return $this;
+    }
+
+    public function replyTo(int $messageId): self
+    {
+        $this->options['reply_to_message_id'] = $messageId;
+
+        return $this;
+    }
+
+    public function replyMarkup(AbstractTelegramReplyMarkup $markup): self
+    {
+        $this->options['reply_markup'] = $markup->toArray();
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -66,13 +66,21 @@ final class TelegramTransport extends AbstractTransport
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, get_debug_type($message)));
         }
 
+        if ($message->getOptions() && !$message->getOptions() instanceof TelegramOptions) {
+            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" for options.', __CLASS__, TelegramOptions::class));
+        }
+
         $endpoint = sprintf('https://%s/bot%s/sendMessage', $this->getEndpoint(), $this->token);
         $options = ($opts = $message->getOptions()) ? $opts->toArray() : [];
         if (!isset($options['chat_id'])) {
             $options['chat_id'] = $message->getRecipientId() ?: $this->chatChannel;
         }
+
+        if (!isset($options['parse_mode'])) {
+            $options['parse_mode'] = TelegramOptions::PARSE_MODE_MARKDOWN_V2;
+        }
+
         $options['text'] = $message->getSubject();
-        $options['parse_mode'] = 'Markdown';
         $response = $this->client->request('POST', $endpoint, [
             'json' => array_filter($options),
         ]);

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -13,12 +13,12 @@ namespace Symfony\Component\Notifier\Bridge\Telegram\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\Notifier\Bridge\Telegram\TelegramOptions;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransport;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
-use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -87,7 +87,7 @@ final class TelegramTransportTest extends TestCase
         $expectedBody = [
             'chat_id' => $channel,
             'text' => 'testMessage',
-            'parse_mode' => 'Markdown',
+            'parse_mode' => 'MarkdownV2',
         ];
 
         $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response, $expectedBody): ResponseInterface {
@@ -116,7 +116,7 @@ final class TelegramTransportTest extends TestCase
         $expectedBody = [
             'chat_id' => $channelOverride,
             'text' => 'testMessage',
-            'parse_mode' => 'Markdown',
+            'parse_mode' => 'MarkdownV2',
         ];
 
         $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response, $expectedBody): ResponseInterface {
@@ -127,11 +127,8 @@ final class TelegramTransportTest extends TestCase
 
         $transport = new TelegramTransport('testToken', 'defaultChannel', $client);
 
-        $messageOptions = $this->createMock(MessageOptionsInterface::class);
-        $messageOptions
-            ->expects($this->once())
-            ->method('getRecipientId')
-            ->willReturn($channelOverride);
+        $messageOptions = new TelegramOptions();
+        $messageOptions->chatId($channelOverride);
 
         $transport->send(new ChatMessage('testMessage', $messageOptions));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes 
| Deprecations? | no 
| License       | MIT

I have added `TelegramOptions` model for sending a telegram message with options like the example I have used  `SlackOptions`. 

Testing notes:
1) Create telegram bot https://core.telegram.org/bots#creating-a-new-bot
2) Open telegram and join to the created chat
3) Send a message to telegram
for testing, I used  the scripts 
[scripts.zip](https://github.com/symfony/symfony/files/4499901/scripts.zip)

