### PR TITLE
[DI] Renamed some PHP-DSL functions

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -24,7 +24,8 @@ DependencyInjection
    configure them explicitly instead.
  * Deprecated `Definition::getDeprecationMessage()`, use `Definition::getDeprecation()` instead.
  * Deprecated `Alias::getDeprecationMessage()`, use `Alias::getDeprecation()` instead.
- * The `inline()` function from the PHP-DSL has been deprecated, use `service()` instead
+ * The `inline()` function from the PHP-DSL has been deprecated, use `inline_service()` instead
+ * The `ref()` function from the PHP-DSL has been deprecated, use `service()` instead
 
 Dotenv
 ------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -24,7 +24,8 @@ DependencyInjection
    configure them explicitly instead.
  * Removed `Definition::getDeprecationMessage()`, use `Definition::getDeprecation()` instead.
  * Removed `Alias::getDeprecationMessage()`, use `Alias::getDeprecation()` instead.
- * The `inline()` function from the PHP-DSL has been removed, use `service()` instead
+ * The `inline()` function from the PHP-DSL has been removed, use `inline_service()` instead.
+ * The `ref()` function from the PHP-DSL has been removed, use `service()` instead.
 
 Dotenv
 ------

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.1.0
 -----
 
+ * deprecated `inline()` in favor of `inline_service()` and `ref()` in favor of `service()` when using the PHP-DSL
  * allow decorators to reference their decorated service using the special `.inner` id
  * added support to autowire public typed properties in php 7.4
  * added support for defining method calls, a configurator, and property setters in `InlineServiceConfigurator`

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -84,20 +84,32 @@ class ContainerConfigurator extends AbstractConfigurator
 
 /**
  * Creates a service reference.
+ *
+ * @deprecated since Symfony 5.1, use service() instead.
  */
 function ref(string $id): ReferenceConfigurator
 {
+    trigger_deprecation('symfony/dependency-injection', '5.1', '"%s()" is deprecated, use "service()" instead.', __FUNCTION__);
+
     return new ReferenceConfigurator($id);
+}
+
+/**
+ * Creates a reference to a service.
+ */
+function service(string $serviceId): ReferenceConfigurator
+{
+    return new ReferenceConfigurator($serviceId);
 }
 
 /**
  * Creates an inline service.
  *
- * @deprecated since Symfony 5.1, use service() instead.
+ * @deprecated since Symfony 5.1, use inline_service() instead.
  */
 function inline(string $class = null): InlineServiceConfigurator
 {
-    trigger_deprecation('symfony/dependency-injection', '5.1', '"%s()" is deprecated, use "service()" instead.', __FUNCTION__);
+    trigger_deprecation('symfony/dependency-injection', '5.1', '"%s()" is deprecated, use "inline_service()" instead.', __FUNCTION__);
 
     return new InlineServiceConfigurator(new Definition($class));
 }
@@ -105,7 +117,7 @@ function inline(string $class = null): InlineServiceConfigurator
 /**
  * Creates an inline service.
  */
