### PR TITLE
[FrameworkBundle] Deprecate some public services to private

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -6,6 +6,12 @@ DependencyInjection
 
  * Deprecated `Definition::setPrivate()` and `Alias::setPrivate()`, use `setPublic()` instead
 
+FrameworkBundle
+---------------
+
+ * Deprecated the public `form.factory`, `form.type.file`, `translator`, `security.csrf.token_manager`, `serializer`,
+   `cache_clearer`, `filesystem` and `validator` services to private.
+
 Mime
 ----
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -55,6 +55,8 @@ FrameworkBundle
  * `MicroKernelTrait::configureRoutes()` is now always called with a `RoutingConfigurator`
  * The "framework.router.utf8" configuration option defaults to `true`
  * Removed `session.attribute_bag` service and `session.flash_bag` service.
+ * The `form.factory`, `form.type.file`, `translator`, `security.csrf.token_manager`, `serializer`,
+   `cache_clearer`, `filesystem` and `validator` services are now private.
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Added `framework.http_cache` configuration tree
  * Added `framework.trusted_proxies` and `framework.trusted_headers` configuration options
+ * Deprecated the public `form.factory`, `form.type.file`, `translator`, `security.csrf.token_manager`, `serializer`,
+   `cache_clearer`, `filesystem` and `validator` services to private.
 
 5.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.php
