### PR TITLE
[Security/Core] fix compat of `NativePasswordEncoder` with pre-PHP74 values of `PASSWORD_*` consts

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
@@ -24,7 +24,7 @@ final class NativePasswordEncoder implements PasswordEncoderInterface, SelfSalti
 {
     private const MAX_PASSWORD_LENGTH = 4096;
 
-    private $algo;
+    private $algo = PASSWORD_BCRYPT;
     private $options;
 
     /**
@@ -48,7 +48,20 @@ final class NativePasswordEncoder implements PasswordEncoderInterface, SelfSalti
             throw new \InvalidArgumentException('$cost must be in the range of 4-31.');
         }
 
-        $this->algo = (string) ($algo ?? (\defined('PASSWORD_ARGON2ID') ? PASSWORD_ARGON2ID : (\defined('PASSWORD_ARGON2I') ? PASSWORD_ARGON2I : PASSWORD_BCRYPT)));
+        $algos = [1 => PASSWORD_BCRYPT, '2y' => PASSWORD_BCRYPT];
+
+        if (\defined('PASSWORD_ARGON2I')) {
+            $this->algo = $algos[2] = $algos['argon2i'] = (string) PASSWORD_ARGON2I;
+        }
+
+        if (\defined('PASSWORD_ARGON2ID')) {
+            $this->algo = $algos[3] = $algos['argon2id'] = (string) PASSWORD_ARGON2ID;
+        }
+
+        if (null !== $algo) {
+            $this->algo = $algos[$algo] ?? $algo;
+        }
+
         $this->options = [
             'cost' => $cost,
             'time_cost' => $opsLimit,

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/NativePasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/NativePasswordEncoderTest.php
@@ -73,6 +73,14 @@ class NativePasswordEncoderTest extends TestCase
         $this->assertStringStartsWith('$2', $result);
     }
 
+    public function testConfiguredAlgorithmWithLegacyConstValue()
+    {
+        $encoder = new NativePasswordEncoder(null, null, null, '1');
+        $result = $encoder->encodePassword('password', null);
+        $this->assertTrue($encoder->isPasswordValid($result, 'password', null));
+        $this->assertStringStartsWith('$2', $result);
+    }
+
     public function testCheckPasswordLength()
     {
         $encoder = new NativePasswordEncoder(null, null, 4);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36451
| License       | MIT
| Doc PR        | -