### PR TITLE
Enable APCu for the php 8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,6 +139,23 @@ before_install:
       }
       export -f tpecl
 
+      install_apcu_dev () {
+          local ref=$1
+          local INI=$2
+
+          wget https://github.com/krakjoe/apcu/archive/${ref}.zip
+          unzip ${ref}.zip
+          cd apcu-${ref}
+          phpize
+          ./configure
+          make
+          mv modules/apcu.so $(php -r "echo ini_get('extension_dir');")
+          echo 'extension = apcu.so' >> $INI
+          cd ..
+          rm -rf apcu-${ref} ${ref}.zip
+      }
+      export -f install_apcu_dev
+
     - |
       # Install sigchild-enabled PHP to test the Process component on the lowest PHP matrix line
       if [[ ! $deps && $TRAVIS_PHP_VERSION = ${MIN_PHP%.*} && ! -d php-$MIN_PHP/sapi ]]; then
@@ -192,6 +209,7 @@ before_install:
               tfold ext.mongodb tpecl mongodb-1.6.0 mongodb.so $INI
           elif [[ $PHP = nightly ]]; then
               tfold ext.memcached tpecl memcached-3.1.5 memcached.so $INI
+              tfold ext.apcu install_apcu_dev 9c36db45100d4d27ec33072f4be90f1f5a0108b7 $INI
           fi
       done
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

This PR enables APCu for the php 8 build on Travis.

Since the latest version release on PECL produces a lot of runtime warnings, I'm pulling the latest master commit from github.