### PR TITLE
[Messenger] Missing description in `messenger:setup-transports` command

### DIFF
--- a/src/Symfony/Component/Messenger/Command/SetupTransportsCommand.php
+++ b/src/Symfony/Component/Messenger/Command/SetupTransportsCommand.php
@@ -41,6 +41,7 @@ class SetupTransportsCommand extends Command
     {
         $this
             ->addArgument('transport', InputArgument::OPTIONAL, 'Name of the transport to setup', null)
+            ->setDescription('Prepares the required infrastructure for the transport')
             ->setHelp(<<<EOF
 The <info>%command.name%</info> command setups the transports:
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

making `bin/console` to show an empty description when the rest of the commands have one.

![image](https://user-images.githubusercontent.com/351553/81716773-122bc200-947a-11ea-84ef-18ec8d19e479.png)