### PR TITLE
Update HttpKernel.php

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -78,7 +78,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
 
         try {
             return $this->handleRaw($request, $type);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             if ($e instanceof RequestExceptionInterface) {
                 $e = new BadRequestHttpException($e->getMessage(), $e);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

HTTP Kernel catches `\Exception`, but PHP 7.0 introduced `\Throwable` and a few errors are not handled by this try/catch.

Symfony registers a global handler `\Symfony\Component\ErrorHandler\ErrorHandler` and at some point `\Symfony\Component\HttpKernel\Event\ExceptionEvent` is triggered, so errors are handled twice