### PR TITLE
[FrameworkBundle] remove getProjectDir method from MicroKernelTrait

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,7 +9,7 @@ CHANGELOG
  * Added the `framework.router.default_uri` configuration option to configure the default `RequestContext`
  * Made `MicroKernelTrait::configureContainer()` compatible with `ContainerConfigurator`
  * Added a new `mailer.message_bus` option to configure or disable the message bus to use to send mails.
- * Added flex-compatible default implementations for `MicroKernelTrait::registerBundles()` and `getProjectDir()`
+ * Added flex-compatible default implementation for `MicroKernelTrait::registerBundles()`
  * Deprecated passing a `RouteCollectionBuilder` to `MicroKernelTrait::configureRoutes()`, type-hint `RoutingConfigurator` instead
  * The `TemplateController` now accepts context argument
  * Deprecated *not* setting the "framework.router.utf8" configuration option as it will default to `true` in Symfony 6.0

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -63,14 +63,6 @@ trait MicroKernelTrait
     /**
      * {@inheritdoc}
      */
-    public function getProjectDir(): string
-    {
-        return \dirname((new \ReflectionObject($this))->getFileName(), 2);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function registerBundles(): iterable
     {
         $contents = require $this->getProjectDir().'/config/bundles.php';

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel/flex-style/src/FlexStyleMicroKernel.php
@@ -50,6 +50,11 @@ class FlexStyleMicroKernel extends Kernel
         return $this->cacheDir;
     }
 
+    public function getProjectDir(): string
+    {
+        return \dirname((new \ReflectionObject($this))->getFileName(), 2);
+    }
+
     public function __sleep(): array
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36719
| License       | MIT
| Doc PR        | not needed

Remove method added in trait, to be able to use same method in base kernel class.