### PR TITLE
[DI] Use require_once instead of require when appending cache warmer-returned files to preload file

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/Preloader.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/Preloader.php
@@ -27,7 +27,7 @@ final class Preloader
 
         foreach ($list as $item) {
             if (0 === strpos($item, $cacheDir)) {
-                file_put_contents($file, sprintf("require __DIR__.%s;\n", var_export(substr($item, \strlen($cacheDir)), true)), FILE_APPEND);
+                file_put_contents($file, sprintf("require_once __DIR__.%s;\n", var_export(substr($item, \strlen($cacheDir)), true)), FILE_APPEND);
                 continue;
             }
 


### PR DESCRIPTION
Use require_once instead of require when appending cache warmer-returned files to preload file.

| Q             | A
| ------------- | ---
| Branch?       | master/5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36793 
| License       | MIT

As requested in #36793, I have changed the Preloader to append files with `require_once` (instead of the existing `require`). This should also help for cases when multiple CacheWarmers return the same file(s).