### PR TITLE
[FrameworkBundle][CacheWarmupCommand] Append files to preload

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -120,7 +120,7 @@ EOF
                 $warmer->enableOnlyOptionalWarmers();
                 $preload = (array) $warmer->warmUp($realCacheDir);
 
-                if (file_exists($preloadFile = $realCacheDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
+                if ($preload && file_exists($preloadFile = $realCacheDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
                     Preloader::append($preloadFile, $preload);
                 }
             }
@@ -200,7 +200,7 @@ EOF
             $warmer->enableOnlyOptionalWarmers();
             $preload = (array) $warmer->warmUp($warmupDir);
 
-            if (file_exists($preloadFile = $warmupDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
+            if ($preload && file_exists($preloadFile = $warmupDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
                 Preloader::append($preloadFile, $preload);
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Dumper\Preloader;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate;
 
 /**
@@ -77,7 +78,11 @@ EOF
             $this->cacheWarmer->enableOptionalWarmers();
         }
 
-        $this->cacheWarmer->warmUp($kernel->getContainer()->getParameter('kernel.cache_dir'));
+        $preload = $this->cacheWarmer->warmUp($cacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir'));
+
+        if ($preload && file_exists($preloadFile = $cacheDir.'/'.$kernel->getContainer()->getParameter('kernel.container_class').'.preload.php')) {
+            Preloader::append($preloadFile, $preload);
+        }
 
         $io->success(sprintf('Cache for the "%s" environment (debug=%s) was successfully warmed.', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -566,7 +566,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         if ($this->container->has('cache_warmer')) {
             $preload = (array) $this->container->get('cache_warmer')->warmUp($this->container->getParameter('kernel.cache_dir'));
 
-            if (method_exists(Preloader::class, 'append') && file_exists($preloadFile = $cacheDir.'/'.$class.'.preload.php')) {
+            if ($preload && method_exists(Preloader::class, 'append') && file_exists($preloadFile = $cacheDir.'/'.$class.'.preload.php')) {
                 Preloader::append($preloadFile, $preload);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Files returned by the warmUp() method must be added to the preload file.

I also added checks to avoid empty preload calls in the preload file like this:
```
$classes = [];
Preloader::preload($classes);
```