### PR TITLE
[Cache] Fixed not supported Redis eviction policies

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
@@ -14,8 +14,8 @@ namespace Symfony\Component\Cache\Adapter;
 use Predis\Connection\Aggregate\ClusterInterface;
 use Predis\Connection\Aggregate\PredisCluster;
 use Predis\Response\Status;
-use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
+use Symfony\Component\Cache\Exception\LogicException;
 use Symfony\Component\Cache\Marshaller\DeflateMarshaller;
 use Symfony\Component\Cache\Marshaller\MarshallerInterface;
 use Symfony\Component\Cache\Marshaller\TagAwareMarshaller;
@@ -95,9 +95,7 @@ class RedisTagAwareAdapter extends AbstractTagAwareAdapter
     {
         $eviction = $this->getRedisEvictionPolicy();
         if ('noeviction' !== $eviction && 0 !== strpos($eviction, 'volatile-')) {
-            CacheItem::log($this->logger, sprintf('Redis maxmemory-policy setting "%s" is *not* supported by RedisTagAwareAdapter, use "noeviction" or  "volatile-*" eviction policies', $eviction));
-
-            return false;
+            throw new LogicException(sprintf('Redis maxmemory-policy setting "%s" is *not* supported by RedisTagAwareAdapter, use "noeviction" or  "volatile-*" eviction policies.', $eviction));
         }
 
         // serialize values


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

**Steps to reproduce:**
1. Define the following redis service on SymfonyCloud:
```
rediscache:
    type: redis:5.0
    size: S
    configuration:
        maxmemory_policy: allkeys-lru
```
2. Deploy the change

**Expected result:**
No redis cache will be populated

**Actual result:**
Following exception is thrown:
```
[2020-04-28T05:35:58.440403-04:00] php.CRITICAL: Uncaught Error: Return value of Symfony\Component\Cache\Adapter\RedisTagAwareAdapter::doSave() must be of the type array, bool returned {"exception":"[object] (TypeError(code: 0): Return value of Symfony\\Component\\Cache\\Adapter\\RedisTagAwareAdapter::doSave() must be of the type array, bool returned at /app/vendor/symfony/cache/Adapter/RedisTagAwareAdapter.php:100)"} []
```