### PR TITLE
Rename AtLeastOneOf new Constraint to OneOf

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/OneOf.php
+++ b/src/Symfony/Component/Validator/Constraints/OneOf.php
@@ -17,12 +17,12 @@ namespace Symfony\Component\Validator\Constraints;
  *
  * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
  */
-class AtLeastOneOf extends Composite
+class OneOf extends Composite
 {
-    public const AT_LEAST_ONE_OF_ERROR = 'f27e6d6c-261a-4056-b391-6673a623531c';
+    public const ONE_OF_ERROR = 'f27e6d6c-261a-4056-b391-6673a623531c';
 
     protected static $errorNames = [
-        self::AT_LEAST_ONE_OF_ERROR => 'AT_LEAST_ONE_OF_ERROR',
+        self::ONE_OF_ERROR => 'ONE_OF_ERROR',
     ];
 
     public $constraints = [];

--- a/src/Symfony/Component/Validator/Constraints/OneOfValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/OneOfValidator.php
@@ -18,15 +18,15 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 /**
  * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
  */
-class AtLeastOneOfValidator extends ConstraintValidator
+class OneOfValidator extends ConstraintValidator
 {
     /**
      * {@inheritdoc}
      */
     public function validate($value, Constraint $constraint)
     {
-        if (!$constraint instanceof AtLeastOneOf) {
-            throw new UnexpectedTypeException($constraint, AtLeastOneOf::class);
+        if (!$constraint instanceof OneOf) {
+            throw new UnexpectedTypeException($constraint, OneOf::class);
         }
 
         $validator = $this->context->getValidator();
@@ -54,7 +54,7 @@ class AtLeastOneOfValidator extends ConstraintValidator
         }
 
         $this->context->buildViolation(implode('', $messages))
-            ->setCode(AtLeastOneOf::AT_LEAST_ONE_OF_ERROR)
+            ->setCode(OneOf::ONE_OF_ERROR)
             ->addViolation()
         ;
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/OneOfTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/OneOfTest.php
@@ -12,18 +12,18 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Validator\Constraints\AtLeastOneOf;
+use Symfony\Component\Validator\Constraints\OneOf;
 use Symfony\Component\Validator\Constraints\Valid;
 
 /**
  * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
  */
-class AtLeastOneOfTest extends TestCase
+class OneOfTest extends TestCase
 {
     public function testRejectNonConstraints()
     {
         $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
-        new AtLeastOneOf([
+        new OneOf([
             'foo',
         ]);
     }
@@ -31,7 +31,7 @@ class AtLeastOneOfTest extends TestCase
     public function testRejectValidConstraint()
     {
         $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
-        new AtLeastOneOf([
+        new OneOf([
             new Valid(),
         ]);
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/OneOfValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/OneOfValidatorTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
-use Symfony\Component\Validator\Constraints\OneOf;
-use Symfony\Component\Validator\Constraints\OneOfValidator;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\Country;
@@ -24,6 +22,8 @@ use Symfony\Component\Validator\Constraints\Language;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\LessThan;
 use Symfony\Component\Validator\Constraints\Negative;
+use Symfony\Component\Validator\Constraints\OneOf;
+use Symfony\Component\Validator\Constraints\OneOfValidator;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraints\Unique;

--- a/src/Symfony/Component/Validator/Tests/Constraints/OneOfValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/OneOfValidatorTest.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
-use Symfony\Component\Validator\Constraints\AtLeastOneOf;
-use Symfony\Component\Validator\Constraints\AtLeastOneOfValidator;
+use Symfony\Component\Validator\Constraints\OneOf;
+use Symfony\Component\Validator\Constraints\OneOfValidator;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\Count;
 use Symfony\Component\Validator\Constraints\Country;
@@ -32,11 +32,11 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 /**
  * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
  */
-class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
+class OneOfValidatorTest extends ConstraintValidatorTestCase
 {
     protected function createValidator()
     {
-        return new AtLeastOneOfValidator();
+        return new OneOfValidator();
     }
 
     /**
@@ -50,7 +50,7 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
             $this->expectViolationsAt($i++, $value, $constraint);
         }
 
-        $this->validator->validate($value, new AtLeastOneOf($constraints));
+        $this->validator->validate($value, new OneOf($constraints));
 
         $this->assertNoViolation();
     }
@@ -94,7 +94,7 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidCombinationsWithDefaultMessage($value, $constraints)
     {
-        $atLeastOneOf = new AtLeastOneOf(['constraints' => $constraints]);
+        $atLeastOneOf = new OneOf(['constraints' => $constraints]);
 
         $message = [$atLeastOneOf->message];
 
@@ -106,7 +106,7 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
 
         $this->validator->validate($value, $atLeastOneOf);
 
-        $this->buildViolation(implode('', $message))->setCode(AtLeastOneOf::AT_LEAST_ONE_OF_ERROR)->assertRaised();
+        $this->buildViolation(implode('', $message))->setCode(OneOf::ONE_OF_ERROR)->assertRaised();
     }
 
     /**
@@ -114,7 +114,7 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidCombinationsWithCustomMessage($value, $constraints)
     {
-        $atLeastOneOf = new AtLeastOneOf(['constraints' => $constraints, 'message' => 'foo', 'includeInternalMessages' => false]);
+        $atLeastOneOf = new OneOf(['constraints' => $constraints, 'message' => 'foo', 'includeInternalMessages' => false]);
 
         $i = 0;
 
@@ -124,7 +124,7 @@ class AtLeastOneOfValidatorTest extends ConstraintValidatorTestCase
 
         $this->validator->validate($value, $atLeastOneOf);
 
-        $this->buildViolation('foo')->setCode(AtLeastOneOf::AT_LEAST_ONE_OF_ERROR)->assertRaised();
+        $this->buildViolation('foo')->setCode(OneOf::ONE_OF_ERROR)->assertRaised();
     }
 
     public function getInvalidCombinations()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | PR: https://github.com/symfony/symfony/pull/35744
| License       | MIT
| Doc PR        | TODO ?

@przemyslaw-bogusz Originally created `AtLeastOne` constraint. Which it seems was merged in 5.1 as `AtLeastOneOf`. (https://github.com/symfony/symfony/pull/35744).

I propose to rename it simply `OneOf` because it stops as soon as one of the constraints has no violations. So At least and One of seems a duplicate of information. Also calling it just `OneOf` is to have the same wording as OpenApi spec.