### PR TITLE
[FrameworkBundle] debug:autowiring: Fix wrong display when using class_alias

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/DebugAutowiringCommand.php
@@ -103,9 +103,10 @@ EOF
         $serviceIdsNb = 0;
         foreach ($serviceIds as $serviceId) {
             $text = [];
+            $resolvedServiceId = $serviceId;
             if (0 !== strpos($serviceId, $previousId)) {
                 $text[] = '';
-                if ('' !== $description = Descriptor::getClassDescription($serviceId, $serviceId)) {
+                if ('' !== $description = Descriptor::getClassDescription($serviceId, $resolvedServiceId)) {
                     if (isset($hasAlias[$serviceId])) {
                         continue;
                     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ClassAliasExampleClass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ClassAliasExampleClass.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+class_alias(
+    ClassAliasTargetClass::class,
+    __NAMESPACE__ . '\ClassAliasExampleClass'
+);
+
+if (false) {
+    class ClassAliasExampleClass
+    {
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ClassAliasTargetClass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ClassAliasTargetClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
+
+class ClassAliasTargetClass
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/DebugAutowiringCommandTest.php
@@ -97,4 +97,16 @@ class DebugAutowiringCommandTest extends AbstractWebTestCase
         $tester->run(['command' => 'debug:autowiring', 'search' => 'redirect', '--all' => true]);
         $this->assertStringContainsString('Pro-tip: use interfaces in your type-hints instead of classes to benefit from the dependency inversion principle.', $tester->getDisplay());
     }
+
+    public function testNotConfusedByClassAliases()
+    {
+        static::bootKernel(['test_case' => 'ContainerDebug', 'root_config' => 'config.yml']);
+
+        $application = new Application(static::$kernel);
+        $application->setAutoExit(false);
+
+        $tester = new ApplicationTester($application);
+        $tester->run(['command' => 'debug:autowiring', 'search' => 'ClassAlias']);
+        $this->assertStringContainsString('Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ClassAliasExampleClass (public)', $tester->getDisplay());
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDebug/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDebug/config.yml
@@ -13,6 +13,7 @@ services:
         public: false
     Symfony\Bundle\FrameworkBundle\Tests\Fixtures\BackslashClass:
         class: Symfony\Bundle\FrameworkBundle\Tests\Fixtures\BackslashClass
+    Symfony\Bundle\FrameworkBundle\Tests\Fixtures\ClassAliasExampleClass: '@public'
     env:
         class: stdClass
         arguments:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | not needed

Imagine that `FooInterface` is an alias, but it is deprecated and so has a `class_alias` to `BarInterface`. Currently, `debug:autowiring` will actually print that's the autowiring alias is `BarInterface`, despite there being no such id in the container.

@nicolas-grekas originally (on purpose) made the 2nd argument to `Descriptor::getClassDescription()` be passed by reference *for* this exact feature - https://github.com/symfony/symfony/commit/56aab09b013029d68e8442b927077898340fe6cc - but I can't figure out why. This change (which effectively removes the by-reference modifying) made no existing tests fail.

Discovered this because the whole deprecated`Doctrine\Common\Persistence\ManagerRegistry` vs newer `Doctrine\Persistence\ManagerRegistry` causes the issue.

Thanks!