### PR TITLE
[String] Fix ellipsis of truncate when not using cut option

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -643,7 +643,11 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
         }
 
         if (!$cut) {
-            $length = $ellipsisLength + ($this->indexOf([' ', "\r", "\n", "\t"], ($length ?: 1) - 1) ?? $stringLength);
+            if (null === $length = $this->indexOf([' ', "\r", "\n", "\t"], ($length ?: 1) - 1)) {
+                return clone $this;
+            }
+
+            $length += $ellipsisLength;
         }
 
         $str = $this->slice(0, $length - $ellipsisLength);

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1450,6 +1450,7 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['foobar...', 'foobar foo', 6, '...', false],
             ['foobar...', 'foobar foo', 7, '...', false],
             ['foobar foo...', 'foobar foo a', 10, '...', false],
+            ['foobar foo aar', 'foobar foo aar', 12, '...', false],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

[Since 5.1](https://symfony.com/blog/new-in-symfony-5-1-string-improvements#keep-the-last-word-when-truncating), we can use a cut option on truncate.
But with this option, we don't have the expected behavior when the entire chain is returned.

Currently:
`u('Lorem Ipsum')->truncate(8, '…', false); // 'Lorem Ipsum...'`
Instead of:
`u('Lorem Ipsum')->truncate(8, '…', false); // 'Lorem Ipsum'`

Thanks to @jmsche for his help.