### PR TITLE
[SecurityCore] use Role instead of RoleInterface in TokenInterface

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Token;
 
-use Symfony\Component\Security\Core\Role\RoleInterface;
+use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
@@ -34,7 +34,7 @@ interface TokenInterface extends \Serializable
     /**
      * Returns the user roles.
      *
-     * @return RoleInterface[] An array of RoleInterface instances
+     * @return Role[] An array of RoleInterface instances
      */
     public function getRoles();
 


### PR DESCRIPTION
AbstractToken now accepts Role only, while AbstractToken::getRoles() returns RoleInterface

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

https://github.com/symfony/symfony/commit/8e873d0b5be64f88b10ba7996300146770f29d1b has broken our static analysis. `AbstractToken::__construct()` now accepts an array of `Role[]` while `TokenInterface::getRoles()` (which `AbstractToken` implements) still returns `RoleInterface[]`.

This is rather simple fix to satisfy static analysis and keeps the consistency of deprecating `RoleInterface`