### PR TITLE
[Mime] fix bad method call on `EmailAddressContains`

### DIFF
--- a/src/Symfony/Component/Mime/Test/Constraint/EmailAddressContains.php
+++ b/src/Symfony/Component/Mime/Test/Constraint/EmailAddressContains.php
@@ -48,7 +48,7 @@ final class EmailAddressContains extends Constraint
 
         $header = $message->getHeaders()->get($this->headerName);
         if ($header instanceof MailboxHeader) {
-            return $this->expectedValue === $header->Address()->getAddress();
+            return $this->expectedValue === $header->getAddress()->getAddress();
         } elseif ($header instanceof MailboxListHeader) {
             foreach ($header->getAddresses() as $address) {
                 if ($this->expectedValue === $address->getAddress()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | -
| License       | MIT
| Doc PR        | -

There is no method `Address` on [`MailboxHeader`](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Mime/Header/MailboxHeader.php), but a method `getAddress`.