### PR TITLE
[Security] Fix missing nullable in CsrfTokenBadge

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/CsrfTokenBadge.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/CsrfTokenBadge.php
@@ -45,7 +45,7 @@ class CsrfTokenBadge implements BadgeInterface
         return $this->csrfTokenId;
     }
 
-    public function getCsrfToken(): string
+    public function getCsrfToken(): ?string
     {
         return $this->csrfToken;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Related to #33558 I noticed a minor 🤏  bug with the method return-type.