### PR TITLE
Change priority of KernelEvents::RESPONSE subscriber

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -119,7 +119,7 @@ class ProfilerListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            KernelEvents::RESPONSE => ['onKernelResponse', -100],
+            KernelEvents::RESPONSE => ['onKernelResponse', -1012],
             KernelEvents::EXCEPTION => ['onKernelException', 0],
             KernelEvents::TERMINATE => ['onKernelTerminate', -1024],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| License       | MIT

This PR changes the priority of the `KernelEvents::RESPONSE` subscriber of the `ProfilerListener` so that it is the penultimate to be executed (just before `StreamedResponseListener`).

The reason is that other listeners that were executed after this one CAN change the response (such as `SessionListener` for example). This creates a headache when debugging, with a discrepancy between what is shown in a curl command, and by the Symfony profiler.