### PR TITLE
[FrameworkBundle] fix type annotation on ControllerTrait::addFlash()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -187,7 +187,7 @@ trait ControllerTrait
      * Adds a flash message to the current session for type.
      *
      * @param string $type    The type
-     * @param string $message The message
+     * @param mixed  $message The message
      *
      * @throws \LogicException
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #28991 Fix #34645
| License       | MIT
| Doc PR        | not yet, see below

Removing `string` type-hint of $message at addFlash()

Closes https://github.com/symfony/symfony/issues/28991 and https://github.com/symfony/symfony/issues/34645

Reasons:

* `addFlash()` is just a convenience shortcut for `FlashBagInterface::add()` which doesn't have the type hint: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Session/Flash/FlashBagInterface.php#L28 . So removing it here improves consistency.

* https://github.com/symfony/symfony/issues/28991#issuecomment-436755949 is a valid use case for having an object as `$message`.

* Twig doesn't have any rendering helpers for the `message`, see https://symfony.com/doc/current/controller.html#flash-messages . And since users have to take care of displaying the `message` themselves, there's no reason to force a string upon them.

* This isn't a real new feature, but it isn't a bugfix either ;-)
* I didn't update `src/**/CHANGELOG.md` yet.
* I'm not sure if it's necessary to update the docs. Maybe a short note https://symfony.com/doc/current/controller.html#flash-messages ?