### PR TITLE
Create a helper function createFormView

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -326,7 +326,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
     {
         return $this->container->get('form.factory')->create($type, $data, $options);
     }
-    
+
     /**
      * Creates and returns a Form view from the type of the form.
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -326,6 +326,14 @@ abstract class AbstractController implements ServiceSubscriberInterface
     {
         return $this->container->get('form.factory')->create($type, $data, $options);
     }
+    
+    /**
+     * Creates and returns a Form view from the type of the form.
+     */
+    protected function createFormView(string $type, $data = null, array $options = []): FormView
+    {
+        return $this->container->get('form.factory')->create($type, $data, $options)->createView();
+    }
 
     /**
      * Creates and returns a form builder instance.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

I have many cases in my code that I do something like this:

```
        return $this->render('@mytwig.html.twig', [
            'form' => $this->createForm(ResendEmailType::class)->createView(),
        ]);
```

would be interesting IMHO if there was a thing like this:

```
        return $this->render('@mytwig.html.twig', [
            'form' => $this->createFormView(ResendEmailType::class),
        ]);
```

- [ ] Need to update changelog.
- [ ] Please let me know if I am targeting the correct version.. Got confused since 5.1 is RC now.. should it be master instead?