### PR TITLE
[HttpKernel] make kernels implementing `WarmableInterface` be part of the cache warmup stage

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * made `WarmableInterface::warmUp()` return a list of classes or files to preload on PHP 7.4+;
    not returning an array is deprecated
+ * made kernels implementing `WarmableInterface` be part of the cache warmup stage
  * deprecated support for `service:action` syntax to reference controllers, use `serviceOrFqcn::method` instead
  * allowed using public aliases to reference controllers
  * added session usage reporting when the `_stateless` attribute of the request is set to `true`

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\ResettableServicePass;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -480,6 +481,14 @@ EOF;
         $this->assertTrue($kernel->getContainer()->getParameter('test.processed'));
     }
 
+    public function testWarmup()
+    {
+        $kernel = new CustomProjectDirKernel();
+        $kernel->boot();
+
+        $this->assertTrue($kernel->warmedUp);
+    }
+
     public function testServicesResetter()
     {
         $httpKernelMock = $this->getMockBuilder(HttpKernelInterface::class)
@@ -603,8 +612,9 @@ class TestKernel implements HttpKernelInterface
     }
 }
 
-class CustomProjectDirKernel extends Kernel
+class CustomProjectDirKernel extends Kernel implements WarmableInterface
 {
+    public $warmedUp = false;
     private $baseDir;
     private $buildContainer;
     private $httpKernel;
@@ -629,6 +639,13 @@ class CustomProjectDirKernel extends Kernel
     public function getProjectDir(): string
     {
         return __DIR__.'/Fixtures';
+    }
+
+    public function warmUp(string $cacheDir): array
+    {
+        $this->warmedUp = true;
+
+        return [];
     }
 
     protected function build(ContainerBuilder $container)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This allows your kernel to return extra classes to preload also (which was my main motivation for creating this PR actually.)

```php
// ...
use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
// ...

class Kernel ... implements ..., WarmableInterface
{
    // ...

    public function warmUp(string $cacheDir): array
    {
        // ...

        return [
            SomeClassToPreload::class,
            AnotherClassClassToPreload::class,
            $cacheDir.'/some-file-to-preload.php',
            // ...
        ];
    }

    // ...
}
```