### PR TITLE
Verify bytes written in Filesystem::dumpFile()

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -685,7 +685,7 @@ class Filesystem
         $tmpFile = $this->tempnam($dir, basename($filename));
 
         if (\is_resource($content)) {
-            $expectedSize = fstat($content)['size'];
+            $expectedSize = fstat($content)['size'] - ftell($content);
         } else {
             $expectedSize = array_sum(array_map('strlen', (array) $content));
         }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -684,13 +684,19 @@ class Filesystem
         // when the filesystem supports chmod.
         $tmpFile = $this->tempnam($dir, basename($filename));
 
+        $expectedSize = false;
+
         if (\is_resource($content)) {
-            $expectedSize = fstat($content)['size'] - ftell($content);
+            $stat = fstat($content);
+            if (false !== $stat) {
+                $expectedSize = $stat['size'] - ftell($content);
+            }
         } else {
             $expectedSize = array_sum(array_map('strlen', (array) $content));
         }
 
-        if ($expectedSize !== ($actualSize = @file_put_contents($tmpFile, $content))) {
+        $actualSize = @file_put_contents($tmpFile, $content);
+        if ((false === $expectedSize && false === $actualSize) && ($actualSize !== $expectedSize)) {
             throw new IOException(sprintf('Failed to write file "%s". Wrote %d of %d bytes.', $filename, $actualSize, $expectedSize), 0, null, $filename);
         }
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -663,8 +663,8 @@ class Filesystem
     /**
      * Atomically dumps content into a file.
      *
-     * @param string $filename The file to be written to
-     * @param string $content  The data to write into the file
+     * @param string                $filename The file to be written to
+     * @param string|resource|array $content  The data to write into the file
      *
      * @throws IOException if the file cannot be written to
      */
@@ -684,8 +684,14 @@ class Filesystem
         // when the filesystem supports chmod.
         $tmpFile = $this->tempnam($dir, basename($filename));
 
-        if (false === @file_put_contents($tmpFile, $content)) {
-            throw new IOException(sprintf('Failed to write file "%s".', $filename), 0, null, $filename);
+        if (\is_resource($content)) {
+            $expectedSize = fstat($content)['size'];
+        } else {
+            $expectedSize = array_sum(array_map('strlen', (array) $content));
+        }
+
+        if ($expectedSize !== ($actualSize = @file_put_contents($tmpFile, $content))) {
+            throw new IOException(sprintf('Failed to write file "%s". Wrote %d of %d bytes.', $filename, $actualSize, $expectedSize), 0, null, $filename);
         }
 
         @chmod($tmpFile, file_exists($filename) ? fileperms($filename) : 0666 & ~umask());

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -663,8 +663,8 @@ class Filesystem
     /**
      * Atomically dumps content into a file.
      *
-     * @param string                $filename The file to be written to
-     * @param string|resource|array $content  The data to write into the file
+     * @param string          $filename The file to be written to
+     * @param string|resource $content  The data to write into the file
      *
      * @throws IOException if the file cannot be written to
      */

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1520,6 +1520,23 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertStringEqualsFile($filename, 'ar');
     }
 
+    /**
+     * @group network
+     */
+    public function testDumpFileWithHttpStream()
+    {
+        if (!\in_array('https', stream_get_wrappers())) {
+            $this->markTestSkipped('"https" stream wrapper is not enabled.');
+        }
+        $sourceFilePath = 'https://symfony.com/images/common/logo/logo_symfony_header.png';
+        $targetFilePath = $this->workspace.\DIRECTORY_SEPARATOR.'dump_target_file';
+
+        $this->filesystem->dumpFile($targetFilePath, fopen($sourceFilePath, 'rb'));
+
+        $this->assertFileExists($targetFilePath);
+        $this->assertEquals(file_get_contents($sourceFilePath), file_get_contents($targetFilePath));
+    }
+
     public function testDumpFileOverwritesAnExistingFile()
     {
         $filename = $this->workspace.\DIRECTORY_SEPARATOR.'foo.txt';

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1505,6 +1505,21 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertStringEqualsFile($filename, 'bar');
     }
 
+    public function testDumpPartialFileWithResource()
+    {
+        $filename = $this->workspace.\DIRECTORY_SEPARATOR.'foo'.\DIRECTORY_SEPARATOR.'baz.txt';
+
+        $resource = fopen('php://memory', 'rw');
+        fwrite($resource, 'bar');
+        fseek($resource, 1);
+
+        $this->filesystem->dumpFile($filename, $resource);
+
+        fclose($resource);
+        $this->assertFileExists($filename);
+        $this->assertStringEqualsFile($filename, 'ar');
+    }
+
     public function testDumpFileOverwritesAnExistingFile()
     {
         $filename = $this->workspace.\DIRECTORY_SEPARATOR.'foo.txt';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |  -
| License       | MIT
| Doc PR        | 

This PR fixes a problem where `dumpFile()` can write some bytes of a file but not all.