### PR TITLE
[Form] apply automatically step=1 for datetime-local input

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -203,6 +203,14 @@ class DateTimeType extends AbstractType
         //  * the html5 is set to true
         if ($options['html5'] && 'single_text' === $options['widget'] && self::HTML5_FORMAT === $options['format']) {
             $view->vars['type'] = 'datetime-local';
+
+            // we need to force the browser to display the seconds by
+            // adding the HTML attribute step if not already defined.
+            // Otherwise the browser will not display and so not send the seconds
+            // therefore the value will always be considered as invalid.
+            if ($options['with_seconds'] && !isset($view->vars['attr']['step'])) {
+                $view->vars['attr']['step'] = 1;
+            }
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -444,6 +444,37 @@ class DateTimeTypeTest extends BaseTypeTest
         $this->assertArrayNotHasKey('type', $view->vars);
     }
 
+    public function testSingleTextWidgetWithSecondsShouldHaveRightStepAttribute()
+    {
+        $view = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'widget' => 'single_text',
+                'with_seconds' => true,
+            ])
+            ->createView()
+        ;
+
+        $this->assertArrayHasKey('step', $view->vars['attr']);
+        $this->assertEquals(1, $view->vars['attr']['step']);
+    }
+
+    public function testSingleTextWidgetWithSecondsShouldNotOverrideStepAttribute()
+    {
+        $view = $this->factory
+            ->create(static::TESTED_TYPE, null, [
+                'widget' => 'single_text',
+                'with_seconds' => true,
+                'attr' => [
+                    'step' => 30,
+                ],
+            ])
+            ->createView()
+        ;
+
+        $this->assertArrayHasKey('step', $view->vars['attr']);
+        $this->assertEquals(30, $view->vars['attr']['step']);
+    }
+
     public function testDateTypeChoiceErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | ~
| License       | MIT
| Doc PR        | 

this PR just reapplies the same fix from `TimeType` (https://github.com/symfony/symfony/pull/10777 thanks @tucksaun) to `DateTimeType`.

### before:
```php
'widget' => 'single_text',
'with_seconds' => true,
```
![image](https://user-images.githubusercontent.com/4582866/79972699-a5369500-8496-11ea-8272-d43b68ff49b5.png)

### after:
```php
'widget' => 'single_text',
'with_seconds' => true,
```
![image](https://user-images.githubusercontent.com/4582866/79972801-cbf4cb80-8496-11ea-9af5-b193445b1f1d.png)


