### PR TITLE
[Mailer] Fix mandrill raw http request setting from email/name

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillHttpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillHttpTransportTest.php
@@ -57,8 +57,9 @@ class MandrillHttpTransportTest extends TestCase
             $body = json_decode($options['body'], true);
             $message = $body['raw_message'];
             $this->assertSame('KEY', $body['key']);
+            $this->assertSame('Fabien', $body['from_name']);
+            $this->assertSame('fabpot@symfony.com', $body['from_email']);
             $this->assertSame('saif.gmati@symfony.com', $body['to'][0]);
-            $this->assertSame('Fabien <fabpot@symfony.com>', $body['from_email']);
 
             $this->assertStringContainsString('Subject: Hello!', $message);
             $this->assertStringContainsString('To: Saif Eddin <saif.gmati@symfony.com>', $message);

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillHttpTransport.php
@@ -49,7 +49,8 @@ class MandrillHttpTransport extends AbstractHttpTransport
                 'to' => array_map(function (Address $recipient): string {
                     return $recipient->getAddress();
                 }, $envelope->getRecipients()),
-                'from_email' => $envelope->getSender()->toString(),
+                'from_email' => $envelope->getSender()->getAddress(),
+                'from_name' => $envelope->getSender()->getName(),
                 'raw_message' => $message->toString(),
             ],
         ]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4, 5.0, 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix #36879 
| License       | MIT
| Doc PR        | None

As describe in https://github.com/symfony/symfony/issues/36879 there is a bug in sending raw http request to mandrill it will not set from email/name correct.

As you can see i make sure to set `from_email` and `from_name` correct now and changed the unit test to check correct you can see the doc that the format is correct https://mandrillapp.com/api/docs/messages.curl.html#method-send-raw
