### PR TITLE
Remove unnecesary catch in AuthenticationProviderManager

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
@@ -16,7 +16,6 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\AuthenticationEvents;
 use Symfony\Component\Security\Core\Event\AuthenticationFailureEvent;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
-use Symfony\Component\Security\Core\Exception\AccountStatusException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\ProviderNotFoundException;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -83,10 +82,6 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
                 if (null !== $result) {
                     break;
                 }
-            } catch (AccountStatusException $e) {
-                $lastException = $e;
-
-                break;
             } catch (AuthenticationException $e) {
                 $lastException = $e;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/13666 is related, but nothing that should concert this PR

Separate catch is not needed as `AccountStatusException extends AuthenticationException`.