### PR TITLE
Kernel: Make sure cache file actually exists before trying to include it

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -455,7 +455,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
                 if (!flock($lock, $wouldBlock ? LOCK_SH : LOCK_EX)) {
                     fclose($lock);
                     $lock = null;
-                } elseif (!\is_object($this->container = include $cachePath)) {
+                } elseif (!file_exists($cachePath) || !\is_object($this->container = include $cachePath)) {
                     $this->container = null;
                 } elseif (!$oldContainer || \get_class($this->container) !== $oldContainer->name) {
                     flock($lock, LOCK_UN);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0 (haven't tested older versions)
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | See #36532
| License       | MIT
| Doc PR        | 

It can happen that the cache file has been deleted on disk, but its contents are still in opcache (see #36532). So before we try including the cache file, make sure it still actually exists on the file system. Otherwise, we might run with an incomplete cache (container has been included, but all the service files are gone). It's a bit hard to reproduce the issue in a unit test because it only occurs when the cache file has been created in an earlier request (i.e. not in the same runtime), but the steps in #36532 demonstrate how this can come to be 
