### PR TITLE
[Messenger] Change the default notify timeout value for PostgreSQL

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -24,11 +24,11 @@ final class PostgreSqlConnection extends Connection
 {
     /**
      * * use_notify: Set to false to disable the use of LISTEN/NOTIFY. Default: true
-     * * check_delayed_interval: The interval to check for delayed messages, in milliseconds. Set to 0 to disable checks. Default: 1000
+     * * check_delayed_interval: The interval to check for delayed messages, in milliseconds. Set to 0 to disable checks. Default: 60000 (1 minute)
      * * get_notify_timeout: The length of time to wait for a response when calling PDO::pgsqlGetNotify, in milliseconds. Default: 0.
      */
     protected const DEFAULT_OPTIONS = parent::DEFAULT_OPTIONS + [
-        'check_delayed_interval' => 1000,
+        'check_delayed_interval' => 60000,
         'get_notify_timeout' => 0,
     ];
 
@@ -75,6 +75,8 @@ final class PostgreSqlConnection extends Connection
             // delayed messages
             (microtime(true) * 1000 - $this->queueEmptiedAt < $this->configuration['check_delayed_interval'])
         ) {
+            usleep(1000);
+
             return null;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1 <!-- see below -->
| Bug fix?      | yes-ish
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | n/a

The default value of 0 means that notify is kind of disable and that incurs many SQL requests. 10 minutes is kind of arbitrary but seems to be a good balance between waiting for a message (blocking) and trying again later in case of an issue.
