### PR TITLE
[Security] Improved upgrade path for custom remember me services

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -167,6 +167,7 @@ Security
 
  * Deprecated `LogoutSuccessHandlerInterface` and `LogoutHandlerInterface`, register a listener on the `LogoutEvent` event instead.
  * Deprecated `DefaultLogoutSuccessHandler` in favor of `DefaultLogoutListener`.
+ * Deprecated `RememberMeServicesInterface` implementations without a `logout(Request $request, Response $response, TokenInterface $token)` method.
 
 Yaml
 ----

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -113,6 +113,7 @@ Security
  * Removed `ROLE_PREVIOUS_ADMIN` role in favor of `IS_IMPERSONATOR` attribute
  * Removed `LogoutSuccessHandlerInterface` and `LogoutHandlerInterface`, register a listener on the `LogoutEvent` event instead.
  * Removed `DefaultLogoutSuccessHandler` in favor of `DefaultLogoutListener`.
+ * Added a `logout(Request $request, Response $response, TokenInterface $token)` method to the `RememberMeServicesInterface`.
 
 Yaml
 ----

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Deprecated `LogoutSuccessHandlerInterface` and `LogoutHandlerInterface` in favor of listening on the `LogoutEvent`.
  * Added experimental new security using `Http\Authenticator\AuthenticatorInterface`, `Http\Authentication\AuthenticatorManager` and `Http\Firewall\AuthenticatorManagerListener`.
  * Added `CustomUserMessageAccountStatusException` to be used when extending `UserCheckerInterface`
+ * Deprecated `RememberMeServicesInterface` implementations without `logout(Request $request, Response $response, TokenInterface $token)` method, this method will be required in Symfony 6.0.
 
 5.0.0
 -----

--- a/src/Symfony/Component/Security/Http/EventListener/RememberMeLogoutListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/RememberMeLogoutListener.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Security\Http\EventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Exception\LogicException;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
-use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
+use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
@@ -25,13 +25,21 @@ class RememberMeLogoutListener implements EventSubscriberInterface
 {
     private $rememberMeServices;
 
-    public function __construct(LogoutHandlerInterface $rememberMeServices)
+    public function __construct(RememberMeServicesInterface $rememberMeServices)
     {
+        if (!method_exists($rememberMeServices, 'logout')) {
+            trigger_deprecation('symfony/security-core', '5.1', '"%s" should implement the "logout(Request $request, Response $response, TokenInterface $token)" method, this method will be added to the "%s" in version 6.0.', \get_class($rememberMeServices), RememberMeServicesInterface::class);
+        }
+
         $this->rememberMeServices = $rememberMeServices;
     }
 
     public function onLogout(LogoutEvent $event): void
     {
+        if (!method_exists($this->rememberMeServices, 'logout')) {
+            return;
+        }
+
         if (null === $event->getResponse()) {
             throw new LogicException(sprintf('No response was set for this logout action. Make sure the DefaultLogoutListener or another listener has set the response before "%s" is called.', __CLASS__));
         }

--- a/src/Symfony/Component/Security/Http/RememberMe/RememberMeServicesInterface.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/RememberMeServicesInterface.php
@@ -24,6 +24,8 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  * - PersistentTokenBasedRememberMeServices (requires a TokenProvider)
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @method logout(Request $request, Response $response, TokenInterface $token)
  */
 interface RememberMeServicesInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | -
| Deprecations? | -
| Tickets       | https://github.com/symfony/symfony/pull/36806#issuecomment-628592543
| License       | MIT
| Doc PR        | 

This improves the upgrade path for custom remember me services now `LogoutHandlerInterface` has been deprecated.

As suggested in https://github.com/symfony/symfony/pull/36806#issuecomment-628592543, the `logout()` method should be added to the `RememberMeServicesInterface` in Symfony 6.

This patch allows developers to write a custom class implementing only `RememberMeServicesInterface` with a `logout()` method. Requiring them to implement `LogoutHandlerInterface` will mean they have to maintain 2 version of the class to support both Symfony 5.1+ and 6.0.