### PR TITLE
[BrowserKit] Raw body with custom Content-Type header

### DIFF
--- a/src/Symfony/Component/BrowserKit/HttpBrowser.php
+++ b/src/Symfony/Component/BrowserKit/HttpBrowser.php
@@ -39,10 +39,13 @@ class HttpBrowser extends AbstractBrowser
         parent::__construct([], $history, $cookieJar);
     }
 
+    /**
+     * @param Request $request
+     */
     protected function doRequest($request): Response
     {
         $headers = $this->getHeaders($request);
-        [$body, $extraHeaders] = $this->getBodyAndExtraHeaders($request);
+        [$body, $extraHeaders] = $this->getBodyAndExtraHeaders($request, $headers);
 
         $response = $this->client->request($request->getMethod(), $request->getUri(), [
             'headers' => array_merge($headers, $extraHeaders),
@@ -56,7 +59,7 @@ class HttpBrowser extends AbstractBrowser
     /**
      * @return array [$body, $headers]
      */
-    private function getBodyAndExtraHeaders(Request $request): array
+    private function getBodyAndExtraHeaders(Request $request, array $headers): array
     {
         if (\in_array($request->getMethod(), ['GET', 'HEAD'])) {
             return ['', []];
@@ -67,6 +70,10 @@ class HttpBrowser extends AbstractBrowser
         }
 
         if (null !== $content = $request->getContent()) {
+            if (isset($headers['content-type'])) {
+                return [$content, []];
+            }
+
             $part = new TextPart($content, 'utf-8', 'plain', '8bit');
 
             return [$part->bodyToString(), $part->getPreparedHeaders()->toArray()];

--- a/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
@@ -59,6 +59,10 @@ class HttpBrowserTest extends AbstractBrowserTest
             ['POST', 'http://example.com/', [], [], [], 'content'],
             ['POST', 'http://example.com/', ['headers' => $defaultHeaders + ['Content-Type: text/plain; charset=utf-8', 'Content-Transfer-Encoding: 8bit'], 'body' => 'content', 'max_redirects' => 0]],
         ];
+        yield 'POST JSON' => [
+            ['POST', 'http://example.com/', [], [], ['CONTENT_TYPE' => 'application/json'], '["content"]'],
+            ['POST', 'http://example.com/', ['headers' => $defaultHeaders + ['content-type' => 'application/json'], 'body' => '["content"]', 'max_redirects' => 0]],
+        ];
     }
 
     public function testMultiPartRequestWithSingleFile()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Currently, if you try to send POST/PUT request with custom `Content-Type` header and specified body, the real request will contain `text/plain` content type.

Following code
```php
$client->request(
    'POST',
    '/url',
    [],
    [],
    [
        'CONTENT_TYPE' => 'application/json'
    ],
    '{"foo":"bar"}'
);
```
produces next request
```
POST /
Content-Type: text/plain; charset=utf-8

{"foo":"bar"}
```

With this fix, the request will be
```
POST /
Content-Type: application/json

{"foo":"bar"}
```