### PR TITLE
[File] Add getFilenameWithoutExtension function

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -62,6 +62,21 @@ class File extends \SplFileInfo
     }
 
     /**
+     * Returns the base file name without the extension.
+     *
+     * If the file has more than one extension, only the last one will be stripped.
+     *
+     * If the file is prefixed with dot, and has no extension (e.g. ".hidden"),
+     * result will be empty string.
+     *
+     * @return string
+     */
+    public function getFilenameWithoutExtension(): string
+    {
+        return pathinfo($this->getFilename(), PATHINFO_FILENAME);
+    }
+
+    /**
      * Returns the mime type of the file.
      *
      * The mime type is guessed using a MimeTypeGuesserInterface instance,

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -68,8 +68,6 @@ class File extends \SplFileInfo
      *
      * If the file is prefixed with dot, and has no extension (e.g. ".hidden"),
      * result will be empty string.
-     *
-     * @return string
      */
     public function getFilenameWithoutExtension(): string
     {

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -46,6 +46,15 @@ class FileTest extends TestCase
         new File(__DIR__.'/Fixtures/not_here');
     }
 
+    public function testGetFilenameWithoutExtension()
+    {
+        $file = new File(__DIR__.'/Fixtures/test.gif');
+        $this->assertEquals('test', $file->getFilenameWithoutExtension());
+
+        $file = new File(__DIR__.'/Fixtures/-test');
+        $this->assertEquals('-test', $file->getFilenameWithoutExtension());
+    }
+
     public function testMove()
     {
         $path = __DIR__.'/Fixtures/test.copy.gif';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This adds the ease of access to file name without it's extension. I have personally found it very useful for file uploads (`Symfony\Component\HttpFoundation\File\UploadedFile`) where the file needs to have a name/title inside a database, and for convenience that name is being read from the file name by default (e.g. `my-dog.jpg` will be called `my-dog`).