### PR TITLE
Fix test skipped method call

### DIFF
--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -92,7 +92,7 @@ class VarExporterTest extends TestCase
         } elseif (\PHP_VERSION_ID < 70400) {
             $fixtureFile = __DIR__.'/Fixtures/'.$testName.'-legacy.php';
         } else {
-            $this->markAsSkipped('PHP >= 7.4.6 required.');
+            $this->markTestSkipped('PHP >= 7.4.6 required.');
         }
         $this->assertStringEqualsFile($fixtureFile, $dump);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0, 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

`markAsSkipped()` isn't a valid method. The correct method is `markTestSkipped()`. This leads to a fatal error if you're using your using Ubuntu 20.04's 7.4.3. Best I can tell this is just a typo and the method never existed in phpunit. Probably based on some similarly named skipped methods in some other tests.

From 1e9486de89cf725159107e3e9cfacd467ff799ae

Note, github shows that commit on 4.4.9 but I can't find it on the 4.4 branch. Not sure what's going on there but since it wasn't in the 4.4 branch I targeted 5.0. Let me know if I need to reroll this a different way.
