### PR TITLE
Automatically provide Messenger Doctrine schema to "diff"

### DIFF
--- a/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaSubscriber.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaSubscriber.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\SchemaListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\DBAL\Event\SchemaCreateTableEventArgs;
+use Doctrine\DBAL\Events;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Doctrine\ORM\Tools\ToolEvents;
+use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransport;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+/**
+ * Automatically adds any required database tables to the Doctrine Schema.
+ *
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ */
+final class MessengerTransportDoctrineSchemaSubscriber implements EventSubscriber
+{
+    private const PROCESSING_TABLE_FLAG = self::class.':processing';
+
+    private $transports;
+
+    /**
+     * @param iterable|TransportInterface[] $transports
+     */
+    public function __construct(iterable $transports)
+    {
+        $this->transports = $transports;
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $event): void
+    {
+        $dbalConnection = $event->getEntityManager()->getConnection();
+        foreach ($this->transports as $transport) {
+            if (!$transport instanceof DoctrineTransport) {
+                continue;
+            }
+
+            $transport->configureSchema($event->getSchema(), $dbalConnection);
+        }
+    }
+
+    public function onSchemaCreateTable(SchemaCreateTableEventArgs $event): void
+    {
+        $table = $event->getTable();
+
+        // if this method triggers a nested create table below, allow Doctrine to work like normal
+        if ($table->hasOption(self::PROCESSING_TABLE_FLAG)) {
+            return;
+        }
+
+        foreach ($this->transports as $transport) {
+            if (!$transport instanceof DoctrineTransport) {
+                continue;
+            }
+
+            $extraSql = $transport->getExtraSetupSqlForTable($table);
+            if (null === $extraSql) {
+                continue;
+            }
+
+            // avoid this same listener from creating a loop on this table
+            $table->addOption(self::PROCESSING_TABLE_FLAG, true);
+            $createTableSql = $event->getPlatform()->getCreateTableSQL($table);
+
+            /*
+             * Add all the SQL needed to create the table and tell Doctrine
+             * to "preventDefault" so that only our SQL is used. This is
+             * the only way to inject some extra SQL.
+             */
+            $event->addSql($createTableSql);
+            $event->addSql($extraSql);
+            $event->preventDefault();
+
+            return;
+        }
+    }
+
+    public function getSubscribedEvents(): array
+    {
+        return [
+            ToolEvents::postGenerateSchema,
+            Events::onSchemaCreateTable,
+        ];
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/SchemaListener/PdoCacheAdapterDoctrineSchemaSubscriber.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/PdoCacheAdapterDoctrineSchemaSubscriber.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\SchemaListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use Doctrine\ORM\Tools\ToolEvents;
+use Symfony\Component\Cache\Adapter\PdoAdapter;
+
+/**
+ * Automatically adds the cache table needed for the PdoAdapter.
+ *
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ */
+final class PdoCacheAdapterDoctrineSchemaSubscriber implements EventSubscriber
+{
+    private $pdoAdapters;
+
+    /**
+     * @param iterable|PdoAdapter[] $pdoAdapters
+     */
+    public function __construct(iterable $pdoAdapters)
+    {
+        $this->pdoAdapters = $pdoAdapters;
+    }
+
+    public function postGenerateSchema(GenerateSchemaEventArgs $event): void
+    {
+        $dbalConnection = $event->getEntityManager()->getConnection();
+        foreach ($this->pdoAdapters as $pdoAdapter) {
+            $pdoAdapter->configureSchema($event->getSchema(), $dbalConnection);
+        }
+    }
+
+    public function getSubscribedEvents(): array
+    {
+        return [
+            ToolEvents::postGenerateSchema,
+        ];
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaSubscriberTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/MessengerTransportDoctrineSchemaSubscriberTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Event\SchemaCreateTableEventArgs;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\SchemaListener\MessengerTransportDoctrineSchemaSubscriber;
+use Symfony\Component\Messenger\Bridge\Doctrine\Transport\DoctrineTransport;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+class MessengerTransportDoctrineSchemaSubscriberTest extends TestCase
+{
+    public function testPostGenerateSchema()
+    {
+        $schema = new Schema();
+        $dbalConnection = $this->createMock(Connection::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($dbalConnection);
+        $event = new GenerateSchemaEventArgs($entityManager, $schema);
+
+        $doctrineTransport = $this->createMock(DoctrineTransport::class);
+        $doctrineTransport->expects($this->once())
+            ->method('configureSchema')
+            ->with($schema, $dbalConnection);
+        $otherTransport = $this->createMock(TransportInterface::class);
+        $otherTransport->expects($this->never())
+            ->method($this->anything());
+
+        $subscriber = new MessengerTransportDoctrineSchemaSubscriber([$doctrineTransport, $otherTransport]);
+        $subscriber->postGenerateSchema($event);
+    }
+
+    public function testOnSchemaCreateTable()
+    {
+        $platform = $this->createMock(AbstractPlatform::class);
+        $table = new Table('queue_table');
+        $event = new SchemaCreateTableEventArgs($table, [], [], $platform);
+
+        $otherTransport = $this->createMock(TransportInterface::class);
+        $otherTransport->expects($this->never())
+            ->method($this->anything());
+
+        $doctrineTransport = $this->createMock(DoctrineTransport::class);
+        $doctrineTransport->expects($this->once())
+            ->method('getExtraSetupSqlForTable')
+            ->with($table)
+            ->willReturn('ALTER TABLE pizza ADD COLUMN extra_cheese boolean');
+
+        // we use the platform to generate the full create table sql
+        $platform->expects($this->once())
+            ->method('getCreateTableSQL')
+            ->with($table)
+            ->willReturn('CREATE TABLE pizza (id integer NOT NULL)');
+
+        $subscriber = new MessengerTransportDoctrineSchemaSubscriber([$otherTransport, $doctrineTransport]);
+        $subscriber->onSchemaCreateTable($event);
+        $this->assertTrue($event->isDefaultPrevented());
+        $this->assertSame([
+            'CREATE TABLE pizza (id integer NOT NULL)',
+            'ALTER TABLE pizza ADD COLUMN extra_cheese boolean',
+        ], $event->getSql());
+    }
+
+    public function testOnSchemaCreateTableNoExtraSql()
+    {
+        $platform = $this->createMock(AbstractPlatform::class);
+        $table = new Table('queue_table');
+        $event = new SchemaCreateTableEventArgs($table, [], [], $platform);
+
+        $doctrineTransport = $this->createMock(DoctrineTransport::class);
+        $doctrineTransport->expects($this->once())
+            ->method('getExtraSetupSqlForTable')
+            ->willReturn(null);
+
+        $platform->expects($this->never())
+            ->method('getCreateTableSQL');
+
+        $subscriber = new MessengerTransportDoctrineSchemaSubscriber([$doctrineTransport]);
+        $subscriber->onSchemaCreateTable($event);
+        $this->assertFalse($event->isDefaultPrevented());
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoCacheAdapterDoctrineSchemaSubscriberTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/SchemaListener/PdoCacheAdapterDoctrineSchemaSubscriberTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\SchemaListener;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\SchemaListener\PdoCacheAdapterDoctrineSchemaSubscriber;
+use Symfony\Component\Cache\Adapter\PdoAdapter;
+
+class PdoCacheAdapterDoctrineSchemaSubscriberTest extends TestCase
+{
+    public function testPostGenerateSchema()
+    {
+        $schema = new Schema();
+        $dbalConnection = $this->createMock(Connection::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())
+            ->method('getConnection')
+            ->willReturn($dbalConnection);
+        $event = new GenerateSchemaEventArgs($entityManager, $schema);
+
+        $pdoAdapter = $this->createMock(PdoAdapter::class);
+        $pdoAdapter->expects($this->once())
+            ->method('configureSchema')
+            ->with($schema, $dbalConnection);
+
+        $subscriber = new PdoCacheAdapterDoctrineSchemaSubscriber([$pdoAdapter]);
+        $subscriber->postGenerateSchema($event);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -26,11 +26,13 @@
     },
     "require-dev": {
         "symfony/stopwatch": "^4.4|^5.0",
+        "symfony/cache": "^5.1",
         "symfony/config": "^4.4|^5.0",
         "symfony/dependency-injection": "^4.4|^5.0",
         "symfony/form": "^5.1",
         "symfony/http-kernel": "^5.0",
         "symfony/messenger": "^4.4|^5.0",
+        "symfony/doctrine-messenger": "^5.1",
         "symfony/property-access": "^4.4|^5.0",
         "symfony/property-info": "^5.0",
         "symfony/proxy-manager-bridge": "^4.4|^5.0",

--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -146,7 +146,7 @@ class PdoStore implements PersistingStoreInterface
     public function putOffExpiration(Key $key, float $ttl)
     {
         if ($ttl < 1) {
-            throw new InvalidTtlException(sprintf('"%s()" expects a TTL greater or equals to 1 second. Got %s.', __METHOD__, $ttl));
+            throw new InvalidTtlException(sprintf('"%s()" expects a TTL greater or equals to 1 second. Got "%s".', __METHOD__, $ttl));
         }
 
         $key->reduceLifetime($ttl);
@@ -249,11 +249,7 @@ class PdoStore implements PersistingStoreInterface
 
         if ($conn instanceof Connection) {
             $schema = new Schema();
-            $table = $schema->createTable($this->table);
-            $table->addColumn($this->idCol, 'string', ['length' => 64]);
-            $table->addColumn($this->tokenCol, 'string', ['length' => 44]);
-            $table->addColumn($this->expirationCol, 'integer', ['unsigned' => true]);
-            $table->setPrimaryKey([$this->idCol]);
+            $this->addTableToSchema($schema);
 
             foreach ($schema->toSql($conn->getDatabasePlatform()) as $sql) {
                 $conn->exec($sql);
@@ -283,6 +279,22 @@ class PdoStore implements PersistingStoreInterface
         }
 
         $conn->exec($sql);
+    }
+
+    /**
+     * Adds the Table to the Schema if it doesn't exist.
+     */
+    public function configureSchema(Schema $schema): void
+    {
+        if (!$this->getConnection() instanceof Connection) {
+            throw new \BadMethodCallException(sprintf('"%s::%s()" is only supported when using a doctrine/dbal Connection.', __CLASS__, __METHOD__));
+        }
+
+        if ($schema->hasTable($this->table)) {
+            return;
+        }
+
+        $this->addTableToSchema($schema);
     }
 
     /**
@@ -350,5 +362,14 @@ class PdoStore implements PersistingStoreInterface
             default:
                 return time();
         }
+    }
+
+    private function addTableToSchema(Schema $schema): void
+    {
+        $table = $schema->createTable($this->table);
+        $table->addColumn($this->idCol, 'string', ['length' => 64]);
+        $table->addColumn($this->tokenCol, 'string', ['length' => 44]);
+        $table->addColumn($this->expirationCol, 'integer', ['unsigned' => true]);
+        $table->setPrimaryKey([$this->idCol]);
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/PdoDbalStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoDbalStoreTest.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Schema\Schema;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\PdoStore;
 
@@ -58,5 +60,13 @@ class PdoDbalStoreTest extends AbstractStoreTest
     public function testAbortAfterExpiration()
     {
         $this->markTestSkipped('Pdo expects a TTL greater than 1 sec. Simulating a slow network is too hard');
+    }
+
+    public function testConfigureSchema()
+    {
+        $store = new PdoStore($this->createMock(Connection::class), ['db_table' => 'lock_table']);
+        $schema = new Schema();
+        $store->configureSchema($schema);
+        $this->assertTrue($schema->hasTable('lock_table'));
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineTransportTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Messenger\Bridge\Doctrine\Tests\Transport;
 
+use Doctrine\DBAL\Connection as DbalConnection;
+use Doctrine\DBAL\Schema\Schema;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Doctrine\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection;
@@ -48,6 +50,23 @@ class DoctrineTransportTest extends TestCase
 
         $envelopes = $transport->get();
         $this->assertSame($decodedMessage, $envelopes[0]->getMessage());
+    }
+
+    public function testConfigureSchema()
+    {
+        $transport = $this->getTransport(
+            null,
+            $connection = $this->createMock(Connection::class)
+        );
+
+        $schema = new Schema();
+        $dbalConnection = $this->createMock(DbalConnection::class);
+
+        $connection->expects($this->once())
+            ->method('configureSchema')
+            ->with($schema, $dbalConnection);
+
+        $transport->configureSchema($schema, $dbalConnection);
     }
 
     private function getTransport(SerializerInterface $serializer = null, Connection $connection = null): DoctrineTransport

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Messenger\Bridge\Doctrine\Transport;
 
+use Doctrine\DBAL\Connection as DbalConnection;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Table;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
@@ -96,6 +99,22 @@ class DoctrineTransport implements TransportInterface, SetupableTransportInterfa
     public function setup(): void
     {
         $this->connection->setup();
+    }
+
+    /**
+     * Adds the Table to the Schema if this transport uses this connection.
+     */
+    public function configureSchema(Schema $schema, DbalConnection $forConnection): void
+    {
+        $this->connection->configureSchema($schema, $forConnection);
+    }
+
+    /**
+     * Adds extra SQL if the given table was created by the Connection.
+     */
+    public function getExtraSetupSqlForTable(Table $createdTable): ?string
+    {
+        return $this->connection->getExtraSetupSqlForTable($createdTable);
     }
 
     private function getReceiver(): DoctrineReceiver

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
@@ -23,6 +23,7 @@
         "symfony/service-contracts": "^1.1|^2"
     },
     "require-dev": {
+        "doctrine/orm": "^2.6.3",
         "symfony/serializer": "^4.4|^5.0",
         "symfony/property-access": "^4.4|^5.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Alternative to #36629
| License       | MIT
| Doc PR        | TODO - WILL be needed

This follows this conversation: https://github.com/symfony/symfony/pull/36629#issuecomment-621745821 - it automatically adds SQL to Doctrine's migration/diff system when features are added the require a database table:

The new feature works for:

### A) Messenger Doctrine transport
**FULL support**
Works perfectly: configure a doctrine transport and run `make:migration`

**Note**: There is no current way to disable this. So if you have `auto_setup` ON and you
run `make:migration` before trying Messenger, it will generate the table SQL. Adding a
flag to disable it might be very complicated, because we need to know (in DoctrineBundle, at compile time) whether or not this feature is enabled/disabled so that we can decide *not* to add `messenger_messages` to the `schema_filter`.

### B) `PdoAdapter` from Cache
**FULL support**
Works perfectly: configure a doctrine transport and run `make:migration`

### C) `PdoStore` from Lock
**PARTIAL support**
I added `PdoStore::configureSchema()` but did NOT add a listener. While `PdoStore` *does* accept a DBAL `Connection`, I don't think it's possible via the `framework.lock` config to create a `PdoStore` that is passed a `Connection`. In other words: if we added a listener that called `PdoStore::configureSchema` if the user configured a `pdo` lock, that service will *never* have a `Connection` object... so it's kind of worthless.

**NEED**: A proper way to inject a DBAL `Connection` into `PdoStore` via `framework.lock` config.

### D) `PdoSessionHandler`
**NO support** 

This class doesn't accept a DBAL `Connection` object. And so, we can't reliably create a listener to add the schema because (if there are multiple connections) we wouldn't know which Connection to use.

We could compare (`===`) the `PDO` instance inside `PdoSessionHandler` to the wrapped `PDO` connection in Doctrine. That would only work if the user has configured their `PdoSessionHandler` to re-use the Doctrine PDO connection.

The `PdoSessionHandler` *already* has a `createTable()` method on it to help with manual migration. But... it's not easy to call from a migration because you would need to fetch the `PdoSessionHandler` service from the container. Adding something 

**NEED**: Either:

A) A way for `PdoSessionHandler` to use a DBAL Connection
or
B) We try to hack this feature by comparing the `PDO` instances in the event subscriber
or
C) We add an easier way to access the `createTable()` method from inside a migration.

TODOs

* [X] Determine service injection XML needed for getting all PdoAdapter pools
* [ ] Finish DoctrineBundle PR: https://github.com/doctrine/DoctrineBundle/pull/1163