### PR TITLE
[FrameworkBundle] Fix enabled_locales behavior

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1094,7 +1094,7 @@ class FrameworkExtension extends Extension
         $defaultOptions['cache_dir'] = $config['cache_dir'];
         $translator->setArgument(4, $defaultOptions);
 
-        $translator->setArgument(6, $config['enabled_locales']);
+        $translator->setArgument(5, $config['enabled_locales']);
 
         $container->setParameter('translator.logging', $config['logging']);
         $container->setParameter('translator.default_path', $config['default_path']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I was experimenting with enabled_locales on my application and I noticed the cache didn't actually change. It seems the generated service definition was invalid: the file `var/cache/dev/ContainerFEQLy1x/App_KernelDevDebugContainer.php` defined `getTranslator_DefaultService` by calling `new Translator` with 7 arguments instead of 6.

It seems to be due to the fact that the DI extension does not replace the right argument. With the following fix applied the behavior works as expected.

However, reading the comment of Javier in https://github.com/symfony/symfony/pull/32433, it seems he tested it against Demo and it worked with the previous code. I'm not sure why, @javiereguiluz I'd be interested in knowing if I'm missing something here :) .