### PR TITLE
Doctrine messenger schema

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Migration.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Migration.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\Doctrine\Transport;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+
+final class Migration
+{
+    private $tableName;
+
+    public function __construct(string $tableName = 'messenger_messages')
+    {
+        $this->tableName = $tableName;
+    }
+
+    public static function up(Schema $schema, Connection $connection): void
+    {
+        $useDeprecatedConstants = !class_exists(Types::class);
+        $table = $schema->createTable($this->tableName);
+        $table->addColumn('id', $useDeprecatedConstants ? Type::BIGINT : Types::BIGINT)->setAutoincrement(true)->setNotnull(true);
+        $table->addColumn('body', $useDeprecatedConstants ? Type::TEXT : Types::TEXT)->setNotnull(true);
+        $table->addColumn('headers', $useDeprecatedConstants ? Type::TEXT : Types::TEXT)->setNotnull(true);
+        $table->addColumn('queue_name', $useDeprecatedConstants ? Type::STRING : Types::STRING)->setNotnull(true);
+        $table->addColumn('created_at', $useDeprecatedConstants ? Type::DATETIME : Types::DATETIME_MUTABLE)->setNotnull(true);
+        $table->addColumn('available_at', $useDeprecatedConstants ? Type::DATETIME : Types::DATETIME_MUTABLE)->setNotnull(true);
+        $table->addColumn('delivered_at', $useDeprecatedConstants ? Type::DATETIME : Types::DATETIME_MUTABLE)->setNotnull(false);
+        $table->setPrimaryKey(['id']);
+        $table->addIndex(['queue_name']);
+        $table->addIndex(['available_at']);
+        $table->addIndex(['delivered_at']);
+
+        if ('postgresql' === $connection->getDatabasePlatform()->getName()) {
+            $sql = sprintf(<<<'SQL'
+LOCK TABLE %1$s;
+-- create trigger function
+CREATE OR REPLACE FUNCTION notify_%1$s() RETURNS TRIGGER AS $$
+    BEGIN
+        PERFORM pg_notify('%1$s', NEW.queue_name::text);
+        RETURN NEW;
+    END;
+$$ LANGUAGE plpgsql;
+
+-- register trigger
+DROP TRIGGER IF EXISTS notify_trigger ON %1$s;
+
+CREATE TRIGGER notify_trigger
+AFTER INSERT
+ON %1$s
+FOR EACH ROW EXECUTE PROCEDURE notify_%1$s();
+SQL
+            , $this->tableName);
+
+            $connection->exec($sql);
+        }
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -79,32 +79,6 @@ final class PostgreSqlConnection extends Connection
         return parent::get();
     }
 
-    public function setup(): void
-    {
-        parent::setup();
-
-        $sql = sprintf(<<<'SQL'
-LOCK TABLE %1$s;
--- create trigger function
-CREATE OR REPLACE FUNCTION notify_%1$s() RETURNS TRIGGER AS $$
-	BEGIN
-		PERFORM pg_notify('%1$s', NEW.queue_name::text);
-		RETURN NEW;
-    END;
-$$ LANGUAGE plpgsql;
-
--- register trigger
-DROP TRIGGER IF EXISTS notify_trigger ON %1$s;
-
-CREATE TRIGGER notify_trigger
-AFTER INSERT
-ON %1$s
-FOR EACH ROW EXECUTE PROCEDURE notify_%1$s();
-SQL
-            , $this->configuration['table_name']);
-        $this->driverConnection->exec($sql);
-    }
-
     private function unlisten()
     {
         if (!$this->listening) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | n/a

When using the Doctrine Messenger integration, `auto_setup` is `true` by default meaning that the table is created on the fly.

When using Doctrine Migrations, that's an issue as the table is not managed by migrations, so a `make:migration` will include the removal of the table. There are workarounds.

But more importantly, if you're using some Doctrine bundle to wrap your tests with transactions to speed them up, things will break. `auto_setup` will set itself to `false` after creating the table, but for the next test, the table will be wiped out. And that's just the beginning of more issues.

Fixing it the "proper way" involves setting `auto_setup` to `false` and creating a proper migration. The problem comes from the fact that the schema is not exposed, so you need to recreate it yourself.

So, I think we need to get rid of that `auto_setup` flag which does more harm than good.

This PR does a first step in that direction by exposing the schema changes so that you can create a migration as a one liner (thanks to `make:migration`):

```php
namespace DoctrineMigrations;

use Doctrine\DBAL\Schema\Schema;
use Doctrine\Migrations\AbstractMigration;
use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Migration as MessengerMigration;

final class VersionXXX extends AbstractMigration
{
    public function up(Schema $schema): void
    {
        $m = new MessengerMigration();
        $m->up($schema, $this->connection);
    }

    public function down(Schema $schema): void
    {
        // don't get me started with down() in migrations :)
    }
}
```

We could even imagine having it generated automatically via `make:migration --messenger`?

Less magic and good integration with best practices is a nice bonus.
