### PR TITLE
[Messenger] Do not stack retry stamp

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageForRetryListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageForRetryListenerTest.php
@@ -76,4 +76,40 @@ class SendFailedMessageForRetryListenerTest extends TestCase
 
         $listener->onMessageFailed($event);
     }
+
+    public function testEnvelopeKeepOnlyTheLast10Stamps()
+    {
+        $exception = new \Exception('no!');
+        $stamps = \array_merge(
+          \array_fill(0, 15, new DelayStamp(1)),
+          \array_fill(0, 3, new RedeliveryStamp(1))
+        );
+        $envelope = new Envelope(new \stdClass(), $stamps);
+
+        $sender = $this->createMock(SenderInterface::class);
+        $sender->expects($this->once())->method('send')->willReturnCallback(function (Envelope $envelope) {
+            $delayStamps = $envelope->all(DelayStamp::class);
+            $redeliveryStamps = $envelope->all(RedeliveryStamp::class);
+
+            $this->assertCount(10, $delayStamps);
+            $this->assertCount(4, $redeliveryStamps);
+
+            return $envelope;
+        });
+        $senderLocator = $this->createMock(ContainerInterface::class);
+        $senderLocator->expects($this->once())->method('has')->willReturn(true);
+        $senderLocator->expects($this->once())->method('get')->willReturn($sender);
+        $retryStategy = $this->createMock(RetryStrategyInterface::class);
+        $retryStategy->expects($this->once())->method('isRetryable')->willReturn(true);
+        $retryStategy->expects($this->once())->method('getWaitingTime')->willReturn(1000);
+        $retryStrategyLocator = $this->createMock(ContainerInterface::class);
+        $retryStrategyLocator->expects($this->once())->method('has')->willReturn(true);
+        $retryStrategyLocator->expects($this->once())->method('get')->willReturn($retryStategy);
+
+        $listener = new SendFailedMessageForRetryListener($senderLocator, $retryStrategyLocator);
+
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', $exception);
+
+        $listener->onMessageFailed($event);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

With the "RecoverableException" or a very high number of retry, the message is currently stacking a lot of stamp, which increase the size of the message sent to queue and (in my case) reach the "maximum size allowed" after 60 retries + php serializer

This PR removes previous stamps before adding the new Delay+RetryStamps. 