### PR TITLE
[Validator] Make ExpressionLanguageSyntax validator usable with annotation

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntax.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntax.php
@@ -37,6 +37,6 @@ class ExpressionLanguageSyntax extends Constraint
      */
     public function validatedBy()
     {
-        return $this->service;
+        return $this->service ?? static::class.'Validator';
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntaxValidator.php
@@ -24,7 +24,7 @@ class ExpressionLanguageSyntaxValidator extends ConstraintValidator
 {
     private $expressionLanguage;
 
-    public function __construct(ExpressionLanguage $expressionLanguage)
+    public function __construct(ExpressionLanguage $expressionLanguage = null)
     {
         $this->expressionLanguage = $expressionLanguage;
     }
@@ -40,6 +40,10 @@ class ExpressionLanguageSyntaxValidator extends ConstraintValidator
 
         if (!\is_string($expression)) {
             throw new UnexpectedTypeException($expression, 'string');
+        }
+
+        if (null === $this->expressionLanguage) {
+            $this->expressionLanguage = new ExpressionLanguage();
         }
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | NA
| License       | MIT
| Doc PR        | NA

When using the new on an entity ExpressionLanguageSyntax (basicaly copy/pasted the sample from https://symfony.com/blog/new-in-symfony-5-1-expressionlanguage-validator), I face a first error:

> Constraint validator "" does not exist or is not enabled. Check the "validatedBy" method in your constraint class "Symfony\Component\Validator\Constraints\ExpressionLanguageSyntax".

indeed, the `service` is [need to generate a valide alias](https://github.com/symfony/symfony/blob/430b88457054179980782629a04c0783e85ba767/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntax.php#L38-L41)

Which looks weird for a Constraint

This PR makes the ExpressionLanguage dependency optionnal in `ExpressionLanguageSyntaxValidator`, and removes the `service` than is not needed anyore