### PR TITLE
Lower the PHP requirement of symfony/uid

### DIFF
--- a/src/Symfony/Component/Uid/composer.json
+++ b/src/Symfony/Component/Uid/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.1.3",
         "symfony/polyfill-uuid": "^1.15"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I wanted to use `symfony/uid` in a Symfony 4.4 project ... but "I can't" because Symfony 4.4 requires PHP 7.1.3 and Symfony Uid requires PHP 7.2.5.

I guess most developers using Symfony 4.4 don't use PHP 7.1 but 7.3 or 7.4 ... but still, you can use Sf 4.4 with PHP 7.1 and that's incompatible with Uid.

So, considering that:

* Symfony 4.4 is supported until November 2022.
* Symfony 4.4 is an LTS and lots of people will use it for years (far beyond the end-of-life date)
* Symfony Uid is an "utility component" (such as String and Yaml) and it's not tightly coupled with the entire Symfony framework

Would you agree lowering the PHP requirement to match Symfony 4.4? Thanks!

