### PR TITLE
[WIP] [Workflow] Choose which Workflow events should be dispatched

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -34,6 +34,7 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\WebLink\HttpHeaderSerializer;
+use Symfony\Component\Workflow\WorkflowEvents;
 
 /**
  * FrameworkExtension configuration structure.
@@ -282,6 +283,7 @@ class Configuration implements ConfigurationInterface
                                 ->fixXmlConfig('support')
                                 ->fixXmlConfig('place')
                                 ->fixXmlConfig('transition')
+                                ->fixXmlConfig('dispatched_event')
                                 ->children()
                                     ->arrayNode('audit_trail')
                                         ->canBeEnabled()
@@ -323,6 +325,22 @@ class Configuration implements ConfigurationInterface
                                         ->beforeNormalization()->castToArray()->end()
                                         ->defaultValue([])
                                         ->prototype('scalar')->end()
+                                    ->end()
+                                    ->arrayNode('dispatched_events')
+                                        ->beforeNormalization()
+                                            ->ifString()
+                                            ->then(function ($v) {
+                                                return [$v];
+                                            })
+                                        ->end()
+                                        // We have to specify a default here as when this config option
+                                        // isn't set the default behaviour of `arrayNode()` is to return an empty
+                                        // array which conflicts with our Definition, and we cannot set a default
+                                        // of `null` for arrayNode()'s
+                                        ->defaultValue(['all'])
+                                        ->prototype('scalar')->end()
+                                        ->info('Select which Transition events should be dispatched for this Workflow')
+                                        ->example(['leave', 'completed'])
                                     ->end()
                                     ->arrayNode('places')
                                         ->beforeNormalization()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -34,7 +34,6 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Validator\Validation;
 use Symfony\Component\WebLink\HttpHeaderSerializer;
-use Symfony\Component\Workflow\WorkflowEvents;
 
 /**
  * FrameworkExtension configuration structure.

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -713,6 +713,17 @@ class FrameworkExtension extends Extension
             $places = array_column($workflow['places'], 'name');
             $initialMarking = $workflow['initial_marking'] ?? [];
 
+            // Record which events should be dispatched
+            if ($workflow['dispatched_events'] === ['all']) {
+                $dispatchedEvents = null;
+            } elseif ($workflow['dispatched_events'] === ['none']) {
+                $dispatchedEvents = [];
+            } else {
+                $dispatchedEvents = array_map(function (string $event) {
+                    return 'workflow.'.$event;
+                }, $workflow['dispatched_events']);
+            }
+
             // Create a Definition
             $definitionDefinition = new Definition(Workflow\Definition::class);
             $definitionDefinition->setPublic(false);
@@ -720,6 +731,7 @@ class FrameworkExtension extends Extension
             $definitionDefinition->addArgument($transitions);
             $definitionDefinition->addArgument($initialMarking);
             $definitionDefinition->addArgument($metadataStoreDefinition);
+            $definitionDefinition->addArgument($dispatchedEvents);
             $definitionDefinition->addTag('workflow.definition', [
                 'name' => $name,
                 'type' => $type,

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -283,6 +283,7 @@
             <xsd:element name="initial-marking" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="marking-store" type="marking_store" minOccurs="0" maxOccurs="1" />
             <xsd:element name="support" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="dispatched-event" type="dispatched_event" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="place" type="place" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="transition" type="transition" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="metadata" type="metadata" minOccurs="0" maxOccurs="unbounded" />
@@ -339,6 +340,19 @@
             <xsd:any minOccurs="0" processContents="lax"/>
         </xsd:sequence>
     </xsd:complexType>
+
+    <xsd:simpleType name="dispatched_event">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="all" />
+            <xsd:enumeration value="none" />
+            <xsd:enumeration value="leave" />
+            <xsd:enumeration value="transition" />
+            <xsd:enumeration value="enter" />
+            <xsd:enumeration value="entered" />
+            <xsd:enumeration value="completed" />
+            <xsd:enumeration value="announce" />
+        </xsd:restriction>
+    </xsd:simpleType>
 
     <xsd:simpleType name="default_middleware">
         <xsd:restriction base="xsd:string">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_all_dispatched_events.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_all_dispatched_events.php
@@ -1,0 +1,41 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest;
+
+$container->loadFromExtension('framework', [
+    'workflows' => [
+        'my_workflow' => [
+            'type' => 'state_machine',
+            'marking_store' => [
+                'type' => 'method',
+                'property' => 'state'
+            ],
+            'supports' => [
+                FrameworkExtensionTest::class,
+            ],
+            'places' => [
+                'one',
+                'two',
+                'three',
+            ],
+            'transitions' => [
+                'count_to_two' => [
+                    'from' => [
+                        'one',
+                    ],
+                    'to' => [
+                        'two',
+                    ],
+                ],
+                'count_to_three' => [
+                    'from' => [
+                        'two',
+                    ],
+                    'to' => [
+                        'three'
+                    ]
+                ]
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_no_dispatched_events.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_no_dispatched_events.php
@@ -1,0 +1,42 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest;
+
+$container->loadFromExtension('framework', [
+    'workflows' => [
+        'my_workflow' => [
+            'type' => 'state_machine',
+            'marking_store' => [
+                'type' => 'method',
+                'property' => 'state'
+            ],
+            'supports' => [
+                FrameworkExtensionTest::class,
+            ],
+            'dispatched_events' => [],
+            'places' => [
+                'one',
+                'two',
+                'three',
+            ],
+            'transitions' => [
+                'count_to_two' => [
+                    'from' => [
+                        'one',
+                    ],
+                    'to' => [
+                        'two',
+                    ],
+                ],
+                'count_to_three' => [
+                    'from' => [
+                        'two',
+                    ],
+                    'to' => [
+                        'three'
+                    ]
+                ]
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_specified_dispatched_events.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflow_with_specified_dispatched_events.php
@@ -1,0 +1,45 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest;
+
+$container->loadFromExtension('framework', [
+    'workflows' => [
+        'my_workflow' => [
+            'type' => 'state_machine',
+            'marking_store' => [
+                'type' => 'method',
+                'property' => 'state'
+            ],
+            'supports' => [
+                FrameworkExtensionTest::class,
+            ],
+            'dispatched_events' => [
+                'leave',
+                'completed'
+            ],
+            'places' => [
+                'one',
+                'two',
+                'three',
+            ],
+            'transitions' => [
+                'count_to_two' => [
+                    'from' => [
+                        'one',
+                    ],
+                    'to' => [
+                        'two',
+                    ],
+                ],
+                'count_to_three' => [
+                    'from' => [
+                        'two',
+                    ],
+                    'to' => [
+                        'three'
+                    ]
+                ]
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_all_dispatched_events.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_all_dispatched_events.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:workflow name="my_workflow" type="state_machine">
+            <framework:initial-marking>one</framework:initial-marking>
+            <framework:marking-store type="method" property="state" />
+            <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
+            <framework:place name="one" />
+            <framework:place name="two" />
+            <framework:place name="three" />
+            <framework:transition name="count_to_two">
+                <framework:from>one</framework:from>
+                <framework:to>two</framework:to>
+            </framework:transition>
+            <framework:transition name="count_to_three">
+                <framework:from>two</framework:from>
+                <framework:to>three</framework:to>
+            </framework:transition>
+        </framework:workflow>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_no_dispatched_events.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_no_dispatched_events.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:workflow name="my_workflow" type="state_machine">
+            <framework:initial-marking>one</framework:initial-marking>
+            <framework:marking-store type="method" property="state" />
+            <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
+            <framework:dispatched-event>none</framework:dispatched-event>
+            <framework:place name="one" />
+            <framework:place name="two" />
+            <framework:place name="three" />
+            <framework:transition name="count_to_two">
+                <framework:from>one</framework:from>
+                <framework:to>two</framework:to>
+            </framework:transition>
+            <framework:transition name="count_to_three">
+                <framework:from>two</framework:from>
+                <framework:to>three</framework:to>
+            </framework:transition>
+        </framework:workflow>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_specified_dispatched_events.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflow_with_specified_dispatched_events.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+                        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:workflow name="my_workflow" type="state_machine">
+            <framework:initial-marking>one</framework:initial-marking>
+            <framework:marking-store type="method" property="state" />
+            <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
+            <framework:dispatched-event>leave</framework:dispatched-event>
+            <framework:dispatched-event>completed</framework:dispatched-event>
+            <framework:place name="one" />
+            <framework:place name="two" />
+            <framework:place name="three" />
+            <framework:transition name="count_to_two">
+                <framework:from>one</framework:from>
+                <framework:to>two</framework:to>
+            </framework:transition>
+            <framework:transition name="count_to_three">
+                <framework:from>two</framework:from>
+                <framework:to>three</framework:to>
+            </framework:transition>
+        </framework:workflow>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_all_dispatched_events.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_all_dispatched_events.yml
@@ -1,0 +1,21 @@
+framework:
+    workflows:
+        my_workflow:
+            type: state_machine
+            initial_marking: one
+            marking_store:
+                type: method
+                property: state
+            supports:
+                - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest
+            places:
+                - one
+                - two
+                - three
+            transitions:
+                count_to_two:
+                    from: one
+                    to: two
+                count_to_three:
+                    from: two
+                    to: three

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_no_dispatched_events.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_no_dispatched_events.yml
@@ -1,0 +1,22 @@
+framework:
+    workflows:
+        my_workflow:
+            type: state_machine
+            initial_marking: one
+            dispatched_events: []
+            marking_store:
+                type: method
+                property: state
+            supports:
+                - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest
+            places:
+                - one
+                - two
+                - three
+            transitions:
+                count_to_two:
+                    from: one
+                    to: two
+                count_to_three:
+                    from: two
+                    to: three

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_specified_dispatched_events.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflow_with_specified_dispatched_events.yml
@@ -1,0 +1,22 @@
+framework:
+    workflows:
+        my_workflow:
+            type: state_machine
+            initial_marking: one
+            dispatched_events: ['leave', 'completed']
+            marking_store:
+                type: method
+                property: state
+            supports:
+                - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest
+            places:
+                - one
+                - two
+                - three
+            transitions:
+                count_to_two:
+                    from: one
+                    to: two
+                count_to_three:
+                    from: two
+                    to: three

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -428,7 +428,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $workflowDefinition = $container->getDefinition('state_machine.my_workflow.definition');
         $dispatchedEvents = $workflowDefinition->getArgument(4);
 
-        $this->assertSame(null, $dispatchedEvents);
+        $this->assertNull($dispatchedEvents);
     }
 
     public function testWorkflowsWithNoDispatchedEvents()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -54,6 +54,7 @@ use Symfony\Component\Translation\DependencyInjection\TranslatorPass;
 use Symfony\Component\Validator\DependencyInjection\AddConstraintValidatorsPass;
 use Symfony\Component\Validator\Mapping\Loader\PropertyInfoLoader;
 use Symfony\Component\Workflow;
+use Symfony\Component\Workflow\WorkflowEvents;
 
 abstract class FrameworkExtensionTest extends TestCase
 {
@@ -418,6 +419,36 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('workflows_explicitly_enabled_named_workflows');
 
         $this->assertTrue($container->hasDefinition('workflow.workflows.definition'));
+    }
+
+    public function testWorkflowsWithAllDispatchedEvents()
+    {
+        $container = $this->createContainerFromFile('workflow_with_all_dispatched_events');
+
+        $workflowDefinition = $container->getDefinition('state_machine.my_workflow.definition');
+        $dispatchedEvents = $workflowDefinition->getArgument(4);
+
+        $this->assertSame(null, $dispatchedEvents);
+    }
+
+    public function testWorkflowsWithNoDispatchedEvents()
+    {
+        $container = $this->createContainerFromFile('workflow_with_no_dispatched_events');
+
+        $workflowDefinition = $container->getDefinition('state_machine.my_workflow.definition');
+        $dispatchedEvents = $workflowDefinition->getArgument(4);
+
+        $this->assertSame([], $dispatchedEvents);
+    }
+
+    public function testWorkflowsWithSpecifiedDispatchedEvents()
+    {
+        $container = $this->createContainerFromFile('workflow_with_specified_dispatched_events');
+
+        $workflowDefinition = $container->getDefinition('state_machine.my_workflow.definition');
+        $dispatchedEvents = $workflowDefinition->getArgument(4);
+
+        $this->assertSame([WorkflowEvents::LEAVE, WorkflowEvents::COMPLETED], $dispatchedEvents);
     }
 
     public function testEnabledPhpErrorsConfig()

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -6,7 +6,6 @@ CHANGELOG
 
  * Added context to `TransitionException` and its child classes whenever they are thrown in `Workflow::apply()`
  * Added `Registry::has()` to check if a workflow exists
- * Added support for `$context[Workflow::DISABLE_ANNOUNCE_EVENT] = true` when calling `workflow->apply()` to not fire the announce event
  * Added support for specifying which events should be dispatched when calling `workflow->apply()`
 
 5.0.0

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Added context to `TransitionException` and its child classes whenever they are thrown in `Workflow::apply()`
  * Added `Registry::has()` to check if a workflow exists
  * Added support for `$context[Workflow::DISABLE_ANNOUNCE_EVENT] = true` when calling `workflow->apply()` to not fire the announce event
+ * Added support for specifying which events should be dispatched when calling `workflow->apply()`
 
 5.0.0
 -----

--- a/src/Symfony/Component/Workflow/Definition.php
+++ b/src/Symfony/Component/Workflow/Definition.php
@@ -22,19 +22,28 @@ use Symfony\Component\Workflow\Metadata\MetadataStoreInterface;
  */
 final class Definition
 {
+    /**
+     * When `null` fire all events (the default behaviour).
+     * Setting this to an empty array `[]` means no events are dispatched except the Guard Event.
+     * Passing an array with WorkflowEvents will allow only those events to be dispatched plus
+     * the Guard Event.
+     *
+     * @var array|string[]
+     */
+    private $dispatchedEvents;
+
     private $places = [];
     private $transitions = [];
     private $initialPlaces = [];
     private $metadataStore;
-    private $dispatchEvents;
 
     /**
      * @param string[]             $places
      * @param Transition[]         $transitions
      * @param string|string[]|null $initialPlaces
-     * @param array|null $dispatchEvents
+     * @param array|null           $dispatchedEvents
      */
-    public function __construct(array $places, array $transitions, $initialPlaces = null, MetadataStoreInterface $metadataStore = null, array $dispatchEvents = null)
+    public function __construct(array $places, array $transitions, $initialPlaces = null, MetadataStoreInterface $metadataStore = null, array $dispatchedEvents = null)
     {
         foreach ($places as $place) {
             $this->addPlace($place);
@@ -48,7 +57,7 @@ final class Definition
 
         $this->metadataStore = $metadataStore ?: new InMemoryMetadataStore();
 
-        $this->dispatchEvents = $dispatchEvents ?? WorkflowEvents::getDefaultDispatchEvents();
+        $this->dispatchedEvents = $dispatchedEvents ?? WorkflowEvents::getDefaultDispatchedEvents();
     }
 
     /**
@@ -83,9 +92,9 @@ final class Definition
     /**
      * @return array
      */
-    public function getDispatchEvents(): array
+    public function getDispatchedEvents(): array
     {
-        return $this->dispatchEvents;
+        return $this->dispatchedEvents;
     }
 
     private function setInitialPlaces($places = null)

--- a/src/Symfony/Component/Workflow/Definition.php
+++ b/src/Symfony/Component/Workflow/Definition.php
@@ -41,7 +41,6 @@ final class Definition
      * @param string[]             $places
      * @param Transition[]         $transitions
      * @param string|string[]|null $initialPlaces
-     * @param array|null           $dispatchedEvents
      */
     public function __construct(array $places, array $transitions, $initialPlaces = null, MetadataStoreInterface $metadataStore = null, array $dispatchedEvents = null)
     {
@@ -89,9 +88,6 @@ final class Definition
         return $this->metadataStore;
     }
 
-    /**
-     * @return array
-     */
     public function getDispatchedEvents(): array
     {
         return $this->dispatchedEvents;

--- a/src/Symfony/Component/Workflow/Definition.php
+++ b/src/Symfony/Component/Workflow/Definition.php
@@ -26,13 +26,15 @@ final class Definition
     private $transitions = [];
     private $initialPlaces = [];
     private $metadataStore;
+    private $dispatchEvents;
 
     /**
      * @param string[]             $places
      * @param Transition[]         $transitions
      * @param string|string[]|null $initialPlaces
+     * @param array|null $dispatchEvents
      */
-    public function __construct(array $places, array $transitions, $initialPlaces = null, MetadataStoreInterface $metadataStore = null)
+    public function __construct(array $places, array $transitions, $initialPlaces = null, MetadataStoreInterface $metadataStore = null, array $dispatchEvents = null)
     {
         foreach ($places as $place) {
             $this->addPlace($place);
@@ -45,6 +47,8 @@ final class Definition
         $this->setInitialPlaces($initialPlaces);
 
         $this->metadataStore = $metadataStore ?: new InMemoryMetadataStore();
+
+        $this->dispatchEvents = $dispatchEvents ?? WorkflowEvents::getDefaultDispatchEvents();
     }
 
     /**
@@ -74,6 +78,14 @@ final class Definition
     public function getMetadataStore(): MetadataStoreInterface
     {
         return $this->metadataStore;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDispatchEvents(): array
+    {
+        return $this->dispatchEvents;
     }
 
     private function setInitialPlaces($places = null)

--- a/src/Symfony/Component/Workflow/DefinitionBuilder.php
+++ b/src/Symfony/Component/Workflow/DefinitionBuilder.php
@@ -137,8 +137,6 @@ class DefinitionBuilder
     }
 
     /**
-     * @param array $dispatchEvents
-     *
      * @return $this
      */
     public function setDispatchEvents(array $dispatchEvents)

--- a/src/Symfony/Component/Workflow/DefinitionBuilder.php
+++ b/src/Symfony/Component/Workflow/DefinitionBuilder.php
@@ -26,6 +26,7 @@ class DefinitionBuilder
     private $transitions = [];
     private $initialPlaces;
     private $metadataStore;
+    private $dispatchEvents = null;
 
     /**
      * @param string[]     $places
@@ -42,7 +43,7 @@ class DefinitionBuilder
      */
     public function build()
     {
-        return new Definition($this->places, $this->transitions, $this->initialPlaces, $this->metadataStore);
+        return new Definition($this->places, $this->transitions, $this->initialPlaces, $this->metadataStore, $this->dispatchEvents);
     }
 
     /**
@@ -56,6 +57,7 @@ class DefinitionBuilder
         $this->transitions = [];
         $this->initialPlaces = null;
         $this->metadataStore = null;
+        $this->dispatchEvents = null;
 
         return $this;
     }
@@ -130,6 +132,18 @@ class DefinitionBuilder
     public function setMetadataStore(MetadataStoreInterface $metadataStore)
     {
         $this->metadataStore = $metadataStore;
+
+        return $this;
+    }
+
+    /**
+     * @param array $dispatchEvents
+     *
+     * @return $this
+     */
+    public function setDispatchEvents(array $dispatchEvents)
+    {
+        $this->dispatchEvents = $dispatchEvents;
 
         return $this;
     }

--- a/src/Symfony/Component/Workflow/Tests/DefinitionBuilderTest.php
+++ b/src/Symfony/Component/Workflow/Tests/DefinitionBuilderTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Workflow\DefinitionBuilder;
 use Symfony\Component\Workflow\Metadata\InMemoryMetadataStore;
 use Symfony\Component\Workflow\Transition;
+use Symfony\Component\Workflow\WorkflowEvents;
 
 class DefinitionBuilderTest extends TestCase
 {
@@ -54,5 +55,33 @@ class DefinitionBuilderTest extends TestCase
         $definition = $builder->build();
 
         $this->assertSame($metadataStore, $definition->getMetadataStore());
+    }
+
+    public function testCheckDefaultDispatchEvents()
+    {
+        $builder = new DefinitionBuilder(['a']);
+        $definition = $builder->build();
+
+        $this->assertSame(WorkflowEvents::getDefaultDispatchEvents(), $definition->getDispatchEvents());
+    }
+
+    public function testSetEmptyDispatchEvents()
+    {
+        $builder = new DefinitionBuilder(['a']);
+        $builder->setDispatchEvents([]);
+        $definition = $builder->build();
+
+        $this->assertSame([], $definition->getDispatchEvents());
+    }
+
+    public function testSetSpecificDispatchEvents()
+    {
+        $events = [WorkflowEvents::ENTERED, WorkflowEvents::COMPLETED];
+
+        $builder = new DefinitionBuilder(['a']);
+        $builder->setDispatchEvents($events);
+        $definition = $builder->build();
+
+        $this->assertSame($events, $definition->getDispatchEvents());
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/DefinitionBuilderTest.php
+++ b/src/Symfony/Component/Workflow/Tests/DefinitionBuilderTest.php
@@ -62,7 +62,7 @@ class DefinitionBuilderTest extends TestCase
         $builder = new DefinitionBuilder(['a']);
         $definition = $builder->build();
 
-        $this->assertSame(WorkflowEvents::getDefaultDispatchEvents(), $definition->getDispatchEvents());
+        $this->assertSame(WorkflowEvents::getDefaultDispatchedEvents(), $definition->getDispatchedEvents());
     }
 
     public function testSetEmptyDispatchEvents()
@@ -71,7 +71,7 @@ class DefinitionBuilderTest extends TestCase
         $builder->setDispatchEvents([]);
         $definition = $builder->build();
 
-        $this->assertSame([], $definition->getDispatchEvents());
+        $this->assertSame([], $definition->getDispatchedEvents());
     }
 
     public function testSetSpecificDispatchEvents()
@@ -82,6 +82,6 @@ class DefinitionBuilderTest extends TestCase
         $builder->setDispatchEvents($events);
         $definition = $builder->build();
 
-        $this->assertSame($events, $definition->getDispatchEvents());
+        $this->assertSame($events, $definition->getDispatchedEvents());
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/Workflow/Tests/DefinitionTest.php
@@ -76,7 +76,7 @@ class DefinitionTest extends TestCase
         $places = range('a', 'b');
         $definition = new Definition($places, [], null, null, null);
 
-        $this->assertSame(WorkflowEvents::getDefaultDispatchEvents(), $definition->getDispatchEvents());
+        $this->assertSame(WorkflowEvents::getDefaultDispatchedEvents(), $definition->getDispatchedEvents());
     }
 
     public function testSetEmptyDispatchEvents()
@@ -84,7 +84,7 @@ class DefinitionTest extends TestCase
         $places = range('a', 'b');
         $definition = new Definition($places, [], null, null, []);
 
-        $this->assertEmpty($definition->getDispatchEvents());
+        $this->assertEmpty($definition->getDispatchedEvents());
     }
 
     public function testSetSpecificDispatchEvents()
@@ -94,6 +94,6 @@ class DefinitionTest extends TestCase
         $places = range('a', 'b');
         $definition = new Definition($places, [], null, null, $events);
 
-        $this->assertSame($events, $definition->getDispatchEvents());
+        $this->assertSame($events, $definition->getDispatchedEvents());
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/Workflow/Tests/DefinitionTest.php
@@ -5,6 +5,7 @@ namespace Symfony\Component\Workflow\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Workflow\Definition;
 use Symfony\Component\Workflow\Transition;
+use Symfony\Component\Workflow\WorkflowEvents;
 
 class DefinitionTest extends TestCase
 {
@@ -68,5 +69,31 @@ class DefinitionTest extends TestCase
         $places = range('a', 'b');
 
         new Definition($places, [new Transition('name', $places[0], 'c')]);
+    }
+
+    public function testSetDefaultDispatchEvents()
+    {
+        $places = range('a', 'b');
+        $definition = new Definition($places, [], null, null, null);
+
+        $this->assertSame(WorkflowEvents::getDefaultDispatchEvents(), $definition->getDispatchEvents());
+    }
+
+    public function testSetEmptyDispatchEvents()
+    {
+        $places = range('a', 'b');
+        $definition = new Definition($places, [], null, null, []);
+
+        $this->assertEmpty($definition->getDispatchEvents());
+    }
+
+    public function testSetSpecificDispatchEvents()
+    {
+        $events = [WorkflowEvents::ENTERED, WorkflowEvents::COMPLETED];
+
+        $places = range('a', 'b');
+        $definition = new Definition($places, [], null, null, $events);
+
+        $this->assertSame($events, $definition->getDispatchEvents());
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -427,30 +427,6 @@ class WorkflowTest extends TestCase
         $this->assertSame($eventNameExpected, $eventDispatcher->dispatchedEvents);
     }
 
-    public function provideApplyWithEventDispatcherForAnnounceTests()
-    {
-        yield [false, [Workflow::DISABLE_ANNOUNCE_EVENT => true]];
-        yield [true, [Workflow::DISABLE_ANNOUNCE_EVENT => false]];
-        yield [true, []];
-    }
-
-    /** @dataProvider provideApplyWithEventDispatcherForAnnounceTests */
-    public function testApplyWithEventDispatcherForAnnounce(bool $fired, array $context)
-    {
-        $definition = $this->createComplexWorkflowDefinition();
-        $subject = new Subject();
-        $eventDispatcher = new EventDispatcherMock();
-        $workflow = new Workflow($definition, new MethodMarkingStore(), $eventDispatcher, 'workflow_name');
-
-        $workflow->apply($subject, 't1', $context);
-
-        if ($fired) {
-            $this->assertContains('workflow.workflow_name.announce', $eventDispatcher->dispatchedEvents);
-        } else {
-            $this->assertNotContains('workflow.workflow_name.announce', $eventDispatcher->dispatchedEvents);
-        }
-    }
-
     public function testApplyDispatchesNoEventsWhenSpecifiedByDefinition()
     {
         $transitions[] = new Transition('a-b', 'a', 'b');

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -420,8 +420,8 @@ class Workflow implements WorkflowInterface
 
         // Check if the WorkflowEvent name is in the events that
         // should be dispatched for this Workflow
-        if (count($dispatchEvents) >= 1) {
-            return in_array($eventName, $dispatchEvents, true);
+        if (\count($dispatchEvents) >= 1) {
+            return \in_array($eventName, $dispatchEvents, true);
         }
 
         return true;

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -33,8 +33,6 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class Workflow implements WorkflowInterface
 {
-    public const DISABLE_ANNOUNCE_EVENT = 'workflow_disable_announce_event';
-
     private $definition;
     private $markingStore;
     private $dispatcher;
@@ -209,9 +207,7 @@ class Workflow implements WorkflowInterface
 
             $this->completed($subject, $transition, $marking);
 
-            if (!($context[self::DISABLE_ANNOUNCE_EVENT] ?? false)) {
-                $this->announce($subject, $transition, $marking);
-            }
+            $this->announce($subject, $transition, $marking);
         }
 
         return $marking;

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -419,7 +419,7 @@ class Workflow implements WorkflowInterface
         }
 
         // Check if the WorkflowEvent name is in the events that
-        // should be dispatched for this Workflow
+        // should be dispatched for this transition
         if (count($dispatchEvents) >= 1) {
             return in_array($eventName, $dispatchEvents, true);
         }

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -419,8 +419,8 @@ class Workflow implements WorkflowInterface
         }
 
         // Check if the WorkflowEvent name is in the events that
-        if (count($dispatchEvents) >= 1) {
-            return in_array($eventName, $dispatchEvents, true);
+        if (\count($dispatchEvents) >= 1) {
+            return \in_array($eventName, $dispatchEvents, true);
         }
 
         return true;

--- a/src/Symfony/Component/Workflow/WorkflowEvents.php
+++ b/src/Symfony/Component/Workflow/WorkflowEvents.php
@@ -56,7 +56,7 @@ final class WorkflowEvents
     {
     }
 
-    public static function getDefaultDispatchEvents(): array
+    public static function getDefaultDispatchedEvents(): array
     {
         return [self::LEAVE, self::TRANSITION, self::ENTER, self::ENTERED, self::COMPLETED, self::ANNOUNCE];
     }

--- a/src/Symfony/Component/Workflow/WorkflowEvents.php
+++ b/src/Symfony/Component/Workflow/WorkflowEvents.php
@@ -55,4 +55,9 @@ final class WorkflowEvents
     private function __construct()
     {
     }
+
+    public static function getDefaultDispatchEvents(): array
+    {
+        return [self::LEAVE, self::TRANSITION, self::ENTER, self::ENTERED, self::COMPLETED, self::ANNOUNCE];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #36617 
| License       | MIT
| Doc PR        | WIP

Allow users to specify which events should be dispatched when calling `workflow->apply()`.

---

- [x] still requires configuration method to be discussed
- [ ] submit changes to the documentation
