### PR TITLE
Fix invalid char in SQS Headers

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsIntegrationTest.php
@@ -45,7 +45,7 @@ class AmazonSqsIntegrationTest extends TestCase
         $connection->setup();
         $this->clearSqs($dsn);
 
-        $connection->send('{"message": "Hi"}', ['type' => DummyMessage::class]);
+        $connection->send('{"message": "Hi"}', ['type' => DummyMessage::class, DummyMessage::class => 'special']);
         $this->assertSame(1, $connection->getMessageCount());
 
         $wait = 0;
@@ -54,7 +54,7 @@ class AmazonSqsIntegrationTest extends TestCase
         }
 
         $this->assertEquals('{"message": "Hi"}', $encoded['body']);
-        $this->assertEquals(['type' => DummyMessage::class], $encoded['headers']);
+        $this->assertEquals(['type' => DummyMessage::class, DummyMessage::class => 'special'], $encoded['headers']);
     }
 
     private function clearSqs(string $dsn): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | https://github.com/symfony/symfony/pull/36525#issuecomment-636658635
| License       | MIT
| Doc PR        | /

From [Amazon documnetation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html) header's name have constraints:
- only `a-zA-Z0-9_\.-` + not start/end with a `.`
- 256 char

This PR serialize ALL headers in a single SQS Attribute.