### PR TITLE
[Debug] php 8 does not pass $context to error handlers

### DIFF
--- a/src/Symfony/Component/Debug/Tests/Fixtures/ErrorHandlerThatUsesThePreviousOne.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/ErrorHandlerThatUsesThePreviousOne.php
@@ -15,8 +15,8 @@ class ErrorHandlerThatUsesThePreviousOne
         return $handler;
     }
 
-    public function handleError($type, $message, $file, $line, $context)
+    public function handleError()
     {
-        return \call_user_func(self::$previous, $type, $message, $file, $line, $context);
+        return \call_user_func_array(self::$previous, \func_get_args());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872
| License       | MIT
| Doc PR        | N/A

php 8 will call error handlers without the optional `$context` parameter. Thus, error handlers that make that parameter mandatory will break.