### PR TITLE
Improve SQS interoperability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ env:
         - SYMFONY_PROCESS_PHP_TEST_BINARY=~/.phpenv/shims/php
         - MESSENGER_AMQP_DSN=amqp://localhost/%2f/messages
         - MESSENGER_REDIS_DSN=redis://127.0.0.1:7006/messages
-        - MESSENGER_SQS_DSN=sqs://localhost:9494/messages?sslmode=disable
-        - MESSENGER_SQS_FIFO_QUEUE_DSN=sqs://localhost:9494/messages.fifo?sslmode=disable
+        - MESSENGER_SQS_DSN="sqs://localhost:9494/messages?sslmode=disable&poll_timeout=0.01"
+        - MESSENGER_SQS_FIFO_QUEUE_DSN="sqs://localhost:9494/messages.fifo?sslmode=disable&poll_timeout=0.01"
         - SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE=1
 
 matrix:
@@ -73,8 +73,8 @@ before_install:
 
     - |
       # Start Sqs server
-      docker pull feathj/fake-sqs
-      docker run -d -p 9494:9494 --name sqs feathj/fake-sqs
+      docker pull asyncaws/testing-sqs
+      docker run -d -p 9494:9494 --name sqs asyncaws/testing-sqs
 
     - |
       # Start Kafka and install an up-to-date librdkafka

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -109,7 +109,7 @@ class ConnectionTest extends TestCase
         $queueUrl = $this->handleGetQueueUrl(0, $httpClient);
 
         $httpClient->expects($this->at(1))->method('request')
-            ->with('POST', $queueUrl, ['body' => ['Action' => 'ReceiveMessage', 'VisibilityTimeout' => null, 'MaxNumberOfMessages' => 9, 'WaitTimeSeconds' => 20]])
+            ->with('POST', $queueUrl, ['body' => ['Action' => 'ReceiveMessage', 'VisibilityTimeout' => null, 'MaxNumberOfMessages' => 9, 'WaitTimeSeconds' => 20, 'MessageAttributeName.1' => 'All']])
             ->willReturn($response);
         $response->expects($this->once())->method('getContent')->willReturn('<ReceiveMessageResponse>
           <ReceiveMessageResult>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | NA
| License       | MIT
| Doc PR        | NA

The Symfony Messenger component provides a SerializerInterface to encode/decode the `Envelope`, this can be used to improve the Interoperability (see [article from jolicode](https://jolicode.com/blog/symfony-messenger-et-linteroperabilite) (french))

Sadly, the current implementation of SQS adapter json_encode the elements of the `Envelope` (`string body` + `string[] headers`) and store everything in the SQS message `Body`. That partially defect the interoperability: 3rd party have to also wrap (unwrap) message form json_encoded Body. 

This PR leverage the AWS SQS `Body` and `MessageAttribute` properties to store message information:

```yaml
# before
SQS Message:
  Body: {"body": "hello world", "headers": {"foo": "bar"}}
  MessageAttributes: {}

# after
SQS Message:
  Body: hello world
  MessageAttributes:
    foor: bar
```

