### PR TITLE
[TwigBundle] FormExtension does not have a constructor anymore since sf 4.0

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/form.xml
@@ -6,12 +6,7 @@
     <services>
         <defaults public="false" />
 
-        <service id="twig.extension.form" class="Symfony\Bridge\Twig\Extension\FormExtension">
-            <argument type="collection">
-                <argument type="service" id="service_container" />
-                <argument>twig.form.renderer</argument>
-            </argument>
-        </service>
+        <service id="twig.extension.form" class="Symfony\Bridge\Twig\Extension\FormExtension" />
 
         <service id="twig.form.engine" class="Symfony\Bridge\Twig\Form\TwigRendererEngine">
             <argument>%twig.form.resources%</argument>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 


