### PR TITLE
[FrameworkBundle] [Routing] Added --sort to debug:router

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
  * Made `BrowserKitAssertionsTrait` report the original error message in case of a failure
  * Added ability for `config:dump-reference` and `debug:config` to dump and debug kernel container extension configuration.
  * Deprecated `session.attribute_bag` service and `session.flash_bag` service.
+ * Added `debug:router --sort` option to see routes sorted by name or path as well as by priority
 
 5.0.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -86,7 +86,7 @@ EOF
         $sortOption = $input->getOption('sort');
         $routes = $this->sortRoutes($this->router->getRouteCollection(), $sortOption);
         if ('priority' !== $sortOption) {
-            $io->caution('The routes list is not sorted in the parsing order.');
+            $io->caution(sprintf('The routes are not sorted in the order they get matched but by %s.', $sortOption));
         }
 
         if ($name) {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -85,6 +85,9 @@ EOF
         $container = $this->fileLinkFormatter ? \Closure::fromCallable([$this, 'getContainerBuilder']) : null;
         $sortOption = $input->getOption('sort');
         $routes = $this->sortRoutes($this->router->getRouteCollection(), $sortOption);
+        if ('priority' !== $sortOption) {
+            $io->caution('The routes list is not sorted in the parsing order.');
+        }
 
         if ($name) {
             if (!($route = $routes->get($name)) && $matchingRoutes = $this->findRouteNameContaining($name, $routes)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -59,7 +59,7 @@ class RouterDebugCommand extends Command
                 new InputOption('show-controllers', null, InputOption::VALUE_NONE, 'Show assigned controllers in overview'),
                 new InputOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, xml, json, or md)', 'txt'),
                 new InputOption('raw', null, InputOption::VALUE_NONE, 'To output raw route(s)'),
-                new InputOption('sort', null, InputOption::VALUE_REQUIRED, 'The sorting field (priority, name, or path)', 'priority'),
+                new InputOption('sort', null, InputOption::VALUE_REQUIRED, 'The sorting criterion (priority, name, or path)', 'priority'),
             ])
             ->setDescription('Displays current routes for an application')
             ->setHelp(<<<'EOF'

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -82,13 +82,9 @@ EOF
         $io = new SymfonyStyle($input, $output);
         $name = $input->getArgument('name');
         $helper = new DescriptorHelper($this->fileLinkFormatter);
-        $routes = $this->router->getRouteCollection();
         $container = $this->fileLinkFormatter ? \Closure::fromCallable([$this, 'getContainerBuilder']) : null;
         $sortOption = $input->getOption('sort');
-
-        if (null !== $sortOption) {
-            $routes = $this->sortRoutes($routes, $sortOption);
-        }
+        $routes = $this->sortRoutes($this->router->getRouteCollection(), $sortOption);
 
         if ($name) {
             if (!($route = $routes->get($name)) && $matchingRoutes = $this->findRouteNameContaining($name, $routes)) {
@@ -135,18 +131,12 @@ EOF
 
     private function sortRoutes(RouteCollection $routes, string $propertyName): RouteCollection
     {
-        $validOptions = ['', 'priority', 'name', 'path'];
         $sortedRoutes = $routes->all();
         if ('name' === $propertyName) {
             ksort($sortedRoutes);
         } elseif ('path' === $propertyName) {
-            uasort(
-                $sortedRoutes,
-                static function (Route $a, Route $b): int {
-                    return $a->getPath() <=> $b->getPath();
-                }
-            );
-        } elseif (!\in_array($propertyName, $validOptions)) {
+            uasort($sortedRoutes, function ($a, $b) { return $a->getPath() <=> $b->getPath(); });
+        } elseif ('priority' !== $propertyName) {
             throw new InvalidArgumentException(sprintf('The option "%s" is not valid.', $propertyName));
         }
         $routeCollection = new RouteCollection();

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\Debug\FileLinkFormatter;
+use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -58,6 +59,7 @@ class RouterDebugCommand extends Command
                 new InputOption('show-controllers', null, InputOption::VALUE_NONE, 'Show assigned controllers in overview'),
                 new InputOption('format', null, InputOption::VALUE_REQUIRED, 'The output format (txt, xml, json, or md)', 'txt'),
                 new InputOption('raw', null, InputOption::VALUE_NONE, 'To output raw route(s)'),
+                new InputOption('sort', null, InputOption::VALUE_REQUIRED, 'The sorting field (priority, name, or path)', 'priority'),
             ])
             ->setDescription('Displays current routes for an application')
             ->setHelp(<<<'EOF'
@@ -82,6 +84,11 @@ EOF
         $helper = new DescriptorHelper($this->fileLinkFormatter);
         $routes = $this->router->getRouteCollection();
         $container = $this->fileLinkFormatter ? \Closure::fromCallable([$this, 'getContainerBuilder']) : null;
+        $sortOption = $input->getOption('sort');
+
+        if (null !== $sortOption) {
+            $routes = $this->sortRoutes($routes, $sortOption);
+        }
 
         if ($name) {
             if (!($route = $routes->get($name)) && $matchingRoutes = $this->findRouteNameContaining($name, $routes)) {
@@ -124,5 +131,29 @@ EOF
         }
 
         return $foundRoutesNames;
+    }
+
+    private function sortRoutes(RouteCollection $routes, string $propertyName): RouteCollection
+    {
+        $validOptions = ['', 'priority', 'name', 'path'];
+        $sortedRoutes = $routes->all();
+        if ('name' === $propertyName) {
+            ksort($sortedRoutes);
+        } elseif ('path' === $propertyName) {
+            uasort(
+                $sortedRoutes,
+                static function (Route $a, Route $b): int {
+                    return $a->getPath() <=> $b->getPath();
+                }
+            );
+        } elseif (!\in_array($propertyName, $validOptions)) {
+            throw new InvalidArgumentException(sprintf('The option "%s" is not valid.', $propertyName));
+        }
+        $routeCollection = new RouteCollection();
+        foreach ($sortedRoutes as $routeName => $route) {
+            $routeCollection->add($routeName, $route);
+        }
+
+        return $routeCollection;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
@@ -21,6 +21,7 @@ class RouterDebugCommandTest extends TestCase
         $result = $tester->execute(['--sort' => 'priority'], ['decorated' => false]);
         $this->assertSame(0, $result, 'Returns 0 in case of success');
         $this->assertRegExp('/(charlie).*\n\W*(alfa).*\n\W*(delta).*\n\W*(bravo)/m', $tester->getDisplay(true));
+        $this->assertStringNotContainsString('! [CAUTION] The routes list is not sorted in the parsing order.', $tester->getDisplay(true));
     }
 
     public function testSortingByName()
@@ -29,6 +30,7 @@ class RouterDebugCommandTest extends TestCase
         $result = $tester->execute(['--sort' => 'name'], ['decorated' => false]);
         $this->assertSame(0, $result, 'Returns 0 in case of success');
         $this->assertRegExp('/(alfa).*\n\W*(bravo).*\n\W*(charlie).*\n\W*(delta)/m', $tester->getDisplay(true));
+        $this->assertStringContainsString('! [CAUTION] The routes list is not sorted in the parsing order.', $tester->getDisplay(true));
     }
 
     public function testSortingByPath()
@@ -37,6 +39,7 @@ class RouterDebugCommandTest extends TestCase
         $result = $tester->execute(['--sort' => 'path'], ['decorated' => false]);
         $this->assertSame(0, $result, 'Returns 0 in case of success');
         $this->assertRegExp('/(\/romeo).*\n.*(\/sierra).*\n.*(\/tango).*\n.*(\/uniform)/m', $tester->getDisplay(true));
+        $this->assertStringContainsString('! [CAUTION] The routes list is not sorted in the parsing order.', $tester->getDisplay(true));
     }
 
     public function testThrowsExceptionWithInvalidParameter()
@@ -59,6 +62,7 @@ class RouterDebugCommandTest extends TestCase
         $result = $tester->execute(['--sort' => 'priority'], ['decorated' => false]);
         $this->assertSame(0, $result, 'Returns 0 in case of success');
         $this->assertRegExp('/(charlie).*\n\W*(alfa).*\n\W*(delta).*\n\W*(bravo).*\n\W*(echo)/m', $tester->getDisplay(true));
+        $this->assertStringNotContainsString('! [CAUTION] The routes list is not sorted in the parsing order.', $tester->getDisplay(true));
     }
 
     public function testSortingByNameWithDuplicatePath()
