### PR TITLE
Added a FrenchInflector for the String component

### DIFF
--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * added a `FrenchInflector` class
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/String/Inflector/FrenchInflector.php
+++ b/src/Symfony/Component/String/Inflector/FrenchInflector.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\String\Inflector;
+
+/**
+ * French inflector.
+ *
+ * This class does only inflect nouns; not adjectives nor composed words like "soixante-dix".
+ */
+final class FrenchInflector implements InflectorInterface
+{
+    /**
+     * A list of all rules for pluralise.
+     * @see https://la-conjugaison.nouvelobs.com/regles/grammaire/le-pluriel-des-noms-121.php
+     */
+    private static $pluralizeRegexp = [
+        // First entry: regexp
+        // Second entry: replacement
+
+        // Words finishing with "s", "x" or "z" are invariables
+        // Les mots finissant par "s", "x" ou "z" sont invariables
+        ['/(s|x|z)$/i', '\1'],
+
+        // Words finishing with "eau" are pluralized with a "x"
+        // Les mots finissant par "eau" prennent tous un "x" au pluriel
+        ['/(eau)$/i', '\1x'],
+
+        // Words finishing with "au" are pluralized with a "x" excepted "landau"
+        // Les mots finissant par "au" prennent un "x" au pluriel sauf "landau"
+        ['/^(landau)$/i', '\1s'],
+        ['/(au)$/i', '\1x'],
+
+        // Words finishing with "eu" are pluralized with a "x" excepted "pneu", "bleu", "émeu"
+        // Les mots finissant en "eu" prennent un "x" au pluriel sauf "pneu", "bleu", "émeu"
+        ['/^(pneu|bleu|émeu)$/i', '\1s'],
+        ['/(eu)$/i', '\1x'],
+
+        // Words finishing with "al" are pluralized with a "aux" excepted
+        // Les mots finissant en "al" se terminent en "aux" sauf
+        ['/^(bal|carnaval|caracal|chacal|choral|corral|étal|festival|récital|val)$/i', '\1s'],
+        ['/al$/i', '\1aux'],
+
+        // Aspirail, bail, corail, émail, fermail, soupirail, travail, vantail et vitrail font leur pluriel en -aux
+        ['/^(aspir|b|cor|ém|ferm|soupir|trav|vant|vitr)ail$/i', '\1aux'],
+
+        // Bijou, caillou, chou, genou, hibou, joujou et pou qui prennent un x au pluriel
+        ['/^(bij|caill|ch|gen|hib|jouj|p)ou$/i', '\1oux'],
+
+        // Invariable words
+        ['/^(cinquante|soixante|mille)$/i', '\1'],
+
+        // French titles
+        ['/^(mon|ma)(sieur|dame|demoiselle|seigneur)$/', 'mes\2s'],
+        ['/^(Mon|Ma)(sieur|dame|demoiselle|seigneur)$/', 'Mes\2s'],
+    ];
+
+    /**
+     * A list of all rules for singularize.
+     */
+    private static $singularizeRegexp = [
+        // First entry: regexp
+        // Second entry: replacement
+
+        // Aspirail, bail, corail, émail, fermail, soupirail, travail, vantail et vitrail font leur pluriel en -aux
+        ['/((aspir|b|cor|ém|ferm|soupir|trav|vant|vitr))aux$/i', '\1ail'],
+
+        // Words finishing with "eau" are pluralized with a "x"
+        // Les mots finissant par "eau" prennent tous un "x" au pluriel
+        ['/(eau)x$/i', '\1'],
+
+        // Words finishing with "al" are pluralized with a "aux" expected
+        // Les mots finissant en "al" se terminent en "aux" sauf
+        ['/(amir|anim|arsen|boc|can|capit|capor|chev|crist|génér|hopit|hôpit|idé|journ|littor|loc|m|mét|minér|princip|radic|termin)aux$/i', '\1al'],
+
+        // Words finishing with "au" are pluralized with a "x" excepted "landau"
+        // Les mots finissant par "au" prennent un "x" au pluriel sauf "landau"
+        ['/(au)x$/i', '\1'],
+
+        // Words finishing with "eu" are pluralized with a "x" excepted "pneu", "bleu", "émeu"
+        // Les mots finissant en "eu" prennent un "x" au pluriel sauf "pneu", "bleu", "émeu"
+        ['/(eu)x$/i', '\1'],
+
+        //  Words finishing with "ou" are pluralized with a "s" excepted bijou, caillou, chou, genou, hibou, joujou, pou
+        // Les mots finissant par "ou" prennent un "s" sauf bijou, caillou, chou, genou, hibou, joujou, pou
+        ['/(bij|caill|ch|gen|hib|jouj|p)oux$/i', '\1ou'],
+
+        // French titles
+        ['/^mes(dame|demoiselle)s$/', 'ma\1'],
+        ['/^Mes(dame|demoiselle)s$/', 'Ma\1'],
+        ['/^mes(sieur|seigneur)s$/', 'mon\1'],
+        ['/^Mes(sieur|seigneur)s$/', 'Mon\1'],
+
+        //Default rule
+        ['/s$/i', ''],
+    ];
+
+    /**
+     * A list of words which should not be inflected.
+     * This list is only used by singularize.
+     */
+    private static $uninflected = '/^(abcès|accès|abus|albatros|anchois|anglais|autobus|bois|brebis|carquois|cas|chas|colis|concours|corps|cours|cyprès|décès|devis|discours|dos|embarras|engrais|entrelacs|excès|fils|fois|gâchis|gars|glas|héros|intrus|jars|jus|kermès|lacis|legs|lilas|marais|mars|matelas|mépris|mets|mois|mors|obus|os|palais|paradis|parcours|pardessus|pays|plusieurs|poids|pois|pouls|printemps|processus|progrès|puits|pus|rabais|radis|recors|recours|refus|relais|remords|remous|rictus|rhinocéros|repas|rubis|sas|secours|sens|souris|succès|talus|tapis|tas|taudis|temps|tiers|univers|velours|verglas|vernis|virus)$/i';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function singularize(string $plural): array
+    {
+        if ($this->isInflectedWord($plural)) {
+            return [$plural];
+        }
+
+        foreach (self::$singularizeRegexp as $rule) {
+            [$regexp, $replace] = $rule;
+
+            if (1 === preg_match($regexp, $plural)) {
+                return [preg_replace($regexp, $replace, $plural)];
+            }
+        }
+
+        return [$plural];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function pluralize(string $singular): array
+    {
+        if ($this->isInflectedWord($singular)) {
+            return [$singular];
+        }
+
+        foreach (self::$pluralizeRegexp as $rule) {
+            [$regexp, $replace] = $rule;
+
+            if (1 === preg_match($regexp, $singular)) {
+                return [preg_replace($regexp, $replace, $singular)];
+            }
+        }
+
+        return [$singular.'s'];
+    }
+
+    private function isInflectedWord(string $word): bool
+    {
+        return 1 === preg_match(self::$uninflected, $word);
+    }
+}

--- a/src/Symfony/Component/String/Tests/FrenchInflectorTest.php
+++ b/src/Symfony/Component/String/Tests/FrenchInflectorTest.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\String\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\String\Inflector\FrenchInflector;
+
+class FrenchInflectorTest extends TestCase
+{
+    public function pluralizeProvider()
+    {
+        return [
+            //Le pluriel par défaut
+            ['voiture', 'voitures'],
+            //special characters
+            ['œuf', 'œufs'],
+            ['oeuf', 'oeufs'],
+
+            //Les mots finissant par s, x, z sont invariables en nombre
+            ['bois', 'bois'],
+            ['fils', 'fils'],
+            ['héros', 'héros'],
+            ['nez', 'nez'],
+            ['rictus', 'rictus'],
+            ['souris', 'souris'],
+            ['tas', 'tas'],
+            ['toux', 'toux'],
+
+            //Les mots finissant en eau prennent tous un x au pluriel
+            ['eau', 'eaux'],
+            ['sceau', 'sceaux'],
+
+            //Les mots finissant en au prennent tous un x au pluriel sauf landau
+            ['noyau', 'noyaux'],
+            ['landau', 'landaus'],
+
+            //Les mots finissant en eu prennent un x au pluriel sauf pneu, bleu et émeu
+            ['pneu', 'pneus'],
+            ['bleu', 'bleus'],
+            ['émeu', 'émeus'],
+            ['cheveu', 'cheveux'],
+
+            //Les mots finissant en al se terminent en aux au pluriel
+            ['amiral', 'amiraux'],
+            ['animal', 'animaux'],
+            ['arsenal', 'arsenaux'],
+            ['bocal', 'bocaux'],
+            ['canal', 'canaux'],
+            ['capital', 'capitaux'],
+            ['caporal', 'caporaux'],
+            ['cheval', 'chevaux'],
+            ['cristal', 'cristaux'],
+            ['général', 'généraux'],
+            ['hopital', 'hopitaux'],
+            ['hôpital', 'hôpitaux'],
+            ['idéal', 'idéaux'],
+            ['journal', 'journaux'],
+            ['littoral', 'littoraux'],
+            ['local', 'locaux'],
+            ['mal', 'maux'],
+            ['métal', 'métaux'],
+            ['minéral', 'minéraux'],
+            ['principal', 'principaux'],
+            ['radical', 'radicaux'],
+            ['terminal', 'terminaux'],
+
+            //sauf bal, carnaval, caracal, chacal, choral, corral, étal, festival, récital et val
+            ['bal', 'bals'],
+            ['carnaval', 'carnavals'],
+            ['caracal', 'caracals'],
+            ['chacal', 'chacals'],
+            ['choral', 'chorals'],
+            ['corral', 'corrals'],
+            ['étal', 'étals'],
+            ['festival', 'festivals'],
+            ['récital', 'récitals'],
+            ['val', 'vals'],
+
+            // Les noms terminés en -ail prennent un s au pluriel.
+            ['portail', 'portails'],
+            ['rail', 'rails'],
+
+            // SAUF aspirail, bail, corail, émail, fermail, soupirail, travail, vantail et vitrail qui font leur pluriel en -aux
+            ['aspirail', 'aspiraux'],
+            ['bail', 'baux'],
+            ['corail', 'coraux'],
+            ['émail', 'émaux'],
+            ['fermail', 'fermaux'],
+            ['soupirail', 'soupiraux'],
+            ['travail', 'travaux'],
+            ['vantail', 'vantaux'],
+            ['vitrail', 'vitraux'],
+
+            // Les noms terminés en -ou prennent un s au pluriel.
+            ['trou', 'trous'],
+            ['fou', 'fous'],
+
+            //SAUF Bijou, caillou, chou, genou, hibou, joujou et pou qui prennent un x au pluriel
+            ['bijou', 'bijoux'],
+            ['caillou', 'cailloux'],
+            ['chou', 'choux'],
+            ['genou', 'genoux'],
+            ['hibou', 'hiboux'],
+            ['joujou', 'joujoux'],
+            ['pou', 'poux'],
+
+            //Inflected word
+            ['cinquante', 'cinquante'],
+            ['soixante', 'soixante'],
+            ['mille', 'mille'],
+
+            //Titles
+            ['monsieur', 'messieurs'],
+            ['madame', 'mesdames'],
+            ['mademoiselle', 'mesdemoiselles'],
+            ['monseigneur', 'messeigneurs'],
+        ];
+    }
+
+    /**
+     * @dataProvider pluralizeProvider
+     */
+    public function testSingularize(string $singular, string $plural)
+    {
+        $this->assertSame([$singular], (new FrenchInflector())->singularize($plural));
+        // test casing: if the first letter was uppercase, it should remain so
+        $this->assertSame([ucfirst($singular)], (new FrenchInflector())->singularize(ucfirst($plural)));
+    }
+
+    /**
+     * @dataProvider pluralizeProvider
+     */
+    public function testPluralize(string $singular, string $plural)
+    {
+        $this->assertSame([$plural], (new FrenchInflector())->pluralize($singular));
+        // test casing: if the first letter was uppercase, it should remain so
+        $this->assertSame([ucfirst($plural)], (new FrenchInflector())->pluralize(ucfirst($singular)));
+    }
+}


### PR DESCRIPTION
I read in [this blog post](https://symfony.com/blog/new-in-symfony-5-1-deprecated-the-inflector-component) this sentence

> Symfony Inflector component converts words between their singular and plural forms (**for now, only in English**)

So I created a FrenchInflector class implementing the InflectorInterface from the String component. This inflector uses regular expressions and it is tested in the FrenchInflectorTest with a lot of the french exceptions.

| Q             | A
| ------------- | ---
| Branch       | master
| Bug fix      | no
| New feature  | yes 
| Deprecations | no
| License       | MIT
| Doc PR        | Not yet

Changelog has been updated, but I'm not sure I did it in the good paragraph.

I don't know if I should update the symfony/symfony-docs, but I have created an example and I could create a PR with it, if you want.

```php
<?php

use Symfony\Component\String\Inflector\FrenchInflector;

$inflector = new FrenchInflector();

$result = $inflector->singularize('dents');     // ['dent']
$result = $inflector->singularize('souris');    // ['souris']
$result = $inflector->singularize('messieurs'); // ['monsieur']

$result = $inflector->pluralize('cinquante'); // ['cinquante']
$result = $inflector->pluralize('pou');       // ['poux']
$result = $inflector->pluralize('cheval');    // ['chevaux']
``` 

**fabbot.io** is detecting a typo, but this is not. The patch done by fabpot suggests to replace the french 'embarras' word by 'embarrass'. I shall not remove or replace it, because "embarras" is an invariant word.
