### PR TITLE
[Serializer] fix issue with PHP 8

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -386,11 +386,19 @@ abstract class AbstractNormalizer extends SerializerAwareNormalizer implements N
     protected function denormalizeParameter(\ReflectionClass $class, \ReflectionParameter $parameter, $parameterName, $parameterData, array $context, $format = null)
     {
         try {
-            if (null !== $parameter->getClass()) {
+            if (\PHP_VERSION_ID < 70100 && null !== $parameterClass = $parameter->getClass()) {
+                $parameterClass = $parameterClass->name;
+            } elseif (\PHP_VERSION_ID >= 70100 && $parameter->hasType() && ($parameterType = $parameter->getType()) && !$parameterType->isBuiltin()) {
+                $parameterClass = $parameterType->getName();
+                new \ReflectionClass($parameterClass); // throws a \ReflectionException if the class doesn't exist
+            } else {
+                $parameterClass = null;
+            }
+
+            if (null !== $parameterClass) {
                 if (!$this->serializer instanceof DenormalizerInterface) {
-                    throw new LogicException(sprintf('Cannot create an instance of "%s" from serialized data because the serializer inject in "%s" is not a denormalizer.', $parameter->getClass(), static::class));
+                    throw new LogicException(sprintf('Cannot create an instance of "%s" from serialized data because the serializer inject in "%s" is not a denormalizer.', $parameterClass, static::class));
                 }
-                $parameterClass = $parameter->getClass()->getName();
 
                 return $this->serializer->denormalize($parameterData, $parameterClass, $format, $this->createChildContext($context, $parameterName, $format));
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The current logic is a bit strange but I guess it's some legacy from PHP 5.

This keeps the current behavior while skipping the use of `ReflectionParameter::getClass()`, which [is deprecated in PHP 8](http://git.php.net/?p=php-src.git;a=commitdiff;h=28af364d2ae2261addc21f8830f175baa8fa72cf).