### PR TITLE
[Messenger] Add "tls" parameter for secure Redis connection

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -102,7 +102,7 @@ class Connection
         if (\array_key_exists('tls', $redisOptions)) {
             if (1 === ($tls = filter_var($redisOptions['tls'], FILTER_VALIDATE_INT))) {
                 $connectionCredentials['host'] = 'tls://'.$connectionCredentials['host'];
-            };
+            }
         }
         
         $autoSetup = null;

--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -99,6 +99,12 @@ class Connection
             parse_str($parsedUrl['query'], $redisOptions);
         }
 
+        if (\array_key_exists('tls', $redisOptions)) {
+            if (1 === ($tls = filter_var($redisOptions['tls'], FILTER_VALIDATE_INT))) {
+                $connectionCredentials['host'] = 'tls://'.$connectionCredentials['host'];
+            };
+        }
+        
         $autoSetup = null;
         if (\array_key_exists('auto_setup', $redisOptions)) {
             $autoSetup = filter_var($redisOptions['auto_setup'], FILTER_VALIDATE_BOOLEAN);

--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -104,7 +104,7 @@ class Connection
                 $connectionCredentials['host'] = 'tls://'.$connectionCredentials['host'];
             }
         }
-        
+
         $autoSetup = null;
         if (\array_key_exists('auto_setup', $redisOptions)) {
             $autoSetup = filter_var($redisOptions['auto_setup'], FILTER_VALIDATE_BOOLEAN);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.4, 5.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

While trying out DigitalOceans managed Redis server i noticed that it's currently not possible for the Symfony 5.0 Messenger to connect using a secure connection. While there is a "tls" parameter for the 5.1 branch, this patch will allow TLS connections in the 5.0 branch (and possibly 4.4).

`MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages?tls=1`