### PR TITLE
[Validator] fix lazy property usage.

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Fixtures/Entity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Entity.php
@@ -53,6 +53,11 @@ class Entity extends EntityParent implements EntityInterfaceB
         $this->internal = $internal;
     }
 
+    public function getFirstName()
+    {
+        return $this->firstName;
+    }
+
     public function getInternal()
     {
         return $this->internal.' from getter';
@@ -140,5 +145,10 @@ class Entity extends EntityParent implements EntityInterfaceB
     public function setChildB($childB)
     {
         $this->childB = $childB;
+    }
+
+    public function getReference()
+    {
+        return $this->reference;
     }
 }

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -677,6 +677,10 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         // See validateClassNode()
         $cascadedGroups = null !== $cascadedGroups && \count($cascadedGroups) > 0 ? $cascadedGroups : $groups;
 
+        if ($value instanceof LazyProperty) {
+            $value = $value->getPropertyValue();
+        }
+
         if (\is_array($value)) {
             // Arrays are always traversed, independent of the specified
             // traversal strategy


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #36343
| License       | MIT
| Doc PR        | 

This attempts to fix a large regression introduced in #36343, which broke recursing values returned from `getter` Constraints, because they are now wrapped  in in a `LazyProperty`. The `LazyProperty` needs to be evaluated because some checks are done on the type of `$value`, i.e `is_array` etc... in `validateGenericNode`.

I'm concerned that the original PR didn't really add sufficient test coverage for the introduction of `LazyProperty`, and I'm not 100% sure that I've caught all the cases where the `instanceof` check are needed in this PR.

For the tests, I added the `@dataProvider getConstraintMethods` to every test that hit the problem area of code.

~~The only issue is that my fixed has broken the test introduced in #36343, `testGroupedMethodConstraintValidateInSequence`.~~

~~I think I need @HeahDude to help me work through this. Maybe there is a more simple solution, one that doesn't require doing `instanceof LazyPropery` checks in multiple places, because this feels very brittle.~~
EDIT: fixed that test.