### PR TITLE
[Validator] Skip validation when email is an empty object

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -51,6 +51,9 @@ class EmailValidator extends ConstraintValidator
         }
 
         $value = (string) $value;
+        if ('' === $value) {
+            return;
+        }
 
         if (null === $constraint->strict) {
             $constraint->strict = $this->isStrict;

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -40,6 +40,13 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    public function testObjectEmptyStringIsValid()
+    {
+        $this->validator->validate(new EmptyEmailObject(), new Email());
+
+        $this->assertNoViolation();
+    }
+
     public function testExpectsStringCompatibleType()
     {
         $this->expectException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
@@ -254,5 +261,13 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
             ['checkMX', Email::MX_CHECK_FAILED_ERROR],
             ['checkHost', Email::HOST_CHECK_FAILED_ERROR],
         ];
+    }
+}
+
+class EmptyEmailObject
+{
+    public function __toString()
+    {
+        return '';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

When the value passed to the email validator is an empty object the validator is still called and will mark the value as invalid. The object should be skipped in this case, as it is also done in the `UrlValidator`

https://github.com/symfony/symfony/blob/bfdbb244fe311008437e3634cc97fefae8cc7446/src/Symfony/Component/Validator/Constraints/UrlValidator.php#L59-L62

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
