### PR TITLE
Add missing port SQS Host Header request

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -334,7 +334,7 @@ class Connection
         $parsedUrl = parse_url($endpoint);
 
         $headers = [
-            'host' => $parsedUrl['host'],
+            'host' => $parsedUrl['host'].($parsedUrl['port'] ? ':'.$parsedUrl['port'] : ''),
             'x-amz-date' => $amzDate,
             'content-type' => 'application/x-www-form-urlencoded',
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

When user provides a custom endpoint, the port is missing from the `Host` headers, leading to wrong URL when calling `getQueueUrl`