@@ -67,6 +71,7 @@ class RouterDebugCommandTest extends TestCase
         $result = $tester->execute(['--sort' => 'name'], ['decorated' => false]);
         $this->assertSame(0, $result, 'Returns 0 in case of success');
         $this->assertRegExp('/(alfa).*\n\W*(bravo).*\n\W*(charlie).*\n\W*(delta).*\n\W*(echo)/m', $tester->getDisplay(true));
+        $this->assertStringContainsString('! [CAUTION] The routes list is not sorted in the parsing order.', $tester->getDisplay(true));
     }
 
     public function testSortingByPathWithDuplicatePath()
@@ -75,6 +80,7 @@ class RouterDebugCommandTest extends TestCase
         $result = $tester->execute(['--sort' => 'path'], ['decorated' => false]);
         $this->assertSame(0, $result, 'Returns 0 in case of success');
         $this->assertRegExp('/(\/romeo).*\n.*(\/sierra).*\n.*(\/tango).*\n.*(\/uniform).*\n.*(\/uniform)/m', $tester->getDisplay(true));
+        $this->assertStringContainsString('! [CAUTION] The routes list is not sorted in the parsing order.', $tester->getDisplay(true));
     }
 
     public function testWithoutCallingSortOptionExplicitly()
@@ -83,6 +89,7 @@ class RouterDebugCommandTest extends TestCase
         $result = $tester->execute([], ['decorated' => false]);
         $this->assertSame(0, $result, 'Returns 0 in case of success');
         $this->assertRegExp('/(charlie).*\n\W*(alfa).*\n\W*(delta).*\n\W*(bravo)/m', $tester->getDisplay(true));
