### PR TITLE
Execute docker dependent tests with github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,101 @@
+name: Tests
+
+on:
+    push:
+    pull_request:
+
+jobs:
+
+    integration:
+        name: Integration
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                php: ['7.1', '7.4']
+
+        services:
+            redis:
+                image: redis:6.0.0
+                ports:
+                    - 6379:6379
+            redis-cluster:
+                image: grokzen/redis-cluster:5.0.4
+                ports:
+                    - 7000:7000
+                    - 7001:7001
+                    - 7002:7002
+                    - 7003:7003
+                    - 7004:7004
+                    - 7005:7005
+                    - 7006:7006
+                    - 7007:7007
+                env:
+                    STANDALONE: true
+            memcached:
+                image: memcached:1.6.5
+                ports:
+                    - 11211:11211
+            rabbitmq:
+                image: rabbitmq:3.8.3
+                ports:
+                    - 5672:5672
+
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v2
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    coverage: "none"
+                    extensions: "memcached,redis,xsl"
+                    ini-values: "memory_limit=-1"
+                    php-version: "${{ matrix.php }}"
+                    tools: flex
+
+            -   name: Configure composer
+                run: |
+                    ([ -d ~/.composer ] || mkdir ~/.composer) && cp .github/composer-config.json ~/.composer/config.json
+                    SYMFONY_VERSION=$(cat composer.json | grep '^ *\"dev-master\". *\"[1-9]' | grep -o '[0-9.]*')
+                    echo "::set-env name=SYMFONY_VERSION::$SYMFONY_VERSION"
+                    echo "::set-env name=COMPOSER_ROOT_VERSION::$SYMFONY_VERSION.x-dev"
+
+            -   name: Determine composer cache directory
+                id: composer-cache
+                run: echo "::set-output name=directory::$(composer config cache-dir)"
+
+            -   name: Cache composer dependencies
+                uses: actions/cache@v1
+                with:
+                    path: ${{ steps.composer-cache.outputs.directory }}
+                    key: ${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
+                    restore-keys: ${{ matrix.php }}-composer-
+
+            -   name: Install dependencies
+                run: |
+                    echo "::group::composer update"
+                    composer update --no-progress --no-suggest --ansi
+                    echo "::endgroup::"
+                    echo "::group::install phpunit"
+                    ./phpunit install
+                    echo "::endgroup::"
+
+            -   name: Run tests
+                run: ./phpunit --verbose --group integration
+                env:
+                    SYMFONY_DEPRECATIONS_HELPER: 'max[indirect]=7'
+                    REDIS_HOST: localhost
+                    REDIS_CLUSTER_HOSTS: 'localhost:7000 localhost:7001 localhost:7002 localhost:7003 localhost:7004 localhost:7005'
+                    MESSENGER_REDIS_DSN: redis://127.0.0.1:7006/messages
+                    MESSENGER_AMQP_DSN: amqp://localhost/%2f/messages
+                    MEMCACHED_HOST: localhost
+
+            -   name: Run HTTP push tests
+                if: matrix.php == '7.4'
+                run: |
+                    [ -d .phpunit ] && mv .phpunit .phpunit.bak
+                    wget -q https://github.com/symfony/binary-utils/releases/download/v0.1/vulcain_0.1.3_Linux_x86_64.tar.gz -O - | tar xz && mv vulcain /usr/local/bin
+                    docker run --rm -e COMPOSER_ROOT_VERSION -e SYMFONY_VERSION -v $(pwd):/app -v $(which composer):/usr/local/bin/composer -v /usr/local/bin/vulcain:/usr/local/bin/vulcain -w /app php:7.4-alpine ./phpunit --verbose src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php --filter testHttp2Push
+                    sudo rm -rf .phpunit
+                    [ -d .phpunit.bak ] && mv .phpunit.bak .phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,11 @@ addons:
         - slapd
         - zookeeperd
         - libzookeeper-mt-dev
-        - rabbitmq-server
 
 env:
     global:
         - MIN_PHP=7.1.3
         - SYMFONY_PROCESS_PHP_TEST_BINARY=~/.phpenv/shims/php
-        - MESSENGER_AMQP_DSN=amqp://localhost/%2f/messages
-        - MESSENGER_REDIS_DSN=redis://127.0.0.1:7006/messages
         - SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE=1
 
 matrix:
@@ -39,13 +36,6 @@ cache:
         - php-$MIN_PHP
         - ~/php-ext
 
-services:
-    - memcached
-    - mongodb
-    - redis-server
-    - rabbitmq
-    - docker
-
 before_install:
     - |
       # Enable Sury ppa
@@ -55,12 +45,6 @@ before_install:
       sudo rm /etc/apt/sources.list.d/mongodb-3.4.list
       sudo apt update
       sudo apt install -y librabbitmq-dev libsodium-dev
-
-    - |
-      # Start Redis cluster
-      docker pull grokzen/redis-cluster:5.0.4
-      docker run -d -p 7000:7000 -p 7001:7001 -p 7002:7002 -p 7003:7003 -p 7004:7004 -p 7005:7005 -p 7006:7006 -p 7007:7007 -e "STANDALONE=true" --name redis-cluster grokzen/redis-cluster:5.0.4
-      export REDIS_CLUSTER_HOSTS='localhost:7000 localhost:7001 localhost:7002 localhost:7003 localhost:7004 localhost:7005'
 
     - |
       # General configuration
@@ -140,12 +124,6 @@ before_install:
           wget http://php.net/get/php-$MIN_PHP.tar.bz2/from/this/mirror -O - | tar -xj &&
           (cd php-$MIN_PHP && ./configure --enable-sigchild --enable-pcntl && make -j2)
       fi
-
-    - |
-      # Install vulcain
-      wget https://github.com/symfony/binary-utils/releases/download/v0.1/vulcain_0.1.3_Linux_x86_64.tar.gz -O - | tar xz
-      sudo mv vulcain /usr/local/bin
-      docker pull php:7.3-alpine
 
     - |
       # php.ini configuration
@@ -267,15 +245,6 @@ install:
       run_tests () {
           set -e
           export PHP=$1
-
-          if [[ !$deps && $PHP = 7.2 ]]; then
-              phpenv global $PHP
-              tfold 'composer update' $COMPOSER_UP
-              [ -d .phpunit ] && mv .phpunit .phpunit.bak
-              tfold src/Symfony/Component/HttpClient.h2push "docker run -it --rm -v $(pwd):/app -v $(phpenv which composer):/usr/local/bin/composer -v /usr/local/bin/vulcain:/usr/local/bin/vulcain -w /app php:7.3-alpine ./phpunit src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php --filter testHttp2Push"
-              sudo rm .phpunit -rf
-              [ -d .phpunit.bak ] && mv .phpunit.bak .phpunit
-          fi
 
           if [[ $PHP != 7.4* && $PHP != $TRAVIS_PHP_VERSION && $TRAVIS_PULL_REQUEST != false ]]; then
               echo -e "\\n\\e[33;1mIntermediate PHP version $PHP is skipped for pull requests.\\e[0m"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -26,9 +26,12 @@ class CachePoolsTest extends AbstractWebTestCase
 
     /**
      * @requires extension redis
+     * @group integration
      */
     public function testRedisCachePools()
     {
+        $this->skipIfRedisUnavailable();
+
         try {
             $this->doTestCachePools(['root_config' => 'redis_config.yml', 'environment' => 'redis_cache'], RedisAdapter::class);
         } catch (\PHPUnit\Framework\Error\Warning $e) {
@@ -51,9 +54,12 @@ class CachePoolsTest extends AbstractWebTestCase
 
     /**
      * @requires extension redis
+     * @group integration
      */
     public function testRedisCustomCachePools()
     {
+        $this->skipIfRedisUnavailable();
+
         try {
             $this->doTestCachePools(['root_config' => 'redis_custom_config.yml', 'environment' => 'custom_redis_cache'], RedisAdapter::class);
         } catch (\PHPUnit\Framework\Error\Warning $e) {
@@ -120,5 +126,14 @@ class CachePoolsTest extends AbstractWebTestCase
     protected static function createKernel(array $options = []): KernelInterface
     {
         return parent::createKernel(['test_case' => 'CachePools'] + $options);
+    }
+
+    private function skipIfRedisUnavailable()
+    {
+        try {
+            (new \Redis())->connect(getenv('REDIS_HOST'));
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
+        }
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
@@ -34,9 +34,10 @@ abstract class AbstractRedisAdapterTest extends AdapterTestCase
         if (!\extension_loaded('redis')) {
             self::markTestSkipped('Extension redis required.');
         }
-        if (!@((new \Redis())->connect(getenv('REDIS_HOST')))) {
-            $e = error_get_last();
-            self::markTestSkipped($e['message']);
+        try {
+            (new \Redis())->connect(getenv('REDIS_HOST'));
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -15,6 +15,9 @@ use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 
+/**
+ * @group integration
+ */
 class MemcachedAdapterTest extends AdapterTestCase
 {
     protected $skippedTests = [

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 use Predis\Connection\StreamConnection;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 
+/**
+ * @group integration
+ */
 class PredisAdapterTest extends AbstractRedisAdapterTest
 {
     public static function setUpBeforeClass(): void

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisClusterAdapterTest.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+/**
+ * @group integration
+ */
 class PredisClusterAdapterTest extends AbstractRedisAdapterTest
 {
     public static function setUpBeforeClass(): void

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 
+/**
+ * @group integration
+ */
 class PredisRedisClusterAdapterTest extends AbstractRedisAdapterTest
 {
     public static function setUpBeforeClass(): void

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareAdapterTest.php
@@ -15,6 +15,9 @@ use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Tests\Traits\TagAwareTestTrait;
 
+/**
+ * @group integration
+ */
 class PredisTagAwareAdapterTest extends PredisAdapterTest
 {
     use TagAwareTestTrait;

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisTagAwareClusterAdapterTest.php
@@ -15,6 +15,9 @@ use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Tests\Traits\TagAwareTestTrait;
 
+/**
+ * @group integration
+ */
 class PredisTagAwareClusterAdapterTest extends PredisClusterAdapterTest
 {
     use TagAwareTestTrait;

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Cache\Tests\Adapter;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 
+/**
+ * @group integration
+ */
 class RedisAdapterSentinelTest extends AbstractRedisAdapterTest
 {
     public static function setUpBeforeClass(): void

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Traits\RedisProxy;
 
+/**
+ * @group integration
+ */
 class RedisAdapterTest extends AbstractRedisAdapterTest
 {
     public static function setUpBeforeClass(): void

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisArrayAdapterTest.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+/**
+ * @group integration
+ */
 class RedisArrayAdapterTest extends AbstractRedisAdapterTest
 {
     public static function setUpBeforeClass(): void

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Traits\RedisClusterProxy;
 
+/**
+ * @group integration
+ */
 class RedisClusterAdapterTest extends AbstractRedisAdapterTest
 {
     public static function setUpBeforeClass(): void

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareAdapterTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Tests\Traits\TagAwareTestTrait;
 use Symfony\Component\Cache\Traits\RedisProxy;
 
+/**
+ * @group integration
+ */
 class RedisTagAwareAdapterTest extends RedisAdapterTest
 {
     use TagAwareTestTrait;

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareArrayAdapterTest.php
@@ -15,6 +15,9 @@ use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Tests\Traits\TagAwareTestTrait;
 
+/**
+ * @group integration
+ */
 class RedisTagAwareArrayAdapterTest extends RedisArrayAdapterTest
 {
     use TagAwareTestTrait;

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisTagAwareClusterAdapterTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
 use Symfony\Component\Cache\Tests\Traits\TagAwareTestTrait;
 use Symfony\Component\Cache\Traits\RedisClusterProxy;
 
+/**
+ * @group integration
+ */
 class RedisTagAwareClusterAdapterTest extends RedisClusterAdapterTest
 {
     use TagAwareTestTrait;

--- a/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
@@ -37,9 +37,10 @@ abstract class AbstractRedisCacheTest extends CacheTestCase
         if (!\extension_loaded('redis')) {
             self::markTestSkipped('Extension redis required.');
         }
-        if (!@((new \Redis())->connect(getenv('REDIS_HOST')))) {
-            $e = error_get_last();
-            self::markTestSkipped($e['message']);
+        try {
+            (new \Redis())->connect(getenv('REDIS_HOST'));
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Cache\Simple\MemcachedCache;
 
 /**
  * @group legacy
+ * @group integration
  */
 class MemcachedCacheTest extends CacheTestCase
 {

--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTextModeTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTextModeTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Cache\Simple\MemcachedCache;
 
 /**
  * @group legacy
+ * @group integration
  */
 class MemcachedCacheTextModeTest extends MemcachedCacheTest
 {

--- a/src/Symfony/Component/Cache/Tests/Simple/RedisArrayCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/RedisArrayCacheTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Tests\Simple;
 
 /**
  * @group legacy
+ * @group integration
  */
 class RedisArrayCacheTest extends AbstractRedisCacheTest
 {

--- a/src/Symfony/Component/Cache/Tests/Simple/RedisCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/RedisCacheTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Cache\Simple\RedisCache;
 
 /**
  * @group legacy
+ * @group integration
  */
 class RedisCacheTest extends AbstractRedisCacheTest
 {

--- a/src/Symfony/Component/Cache/Tests/Simple/RedisClusterCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/RedisClusterCacheTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Tests\Simple;
 
 /**
  * @group legacy
+ * @group integration
  */
 class RedisClusterCacheTest extends AbstractRedisCacheTest
 {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractRedisSessionHandlerTestCase.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractRedisSessionHandlerTestCase.php
@@ -44,6 +44,11 @@ abstract class AbstractRedisSessionHandlerTestCase extends TestCase
         if (!\extension_loaded('redis')) {
             self::markTestSkipped('Extension redis required.');
         }
+        try {
+            (new \Redis())->connect(getenv('REDIS_HOST'));
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
+        }
 
         $host = getenv('REDIS_HOST') ?: 'localhost';
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PredisClusterSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PredisClusterSessionHandlerTest.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use Predis\Client;
 
+/**
+ * @group integration
+ */
 class PredisClusterSessionHandlerTest extends AbstractRedisSessionHandlerTestCase
 {
     protected function createRedisClient(string $host): Client

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PredisSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PredisSessionHandlerTest.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
 use Predis\Client;
 
+/**
+ * @group integration
+ */
 class PredisSessionHandlerTest extends AbstractRedisSessionHandlerTestCase
 {
     protected function createRedisClient(string $host): Client

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisArraySessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisArraySessionHandlerTest.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
+/**
+ * @group integration
+ */
 class RedisArraySessionHandlerTest extends AbstractRedisSessionHandlerTestCase
 {
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisClusterSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisClusterSessionHandlerTest.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
+/**
+ * @group integration
+ */
 class RedisClusterSessionHandlerTest extends AbstractRedisSessionHandlerTestCase
 {
     public static function setUpBeforeClass(): void

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
+/**
+ * @group integration
+ */
 class RedisSessionHandlerTest extends AbstractRedisSessionHandlerTestCase
 {
     /**

--- a/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Lock\Store\MemcachedStore;
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
  * @requires extension memcached
+ * @group integration
  */
 class MemcachedStoreTest extends AbstractStoreTest
 {

--- a/src/Symfony/Component/Lock/Tests/Store/PredisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PredisStoreTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Lock\Tests\Store;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
+ * @group integration
  */
 class PredisStoreTest extends AbstractRedisStoreTest
 {

--- a/src/Symfony/Component/Lock/Tests/Store/RedisArrayStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisArrayStoreTest.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Lock\Tests\Store;
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
  * @requires extension redis
+ * @group integration
  */
 class RedisArrayStoreTest extends AbstractRedisStoreTest
 {
@@ -23,9 +24,10 @@ class RedisArrayStoreTest extends AbstractRedisStoreTest
         if (!class_exists('RedisArray')) {
             self::markTestSkipped('The RedisArray class is required.');
         }
-        if (!@((new \Redis())->connect(getenv('REDIS_HOST')))) {
-            $e = error_get_last();
-            self::markTestSkipped($e['message']);
+        try {
+            (new \Redis())->connect(getenv('REDIS_HOST'));
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/RedisClusterStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisClusterStoreTest.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Lock\Tests\Store;
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
  * @requires extension redis
+ * @group integration
  */
 class RedisClusterStoreTest extends AbstractRedisStoreTest
 {

--- a/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
@@ -17,14 +17,16 @@ use Symfony\Component\Lock\Store\RedisStore;
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
  * @requires extension redis
+ * @group integration
  */
 class RedisStoreTest extends AbstractRedisStoreTest
 {
     public static function setUpBeforeClass(): void
     {
-        if (!@((new \Redis())->connect(getenv('REDIS_HOST')))) {
-            $e = error_get_last();
-            self::markTestSkipped($e['message']);
+        try {
+            (new \Redis())->connect(getenv('REDIS_HOST'));
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpExtIntegrationTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
 /**
  * @requires extension amqp
+ * @group integration
  */
 class AmqpExtIntegrationTest extends TestCase
 {

--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -17,14 +17,14 @@ use Symfony\Component\Messenger\Transport\RedisExt\Connection;
 
 /**
  * @requires extension redis >= 4.3.0
+ * @group integration
  */
 class ConnectionTest extends TestCase
 {
     public static function setUpBeforeClass(): void
     {
-        $redis = Connection::fromDsn('redis://localhost/queue');
-
         try {
+            $redis = Connection::fromDsn('redis://localhost/queue');
             $redis->get();
         } catch (TransportException $e) {
             if (0 === strpos($e->getMessage(), 'ERR unknown command \'X')) {
@@ -32,6 +32,8 @@ class ConnectionTest extends TestCase
             }
 
             throw $e;
+        } catch (\RedisException $e) {
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisExtIntegrationTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Messenger\Transport\RedisExt\Connection;
 /**
  * @requires extension redis
  * @group time-sensitive
+ * @group integration
  */
 class RedisExtIntegrationTest extends TestCase
 {
@@ -30,10 +31,14 @@ class RedisExtIntegrationTest extends TestCase
             $this->markTestSkipped('The "MESSENGER_REDIS_DSN" environment variable is required.');
         }
 
-        $this->redis = new \Redis();
-        $this->connection = Connection::fromDsn(getenv('MESSENGER_REDIS_DSN'), [], $this->redis);
-        $this->connection->cleanup();
-        $this->connection->setup();
+        try {
+            $this->redis = new \Redis();
+            $this->connection = Connection::fromDsn(getenv('MESSENGER_REDIS_DSN'), [], $this->redis);
+            $this->connection->cleanup();
+            $this->connection->setup();
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
+        }
     }
 
     public function testConnectionSendAndGet()

--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisTransportFactoryTest.php
@@ -31,12 +31,26 @@ class RedisTransportFactoryTest extends TestCase
         $this->assertFalse($factory->supports('invalid-dsn', []));
     }
 
+    /**
+     * @group integration
+     */
     public function testCreateTransport()
     {
+        $this->skipIfRedisUnavailable();
+
         $factory = new RedisTransportFactory();
         $serializer = $this->getMockBuilder(SerializerInterface::class)->getMock();
-        $expectedTransport = new RedisTransport(Connection::fromDsn('redis://localhost', ['foo' => 'bar']), $serializer);
+        $expectedTransport = new RedisTransport(Connection::fromDsn('redis://'.getenv('REDIS_HOST'), ['foo' => 'bar']), $serializer);
 
-        $this->assertEquals($expectedTransport, $factory->createTransport('redis://localhost', ['foo' => 'bar'], $serializer));
+        $this->assertEquals($expectedTransport, $factory->createTransport('redis://'.getenv('REDIS_HOST'), ['foo' => 'bar'], $serializer));
+    }
+
+    private function skipIfRedisUnavailable()
+    {
+        try {
+            (new \Redis())->connect(getenv('REDIS_HOST'));
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
+        }
     }
 }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/RedisCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/RedisCasterTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\VarDumper\Test\VarDumperTestTrait;
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  * @requires extension redis
+ * @group integration
  */
 class RedisCasterTest extends TestCase
 {
@@ -37,16 +38,18 @@ EODUMP;
 
     public function testConnected()
     {
+        $redisHost = getenv('REDIS_HOST');
         $redis = new \Redis();
-        if (!@$redis->connect('127.0.0.1')) {
-            $e = error_get_last();
-            self::markTestSkipped($e['message']);
+        try {
+            $redis->connect($redisHost);
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
         }
 
-        $xCast = <<<'EODUMP'
+        $xCast = <<<EODUMP
 Redis {%A
   isConnected: true
-  host: "127.0.0.1"
+  host: "$redisHost"
   port: 6379
   auth: null
   mode: ATOMIC


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fixes #36427
| License       | MIT
| Doc PR        | -

* redis, memcached, rabbitmq and vulcain dependent tests moved to the github action
* run on PHP 7.1 and 7.4 only
* use the `integration` group for all tests that depend on docker services
* do not exclude the `integration` group on Travis, but make sure tests that depend on docker services are skipped properly

[<img width="1222" alt="image" src="https://user-images.githubusercontent.com/190447/80806323-48339100-8bb2-11ea-95cd-5ce773c74ce6.png">](https://github.com/jakzal/symfony/runs/636461875?check_suite_focus=true)
