### PR TITLE
[HttpClient] fix PHP warning + accept status code >= 600

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -312,8 +312,15 @@ final class CurlResponse implements ResponseInterface
         }
 
         if ("\r\n" !== $data) {
-            // Regular header line: add it to the list
-            self::addResponseHeaders([substr($data, 0, -2)], $info, $headers);
+            try {
+                // Regular header line: add it to the list
+                self::addResponseHeaders([substr($data, 0, -2)], $info, $headers);
+            } catch (TransportException $e) {
+                $multi->handlesActivity[$id][] = null;
+                $multi->handlesActivity[$id][] = $e;
+
+                return \strlen($data);
+            }
 
             if (0 !== strpos($data, 'HTTP/')) {
                 if (0 === stripos($data, 'Location:')) {

--- a/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
@@ -253,7 +253,7 @@ trait ResponseTrait
     private static function addResponseHeaders(array $responseHeaders, array &$info, array &$headers, string &$debug = ''): void
     {
         foreach ($responseHeaders as $h) {
-            if (11 <= \strlen($h) && '/' === $h[4] && preg_match('#^HTTP/\d+(?:\.\d+)? ([12345]\d\d)(?: |$)#', $h, $m)) {
+            if (11 <= \strlen($h) && '/' === $h[4] && preg_match('#^HTTP/\d+(?:\.\d+)? ([1-9]\d\d)(?: |$)#', $h, $m)) {
                 if ($headers) {
                     $debug .= "< \r\n";
                     $headers = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36717
| License       | MIT
| Doc PR        | -

This fixes the PHP warning reported in the linked issue.

This also relaxes the accepted status codes, with https://www.linkedin.com/company/linkedin/ as an example that returns a non-conformant one (`999`). Some more at https://en.wikipedia.org/wiki/List_of_HTTP_status_codes

These are now handled as 5xx codes, ie they trigger a ServerException.