### PR TITLE
Fix TransformationFailedException for empty WeekType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/WeekToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/WeekToArrayTransformer.php
@@ -33,7 +33,7 @@ class WeekToArrayTransformer implements DataTransformerInterface
      */
     public function transform($value)
     {
-        if (null === $value) {
+        if (null === $value || '' === $value) {
             return ['year' => null, 'week' => null];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

There is an exception when you submit an empty `type='week'` field for `Symfony\Component\Form\Extension\Core\Type\WeekType`.