### PR TITLE
[DI][EventDispatcher] added contract for implementation

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
@@ -40,6 +40,9 @@ interface EventSubscriberInterface
      *  * ['eventName' => ['methodName', $priority]]
      *  * ['eventName' => [['methodName1', $priority], ['methodName2']]]
      *
+     * The code must not depend on runtime state as it will only be called at compile time.
+     * All logic depending on runtime state must be put into the individual methods handling the events.
+     *
      * @return array The event names to listen to
      */
     public static function getSubscribedEvents();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #36708
| License       | MIT

As described in the attached issue a comment in the documentation of the `EventSubscriberInterface` would be helpful to make sure users do not use logic based on runtime state in their implementation of `getSubscribedEvents`.