### PR TITLE
[HttpClient] add TimeoutExceptionInterface

### DIFF
--- a/src/Symfony/Component/HttpClient/Chunk/ErrorChunk.php
+++ b/src/Symfony/Component/HttpClient/Chunk/ErrorChunk.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpClient\Chunk;
 
+use Symfony\Component\HttpClient\Exception\TimeoutException;
 use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Contracts\HttpClient\ChunkInterface;
 
@@ -61,7 +62,7 @@ class ErrorChunk implements ChunkInterface
     public function isFirst(): bool
     {
         $this->didThrow = true;
-        throw new TransportException($this->errorMessage, 0, $this->error);
+        throw null !== $this->error ? new TransportException($this->errorMessage, 0, $this->error) : new TimeoutException($this->errorMessage);
     }
 
     /**
@@ -70,7 +71,7 @@ class ErrorChunk implements ChunkInterface
     public function isLast(): bool
     {
         $this->didThrow = true;
-        throw new TransportException($this->errorMessage, 0, $this->error);
+        throw null !== $this->error ? new TransportException($this->errorMessage, 0, $this->error) : new TimeoutException($this->errorMessage);
     }
 
     /**
@@ -79,7 +80,7 @@ class ErrorChunk implements ChunkInterface
     public function getInformationalStatus(): ?array
     {
         $this->didThrow = true;
-        throw new TransportException($this->errorMessage, 0, $this->error);
+        throw null !== $this->error ? new TransportException($this->errorMessage, 0, $this->error) : new TimeoutException($this->errorMessage);
     }
 
     /**
@@ -88,7 +89,7 @@ class ErrorChunk implements ChunkInterface
     public function getContent(): string
     {
         $this->didThrow = true;
-        throw new TransportException($this->errorMessage, 0, $this->error);
+        throw null !== $this->error ? new TransportException($this->errorMessage, 0, $this->error) : new TimeoutException($this->errorMessage);
     }
 
     /**
@@ -119,7 +120,7 @@ class ErrorChunk implements ChunkInterface
     {
         if (!$this->didThrow) {
             $this->didThrow = true;
-            throw new TransportException($this->errorMessage, 0, $this->error);
+            throw null !== $this->error ? new TransportException($this->errorMessage, 0, $this->error) : new TimeoutException($this->errorMessage);
         }
     }
 }

--- a/src/Symfony/Component/HttpClient/Exception/TimeoutException.php
+++ b/src/Symfony/Component/HttpClient/Exception/TimeoutException.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\Component\HttpClient\Exception;
 
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TimeoutExceptionInterface;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class TransportException extends \RuntimeException implements TransportExceptionInterface
+final class TimeoutException extends TransportException implements TimeoutExceptionInterface
 {
 }

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\HttpClient\Tests;
 
 use Symfony\Component\HttpClient\Exception\ClientException;
-use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -103,32 +102,6 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $this->assertSame('<2>', fread($stream, 8192));
         $this->assertSame('', fread($stream, 8192));
         $this->assertTrue(feof($stream));
-    }
-
-    public function testTimeoutIsNotAFatalError()
-    {
-        $client = $this->getHttpClient(__FUNCTION__);
-        $response = $client->request('GET', 'http://localhost:8057/timeout-body', [
-            'timeout' => 0.25,
-        ]);
-
-        try {
-            $response->getContent();
-            $this->fail(TransportException::class.' expected');
-        } catch (TransportException $e) {
-        }
-
-        for ($i = 0; $i < 10; ++$i) {
-            try {
-                $this->assertSame('<1><2>', $response->getContent());
-                break;
-            } catch (TransportException $e) {
-            }
-        }
-
-        if (10 === $i) {
-            throw $e;
-        }
     }
 
     public function testResponseStreamRewind()

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.2.5",
         "psr/log": "^1.0",
-        "symfony/http-client-contracts": "^1.1.8|^2",
+        "symfony/http-client-contracts": "^2.1.1",
         "symfony/polyfill-php73": "^1.11",
         "symfony/polyfill-php80": "^1.15",
         "symfony/service-contracts": "^1.0|^2"

--- a/src/Symfony/Contracts/HttpClient/Exception/TimeoutExceptionInterface.php
+++ b/src/Symfony/Contracts/HttpClient/Exception/TimeoutExceptionInterface.php
@@ -9,13 +9,13 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\HttpClient\Exception;
-
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+namespace Symfony\Contracts\HttpClient\Exception;
 
 /**
+ * When an idle timeout occurs.
+ *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class TransportException extends \RuntimeException implements TransportExceptionInterface
+interface TimeoutExceptionInterface extends TransportExceptionInterface
 {
 }

--- a/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
+++ b/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
@@ -116,7 +116,7 @@ switch ($vars['REQUEST_URI']) {
         echo '<1>';
         @ob_flush();
         flush();
-        usleep(500000);
+        usleep(600000);
         echo '<2>';
         exit;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This is fixing a design issue: unlike any other `TransportExceptionInterface`, timeouts are not fatal transport errors. For this reason, we must allow one to identify them.

~This PR also marks exception classes as `@internal`, to encourage ppl to catch them using their interface and not their class name.~ this would revert #30549