### PR TITLE
[BrowserKit] Allow Referer set by history to be overridden

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -294,7 +294,7 @@ abstract class Client
             $uri = preg_replace('{^'.parse_url($uri, PHP_URL_SCHEME).'}', $server['HTTPS'] ? 'https' : 'http', $uri);
         }
 
-        if (!$this->history->isEmpty()) {
+        if (!isset($server['HTTP_REFERER']) && !$this->history->isEmpty()) {
             $server['HTTP_REFERER'] = $this->history->current()->getUri();
         }
 

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -233,6 +233,15 @@ class ClientTest extends TestCase
         $this->assertEquals('http://www.example.com/foo/foobar', $server['HTTP_REFERER'], '->request() sets the referer');
     }
 
+    public function testRequestRefererCanBeOverridden()
+    {
+        $client = new TestClient();
+        $client->request('GET', 'http://www.example.com/foo/foobar');
+        $client->request('GET', 'bar', [], [], ['HTTP_REFERER' => 'xyz']);
+        $server = $client->getRequest()->getServer();
+        $this->assertEquals('xyz', $server['HTTP_REFERER'], '->request() allows referer to be overridden');
+    }
+
     public function testRequestHistory()
     {
         $client = new TestClient();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4, see https://github.com/symfony/symfony/pull/36591 for 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 