### PR TITLE
[VarDumper] ReflectionFunction::isDisabled() is deprecated

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
@@ -333,6 +333,10 @@ class ReflectionCaster
     private static function addMap(&$a, \Reflector $c, $map, $prefix = Caster::PREFIX_VIRTUAL)
     {
         foreach ($map as $k => $m) {
+            if (\PHP_VERSION_ID >= 80000 && 'isDisabled' === $k) {
+                continue;
+            }
+
             if (method_exists($c, $m) && false !== ($m = $c->$m()) && null !== $m) {
                 $a[$prefix.$k] = $m instanceof \Reflector ? $m->name : $m;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872
| License       | MIT
| Doc PR        | N/A

See php/php-src#5473. Calling `ReflectionFunction::isDisabled()` is pointless on php 8 and doing so triggers a deprecation warning.

Someone who is more familiar with that component might want to have a second look on this PR. I'm not really sure if this is the right way to fix the issue.