### PR TITLE
[FrameworkBundle] Extension Serializer issue

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1379,7 +1379,7 @@ class FrameworkExtension extends Extension
 
     private function registerPropertyAccessConfiguration(array $config, ContainerBuilder $container, XmlFileLoader $loader)
     {
-        if (!class_exists('Symfony\Component\PropertyAccess\PropertyAccessor')) {
+        if (!class_exists(PropertyAccessor::class)) {
             return;
         }
 
@@ -1463,7 +1463,7 @@ class FrameworkExtension extends Extension
 
         $chainLoader = $container->getDefinition('serializer.mapping.chain_loader');
 
-        if (!class_exists('Symfony\Component\PropertyAccess\PropertyAccessor')) {
+        if (!class_exists(PropertyAccessor::class)) {
             $container->removeAlias('serializer.property_accessor');
             $container->removeDefinition('serializer.normalizer.object');
         }
@@ -1472,7 +1472,7 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('serializer.encoder.yaml');
         }
 
-        if (!class_exists(UnwrappingDenormalizer::class)) {
+        if (!class_exists(UnwrappingDenormalizer::class) || !class_exists(PropertyAccessor::class)) {
             $container->removeDefinition('serializer.denormalizer.unwrapping');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | ???
| License       | MIT
| Doc PR        | 

Hi,

When creating a new Symfony project and requiring `symfony/serializer` we have an issue with required service.

Here is a simple reproducer:
![image](https://user-images.githubusercontent.com/944409/83497176-6266d480-a4ba-11ea-98cb-7e354be0a273.png)

This bug was introduced by https://github.com/symfony/symfony/pull/31390
