### PR TITLE
[TwigBundle] Deprecate the public "twig" service to private

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -11,6 +11,11 @@ Mime
 
  * Deprecated `Address::fromString()`, use `Address::create()` instead
 
+TwigBundle
+----------
+
+ * Deprecated the public `twig` service to private.
+
 Validator
 ---------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -121,6 +121,11 @@ Security
  * Removed `DefaultLogoutSuccessHandler` in favor of `DefaultLogoutListener`.
  * Added a `logout(Request $request, Response $response, TokenInterface $token)` method to the `RememberMeServicesInterface`.
 
+TwigBundle
+----------
+
+ * The `twig` service is now private.
+
 Validator
 ---------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/BundlePathsTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/BundlePathsTest.php
@@ -40,7 +40,7 @@ class BundlePathsTest extends AbstractWebTestCase
     public function testBundleTwigTemplatesDir()
     {
         static::bootKernel(['test_case' => 'BundlePaths']);
-        $twig = static::$container->get('twig');
+        $twig = static::$container->get('twig.alias');
         $bundlesMetadata = static::$container->getParameter('kernel.bundles_metadata');
 
         $this->assertSame([$bundlesMetadata['LegacyBundle']['path'].'/Resources/views'], $twig->getLoader()->getPaths('Legacy'));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/BundlePaths/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/BundlePaths/config.yml
@@ -8,3 +8,8 @@ framework:
 
 twig:
     strict_variables: '%kernel.debug%'
+
+services:
+    twig.alias:
+        alias: twig
+        public: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Controller/LoginController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Controller/LoginController.php
@@ -11,14 +11,21 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\CsrfFormLoginBundle\Controller;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Twig\Environment;
 
-class LoginController implements ContainerAwareInterface
+class LoginController implements ServiceSubscriberInterface
 {
-    use ContainerAwareTrait;
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
 
     public function loginAction()
     {
@@ -42,5 +49,16 @@ class LoginController implements ContainerAwareInterface
     public function secureAction()
     {
         throw new \Exception('Wrapper', 0, new \Exception('Another Wrapper', 0, new AccessDeniedException()));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedServices()
+    {
+        return [
+            'form.factory' => FormFactoryInterface::class,
+            'twig' => Environment::class,
+        ];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LocalizedController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LocalizedController.php
@@ -11,15 +11,21 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\Controller;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Security;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Twig\Environment;
 
-class LocalizedController implements ContainerAwareInterface
+class LocalizedController implements ServiceSubscriberInterface
 {
-    use ContainerAwareTrait;
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
 
     public function loginAction(Request $request)
     {
@@ -60,5 +66,15 @@ class LocalizedController implements ContainerAwareInterface
     public function homepageAction()
     {
         return (new Response('<html><body>Homepage</body></html>'))->setPublic();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedServices()
+    {
+        return [
+            'twig' => Environment::class,
+        ];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LoginController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LoginController.php
@@ -11,17 +11,23 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\Controller;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Twig\Environment;
 
-class LoginController implements ContainerAwareInterface
+class LoginController implements ServiceSubscriberInterface
 {
-    use ContainerAwareTrait;
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
 
     public function loginAction(Request $request, UserInterface $user = null)
     {
@@ -52,5 +58,15 @@ class LoginController implements ContainerAwareInterface
     public function secureAction()
     {
         throw new \Exception('Wrapper', 0, new \Exception('Another Wrapper', 0, new AccessDeniedException()));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedServices()
+    {
+        return [
+            'twig' => Environment::class,
+        ];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/FormLoginBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/FormLoginBundle.php
@@ -11,8 +11,28 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle;
 
+use Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\Controller\LocalizedController;
+use Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\Controller\LoginController;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class FormLoginBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container
+            ->register(LoginController::class)
+            ->setPublic(true)
+            ->addTag('container.service_subscriber');
+
+        $container
+            ->register(LocalizedController::class)
+            ->setPublic(true)
+            ->addTag('container.service_subscriber');
+    }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/base_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/base_config.yml
@@ -9,6 +9,11 @@ services:
         tags:
             - { name: form.type }
 
+    Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\CsrfFormLoginBundle\Controller\LoginController:
+        public: true
+        tags:
+            - { name: container.service_subscriber }
+
 security:
     encoders:
         Symfony\Component\Security\Core\User\User: plaintext

--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * deprecated the public `twig` service to private
+
 5.0.0
 -----
 

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
@@ -63,6 +63,7 @@ return static function (ContainerConfigurator $container) {
             ->tag('container.preload', ['class' => ExtensionSet::class])
             ->tag('container.preload', ['class' => Template::class])
             ->tag('container.preload', ['class' => TemplateWrapper::class])
+            ->tag('container.private', ['package' => 'symfony/twig-bundle', 'version' => '5.2'])
 
         ->alias('Twig_Environment', 'twig')
         ->alias(Environment::class, 'twig')

--- a/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Functional/NoTemplatingEntryTest.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\TwigBundle\Tests\TestCase;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -26,7 +27,7 @@ class NoTemplatingEntryTest extends TestCase
         $kernel->boot();
 
         $container = $kernel->getContainer();
-        $content = $container->get('twig')->render('index.html.twig');
+        $content = $container->get('twig.alias')->render('index.html.twig');
         $this->assertStringContainsString('{ a: b }', $content);
     }
 
@@ -60,7 +61,7 @@ class NoTemplatingEntryKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load(function ($container) {
+        $loader->load(function (ContainerBuilder $container) {
             $container
                 ->loadFromExtension('framework', [
                     'secret' => '$ecret',
@@ -69,6 +70,7 @@ class NoTemplatingEntryKernel extends Kernel
                 ->loadFromExtension('twig', [
                     'default_path' => __DIR__.'/templates',
                 ])
+                ->setAlias('twig.alias', 'twig')->setPublic(true)
             ;
         });
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

I think the `twig` service don't need to be public anymore - we never need to access it directly in Symfony's code.