### PR TITLE
[FrameworkBundle] remove getContainer overwrites in tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/AppKernel.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\app;
 use Psr\Log\NullLogger;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -96,14 +95,5 @@ class AppKernel extends Kernel
         $parameters['kernel.test_case'] = $this->testCase;
 
         return $parameters;
-    }
-
-    public function getContainer(): ContainerInterface
-    {
-        if (!$this->container) {
-            throw new \LogicException('Cannot access the container on a non-booted kernel. Did you forget to boot it?');
-        }
-
-        return parent::getContainer();
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional\app;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -98,14 +97,5 @@ class AppKernel extends Kernel
         $parameters['kernel.test_case'] = $this->testCase;
 
         return $parameters;
-    }
-
-    public function getContainer(): ContainerInterface
-    {
-        if (!$this->container) {
-            throw new \LogicException('Cannot access the container on a non-booted kernel. Did you forget to boot it?');
-        }
-
-        return parent::getContainer();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| Doc PR        | 

Since 5.0 the parent implementation throws an exception anyway making the overwrites obsolete, see https://github.com/symfony/symfony/pull/31202
