### PR TITLE
[ErrorHandler] fix setting $trace to null in FatalError

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Error/FatalError.php
+++ b/src/Symfony/Component/ErrorHandler/Error/FatalError.php
@@ -72,9 +72,11 @@ class FatalError extends \Error
             'line' => $error['line'],
             'trace' => $trace,
         ] as $property => $value) {
-            $refl = new \ReflectionProperty(\Error::class, $property);
-            $refl->setAccessible(true);
-            $refl->setValue($this, $value);
+            if (null !== $value) {
+                $refl = new \ReflectionProperty(\Error::class, $property);
+                $refl->setAccessible(true);
+                $refl->setValue($this, $value);
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Spotted by @nikic in https://github.com/php/php-src/pull/5620#issuecomment-635258024