### PR TITLE
[String] use base58 by default in ByteString::fromRandom()

### DIFF
--- a/src/Symfony/Component/String/ByteString.php
+++ b/src/Symfony/Component/String/ByteString.php
@@ -25,7 +25,7 @@ use Symfony\Component\String\Exception\RuntimeException;
  */
 class ByteString extends AbstractString
 {
-    private const ALPHABET_ALPHANUMERIC = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    private const ALPHABET_ALPHANUMERIC = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
 
     public function __construct(string $string = '')
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This is the list from the [bitcoin alphabet](https://en.wikipedia.org/wiki/Base58): it's been designed to avoid characters that look ambiguous when printed.