### PR TITLE
[PropertyAccess] Fix getter call order BC

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
@@ -69,6 +69,11 @@ class TestClass
         return $this->publicAccessor;
     }
 
+    public function isPublicAccessor($param)
+    {
+        throw new \LogicException('This method should never have been called.');
+    }
+
     public function getPublicAccessorWithDefaultValue()
     {
         return $this->publicAccessorWithDefaultValue;

--- a/src/Symfony/Component/PropertyAccess/composer.json
+++ b/src/Symfony/Component/PropertyAccess/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "symfony/inflector": "^4.4|^5.0",
         "symfony/polyfill-php80": "^1.15",
-        "symfony/property-info": "^5.1"
+        "symfony/property-info": "^5.1.1"
     },
     "require-dev": {
         "symfony/cache": "^4.4|^5.0"

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -40,7 +40,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     /**
      * @internal
      */
-    public static $defaultAccessorPrefixes = ['is', 'can', 'get', 'has'];
+    public static $defaultAccessorPrefixes = ['get', 'is', 'has', 'can'];
 
     /**
      * @internal


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #37052
| License       | MIT
| Doc PR        | -

Property Accessor breaks BC due to a change in the order of calling the getters, see #37052