### PR TITLE
[HttpClient] preserve the identity of responses streamed by TraceableHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/TraceableHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/TraceableHttpClientTest.php
@@ -88,11 +88,12 @@ class TraceableHttpClientTest extends TestCase
         TestHttpServer::start();
 
         $sut = new TraceableHttpClient(new NativeHttpClient());
-        $chunked = $sut->request('GET', 'http://localhost:8057/chunked');
+        $response = $sut->request('GET', 'http://localhost:8057/chunked');
         $chunks = [];
-        foreach ($sut->stream($chunked) as $response) {
-            $chunks[] = $response->getContent();
+        foreach ($sut->stream($response) as $r => $chunk) {
+            $chunks[] = $chunk->getContent();
         }
+        $this->assertSame($response, $r);
         $this->assertGreaterThan(1, \count($chunks));
         $this->assertSame('Symfony is awesome!', implode('', $chunks));
     }

--- a/src/Symfony/Component/HttpClient/TraceableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/TraceableHttpClient.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpClient;
 
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Component\HttpClient\Response\TraceableResponse;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -70,15 +71,7 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface, 
             throw new \TypeError(sprintf('"%s()" expects parameter 1 to be an iterable of TraceableResponse objects, "%s" given.', __METHOD__, get_debug_type($responses)));
         }
 
-        return $this->client->stream(\Closure::bind(static function () use ($responses) {
-            foreach ($responses as $k => $r) {
-                if (!$r instanceof TraceableResponse) {
-                    throw new \TypeError(sprintf('"%s()" expects parameter 1 to be an iterable of TraceableResponse objects, "%s" given.', __METHOD__, get_debug_type($r)));
-                }
-
-                yield $k => $r->response;
-            }
-        }, null, TraceableResponse::class)(), $timeout);
+        return new ResponseStream(TraceableResponse::stream($this->client, $responses, $timeout));
     }
 
     public function getTracedRequests(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -