### PR TITLE
Add Notifier SentMessage

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.0"
+        "symfony/notifier": "^5.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Firebase\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\FreeMobile;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Transport\AbstractTransport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -51,7 +52,7 @@ final class FreeMobileTransport extends AbstractTransport
         return $message instanceof SmsMessage && $this->phone === $message->getPhone();
     }
 
-    protected function doSend(MessageInterface $message): void
+    protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$this->supports($message)) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given) and configured with your phone number.', __CLASS__, SmsMessage::class, \get_class($message)));
@@ -75,5 +76,7 @@ final class FreeMobileTransport extends AbstractTransport
 
             throw new TransportException(sprintf('Unable to send the SMS: error %d: ', $response->getStatusCode()).($errors[$response->getStatusCode()] ?? ''), $response);
         }
+
+        return new SentMessage($message, (string) $this);
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.1",
-        "symfony/notifier": "^5.1"
+        "symfony/notifier": "^5.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\FreeMobile\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.0"
+        "symfony/notifier": "^5.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mattermost\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.0"
+        "symfony/notifier": "^5.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Nexmo\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\OvhCloud;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Transport\AbstractTransport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -53,7 +54,7 @@ final class OvhCloudTransport extends AbstractTransport
         return $message instanceof SmsMessage;
     }
 
-    protected function doSend(MessageInterface $message): void
+    protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof SmsMessage) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, SmsMessage::class, get_debug_type($message)));
@@ -90,6 +91,13 @@ final class OvhCloudTransport extends AbstractTransport
 
             throw new TransportException(sprintf('Unable to send the SMS: %s.', $error['message']), $response);
         }
+
+        $success = $response->toArray(false);
+
+        $message = new SentMessage($message, (string) $this);
+        $message->setMessageId($success['ids'][0]);
+
+        return $message;
     }
 
     /**

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.0"
+        "symfony/notifier": "^5.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\OvhCloud\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.0"
+        "symfony/notifier": "^5.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\RocketChat\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransport.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\Sinch;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Transport\AbstractTransport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -51,7 +52,7 @@ final class SinchTransport extends AbstractTransport
         return $message instanceof SmsMessage;
     }
 
-    protected function doSend(MessageInterface $message): void
+    protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof SmsMessage) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, SmsMessage::class, get_debug_type($message)));
@@ -72,5 +73,12 @@ final class SinchTransport extends AbstractTransport
 
             throw new TransportException(sprintf('Unable to send the SMS: %s (%s).', $error['text'], $error['code']), $response);
         }
+
+        $success = $response->toArray(false);
+
+        $message = new SentMessage($message, (string) $this);
+        $message->setMessageId($success['id']);
+
+        return $message;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.0"
+        "symfony/notifier": "^5.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sinch\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
@@ -15,6 +15,7 @@ use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Transport\AbstractTransport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -58,7 +59,7 @@ final class SlackTransport extends AbstractTransport
         return $message instanceof ChatMessage && (null === $message->getOptions() || $message->getOptions() instanceof SlackOptions);
     }
 
-    protected function doSend(MessageInterface $message): void
+    protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof ChatMessage) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, get_debug_type($message)));
@@ -86,5 +87,7 @@ final class SlackTransport extends AbstractTransport
         if ('ok' !== $result) {
             throw new TransportException('Unable to post the Slack message: '.$result, $response);
         }
+
+        return new SentMessage($message, (string) $this);
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.1"
+        "symfony/notifier": "^5.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^4.3|^5.0"

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -15,6 +15,7 @@ use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Transport\AbstractTransport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -60,7 +61,7 @@ final class TelegramTransport extends AbstractTransport
     /**
      * @see https://core.telegram.org/bots/api
      */
-    protected function doSend(MessageInterface $message): void
+    protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof ChatMessage) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, get_debug_type($message)));
@@ -82,5 +83,12 @@ final class TelegramTransport extends AbstractTransport
 
             throw new TransportException('Unable to post the Telegram message: '.$result['description'].sprintf(' (code %s).', $result['error_code']), $response);
         }
+
+        $success = $response->toArray(false);
+
+        $message = new SentMessage($message, (string) $this);
+        $message->setMessageId($success['result']['message_id']);
+
+        return $message;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -80,9 +80,34 @@ final class TelegramTransportTest extends TestCase
         $response->expects($this->exactly(2))
             ->method('getStatusCode')
             ->willReturn(200);
+
+        $content = <<<JSON
+            {
+                "ok": true,
+                "result": {
+                    "message_id": 1,
+                    "from": {
+                        "id": 12345678,
+                        "first_name": "YourBot",
+                        "username": "YourBot"
+                    },
+                    "chat": {
+                        "id": 1234567890,
+                        "first_name": "John",
+                        "last_name": "Doe",
+                        "username": "JohnDoe",
+                        "type": "private"
+                    },
+                    "date": 1459958199,
+                    "text": "Hello from Bot!"
+                }
+            }
+JSON;
+
         $response->expects($this->once())
             ->method('getContent')
