### PR TITLE
[HttpKernel] Prevent calling method_exists() with non-string values

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -77,7 +77,7 @@ class ControllerResolver implements ArgumentResolverInterface, ControllerResolve
             throw new \InvalidArgumentException(sprintf('Controller "%s" for URI "%s" is not callable.', \get_class($controller), $request->getPathInfo()));
         }
 
-        if (false === strpos($controller, ':')) {
+        if (\is_string($controller) && false === strpos($controller, ':')) {
             if (method_exists($controller, '__invoke')) {
                 return $this->instantiateController($controller);
             } elseif (\function_exists($controller)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

On php 8, `method_exists()` will raise a `TypeError` if the first argument is neither an object or string. We do have a test case that calls the `ControllerResolver` with integer `1` as `$controller`. This test should work as expected again on php 8.