### PR TITLE
[Validator] Allow multiple atPath() on ConstraintViolationBuilder

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.1.0
 -----
 
+ * allow multiple `atPath()` on ConstraintViolationBuilder
  * added the `Hostname` constraint and validator
  * added the `alpha3` option to the `Country` and `Language` constraints
  * allow to define a reusable set of constraints by extending the `Compound` constraint

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationBuilderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Translator;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilder;
+
+class ConstraintViolationBuilderTest extends TestCase
+{
+    private $violations;
+    private $builder;
+
+    protected function setUp(): void
+    {
+        $this->violations = new ConstraintViolationList();
+
+        $this->builder = new ConstraintViolationBuilder(
+            $this->violations,
+            new NotBlank(),
+            "myMessage",
+            [],
+            null,
+            'root',
+            null,
+            new Translator('en_EN')
+        );
+    }
+
+    public function testMultipleAtPathCall() {
+        $this->builder
+            ->atPath('firstName')
+            ->atPath('lastName')
+            ->atPath('email')
+            ->addViolation();
+
+        $violationFirst = $this->violations->get(0);
+        $violationLast = $this->violations->get(2);
+
+        $this->assertCount(3, $this->violations);
+        $this->assertEquals('root.firstName', $violationFirst->getPropertyPath());
+        $this->assertEquals('myMessage', $violationFirst->getMessage());
+        $this->assertEquals('root.email', $violationLast->getPropertyPath());
+        $this->assertEquals('myMessage', $violationLast->getMessage());
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationBuilderTest.php
@@ -29,7 +29,7 @@ class ConstraintViolationBuilderTest extends TestCase
         $this->builder = new ConstraintViolationBuilder(
             $this->violations,
             new NotBlank(),
-            "myMessage",
+            'myMessage',
             [],
             null,
             'root',
@@ -38,7 +38,8 @@ class ConstraintViolationBuilderTest extends TestCase
         );
     }
 
-    public function testMultipleAtPathCall() {
+    public function testMultipleAtPathCall()
+    {
         $this->builder
             ->atPath('firstName')
             ->atPath('lastName')

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
@@ -146,6 +146,8 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
      */
     public function addViolation()
     {
+        $paths = empty($this->propertyPaths) ? [$this->basePropertyPath] : $this->propertyPaths;
+
         if (null === $this->plural) {
             $translatedMessage = $this->translator->trans(
                 $this->message,
@@ -160,7 +162,7 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
             );
         }
 
-        foreach ($this->propertyPaths as $propertyPath) {
+        foreach ($paths as $propertyPath) {
             $this->violations->add(new ConstraintViolation(
                 $translatedMessage,
                 $this->message,

--- a/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
+++ b/src/Symfony/Component/Validator/Violation/ConstraintViolationBuilder.php
@@ -31,7 +31,8 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
     private $parameters;
     private $root;
     private $invalidValue;
-    private $propertyPath;
+    private $basePropertyPath;
+    private $propertyPaths;
     private $translator;
     private $translationDomain;
     private $plural;
@@ -52,7 +53,8 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
         $this->message = $message;
         $this->parameters = $parameters;
         $this->root = $root;
-        $this->propertyPath = $propertyPath;
+        $this->basePropertyPath = $propertyPath;
+        $this->propertyPaths = [];
         $this->invalidValue = $invalidValue;
         $this->translator = $translator;
         $this->translationDomain = $translationDomain;
@@ -64,7 +66,7 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
      */
     public function atPath(string $path)
     {
-        $this->propertyPath = PropertyPath::append($this->propertyPath, $path);
+        $this->propertyPaths[] = PropertyPath::append($this->basePropertyPath, $path);
 
         return $this;
     }
@@ -158,17 +160,19 @@ class ConstraintViolationBuilder implements ConstraintViolationBuilderInterface
             );
         }
 
-        $this->violations->add(new ConstraintViolation(
-            $translatedMessage,
-            $this->message,
-            $this->parameters,
-            $this->root,
-            $this->propertyPath,
-            $this->invalidValue,
-            $this->plural,
-            $this->code,
-            $this->constraint,
-            $this->cause
-        ));
+        foreach ($this->propertyPaths as $propertyPath) {
+            $this->violations->add(new ConstraintViolation(
+                $translatedMessage,
+                $this->message,
+                $this->parameters,
+                $this->root,
+                $propertyPath,
+                $this->invalidValue,
+                $this->plural,
+                $this->code,
+                $this->constraint,
+                $this->cause
+            ));
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36544 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Allow multiple `atPath()` in `ConstraintViolationBuilder` to add multiple `ConstraintViolation`s at the same time.