### PR TITLE
[Notifier] Fix Notification::getChannels() signature (remove unused argument)

### DIFF
--- a/src/Symfony/Component/Notifier/Notification/Notification.php
+++ b/src/Symfony/Component/Notifier/Notification/Notification.php
@@ -158,7 +158,7 @@ class Notification
         return $this;
     }
 
-    public function getChannels(Recipient $recipient): array
+    public function getChannels(): array
     {
         return $this->channels;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT
