### PR TITLE
[Security] Require entry_point to be configured with multiple authenticators

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -109,6 +109,14 @@ Routing
  * Added argument `$priority` to `RouteCollection::add()`
  * Deprecated the `RouteCompiler::REGEX_DELIMITER` constant
 
+SecurityBundle
+--------------
+
+ * Marked the `AbstractFactory`, `AnonymousFactory`, `FormLoginFactory`, `FormLoginLdapFactory`, `GuardAuthenticationFactory`,
+   `HttpBasicFactory`, `HttpBasicLdapFactory`, `JsonLoginFactory`, `JsonLoginLdapFactory`, `RememberMeFactory`, `RemoteUserFactory`
+   and `X509Factory` as `@internal`. Instead of extending these classes, create your own implementation based on
+   `SecurityFactoryInterface`.
+
 Security
 --------
 

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Added XSD for configuration
  * Added security configuration for priority-based access decision strategy
+ * Marked the `AbstractFactory`, `AnonymousFactory`, `FormLoginFactory`, `FormLoginLdapFactory`, `GuardAuthenticationFactory`, `HttpBasicFactory`, `HttpBasicLdapFactory`, `JsonLoginFactory`, `JsonLoginLdapFactory`, `RememberMeFactory`, `RemoteUserFactory` and `X509Factory` as `@internal`
+ * Renamed method `AbstractFactory#createEntryPoint()` to `AbstractFactory#createDefaultEntryPoint()`
 
 5.0.0
 -----

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -23,6 +23,8 @@ use Symfony\Component\DependencyInjection\Reference;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @internal
  */
 abstract class AbstractFactory implements SecurityFactoryInterface
 {
@@ -65,7 +67,7 @@ abstract class AbstractFactory implements SecurityFactoryInterface
         }
 
         // create entry point if applicable (optional)
-        $entryPointId = $this->createEntryPoint($container, $id, $config, $defaultEntryPointId);
+        $entryPointId = $this->createDefaultEntryPoint($container, $id, $config, $defaultEntryPointId);
 
         return [$authProviderId, $listenerId, $entryPointId];
     }
@@ -126,7 +128,7 @@ abstract class AbstractFactory implements SecurityFactoryInterface
      *
      * @return string|null the entry point id
      */