+        $this->assertStringNotContainsString('! [CAUTION] The routes list is not sorted in the parsing order.', $tester->getDisplay(true));
     }
 
     private function createCommandTester(): CommandTester

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
@@ -19,7 +19,7 @@ class RouterDebugCommandTest extends TestCase
     {
         $tester = $this->createCommandTester();
         $result = $tester->execute(['--sort' => 'priority'], ['decorated' => false]);
-        $this->assertEquals(0, $result, 'Returns 0 in case of success');
+        $this->assertSame(0, $result, 'Returns 0 in case of success');
         $this->assertRegExp('/(charlie).*\n\W*(alfa).*\n\W*(delta).*\n\W*(bravo)/m', $tester->getDisplay(true));
     }
 
@@ -27,7 +27,7 @@ class RouterDebugCommandTest extends TestCase
     {
         $tester = $this->createCommandTester();
         $result = $tester->execute(['--sort' => 'name'], ['decorated' => false]);
-        $this->assertEquals(0, $result, 'Returns 0 in case of success');
+        $this->assertSame(0, $result, 'Returns 0 in case of success');
         $this->assertRegExp('/(alfa).*\n\W*(bravo).*\n\W*(charlie).*\n\W*(delta)/m', $tester->getDisplay(true));
     }
 
@@ -35,7 +35,7 @@ class RouterDebugCommandTest extends TestCase
     {
         $tester = $this->createCommandTester();
         $result = $tester->execute(['--sort' => 'path'], ['decorated' => false]);
-        $this->assertEquals(0, $result, 'Returns 0 in case of success');
+        $this->assertSame(0, $result, 'Returns 0 in case of success');
         $this->assertRegExp('/(\/romeo).*\n.*(\/sierra).*\n.*(\/tango).*\n.*(\/uniform)/m', $tester->getDisplay(true));
     }
 
