### PR TITLE
[Intl] Fix call to ReflectionProperty::getValue() for static properties

### DIFF
--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -602,7 +602,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
 
         $r = new \ReflectionProperty('Symfony\Component\Intl\NumberFormatter\NumberFormatter', 'enSymbols');
         $r->setAccessible(true);
-        $expected = $r->getValue('Symfony\Component\Intl\NumberFormatter\NumberFormatter');
+        $expected = $r->getValue();
 
         for ($i = 0; $i <= 17; ++$i) {
             $this->assertSame($expected[1][$i], $decimalFormatter->getSymbol($i));
@@ -619,7 +619,7 @@ abstract class AbstractNumberFormatterTest extends TestCase
 
         $r = new \ReflectionProperty('Symfony\Component\Intl\NumberFormatter\NumberFormatter', 'enTextAttributes');
         $r->setAccessible(true);
-        $expected = $r->getValue('Symfony\Component\Intl\NumberFormatter\NumberFormatter');
+        $expected = $r->getValue();
 
         for ($i = 0; $i <= 5; ++$i) {
             $this->assertSame($expected[1][$i], $decimalFormatter->getTextAttribute($i));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

When we call `ReflectionProperty::getValue()` for a static property, we don't need to pass any arguments. The code that was fixed here raised a `TypeError` on php 8 because the argument has to be an object now.