### PR TITLE
[Notifier] Fix error handling for Free mobile

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
@@ -66,9 +66,14 @@ final class FreeMobileTransport extends AbstractTransport
         ]);
 
         if (200 !== $response->getStatusCode()) {
-            $error = $response->toArray(false);
+            $errors = [
+                400 => 'Missing required parameter or wrongly formatted message.',
+                402 => 'Too many messages have been sent too fast.',
+                403 => 'Service not enabled or wrong credentials.',
+                500 => 'Server error, please try again later.',
+            ];
 
-            throw new TransportException(sprintf('Unable to send the SMS: "%s" (see "%s").', $error['message'], $error['more_info']), $response);
+            throw new TransportException(sprintf('Unable to send the SMS: error %d: ', $response->getStatusCode()).($errors[$response->getStatusCode()] ?? ''), $response);
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | n/a

Looks like the error handling code for Free mobile is a copy/paste from Twilio.

/cc @noniagriconomie
