### PR TITLE
[Serializer] do not transform empty \Traversable to Array

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -157,6 +157,10 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
         }
 
         if (\is_array($data) || $data instanceof \Traversable) {
+            if ($data instanceof \Countable && 0 === $data->count()) {
+                return $data;
+            }
+
             $normalized = [];
             foreach ($data as $key => $val) {
                 $normalized[$key] = $this->normalize($val, $format, $context);

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
@@ -488,6 +489,26 @@ class SerializerTest extends TestCase
         $this->expectExceptionMessage('An unexpected value could not be normalized: stream resource');
 
         (new Serializer())->normalize(tmpfile());
+    }
+
+    public function testNormalizePreserveEmptyArrayObject()
+    {
+        $serializer = new Serializer(
+          [
+              new PropertyNormalizer(),
+              new ObjectNormalizer(),
+              new ArrayDenormalizer(),
+          ],
+          [
+              'json' => new JsonEncoder(),
+          ]
+        );
+
+        $object = [];
+        $object['foo'] = new \ArrayObject();
+        $object['bar'] = new \ArrayObject(['notempty']);
+        $object['baz'] = new \ArrayObject(['nested' => new \ArrayObject()]);
+        $this->assertEquals('{"foo":{},"bar":["notempty"],"baz":{"nested":{}}}', $serializer->serialize($object, 'json', [AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true]));
     }
 
     private function serializerWithClassDiscriminator()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | na
| License       | MIT
| Doc PR        | na

Today, using `PRESERVE_EMPTY_OBJECTS` ([introduced in 4.0](https://github.com/symfony/symfony/commit/f28e826627e8d0db7db43a11e6e8d9b568e7870e)), the JSON serialization of:

```php
<?php
$object = [];
$object['foo'] = new \ArrayObject();
$object['bar'] = new \ArrayObject(['notempty']);
$object['baz'] = new \ArrayObject(['nested' => new \ArrayObject()]);
```

Outputs:

```json
{"foo":[],"bar":["notempty"],"baz":{"nested":[]}}
```

Instead of the expected:

```json
{"foo":{},"bar":["notempty"],"baz":{"nested":{}}}
```

This issue comes from the Serializer that transforms `Traversable` to an Array [here](https://github.com/symfony/symfony/blob/11a707200d65d1142b681100fdfd5a9782f93f02/src/Symfony/Component/Serializer/Serializer.php#L159). Also, the `AbstractObjectNormalizer` [doesn't support Traversable](https://github.com/symfony/symfony/blob/11a707200d65d1142b681100fdfd5a9782f93f02/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php#L134), but he allows to preserve empty objects.

I propose this patch where the fix doesn't transform a `Traversable` to an Array. I see another way to patch this in which we could allow empty Traversable in the `AbstractObjectNormalizer` (not sure it's better though). See attached [other-fix.patch](https://github.com/symfony/symfony/files/4539865/other-fix.log) to see the alternative patch.