### PR TITLE
[WebProfilerBundle] changed label of peak memory usage in the time & memory panels (MB into MiB)

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/memory.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/memory.html.twig
@@ -5,18 +5,18 @@
         {% set status_color = (collector.memory / 1024 / 1024) > 50 ? 'yellow' : '' %}
         {{ include('@WebProfiler/Icon/memory.svg') }}
         <span class="sf-toolbar-value">{{ '%.1f'|format(collector.memory / 1024 / 1024) }}</span>
-        <span class="sf-toolbar-label">MB</span>
+        <span class="sf-toolbar-label">MiB</span>
     {% endset %}
 
     {% set text %}
         <div class="sf-toolbar-info-piece">
             <b>Peak memory usage</b>
-            <span>{{ '%.1f'|format(collector.memory / 1024 / 1024) }} MB</span>
+            <span>{{ '%.1f'|format(collector.memory / 1024 / 1024) }} MiB</span>
         </div>
 
         <div class="sf-toolbar-info-piece">
             <b>PHP memory limit</b>
-            <span>{{ collector.memoryLimit == -1 ? 'Unlimited' : '%.0f MB'|format(collector.memoryLimit / 1024 / 1024) }}</span>
+            <span>{{ collector.memoryLimit == -1 ? 'Unlimited' : '%.0f MiB'|format(collector.memoryLimit / 1024 / 1024) }}</span>
         </div>
     {% endset %}
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -64,7 +64,7 @@
 
         {% if profile.collectors.memory %}
             <div class="metric">
-                <span class="value">{{ '%.2f'|format(profile.collectors.memory.memory / 1024 / 1024) }} <span class="unit">MB</span></span>
+                <span class="value">{{ '%.2f'|format(profile.collectors.memory.memory / 1024 / 1024) }} <span class="unit">MiB</span></span>
                 <span class="label">Peak memory usage</span>
             </div>
         {% endif %}
@@ -386,7 +386,7 @@
                     ctx.fillStyle = "#444";
                     ctx.font = "12px sans-serif";
                     text = event.name;
-                    ms = "  " + (event.duration < 1 ? event.duration : parseInt(event.duration, 10)) + " ms / " + event.memory + " MB";
+                    ms = "  " + (event.duration < 1 ? event.duration : parseInt(event.duration, 10)) + " ms / " + event.memory + " MiB";
                     if (x + event.starttime * ratio + ctx.measureText(text + ms).width > width) {
                         ctx.textAlign = "end";
                         ctx.font = "10px sans-serif";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36533
| License       | MIT
| Doc PR        | none
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
This PR changes the label of the peak memory usage from `MB` into `MiB` in the time and memory panels of the web profiler, as discussed in #36533.

The changed file `Resources/views/Collector/time.html.twig` is completely updated by commit https://github.com/symfony/web-profiler-bundle/commit/c9433b00905b2d910559c1c14ac4dab7b0218ddc for v4.3. So for correctly displaying the label in 4.4 (& 5.0), the file `Resources/views/Collector/time.js` needs to be updated.
