### PR TITLE
[Security] Unserialize $parentData, if needed, to avoid errors

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
@@ -68,6 +68,7 @@ class AnonymousToken extends AbstractToken
     public function __unserialize(array $data): void
     {
         [$this->secret, $parentData] = $data;
+        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
@@ -26,7 +26,6 @@ class PreAuthenticatedToken extends AbstractToken
     /**
      * @param string|\Stringable|UserInterface $user
      * @param mixed                            $credentials
-     * @param string                           $providerKey
      * @param string[]                         $roles
      */
     public function __construct($user, $credentials, string $providerKey, array $roles = [])
@@ -88,6 +87,7 @@ class PreAuthenticatedToken extends AbstractToken
     public function __unserialize(array $data): void
     {
         [$this->credentials, $this->providerKey, $parentData] = $data;
+        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -101,6 +101,7 @@ class RememberMeToken extends AbstractToken
     public function __unserialize(array $data): void
     {
         [$this->secret, $this->providerKey, $parentData] = $data;
+        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/SwitchUserToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/SwitchUserToken.php
@@ -54,6 +54,7 @@ class SwitchUserToken extends UsernamePasswordToken
     public function __unserialize(array $data): void
     {
         [$this->originalToken, $parentData] = $data;
+        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -99,6 +99,7 @@ class UsernamePasswordToken extends AbstractToken
     public function __unserialize(array $data): void
     {
         [$this->credentials, $this->providerKey, $parentData] = $data;
+        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
@@ -53,6 +53,7 @@ abstract class AccountStatusException extends AuthenticationException
     public function __unserialize(array $data): void
     {
         [$this->user, $parentData] = $data;
+        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
@@ -69,6 +69,7 @@ class CustomUserMessageAuthenticationException extends AuthenticationException
     public function __unserialize(array $data): void
     {
         [$parentData, $this->messageKey, $this->messageData] = $data;
+        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
@@ -71,6 +71,7 @@ class UsernameNotFoundException extends AuthenticationException
     public function __unserialize(array $data): void
     {
         [$this->username, $parentData] = $data;
+        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
+++ b/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
@@ -83,6 +83,7 @@ class PostAuthenticationGuardToken extends AbstractToken implements GuardTokenIn
     public function __unserialize(array $data): void
     {
         [$this->providerKey, $parentData] = $data;
+        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }
 }


### PR DESCRIPTION
Check that the $parentData is an array. If it's a string, the variable is unserialized.
Useful to not break the compatibility with the older versions.
Bug reproduced when upgrading from 3.4 to 4.4

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36813
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
