### PR TITLE
[Notifier] Throw an exception when the Slack DSN is not valid

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransportFactory.php
@@ -34,8 +34,8 @@ final class FreeMobileTransportFactory extends AbstractTransportFactory
         $password = $this->getPassword($dsn);
         $phone = $dsn->getOption('phone');
 
-        if (null === $phone || '' === $phone) {
-            throw new IncompleteDsnException('Missing phone.');
+        if (!$phone) {
+            throw new IncompleteDsnException('Missing phone.', $dsn->getOriginalDsn());
         }
 
         if ('freemobile' === $scheme) {

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Slack;
 
+use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -32,6 +33,10 @@ final class SlackTransportFactory extends AbstractTransportFactory
         $id = ltrim($dsn->getPath(), '/');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
+
+        if (!$id) {
+            throw new IncompleteDsnException('Missing path (maybe you haven\'t update the DSN when upgrading from 5.0).', $dsn->getOriginalDsn());
+        }
 
         if ('slack' === $scheme) {
             return (new SlackTransport($id, $this->client, $this->dispatcher))->setHost($host)->setPort($port);

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransportFactory.php
@@ -50,11 +50,11 @@ final class TelegramTransportFactory extends AbstractTransportFactory
     private function getToken(Dsn $dsn): string
     {
         if (null === $dsn->getUser() && null === $dsn->getPassword()) {
-            throw new IncompleteDsnException('Missing token.');
+            throw new IncompleteDsnException('Missing token.', $dsn->getOriginalDsn());
         }
 
         if (null === $dsn->getPassword()) {
-            throw new IncompleteDsnException('Malformed token.');
+            throw new IncompleteDsnException('Malformed token.', $dsn->getOriginalDsn());
         }
 
         return sprintf('%s:%s', $dsn->getUser(), $dsn->getPassword());

--- a/src/Symfony/Component/Notifier/Exception/IncompleteDsnException.php
+++ b/src/Symfony/Component/Notifier/Exception/IncompleteDsnException.php
@@ -18,4 +18,20 @@ namespace Symfony\Component\Notifier\Exception;
  */
 class IncompleteDsnException extends InvalidArgumentException
 {
+    private $dsn;
+
+    public function __construct(string $message, string $dsn = null, ?\Throwable $previous = null)
+    {
+        $this->dsn = $dsn;
+        if ($dsn) {
+            $message = sprintf('Invalid "%s" notifier DSN: ', $dsn).$message;
+        }
+
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function getOriginalDsn(): string
+    {
+        return $this->dsn;
+    }
 }

--- a/src/Symfony/Component/Notifier/Transport/AbstractTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Transport/AbstractTransportFactory.php
@@ -48,7 +48,7 @@ abstract class AbstractTransportFactory implements TransportFactoryInterface
     {
         $user = $dsn->getUser();
         if (null === $user) {
-            throw new IncompleteDsnException('User is not set.');
+            throw new IncompleteDsnException('User is not set.', $dsn->getOriginalDsn());
         }
 
         return $user;
@@ -58,7 +58,7 @@ abstract class AbstractTransportFactory implements TransportFactoryInterface
     {
         $password = $dsn->getPassword();
         if (null === $password) {
-            throw new IncompleteDsnException('Password is not set.');
+            throw new IncompleteDsnException('Password is not set.', $dsn->getOriginalDsn());
         }
 
         return $password;

--- a/src/Symfony/Component/Notifier/Transport/Dsn.php
+++ b/src/Symfony/Component/Notifier/Transport/Dsn.php
@@ -27,6 +27,7 @@ final class Dsn
     private $port;
     private $options;
     private $path;
+    private $dsn;
 
     public function __construct(string $scheme, string $host, ?string $user = null, ?string $password = null, ?int $port = null, array $options = [], ?string $path = null)
     {
@@ -59,7 +60,10 @@ final class Dsn
         $path = $parsedDsn['path'] ?? null;
         parse_str($parsedDsn['query'] ?? '', $query);
 
-        return new self($parsedDsn['scheme'], $parsedDsn['host'], $user, $password, $port, $query, $path);
+        $dsnObject = new self($parsedDsn['scheme'], $parsedDsn['host'], $user, $password, $port, $query, $path);
+        $dsnObject->dsn = $dsn;
+
+        return $dsnObject;
     }
 
     public function getScheme(): string
@@ -95,5 +99,10 @@ final class Dsn
     public function getPath(): ?string
     {
         return $this->path;
+    }
+
+    public function getOriginalDsn(): string
+    {
+        return $this->dsn;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes-ish
| New feature?  | yes-ish <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | n/a

Improved errors in case of a DSN issue.
+ proper error for the Slack DSN when path is empty (will help catch when people haven't updated their Slack DSN for 5.1).
