### PR TITLE
[Messenger] Add AvailableAtStamp to delay messages until fixed DateTime

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -98,3 +98,8 @@ Security
  * Removed `ROLE_PREVIOUS_ADMIN` role in favor of `IS_IMPERSONATOR` attribute
  * Removed `LogoutSuccessHandlerInterface` and `LogoutHandlerInterface`, register a listener on the `LogoutEvent` event instead.
  * Removed `DefaultLogoutSuccessHandler` in favor of `DefaultLogoutListener`.
+
+Yaml
+----
+
+ * Removed support for using the `!php/object` and `!php/const` tags without a value.

--- a/src/Symfony/Component/Messenger/Middleware/AvailableAtStampMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/AvailableAtStampMiddleware.php
@@ -1,16 +1,22 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Messenger\Middleware;
 
 use DateTime;
 use Symfony\Component\Messenger\Envelope;
-use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
-use Symfony\Component\Messenger\Middleware\StackInterface;
 use Symfony\Component\Messenger\Stamp\AvailableAtStamp;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 
 /**
- *
  * @author Antonio del Olmo García <adelolmog@gmail.com>
  */
 class AvailableAtStampMiddleware implements MiddlewareInterface

--- a/src/Symfony/Component/Messenger/Middleware/AvailableAtStampMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/AvailableAtStampMiddleware.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use DateTime;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+use Symfony\Component\Messenger\Stamp\AvailableAtStamp;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+
+/**
+ *
+ * @author Antonio del Olmo García <adelolmog@gmail.com>
+ */
+class AvailableAtStampMiddleware implements MiddlewareInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $availableAtStamp = $envelope->last(AvailableAtStamp::class);
+
+        if (null !== $availableAtStamp) {
+            $availableAt = $availableAtStamp->getAvailableAt();
+            $now = new DateTime();
+
+            $delay = $availableAt->getTimestamp() - $now->getTimestamp();
+
+            $envelope = $envelope->with(
+                new DelayStamp($delay * 1000)
+            );
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/AvailableAtStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/AvailableAtStamp.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Symfony\Component\Messenger\Stamp;
+
+use DateTime;
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+/**
+ * Stamp used to identify when a message should become available
+ *
+ * @author Antonio del Olmo García <adelolmog@gmail.com>
+ */
+class AvailableAtStamp implements StampInterface
+{
+    /**
+     * @var \DateTime
+     */
+    protected $availableAt;
+
+    /**
+     *
+     * @param \DateTime $availableAt
+     */
+    public function __construct(DateTime $availableAt)
+    {
+        $this->availableAt = $availableAt;
+    }
+
+    /**
+     * The date and time on which the message will be available
+     *
+     * @return \DateTime
+     */
+    public function getAvailableAt(): DateTime
+    {
+        return $this->availableAt;
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/AvailableAtStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/AvailableAtStamp.php
@@ -1,12 +1,20 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Messenger\Stamp;
 
 use DateTime;
-use Symfony\Component\Messenger\Stamp\StampInterface;
 
 /**
- * Stamp used to identify when a message should become available
+ * Stamp used to identify when a message should become available.
  *
  * @author Antonio del Olmo García <adelolmog@gmail.com>
  */
@@ -17,19 +25,13 @@ class AvailableAtStamp implements StampInterface
      */
     protected $availableAt;
 
-    /**
-     *
-     * @param \DateTime $availableAt
-     */
     public function __construct(DateTime $availableAt)
     {
         $this->availableAt = $availableAt;
     }
 
     /**
-     * The date and time on which the message will be available
-     *
-     * @return \DateTime
+     * The date and time on which the message will be available.
      */
     public function getAvailableAt(): DateTime
     {

--- a/src/Symfony/Component/Messenger/Tests/Middleware/AvailableAtStampMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/AvailableAtStampMiddlewareTest.php
@@ -35,7 +35,7 @@ class AvailableAtStampMiddlewareTest extends MiddlewareTestCase
         $envelope = new Envelope(
             new DummyMessage('the message'),
             [
-                $availableAtStamp
+                $availableAtStamp,
             ]
         );
 

--- a/src/Symfony/Component/Messenger/Tests/Middleware/AvailableAtStampMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/AvailableAtStampMiddlewareTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use DateTime;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\AvailableAtStampMiddleware;
+use Symfony\Component\Messenger\Stamp\AvailableAtStamp;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+
+/**
+ * @author Antonio del Olmo García <adelolmog@gmail.com>
+ */
+class AvailableAtStampMiddlewareTest extends MiddlewareTestCase
+{
+    public function testAvailableAtAndDelayStampAreAdded()
+    {
+        $now = new DateTime();
+        $availableAt = (clone $now)->modify('+1000 seconds');
+        $availableAtStamp = new AvailableAtStamp($availableAt);
+
+        $middleware = new AvailableAtStampMiddleware();
+
+        $envelope = new Envelope(
+            new DummyMessage('the message'),
+            [
+                $availableAtStamp
+            ]
+        );
+
+        $finalEnvelope = $middleware->handle($envelope, $this->getStackMock());
+
+        /** @var AvailableAtStamp $availableAtStamp */
+        $availableAtStamp = $finalEnvelope->last(AvailableAtStamp::class);
+        $this->assertNotNull($availableAtStamp);
+        $this->assertSame($availableAt, $availableAtStamp->getAvailableAt());
+
+        /** @var DelayStamp $delayStamp */
+        $delayStamp = $finalEnvelope->last(DelayStamp::class);
+        $this->assertNotNull($delayStamp);
+        $this->assertSame(1000 * 1000, $delayStamp->getDelay());
+
+        // the stamp should not be added over and over again
+        $finalEnvelope = $middleware->handle($finalEnvelope, $this->getStackMock());
+        $this->assertCount(1, $finalEnvelope->all(AvailableAtStamp::class));
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Stamp/AvailableAtStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/AvailableAtStampTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Stamp;
+
+use DateTime;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Stamp\AvailableAtStamp;
+
+/**
+ * @author Antonio del Olmo García <adelolmog@gmail.com>
+ */
+class AvailableAtStampTest extends TestCase
+{
+    public function testStamp()
+    {
+        $stamp = new AvailableAtStamp($availableAt = new DateTime());
+        $this->assertSame($availableAt, $stamp->getAvailableAt());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

An AvailableAtStamp and an AvailableAtStampMiddleware have been added to allow posponing a message to a fixed date and time. Internally, the middleware calculates the difference in milliseconds between the desired date and the current date and adds a DelayStamp to the envelope.