@@ -57,7 +57,7 @@ class RouterDebugCommandTest extends TestCase
     {
         $tester = $this->createCommandTesterWithDuplicatePath();
         $result = $tester->execute(['--sort' => 'priority'], ['decorated' => false]);
-        $this->assertEquals(0, $result, 'Returns 0 in case of success');
+        $this->assertSame(0, $result, 'Returns 0 in case of success');
         $this->assertRegExp('/(charlie).*\n\W*(alfa).*\n\W*(delta).*\n\W*(bravo).*\n\W*(echo)/m', $tester->getDisplay(true));
     }
 
@@ -65,7 +65,7 @@ class RouterDebugCommandTest extends TestCase
     {
         $tester = $this->createCommandTesterWithDuplicatePath();
         $result = $tester->execute(['--sort' => 'name'], ['decorated' => false]);
-        $this->assertEquals(0, $result, 'Returns 0 in case of success');
+        $this->assertSame(0, $result, 'Returns 0 in case of success');
         $this->assertRegExp('/(alfa).*\n\W*(bravo).*\n\W*(charlie).*\n\W*(delta).*\n\W*(echo)/m', $tester->getDisplay(true));
     }
 
@@ -73,8 +73,16 @@ class RouterDebugCommandTest extends TestCase
     {
         $tester = $this->createCommandTesterWithDuplicatePath();
         $result = $tester->execute(['--sort' => 'path'], ['decorated' => false]);
-        $this->assertEquals(0, $result, 'Returns 0 in case of success');
+        $this->assertSame(0, $result, 'Returns 0 in case of success');
         $this->assertRegExp('/(\/romeo).*\n.*(\/sierra).*\n.*(\/tango).*\n.*(\/uniform).*\n.*(\/uniform)/m', $tester->getDisplay(true));
+    }
+
+    public function testWithoutCallingSortOptionExplicitly()
+    {
+        $tester = $this->createCommandTester();
+        $result = $tester->execute([], ['decorated' => false]);
+        $this->assertSame(0, $result, 'Returns 0 in case of success');
+        $this->assertRegExp('/(charlie).*\n\W*(alfa).*\n\W*(delta).*\n\W*(bravo)/m', $tester->getDisplay(true));
     }
 
     private function createCommandTester(): CommandTester

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/RouterDebugCommandTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Command\RouterDebugCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouterInterface;
+
+class RouterDebugCommandTest extends TestCase
+{
+    public function testSortingByPriority()
+    {
+        $tester = $this->createCommandTester();
+        $result = $tester->execute(['--sort' => 'priority'], ['decorated' => false]);
+        $this->assertEquals(0, $result, 'Returns 0 in case of success');
+        $this->assertRegExp('/(charlie).*\n\W*(alfa).*\n\W*(delta).*\n\W*(bravo)/m', $tester->getDisplay(true));
+    }
+
+    public function testSortingByName()
+    {
+        $tester = $this->createCommandTester();
+        $result = $tester->execute(['--sort' => 'name'], ['decorated' => false]);
+        $this->assertEquals(0, $result, 'Returns 0 in case of success');
+        $this->assertRegExp('/(alfa).*\n\W*(bravo).*\n\W*(charlie).*\n\W*(delta)/m', $tester->getDisplay(true));
+    }
+
+    public function testSortingByPath()
+    {
+        $tester = $this->createCommandTester();
+        $result = $tester->execute(['--sort' => 'path'], ['decorated' => false]);
+        $this->assertEquals(0, $result, 'Returns 0 in case of success');
+        $this->assertRegExp('/(\/romeo).*\n.*(\/sierra).*\n.*(\/tango).*\n.*(\/uniform)/m', $tester->getDisplay(true));
+    }
+
+    public function testThrowsExceptionWithInvalidParameter()
+    {
+        $tester = $this->createCommandTester();
+        $this->expectExceptionMessage('The option "foobar" is not valid');
+        $tester->execute(['--sort' => 'foobar'], ['decorated' => false]);
+    }
+
+    public function testThrowsExceptionWithNullParameter()
+    {
+        $tester = $this->createCommandTester();
+        $this->expectExceptionMessage('The "--sort" option requires a value.');
+        $tester->execute(['--sort' => null], ['decorated' => false]);
+    }
+
+    public function testSortingByPriorityWithDuplicatePath()
+    {
+        $tester = $this->createCommandTesterWithDuplicatePath();
+        $result = $tester->execute(['--sort' => 'priority'], ['decorated' => false]);
+        $this->assertEquals(0, $result, 'Returns 0 in case of success');
+        $this->assertRegExp('/(charlie).*\n\W*(alfa).*\n\W*(delta).*\n\W*(bravo).*\n\W*(echo)/m', $tester->getDisplay(true));
+    }
+
+    public function testSortingByNameWithDuplicatePath()
+    {
+        $tester = $this->createCommandTesterWithDuplicatePath();
+        $result = $tester->execute(['--sort' => 'name'], ['decorated' => false]);
+        $this->assertEquals(0, $result, 'Returns 0 in case of success');
+        $this->assertRegExp('/(alfa).*\n\W*(bravo).*\n\W*(charlie).*\n\W*(delta).*\n\W*(echo)/m', $tester->getDisplay(true));
+    }
+
+    public function testSortingByPathWithDuplicatePath()
+    {
+        $tester = $this->createCommandTesterWithDuplicatePath();
+        $result = $tester->execute(['--sort' => 'path'], ['decorated' => false]);
+        $this->assertEquals(0, $result, 'Returns 0 in case of success');
+        $this->assertRegExp('/(\/romeo).*\n.*(\/sierra).*\n.*(\/tango).*\n.*(\/uniform).*\n.*(\/uniform)/m', $tester->getDisplay(true));
+    }
+
+    private function createCommandTester(): CommandTester
+    {
+        $application = new Application($this->getKernel());
+        $application->add(new RouterDebugCommand($this->getRouter()));
+
+        return new CommandTester($application->find('debug:router'));
+    }
+
+    private function createCommandTesterWithDuplicatePath(): CommandTester
+    {
+        $application = new Application($this->getKernel());
+        $application->add(new RouterDebugCommand($this->getRouterWithDuplicatePath()));
+
+        return new CommandTester($application->find('debug:router'));
+    }
+
+    private function getRouter()
+    {
+        $routeCollection = new RouteCollection();
+        $routeCollection->add('charlie', new Route('uniform'));
+        $routeCollection->add('alfa', new Route('sierra'));
+        $routeCollection->add('delta', new Route('tango'));
+        $routeCollection->add('bravo', new Route('romeo'));
+        $requestContext = new RequestContext();
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects($this->any())
+            ->method('getRouteCollection')
+            ->willReturn($routeCollection);
+        $router
+            ->expects($this->any())
+            ->method('getContext')
+            ->willReturn($requestContext);
+
+        return $router;
+    }
+
+    private function getRouterWithDuplicatePath()
+    {
+        $routeCollection = new RouteCollection();
+        $routeCollection->add('charlie', (new Route('uniform'))->setMethods('GET'));
+        $routeCollection->add('alfa', new Route('sierra'));
+        $routeCollection->add('delta', new Route('tango'));
+        $routeCollection->add('bravo', new Route('romeo'));
+        $routeCollection->add('echo', (new Route('uniform'))->setMethods('POST'));
+
+        $requestContext = new RequestContext();
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->expects($this->any())
+            ->method('getRouteCollection')
+            ->willReturn($routeCollection);
+        $router
+            ->expects($this->any())
+            ->method('getContext')
+            ->willReturn($requestContext);
+
+        return $router;
+    }
+
+    private function getKernel()
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->atLeastOnce())
+            ->method('has')
+            ->willReturnCallback(function ($id) {
+                return 'console.command_loader' !== $id;
+            })
+        ;
+        $container
+            ->expects($this->any())
+            ->method('get')
+            ->with('router')
+            ->willReturn($this->getRouter())
+        ;
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel
+            ->expects($this->any())
+            ->method('getContainer')
+            ->willReturn($container)
+        ;
+        $kernel
+            ->expects($this->once())
+            ->method('getBundles')
+            ->willReturn([])
+        ;
+
+        return $kernel;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#13591

This PR adds a `--sort `functionality to `console debug:router.` It allows to sort by name, path or priority (default).