### PR TITLE
[SecurityBundle] Fixed version constraint on security-core and security-guard

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -23,9 +23,9 @@
         "symfony/event-dispatcher": "^5.1",
         "symfony/http-kernel": "^5.0",
         "symfony/polyfill-php80": "^1.15",
-        "symfony/security-core": "^4.4|^5.0",
+        "symfony/security-core": "^5.1",
         "symfony/security-csrf": "^4.4|^5.0",
-        "symfony/security-guard": "^4.4|^5.0",
+        "symfony/security-guard": "^5.1",
         "symfony/security-http": "^5.1"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://symfony.com/blog/new-in-symfony-5-1-updated-security-system#comment-24048
| License       | MIT
| Doc PR        | -

We somehow completely forgot to upgrade these version constraints to `^5.1`.

*build failures are unrelated*