### PR TITLE
[HttpFoundation][HttpKernel] Add more preload always-needed symbols

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -20,6 +20,7 @@ class_exists(AcceptHeader::class);
 class_exists(FileBag::class);
 class_exists(HeaderBag::class);
 class_exists(HeaderUtils::class);
+class_exists(InputBag::class);
 class_exists(ParameterBag::class);
 class_exists(ServerBag::class);
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -39,6 +39,9 @@ use Symfony\Component\HttpKernel\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\AddAnnotatedClassesToCachePass;
 use Symfony\Component\HttpKernel\DependencyInjection\MergeExtensionConfigurationPass;
 
+// Help opcache.preload discover always-needed symbols
+class_exists(ConfigCache::class);
+
 /**
  * The Kernel is the heart of the Symfony system.
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Part of https://github.com/orgs/symfony/projects/1#card-37082675
| License       | MIT
| Doc PR        | -

`ConfigCache` is in the hot path because it is used for every request in the kernel boot (initializeContainer() method). I guess we can consider that every kernel is going to be booted so it should always be used.

`InputBag` should be added too - it is used in the Request initialization so it will likely be hit on every request as well - but maybe it wasn't added in the first place for a reason since other bags are already there?