### PR TITLE
[FrameworkBundle] add "run" method to the MicroKernelTrait

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
  * Made `BrowserKitAssertionsTrait` report the original error message in case of a failure
  * Added ability for `config:dump-reference` and `debug:config` to dump and debug kernel container extension configuration.
  * Deprecated `session.attribute_bag` service and `session.flash_bag` service.
+ * Added `run` method to the MicroKernelTrait
 
 5.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -17,6 +17,8 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\AbstractConfigurat
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader as ContainerPhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ErrorHandler\Debug;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\Component\Routing\Loader\PhpFileLoader as RoutingPhpFileLoader;
 use Symfony\Component\Routing\RouteCollection;
@@ -180,5 +182,20 @@ trait MicroKernelTrait
         $this->configureRoutes($routes);
 
         return $routes->build();
+    }
+
+    public static function run(string $environment, bool $debug): void
+    {
+        if ($debug) {
+            umask(0000);
+
+            Debug::enable();
+        }
+
+        $kernel = new static($environment, $debug);
+        $request = Request::createFromGlobals();
+        $response = $kernel->handle($request);
+        $response->send();
+        $kernel->terminate($request, $response);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TODO

One user commented on the MicroKernel [article](https://symfony.com/blog/new-in-symfony-5-1-improved-microkernel) published today, about the code verbosity at the end of the example shown:

```php
// ... 

$app = new App('dev', true);
$request = Request::createFromGlobals();
$response = $app->handle($request);
$response->send();
$app->terminate($request, $response);
```

Taking into account also this code doesn't change normally between apps (almost never) I think he's right and this code can be moved to a new method, making the single-file app API more concise.

Inspired on [Silex](https://silex.symfony.com) this is what I propose:
```php
// ...

App::run('dev', true);
```

In a nutshell, this is how it would look after these changes:
```php
// index.php (single-file app)

require __DIR__.'/../vendor/autoload.php';

class App extends Kernel
{
    use MicroKernelTrait;

    public function registerBundles(): iterable
    {
        yield new Symfony\Bundle\FrameworkBundle\FrameworkBundle();
    }

    protected function configureRoutes(RoutingConfigurator $routes)
    {
        $routes->import(__CLASS__, 'annotation'); // require doctrine/annotations
    }

    protected function configureContainer(ContainerConfigurator $c)
    {
        $c->extension('framework', ['secret' => '12345']);
    }

    /**
     * @Route("/")
     */
    public function index()
    {
        return new Response('Hello World');
    }
}

App::run('dev', true);
```
What do you think?