### PR TITLE
[Cache][Lock][Messenger] Don't execute tests with DBAL 2.x on php 8

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use Doctrine\DBAL\Version;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
@@ -28,6 +29,10 @@ class PdoAdapterTest extends AdapterTestCase
     {
         if (!\extension_loaded('pdo_sqlite')) {
             self::markTestSkipped('Extension pdo_sqlite required.');
+        }
+
+        if (\PHP_VERSION_ID >= 80000 && class_exists(Version::class)) {
+            self::markTestSkipped('Doctrine DBAL 2.x is incompatible with PHP 8.');
         }
 
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_cache');

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoDbalAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Version;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
@@ -29,6 +30,10 @@ class PdoDbalAdapterTest extends AdapterTestCase
     {
         if (!\extension_loaded('pdo_sqlite')) {
             self::markTestSkipped('Extension pdo_sqlite required.');
+        }
+
+        if (\PHP_VERSION_ID >= 80000 && class_exists(Version::class)) {
+            self::markTestSkipped('Doctrine DBAL 2.x is incompatible with PHP 8.');
         }
 
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_cache');

--- a/src/Symfony/Component/Cache/Tests/Simple/PdoDbalCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PdoDbalCacheTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Simple;
 
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Version;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\PdoCache;
 use Symfony\Component\Cache\Tests\Traits\PdoPruneableTrait;
@@ -30,6 +31,10 @@ class PdoDbalCacheTest extends CacheTestCase
     {
         if (!\extension_loaded('pdo_sqlite')) {
             self::markTestSkipped('Extension pdo_sqlite required.');
+        }
+
+        if (\PHP_VERSION_ID >= 80000 && class_exists(Version::class)) {
+            self::markTestSkipped('Doctrine DBAL 2.x is incompatible with PHP 8.');
         }
 
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_cache');

--- a/src/Symfony/Component/Lock/Tests/Store/PdoDbalStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoDbalStoreTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Lock\Tests\Store;
 
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Version;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\PdoStore;
 
@@ -29,6 +30,10 @@ class PdoDbalStoreTest extends AbstractStoreTest
     public static function setUpBeforeClass(): void
     {
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_lock');
+
+        if (\PHP_VERSION_ID >= 80000 && class_exists(Version::class)) {
+            self::markTestSkipped('Doctrine DBAL 2.x is incompatible with PHP 8.');
+        }
 
         $store = new PdoStore(DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => self::$dbFile]));
         $store->createTable();

--- a/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PdoStoreTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Doctrine\DBAL\Version;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\PdoStore;
@@ -29,6 +30,10 @@ class PdoStoreTest extends AbstractStoreTest
     public static function setUpBeforeClass(): void
     {
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_lock');
+
+        if (\PHP_VERSION_ID >= 80000 && class_exists(Version::class)) {
+            self::markTestSkipped('Doctrine DBAL 2.x is incompatible with PHP 8.');
+        }
 
         $store = new PdoStore('sqlite:'.self::$dbFile);
         $store->createTable();

--- a/src/Symfony/Component/Lock/composer.json
+++ b/src/Symfony/Component/Lock/composer.json
@@ -20,7 +20,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "doctrine/dbal": "~2.5",
+        "doctrine/dbal": "^2.5|^3.0",
         "predis/predis": "~1.0"
     },
     "conflict": {

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Tests\Transport\Doctrine;
 
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Version;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Transport\Doctrine\Connection;
@@ -27,6 +28,13 @@ class DoctrineIntegrationTest extends TestCase
     private $connection;
     /** @var string */
     private $sqliteFile;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (\PHP_VERSION_ID >= 80000 && class_exists(Version::class)) {
+            self::markTestSkipped('Doctrine DBAL 2.x is incompatible with PHP 8.');
+        }
+    }
 
     protected function setUp(): void
     {

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -20,7 +20,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "doctrine/dbal": "^2.6",
+        "doctrine/dbal": "^2.6|^3.0",
         "psr/cache": "~1.0",
         "doctrine/persistence": "^1.3",
         "symfony/console": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

Follow-up to #36895: If we autoload the `PDOConnection` from DBAL 2.x during a test on php8, our test suite goes :boom: 

What this PR does:
* Some more Cache tests are skipped if DBAL 2 is installed on php 8.
* The Lock and Messenger components are tested against DBAL 3.