### PR TITLE
[Messenger] Move doctrine deps to require-dev

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/composer.json
@@ -20,10 +20,10 @@
         "symfony/messenger": "^5.1"
     },
     "require-dev": {
-        "symfony/property-access": "^4.4|^5.0",
-        "symfony/serializer": "^4.4|^5.0",
         "symfony/event-dispatcher": "^4.4|^5.0",
-        "symfony/process": "^4.4|^5.0"
+        "symfony/process": "^4.4|^5.0",
+        "symfony/property-access": "^4.4|^5.0",
+        "symfony/serializer": "^4.4|^5.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Messenger\\Bridge\\Amqp\\": "" },

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
@@ -17,15 +17,15 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "doctrine/dbal": "^2.6",
-        "doctrine/persistence": "^1.3",
         "symfony/messenger": "^5.1",
         "symfony/service-contracts": "^1.1|^2"
     },
     "require-dev": {
+        "doctrine/dbal": "^2.6",
         "doctrine/orm": "^2.6.3",
-        "symfony/serializer": "^4.4|^5.0",
-        "symfony/property-access": "^4.4|^5.0"
+        "doctrine/persistence": "^1.3",
+        "symfony/property-access": "^4.4|^5.0",
+        "symfony/serializer": "^4.4|^5.0"
     },
     "conflict": {
         "doctrine/persistence": "<1.3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #36740 
| License       | MIT

To avoid requiring all doctrine stuff when require symfony/messenger
(that require symfony/doctrine-messenger to ensure BC)

