### PR TITLE
[DI][Preload] Remove preload primitive types

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -347,7 +347,7 @@ require __DIR__.'/$preloadedFiles';
 EOF;
 
                 foreach ($this->preload as $class) {
-                    if (!$class || false !== strpos($class, '$')) {
+                    if (!$class || false !== strpos($class, '$') || \in_array($class, ['int', 'float', 'string', 'bool', 'resource', 'object', 'array', 'null', 'callable', 'iterable', 'mixed', 'void'], true)) {
                         continue;
                     }
                     if (!(class_exists($class, false) || interface_exists($class, false) || trait_exists($class, false)) || (new \ReflectionClass($class))->isUserDefined()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no, but it could be for the future
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

After bump my project to  5.1.x-dev I saw the generated file of `*.preload.php` contains classes that are primitive types like int, string, bool.

```
composer create-project symfony/website-skeleton preload "5.1.x-dev"
cat preload/var/cache/dev/App_KernelDevDebugContainer.preload.php | grep "bool\|string\|int"
```

```
$ cat test/var/cache/dev/App_KernelDevDebugContainer.preload.php | grep "bool\|string\|int"
$classes[] = 'int';
$classes[] = 'string';
$classes[] = 'Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator';
$classes[] = 'Symfony\Component\Security\Http\EntryPoint\RetryAuthenticationEntryPoint';
$classes[] = 'Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator';
$classes[] = 'Symfony\Component\Serializer\Normalizer\ConstraintViolationListNormalizer';
$classes[] = 'bool';
$classes[] = 'Symfony\Component\Validator\ContainerConstraintValidatorFactory';
$classes[] = 'Symfony\Component\Validator\Constraints\EmailValidator';
$classes[] = 'Symfony\Component\Validator\Constraints\ExpressionValidator';
$classes[] = 'Symfony\Component\Validator\Constraints\NotCompromisedPasswordValidator';
$classes[] = 'Symfony\\Component\\Form\\Extension\\Validator\\Constraints\\Form';
```

I don't know if it is expected behaviour, but if not - then PR fix it.

~~In addition, classes are sorted for better reading.~~