### PR TITLE
[Notifier] Add Mobyt bridge

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -99,6 +99,7 @@ use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransportFactory;
 use Symfony\Component\Notifier\Bridge\GoogleChat\GoogleChatTransportFactory;
 use Symfony\Component\Notifier\Bridge\Infobip\InfobipTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
+use Symfony\Component\Notifier\Bridge\Mobyt\MobytTransportFactory;
 use Symfony\Component\Notifier\Bridge\Nexmo\NexmoTransportFactory;
 use Symfony\Component\Notifier\Bridge\OvhCloud\OvhCloudTransportFactory;
 use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
@@ -2091,6 +2092,7 @@ class FrameworkExtension extends Extension
             OvhCloudTransportFactory::class => 'notifier.transport_factory.ovhcloud',
             SinchTransportFactory::class => 'notifier.transport_factory.sinch',
             ZulipTransportFactory::class => 'notifier.transport_factory.zulip',
+            MobytTransportFactory::class => 'notifier.transport_factory.mobyt',
         ];
 
         foreach ($classToServices as $class => $service) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -16,6 +16,7 @@ use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransportFactory;
 use Symfony\Component\Notifier\Bridge\GoogleChat\GoogleChatTransportFactory;
 use Symfony\Component\Notifier\Bridge\Infobip\InfobipTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
+use Symfony\Component\Notifier\Bridge\Mobyt\MobytTransportFactory;
 use Symfony\Component\Notifier\Bridge\Nexmo\NexmoTransportFactory;
 use Symfony\Component\Notifier\Bridge\OvhCloud\OvhCloudTransportFactory;
 use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
