### PR TITLE
Address deprecation of ReflectionType::getClass()

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -525,7 +525,16 @@ class AutowirePass extends AbstractRecursivePass
         $methodArgumentsMetadata = [];
         foreach ($method->getParameters() as $parameter) {
             try {
-                $class = $parameter->getClass();
+                if (method_exists($parameter, 'getType')) {
+                    $type = $parameter->getType();
+                    if ($type && !$type->isBuiltin()) {
+                        $class = new \ReflectionClass(method_exists($type, 'getName') ? $type->getName() : (string) $type);
+                    } else {
+                        $class = null;
+                    }
+                } else {
+                    $class = $parameter->getClass();
+                }
             } catch (\ReflectionException $e) {
                 // type-hint is against a non-existent class
                 $class = false;

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -136,7 +136,7 @@ class ControllerResolver implements ArgumentResolverInterface, ControllerResolve
                 } else {
                     $arguments[] = $attributes[$param->name];
                 }
-            } elseif ($param->getClass() && $param->getClass()->isInstance($request)) {
+            } elseif ($this->typeMatchesRequestClass($param, $request)) {
                 $arguments[] = $request;
             } elseif ($param->isDefaultValueAvailable()) {
                 $arguments[] = $param->getDefaultValue();
@@ -259,5 +259,23 @@ class ControllerResolver implements ArgumentResolverInterface, ControllerResolve
         }
 
         return $message;
+    }
+
+    /**
+     * @return bool
+     */
+    private function typeMatchesRequestClass(\ReflectionParameter $param, Request $request)
+    {
+        if (!method_exists($param, 'getType')) {
+            return $param->getClass() && $param->getClass()->isInstance($request);
+        }
+
+        if (!($type = $param->getType()) || $type->isBuiltin()) {
+            return false;
+        }
+
+        $class = new \ReflectionClass(method_exists($type, 'getName') ? $type->getName() : (string) $type);
+
+        return $class && $class->isInstance($request);
     }
 }

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -146,7 +146,7 @@ class OptionsResolver implements Options
             $reflClosure = new \ReflectionFunction($value);
             $params = $reflClosure->getParameters();
 
-            if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && Options::class === $class->name) {
+            if (isset($params[0]) && Options::class === $this->getParameterClassName($params[0])) {
                 // Initialize the option if no previous value exists
                 if (!isset($this->defaults[$option])) {
                     $this->defaults[$option] = null;
@@ -1065,5 +1065,21 @@ class OptionsResolver implements Options
     private static function isValueValidType($type, $value)
     {
         return (\function_exists($isFunction = 'is_'.$type) && $isFunction($value)) || $value instanceof $type;
+    }
+
+    /**
+     * @return string|null
+     */
+    private function getParameterClassName(\ReflectionParameter $parameter)
+    {
+        if (!method_exists($parameter, 'getType')) {
+            return ($class = $parameter->getClass()) ? $class->name : null;
+        }
+
+        if (!($type = $parameter->getType()) || $type->isBuiltin()) {
+            return null;
+        }
+
+        return method_exists($type, 'getName') ? $type->getName() : (string) $type;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872
| License       | MIT
| Doc PR        | N/A

Calling `ReflectionType::getClass()` will trigger a deprecation warning on php 8. This PR switches to `getType()` if available.