### PR TITLE
[FrameworkBundle] Fix session.attribute_bag service definition

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -41,7 +41,8 @@
         <service id="Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface" alias="session.flash_bag" />
 
         <service id="session.attribute_bag" class="Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag">
-            <factory service="session" method="getAttributeBag"/>
+            <factory service="session" method="getBag"/>
+            <argument>attributes</argument>
         </service>
 
         <service id="session.storage.mock_file" class="Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/36465
| License       | MIT
| Doc PR        | -

It looks like in https://github.com/symfony/symfony/pull/36063, the fact the the `getAttributeBag` method is private was forgotten. It cannot be used as the factory method. I guess we can make it public. Should it maybe marked `@internal`?
