### PR TITLE
[Messenger] Add option to prevent Redis from deleting messages on rejection

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * Added a `delete_after_reject` option to the DSN to allow control over message
+   deletion, similar to `delete_after_ack`.
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -346,6 +346,21 @@ class ConnectionTest extends TestCase
         $connection->ack('1');
     }
 
+    public function testDeleteAfterReject()
+    {
+        $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();
+
+        $redis->expects($this->exactly(1))->method('xack')
+            ->with('queue', 'symfony', ['1'])
+            ->willReturn(1);
+        $redis->expects($this->exactly(1))->method('xdel')
+            ->with('queue', ['1'])
+            ->willReturn(1);
+
+        $connection = Connection::fromDsn('redis://localhost/queue?delete_after_reject=true', [], $redis); // 1 = always
+        $connection->reject('1');
+    }
+
     public function testLastErrorGetsCleared()
     {
         $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();


### PR DESCRIPTION
~Unless `delete_after_ack` configuration is set to `true`.~

Introduces `delete_after_reject` configuration property.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | ~no~ yes (introduces config property)
| Deprecations? | no
| Tickets       | Fix #36619
| License       | MIT

> Redis Messenger transport deletes messages when rejecting, causing other consumers / applications to be unable to reach that message.

> This affects primarily cases where Messenger component is used to read/write with other, third party applications.
