### PR TITLE
[Security] Update test to test AccountStatusException behavior

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationProviderManagerTest.php
@@ -54,9 +54,15 @@ class AuthenticationProviderManagerTest extends TestCase
 
     public function testAuthenticateWhenProviderReturnsAccountStatusException()
     {
+        $secondAuthenticationProvider = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface')->getMock();
+
         $manager = new AuthenticationProviderManager([
             $this->getAuthenticationProvider(true, null, 'Symfony\Component\Security\Core\Exception\AccountStatusException'),
+            $secondAuthenticationProvider,
         ]);
+
+        // AccountStatusException stops authentication
+        $secondAuthenticationProvider->expects($this->never())->method('supports');
 
         try {
             $manager->authenticate($token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 (behavior is this way since 2.0)
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

See https://github.com/symfony/symfony/pull/36822

This PR updates the `AccountStatusException` test to test the expected behavior of this exception (and its difference from `AuthenticationException`).