### PR TITLE
[String] introduce AbstractString::EMPTY

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -39,7 +39,9 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
     public const PREG_SPLIT_DELIM_CAPTURE = PREG_SPLIT_DELIM_CAPTURE;
     public const PREG_SPLIT_OFFSET_CAPTURE = PREG_SPLIT_OFFSET_CAPTURE;
 
-    protected $string = '';
+    public const EMPTY = '';
+
+    protected $string = self::EMPTY;
     protected $ignoreCase = false;
 
     abstract public function __construct(string $string = '');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | 

I know this might be controversial and I don't know much about PHP internals, whats cheaper in case of memory, to initialize an empty string with `''` or using a constant. 

Eitherway I know C# has a String.Empty() function (default value of String class) and we may have one in PHP, too.

Any comments?
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
