### PR TITLE
Add `getAny` in InputBag

### DIFF
--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -63,7 +63,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
                     return;
                 }
 
-                $data = $request->query->all()[$name];
+                $data = $request->query->getAny($name);
             }
         } else {
             // Mark the form with an error if the uploaded size was too large
@@ -87,7 +87,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
                 $files = $request->files->all();
             } elseif ($request->request->has($name) || $request->files->has($name)) {
                 $default = $form->getConfig()->getCompound() ? [] : null;
-                $params = $request->request->all()[$name] ?? $default;
+                $params = $request->request->getAny($name, $default);
                 $files = $request->files->get($name, $default);
             } else {
                 // Don't submit the form if it is not present in the request

--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -43,6 +43,18 @@ final class InputBag extends ParameterBag
     }
 
     /**
+     * Returns any input value by name.
+     *
+     * @param mixed $default The default value if the input key does not exist
+     *
+     * @return mixed
+     */
+    public function getAny(string $key, $default = null)
+    {
+        return \array_key_exists($key, $this->parameters) ? $this->parameters[$key] : $default;
+    }
+
+    /**
      * Returns the inputs.
      *
      * @param string|null $key The name of the input to return or null to get them all
@@ -99,7 +111,7 @@ final class InputBag extends ParameterBag
      */
     public function filter(string $key, $default = null, int $filter = FILTER_DEFAULT, $options = [])
     {
-        $value = $this->has($key) ? $this->all()[$key] : $default;
+        $value = $this->getAny($key, $default);
 
         // Always turn $options into an array - this allows filter_var option shortcuts.
         if (!\is_array($options) && $options) {

--- a/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/InputBagTest.php
@@ -36,6 +36,17 @@ class InputBagTest extends TestCase
         $this->assertNull($bag->get('foo[bar]'));
     }
 
+    public function testGetAny()
+    {
+        $bag = new InputBag(['foo' => 'bar', 'null' => null, 'arr' => [1], 'num' => 1]);
+
+        $this->assertSame('bar', $bag->getAny('foo'), '->getAny() gets the value of a parameter (string)');
+        $this->assertSame([1], $bag->getAny('arr'), '->getAny() gets the value of a parameter (array)');
+        $this->assertSame(1, $bag->getAny('num'), '->getAny() gets the value of a parameter (int)');
+        $this->assertSame([], $bag->getAny('unknown', []), '->getAny() returns second argument as default if a parameter is not defined');
+        $this->assertNull($bag->getAny('null'), '->getAny() returns null if null is set');
+    }
+
     public function testAllWithInputKey()
     {
         $bag = new InputBag(['foo' => ['bar', 'baz'], 'null' => null]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->

The new `InputBag` was introduced in #34363 but there is an "edge case" to get a value of any type, I find it's better to be explicit and to have a new `->getAny('foo', 'default')` instead of `->all()['foo'] ?? 'default` (or `array_key_exists('foo', $...->all()) ? ...->all()['foo'] : 'default'` to be exact).

Alternatively having a `->getString()` is more explicit than a generic `->get()`.