### PR TITLE
Fix Form annotation

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -932,7 +932,7 @@ class Form implements \IteratorAggregate, FormInterface
      *
      * @return FormInterface The child form
      *
-     * @throws \OutOfBoundsException if the named child does not exist
+     * @throws OutOfBoundsException if the named child does not exist
      */
     public function offsetGet($name)
     {

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -62,7 +62,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return self
      *
-     * @throws \OutOfBoundsException if the named child does not exist
+     * @throws Exception\OutOfBoundsException if the named child does not exist
      */
     public function get($name);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| License       | MIT

Symfony form component provide his own exception `OutOfBoundsException` which is implementing `ExceptionInterface`. Form are returning this custom `OutOfBoundsException`, but the phpDoc say it's an original `\OutOfBoundsException`, which is not extending the `ExceptionInterface`.

This can provide issue with static analysis tools.