### PR TITLE
[PhpUnitBridge] fix installing under PHP >= 8

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -87,6 +87,31 @@ if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__
         rename("phpunit-$PHPUNIT_VERSION", "phpunit-$PHPUNIT_VERSION.old");
         passthru(sprintf('\\' === DIRECTORY_SEPARATOR ? 'rmdir /S /Q %s': 'rm -rf %s', "phpunit-$PHPUNIT_VERSION.old"));
     }
+
+    $info = array();
+    foreach (explode("\n", `$COMPOSER info -a -n phpunit/phpunit "$PHPUNIT_VERSION.*"`) as $line) {
+        $line = rtrim($line);
+
+        if (!$info && preg_match('/^versions +: /', $line)) {
+            $info['versions'] = explode(', ', ltrim(substr($line, 9), ': '));
+        } elseif (isset($info['requires'])) {
+            if ('' === $line) {
+                break;
+            }
+
+            $line = explode(' ', $line, 2);
+            $info['requires'][$line[0]] = $line[1];
+        } elseif ($info && 'requires' === $line) {
+            $info['requires'] = array();
+        }
+    }
+
+    if (1 === \count($info['versions'])) {
+        $passthruOrFail("$COMPOSER create-project --ignore-platform-reqs --no-install --prefer-dist --no-scripts --no-plugins --no-progress --ansi -s dev phpunit/phpunit $PHPUNIT_VERSION_DIR \"$PHPUNIT_VERSION.*\"");
+    } else {
+        $passthruOrFail("$COMPOSER create-project --ignore-platform-reqs --no-install --prefer-dist --no-scripts --no-plugins --no-progress --ansi phpunit/phpunit $PHPUNIT_VERSION_DIR \"$PHPUNIT_VERSION.*\"");
+    }
+
     $passthruOrFail("$COMPOSER create-project --no-install --prefer-dist --no-scripts --no-plugins --no-progress --ansi phpunit/phpunit phpunit-$PHPUNIT_VERSION \"$PHPUNIT_VERSION.*\"");
     @copy("phpunit-$PHPUNIT_VERSION/phpunit.xsd", 'phpunit.xsd');
     chdir("phpunit-$PHPUNIT_VERSION");
@@ -97,6 +122,9 @@ if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__
         $passthruOrFail("$COMPOSER require --no-update phpunit/phpunit-mock-objects \"~3.1.0\"");
     }
 
+    if ($info['requires']['php'] !== $phpVersion = preg_replace('{\^([\d\.]++)$}', '>=$1', $info['requires']['php'])) {
+        $passthruOrFail("$COMPOSER require --no-update \"php:$phpVersion\"");
+    }
     $passthruOrFail("$COMPOSER config --unset platform.php");
     if (file_exists($path = $root.'/vendor/symfony/phpunit-bridge')) {
         $passthruOrFail("$COMPOSER require --no-update symfony/phpunit-bridge \"*@dev\"");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

[As experimented on Twig](https://github.com/twigphp/Twig/pull/3331/commits/b952011f95eb04e6c08435a5a0c2abfb6b85be93), using `simple-phpunit` is not simple enough when testing with PHP 8.

This PR fixes the issue so that we could remove these lines in Twig.

On 3.4 since supporting new versions of PHP is a bugfix according to our policies.