### PR TITLE
[BrowserKit] Allow Referer set by history to be overridden

### DIFF
--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -366,7 +366,7 @@ abstract class AbstractBrowser
             $uri = preg_replace('{^'.parse_url($uri, PHP_URL_SCHEME).'}', $server['HTTPS'] ? 'https' : 'http', $uri);
         }
 
-        if (!$this->history->isEmpty()) {
+        if (!isset($server['HTTP_REFERER']) && !$this->history->isEmpty()) {
             $server['HTTP_REFERER'] = $this->history->current()->getUri();
         }
 

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -215,6 +215,15 @@ class AbstractBrowserTest extends TestCase
         $this->assertEquals('http://www.example.com/foo/foobar', $server['HTTP_REFERER'], '->request() sets the referer');
     }
 
+    public function testRequestRefererCanBeOverridden()
+    {
+        $client = $this->getBrowser();
+        $client->request('GET', 'http://www.example.com/foo/foobar');
+        $client->request('GET', 'bar', [], [], ['HTTP_REFERER' => 'xyz']);
+        $server = $client->getRequest()->getServer();
+        $this->assertEquals('xyz', $server['HTTP_REFERER'], '->request() allows referer to be overridden');
+    }
+
     public function testRequestHistory()
     {
         $client = $this->getBrowser();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0, see https://github.com/symfony/symfony/pull/36592 for 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Hi, the patch should also by applied to 3.4 and 4.4, but the file tree changed, so separated PR is ~needed~ https://github.com/symfony/symfony/pull/36592