### PR TITLE
[Cache] Accessing undefined constants raises an Error in php8

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -66,8 +66,14 @@ class MemcachedAdapterTest extends AdapterTestCase
      */
     public function testBadOptions($name, $value)
     {
-        $this->expectException('ErrorException');
-        $this->expectExceptionMessage('constant(): Couldn\'t find constant Memcached::');
+        if (\PHP_VERSION_ID < 80000) {
+            $this->expectException('ErrorException');
+            $this->expectExceptionMessage('constant(): Couldn\'t find constant Memcached::');
+        } else {
+            $this->expectException('Error');
+            $this->expectExceptionMessage('Undefined class constant \'Memcached::');
+        }
+
         MemcachedAdapter::createConnection([], [$name => $value]);
     }
 

--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
@@ -76,8 +76,14 @@ class MemcachedCacheTest extends CacheTestCase
      */
     public function testBadOptions($name, $value)
     {
-        $this->expectException('ErrorException');
-        $this->expectExceptionMessage('constant(): Couldn\'t find constant Memcached::');
+        if (\PHP_VERSION_ID < 80000) {
+            $this->expectException('ErrorException');
+            $this->expectExceptionMessage('constant(): Couldn\'t find constant Memcached::');
+        } else {
+            $this->expectException('Error');
+            $this->expectExceptionMessage('Undefined class constant \'Memcached::');
+        }
+
         MemcachedCache::createConnection([], [$name => $value]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

Calling `constant()` for an undefined constant will raise an `Error` on php 8. This PR adjust the Memcached tests to this new behavior.