### PR TITLE
[DomCrawler] Catch expected ValueError

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -193,9 +193,10 @@ class Crawler implements \Countable, \IteratorAggregate
             // Convert charset to HTML-entities to work around bugs in DOMDocument::loadHTML()
             $content = mb_convert_encoding($content, 'HTML-ENTITIES', $charset);
         } catch (\Exception $e) {
+        } catch (\ValueError $e) {
+        } finally {
+            restore_error_handler();
         }
-
-        restore_error_handler();
 
         if ('' !== trim($content)) {
             @$dom->loadHTML($content);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

`mb_convert_encoding()` raises a `ValueError` on php 8 if an unknown character set is passed. This causes trouble with the whole test suite because the temporary error handler is not deregistered in that case.

Since the previously raised warning was actively ignored by that error handler, I'm now ignoring the `ValueError` as well. Also, I've wrapped the `restore_error_handler()` call into a `finally` statement to make the whole construct a bit more robust.