### PR TITLE
[Security] Apply left-over review comments from #33558

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -77,7 +77,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
     public function supports(Request $request): ?bool
     {
         if (null !== $this->logger) {
-            $context = ['firewall_key' => $this->firewallName];
+            $context = ['firewall_name' => $this->firewallName];
 
             if ($this->authenticators instanceof \Countable || \is_array($this->authenticators)) {
                 $context['authenticators'] = \count($this->authenticators);
@@ -90,14 +90,14 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
         $lazy = true;
         foreach ($this->authenticators as $authenticator) {
             if (null !== $this->logger) {
-                $this->logger->debug('Checking support on authenticator.', ['firewall_key' => $this->firewallName, 'authenticator' => \get_class($authenticator)]);
+                $this->logger->debug('Checking support on authenticator.', ['firewall_name' => $this->firewallName, 'authenticator' => \get_class($authenticator)]);
             }
 
             if (false !== $supports = $authenticator->supports($request)) {
                 $authenticators[] = $authenticator;
                 $lazy = $lazy && null === $supports;
             } elseif (null !== $this->logger) {
-                $this->logger->debug('Authenticator does not support the request.', ['firewall_key' => $this->firewallName, 'authenticator' => \get_class($authenticator)]);
+                $this->logger->debug('Authenticator does not support the request.', ['firewall_name' => $this->firewallName, 'authenticator' => \get_class($authenticator)]);
             }
         }
 

--- a/src/Symfony/Component/Security/Http/Authentication/NoopAuthenticationManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/NoopAuthenticationManager.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  *
  * This is used to not break AuthenticationChecker and ContextListener when
  * using the authenticator system. Once the authenticator system is no longer
- * experimental, this class can be used trigger deprecation notices.
+ * experimental, this class can be used to trigger deprecation notices.
  *
  * @internal
  *

--- a/src/Symfony/Component/Security/Http/Authentication/UserAuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/UserAuthenticatorInterface.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 interface UserAuthenticatorInterface
 {
     /**
-     * Convenience method to manually login a user and return a
+     * Convenience method to programmatically login a user and return a
      * Response *if any* for success.
      */
     public function authenticateUser(UserInterface $user, AuthenticatorInterface $authenticator, Request $request): ?Response;

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/PasswordUpgradeBadge.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/PasswordUpgradeBadge.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Authenticator\Passport\Badge;
 
+use Symfony\Component\Security\Core\Exception\LogicException;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 
 /**
@@ -38,22 +39,21 @@ class PasswordUpgradeBadge implements BadgeInterface
         $this->passwordUpgrader = $passwordUpgrader;
     }
 
-    public function getPlaintextPassword(): string
+    public function getAndErasePlaintextPassword(): string
     {
-        return $this->plaintextPassword;
+        $password = $this->plaintextPassword;
+        if (null === $password) {
+            throw new LogicException('The password is erased as another listener already used this badge.');
+        }
+
+        $this->plaintextPassword = null;
+
+        return $password;
     }
 
     public function getPasswordUpgrader(): PasswordUpgraderInterface
     {
         return $this->passwordUpgrader;
-    }
-
-    /**
-     * @internal
-     */
-    public function eraseCredentials()
-    {
-        $this->plaintextPassword = null;
     }
 
     public function isResolved(): bool

--- a/src/Symfony/Component/Security/Http/EventListener/PasswordMigratingListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/PasswordMigratingListener.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Security\Http\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -32,8 +41,7 @@ class PasswordMigratingListener implements EventSubscriberInterface
 
         /** @var PasswordUpgradeBadge $badge */
         $badge = $passport->getBadge(PasswordUpgradeBadge::class);
-        $plaintextPassword = $badge->getPlaintextPassword();
-        $badge->eraseCredentials();
+        $plaintextPassword = $badge->getAndErasePlaintextPassword();
 
         if ('' === $plaintextPassword) {
             return;

--- a/src/Symfony/Component/Security/Http/EventListener/SessionStrategyListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/SessionStrategyListener.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
 
 /**
- * Migrates/invalidate the session after successful login.
+ * Migrates/invalidates the session after successful login.
  *
  * This should be registered as subscriber to any "stateful" firewalls.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | n/a

This applies the review comments of @noniagriconomie in #33558. It's mostly doc fixes and one extra security-safeguard by resetting the plaintext password early (similair to what is done in `PasswordCredentials`).