@@ -82,6 +83,10 @@ return static function (ContainerConfigurator $container) {
             ->tag('texter.transport_factory')
 
         ->set('notifier.transport_factory.infobip', InfobipTransportFactory::class)
+            ->parent('notifier.transport_factory.abstract')
+            ->tag('texter.transport_factory')
+
+        ->set('notifier.transport_factory.mobyt', MobytTransportFactory::class)
             ->parent('notifier.transport_factory.abstract')
             ->tag('texter.transport_factory')
 

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.2.0
+-----
+
+ * Added the bridge

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2019-2020 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytOptions.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Mobyt;
+
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+use Symfony\Component\Notifier\Notification\Notification;
+
+/**
+ * @author Bastien Durand <bdurand-dev@outlook.com>
+ *
+ * @experimental in 5.2
+ */
+final class MobytOptions implements MessageOptionsInterface
+{
+    const MESSAGE_TYPE_QUALITY_HIGH = 'N';
+    const MESSAGE_TYPE_QUALITY_MEDIUM = 'L';
+    const MESSAGE_TYPE_QUALITY_LOW = 'LL';
+
+    private $options = [];
+
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+    }
+
+    public static function fromNotification(Notification $notification): self
+    {
+        $options = new self();
+        switch ($notification->getImportance()) {
+            case Notification::IMPORTANCE_HIGH:
+            case Notification::IMPORTANCE_URGENT:
+                $options->messageType(self::MESSAGE_TYPE_QUALITY_HIGH);
+                break;
+            case Notification::IMPORTANCE_MEDIUM:
+                $options->messageType(self::MESSAGE_TYPE_QUALITY_MEDIUM);
+                break;
+            case Notification::IMPORTANCE_LOW:
+                $options->messageType(self::MESSAGE_TYPE_QUALITY_LOW);
+                break;
+            default:
+                $options->messageType(self::MESSAGE_TYPE_QUALITY_HIGH);
+        }
+
+        return $options;
+    }
+
+    public function toArray(): array
+    {
+        $options = $this->options;
+        unset($options['message'], $options['recipient']);
+
+        return $options;
+    }
+
+    public function getRecipientId(): ?string
+    {
+        return $this->options['recipient'] ?? null;
+    }
+
+    public function messageType(string $type)
+    {
+        $this->options['message_type'] = $type;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransport.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Mobyt;
+
+use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Basien Durand <bdurand-dev@outlook.com>
+ *
+ * @experimental in 5.2
+ */
+final class MobytTransport extends AbstractTransport
+{
+    protected const HOST = 'app.mobyt.fr';
+
+    private $accountSid;
+    private $authToken;
+    private $from;
+    private $typeQuality;
+
+    public function __construct(string $accountSid, string $authToken, $from, string $typeQuality, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    {
+        $this->accountSid = $accountSid;
+        $this->authToken = $authToken;
+        $this->from = $from;
+        $this->typeQuality = $typeQuality;
+
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('mobyt://%s?from=%s&type_quality=%s', $this->getEndpoint(), $this->from, $this->typeQuality);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof SmsMessage;
+    }
+
+    protected function doSend(MessageInterface $message): SentMessage
+    {
+        if (!$message instanceof SmsMessage) {
+            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, SmsMessage::class, \get_class($message)));
+        }
+
+        if ($message->getOptions() && !$message->getOptions() instanceof MobytOptions) {
+            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" for options.', __CLASS__, MobytOptions::class));
+        }
+
+        $options = $message->getOptions() ? $message->getOptions()->toArray() : [];
+        $options['message_type'] = $options['message_type'] ?? $this->typeQuality;
+
+        $options['message'] = $options['message'] ?? $message->getSubject();
+        $options['recipient'] = [$message->getPhone()];
+
+        $options['sender'] = $options['sender'] ?? $this->from;
+
+        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/API/v1.0/REST/sms', [
+            'headers' => [
+                'Content-type: application/json',
+                'user_key: '.$this->accountSid,
+                'Access_token: '.$this->authToken,
+            ],
+            'body' => json_encode(array_filter($options)),
+        ]);
+
+        if (401 === $response->getStatusCode() || 404 === $response->getStatusCode()) {
+            throw new TransportException(sprintf('Unable to send the SMS: "%s". Check your credentials.', $message->getSubject()), $response);
+        }
+
+        if (201 !== $response->getStatusCode()) {
+            $error = $response->toArray(false);
+
+            throw new TransportException(sprintf('Unable to send the SMS: "%s".', $error['result']), $response);
+        }
+
+        $success = $response->toArray(false);
+
+        $message = new SentMessage($message, (string) $this);
+        $message->setMessageId($success['order_id']);
+
+        return $message;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransportFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Mobyt;
+
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+
+/**
+ * @author Bastien Durand <bdurand-dev@outlook.com>
+ *
+ * @experimental in 5.2
+ */
+final class MobytTransportFactory extends AbstractTransportFactory
+{
+    /**
+     * @return MobytTransport
+     */
+    public function create(Dsn $dsn): TransportInterface
+    {
+        $scheme = $dsn->getScheme();
+        $accountSid = $this->getUser($dsn);
+        $authToken = $this->getPassword($dsn);
+        $from = $dsn->getOption('from');
+        $typeQuality = $dsn->getOption('type_quality', MobytOptions::MESSAGE_TYPE_QUALITY_LOW);
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        if ('mobyt' === $scheme) {
+            return (new MobytTransport($accountSid, $authToken, $from, $typeQuality, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        }
+
+        throw new UnsupportedSchemeException($dsn, 'mobyt', $this->getSupportedSchemes());
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['mobyt'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/README.md
@@ -1,0 +1,20 @@
+Mobyt Notifier
+===============
+
+Provides [Mobyt](https://www.mobyt.it/en/) integration for Symfony Notifier.
+
+DSN should be as follow:
+
+```
+mobyt://USER_KEY:ACCESS_TOKEN@default?from=FROM
+```
+
+`USER_KEY` and `ACCESS_TOKEN` are given by Mobyt ; `FROM` is the sender name.
+
+Resources
+---------
+
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/Tests/MobytOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/Tests/MobytOptionsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Symfony\Component\Notifier\Bridge\Mobyt\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\Mobyt\MobytOptions;
+use Symfony\Component\Notifier\Notification\Notification;
+
+class MobytOptionsTest extends TestCase
+{
+    /**
+     * @dataProvider fromNotificationDataProvider
+     */
+    public function testFromNotification($importance, $expectedMessageType)
+    {
+        $notification = (new Notification('Foo'))->importance($importance);
+
+        $options = (MobytOptions::fromNotification($notification))->toArray();
+
+        $this->assertEquals($expectedMessageType, $options['message_type']);
+    }
+
+    public function testFromNotificationDefaultLevel()
+    {
+        $notification = (new Notification('Foo'))->importance('Bar');
+
+        $options = (MobytOptions::fromNotification($notification))->toArray();
+
+        $this->assertEquals(MobytOptions::MESSAGE_TYPE_QUALITY_HIGH, $options['message_type']);
+    }
+
+    public function fromNotificationDataProvider(): \Generator
+    {
+        yield [Notification::IMPORTANCE_URGENT, MobytOptions::MESSAGE_TYPE_QUALITY_HIGH];
+        yield [Notification::IMPORTANCE_HIGH, MobytOptions::MESSAGE_TYPE_QUALITY_HIGH];
+        yield [Notification::IMPORTANCE_MEDIUM, MobytOptions::MESSAGE_TYPE_QUALITY_MEDIUM];
+        yield [Notification::IMPORTANCE_LOW, MobytOptions::MESSAGE_TYPE_QUALITY_LOW];
+    }
+
+    public function testGetRecipientIdWhenSet()
+    {
+        $options = [
+            'recipient' => 'foo',
+        ];
+        $mobytOptions = new MobytOptions($options);
+
+        $this->assertEquals('foo', $mobytOptions->getRecipientId());
+    }
+
+    public function testGetRecipientIdWhenNotSet()
+    {
+        $this->assertNull((new MobytOptions())->getRecipientId());
+    }
+
+    public function testToArray()
+    {
+        $options = [
+            'message' => 'foo',
+            'recipient' => 'bar',
+        ];
+        $this->assertEmpty((new MobytOptions($options))->toArray());
+    }
+
+    public function testMessageType()
+    {
+        $mobytOptions = new MobytOptions();
+        $mobytOptions->messageType('foo');
+
+        $this->assertEquals(['message_type' => 'foo'], $mobytOptions->toArray());
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
@@ -1,0 +1,36 @@
+{
+    "name": "symfony/mobyt-notifier",
+    "type": "symfony-bridge",
+    "description": "Symfony Mobyt Notifier Bridge",
+    "keywords": ["sms", "mobyt", "notifier"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Bastien Durand",
+            "email": "bdurand-dev@outlook.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "ext-json": "*",
+        "php": "^7.2.5",
+        "symfony/http-client": "^4.3|^5.0",
+        "symfony/notifier": "^5.2"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mobyt\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "5.2-dev"
+        }
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Mobyt Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -15,6 +15,7 @@ use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransportFactory;
 use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransportFactory;
 use Symfony\Component\Notifier\Bridge\Infobip\InfobipTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
+use Symfony\Component\Notifier\Bridge\Mobyt\MobytTransportFactory;
 use Symfony\Component\Notifier\Bridge\Nexmo\NexmoTransportFactory;
 use Symfony\Component\Notifier\Bridge\OvhCloud\OvhCloudTransportFactory;
 use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
@@ -54,6 +55,7 @@ class Transport
         SinchTransportFactory::class,
         FreeMobileTransportFactory::class,
         ZulipTransportFactory::class,
+        MobytTransportFactory::class,
     ];
 
     private $factories;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |  #33687
| License       | MIT
| Doc PR        | symfony/symfony-docs#13606
| recipe PR   | symfony/recipes#768 

Add Mobyt notifier bridge.

In this SMS Provider, you can choose a sort of "quality service" to send the message.

I updated `src/Symfony/Component/Notifier/Message/SmsMessage.php` to add the notification in order to be able to use the notification importance when creating options.