@@ -61,6 +61,7 @@ return static function (ContainerConfigurator $container) {
         ->set('form.factory', FormFactory::class)
             ->public()
             ->args([service('form.registry')])
+            ->tag('container.private', ['package' => 'symfony/framework-bundle', 'version' => '5.2'])
 
         ->alias(FormFactoryInterface::class, 'form.factory')
 
@@ -103,6 +104,7 @@ return static function (ContainerConfigurator $container) {
             ->public()
             ->args([service('translator')->ignoreOnInvalid()])
             ->tag('form.type')
+            ->tag('container.private', ['package' => 'symfony/framework-bundle', 'version' => '5.2'])
 
         ->set('form.type.color', ColorType::class)
             ->args([service('translator')->ignoreOnInvalid()])

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/identity_translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/identity_translator.php
@@ -18,6 +18,7 @@ return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('translator', IdentityTranslator::class)
             ->public()
+            ->tag('container.private', ['package' => 'symfony/framework-bundle', 'version' => '5.2'])
         ->alias(TranslatorInterface::class, 'translator')
 
         ->set('identity_translator', IdentityTranslator::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.php
@@ -38,6 +38,7 @@ return static function (ContainerConfigurator $container) {
                 service('security.csrf.token_storage'),
                 service('request_stack')->ignoreOnInvalid(),
             ])
+            ->tag('container.private', ['package' => 'symfony/framework-bundle', 'version' => '5.2'])
 
         ->alias(CsrfTokenManagerInterface::class, 'security.csrf.token_manager')
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/serializer.php
@@ -55,6 +55,7 @@ return static function (ContainerConfigurator $container) {
         ->set('serializer', Serializer::class)
             ->public()
             ->args([[], []])
+            ->tag('container.private', ['package' => 'symfony/framework-bundle', 'version' => '5.2'])
 
         ->alias(SerializerInterface::class, 'serializer')
         ->alias(NormalizerInterface::class, 'serializer')

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -118,6 +118,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 tagged_iterator('kernel.cache_clearer'),
             ])
+            ->tag('container.private', ['package' => 'symfony/framework-bundle', 'version' => '5.2'])
 
         ->set('kernel')
             ->synthetic()
@@ -126,6 +127,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('filesystem', Filesystem::class)
             ->public()
+            ->tag('container.private', ['package' => 'symfony/framework-bundle', 'version' => '5.2'])
         ->alias(Filesystem::class, 'filesystem')
 
         ->set('file_locator', FileLocator::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
@@ -30,6 +30,7 @@ return static function (ContainerConfigurator $container) {
         ->set('validator', ValidatorInterface::class)
             ->public()
             ->factory([service('validator.builder'), 'getValidator'])
+            ->tag('container.private', ['package' => 'symfony/framework-bundle', 'version' => '5.2'])
         ->alias(ValidatorInterface::class, 'validator')
 
         ->set('validator.builder', ValidatorBuilder::class)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/validation_annotations.php
@@ -7,3 +7,5 @@ $container->loadFromExtension('framework', [
         'enable_annotations' => true,
     ],
 ]);
+
+$container->setAlias('validator.alias', 'validator')->setPublic(true);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/validation_annotations.xml
@@ -9,4 +9,8 @@
     <framework:config secret="s3cr3t">
         <framework:validation enabled="true" enable-annotations="true" />
     </framework:config>
+
+    <services>
+        <service id="validator.alias" alias="validator" public="true" />
+    </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_annotations.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/validation_annotations.yml
@@ -3,3 +3,8 @@ framework:
     validation:
         enabled:     true
         enable_annotations: true
+
+services:
+    validator.alias:
+        alias: validator
+        public: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -839,7 +839,7 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainerFromFile('validation_annotations', ['kernel.charset' => 'UTF-8'], false);
 
-        $this->assertInstanceOf('Symfony\Component\Validator\Validator\ValidatorInterface', $container->get('validator'));
+        $this->assertInstanceOf('Symfony\Component\Validator\Validator\ValidatorInterface', $container->get('validator.alias'));
     }
 
     public function testAnnotations()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/BundlePathsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/BundlePathsTest.php
@@ -53,7 +53,7 @@ class BundlePathsTest extends AbstractWebTestCase
     public function testBundleTranslationsDir()
     {
         static::bootKernel(['test_case' => 'BundlePaths']);
-        $translator = static::$container->get('translator');
+        $translator = static::$container->get('translator.alias');
 
         $this->assertSame('OK', $translator->trans('ok_label', [], 'legacy'));
         $this->assertSame('OK', $translator->trans('ok_label', [], 'modern'));
@@ -62,7 +62,7 @@ class BundlePathsTest extends AbstractWebTestCase
     public function testBundleValidationConfigDir()
     {
         static::bootKernel(['test_case' => 'BundlePaths']);
-        $validator = static::$container->get('validator');
+        $validator = static::$container->get('validator.alias');
 
         $this->assertTrue($validator->hasMetadataFor(LegacyPerson::class));
         $this->assertCount(1, $constraintViolationList = $validator->validate(new LegacyPerson('john', 5)));
@@ -76,7 +76,7 @@ class BundlePathsTest extends AbstractWebTestCase
     public function testBundleSerializationConfigDir()
     {
         static::bootKernel(['test_case' => 'BundlePaths']);
-        $serializer = static::$container->get('serializer');
+        $serializer = static::$container->get('serializer.alias');
 
         $this->assertEquals(['full_name' => 'john', 'age' => 5], $serializer->normalize(new LegacyPerson('john', 5), 'json'));
         $this->assertEquals(['full_name' => 'john', 'age' => 5], $serializer->normalize(new ModernPerson('john', 5), 'json'));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolsTest.php
@@ -96,7 +96,7 @@ class CachePoolsTest extends AbstractWebTestCase
         $pool2 = $container->get('cache.pool2');
         $pool2->save($item);
 
-        $container->get('cache_clearer')->clear($container->getParameter('kernel.cache_dir'));
+        $container->get('cache_clearer.alias')->clear($container->getParameter('kernel.cache_dir'));
         $item = $pool1->getItem($key);
         $this->assertFalse($item->isHit());
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SerializerTest.php
@@ -20,7 +20,7 @@ class SerializerTest extends AbstractWebTestCase
     {
         static::bootKernel(['test_case' => 'Serializer']);
 
-        $result = static::$container->get('serializer')->deserialize('{"bars": [{"id": 1}, {"id": 2}]}', Foo::class, 'json');
+        $result = static::$container->get('serializer.alias')->deserialize('{"bars": [{"id": 1}, {"id": 2}]}', Foo::class, 'json');
 
         $bar1 = new Bar();
         $bar1->id = 1;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/BundlePaths/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/BundlePaths/config.yml
@@ -12,4 +12,15 @@ twig:
 services:
     twig.alias:
         alias: twig
+
+    validator.alias:
+        alias: validator
+        public: true
+
+    serializer.alias:
+        alias: serializer
+        public: true
+
+    translator.alias:
+        alias: translator
         public: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/CachePools/config.yml
@@ -24,3 +24,8 @@ framework:
             cache.pool7:
                 adapter: cache.pool4
                 public: true
+
+services:
+    cache_clearer.alias:
+        alias: cache_clearer
+        public: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Serializer/config.yml
@@ -4,3 +4,8 @@ imports:
 framework:
     serializer: { enabled: true }
     property_info: { enabled: true }
+
+services:
+    serializer.alias:
+        alias: serializer
+        public: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Now that we can deprecate public services to private, here is a first pass on the FWB. I think all those services don't need to be public, ie we never need to access them directly in Symfony's code (except in some tests that I had to modify accordingly). I think most of theses services needed to be public before we hooked the AbstractController with a service subscriber. There are definitely more of them that can be deprecated (ie: created workflows and state machines are public but don't need to be ?) but let's start with the easy ones.