-            ->willReturn('');
+            ->willReturn($content)
+        ;
 
         $expectedBody = [
             'chat_id' => $channel,
@@ -98,7 +123,10 @@ final class TelegramTransportTest extends TestCase
 
         $transport = new TelegramTransport('testToken', $channel, $client);
 
-        $transport->send(new ChatMessage('testMessage'));
+        $sentMessage = $transport->send(new ChatMessage('testMessage'));
+
+        $this->assertEquals(1, $sentMessage->getMessageId());
+        $this->assertEquals('telegram://api.telegram.org?channel=testChannel', $sentMessage->getTransport());
     }
 
     public function testSendWithChannelOverride(): void
@@ -109,9 +137,33 @@ final class TelegramTransportTest extends TestCase
         $response->expects($this->exactly(2))
             ->method('getStatusCode')
             ->willReturn(200);
+        $content = <<<JSON
+            {
+                "ok": true,
+                "result": {
+                    "message_id": 1,
+                    "from": {
+                        "id": 12345678,
+                        "first_name": "YourBot",
+                        "username": "YourBot"
+                    },
+                    "chat": {
+                        "id": 1234567890,
+                        "first_name": "John",
+                        "last_name": "Doe",
+                        "username": "JohnDoe",
+                        "type": "private"
+                    },
+                    "date": 1459958199,
+                    "text": "Hello from Bot!"
+                }
+            }
+JSON;
+
         $response->expects($this->once())
             ->method('getContent')
-            ->willReturn('');
+            ->willReturn($content)
+        ;
 
         $expectedBody = [
             'chat_id' => $channelOverride,
@@ -133,6 +185,9 @@ final class TelegramTransportTest extends TestCase
             ->method('getRecipientId')
             ->willReturn($channelOverride);
 
-        $transport->send(new ChatMessage('testMessage', $messageOptions));
+        $sentMessage = $transport->send(new ChatMessage('testMessage', $messageOptions));
+
+        $this->assertEquals(1, $sentMessage->getMessageId());
+        $this->assertEquals('telegram://api.telegram.org?channel=defaultChannel', $sentMessage->getTransport());
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.1"
+        "symfony/notifier": "^5.2"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^4.3|^5.0"

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\Twilio;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Transport\AbstractTransport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -51,7 +52,7 @@ final class TwilioTransport extends AbstractTransport
         return $message instanceof SmsMessage;
     }
 
-    protected function doSend(MessageInterface $message): void
+    protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof SmsMessage) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, SmsMessage::class, get_debug_type($message)));
@@ -72,5 +73,12 @@ final class TwilioTransport extends AbstractTransport
 
             throw new TransportException('Unable to send the SMS: '.$error['message'].sprintf(' (see %s).', $error['more_info']), $response);
         }
+
+        $success = $response->toArray(false);
+
+        $message = new SentMessage($message, (string) $this);
+        $message->setMessageId($success['sid']);
+
+        return $message;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.0"
+        "symfony/notifier": "^5.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Twilio\\": "" },

--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * [BC BREAK] The `TransportInterface::send()` and `AbstractTransport::doSend()` methods changed to return a `SentMessage` instance instead of `void`.
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/Notifier/Chatter.php
+++ b/src/Symfony/Component/Notifier/Chatter.php
@@ -16,6 +16,7 @@ use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Notifier\Event\MessageEvent;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -47,12 +48,10 @@ final class Chatter implements ChatterInterface
         return $this->transport->supports($message);
     }
 
