### PR TITLE
[Validator] never directly validate Existence (Required/Optional) constraints

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Optional;
+use Symfony\Component\Validator\Constraints\Required;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Context\ExecutionContextFactory;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
@@ -156,5 +158,19 @@ class RecursiveValidatorTest extends AbstractTest
         $this->assertCount(2, $violations);
         $this->assertInstanceOf(NotBlank::class, $violations->get(0)->getConstraint());
         $this->assertInstanceOf(Length::class, $violations->get(1)->getConstraint());
+    }
+
+    public function testRequiredConstraintIsIgnored()
+    {
+        $violations = $this->validator->validate([], new Required());
+
+        $this->assertCount(0, $violations);
+    }
+
+    public function testOptionalConstraintIsIgnored()
+    {
+        $violations = $this->validator->validate([], new Optional());
+
+        $this->assertCount(0, $violations);
     }
 }

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Validator\Validator;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Composite;
+use Symfony\Component\Validator\Constraints\Existence;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintValidatorFactoryInterface;
@@ -790,6 +791,10 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         $context->setGroup($group);
 
         foreach ($metadata->findConstraints($group) as $constraint) {
+            if ($constraint instanceof Existence) {
+                continue;
+            }
+
             // Prevent duplicate validation of constraints, in the case
             // that constraints belong to multiple validated groups
             if (null !== $cacheKey) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36637 #36723
| License       | MIT
| Doc PR        | 

Using `Optional` or `Required` like "regular" constraints does not make any sense, but doing so didn't break before #36365. I suggest to ignore them for now and deprecate using them outside the `Collection` constraint in 5.2.