### PR TITLE
[FrameworkBundle] display actual target for error in AssetsInstallCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -121,7 +121,7 @@ EOT
                 if (is_dir(\dirname($targetArg).'/web')) {
                     $targetArg = \dirname($targetArg).'/web';
                 } else {
-                    throw new InvalidArgumentException(sprintf('The target directory "%s" does not exist.', $input->getArgument('target')));
+                    throw new InvalidArgumentException(sprintf('The target directory "%s" does not exist.', $targetArg));
                 }
             }
         }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT

When assets:install fails because the target directory does not exist, it should display the actual directory it wanted to have instead of the configuration directive. In most cases, the target directory is retrieved from the kernel config and thus differs from the argument.
