### PR TITLE
Add cache.adapter.redis_tag_aware to use RedisCacheAwareAdapter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecated the public `form.factory`, `form.type.file`, `translator`, `security.csrf.token_manager`, `serializer`,
    `cache_clearer`, `filesystem` and `validator` services to private.
  * Added `TemplateAwareDataCollectorInterface` and `AbstractDataCollector` to simplify custom data collector creation and leverage autoconfiguration
+ * Add `cache.adapter.redis_tag_aware` tag to use `RedisCacheAwareAdapter`
 
 5.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1861,8 +1861,11 @@ class FrameworkExtension extends Extension
         foreach ($config['pools'] as $name => $pool) {
             $pool['adapters'] = $pool['adapters'] ?: ['cache.app'];
 
+            $isRedisTagAware = ['cache.adapter.redis_tag_aware'] === $pool['adapters'];
             foreach ($pool['adapters'] as $provider => $adapter) {
-                if ($config['pools'][$adapter]['tags'] ?? false) {
+                if (($config['pools'][$adapter]['adapters'] ?? null) === ['cache.adapter.redis_tag_aware']) {
+                    $isRedisTagAware = true;
+                } elseif ($config['pools'][$adapter]['tags'] ?? false) {
                     $pool['adapters'][$provider] = $adapter = '.'.$adapter.'.inner';
                 }
             }
@@ -1877,7 +1880,10 @@ class FrameworkExtension extends Extension
                 $pool['reset'] = 'reset';
             }
 
-            if ($pool['tags']) {
+            if ($isRedisTagAware) {
+                $tagAwareId = $name;
+                $container->setAlias('.'.$name.'.inner', $name);
+            } elseif ($pool['tags']) {
                 if (true !== $pool['tags'] && ($config['pools'][$pool['tags']]['tags'] ?? false)) {
                     $pool['tags'] = '.'.$pool['tags'].'.inner';
                 }
@@ -1887,22 +1893,20 @@ class FrameworkExtension extends Extension
                     ->setPublic($pool['public'])
                 ;
 
-                $pool['name'] = $name;
+                $pool['name'] = $tagAwareId = $name;
                 $pool['public'] = false;
                 $name = '.'.$name.'.inner';
-
-                if (!\in_array($pool['name'], ['cache.app', 'cache.system'], true)) {
-                    $container->registerAliasForArgument($pool['name'], TagAwareCacheInterface::class);
-                    $container->registerAliasForArgument($name, CacheInterface::class, $pool['name']);
-                    $container->registerAliasForArgument($name, CacheItemPoolInterface::class, $pool['name']);
-                }
             } elseif (!\in_array($name, ['cache.app', 'cache.system'], true)) {
-                $container->register('.'.$name.'.taggable', TagAwareAdapter::class)
+                $tagAwareId = '.'.$name.'.taggable';
+                $container->register($tagAwareId, TagAwareAdapter::class)
                     ->addArgument(new Reference($name))
                 ;
-                $container->registerAliasForArgument('.'.$name.'.taggable', TagAwareCacheInterface::class, $name);
-                $container->registerAliasForArgument($name, CacheInterface::class);
-                $container->registerAliasForArgument($name, CacheItemPoolInterface::class);
+            }
+
+            if (!\in_array($name, ['cache.app', 'cache.system'], true)) {
+                $container->registerAliasForArgument($tagAwareId, TagAwareCacheInterface::class, $pool['name'] ?? $name);
+                $container->registerAliasForArgument($name, CacheInterface::class, $pool['name'] ?? $name);
+                $container->registerAliasForArgument($name, CacheItemPoolInterface::class, $pool['name'] ?? $name);
             }
 
             $definition->setPublic($pool['public']);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
@@ -22,6 +22,7 @@ use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 use Symfony\Component\Cache\Adapter\ProxyAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
 use Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer;
@@ -133,6 +134,22 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('cache.adapter.redis', RedisAdapter::class)
+            ->abstract()
+            ->args([
+                abstract_arg('Redis connection service'),
+                '', // namespace
+                0, // default lifetime
+                service('cache.default_marshaller')->ignoreOnInvalid(),
+            ])
+            ->call('setLogger', [service('logger')->ignoreOnInvalid()])
+            ->tag('cache.pool', [
+                'provider' => 'cache.default_redis_provider',
+                'clearer' => 'cache.default_clearer',
+                'reset' => 'reset',
+            ])
+            ->tag('monolog.logger', ['channel' => 'cache'])
+
+        ->set('cache.adapter.redis_tag_aware', RedisTagAwareAdapter::class)
             ->abstract()
             ->args([
                 abstract_arg('Redis connection service'),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
@@ -32,6 +32,27 @@ $container->loadFromExtension('framework', [
                     'redis://foo' => 'cache.adapter.redis',
                 ],
             ],
+            'cache.redis_tag_aware.foo' => [
+                'adapter' => 'cache.adapter.redis_tag_aware',
+            ],
+            'cache.redis_tag_aware.foo2' => [
+                'tags' => true,
+                'adapter' => 'cache.adapter.redis_tag_aware',
+            ],
+            'cache.redis_tag_aware.bar' => [
+                'adapter' => 'cache.redis_tag_aware.foo',
+            ],
+            'cache.redis_tag_aware.bar2' => [
+                'tags' => true,
+                'adapter' => 'cache.redis_tag_aware.foo',
+            ],
+            'cache.redis_tag_aware.baz' => [
+                'adapter' => 'cache.redis_tag_aware.foo2',
+            ],
+            'cache.redis_tag_aware.baz2' => [
+                'tags' => true,
+                'adapter' => 'cache.redis_tag_aware.foo2',
+            ],
         ],
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
@@ -17,6 +17,12 @@
                 <framework:adapter name="cache.adapter.filesystem" />
                 <framework:adapter name="cache.adapter.redis" provider="redis://foo" />
             </framework:pool>
+            <framework:pool name="cache.redis_tag_aware.foo" adapter="cache.adapter.redis_tag_aware" />
+            <framework:pool name="cache.redis_tag_aware.foo2" tags="true" adapter="cache.adapter.redis_tag_aware" />
+            <framework:pool name="cache.redis_tag_aware.bar" adapter="cache.redis_tag_aware.foo" />
+            <framework:pool name="cache.redis_tag_aware.bar2" tags="true" adapter="cache.redis_tag_aware.foo" />
+            <framework:pool name="cache.redis_tag_aware.baz" adapter="cache.redis_tag_aware.foo2" />
+            <framework:pool name="cache.redis_tag_aware.baz2" tags="true" adapter="cache.redis_tag_aware.foo2" />
         </framework:cache>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
@@ -23,3 +23,18 @@ framework:
                     - cache.adapter.array
                     - cache.adapter.filesystem
                     - {name: cache.adapter.redis, provider: 'redis://foo'}
+            cache.redis_tag_aware.foo:
+                adapter: cache.adapter.redis_tag_aware
+            cache.redis_tag_aware.foo2:
+                tags: true
+                adapter: cache.adapter.redis_tag_aware
+            cache.redis_tag_aware.bar:
+                adapter: cache.redis_tag_aware.foo
+            cache.redis_tag_aware.bar2:
+                tags: true
+                adapter: cache.redis_tag_aware.foo
+            cache.redis_tag_aware.baz:
+                adapter: cache.redis_tag_aware.foo2
+            cache.redis_tag_aware.baz2:
+                tags: true
+                adapter: cache.redis_tag_aware.foo2


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/orgs/symfony/projects/1#card-33761315
| License       | MIT
| Doc PR        | symfony/symfony-docs#14078

