### PR TITLE
Allow bool value in FormInterface::submit docblock

### DIFF
--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -299,11 +299,11 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Submits data to the form.
      *
-     * @param string|array|null $submittedData The submitted data
-     * @param bool              $clearMissing  Whether to set fields to NULL
-     *                                         when they are missing in the
-     *                                         submitted data. This argument
-     *                                         is only used in compound form
+     * @param string|array|bool|null $submittedData The submitted data
+     * @param bool                   $clearMissing  Whether to set fields to NULL
+     *                                              when they are missing in the
+     *                                              submitted data. This argument
+     *                                              is only used in compound form
      *
      * @return $this
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | 
| Tickets       | 
| License       | MIT
| Doc PR        | 

We are passing `false` there directly (in our case as a workaround for https://github.com/symfony/symfony/issues/17899) for years without issues