### PR TITLE
Queue name is a required parameter

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -412,7 +412,7 @@ class Connection
                 // If we get a 404 for the queue, it means we need to set up the exchange & queue.
                 $this->setupExchangeAndQueues();
 
-                return $this->get();
+                return $this->get($queueName);
             }
 
             throw $e;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | -
| License       | MIT
| Doc PR        | -

Queue name is required parameter, which means this block will just fail