### PR TITLE
[HttpFoundation] Avoid TypeError when calling \SessionHandlerInterface::gc()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MarshallingSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MarshallingSessionHandlerTest.php
@@ -72,9 +72,9 @@ class MarshallingSessionHandlerTest extends TestCase
         $marshallingSessionHandler = new MarshallingSessionHandler($this->handler, $this->marshaller);
 
         $this->handler->expects($this->once())->method('gc')
-            ->with('maxlifetime')->willReturn(true);
+            ->with(4711)->willReturn(true);
 
-        $marshallingSessionHandler->gc('maxlifetime');
+        $marshallingSessionHandler->gc(4711);
     }
 
     public function testRead()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

This should fix the remaining red php 8 test of the HttpFoundation suite.