### PR TITLE
[TwigBridge] fix fallback html-to-txt body converter

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php
+++ b/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php
@@ -74,6 +74,6 @@ final class BodyRenderer implements BodyRendererInterface
             return $this->converter->convert($html);
         }
 
-        return strip_tags($html);
+        return strip_tags(preg_replace('{<(head|style)\b.*?</\1>}i', '', $html));
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Mime/BodyRendererTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/BodyRendererTest.php
@@ -29,11 +29,12 @@ class BodyRendererTest extends TestCase
 
     public function testRenderHtmlOnly(): void
     {
-        $email = $this->prepareEmail(null, '<b>HTML</b>');
+        $html = '<head>head</head><b>HTML</b><style type="text/css">css</style>';
+        $email = $this->prepareEmail(null, $html);
         $body = $email->getBody();
         $this->assertInstanceOf(AlternativePart::class, $body);
         $this->assertEquals('HTML', $body->getParts()[0]->bodyToString());
-        $this->assertEquals('<b>HTML</b>', $body->getParts()[1]->bodyToString());
+        $this->assertEquals(str_replace('=', '=3D', $html), $body->getParts()[1]->bodyToString());
     }
 
     public function testRenderHtmlOnlyWithTextSet(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Right now, the content of the `<head>` and `<style>` are dumped as text. This fixes it.

Of course, use `league/html-to-markdown` if you need a better parser.