### PR TITLE
[DependencyInjection] Apply ExpressionLanguageProviderPass to router.default

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddExpressionLanguageProvidersPass.php
@@ -28,8 +28,8 @@ class AddExpressionLanguageProvidersPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         // routing
-        if ($container->has('router')) {
-            $definition = $container->findDefinition('router');
+        if ($container->has('router.default')) {
+            $definition = $container->findDefinition('router.default');
             foreach ($container->findTaggedServiceIds('routing.expression_language_provider', true) as $id => $attributes) {
                 $definition->addMethodCall('addExpressionLanguageProvider', [new Reference($id)]);
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddExpressionLanguageProvidersPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddExpressionLanguageProvidersPassTest.php
@@ -22,16 +22,16 @@ class AddExpressionLanguageProvidersPassTest extends TestCase
     public function testProcessForRouter()
     {
         $container = new ContainerBuilder();
-        $container->addCompilerPass(new AddExpressionLanguageProvidersPass(false));
+        $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
 
         $definition = new Definition('\stdClass');
         $definition->addTag('routing.expression_language_provider');
         $container->setDefinition('some_routing_provider', $definition->setPublic(true));
 
-        $container->register('router', '\stdClass')->setPublic(true);
+        $container->register('router.default', '\stdClass')->setPublic(true);
         $container->compile();
 
-        $router = $container->getDefinition('router');
+        $router = $container->getDefinition('router.default');
         $calls = $router->getMethodCalls();
         $this->assertCount(1, $calls);
         $this->assertEquals('addExpressionLanguageProvider', $calls[0][0]);
@@ -41,14 +41,14 @@ class AddExpressionLanguageProvidersPassTest extends TestCase
     public function testProcessForRouterAlias()
     {
         $container = new ContainerBuilder();
-        $container->addCompilerPass(new AddExpressionLanguageProvidersPass(false));
+        $container->addCompilerPass(new AddExpressionLanguageProvidersPass());
 
         $definition = new Definition('\stdClass');
         $definition->addTag('routing.expression_language_provider');
         $container->setDefinition('some_routing_provider', $definition->setPublic(true));
 
         $container->register('my_router', '\stdClass')->setPublic(true);
-        $container->setAlias('router', 'my_router');
+        $container->setAlias('router.default', 'my_router');
         $container->compile();
 
         $router = $container->getDefinition('my_router');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/37042
| License       | MIT

Using a `chain_router` usually replaces the `router` and add the `router.default` to it's chain.

This would `addExpressionLanguageProvider` to the default router only as the chain router is not expected to have `addExpressionLanguageProvider` as it is not part of the router interface.

