### PR TITLE
[Security] Fixed handling of CSRF logout error

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -102,7 +102,7 @@ class ExceptionListener
             }
 
             if ($exception instanceof LogoutException) {
-                $this->handleLogoutException($exception);
+                $this->handleLogoutException($event, $exception);
 
                 return;
             }
@@ -172,10 +172,12 @@ class ExceptionListener
         }
     }
 
-    private function handleLogoutException(LogoutException $exception)
+    private function handleLogoutException(GetResponseForExceptionEvent $event, LogoutException $exception)
     {
+        $event->setException(new AccessDeniedHttpException($exception->getMessage(), $exception));
+
         if (null !== $this->logger) {
-            $this->logger->info('A LogoutException was thrown.', ['exception' => $exception]);
+            $this->logger->info('A LogoutException was thrown; wrapping with AccessDeniedHttpException', ['exception' => $exception]);
         }
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverIn
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\LogoutException;
 use Symfony\Component\Security\Http\Authorization\AccessDeniedHandlerInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener;
@@ -158,6 +159,17 @@ class ExceptionListenerTest extends TestCase
 
         $this->assertEquals('OK', $event->getResponse()->getContent());
         $this->assertSame(null === $eventException ? $exception : $eventException, $event->getException()->getPrevious());
+    }
+
+    public function testLogoutException()
+    {
+        $event = $this->createEvent(new LogoutException('Invalid CSRF.'));
+
+        $listener = $this->createExceptionListener();
+        $listener->onKernelException($event);
+
+        $this->assertEquals('Invalid CSRF.', $event->getException()->getMessage());
+        $this->assertEquals(403, $event->getException()->getStatusCode());
     }
 
     public function getAccessDeniedExceptionProvider()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36814
| License       | MIT
| Doc PR        | -

8 years ago, a typo was made while refactoring the `ExceptionListener`, loosing this logic (https://github.com/symfony/symfony/commit/46071f3238f0670916a1f043a620df9616497012). I think we should fix it.

The `LogoutException` is a very generic name for something only used when the CSRF token is invalid. Should we match the exception message to make sure only this CSRF error is transformed into 403? I didn't yet do it because any usage of `LogoutException` would have resulted in 500, which always is worse than 403.