### PR TITLE
[DependencyInjection] Add abstract_arg() and param()

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -85,6 +86,7 @@ abstract class AbstractConfigurator
             case $value instanceof Definition:
             case $value instanceof Expression:
             case $value instanceof Parameter:
+            case $value instanceof AbstractArgument:
             case $value instanceof Reference:
                 if ($allowServices) {
                     return $value;

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
@@ -80,6 +81,14 @@ class ContainerConfigurator extends AbstractConfigurator
 
         return $clone;
     }
+}
+
+/**
+ * Creates a parameter.
+ */
+function param(string $name): string
+{
+    return '%'.$name.'%';
 }
 
 /**
@@ -164,4 +173,12 @@ function tagged_locator(string $tag, string $indexAttribute = null, string $defa
 function expr(string $expression): Expression
 {
     return new Expression($expression);
+}
+
+/**
+ * Creates an abstract argument.
+ */
+function abstract_arg(string $description): AbstractArgument
+{
+    return new AbstractArgument($description);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | maste
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | -

Added abstract_arg() and param() to configuration abstract arguments in PHP DSL.
