### PR TITLE
[property-info] Detect invalid tags and throw error accordingly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
         "egulias/email-validator": "~1.2,>=1.2.8|~2.0",
         "symfony/phpunit-bridge": "^3.4.31|^4.3.4|~5.0",
         "symfony/security-acl": "~2.8|~3.0",
-        "phpdocumentor/reflection-docblock": "^3.0|^4.0"
+        "phpdocumentor/reflection-docblock": "^3.0||^4.0||^5.0"
     },
     "conflict": {
         "monolog/monolog": ">=2",

--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
         "egulias/email-validator": "~1.2,>=1.2.8|~2.0",
         "symfony/phpunit-bridge": "^3.4.31|^4.3.4|~5.0",
         "symfony/security-acl": "~2.8|~3.0",
-        "phpdocumentor/reflection-docblock": "^3.0||^4.0||^5.0"
+        "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0"
     },
     "conflict": {
         "monolog/monolog": ">=2",

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -83,6 +83,10 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         }
 
         foreach ($docBlock->getTagsByName('var') as $var) {
+            if (is_a($var, 'phpDocumentor\Reflection\DocBlock\Tags\InvalidTag')) {
+                throw new \InvalidArgumentException(sprintf('Failed to get the description of the @var tag "%s" for class "%s". Please check that the @var tag is correctly defined.', $property, $class));
+            }
+
             $varDescription = $var->getDescription()->render();
 
             if (!empty($varDescription)) {
@@ -137,6 +141,10 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         $types = [];
         /** @var DocBlock\Tags\Var_|DocBlock\Tags\Return_|DocBlock\Tags\Param $tag */
         foreach ($docBlock->getTagsByName($tag) as $tag) {
+            if (is_a($tag, 'phpDocumentor\Reflection\DocBlock\Tags\InvalidTag')) {
+                return null;
+            }
+
             if ($tag && null !== $tag->getType()) {
                 $types = array_merge($types, $this->phpDocTypeHelper->getTypes($tag->getType()));
             }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -102,7 +102,7 @@ class PhpDocExtractorTest extends TestCase
             ['donotexist', null, null, null],
             ['staticGetter', null, null, null],
             ['staticSetter', null, null, null],
-            ['emptyVar', null, null, null],
+            ['emptyVar', null, 'This should not be removed.', null],
         ];
     }
 
@@ -191,6 +191,14 @@ class PhpDocExtractorTest extends TestCase
         $this->assertNull($this->extractor->getShortDescription(EmptyDocBlock::class, 'foo'));
     }
 
+    public function testReturnNullOnIncompleteDocBlock()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Failed to get the description of the @var tag "foo" for class "Symfony\Component\PropertyInfo\Tests\Extractor\IncompleteDocBlock". Please check that the @var tag is correctly defined.');
+
+        $this->extractor->getShortDescription(IncompleteDocBlock::class, 'foo');
+    }
+
     public function dockBlockFallbackTypesProvider()
     {
         return [
@@ -213,6 +221,16 @@ class PhpDocExtractorTest extends TestCase
     {
         $this->assertEquals($types, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\DockBlockFallback', $property));
     }
+}
+
+class IncompleteDocBlock
+{
+    /**
+     * @var
+     * @ORM\Id
+     * @ORM\Column(name="FOO", type="integer")
+     */
+    public $foo;
 }
 
 class EmptyDocBlock

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -30,7 +30,7 @@
         "symfony/serializer": "~2.8|~3.0|~4.0",
         "symfony/cache": "~3.1|~4.0",
         "symfony/dependency-injection": "~3.3|~4.0",
-        "phpdocumentor/reflection-docblock": "^3.0||^4.0||^5.0",
+        "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "doctrine/annotations": "~1.7"
     },
     "conflict": {

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -30,7 +30,7 @@
         "symfony/serializer": "~2.8|~3.0|~4.0",
         "symfony/cache": "~3.1|~4.0",
         "symfony/dependency-injection": "~3.3|~4.0",
-        "phpdocumentor/reflection-docblock": "^3.0|^4.0",
+        "phpdocumentor/reflection-docblock": "^3.0||^4.0||^5.0",
         "doctrine/annotations": "~1.7"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36049 and https://github.com/api-platform/core/issues/3565
| License       | MIT

I'm doing this as a work in progress.

This PR:
- [x] Update composer.json and support phpdocumentor/reflection-docblock version ^3, ^4 and ^5.
- [x] Add a new test to check if an invalid tag returns the proper exception
- [ ] Tests are passing when building with lowest deps (_I don't know how to deal with that yet_)
- [x] Tests are passing using highest deps

Questions:
1. How to deal with the test when the `InvalidTag` class is not available ?
2. Throwing an exception might be a BC break
3. If instead of throwing an `InvalidArgumentException`, we ignore it, then the following tests are failing:

```
1) Symfony\Component\PropertyInfo\Tests\Extractor\PhpDocExtractorTest::testExtract with data set #27 ('emptyVar', null, null, null)

Error: Call to undefined method phpDocumentor\Reflection\DocBlock\Tags\InvalidTag::getType()

/home/devlin/dev/git/symfony/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php:151
/home/devlin/dev/git/symfony/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php:40
```