### PR TITLE
[Mime] handle passing custom mime types as string

### DIFF
--- a/src/Symfony/Component/Mime/MimeTypes.php
+++ b/src/Symfony/Component/Mime/MimeTypes.php
@@ -51,7 +51,7 @@ final class MimeTypes implements MimeTypesInterface
             $this->extensions[$mimeType] = $extensions;
 
             foreach ($extensions as $extension) {
-                $this->mimeTypes[$extension] = $mimeType;
+                $this->mimeTypes[$extension][] = $mimeType;
             }
         }
         $this->registerGuesser(new FileBinaryMimeTypeGuesser());

--- a/src/Symfony/Component/Mime/Tests/MimeTypesTest.php
+++ b/src/Symfony/Component/Mime/Tests/MimeTypesTest.php
@@ -62,4 +62,15 @@ class MimeTypesTest extends AbstractMimeTypeGuesserTest
         $this->assertContains('image/svg', $mt->getMimeTypes('svg'));
         $this->assertSame([], $mt->getMimeTypes('symfony'));
     }
+
+    public function testCustomMimeTypes()
+    {
+        $mt = new MimeTypes([
+            'text/bar' => ['foo'],
+            'text/baz' => ['foo', 'moof'],
+        ]);
+        $this->assertContains('text/bar', $mt->getMimeTypes('foo'));
+        $this->assertContains('text/baz', $mt->getMimeTypes('foo'));
+        $this->assertSame(['foo', 'moof'], $mt->getExtensions('text/baz'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36715
| License       | MIT
| Doc PR        | none
Fix's issue where custom mimetypes were failing
