### PR TITLE
[Security/Core] Add CustomUserMessageAccountStatusException

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Added `LogoutEvent` to allow custom logout listeners.
  * Deprecated `LogoutSuccessHandlerInterface` and `LogoutHandlerInterface` in favor of listening on the `LogoutEvent`.
  * Added experimental new security using `Http\Authenticator\AuthenticatorInterface`, `Http\Authentication\AuthenticatorManager` and `Http\Firewall\AuthenticatorManagerListener`.
+ * Added `CustomUserMessageAccountStatusException` to be used when extending `UserCheckerInterface`
 
 5.0.0
 -----

--- a/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAccountStatusException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAccountStatusException.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Exception;
+
+/**
+ * An authentication exception caused by the user account status
+ * where you can control the message shown to the user.
+ *
+ * Be sure that the message passed to this exception is something that
+ * can be shown safely to your user. In other words, avoid catching
+ * other exceptions and passing their message directly to this class.
+ *
+ * @author Vincent Langlet <vincentlanglet@github.com>
+ */
+class CustomUserMessageAccountStatusException extends AccountStatusException
+{
+    private $messageKey;
+
+    private $messageData = [];
+
+    public function __construct(string $message = '', array $messageData = [], int $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->setSafeMessage($message, $messageData);
+    }
+
+    /**
+     * Set a message that will be shown to the user.
+     *
+     * @param string $messageKey  The message or message key
+     * @param array  $messageData Data to be passed into the translator
+     */
+    public function setSafeMessage(string $messageKey, array $messageData = [])
+    {
+        $this->messageKey = $messageKey;
+        $this->messageData = $messageData;
+    }
+
+    public function getMessageKey()
+    {
+        return $this->messageKey;
+    }
+
+    public function getMessageData()
+    {
+        return $this->messageData;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __serialize(): array
+    {
+        return [parent::__serialize(), $this->messageKey, $this->messageData];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __unserialize(array $data): void
+    {
+        [$parentData, $this->messageKey, $this->messageData] = $data;
+        parent::__unserialize($parentData);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | Not really needed

When implementing the `UserCheckerInterface`, we can throw `AccountStatusException`. Similar to `CustomUserMessageAuthenticationException`, this exception allow to throw an `AccountStatusException` with a custom message.