### PR TITLE
[Security/Core] fix escape for username in LdapBindAuthenticationProvider.php

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/LdapBindAuthenticationProvider.php
@@ -87,9 +87,8 @@ class LdapBindAuthenticationProvider extends UserAuthenticationProvider
         }
 
         try {
-            $username = $this->ldap->escape($username, '', LdapInterface::ESCAPE_DN);
-
             if ($this->queryString) {
+                $username = $this->ldap->escape($username, '', LdapInterface::ESCAPE_FILTER);
                 $query = str_replace('{username}', $username, $this->queryString);
                 $result = $this->ldap->query($this->dnString, $query)->execute();
                 if (1 !== $result->count()) {
@@ -98,6 +97,7 @@ class LdapBindAuthenticationProvider extends UserAuthenticationProvider
 
                 $dn = $result[0]->getDn();
             } else {
+                $username = $this->ldap->escape($username, '', LdapInterface::ESCAPE_DN);
                 $dn = str_replace('{username}', $username, $this->dnString);
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

I think that when we call `ldap_search()` as definitely it will do the `$this->ldap->query()` call, the proper filter applied should be `LdapInterface::ESCAPE_FILTER` as documented in
https://www.php.net/manual/en/function.ldap-escape.php while `LdapInterface::ESCAPE_DN` should be used for `dn` only

This simple change should fix, I'm sorry if I'm wrong.