### PR TITLE
[Config] Removed implicit cast of ReflectionProperty to string

### DIFF
--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -139,7 +139,11 @@ class ReflectionClassResource implements SelfCheckingResourceInterface, \Seriali
             $defaults = $class->getDefaultProperties();
 
             foreach ($class->getProperties(\ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_PROTECTED) as $p) {
-                yield $p->getDocComment().$p;
+                yield $p->getDocComment();
+                yield $p->isDefault() ? '<default>' : '';
+                yield $p->isPublic() ? 'public' : 'protected';
+                yield $p->isStatic() ? 'static' : '';
+                yield '$'.$p->name;
                 yield print_r(isset($defaults[$p->name]) && !\is_object($defaults[$p->name]) ? $defaults[$p->name] : null, true);
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872
| License       | MIT
| Doc PR        | N/A

PHP 8 does not allow casting `ReflectionProperty` instances to string anymore.
