### PR TITLE
Short Circuting Undefined Vars

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/ExpressionLanguage/Tests/ExpressionLanguageTest.php
@@ -123,6 +123,15 @@ class ExpressionLanguageTest extends TestCase
             ['false && object.foo()', ['object' => $object], false],
             ['true || object.foo()', ['object' => $object], true],
             ['true or object.foo()', ['object' => $object], true],
+            ['true ? false : object.foo()', ['object' => $object], false],
+            ['false ? object.foo() : true', ['object' => $object], true],
+
+            ['false and foo', ['object' => $object], false],
+            ['false && foo', ['object' => $object], false],
+            ['true || foo', ['object' => $object], true],
+            ['true or foo', ['object' => $object], true],
+            ['true ? false : foo', ['object' => $object], false],
+            ['false ? foo : true', ['object' => $object], true],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | None yet

Is it intended that the expression language component should support undefined vars when short-circuiting? At the moment short circuiting is provided in as much as unreached branches won't be evaluated, but they must still compile.

My use-case was checking if a variable is defined to set a default, using a custom function...

`defined('foo') ? foo : the_default`

This is a question, but I've provided this as a PR to demonstrate.