### PR TITLE
[PropertyInfo] Support using the SerializerExtractor with no group check

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -35,7 +35,7 @@ class SerializerExtractor implements PropertyListExtractorInterface
      */
     public function getProperties(string $class, array $context = []): ?array
     {
-        if (!isset($context['serializer_groups']) || !\is_array($context['serializer_groups'])) {
+        if (!\array_key_exists('serializer_groups', $context) || (null !== $context['serializer_groups'] && !\is_array($context['serializer_groups']))) {
             return null;
         }
 
@@ -48,7 +48,7 @@ class SerializerExtractor implements PropertyListExtractorInterface
 
         foreach ($serializerClassMetadata->getAttributesMetadata() as $serializerAttributeMetadata) {
             $ignored = method_exists($serializerClassMetadata, 'isIgnored') && $serializerAttributeMetadata->isIgnored();
-            if (!$ignored && array_intersect($context['serializer_groups'], $serializerAttributeMetadata->getGroups())) {
+            if (!$ignored && (null === $context['serializer_groups'] || array_intersect($context['serializer_groups'], $serializerAttributeMetadata->getGroups()))) {
                 $properties[] = $serializerAttributeMetadata->getName();
             }
         }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
@@ -40,4 +40,9 @@ class SerializerExtractorTest extends TestCase
             $this->extractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', ['serializer_groups' => ['a']])
         );
     }
+
+    public function testGetPropertiesWithAnyGroup()
+    {
+        $this->assertSame(['analyses', 'feet'], $this->extractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy', ['serializer_groups' => null]));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

It seems there is no way currently to leverage the new `@Ignore` annotation metadata without using serializer groups in third party code.
Indeed the only way to access the serializer's metadata is through the PropertyInfo component since metadata are marked as `@internal` in the Serializer component itself. However, the PropertyInfo component doesn't allow accessing them without using a groups constraint.

This PR proposes a fix by interpreting `serializer_groups = null` as no groups constraint.

This feature would be useful in NelmioApiDocBundle, see https://github.com/nelmio/NelmioApiDocBundle/issues/1595.