### PR TITLE
[HttpClient] fix management of shorter-than-requested timeouts with AmpHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTest.php
@@ -12,18 +12,15 @@
 namespace Symfony\Component\HttpClient\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpClient\AmpHttpClient;
-use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\NativeHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class HttpClientTest extends TestCase
 {
     public function testCreateClient()
     {
-        if (\extension_loaded('curl') && ('\\' !== \DIRECTORY_SEPARATOR || ini_get('curl.cainfo') || ini_get('openssl.cafile') || ini_get('openssl.capath')) && 0x073d00 <= curl_version()['version_number']) {
-            $this->assertInstanceOf(CurlHttpClient::class, HttpClient::create());
-        } else {
-            $this->assertInstanceOf(AmpHttpClient::class, HttpClient::create());
-        }
+        $this->assertInstanceOf(HttpClientInterface::class, HttpClient::create());
+        $this->assertNotInstanceOf(NativeHttpClient::class, HttpClient::create());
     }
 }

--- a/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
+++ b/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
@@ -116,7 +116,7 @@ switch ($vars['REQUEST_URI']) {
         echo '<1>';
         @ob_flush();
         flush();
-        usleep(600000);
+        usleep(500000);
         echo '<2>';
         exit;
 

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -745,7 +745,7 @@ abstract class HttpClientTestCase extends TestCase
         usleep(300000); // wait for the previous test to release the server
         $client = $this->getHttpClient(__FUNCTION__);
         $response = $client->request('GET', 'http://localhost:8057/timeout-body', [
-            'timeout' => 0.3,
+            'timeout' => 0.25,
         ]);
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This will fix the most transient test in our CI, which was not a false positive.