### PR TITLE
[Messenger] Fixed check for allowed options in AwsSqs configuration

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -23,6 +23,36 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class ConnectionTest extends TestCase
 {
+    public function testExtraOptions()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Connection::fromDsn('sqs://default/queue', [
+            'extra_key',
+        ]);
+    }
+
+    public function testExtraParamsInQuery()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Connection::fromDsn('sqs://default/queue?extra_param=some_value');
+    }
+
+    public function testConfigureWithCredentials()
+    {
+        $awsKey = 'some_aws_access_key_value';
+        $awsSecret = 'some_aws_secret_value';
+        $region = 'eu-west-1';
+        $httpClient = $this->getMockBuilder(HttpClientInterface::class)->getMock();
+        $this->assertEquals(
+            new Connection(['queue_name' => 'queue'], new SqsClient(['region' => $region, 'accessKeyId' => $awsKey, 'accessKeySecret' => $awsSecret], null, $httpClient)),
+            Connection::fromDsn('sqs://default/queue', [
+                'access_key' => $awsKey,
+                'secret_key' => $awsSecret,
+                'region' => $region,
+            ], $httpClient)
+        );
+    }
+
     public function testFromInvalidDsn()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -124,13 +124,13 @@ class Connection
         $configuration['account'] = 2 === \count($parsedPath) ? $parsedPath[0] : null;
 
         // check for extra keys in options
-        $optionsExtraKeys = array_diff(array_keys($options), array_keys($configuration));
+        $optionsExtraKeys = array_diff(array_keys($options), array_keys(self::DEFAULT_OPTIONS));
         if (0 < \count($optionsExtraKeys)) {
             throw new InvalidArgumentException(sprintf('Unknown option found : [%s]. Allowed options are [%s].', implode(', ', $optionsExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
         }
 
         // check for extra keys in options
-        $queryExtraKeys = array_diff(array_keys($query), array_keys($configuration));
+        $queryExtraKeys = array_diff(array_keys($query), array_keys(self::DEFAULT_OPTIONS));
         if (0 < \count($queryExtraKeys)) {
             throw new InvalidArgumentException(sprintf('Unknown option found in DSN: [%s]. Allowed options are [%s].', implode(', ', $queryExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | no
| License       | MIT

Before this fix it was unavailable to create Connection with access_key and secret_key in options, because they were added to $clientConfiguration var, and check for extra options was against $configuration var. Which lead to exception.
The idea is to check input options against self::DEFAULT_OPTIONS (which contains all available options)
