### PR TITLE
[Messenger] Fix messenger:failed:remove can not remove single message

### DIFF
--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRemoveCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRemoveCommand.php
@@ -61,7 +61,7 @@ EOF
         $receiver = $this->getReceiver();
 
         $shouldForce = $input->getOption('force');
-        $ids = $input->getArgument('id');
+        $ids = (array) $input->getArgument('id');
         $shouldDisplayMessages = $input->getOption('show-messages') || 1 === \count($ids);
         $this->removeMessages($ids, $receiver, $io, $shouldForce, $shouldDisplayMessages);
 

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesRemoveCommandTest.php
@@ -19,6 +19,23 @@ use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 
 class FailedMessagesRemoveCommandTest extends TestCase
 {
+    public function testRemoveSingleMessage()
+    {
+        $receiver = $this->createMock(ListableReceiverInterface::class);
+        $receiver->expects($this->once())->method('find')->with(20)->willReturn(new Envelope(new \stdClass()));
+
+        $command = new FailedMessagesRemoveCommand(
+            'failure_receiver',
+            $receiver
+        );
+
+        $tester = new CommandTester($command);
+        $tester->execute(['id' => 20, '--force' => true]);
+
+        $this->assertStringContainsString('Failed Message Details', $tester->getDisplay());
+        $this->assertStringContainsString('Message with id 20 removed.', $tester->getDisplay());
+    }
+
     public function testRemoveUniqueMessage()
     {
         $receiver = $this->createMock(ListableReceiverInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36659
| License       | MIT
| Doc PR        | -

Fix this error:
```
count(): Parameter must be an array or an object that implements Countable
```
When calling `messenger:failed:remove` command from other code with single id
