### PR TITLE
[Security] Renamed VerifyAuthenticatorCredentialsEvent to CheckPassportEvent

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/EventListener/FirewallEventBubblingListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/EventListener/FirewallEventBubblingListener.php
@@ -12,10 +12,10 @@
 namespace Symfony\Bundle\SecurityBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\LoginFailureEvent;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
-use Symfony\Component\Security\Http\Event\VerifyAuthenticatorCredentialsEvent;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -39,7 +39,7 @@ class FirewallEventBubblingListener implements EventSubscriberInterface
             LogoutEvent::class => 'bubbleEvent',
             LoginFailureEvent::class => 'bubbleEvent',
             LoginSuccessEvent::class => 'bubbleEvent',
-            VerifyAuthenticatorCredentialsEvent::class => 'bubbleEvent',
+            CheckPassportEvent::class => 'bubbleEvent',
         ];
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.xml
@@ -44,7 +44,7 @@
 
         <!-- Listeners -->
 
-        <service id="security.listener.verify_authenticator_credentials" class="Symfony\Component\Security\Http\EventListener\VerifyAuthenticatorCredentialsListener">
+        <service id="security.listener.check_authenticator_credentials" class="Symfony\Component\Security\Http\EventListener\CheckCredentialsListener">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="security.encoder_factory" />
         </service>

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -26,10 +26,10 @@ use Symfony\Component\Security\Http\Authenticator\Passport\AnonymousPassport;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\Event\LoginFailureEvent;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
-use Symfony\Component\Security\Http\Event\VerifyAuthenticatorCredentialsEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -159,7 +159,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
             $passport = $authenticator->authenticate($request);
 
             // check the passport (e.g. password checking)
-            $event = new VerifyAuthenticatorCredentialsEvent($authenticator, $passport);
+            $event = new CheckPassportEvent($authenticator, $passport);
             $this->eventDispatcher->dispatch($event);
 
             // check if all badges are resolved

--- a/src/Symfony/Component/Security/Http/Authenticator/Token/PostAuthenticationToken.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Token/PostAuthenticationToken.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Security\Http\Authenticator\Token;
 
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;

