### PR TITLE
fix compatibility with phpunit above 9.1.1

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -50,8 +50,14 @@ class SymfonyTestsListenerTrait
      */
     public function __construct(array $mockedNamespaces = [])
     {
-        Blacklist::$blacklistedClassNames['\Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerTrait'] = 2;
-
+        if (class_exists('PHPUnit_Util_Blacklist')) {
+            \PHPUnit_Util_Blacklist::$blacklistedClassNames[__CLASS__] = 2;
+        } elseif (method_exists(Blacklist::class, 'addDirectory')) {
+            (new BlackList())->getBlacklistedDirectories();
+            Blacklist::addDirectory(\dirname((new \ReflectionClass(__CLASS__))->getFileName(), 2));
+        } else {
+            Blacklist::$blacklistedClassNames[__CLASS__] = 2;
+        }
         $enableDebugClassLoader = class_exists(DebugClassLoader::class) || class_exists(LegacyDebugClassLoader::class);
 
         foreach ($mockedNamespaces as $type => $namespaces) {


### PR DESCRIPTION
Issue https://github.com/symfony/symfony/issues/36499
Error appears in symfony 5 when we use phpunit 9.1.3 and symfony/phpunit-bridge 5.0.7

| Q             | A
| ------------- | ---
| Branch       | 5.0.7
| Bug fix      | yes
| New feature  | no
| Deprecations | no
| Tickets       | Fix #36499
| License       | MIT
<!--
Fix compatibility with phpunit above 9.1.1
Issue https://github.com/symfony/symfony/issues/36499
I found out that the same error was fixed in symfony  3.4 but not in version 5  
The error appears in symfony 5 when we use phpunit 9.1.3 and symfony/phpunit-bridge 5.0.7