-function service(string $class = null): InlineServiceConfigurator
+function inline_service(string $class = null): InlineServiceConfigurator
 {
     return new InlineServiceConfigurator(new Definition($class));
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
@@ -27,7 +27,7 @@ trait FactoryTrait
         if (\is_string($factory) && 1 === substr_count($factory, ':')) {
             $factoryParts = explode(':', $factory);
 
-            throw new InvalidArgumentException(sprintf('Invalid factory "%s": the "service:method" notation is not available when using PHP-based DI configuration. Use "[ref(\'%s\'), \'%s\']" instead.', $factory, $factoryParts[0], $factoryParts[1]));
+            throw new InvalidArgumentException(sprintf('Invalid factory "%s": the "service:method" notation is not available when using PHP-based DI configuration. Use "[service(\'%s\'), \'%s\']" instead.', $factory, $factoryParts[0], $factoryParts[1]));
         }
 
         $this->definition->setFactory(static::processValue($factory, true));

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/anonymous.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/anonymous.php
@@ -13,7 +13,7 @@ return function (ContainerConfigurator $c) {
 
     $s->set(null, StdClassDecorator::class)
         ->decorate('decorated', 'decorator42')
-        ->args([ref('decorator42')]);
+        ->args([service('decorator42')]);
 
     $s->set('listener_aggregator', FooClass::class)->public()->args([tagged_iterator('listener')]);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/basic.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/basic.php
@@ -7,5 +7,5 @@ use App\BarService;
 return function (ContainerConfigurator $c) {
     $s = $c->services()->defaults()->public();
     $s->set(BarService::class)
-        ->args([service('FooClass')]);
+        ->args([inline_service('FooClass')]);
 };

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/child.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/child.php
@@ -15,7 +15,7 @@ return function (ContainerConfigurator $c) {
             ->parent(BarService::class)
             ->public()
             ->decorate('bar', 'b', 1)
-            ->args([ref('b')])
+            ->args([service('b')])
             ->class('Class2')
             ->file('file.php')
             ->parent('bar')

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/defaults.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/defaults.php
@@ -13,9 +13,9 @@ return function (ContainerConfigurator $c) {
         ->autoconfigure()
         ->autowire()
         ->tag('t', ['a' => 'b'])
-        ->bind(Foo::class, ref('bar'))
+        ->bind(Foo::class, service('bar'))
         ->public();
 
-    $s->set(Foo::class)->args([ref('bar')])->public();
+    $s->set(Foo::class)->args([service('bar')])->public();
     $s->set('bar', Foo::class)->call('setFoo')->autoconfigure(false);
 };

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/instanceof.php
@@ -9,7 +9,7 @@ return function (ContainerConfigurator $c) {
     $s = $c->services()->defaults()->public();
     $s->instanceof(Prototype\Foo::class)
         ->property('p', 0)
-        ->call('setFoo', [ref('foo')])
+        ->call('setFoo', [service('foo')])
         ->tag('tag', ['k' => 'v'])
         ->share(false)
         ->lazy()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/object.php
@@ -9,6 +9,6 @@ return new class() {
     {
         $s = $c->services()->defaults()->public();
         $s->set(BarService::class)
-            ->args([service('FooClass')]);
+            ->args([inline_service('FooClass')]);
     }
 };

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/php7.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/php7.php
@@ -11,7 +11,7 @@ return function (ContainerConfigurator $c) {
     ;
     $c->services()->defaults()->public()
         (Foo::class)
-            ->arg('$bar', ref('bar'))
+            ->arg('$bar', service('bar'))
             ->public()
         ('bar', Foo::class)
             ->call('setFoo')

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/services9.php
@@ -18,16 +18,16 @@ return function (ContainerConfigurator $c) {
 
     $s = $c->services()->defaults()->public();
     $s->set('foo')
-        ->args(['foo', ref('foo.baz'), ['%foo%' => 'foo is %foo%', 'foobar' => '%foo%'], true, ref('service_container')])
+        ->args(['foo', service('foo.baz'), ['%foo%' => 'foo is %foo%', 'foobar' => '%foo%'], true, service('service_container')])
         ->class(FooClass::class)
         ->tag('foo', ['foo' => 'foo'])
         ->tag('foo', ['bar' => 'bar', 'baz' => 'baz'])
         ->tag('foo', ['name' => 'bar', 'baz' => 'baz'])
         ->factory([FooClass::class, 'getInstance'])
         ->property('foo', 'bar')
-        ->property('moo', ref('foo.baz'))
+        ->property('moo', service('foo.baz'))
         ->property('qux', ['%foo%' => 'foo is %foo%', 'foobar' => '%foo%'])
-        ->call('setBar', [ref('bar')])
+        ->call('setBar', [service('bar')])
         ->call('initialize')
         ->configurator('sc_configure');
 
@@ -36,48 +36,48 @@ return function (ContainerConfigurator $c) {
         ->configurator(['%baz_class%', 'configureStatic1']);
 
     $s->set('bar', FooClass::class)
-        ->args(['foo', ref('foo.baz'), new Parameter('foo_bar')])
-        ->configurator([ref('foo.baz'), 'configure']);
+        ->args(['foo', service('foo.baz'), new Parameter('foo_bar')])
+        ->configurator([service('foo.baz'), 'configure']);
 
     $s->set('foo_bar', '%foo_class%')
-        ->args([ref('deprecated_service')])
+        ->args([service('deprecated_service')])
         ->share(false);
 
     $s->set('method_call1', 'Bar\FooClass')
         ->file(realpath(__DIR__.'/../includes/foo.php'))
-        ->call('setBar', [ref('foo')])
-        ->call('setBar', [ref('foo2')->nullOnInvalid()])
-        ->call('setBar', [ref('foo3')->ignoreOnInvalid()])
-        ->call('setBar', [ref('foobaz')->ignoreOnInvalid()])
+        ->call('setBar', [service('foo')])
+        ->call('setBar', [service('foo2')->nullOnInvalid()])
+        ->call('setBar', [service('foo3')->ignoreOnInvalid()])
+        ->call('setBar', [service('foobaz')->ignoreOnInvalid()])
         ->call('setBar', [expr('service("foo").foo() ~ (container.hasParameter("foo") ? parameter("foo") : "default")')]);
 
     $s->set('foo_with_inline', 'Foo')
-        ->call('setBar', [ref('inlined')]);
+        ->call('setBar', [service('inlined')]);
 
     $s->set('inlined', 'Bar')
         ->property('pub', 'pub')
-        ->call('setBaz', [ref('baz')])
+        ->call('setBaz', [service('baz')])
         ->private();
 
     $s->set('baz', 'Baz')
-        ->call('setFoo', [ref('foo_with_inline')]);
+        ->call('setFoo', [service('foo_with_inline')]);
 
     $s->set('request', 'Request')
         ->synthetic();
 
     $s->set('configurator_service', 'ConfClass')
         ->private()
-        ->call('setFoo', [ref('baz')]);
+        ->call('setFoo', [service('baz')]);
 
     $s->set('configured_service', 'stdClass')
-        ->configurator([ref('configurator_service'), 'configureStdClass']);
+        ->configurator([service('configurator_service'), 'configureStdClass']);
 
     $s->set('configurator_service_simple', 'ConfClass')
         ->args(['bar'])
         ->private();
 
     $s->set('configured_service_simple', 'stdClass')
-        ->configurator([ref('configurator_service_simple'), 'configureStdClass']);
+        ->configurator([service('configurator_service_simple'), 'configureStdClass']);
 
     $s->set('decorated', 'stdClass');
 
@@ -95,11 +95,11 @@ return function (ContainerConfigurator $c) {
         ->private();
 
     $s->set('factory_service', 'Bar')
-        ->factory([ref('foo.baz'), 'getInstance']);
+        ->factory([service('foo.baz'), 'getInstance']);
 
     $s->set('new_factory_service', 'FooBarBaz')
         ->property('foo', 'bar')
-        ->factory([ref('new_factory'), 'getInstance']);
+        ->factory([service('new_factory'), 'getInstance']);
 
     $s->set('service_from_static_method', 'Bar\FooClass')
         ->factory(['Bar\FooClass', 'getInstance']);
@@ -110,15 +110,15 @@ return function (ContainerConfigurator $c) {
         ->private();
 
     $s->set('factory_service_simple', 'Bar')
-        ->factory([ref('factory_simple'), 'getInstance']);
+        ->factory([service('factory_simple'), 'getInstance']);
 
     $s->set('lazy_context', 'LazyContext')
-        ->args([iterator(['k1' => ref('foo.baz'), 'k2' => ref('service_container')]), iterator([])]);
+        ->args([iterator(['k1' => service('foo.baz'), 'k2' => service('service_container')]), iterator([])]);
 
     $s->set('lazy_context_ignore_invalid_ref', 'LazyContext')
-        ->args([iterator([ref('foo.baz'), ref('invalid')->ignoreOnInvalid()]), iterator([])]);
+        ->args([iterator([service('foo.baz'), service('invalid')->ignoreOnInvalid()]), iterator([])]);
 
-    $s->set('BAR', 'stdClass')->property('bar', ref('bar'));
+    $s->set('BAR', 'stdClass')->property('bar', service('bar'));
     $s->set('bar2', 'stdClass');
     $s->set('BAR2', 'stdClass');
 
@@ -138,5 +138,5 @@ return function (ContainerConfigurator $c) {
         ->public();
 
     $s->alias('alias_for_foo', 'foo')->private()->public();
-    $s->alias('alias_for_alias', ref('alias_for_foo'));
+    $s->alias('alias_for_alias', service('alias_for_foo'));
 };

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/stack.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/stack.php
@@ -8,43 +8,43 @@ return function (ContainerConfigurator $c) {
     $services = $c->services();
 
     $services->stack('stack_a', [
-        service('stdClass')
+        inline_service('stdClass')
             ->property('label', 'A')
-            ->property('inner', ref('.inner')),
-        service('stdClass')
+            ->property('inner', service('.inner')),
+        inline_service('stdClass')
             ->property('label', 'B')
-            ->property('inner', ref('.inner')),
-        service('stdClass')
+            ->property('inner', service('.inner')),
+        inline_service('stdClass')
             ->property('label', 'C'),
     ])->public();
 
     $services->stack('stack_abstract', [
-        service('stdClass')
+        inline_service('stdClass')
             ->property('label', 'A')
-            ->property('inner', ref('.inner')),
-        service('stdClass')
+            ->property('inner', service('.inner')),
+        inline_service('stdClass')
             ->property('label', 'B')
-            ->property('inner', ref('.inner')),
+            ->property('inner', service('.inner')),
     ]);
 
     $services->stack('stack_b', [
-        ref('stack_abstract'),
-        service('stdClass')
+        service('stack_abstract'),
+        inline_service('stdClass')
             ->property('label', 'C'),
     ])->public();
 
     $services->stack('stack_c', [
-        service('stdClass')
+        inline_service('stdClass')
             ->property('label', 'Z')
-            ->property('inner', ref('.inner')),
-        ref('stack_a'),
+            ->property('inner', service('.inner')),
+        service('stack_a'),
     ])->public();
 
     $services->stack('stack_d', [
-        service()
+        inline_service()
             ->parent('stack_abstract')
             ->property('label', 'Z'),
-        service('stdClass')
+        inline_service('stdClass')
             ->property('label', 'C'),
     ])->public();
 };

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -96,7 +96,7 @@ class PhpFileLoaderTest extends TestCase
     public function testFactoryShortNotationNotAllowed()
     {
         $this->expectException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('Invalid factory "factory:method": the "service:method" notation is not available when using PHP-based DI configuration. Use "[ref(\'factory\'), \'method\']" instead.');
+        $this->expectExceptionMessage('Invalid factory "factory:method": the "service:method" notation is not available when using PHP-based DI configuration. Use "[service(\'factory\'), \'method\']" instead.');
         $fixtures = realpath(__DIR__.'/../Fixtures');
         $container = new ContainerBuilder();
         $loader = new PhpFileLoader($container, new FileLocator());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As discussed in #36778, Symfony wants to move from XML to PHP for its own configuration. I propose these function renames to make the PHP-DSL a bit easier to understand:

```php
<?php
// Before
$services->set(Foo::class)
    ->args([ref(Bar::class), service('stdClass')]);

// After
$services->set(Foo::class)
    ->args([service(Bar::class), inline_service('stdClass')]);
```