### PR TITLE
Add php 8 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,11 @@ matrix:
           env: deps=high
         - php: 7.4
           env: deps=low
+        - php: nightly
+          services: [memcached]
     fast_finish: true
+    allow_failures:
+      - php: nightly
 
 cache:
     directories:
@@ -54,9 +58,11 @@ before_install:
 
     - |
       # Start Redis cluster
-      docker pull grokzen/redis-cluster:4.0.8
-      docker run -d -p 7000:7000 -p 7001:7001 -p 7002:7002 -p 7003:7003 -p 7004:7004 -p 7005:7005 --name redis-cluster grokzen/redis-cluster:4.0.8
-      export REDIS_CLUSTER_HOSTS='localhost:7000 localhost:7001 localhost:7002 localhost:7003 localhost:7004 localhost:7005'
+      if [[ $TRAVIS_PHP_VERSION != nightly ]]; then
+          docker pull grokzen/redis-cluster:4.0.8
+          docker run -d -p 7000:7000 -p 7001:7001 -p 7002:7002 -p 7003:7003 -p 7004:7004 -p 7005:7005 --name redis-cluster grokzen/redis-cluster:4.0.8
+          export REDIS_CLUSTER_HOSTS='localhost:7000 localhost:7001 localhost:7002 localhost:7003 localhost:7004 localhost:7005'
+      fi
 
     - |
       # General configuration
@@ -157,11 +163,14 @@ before_install:
           echo opcache.enable_cli = 1 >> $INI
           echo hhvm.jit = 0 >> $INI
           echo apc.enable_cli = 1 >> $INI
-          echo extension = redis.so >> $INI
-          echo extension = memcached.so >> $INI
           if [[ $PHP = 5.* ]]; then
+              echo extension = redis.so >> $INI
+              echo extension = memcached.so >> $INI
               echo extension = memcache.so >> $INI
               echo extension = mongo.so >> $INI
+          elif [[ $PHP = 7.* ]]; then
+              echo extension = redis.so >> $INI
+              echo extension = memcached.so >> $INI
           fi
       done
 
@@ -183,6 +192,8 @@ before_install:
           elif [[ $PHP = 7.* ]]; then
               tfold ext.apcu tpecl apcu-5.1.17 apcu.so $INI
               tfold ext.mongodb tpecl mongodb-1.6.0 mongodb.so $INI
+          elif [[ $PHP = nightly ]]; then
+              tfold ext.memcached tpecl memcached-3.1.5 memcached.so $INI
           fi
       done
 
@@ -247,6 +258,13 @@ install:
       # Skip the phpunit-bridge on not-master branches when $deps is empty
       if [[ ! $deps && $TRAVIS_BRANCH != master ]]; then
           export COMPONENTS=$(find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -printf '%h\n' | sort)
+      fi
+
+    - |
+      # Set composer's platform to php 7.4 if we're on php 8.
+      echo $PHP
+      if [[ $PHP = nightly ]]; then
+          composer config platform.php 7.4.6
       fi
 
     - |


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

This PR adds an extra php 8 job to travis that is allowed to fail. This will allow us to monitor the remaining work.

* I did not include APCu because loading the extension would clutter our log with warnings. We might fix this by compiling APCu from master though.
* I did not manage to compile `ext-redis` and `ext-mongodb`.
* But hey, `ext-memcached` works!