### PR TITLE
[Translation] Fix for translation:update command updating ICU messages

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -356,7 +356,14 @@ EOF
     {
         $filteredCatalogue = new MessageCatalogue($catalogue->getLocale());
 
-        if ($messages = $catalogue->all($domain)) {
+        // extract intl-icu messages only
+        $intlDomain = $domain.MessageCatalogueInterface::INTL_DOMAIN_SUFFIX;
+        if ($intlMessages = $catalogue->all($intlDomain)) {
+            $filteredCatalogue->add($intlMessages, $intlDomain);
+        }
+
+        // extract all messages and subtract intl-icu messages
+        if ($messages = array_diff($catalogue->all($domain), $intlMessages)) {
             $filteredCatalogue->add($messages, $domain);
         }
         foreach ($catalogue->getResources() as $resource) {

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -72,6 +72,11 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
     public function all($domain = null)
     {
         if (null !== $domain) {
+            // skip messages merge if intl-icu requested explicitly
+            if (false !== strpos($domain, self::INTL_DOMAIN_SUFFIX)) {
+                return $this->messages[$domain] ?? [];
+            }
+
             return ($this->messages[$domain.self::INTL_DOMAIN_SUFFIX] ?? []) + ($this->messages[$domain] ?? []);
         }
 

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -67,6 +67,30 @@ class MessageCatalogueTest extends TestCase
         $this->assertEquals($messages, $catalogue->all());
     }
 
+    public function testAllIntICU()
+    {
+        $messages = [
+            'domain1+intl-icu' => ['foo' => 'bar'],
+            'domain2+intl-icu' => ['bar' => 'foo'],
+            'domain2' => ['biz' => 'biz'],
+        ];
+        $catalogue = new MessageCatalogue('en', $messages);
+
+        // separated domains
+        $this->assertSame(['foo' => 'bar'], $catalogue->all('domain1+intl-icu'));
+        $this->assertSame(['bar' => 'foo'], $catalogue->all('domain2+intl-icu'));
+
+        // merged, intl-icu ignored
+        $this->assertSame(['bar' => 'foo', 'biz' => 'biz'], $catalogue->all('domain2'));
+
+        // intl-icu ignored
+        $messagesExpected = [
+            'domain1' => ['foo' => 'bar'],
+            'domain2' => ['bar' => 'foo', 'biz' => 'biz'],
+        ];
+        $this->assertSame($messagesExpected, $catalogue->all());
+    }
+
     public function testHas()
     {
         $catalogue = new MessageCatalogue('en', ['domain1' => ['foo' => 'foo'], 'domain2+intl-icu' => ['bar' => 'bar']]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36459
| License       | MIT

If `translation:update` command executed with option `--domain=messages`  – it  ignore `messages-intl-icu` file and just create new `messages`

Method `TranslationUpdateCommand::filterCatalogue()` on `MessageCatalogue::all()` method to get all messages for domain
But `MessageCatalogue::all()` method disredard `intl-icu` domains and simply merge all.

[Translation] added $strict parameter for MessageCatalogueInterface::all() to be able to get only defined domain messages
[FrameworkBundle] modified translation:update command to respect intl-icu domain
