### PR TITLE
[Yaml] fix parse error when unindented collections contain a comment

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -619,8 +619,14 @@ class Parser
         }
 
         $isItUnindentedCollection = $this->isStringUnIndentedCollectionItem();
+        $isItComment = $this->isCurrentLineComment();
 
         while ($this->moveToNextLine()) {
+            if ($isItComment && !$isItUnindentedCollection) {
+                $isItUnindentedCollection = $this->isStringUnIndentedCollectionItem();
+                $isItComment = $this->isCurrentLineComment();
+            }
+
             $indent = $this->getCurrentLineIndentation();
 
             if ($isItUnindentedCollection && !$this->isCurrentLineEmpty() && !$this->isStringUnIndentedCollectionItem() && $newIndent === $indent) {

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/sfComments.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/sfComments.yml
@@ -74,3 +74,17 @@ yaml: |
     'foo #': baz
 php: |
     ['foo #' => 'baz']
+---
+test: Comment before first item in unindented collection
+brief: >
+    Comment directly before unindented collection is allowed
+yaml: |
+    collection1:
+    # comment
+    - a
+    - b
+    collection2:
+    - a
+    - b
+php: |
+    ['collection1' => ['a', 'b'], 'collection2' => ['a', 'b']]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36558 
| License       | MIT

### Problem
The method `Parser::getNextEmbedBlock` did not determine the yaml-block correctly when there was a comment before the first unindented collection item. This was caused by the fact that the check for unindented collection items was done for the _first line of the block only_. So in case this first line is a comment, this check will result in _false_, while in fact the parser is in an unindented collection.

### Solution
In the solution I implemented the parser will check for comment lines as well. As long as the loop encounters a comment line, it will check (in the next iteration) whether the line is an unindented collection item. So this check will be done until all comments before the first uncommented item are parsed.