-    public function send(MessageInterface $message): void
+    public function send(MessageInterface $message): SentMessage
     {
         if (null === $this->bus) {
-            $this->transport->send($message);
-
-            return;
+            return $this->transport->send($message);
         }
 
         if (null !== $this->dispatcher) {

--- a/src/Symfony/Component/Notifier/Message/SentMessage.php
+++ b/src/Symfony/Component/Notifier/Message/SentMessage.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Message;
+
+/**
+ * @author Jérémy Romey <jeremy@free-agent.fr>
+ *
+ * @experimental in 5.2
+ */
+final class SentMessage
+{
+    private $original;
+    private $transport;
+    private $messageId;
+
+    public function __construct(MessageInterface $original, string $transport)
+    {
+        $this->original = $original;
+        $this->transport = $transport;
+    }
+
+    public function getOriginalMessage(): MessageInterface
+    {
+        return $this->original;
+    }
+
+    public function getTransport(): string
+    {
+        return $this->transport;
+    }
+
+    public function setMessageId(string $id): void
+    {
+        $this->messageId = $id;
+    }
+
+    public function getMessageId(): ?string
+    {
+        return $this->messageId;
+    }
+}

--- a/src/Symfony/Component/Notifier/Texter.php
+++ b/src/Symfony/Component/Notifier/Texter.php
@@ -16,6 +16,7 @@ use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Notifier\Event\MessageEvent;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -47,12 +48,10 @@ final class Texter implements TexterInterface
         return $this->transport->supports($message);
     }
 
-    public function send(MessageInterface $message): void
+    public function send(MessageInterface $message): SentMessage
     {
         if (null === $this->bus) {
-            $this->transport->send($message);
-
-            return;
+            return $this->transport->send($message);
         }
 
         if (null !== $this->dispatcher) {

--- a/src/Symfony/Component/Notifier/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Notifier/Transport/AbstractTransport.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Notifier\Event\MessageEvent;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -69,16 +70,16 @@ abstract class AbstractTransport implements TransportInterface
         return $this;
     }
 
-    public function send(MessageInterface $message): void
+    public function send(MessageInterface $message): SentMessage
     {
         if (null !== $this->dispatcher) {
             $this->dispatcher->dispatch(new MessageEvent($message));
         }
 
-        $this->doSend($message);
+        return $this->doSend($message);
     }
 
-    abstract protected function doSend(MessageInterface $message): void;
+    abstract protected function doSend(MessageInterface $message): SentMessage;
 
     protected function getEndpoint(): ?string
     {

--- a/src/Symfony/Component/Notifier/Transport/NullTransport.php
+++ b/src/Symfony/Component/Notifier/Transport/NullTransport.php
@@ -15,6 +15,7 @@ use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\Notifier\Event\MessageEvent;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -31,11 +32,13 @@ class NullTransport implements TransportInterface
         $this->dispatcher = class_exists(Event::class) ? LegacyEventDispatcherProxy::decorate($dispatcher) : $dispatcher;
     }
 
-    public function send(MessageInterface $message): void
+    public function send(MessageInterface $message): SentMessage
     {
         if (null !== $this->dispatcher) {
             $this->dispatcher->dispatch(new MessageEvent($message));
         }
+
+        return new SentMessage($message, (string) $this);
     }
 
     public function __toString(): string

--- a/src/Symfony/Component/Notifier/Transport/RoundRobinTransport.php
+++ b/src/Symfony/Component/Notifier/Transport/RoundRobinTransport.php
@@ -15,6 +15,7 @@ use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\RuntimeException;
 use Symfony\Component\Notifier\Exception\TransportExceptionInterface;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
 
 /**
  * Uses several Transports using a round robin algorithm.
@@ -63,13 +64,11 @@ class RoundRobinTransport implements TransportInterface
         return false;
     }
 
-    public function send(MessageInterface $message): void
+    public function send(MessageInterface $message): SentMessage
     {
         while ($transport = $this->getNextTransport($message)) {
             try {
-                $transport->send($message);
-
-                return;
+                return $transport->send($message);
             } catch (TransportExceptionInterface $e) {
                 $this->deadTransports[$transport] = microtime(true);
             }

--- a/src/Symfony/Component/Notifier/Transport/TransportInterface.php
+++ b/src/Symfony/Component/Notifier/Transport/TransportInterface.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Transport;
 
 use Symfony\Component\Notifier\Exception\TransportExceptionInterface;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -24,7 +25,7 @@ interface TransportInterface
     /**
      * @throws TransportExceptionInterface
      */
-    public function send(MessageInterface $message): void;
+    public function send(MessageInterface $message): SentMessage;
 
     public function supports(MessageInterface $message): bool;
 

--- a/src/Symfony/Component/Notifier/Transport/Transports.php
+++ b/src/Symfony/Component/Notifier/Transport/Transports.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Transport;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -51,17 +52,14 @@ final class Transports implements TransportInterface
         return false;
     }
 
-    public function send(MessageInterface $message): void
+    public function send(MessageInterface $message): SentMessage
     {
         if (!$transport = $message->getTransport()) {
             foreach ($this->transports as $transport) {
                 if ($transport->supports($message)) {
-                    $transport->send($message);
-
-                    return;
+                    return $transport->send($message);
                 }
             }
-
             throw new LogicException(sprintf('None of the available transports support the given message (available transports: "%s").', implode('", "', array_keys($this->transports))));
         }
 
@@ -73,6 +71,6 @@ final class Transports implements TransportInterface
             throw new LogicException(sprintf('The "%s" transport does not support the given message.', $transport));
         }
 
-        $this->transports[$transport]->send($message);
+        return $this->transports[$transport]->send($message);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/13624

Like Mailer, Notifier returns now a SentMessage that contains the messageId (returned by the provider in the response). It contains also the body of the response as array to have more info about price, number of sms sent, status and so on.

- [x] apply to bridges
