### PR TITLE
[HttpFoundation] fix perf of ResponseHeaderBag::initDate()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -286,8 +286,6 @@ class ResponseHeaderBag extends HeaderBag
 
     private function initDate(): void
     {
-        $now = \DateTime::createFromFormat('U', time());
-        $now->setTimezone(new \DateTimeZone('UTC'));
-        $this->set('Date', $now->format('D, d M Y H:i:s').' GMT');
+        $this->set('Date', gmdate('D, d M Y H:i:s').' GMT');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This change alone makes a skeleton hello world go from 1600 req/s to 1800 req/s on my machine (with preloading enabled to remove the cost of the autoloader).

Another discovery by
[![image](https://user-images.githubusercontent.com/243674/81168746-e00cf280-8f97-11ea-9f18-7e14e84b2828.png)](https://blackfire.io/)
