### PR TITLE
[HttpClient] fix dealing with informational response

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -200,7 +200,7 @@ final class AmpResponse implements ResponseInterface
 
             $options = null;
 
-            $activity[$id] = [new FirstChunk()];
+            $activity[$id][] = new FirstChunk();
 
             if ('HEAD' === $response->getRequest()->getMethod() || \in_array($info['http_code'], [204, 304], true)) {
                 $activity[$id][] = null;

--- a/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/AmpHttpClientTest.php
@@ -25,13 +25,4 @@ class AmpHttpClientTest extends HttpClientTestCase
     {
         $this->markTestSkipped('A real proxy server would be needed.');
     }
-
-    public function testInformationalResponseStream()
-    {
-        if (getenv('TRAVIS_PULL_REQUEST')) {
-            $this->markTestIncomplete('This test always fails on Travis.');
-        }
-
-        parent::testInformationalResponseStream();
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Skipping the test was a bad idea, the failure was legit.