--- a/src/Symfony/Component/Security/Http/Event/CheckPassportEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/CheckPassportEvent.php
@@ -1,9 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Security\Http\Event;
 
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -17,7 +24,7 @@ use Symfony\Contracts\EventDispatcher\Event;
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
-class VerifyAuthenticatorCredentialsEvent extends Event
+class CheckPassportEvent extends Event
 {
     private $authenticator;
     private $passport;

--- a/src/Symfony/Component/Security/Http/EventListener/CheckCredentialsListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/CheckCredentialsListener.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Security\Http\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -8,7 +17,7 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\CustomCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\UserPassportInterface;
-use Symfony\Component\Security\Http\Event\VerifyAuthenticatorCredentialsEvent;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 
 /**
  * This listeners uses the interfaces of authenticators to
@@ -19,7 +28,7 @@ use Symfony\Component\Security\Http\Event\VerifyAuthenticatorCredentialsEvent;
  * @final
  * @experimental in 5.1
  */
-class VerifyAuthenticatorCredentialsListener implements EventSubscriberInterface
+class CheckCredentialsListener implements EventSubscriberInterface
 {
     private $encoderFactory;
 
@@ -28,7 +37,7 @@ class VerifyAuthenticatorCredentialsListener implements EventSubscriberInterface
         $this->encoderFactory = $encoderFactory;
     }
 
-    public function onAuthenticating(VerifyAuthenticatorCredentialsEvent $event): void
+    public function checkPassport(CheckPassportEvent $event): void
     {
         $passport = $event->getPassport();
         if ($passport instanceof UserPassportInterface && $passport->hasBadge(PasswordCredentials::class)) {
@@ -74,6 +83,6 @@ class VerifyAuthenticatorCredentialsListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents(): array
     {
-        return [VerifyAuthenticatorCredentialsEvent::class => ['onAuthenticating', 128]];
+        return [CheckPassportEvent::class => 'checkPassport'];
     }
 }

--- a/src/Symfony/Component/Security/Http/EventListener/CsrfProtectionListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/CsrfProtectionListener.php
@@ -16,7 +16,7 @@ use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
-use Symfony\Component\Security\Http\Event\VerifyAuthenticatorCredentialsEvent;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
@@ -33,7 +33,7 @@ class CsrfProtectionListener implements EventSubscriberInterface
         $this->csrfTokenManager = $csrfTokenManager;
     }
 
-    public function verifyCredentials(VerifyAuthenticatorCredentialsEvent $event): void
+    public function checkPassport(CheckPassportEvent $event): void
     {
         $passport = $event->getPassport();
         if (!$passport->hasBadge(CsrfTokenBadge::class)) {
@@ -57,6 +57,6 @@ class CsrfProtectionListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents(): array
     {
-        return [VerifyAuthenticatorCredentialsEvent::class => ['verifyCredentials', 256]];
+        return [CheckPassportEvent::class => ['checkPassport', 128]];
     }
 }

--- a/src/Symfony/Component/Security/Http/EventListener/UserCheckerListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/UserCheckerListener.php
@@ -1,13 +1,22 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Security\Http\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PreAuthenticatedUserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\UserPassportInterface;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
-use Symfony\Component\Security\Http\Event\VerifyAuthenticatorCredentialsEvent;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
@@ -24,7 +33,7 @@ class UserCheckerListener implements EventSubscriberInterface
         $this->userChecker = $userChecker;
     }
 
-    public function preCredentialsVerification(VerifyAuthenticatorCredentialsEvent $event): void
+    public function preCheckCredentials(CheckPassportEvent $event): void
     {
         $passport = $event->getPassport();
         if (!$passport instanceof UserPassportInterface || $passport->hasBadge(PreAuthenticatedUserBadge::class)) {
@@ -34,7 +43,7 @@ class UserCheckerListener implements EventSubscriberInterface
         $this->userChecker->checkPreAuth($passport->getUser());
     }
 
-    public function postCredentialsVerification(LoginSuccessEvent $event): void
+    public function postCheckCredentials(LoginSuccessEvent $event): void
     {
         $passport = $event->getPassport();
         if (!$passport instanceof UserPassportInterface || null === $passport->getUser()) {
@@ -47,8 +56,8 @@ class UserCheckerListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            VerifyAuthenticatorCredentialsEvent::class => [['preCredentialsVerification', 256]],
-            LoginSuccessEvent::class => ['postCredentialsVerification', 256],
+            CheckPassportEvent::class => ['preCheckCredentials', 256],
+            LoginSuccessEvent::class => ['postCheckCredentials', 256],
         ];
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterf
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
-use Symfony\Component\Security\Http\Event\VerifyAuthenticatorCredentialsEvent;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 
 class AuthenticatorManagerTest extends TestCase
 {
@@ -95,7 +95,7 @@ class AuthenticatorManagerTest extends TestCase
         $matchingAuthenticator->expects($this->any())->method('authenticate')->willReturn(new SelfValidatingPassport($this->user));
 
         $listenerCalled = false;
-        $this->eventDispatcher->addListener(VerifyAuthenticatorCredentialsEvent::class, function (VerifyAuthenticatorCredentialsEvent $event) use (&$listenerCalled, $matchingAuthenticator) {
+        $this->eventDispatcher->addListener(CheckPassportEvent::class, function (CheckPassportEvent $event) use (&$listenerCalled, $matchingAuthenticator) {
             if ($event->getAuthenticator() === $matchingAuthenticator && $event->getPassport()->getUser() === $this->user) {
                 $listenerCalled = true;
             }
@@ -106,7 +106,7 @@ class AuthenticatorManagerTest extends TestCase
 
         $manager = $this->createManager($authenticators);
         $this->assertNull($manager->authenticateRequest($this->request));
-        $this->assertTrue($listenerCalled, 'The VerifyAuthenticatorCredentialsEvent listener is not called');
+        $this->assertTrue($listenerCalled, 'The CheckPassportEvent listener is not called');
     }
 
     public function provideMatchingAuthenticatorIndex()

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/CheckCredentialsListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/CheckCredentialsListenerTest.php
@@ -21,10 +21,10 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\CustomCre
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
-use Symfony\Component\Security\Http\Event\VerifyAuthenticatorCredentialsEvent;
-use Symfony\Component\Security\Http\EventListener\VerifyAuthenticatorCredentialsListener;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+use Symfony\Component\Security\Http\EventListener\CheckCredentialsListener;
 
-class VerifyAuthenticatorCredentialsListenerTest extends TestCase
+class CheckCredentialsListenerTest extends TestCase
 {
     private $encoderFactory;
     private $listener;
@@ -33,7 +33,7 @@ class VerifyAuthenticatorCredentialsListenerTest extends TestCase
     protected function setUp(): void
     {
         $this->encoderFactory = $this->createMock(EncoderFactoryInterface::class);
-        $this->listener = new VerifyAuthenticatorCredentialsListener($this->encoderFactory);
+        $this->listener = new CheckCredentialsListener($this->encoderFactory);
         $this->user = new User('wouter', 'encoded-password');
     }
 
@@ -53,7 +53,7 @@ class VerifyAuthenticatorCredentialsListenerTest extends TestCase
         }
 
         $credentials = new PasswordCredentials($password);
-        $this->listener->onAuthenticating($this->createEvent(new Passport($this->user, $credentials)));
+        $this->listener->checkPassport($this->createEvent(new Passport($this->user, $credentials)));
 
         if (true === $result) {
             $this->assertTrue($credentials->isResolved());
@@ -74,7 +74,7 @@ class VerifyAuthenticatorCredentialsListenerTest extends TestCase
         $this->encoderFactory->expects($this->never())->method('getEncoder');
 
         $event = $this->createEvent(new Passport($this->user, new PasswordCredentials('')));
-        $this->listener->onAuthenticating($event);
+        $this->listener->checkPassport($event);
     }
 
     /**
@@ -91,7 +91,7 @@ class VerifyAuthenticatorCredentialsListenerTest extends TestCase
         $credentials = new CustomCredentials(function () use ($result) {
             return $result;
         }, ['password' => 'foo']);
-        $this->listener->onAuthenticating($this->createEvent(new Passport($this->user, $credentials)));
+        $this->listener->checkPassport($this->createEvent(new Passport($this->user, $credentials)));
 
         if (true === $result) {
             $this->assertTrue($credentials->isResolved());
@@ -109,11 +109,11 @@ class VerifyAuthenticatorCredentialsListenerTest extends TestCase
         $this->encoderFactory->expects($this->never())->method('getEncoder');
 
         $event = $this->createEvent(new SelfValidatingPassport($this->user));
-        $this->listener->onAuthenticating($event);
+        $this->listener->checkPassport($event);
     }
 
     private function createEvent($passport)
     {
-        return new VerifyAuthenticatorCredentialsEvent($this->createMock(AuthenticatorInterface::class), $passport);
+        return new CheckPassportEvent($this->createMock(AuthenticatorInterface::class), $passport);
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/CsrfProtectionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/CsrfProtectionListenerTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
-use Symfony\Component\Security\Http\Event\VerifyAuthenticatorCredentialsEvent;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\EventListener\CsrfProtectionListener;
 
 class CsrfProtectionListenerTest extends TestCase
@@ -38,7 +38,7 @@ class CsrfProtectionListenerTest extends TestCase
         $this->csrfTokenManager->expects($this->never())->method('isTokenValid');
 
         $event = $this->createEvent($this->createPassport(null));
-        $this->listener->verifyCredentials($event);
+        $this->listener->checkPassport($event);
     }
 
     public function testValidCsrfToken()
@@ -49,7 +49,7 @@ class CsrfProtectionListenerTest extends TestCase
             ->willReturn(true);
 
         $event = $this->createEvent($this->createPassport(new CsrfTokenBadge('authenticator_token_id', 'abc123')));
-        $this->listener->verifyCredentials($event);
+        $this->listener->checkPassport($event);
 
         $this->expectNotToPerformAssertions();
     }
@@ -65,12 +65,12 @@ class CsrfProtectionListenerTest extends TestCase
             ->willReturn(false);
 
         $event = $this->createEvent($this->createPassport(new CsrfTokenBadge('authenticator_token_id', 'abc123')));
-        $this->listener->verifyCredentials($event);
+        $this->listener->checkPassport($event);
     }
 
     private function createEvent($passport)
     {
-        return new VerifyAuthenticatorCredentialsEvent($this->createMock(AuthenticatorInterface::class), $passport);
+        return new CheckPassportEvent($this->createMock(AuthenticatorInterface::class), $passport);
     }
 
     private function createPassport(?CsrfTokenBadge $badge)

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/UserCheckerListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/UserCheckerListenerTest.php
@@ -20,8 +20,8 @@ use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PreAuthenticatedUserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
-use Symfony\Component\Security\Http\Event\VerifyAuthenticatorCredentialsEvent;
 use Symfony\Component\Security\Http\EventListener\UserCheckerListener;
 
 class UserCheckerListenerTest extends TestCase
@@ -41,44 +41,44 @@ class UserCheckerListenerTest extends TestCase
     {
         $this->userChecker->expects($this->once())->method('checkPreAuth')->with($this->user);
 
-        $this->listener->preCredentialsVerification($this->createVerifyAuthenticatorCredentialsEvent());
+        $this->listener->preCheckCredentials($this->createCheckPassportEvent());
     }
 
     public function testPreAuthNoUser()
     {
         $this->userChecker->expects($this->never())->method('checkPreAuth');
 
-        $this->listener->preCredentialsVerification($this->createVerifyAuthenticatorCredentialsEvent($this->createMock(PassportInterface::class)));
+        $this->listener->preCheckCredentials($this->createCheckPassportEvent($this->createMock(PassportInterface::class)));
     }
 
     public function testPreAuthenticatedBadge()
     {
         $this->userChecker->expects($this->never())->method('checkPreAuth');
 
-        $this->listener->preCredentialsVerification($this->createVerifyAuthenticatorCredentialsEvent(new SelfValidatingPassport($this->user, [new PreAuthenticatedUserBadge()])));
+        $this->listener->preCheckCredentials($this->createCheckPassportEvent(new SelfValidatingPassport($this->user, [new PreAuthenticatedUserBadge()])));
     }
 
     public function testPostAuthValidCredentials()
     {
         $this->userChecker->expects($this->once())->method('checkPostAuth')->with($this->user);
 
-        $this->listener->postCredentialsVerification($this->createLoginSuccessEvent());
+        $this->listener->postCheckCredentials($this->createLoginSuccessEvent());
     }
 
     public function testPostAuthNoUser()
     {
         $this->userChecker->expects($this->never())->method('checkPostAuth');
 
-        $this->listener->postCredentialsVerification($this->createLoginSuccessEvent($this->createMock(PassportInterface::class)));
+        $this->listener->postCheckCredentials($this->createLoginSuccessEvent($this->createMock(PassportInterface::class)));
     }
 
-    private function createVerifyAuthenticatorCredentialsEvent($passport = null)
+    private function createCheckPassportEvent($passport = null)
     {
         if (null === $passport) {
             $passport = new SelfValidatingPassport($this->user);
         }
 
-        return new VerifyAuthenticatorCredentialsEvent($this->createMock(AuthenticatorInterface::class), $passport);
+        return new CheckPassportEvent($this->createMock(AuthenticatorInterface::class), $passport);
     }
 
     private function createLoginSuccessEvent($passport = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36608
| License       | MIT
| Doc PR        | -

This event was named long before we introduced the concept of passports. Listeners on this event check the user, the credentials and any badges of the Security passport. I think `CheckPassportEvent` makes the most sense (more than `CheckCredentialsEvent`).

Also, I managed to break fabbot in the large PR. Just checked all new classes and added license headers in case they were missing (fabbot complained about most of them in this PR already).