### PR TITLE
[PropertyAccess] For property-accessor custom method for check in_array for collection of object

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -568,6 +568,25 @@ class PropertyAccessor implements PropertyAccessorInterface
     }
 
     /**
+     * Checks if a value exists in an array
+     */
+    private function inArray($value, array $collection): bool
+    {
+        if (\is_object($value) && method_exists($value,'getId') && $value->getId()) {
+            foreach ($collection as $element) {
+                if (method_exists($element, 'getId') && $value->getId() === $element->getId()) {
+                    return true;
+                }
+            }
+        }
+        if (\in_array($value, $collection, true)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Adjusts a collection-valued property by calling add*() and remove*() methods.
      */
     private function writeCollection(array $zval, string $property, iterable $collection, string $addMethod, string $removeMethod)
@@ -584,7 +603,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                 $collection = iterator_to_array($collection);
             }
             foreach ($previousValue as $key => $item) {
-                if (!\in_array($item, $collection, true)) {
+                if (!$this->inArray($item, $collection)) {
                     unset($previousValue[$key]);
                     $zval[self::VALUE]->{$removeMethod}($item);
                 }
@@ -594,7 +613,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         }
 
         foreach ($collection as $item) {
-            if (!$previousValue || !\in_array($item, $previousValue, true)) {
+            if (!$previousValue || !$this->inArray($item, $previousValue)) {
                 $zval[self::VALUE]->{$addMethod}($item);
             }
         }

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -568,11 +568,11 @@ class PropertyAccessor implements PropertyAccessorInterface
     }
 
     /**
-     * Checks if a value exists in an array
+     * Checks if a value exists in an array.
      */
     private function inArray($value, array $collection): bool
     {
-        if (\is_object($value) && method_exists($value,'getId') && $value->getId()) {
+        if (\is_object($value) && method_exists($value, 'getId') && $value->getId()) {
             foreach ($collection as $element) {
                 if (method_exists($element, 'getId') && $value->getId() === $element->getId()) {
                     return true;


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       |  4.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I found problem. I use api-platform with jsonapi, and if use collection related object with id already force recreate all database record. I add custom compare inArray, for this record. I understand my request is incorrect please help me we create correct fix for this problem.
