### PR TITLE
[Cache] Allow invalidateTags calls to be traced by data collector

### DIFF
--- a/src/Symfony/Component/Cache/DependencyInjection/CacheCollectorPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CacheCollectorPass.php
@@ -46,29 +46,38 @@ class CacheCollectorPass implements CompilerPassInterface
             return;
         }
 
-        $collectorDefinition = $container->getDefinition($this->dataCollectorCacheId);
         foreach ($container->findTaggedServiceIds($this->cachePoolTag) as $id => $attributes) {
-            $definition = $container->getDefinition($id);
-            if ($definition->isAbstract()) {
-                continue;
+            $this->addToCollector($id, $container);
+
+            if (($attributes[0]['name'] ?? $id) !== $id) {
+                $this->addToCollector($attributes[0]['name'], $container);
             }
-
-            $recorder = new Definition(is_subclass_of($definition->getClass(), TagAwareAdapterInterface::class) ? TraceableTagAwareAdapter::class : TraceableAdapter::class);
-            $recorder->setTags($definition->getTags());
-            if (!$definition->isPublic() || !$definition->isPrivate()) {
-                $recorder->setPublic($definition->isPublic());
-            }
-            $recorder->setArguments([new Reference($innerId = $id.$this->cachePoolRecorderInnerSuffix)]);
-
-            $definition->setTags([]);
-            $definition->setPublic(false);
-
-            $container->setDefinition($innerId, $definition);
-            $container->setDefinition($id, $recorder);
-
-            // Tell the collector to add the new instance
-            $collectorDefinition->addMethodCall('addInstance', [$id, new Reference($id)]);
-            $collectorDefinition->setPublic(false);
         }
+    }
+
+    private function addToCollector(string $id, ContainerBuilder $container)
+    {
+        $definition = $container->getDefinition($id);
+        if ($definition->isAbstract()) {
+            return;
+        }
+
+        $collectorDefinition = $container->getDefinition($this->dataCollectorCacheId);
+        $recorder = new Definition(is_subclass_of($definition->getClass(), TagAwareAdapterInterface::class) ? TraceableTagAwareAdapter::class : TraceableAdapter::class);
+        $recorder->setTags($definition->getTags());
+        if (!$definition->isPublic() || !$definition->isPrivate()) {
+            $recorder->setPublic($definition->isPublic());
+        }
+        $recorder->setArguments([new Reference($innerId = $id.$this->cachePoolRecorderInnerSuffix)]);
+
+        $definition->setTags([]);
+        $definition->setPublic(false);
+
+        $container->setDefinition($innerId, $definition);
+        $container->setDefinition($id, $recorder);
+
+        // Tell the collector to add the new instance
+        $collectorDefinition->addMethodCall('addInstance', [$id, new Reference($id)]);
+        $collectorDefinition->setPublic(false);
     }
 }

--- a/src/Symfony/Component/Cache/Tests/DependencyInjection/CacheCollectorPassTest.php
+++ b/src/Symfony/Component/Cache/Tests/DependencyInjection/CacheCollectorPassTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Adapter\TraceableAdapter;
 use Symfony\Component\Cache\Adapter\TraceableTagAwareAdapter;
@@ -34,16 +35,29 @@ class CacheCollectorPassTest extends TestCase
             ->addArgument(new Reference('fs'))
             ->addTag('cache.pool');
 
+        $container
+            ->register('.php.inner', PhpArrayAdapter::class)
+            ->addTag('cache.pool', ['name' => 'php']);
+        $container
+            ->register('php', TagAwareAdapter::class)
+            ->addArgument(new Reference('.php.inner'));
+
         $collector = $container->register('data_collector.cache', CacheDataCollector::class);
         (new CacheCollectorPass())->process($container);
 
         $this->assertEquals([
             ['addInstance', ['fs', new Reference('fs')]],
             ['addInstance', ['tagged_fs', new Reference('tagged_fs')]],
+            ['addInstance', ['.php.inner', new Reference('.php.inner')]],
+            ['addInstance', ['php', new Reference('php')]],
         ], $collector->getMethodCalls());
 
         $this->assertSame(TraceableAdapter::class, $container->findDefinition('fs')->getClass());
         $this->assertSame(TraceableTagAwareAdapter::class, $container->getDefinition('tagged_fs')->getClass());
+
+        $this->assertSame(TraceableAdapter::class, $container->findDefinition('.php.inner')->getClass());
+        $this->assertSame(TraceableTagAwareAdapter::class, $container->getDefinition('php')->getClass());
+
         $this->assertFalse($collector->isPublic(), 'The "data_collector.cache" should be private after processing');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #34810
| License       | MIT
| Doc PR        | 

`TraceableTagAwareAdapter` is not used in the fullstack framework since tag aware pools don't have the `cache.pool` tag (it's the decorated adapter that has it). This PR aims to use `TraceableTagAwareAdapter` when a pool is configured with `tags: true`