### PR TITLE
[Security] Fixed PUBLIC_ACCESS in authenticated sessions

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -95,11 +95,13 @@ class AccessListener extends AbstractListener
                 return;
             }
 
-            if ([self::PUBLIC_ACCESS] === $attributes) {
-                return;
+            if ([self::PUBLIC_ACCESS] !== $attributes) {
+                throw $this->createAccessDeniedException($request, $attributes);
             }
+        }
 
-            throw $this->createAccessDeniedException($request, $attributes);
+        if ([self::PUBLIC_ACCESS] === $attributes) {
+            return;
         }
 
         if (!$token->isAuthenticated()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Found while testing https://github.com/scheb/2fa/pull/8, sorry for not spotting it before the stable release :disappointed: 

Currently, authenticated users are denied access for pages that have `PUBLIC_ACCESS` set, as this attribute is only checked when no token was set. It should be checked for both cases.