### PR TITLE
[String] Move Inflector's polyfill-ctype dependency to String

### DIFF
--- a/src/Symfony/Component/Inflector/composer.json
+++ b/src/Symfony/Component/Inflector/composer.json
@@ -25,7 +25,6 @@
     "require": {
         "php": "^7.2.5",
         "symfony/deprecation-contracts": "^2.1",
-        "symfony/polyfill-ctype": "~1.8",
         "symfony/string": "^5.1"
     },
     "autoload": {

--- a/src/Symfony/Component/String/composer.json
+++ b/src/Symfony/Component/String/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.2.5",
+        "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-intl-grapheme": "~1.0",
         "symfony/polyfill-intl-normalizer": "~1.0",
         "symfony/polyfill-mbstring": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

With  #35092, the inflector implementation was moved to the string component, including all calls to `ext-ctype`. This is why I think the dependency on the corresponding polyfill should be moved as well, which is what this PR does.