### PR TITLE
[Console][WIP][POC] Add support for arrow keys in QuestionHelper

### DIFF
--- a/src/Symfony/Component/Console/Cursor.php
+++ b/src/Symfony/Component/Console/Cursor.php
@@ -163,6 +163,10 @@ final class Cursor
 
         sscanf($code, "\033[%d;%dR", $row, $col);
 
+        if (null === $row && null === $col) {
+            sscanf($code, "~\033[%d;%dR", $row, $col);
+        }
+
         return [$col, $row];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #36657
| License       | MIT
| Doc PR        | TBD

Add support for using arrow keys in the QuestionHelper.

The approach here does not depend on `readline` at all (which had some issues and was removed in #17669)

This PR also solves some of the issues experienced by @javiereguiluz in #15583, as well as supports decorated messages (which readline doesn't, as per https://github.com/symfony/symfony/pull/16458#issuecomment-153718094).

Before I finish the PR, I just want to get some feedback first if this approach is acceptable.

**TODO**:

- [ ] Fix current tests
- [ ] Add new tests
- [ ] Support arrow keys when question is autocompleted
