### PR TITLE
RememberMeLogoutListener should depend on LogoutHandlerInterface

### DIFF
--- a/src/Symfony/Component/Security/Http/EventListener/RememberMeLogoutListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/RememberMeLogoutListener.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Security\Http\EventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Exception\LogicException;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
-use Symfony\Component\Security\Http\RememberMe\AbstractRememberMeServices;
+use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
@@ -25,7 +25,7 @@ class RememberMeLogoutListener implements EventSubscriberInterface
 {
     private $rememberMeServices;
 
-    public function __construct(AbstractRememberMeServices $rememberMeServices)
+    public function __construct(LogoutHandlerInterface $rememberMeServices)
     {
         $this->rememberMeServices = $rememberMeServices;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

`RememberMeLogoutListener`, which was introduced together with the new authenticator security in Symfony 5.1,  depends on `AbstractRememberMeServices`. This forces people to always extend from `AbstractRememberMeServices`, even when they're implementing the correct interface.

I'd suggest to depend on the minimum interface, which is `LogoutHandlerInterface`, instead.

Example of the type errors you'd get otherwise:
`
Argument 1 passed to Symfony\Component\Security\Http\EventListener\RememberMeLogoutListener::__construct() must be an instance of Symfony\Component\Security\Http\RememberMe\AbstractRememberMeServices, instance of Scheb\TwoFactorBundle\Security\Authentication\RememberMe\RememberMeServicesDecorator given, called in var/cache/dev/Container3IpOCEd/getSecurity_Logout_Listener_RememberMe_MainService.php on line 22
`

with

```php
class RememberMeServicesDecorator implements RememberMeServicesInterface, LogoutHandlerInterface
[...]
```