### PR TITLE
Remove patches for Doctrine bugs and deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.6",
         "doctrine/data-fixtures": "1.0.*",
-        "doctrine/dbal": "~2.4,<=2.10.2",
+        "doctrine/dbal": "~2.4",
         "doctrine/orm": "~2.4,>=2.4.5",
         "doctrine/doctrine-bundle": "~1.4",
         "monolog/monolog": "~1.11",

--- a/phpunit
+++ b/phpunit
@@ -21,14 +21,4 @@ if (!getenv('SYMFONY_PATCH_TYPE_DECLARATIONS')) {
     putenv('SYMFONY_PATCH_TYPE_DECLARATIONS=deprecations=1');
 }
 putenv('SYMFONY_PHPUNIT_DIR='.__DIR__.'/.phpunit');
-
-if (!getenv('SYMFONY_DEPRECATIONS_HELPER')) {
-    foreach ($_SERVER['argv'] as $v) {
-        if (false !== strpos($v, 'Bridge/Doctrine')) {
-            putenv('SYMFONY_DEPRECATIONS_HELPER=max[indirect]=7');
-            break;
-        }
-    }
-}
-
 require __DIR__.'/vendor/symfony/phpunit-bridge/bin/simple-phpunit';

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -35,7 +35,7 @@
         "symfony/validator": "^3.2.5|~4.0",
         "symfony/translation": "~2.8|~3.0|~4.0",
         "doctrine/data-fixtures": "1.0.*",
-        "doctrine/dbal": "~2.4,<=2.10.2",
+        "doctrine/dbal": "~2.4",
         "doctrine/orm": "^2.4.5"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This PR removes patches put in place because of a bug fixed in doctrine/dbal#3994, and because of deprecations addressed in doctrine/orm#7953