### PR TITLE
Handle fetch mode deprecation of DBAL 2.11.

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -63,7 +63,7 @@ class DoctrineTokenProvider implements TokenProviderInterface
         $paramValues = ['series' => $series];
         $paramTypes = ['series' => \PDO::PARAM_STR];
         $stmt = $this->conn->executeQuery($sql, $paramValues, $paramTypes);
-        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        $row = method_exists($stmt, 'fetchAssociative') ? $stmt->fetchAssociative() : $stmt->fetch(\PDO::FETCH_ASSOC);
 
         if ($row) {
             return new PersistentToken($row['class'], $row['username'], $series, $row['value'], new \DateTime($row['last_used']));

--- a/src/Symfony/Bridge/Doctrine/Tests/Security/RememberMe/DoctrineTokenProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/RememberMe/DoctrineTokenProviderTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Security\RememberMe;
+
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Security\RememberMe\DoctrineTokenProvider;
+use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
+use Symfony\Component\Security\Core\Exception\TokenNotFoundException;
+
+/**
+ * @requires extension pdo_sqlite
+ */
+class DoctrineTokenProviderTest extends TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        if (\PHP_VERSION_ID >= 80000) {
+            self::markTestSkipped('Doctrine DBAL 2.x is incompatible with PHP 8.');
+        }
+    }
+
+    public function testCreateNewToken()
+    {
+        $provider = $this->bootstrapProvider();
+
+        $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTime('2013-01-26T18:23:51'));
+        $provider->createNewToken($token);
+
+        $this->assertEquals($provider->loadTokenBySeries('someSeries'), $token);
+    }
+
+    public function testLoadTokenBySeriesThrowsNotFoundException()
+    {
+        $provider = $this->bootstrapProvider();
+
+        $this->expectException(TokenNotFoundException::class);
+        $provider->loadTokenBySeries('someSeries');
+    }
+
+    public function testUpdateToken()
+    {
+        $provider = $this->bootstrapProvider();
+
+        $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTime('2013-01-26T18:23:51'));
+        $provider->createNewToken($token);
+        $provider->updateToken('someSeries', 'newValue', $lastUsed = new \DateTime('2014-06-26T22:03:46'));
+        $token = $provider->loadTokenBySeries('someSeries');
+
+        $this->assertEquals('newValue', $token->getTokenValue());
+        $this->assertEquals($token->getLastUsed(), $lastUsed);
+    }
+
+    public function testDeleteToken()
+    {
+        $provider = $this->bootstrapProvider();
+        $token = new PersistentToken('someClass', 'someUser', 'someSeries', 'tokenValue', new \DateTime('2013-01-26T18:23:51'));
+        $provider->createNewToken($token);
+        $provider->deleteTokenBySeries('someSeries');
+
+        $this->expectException(TokenNotFoundException::class);
+
+        $provider->loadTokenBySeries('someSeries');
+    }
+
+    /**
+     * @return DoctrineTokenProvider
+     */
+    private function bootstrapProvider()
+    {
+        $connection = DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'url' => 'sqlite:///:memory:',
+        ]);
+        $connection->executeUpdate(<<< 'SQL'
+            CREATE TABLE rememberme_token (
+                series   char(88)     UNIQUE PRIMARY KEY NOT NULL,
+                value    char(88)     NOT NULL,
+                lastUsed datetime     NOT NULL,
+                class    varchar(100) NOT NULL,
+                username varchar(200) NOT NULL
+            );
+SQL
+        );
+
+        return new DoctrineTokenProvider($connection);
+    }
+}

--- a/src/Symfony/Component/Cache/Tests/Traits/PdoPruneableTrait.php
+++ b/src/Symfony/Component/Cache/Tests/Traits/PdoPruneableTrait.php
@@ -24,11 +24,11 @@ trait PdoPruneableTrait
         $getPdoConn = $o->getMethod('getConnection');
         $getPdoConn->setAccessible(true);
 
-        /** @var \Doctrine\DBAL\Statement $select */
+        /** @var \Doctrine\DBAL\Statement|\PDOStatement $select */
         $select = $getPdoConn->invoke($cache)->prepare('SELECT 1 FROM cache_items WHERE item_id LIKE :id');
         $select->bindValue(':id', sprintf('%%%s', $name));
         $select->execute();
 
-        return 0 === \count($select->fetchAll(\PDO::FETCH_COLUMN));
+        return 1 !== (int) (method_exists($select, 'fetchOne') ? $select->fetchOne() : $select->fetch(\PDO::FETCH_COLUMN));
     }
 }

--- a/src/Symfony/Component/Cache/Traits/PdoTrait.php
+++ b/src/Symfony/Component/Cache/Traits/PdoTrait.php
@@ -177,7 +177,13 @@ trait PdoTrait
         }
         $stmt->execute();
 
-        while ($row = $stmt->fetch(\PDO::FETCH_NUM)) {
+        if (method_exists($stmt, 'iterateNumeric')) {
+            $stmt = $stmt->iterateNumeric();
+        } else {
+            $stmt->setFetchMode(\PDO::FETCH_NUM);
+        }
+
+        foreach ($stmt as $row) {
             if (null === $row[1]) {
                 $expired[] = $row[0];
             } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | N/A

See doctrine/dbal#4019

DBAL has deprecated PDO-style fetch modes in favor of more explicit methods.