### PR TITLE
[Validator] Catch expected ValueError

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/LengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LengthValidator.php
@@ -39,8 +39,14 @@ class LengthValidator extends ConstraintValidator
 
         $stringValue = (string) $value;
 
-        if (!$invalidCharset = !@mb_check_encoding($stringValue, $constraint->charset)) {
-            $length = mb_strlen($stringValue, $constraint->charset);
+        try {
+            $invalidCharset = !@mb_check_encoding($stringValue, $constraint->charset);
+        } catch (\ValueError $e) {
+            if (!str_starts_with($e->getMessage(), 'mb_check_encoding(): Argument #2 ($encoding) must be a valid encoding')) {
+                throw $e;
+            }
+
+            $invalidCharset = true;
         }
 
         if ($invalidCharset) {
@@ -53,6 +59,8 @@ class LengthValidator extends ConstraintValidator
 
             return;
         }
+
+        $length = mb_strlen($stringValue, $constraint->charset);
 
         if (null !== $constraint->max && $length > $constraint->max) {
             $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->maxMessage)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

`mb_check_encoding()` raises a `ValueError` on php 8 if an invalid encoding was passed. The validator that was patched here is expected to fail gracefully in that situation. This PR restores that behavior under php 8.

Maybe we can reconsider this behavior for Symfony 5.2. It feels a bit odd to me because we swallow a potential misconfiguration of the validator.