### PR TITLE
[Validator] use "allowedVariables" to configure the ExpressionLanguageSyntax constraint

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntax.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntax.php
@@ -29,8 +29,7 @@ class ExpressionLanguageSyntax extends Constraint
 
     public $message = 'This value should be a valid expression.';
     public $service;
-    public $validateNames = true;
-    public $names = [];
+    public $allowedVariables = null;
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntaxValidator.php
@@ -16,6 +16,7 @@ use Symfony\Component\ExpressionLanguage\SyntaxError;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 /**
  * @author Andrey Sevastianov <mrpkmail@gmail.com>
@@ -39,7 +40,7 @@ class ExpressionLanguageSyntaxValidator extends ConstraintValidator
         }
 
         if (!\is_string($expression)) {
-            throw new UnexpectedTypeException($expression, 'string');
+            throw new UnexpectedValueException($expression, 'string');
         }
 
         if (null === $this->expressionLanguage) {
@@ -47,7 +48,7 @@ class ExpressionLanguageSyntaxValidator extends ConstraintValidator
         }
 
         try {
-            $this->expressionLanguage->lint($expression, ($constraint->validateNames ? ($constraint->names ?? []) : null));
+            $this->expressionLanguage->lint($expression, $constraint->allowedVariables);
         } catch (SyntaxError $exception) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ syntax_error }}', $this->formatValue($exception->getMessage()))

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Constraints\ExpressionLanguageSyntax;
 use Symfony\Component\Validator\Constraints\ExpressionLanguageSyntaxValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
-class ExpressionLanguageSyntaxTest extends ConstraintValidatorTestCase
+class ExpressionLanguageSyntaxValidatorTest extends ConstraintValidatorTestCase
 {
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|ExpressionLanguage
@@ -45,6 +45,7 @@ class ExpressionLanguageSyntaxTest extends ConstraintValidatorTestCase
 
         $this->validator->validate($this->value, new ExpressionLanguageSyntax([
             'message' => 'myMessage',
+            'allowedVariables' => [],
         ]));
 
         $this->assertNoViolation();
@@ -58,7 +59,6 @@ class ExpressionLanguageSyntaxTest extends ConstraintValidatorTestCase
 
         $this->validator->validate($this->value, new ExpressionLanguageSyntax([
             'message' => 'myMessage',
-            'validateNames' => false,
         ]));
 
         $this->assertNoViolation();
@@ -73,6 +73,7 @@ class ExpressionLanguageSyntaxTest extends ConstraintValidatorTestCase
 
         $this->validator->validate($this->value, new ExpressionLanguageSyntax([
             'message' => 'myMessage',
+            'allowedVariables' => [],
         ]));
 
         $this->buildViolation('myMessage')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix symfony/symfony-docs#13669
| License       | MIT
| Doc PR        | 