### PR TITLE
[Security\Core] Fix NoopAuthenticationManager::authenticate() return value

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -111,6 +111,10 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $loader->load('security_rememberme.xml');
 
         if ($this->authenticatorManagerEnabled = $config['enable_authenticator_manager']) {
+            if ($config['always_authenticate_before_granting']) {
+                throw new InvalidConfigurationException('The security option "always_authenticate_before_granting" cannot be used when "enable_authenticator_manager" is set to true. If you rely on this behavior, set it to false.');
+            }
+
             $loader->load('security_authenticator.xml');
 
             // The authenticator system no longer has anonymous tokens. This makes sure AccessListener

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -505,6 +505,21 @@ class SecurityExtensionTest extends TestCase
         ];
     }
 
+    public function testAlwaysAuthenticateBeforeGrantingCannotBeTrueWithAuthenticationManager()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('The security option "always_authenticate_before_granting" cannot be used when "enable_authenticator_manager" is set to true. If you rely on this behavior, set it to false.');
+
+        $container = $this->getRawContainer();
+        $container->loadFromExtension('security', [
+            'enable_authenticator_manager' => true,
+            'always_authenticate_before_granting' => true,
+            'firewalls' => ['main' => []],
+        ]);
+
+        $container->compile();
+    }
+
     protected function getRawContainer()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/Security/Http/Authentication/NoopAuthenticationManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/NoopAuthenticationManager.php
@@ -29,5 +29,6 @@ class NoopAuthenticationManager implements AuthenticationManagerInterface
 {
     public function authenticate(TokenInterface $token)
     {
+        return $token;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36804 
| License       | MIT
| Doc PR        | -
