### PR TITLE
[FrameworkBundle] fix type annotation on ControllerTrait::addFlash()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -187,7 +187,7 @@ trait ControllerTrait
      * Adds a flash message to the current session for type.
      *
      * @param string $type    The type
-     * @param string $message The message
+     * @param mixed $message The message
      *
      * @throws \LogicException
      *

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -187,7 +187,7 @@ trait ControllerTrait
      * Adds a flash message to the current session for type.
      *
      * @param string $type    The type
-     * @param mixed $message The message
+     * @param mixed  $message The message
      *
      * @throws \LogicException
      *


### PR DESCRIPTION
Second part of https://github.com/symfony/symfony/pull/36913 - see https://github.com/symfony/symfony/pull/36913#issuecomment-636428437
(Couldn't figure out how to include it in the same PR)

