### PR TITLE
[WebProfiler] Remove 'none' when appending CSP tokens

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Csp/ContentSecurityPolicyHandler.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Csp/ContentSecurityPolicyHandler.php
@@ -133,6 +133,12 @@ class ContentSecurityPolicyHandler
                         continue;
                     }
 
+                    if (['\'none\''] === $fallback) {
+                        // Fallback came from "default-src: 'none'"
+                        // 'none' is invalid if it's not the only expression in the source list, so we leave it out
+                        $fallback = [];
+                    }
+
                     $headers[$header][$type] = $fallback;
                 }
                 $ruleIsSet = true;

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Csp/ContentSecurityPolicyHandlerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Csp/ContentSecurityPolicyHandlerTest.php
@@ -144,6 +144,13 @@ class ContentSecurityPolicyHandlerTest extends TestCase
                 $nonce,
                 ['csp_script_nonce' => $nonce, 'csp_style_nonce' => $nonce],
                 $this->createRequest(),
+                $this->createResponse(['Content-Security-Policy' => 'default-src \'none\'', 'Content-Security-Policy-Report-Only' => 'default-src \'none\'']),
+                ['Content-Security-Policy' => 'default-src \'none\'; script-src \'unsafe-inline\' \'nonce-'.$nonce.'\'; style-src \'unsafe-inline\' \'nonce-'.$nonce.'\'', 'Content-Security-Policy-Report-Only' => 'default-src \'none\'; script-src \'unsafe-inline\' \'nonce-'.$nonce.'\'; style-src \'unsafe-inline\' \'nonce-'.$nonce.'\'', 'X-Content-Security-Policy' => null],
+            ],
+            [
+                $nonce,
+                ['csp_script_nonce' => $nonce, 'csp_style_nonce' => $nonce],
+                $this->createRequest(),
                 $this->createResponse(['Content-Security-Policy' => 'script-src \'self\' \'unsafe-inline\'']),
                 ['Content-Security-Policy' => 'script-src \'self\' \'unsafe-inline\'', 'X-Content-Security-Policy' => null],
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4, 4.4, 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix #36645
| License       | MIT
| Doc PR        | n/a

@nicolas-grekas  asked me to to have a look at this after #36678.

If a user has a CSP policy of `default-src 'none'`, then the WebProfiler copies `'none'` to `script-src` and `style-src` then adds other sources. This creates an invalid policy since `'none'` is only allowed when it's the only item in the source list.

This will probably need to be merged into 3.4 first, I started on 4.4 so I can test in my current symfony project which requires 4.4.