### PR TITLE
Use is_file() instead of file_exists() where possible

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -198,7 +198,7 @@ class KernelBrowser extends HttpKernelBrowser
             if (0 === strpos($class, 'ComposerAutoloaderInit')) {
                 $r = new \ReflectionClass($class);
                 $file = \dirname($r->getFileName(), 2).'/autoload.php';
-                if (file_exists($file)) {
+                if (is_file($file)) {
                     $requires .= 'require_once '.var_export($file, true).";\n";
                 }
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/DotenvVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/DotenvVault.php
@@ -38,7 +38,7 @@ class DotenvVault extends AbstractVault
         $this->validateName($name);
         $v = str_replace("'", "'\\''", $value);
 
-        $content = file_exists($this->dotenvFile) ? file_get_contents($this->dotenvFile) : '';
+        $content = is_file($this->dotenvFile) ? file_get_contents($this->dotenvFile) : '';
         $content = preg_replace("/^$name=((\\\\'|'[^']++')++|.*)/m", "$name='$v'", $content, -1, $count);
 
         if (!$count) {
@@ -70,7 +70,7 @@ class DotenvVault extends AbstractVault
         $this->lastMessage = null;
         $this->validateName($name);
 
-        $content = file_exists($this->dotenvFile) ? file_get_contents($this->dotenvFile) : '';
+        $content = is_file($this->dotenvFile) ? file_get_contents($this->dotenvFile) : '';
         $content = preg_replace("/^$name=((\\\\'|'[^']++')++|.*)\n?/m", '', $content, -1, $count);
 
         if ($count) {

--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
@@ -58,7 +58,7 @@ class SodiumVault extends AbstractVault implements EnvVarLoaderInterface
             // ignore failures to load keys
         }
 
-        if ('' !== $this->decryptionKey && !file_exists($this->pathPrefix.'encrypt.public.php')) {
+        if ('' !== $this->decryptionKey && !is_file($this->pathPrefix.'encrypt.public.php')) {
             $this->export('encrypt.public', $this->encryptionKey);
         }
 
@@ -99,7 +99,7 @@ class SodiumVault extends AbstractVault implements EnvVarLoaderInterface
         $this->lastMessage = null;
         $this->validateName($name);
 
-        if (!file_exists($file = $this->pathPrefix.$name.'.'.substr_replace(md5($name), '.php', -26))) {
+        if (!is_file($file = $this->pathPrefix.$name.'.'.substr_replace(md5($name), '.php', -26))) {
             $this->lastMessage = sprintf('Secret "%s" not found in "%s".', $name, $this->getPrettyPath(\dirname($this->pathPrefix).\DIRECTORY_SEPARATOR));
 
             return null;
@@ -133,7 +133,7 @@ class SodiumVault extends AbstractVault implements EnvVarLoaderInterface
         $this->lastMessage = null;
         $this->validateName($name);
 
-        if (!file_exists($file = $this->pathPrefix.$name.'.'.substr_replace(md5($name), '.php', -26))) {
+        if (!is_file($file = $this->pathPrefix.$name.'.'.substr_replace(md5($name), '.php', -26))) {
             $this->lastMessage = sprintf('Secret "%s" not found in "%s".', $name, $this->getPrettyPath(\dirname($this->pathPrefix).\DIRECTORY_SEPARATOR));
 
             return false;
@@ -152,7 +152,7 @@ class SodiumVault extends AbstractVault implements EnvVarLoaderInterface
     {
         $this->lastMessage = null;
 
-        if (!file_exists($file = $this->pathPrefix.'list.php')) {
+        if (!is_file($file = $this->pathPrefix.'list.php')) {
             return [];
         }
 
@@ -184,11 +184,11 @@ class SodiumVault extends AbstractVault implements EnvVarLoaderInterface
             return;
         }
 
-        if (file_exists($this->pathPrefix.'decrypt.private.php')) {
+        if (is_file($this->pathPrefix.'decrypt.private.php')) {
             $this->decryptionKey = (string) include $this->pathPrefix.'decrypt.private.php';
         }
 
-        if (file_exists($this->pathPrefix.'encrypt.public.php')) {
+        if (is_file($this->pathPrefix.'encrypt.public.php')) {
             $this->encryptionKey = (string) include $this->pathPrefix.'encrypt.public.php';
         } elseif ('' !== $this->decryptionKey) {
             $this->encryptionKey = sodium_crypto_box_publickey($this->decryptionKey);

--- a/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
@@ -53,7 +53,7 @@ class JsonManifestVersionStrategy implements VersionStrategyInterface
     private function getManifestPath(string $path): ?string
     {
         if (null === $this->manifestData) {
-            if (!file_exists($this->manifestPath)) {
+            if (!is_file($this->manifestPath)) {
                 throw new \RuntimeException(sprintf('Asset manifest file "%s" does not exist.', $this->manifestPath));
             }
 

--- a/src/Symfony/Component/Cache/Adapter/FilesystemTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/FilesystemTagAwareAdapter.php
@@ -65,11 +65,11 @@ class FilesystemTagAwareAdapter extends AbstractTagAwareAdapter implements Prune
                 }
 
                 for ($i = 0; $i < 38; ++$i) {
-                    if (!file_exists($dir.$chars[$i])) {
+                    if (!is_dir($dir.$chars[$i])) {
                         continue;
                     }
                     for ($j = 0; $j < 38; ++$j) {
-                        if (!file_exists($d = $dir.$chars[$i].\DIRECTORY_SEPARATOR.$chars[$j])) {
+                        if (!is_dir($d = $dir.$chars[$i].\DIRECTORY_SEPARATOR.$chars[$j])) {
                             continue;
                         }
                         foreach (scandir($d, SCANDIR_SORT_NONE) ?: [] as $link) {
@@ -136,7 +136,7 @@ class FilesystemTagAwareAdapter extends AbstractTagAwareAdapter implements Prune
     {
         foreach ($ids as $id) {
             $file = $this->getFile($id);
-            if (!file_exists($file) || !$h = @fopen($file, 'rb')) {
+            if (!is_file($file) || !$h = @fopen($file, 'rb')) {
                 continue;
             }
 
@@ -193,7 +193,7 @@ class FilesystemTagAwareAdapter extends AbstractTagAwareAdapter implements Prune
     protected function doInvalidate(array $tagIds): bool
     {
         foreach ($tagIds as $tagId) {
-            if (!file_exists($tagFolder = $this->getTagFolder($tagId))) {
+            if (!is_dir($tagFolder = $this->getTagFolder($tagId))) {
                 continue;
             }
 

--- a/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PhpArrayAdapter.php
@@ -390,7 +390,7 @@ EOF;
     {
         if (isset(self::$valuesCache[$this->file])) {
             $values = self::$valuesCache[$this->file];
-        } elseif (!file_exists($this->file)) {
+        } elseif (!is_file($this->file)) {
             $this->keys = $this->values = [];
 
             return;

--- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
@@ -38,7 +38,7 @@ trait FilesystemCommonTrait
         } else {
             $directory .= \DIRECTORY_SEPARATOR.'@';
         }
-        if (!file_exists($directory)) {
+        if (!is_dir($directory)) {
             @mkdir($directory, 0777, true);
         }
         $directory .= \DIRECTORY_SEPARATOR;
@@ -77,7 +77,7 @@ trait FilesystemCommonTrait
 
         foreach ($ids as $id) {
             $file = $this->getFile($id);
-            $ok = (!file_exists($file) || $this->doUnlink($file) || !file_exists($file)) && $ok;
+            $ok = (!is_file($file) || $this->doUnlink($file) || !file_exists($file)) && $ok;
         }
 
         return $ok;
@@ -113,7 +113,7 @@ trait FilesystemCommonTrait
         $hash = str_replace('/', '-', base64_encode(hash('md5', static::class.$id, true)));
         $dir = ($directory ?? $this->directory).strtoupper($hash[0].\DIRECTORY_SEPARATOR.$hash[1].\DIRECTORY_SEPARATOR);
 
-        if ($mkdir && !file_exists($dir)) {
+        if ($mkdir && !is_dir($dir)) {
             @mkdir($dir, 0777, true);
         }
 
@@ -127,19 +127,19 @@ trait FilesystemCommonTrait
 
     private function scanHashDir(string $directory): \Generator
     {
-        if (!file_exists($directory)) {
+        if (!is_dir($directory)) {
             return;
         }
 
         $chars = '+-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 
         for ($i = 0; $i < 38; ++$i) {
-            if (!file_exists($directory.$chars[$i])) {
+            if (!is_dir($directory.$chars[$i])) {
                 continue;
             }
 
             for ($j = 0; $j < 38; ++$j) {
-                if (!file_exists($dir = $directory.$chars[$i].\DIRECTORY_SEPARATOR.$chars[$j])) {
+                if (!is_dir($dir = $directory.$chars[$i].\DIRECTORY_SEPARATOR.$chars[$j])) {
                     continue;
                 }
 
@@ -178,7 +178,7 @@ trait FilesystemCommonTrait
         if (method_exists(parent::class, '__destruct')) {
             parent::__destruct();
         }
-        if (null !== $this->tmp && file_exists($this->tmp)) {
+        if (null !== $this->tmp && is_file($this->tmp)) {
             unlink($this->tmp);
         }
     }

--- a/src/Symfony/Component/Cache/Traits/FilesystemTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemTrait.php
@@ -59,7 +59,7 @@ trait FilesystemTrait
 
         foreach ($ids as $id) {
             $file = $this->getFile($id);
-            if (!file_exists($file) || !$h = @fopen($file, 'rb')) {
+            if (!is_file($file) || !$h = @fopen($file, 'rb')) {
                 continue;
             }
             if (($expiresAt = (int) fgets($h)) && $now >= $expiresAt) {
@@ -85,7 +85,7 @@ trait FilesystemTrait
     {
         $file = $this->getFile($id);
 
-        return file_exists($file) && (@filemtime($file) > time() || $this->doFetch([$id]));
+        return is_file($file) && (@filemtime($file) > time() || $this->doFetch([$id]));
     }
 
     /**

--- a/src/Symfony/Component/Config/Resource/ComposerResource.php
+++ b/src/Symfony/Component/Config/Resource/ComposerResource.php
@@ -61,7 +61,7 @@ class ComposerResource implements SelfCheckingResourceInterface
             if ('C' === $class[0] && 0 === strpos($class, 'ComposerAutoloaderInit')) {
                 $r = new \ReflectionClass($class);
                 $v = \dirname($r->getFileName(), 2);
-                if (file_exists($v.'/composer/installed.json')) {
+                if (is_file($v.'/composer/installed.json')) {
                     self::$runtimeVendors[$v] = @filemtime($v.'/composer/installed.json');
                 }
             }

--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -83,7 +83,7 @@ class ReflectionClassResource implements SelfCheckingResourceInterface
         }
         do {
             $file = $class->getFileName();
-            if (false !== $file && file_exists($file)) {
+            if (false !== $file && is_file($file)) {
                 foreach ($this->excludedVendors as $vendor) {
                     if (0 === strpos($file, $vendor) && false !== strpbrk(substr($file, \strlen($vendor), 1), '/'.\DIRECTORY_SEPARATOR)) {
                         $file = false;

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -114,7 +114,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             if (!is_scalar($file = $getEnv($name))) {
                 throw new RuntimeException(sprintf('Invalid file name: env var "%s" is non-scalar.', $name));
             }
-            if (!file_exists($file)) {
+            if (!is_file($file)) {
                 throw new EnvNotFoundException(sprintf('File "%s" not found (resolved from "%s").', $file, $name));
             }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -670,7 +670,7 @@ class YamlFileLoader extends FileLoader
             throw new InvalidArgumentException(sprintf('This is not a local file "%s".', $file));
         }
 
-        if (!file_exists($file)) {
+        if (!is_file($file)) {
             throw new InvalidArgumentException(sprintf('The file "%s" does not exist.', $file));
         }
 

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -110,7 +110,7 @@ final class Dotenv
     {
         $k = $envKey ?? $this->envKey;
 
-        if (file_exists($path) || !file_exists($p = "$path.dist")) {
+        if (is_file($path) || !is_file($p = "$path.dist")) {
             $this->load($path);
         } else {
             $this->load($p);
@@ -120,7 +120,7 @@ final class Dotenv
             $this->populate([$k => $env = $defaultEnv]);
         }
 
-        if (!\in_array($env, $testEnvs, true) && file_exists($p = "$path.local")) {
+        if (!\in_array($env, $testEnvs, true) && is_file($p = "$path.local")) {
             $this->load($p);
             $env = $_SERVER[$k] ?? $_ENV[$k] ?? $env;
         }
@@ -129,11 +129,11 @@ final class Dotenv
             return;
         }
 
-        if (file_exists($p = "$path.$env")) {
+        if (is_file($p = "$path.$env")) {
             $this->load($p);
         }
 
-        if (file_exists($p = "$path.$env.local")) {
+        if (is_file($p = "$path.$env.local")) {
             $this->load($p);
         }
     }
@@ -148,7 +148,7 @@ final class Dotenv
     public function bootEnv(string $path, string $defaultEnv = 'dev', array $testEnvs = ['test']): void
     {
         $p = $path.'.local.php';
-        $env = (\function_exists('opcache_is_script_cached') && @opcache_is_script_cached($p)) || file_exists($p) ? include $p : null;
+        $env = is_file($p) ? include $p : null;
         $k = $this->envKey;
 
         if (\is_array($env) && (!isset($env[$k]) || ($_SERVER[$k] ?? $_ENV[$k] ?? $env[$k]) === $env[$k])) {

--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -185,7 +185,7 @@ class DebugClassLoader
         ];
 
         if (!isset(self::$caseCheck)) {
-            $file = file_exists(__FILE__) ? __FILE__ : rtrim(realpath('.'), \DIRECTORY_SEPARATOR);
+            $file = is_file(__FILE__) ? __FILE__ : rtrim(realpath('.'), \DIRECTORY_SEPARATOR);
             $i = strrpos($file, \DIRECTORY_SEPARATOR);
             $dir = substr($file, 0, 1 + $i);
             $file = substr($file, 1 + $i);
@@ -904,7 +904,7 @@ class DebugClassLoader
         static $patchedMethods = [];
         static $useStatements = [];
 
-        if (!file_exists($file = $method->getFileName()) || isset($patchedMethods[$file][$startLine = $method->getStartLine()])) {
+        if (!is_file($file = $method->getFileName()) || isset($patchedMethods[$file][$startLine = $method->getStartLine()])) {
             return;
         }
 
@@ -1002,7 +1002,7 @@ EOTXT;
         $useMap = [];
         $useOffset = 0;
 
-        if (!file_exists($file)) {
+        if (!is_file($file)) {
             return [$namespace, $useOffset, $useMap];
         }
 
@@ -1045,7 +1045,7 @@ EOTXT;
             return;
         }
 
-        if (!file_exists($file = $method->getFileName())) {
+        if (!is_file($file = $method->getFileName())) {
             return;
         }
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -280,12 +280,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         if (null === $this->projectDir) {
             $r = new \ReflectionObject($this);
 
-            if (!file_exists($dir = $r->getFileName())) {
+            if (!is_file($dir = $r->getFileName())) {
                 throw new \LogicException(sprintf('Cannot auto-detect project dir for kernel of class "%s".', $r->name));
             }
 
             $dir = $rootDir = \dirname($dir);
-            while (!file_exists($dir.'/composer.json')) {
+            while (!is_file($dir.'/composer.json')) {
                 if ($dir === \dirname($dir)) {
                     return $this->projectDir = $rootDir;
                 }
@@ -432,7 +432,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $errorLevel = error_reporting(E_ALL ^ E_WARNING);
 
         try {
-            if (file_exists($cachePath) && \is_object($this->container = include $cachePath)
+            if (is_file($cachePath) && \is_object($this->container = include $cachePath)
                 && (!$this->debug || (self::$freshCache[$cachePath] ?? $cache->isFresh()))
             ) {
                 self::$freshCache[$cachePath] = true;

--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -212,7 +212,7 @@ class ExceptionCaster
                 $ellipsisTail = isset($ellipsis->attr['ellipsis-tail']) ? $ellipsis->attr['ellipsis-tail'] : 0;
                 $ellipsis = isset($ellipsis->attr['ellipsis']) ? $ellipsis->attr['ellipsis'] : 0;
 
-                if (file_exists($f['file']) && 0 <= self::$srcContext) {
+                if (is_file($f['file']) && 0 <= self::$srcContext) {
                     if (!empty($f['class']) && (is_subclass_of($f['class'], 'Twig\Template') || is_subclass_of($f['class'], 'Twig_Template')) && method_exists($f['class'], 'getDebugInfo')) {
                         $template = isset($f['object']) ? $f['object'] : unserialize(sprintf('O:%d:"%s":0:{}', \strlen($f['class']), $f['class']));
 
@@ -220,7 +220,7 @@ class ExceptionCaster
                         $templateSrc = method_exists($template, 'getSourceContext') ? $template->getSourceContext()->getCode() : (method_exists($template, 'getSource') ? $template->getSource() : '');
                         $templateInfo = $template->getDebugInfo();
                         if (isset($templateInfo[$f['line']])) {
-                            if (!method_exists($template, 'getSourceContext') || !file_exists($templatePath = $template->getSourceContext()->getPath())) {
+                            if (!method_exists($template, 'getSourceContext') || !is_file($templatePath = $template->getSourceContext()->getPath())) {
                                 $templatePath = null;
                             }
                             if ($templateSrc) {

--- a/src/Symfony/Component/VarDumper/Caster/LinkStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/LinkStub.php
@@ -43,7 +43,7 @@ class LinkStub extends ConstStub
 
             return;
         }
-        if (!file_exists($href)) {
+        if (!is_file($href)) {
             return;
         }
         if ($line) {
@@ -72,7 +72,7 @@ class LinkStub extends ConstStub
                 if ('C' === $class[0] && 0 === strpos($class, 'ComposerAutoloaderInit')) {
                     $r = new \ReflectionClass($class);
                     $v = \dirname($r->getFileName(), 2);
-                    if (file_exists($v.'/composer/installed.json')) {
+                    if (is_file($v.'/composer/installed.json')) {
                         self::$vendorRoots[] = $v.\DIRECTORY_SEPARATOR;
                     }
                 }
@@ -91,7 +91,7 @@ class LinkStub extends ConstStub
         }
 
         $parent = $dir;
-        while (!@file_exists($parent.'/composer.json')) {
+        while (!@is_file($parent.'/composer.json')) {
             if (!@file_exists($parent)) {
                 // open_basedir restriction in effect
                 break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36493
| License       | MIT
| Doc PR        | -

Thanks to caching, `is_file()` is much faster than `file_exists()`.
I screened the codebase for places where it could matter, here they are.