-    protected function createEntryPoint(ContainerBuilder $container, string $id, array $config, ?string $defaultEntryPointId)
+    protected function createDefaultEntryPoint(ContainerBuilder $container, string $id, array $config, ?string $defaultEntryPointId)
     {
         return $defaultEntryPointId;
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AnonymousFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AnonymousFactory.php
@@ -18,6 +18,8 @@ use Symfony\Component\DependencyInjection\Parameter;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
+ *
+ * @internal
  */
 class AnonymousFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface
 {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/CustomAuthenticatorFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/CustomAuthenticatorFactory.php
@@ -15,6 +15,12 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ *
+ * @internal
+ * @experimental in Symfony 5.1
+ */
 class CustomAuthenticatorFactory implements AuthenticatorFactoryInterface, SecurityFactoryInterface
 {
     public function create(ContainerBuilder $container, string $id, array $config, string $userProvider, ?string $defaultEntryPoint)

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/EntryPointFactoryInterface.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/EntryPointFactoryInterface.php
@@ -23,5 +23,5 @@ interface EntryPointFactoryInterface
     /**
      * Creates the entry point and returns the service ID.
      */
-    public function createEntryPoint(ContainerBuilder $container, string $id, array $config, ?string $defaultEntryPointId): string;
+    public function createEntryPoint(ContainerBuilder $container, string $id, array $config): ?string;
 }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
@@ -22,6 +22,8 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @internal
  */
 class FormLoginFactory extends AbstractFactory implements AuthenticatorFactoryInterface, EntryPointFactoryInterface
 {
@@ -90,7 +92,12 @@ class FormLoginFactory extends AbstractFactory implements AuthenticatorFactoryIn
         return $listenerId;
     }
 
-    public function createEntryPoint(ContainerBuilder $container, string $id, array $config, ?string $defaultEntryPoint): string
+    protected function createDefaultEntryPoint(ContainerBuilder $container, string $id, array $config, ?string $defaultEntryPointId)
+    {
+        return $this->createEntryPoint($container, $id, $config);
+    }
+
+    public function createEntryPoint(ContainerBuilder $container, string $id, array $config): string
     {
         $entryPointId = 'security.authentication.form_entry_point.'.$id;
         $container

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginLdapFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginLdapFactory.php
@@ -22,6 +22,8 @@ use Symfony\Component\Security\Core\Exception\LogicException;
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Charles Sarrazin <charles@sarraz.in>
+ *
+ * @internal
  */
 class FormLoginLdapFactory extends FormLoginFactory
 {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/GuardAuthenticationFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/GuardAuthenticationFactory.php
@@ -23,6 +23,8 @@ use Symfony\Component\Security\Guard\Authenticator\GuardBridgeAuthenticator;
  * Configures the "guard" authentication provider key under a firewall.
  *
  * @author Ryan Weaver <ryan@knpuniversity.com>
+ *
+ * @internal
  */
 class GuardAuthenticationFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface, EntryPointFactoryInterface
 {
@@ -111,9 +113,15 @@ class GuardAuthenticationFactory implements SecurityFactoryInterface, Authentica
         return $authenticatorIds;
     }
 
-    public function createEntryPoint(ContainerBuilder $container, string $id, array $config, ?string $defaultEntryPointId): string
+    public function createEntryPoint(ContainerBuilder $container, string $id, array $config): ?string
     {
-        return $this->determineEntryPoint($defaultEntryPointId, $config);
+        try {
+            return $this->determineEntryPoint(null, $config);
+        } catch (\LogicException $e) {
+            // ignore the exception, the new system prefers setting "entry_point" over "guard.entry_point"
+        }
+
+        return null;
     }
 
     private function determineEntryPoint(?string $defaultEntryPointId, array $config): string

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
@@ -20,8 +20,10 @@ use Symfony\Component\DependencyInjection\Reference;
  * HttpBasicFactory creates services for HTTP basic authentication.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @internal
  */
-class HttpBasicFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface
+class HttpBasicFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface, EntryPointFactoryInterface
 {
     public function create(ContainerBuilder $container, string $id, array $config, string $userProvider, ?string $defaultEntryPoint)
     {
@@ -34,7 +36,10 @@ class HttpBasicFactory implements SecurityFactoryInterface, AuthenticatorFactory
         ;
 
         // entry point
-        $entryPointId = $this->createEntryPoint($container, $id, $config, $defaultEntryPoint);
+        $entryPointId = $defaultEntryPoint;
+        if (null === $entryPointId) {
+            $entryPointId = $this->createEntryPoint($container, $id, $config);
+        }
 
         // listener
         $listenerId = 'security.authentication.listener.basic.'.$id;
@@ -77,12 +82,8 @@ class HttpBasicFactory implements SecurityFactoryInterface, AuthenticatorFactory
         ;
     }
 
-    protected function createEntryPoint(ContainerBuilder $container, string $id, array $config, ?string $defaultEntryPoint)
+    public function createEntryPoint(ContainerBuilder $container, string $id, array $config): string
     {
-        if (null !== $defaultEntryPoint) {
-            return $defaultEntryPoint;
-        }
-
         $entryPointId = 'security.authentication.basic_entry_point.'.$id;
         $container
             ->setDefinition($entryPointId, new ChildDefinition('security.authentication.basic_entry_point'))

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicLdapFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicLdapFactory.php
@@ -23,6 +23,8 @@ use Symfony\Component\Security\Core\Exception\LogicException;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  * @author Charles Sarrazin <charles@sarraz.in>
+ *
+ * @internal
  */
 class HttpBasicLdapFactory extends HttpBasicFactory
 {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/JsonLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/JsonLoginFactory.php
@@ -19,6 +19,8 @@ use Symfony\Component\DependencyInjection\Reference;
  * JsonLoginFactory creates services for JSON login authentication.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
+ *
+ * @internal
  */
 class JsonLoginFactory extends AbstractFactory implements AuthenticatorFactoryInterface
 {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/JsonLoginLdapFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/JsonLoginLdapFactory.php
@@ -19,6 +19,8 @@ use Symfony\Component\Security\Core\Exception\LogicException;
 
 /**
  * JsonLoginLdapFactory creates services for json login ldap authentication.
+ *
+ * @internal
  */
 class JsonLoginLdapFactory extends JsonLoginFactory
 {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -20,6 +20,9 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\Security\Http\EventListener\RememberMeLogoutListener;
 
+/**
+ * @internal
+ */
 class RememberMeFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface
 {
     protected $options = [

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RemoteUserFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RemoteUserFactory.php
@@ -21,6 +21,8 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Maxime Douailin <maxime.douailin@gmail.com>
+ *
+ * @internal
  */
 class RemoteUserFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface
 {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/X509Factory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/X509Factory.php
@@ -20,6 +20,8 @@ use Symfony\Component\DependencyInjection\Reference;
  * X509Factory creates services for X509 certificate authentication.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @internal
  */
 class X509Factory implements SecurityFactoryInterface, AuthenticatorFactoryInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | tbd

See @weaverryan's comment at https://github.com/symfony/symfony/pull/33558#discussion_r403740402: 

> I have it on my list to look at the entrypoint stuff more closely. But my gut reaction is this: let's fix them (or try to... or maybe in a PR after this) :). What I mean is this:
>
> -    It's always been confusing that your firewall may have multiple auth mechanisms that have their own "entry point"... and one is chosen seemingly at random :). I know it's not random, but why does the entrypoint from `form_login` "win" over `http_basic` if I have both defined under my firewall?
>
> -    Since we're moving to a new system, why not throw an exception the _moment_ that a firewall has multiple entrypoints available to it. Then we _force_ the user to choose the _one_ entrypoint that should be used.

---

**Before** (one authenticator)
```yaml
security:
  enable_authenticator_manager: true

  firewalls:
    main:
      form_login: ...

# form login is your entry point
```

**After**
Same as before

---

**Before** (multiple authenticators)
```yaml
security:
  enable_authenticator_manager: true

  firewalls:
    main:
      http_basic: ...
      form_login: ...

# for some reason, FormLogin is now your entry point! (config order doesn't matter)
```

**After**
```yaml
security:
  enable_authenticator_manager: true

  firewalls:
    main:
      http_basic: ...
      form_login: ...
      entry_point: form_login
```

---


**Before** (custom entry point service)
```yaml
security:
  enable_authenticator_manager: true

  firewalls:
    main:
      http_basic: ...
      form_login: ...
      entry_point: App\Security\CustomEntryPoint
```

**After**
Same as before