### PR TITLE
UploadedFile minor fixes

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
  */
 class UploadedFile extends File
 {
-    private $test = false;
+    private $test;
     private $originalName;
     private $mimeType;
     private $size;
@@ -72,7 +72,7 @@ class UploadedFile extends File
      * It is extracted from the request from which the file has been uploaded.
      * Then it should not be considered as a safe value.
      *
-     * @return string|null The original name
+     * @return string The original name
      */
     public function getClientOriginalName()
     {
@@ -101,7 +101,7 @@ class UploadedFile extends File
      * For a trusted mime type, use getMimeType() instead (which guesses the mime
      * type based on the file content).
      *
-     * @return string|null The mime type
+     * @return string The mime type
      *
      * @see getMimeType()
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | none <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | no

According to the [constructor assignments](https://github.com/symfony/symfony/blob/cb7e78c809f28fc6baffe39a64b91455929c51fb/src/Symfony/Component/HttpFoundation/File/UploadedFile.php#L60), properties `$originalName` and `$mimeType` are never null in `UploadedFile`, so `getClientOriginalName()` and `getClientMimeType()` always return `string`. Also `$test` does not need a default value because it's always set in the constructor.