### PR TITLE
Secrets, Security, and Messenger commands descriptions should not end with a "." (dot)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsDecryptToLocalCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsDecryptToLocalCommand.php
@@ -42,7 +42,7 @@ final class SecretsDecryptToLocalCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Decrypts all secrets and stores them in the local vault.')
+            ->setDescription('Decrypts all secrets and stores them in the local vault')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Forces overriding of secrets that already exist in the local vault')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command decrypts all secrets and copies them in the local vault.

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsEncryptFromLocalCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsEncryptFromLocalCommand.php
@@ -41,7 +41,7 @@ final class SecretsEncryptFromLocalCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Encrypts all local secrets to the vault.')
+            ->setDescription('Encrypts all local secrets to the vault')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command encrypts all locally overridden secrets to the vault.
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsGenerateKeysCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsGenerateKeysCommand.php
@@ -44,7 +44,7 @@ final class SecretsGenerateKeysCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Generates new encryption keys.')
+            ->setDescription('Generates new encryption keys')
             ->addOption('local', 'l', InputOption::VALUE_NONE, 'Updates the local vault.')
             ->addOption('rotate', 'r', InputOption::VALUE_NONE, 'Re-encrypts existing secrets with the newly generated keys.')
             ->setHelp(<<<'EOF'

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsListCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsListCommand.php
@@ -45,7 +45,7 @@ final class SecretsListCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Lists all secrets.')
+            ->setDescription('Lists all secrets')
             ->addOption('reveal', 'r', InputOption::VALUE_NONE, 'Display decrypted values alongside names')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command list all stored secrets.

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsRemoveCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsRemoveCommand.php
@@ -44,7 +44,7 @@ final class SecretsRemoveCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Removes a secret from the vault.')
+            ->setDescription('Removes a secret from the vault')
             ->addArgument('name', InputArgument::REQUIRED, 'The name of the secret')
             ->addOption('local', 'l', InputOption::VALUE_NONE, 'Updates the local vault.')
             ->setHelp(<<<'EOF'

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsSetCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsSetCommand.php
@@ -45,7 +45,7 @@ final class SecretsSetCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Sets a secret in the vault.')
+            ->setDescription('Sets a secret in the vault')
             ->addArgument('name', InputArgument::REQUIRED, 'The name of the secret')
             ->addArgument('file', InputArgument::OPTIONAL, 'A file where to read the secret from or "-" for reading from STDIN')
             ->addOption('local', 'l', InputOption::VALUE_NONE, 'Updates the local vault.')

--- a/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
@@ -52,7 +52,7 @@ class UserPasswordEncoderCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription('Encodes a password.')
+            ->setDescription('Encodes a password')
             ->addArgument('password', InputArgument::OPTIONAL, 'The plain password to encode.')
             ->addArgument('user-class', InputArgument::OPTIONAL, 'The User entity class path associated with the encoder used to encode the password.')
             ->addOption('empty-salt', null, InputOption::VALUE_NONE, 'Do not generate a salt or let the encoder generate one.')

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRemoveCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRemoveCommand.php
@@ -39,7 +39,7 @@ class FailedMessagesRemoveCommand extends AbstractFailedMessagesCommand
                 new InputOption('force', null, InputOption::VALUE_NONE, 'Force the operation without confirmation'),
                 new InputOption('show-messages', null, InputOption::VALUE_NONE, 'Display messages before removing it (if multiple ids are given)'),
             ])
-            ->setDescription('Remove given messages from the failure transport.')
+            ->setDescription('Remove given messages from the failure transport')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> removes given messages that are pending in the failure transport.
 

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -59,7 +59,7 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand
                 new InputArgument('id', InputArgument::IS_ARRAY, 'Specific message id(s) to retry'),
                 new InputOption('force', null, InputOption::VALUE_NONE, 'Force action without confirmation'),
             ])
-            ->setDescription('Retries one or more messages from the failure transport.')
+            ->setDescription('Retries one or more messages from the failure transport')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> retries message in the failure transport.
 

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -37,7 +37,7 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
                 new InputArgument('id', InputArgument::OPTIONAL, 'Specific message id to show'),
                 new InputOption('max', null, InputOption::VALUE_REQUIRED, 'Maximum number of messages to list', 50),
             ])
-            ->setDescription('Shows one or more messages from the failure transport.')
+            ->setDescription('Shows one or more messages from the failure transport')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> shows message that are pending in the failure transport.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 (to be switched while merging)
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

When running `bin/console` almost all the command descriptions do not end with a ".". So in order to be consistent, we should remove it from the Secrets Commands.

**Current Output for Secrets Commands (with dots)**
![image](https://user-images.githubusercontent.com/351553/81734096-4a8bca00-9493-11ea-8d5c-bb1dda20bcb0.png)

**Other Command Descriptions (without dots)**
![image](https://user-images.githubusercontent.com/351553/81734428-c84fd580-9493-11ea-8312-05557c7e6f0b.png)

![image](https://user-images.githubusercontent.com/351553/81734489-def62c80-9493-11ea-8d2b-1eb3668291cc.png)

**Symfony CLI output (without dots)**
![image](https://user-images.githubusercontent.com/351553/81734720-3eecd300-9494-11ea-805e-2a3ae3178e8c.png)



