### PR TITLE
[Mime] Allow email message to have "To", "Cc", or "Bcc" header to be valid

### DIFF
--- a/src/Symfony/Component/Mime/Message.php
+++ b/src/Symfony/Component/Mime/Message.php
@@ -122,8 +122,8 @@ class Message extends RawMessage
 
     public function ensureValidity()
     {
-        if (!$this->headers->has('To')) {
-            throw new LogicException('An email must have a "To" header.');
+        if (!$this->headers->has('To') && !$this->headers->has('Cc') && !$this->headers->has('Bcc')) {
+            throw new LogicException('An email must have a "To", "Cc", or "Bcc" header.');
         }
 
         if (!$this->headers->has('From') && !$this->headers->has('Sender')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36944
| License       | MIT
| Doc PR        | N/A

Allow emails to have any one of To:, Cc:, or Bcc: fields rather than forcing a required To: field.