### PR TITLE
[HttpClient] Throw JsonException instead of TransportException on empty response in Response::toArray()

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
@@ -137,7 +137,7 @@ trait ResponseTrait
     public function toArray(bool $throw = true): array
     {
         if ('' === $content = $this->getContent($throw)) {
-            throw new TransportException('Response body is empty.');
+            throw new JsonException('Response body is empty.');
         }
 
         if (null !== $this->jsonData) {

--- a/src/Symfony/Component/HttpClient/Tests/Response/MockResponseTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Response/MockResponseTest.php
@@ -36,6 +36,12 @@ class MockResponseTest extends TestCase
     public function toArrayErrors()
     {
         yield [
+            'content' => '',
+            'responseHeaders' => [],
+            'message' => 'Response body is empty.',
+        ];
+
+        yield [
             'content' => '{}',
             'responseHeaders' => ['content-type' => 'plain/text'],
             'message' => 'Response content-type is "plain/text" while a JSON-compatible one was expected for "https://example.com/file.json".',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37064
| License       | MIT