### PR TITLE
[WebProfilerBundle] changed label of memory usage in time panel (Mb into MiB)

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.js
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.js
@@ -94,7 +94,7 @@ class TimelineEngine {
 
     createLabel(name, duration, memory, period) {
         const label = this.renderer.createText(name, period.start * this.scale, this.labelY, 'timeline-label');
-        const sublabel = this.renderer.createTspan(`  ${duration} ms / ${memory} Mb`, 'timeline-sublabel');
+        const sublabel = this.renderer.createTspan(`  ${duration} ms / ${memory} MiB`, 'timeline-sublabel');
 
         label.appendChild(sublabel);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #36533
| License       | MIT
| Doc PR        | -

This PR fixes the memory usage labels in the time panel of the web profiler for 4.4+. PR #36571 already fixed this for 3.4 but since the time panel has been rewritten in 4.3, that minor fix has not correctly been transferred into 4.4+.