### PR TITLE
WIP: Add possibility to clean or write http cache in on terminate

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -248,6 +248,10 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      */
     public function terminate(Request $request, Response $response)
     {
+        if ($this->getStore() instanceof TerminableInterface) {
+            $this->getStore()->terminate($request, $response);
+        }
+
         if ($this->getKernel() instanceof TerminableInterface) {
             $this->getKernel()->terminate($request, $response);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #...
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

It would be great to do the pruning of the [PSR6HttpCache](https://github.com/Toflar/psr6-symfony-http-cache-store/blob/7e8e3638b0a660ffef6a196b62ce596e1d55b72a/src/Psr6Store.php#L544) in terminate instead of doing it directly in the requests, so the page is available as fast as possible. Theoretically we could also move the whole cache write process into the terminate [like here](https://github.com/Toflar/psr6-symfony-http-cache-store/pull/33/files).

What do you think does this make any sense? @Toflar, @dbu, @andrerom

#### TODO

 - [ ] Tests