### PR TITLE
[FrameworkBundle] don't use abstract methods in MicroKernelTrait, their semantics changed in PHP 8

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -39,7 +39,7 @@ trait MicroKernelTrait
      *         ->controller('App\Controller\AdminController::dashboard')
      *     ;
      */
-    abstract protected function configureRoutes(RoutingConfigurator $routes);
+    //abstract protected function configureRoutes(RoutingConfigurator $routes);
 
     /**
      * Configures the container.
@@ -58,7 +58,7 @@ trait MicroKernelTrait
      *
      *     $c->parameters()->set('halloween', 'lot of fun');
      */
-    abstract protected function configureContainer(ContainerConfigurator $c);
+    //abstract protected function configureContainer(ContainerConfigurator $c);
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In PHP 8, abstract methods on traits are now enforcing that their using classes match the signature.

But this is not the semantics we need in this trait: we want to allow ppl to use a different type of configurators, to provide extensibility of the DSL each provide.

This makes nightly job fail with fatal error currently.

There is no other options here.

/cc @nikic FYI