### PR TITLE
[Debug] Skip test that would trigger a fatal error on php 8

### DIFF
--- a/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/Debug/Tests/DebugClassLoaderTest.php
@@ -97,6 +97,9 @@ class DebugClassLoaderTest extends TestCase
         $this->assertStringMatchesFormat('%aParse error%a', $output);
     }
 
+    /**
+     * @requires PHP < 8.0
+     */
     public function testStacking()
     {
         // the ContextErrorException must not be loaded to test the workaround


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

This PR skips a test of `DebugClassLoader`. The test uses incompatible method signatures in class inheritance to provoke a php warning that should be handled by the debug class loader. On php 8 however, this error is not recoverable anymore, so the tested logic will be obsolete there.