### PR TITLE
Add meaningful message when using ProcessHelper and Process is not installed

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProcessHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProcessHelper.php
@@ -37,6 +37,10 @@ class ProcessHelper extends Helper
      */
     public function run(OutputInterface $output, $cmd, $error = null, callable $callback = null, $verbosity = OutputInterface::VERBOSITY_VERY_VERBOSE)
     {
+        if (!class_exists(Process::class)) {
+            throw new \LogicException('The Process helper requires the "Process" component. Install "symfony/process" to use it.');
+        }
+
         if ($output instanceof ConsoleOutputInterface) {
             $output = $output->getErrorOutput();
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When using the process helper without the `Process` component, a php fatal error is triggered (`PHP Fatal error:  Uncaught Error: Class 'Symfony\Component\Process\Process' not found`). This PR adds a meaningful exception; allowing to display a console error message instead of a raw php fatal error.
