### PR TITLE
[DependencyInjection] Fixed tests for wither with static return type

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/WitherStaticReturnType.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/WitherStaticReturnType.php
@@ -2,6 +2,8 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
+use Symfony\Component\DependencyInjection\Tests\Compiler\Foo;
+
 class WitherStaticReturnType
 {
     public $foo;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_staticreturntype.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_wither_staticreturntype.php
@@ -48,11 +48,11 @@ class Symfony_DI_PhpDumper_Service_WitherStaticReturnType extends Container
     /**
      * Gets the public 'wither' shared autowired service.
      *
-     * @return \Symfony\Component\DependencyInjection\Tests\Compiler\WitherStaticReturnType
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\WitherStaticReturnType
      */
     protected function getWitherService()
     {
-        $instance = new \Symfony\Component\DependencyInjection\Tests\Compiler\WitherStaticReturnType();
+        $instance = new \Symfony\Component\DependencyInjection\Tests\Fixtures\WitherStaticReturnType();
 
         $a = new \Symfony\Component\DependencyInjection\Tests\Compiler\Foo();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

This PR fixes the remaining failing test on php 8 for the DependencyInjection suite.