### PR TITLE
[FrameworkBundle] Fix MicroKernelTrait for php 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,6 @@ matrix:
         - php: nightly
           services: [memcached]
     fast_finish: true
-    allow_failures:
-      - php: nightly
 
 cache:
     directories:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

This PR fixes several php 8 related issues with `MicroKernelTrait`.

* Anonymous microkernel classes were not handled properly. I've added a test case to cover this scenario and fixed the issues.
* As part of the upgrade path, the trait logic parsed `TypeErrors` raised by php. That code broke because the wording of those errors has changed. I've replaced that logic with a hopefully less brittle reflection-based approach.
* In order to fix compatibility issues, @nicolas-grekas has already commented out the two abstract methods of the trait. If someone forgets to implement them, they would've ran into rather cryptic errors. I've added tests for these scenarios as well and introduced user-friendly exceptions.

I've noticed that implementing an old-style `configureContainer()` does not raise any deprecation. Is that on purpose? I really think that we should deprecate the old way, so we can re-add the abstract methods again in Symfony 6.