### PR TITLE
[PropertyInfo] Make PhpDocExtractor compatible with phpDocumentor v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,7 +121,7 @@
         "egulias/email-validator": "~1.2,>=1.2.8|~2.0",
         "symfony/phpunit-bridge": "^5.0.8",
         "symfony/security-acl": "~2.8|~3.0",
-        "phpdocumentor/reflection-docblock": "^3.0|^4.0",
+        "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "twig/cssinliner-extra": "^2.12",
         "twig/inky-extra": "^2.12",
         "twig/markdown-extra": "^2.12"

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PropertyInfo\Extractor;
 
 use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\DocBlockFactory;
 use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use phpDocumentor\Reflection\Types\Context;
@@ -88,10 +89,12 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         }
 
         foreach ($docBlock->getTagsByName('var') as $var) {
-            $varDescription = $var->getDescription()->render();
+            if ($var && !$var instanceof InvalidTag) {
+                $varDescription = $var->getDescription()->render();
 
-            if (!empty($varDescription)) {
-                return $varDescription;
+                if (!empty($varDescription)) {
+                    return $varDescription;
+                }
             }
         }
 
@@ -142,7 +145,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         $types = [];
         /** @var DocBlock\Tags\Var_|DocBlock\Tags\Return_|DocBlock\Tags\Param $tag */
         foreach ($docBlock->getTagsByName($tag) as $tag) {
-            if ($tag && null !== $tag->getType()) {
+            if ($tag && !$tag instanceof InvalidTag && null !== $tag->getType()) {
                 $types = array_merge($types, $this->phpDocTypeHelper->getTypes($tag->getType()));
             }
         }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/InvalidDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/InvalidDummy.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+/**
+ * @author Martin Rademacher <mano@radebatz.net>
+ */
+class InvalidDummy
+{
+    /**
+     * @var
+     */
+    public $pub;
+
+    /**
+     * @return
+     */
+    public static function getStat()
+    {
+        return 'stat';
+    }
+
+    /**
+     * Foo.
+     *
+     * @param
+     */
+    public function setFoo($foo)
+    {
+    }
+
+    /**
+     * Bar.
+     *
+     * @return
+     */
+    public function getBar()
+    {
+        return 'bar';
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/composer.json
+++ b/src/Symfony/Component/PropertyInfo/composer.json
@@ -30,7 +30,7 @@
         "symfony/serializer": "^3.4|^4.0|^5.0",
         "symfony/cache": "^3.4|^4.0|^5.0",
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-        "phpdocumentor/reflection-docblock": "^3.0|^4.0",
+        "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "doctrine/annotations": "~1.7"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36049
| License       | MIT
| Doc PR        | N/A

Version 5 of phpDocumentor introduced some changes to the `getTagsByName()` method that break the `PhpDocExtractor`.

More specific, it now returns an instance of `InvalidTag` instead of `null` when parsing an invalid tag.