### PR TITLE
[ErrorHandler] add error enhancer for calling method of a non object

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Error/NonObjectMethodError.php
+++ b/src/Symfony/Component/ErrorHandler/Error/NonObjectMethodError.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ErrorHandler\Error;
+
+class NonObjectMethodError extends \Error
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(string $message, \Throwable $previous)
+    {
+        parent::__construct($message, $previous->getCode(), $previous->getPrevious());
+
+        foreach ([
+            'file' => $previous->getFile(),
+            'line' => $previous->getLine(),
+            'trace' => $previous->getTrace(),
+        ] as $property => $value) {
+            $refl = new \ReflectionProperty(\Error::class, $property);
+            $refl->setAccessible(true);
+            $refl->setValue($this, $value);
+        }
+    }
+}

--- a/src/Symfony/Component/ErrorHandler/ErrorEnhancer/NonObjectMethodErrorEnhancer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorEnhancer/NonObjectMethodErrorEnhancer.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ErrorHandler\ErrorEnhancer;
+
+use Symfony\Component\ErrorHandler\Error\FatalError;
+use Symfony\Component\ErrorHandler\Error\NonObjectMethodError;
+
+/**
+ * Class NonObjectMethodErrorEnhancer.
+ */
+class NonObjectMethodErrorEnhancer implements ErrorEnhancerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function enhance(\Throwable $error): ?\Throwable
+    {
+        if ($error instanceof FatalError) {
+            return null;
+        }
+
+        $message = $error->getMessage();
+        preg_match('/^Call to a member function (.*\(\)) on (.*)$/', $message, $matches);
+        if (!$matches) {
+            return null;
+        }
+
+        $methodName = $matches[1];
+        $objectTypeName = $matches[2];
+
+        if (!\in_array($objectTypeName, ['null', 'array'])) {
+            return null;
+        }
+
+        $messageTemplate = $this->prepareMessage($objectTypeName);
+
+        $line = @file($error->getFile())[$error->getLine() - 1] ?? false;
+        if (!$line) {
+            return null;
+        }
+
+        $expression = $this->extractExpression($line, $methodName);
+        if (!$expression) {
+            return null;
+        }
+
+        $message = sprintf($messageTemplate, $methodName, $expression);
+
+        return new NonObjectMethodError($message, $error);
+    }
+
+    private function prepareMessage(string $objectTypeName): string
+    {
+        if ('array' === $objectTypeName) {
+            return 'Attempted to call method "%s" of expression "%s", which contains a non object, but an array.';
+        }
+
+        return 'Attempted to call method "%s" of expression "%s", which contains a non object, but a null.';
+    }
+
+    private function extractExpression(string $line, string $methodName): string
+    {
+        $pattern = '/(((self|static|[\w]+)::(([\w\(\s\$\,\)\"\'\-\>]+)|(\$[\w\-\>]+)))|(\$[\w\(\s\,\)\"\'\-\>]+))\-\>%s/';
+
+        $patternExpression = sprintf($pattern, $methodName);
+
+        preg_match($patternExpression, $line, $matches);
+
+        if (!$matches) {
+            return '';
+        }
+
+        return $matches[1];
+    }
+}

--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -17,6 +17,7 @@ use Symfony\Component\ErrorHandler\Error\FatalError;
 use Symfony\Component\ErrorHandler\Error\OutOfMemoryError;
 use Symfony\Component\ErrorHandler\ErrorEnhancer\ClassNotFoundErrorEnhancer;
 use Symfony\Component\ErrorHandler\ErrorEnhancer\ErrorEnhancerInterface;
+use Symfony\Component\ErrorHandler\ErrorEnhancer\NonObjectMethodErrorEnhancer;
 use Symfony\Component\ErrorHandler\ErrorEnhancer\UndefinedFunctionErrorEnhancer;
 use Symfony\Component\ErrorHandler\ErrorEnhancer\UndefinedMethodErrorEnhancer;
 use Symfony\Component\ErrorHandler\ErrorRenderer\CliErrorRenderer;
@@ -736,6 +737,7 @@ class ErrorHandler
             new UndefinedFunctionErrorEnhancer(),
             new UndefinedMethodErrorEnhancer(),
             new ClassNotFoundErrorEnhancer(),
+            new NonObjectMethodErrorEnhancer(),
         ];
     }
 

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorEnhancer/NonObjectMethodErrorEnhancerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorEnhancer/NonObjectMethodErrorEnhancerTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ErrorHandler\Tests\ErrorEnhancer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\ErrorHandler\Error\NonObjectMethodError;
+use Symfony\Component\ErrorHandler\ErrorEnhancer\NonObjectMethodErrorEnhancer;
+
+class NonObjectMethodErrorEnhancerTest extends TestCase
+{
+    public $nullProperty = null;
+
+    public static function method($return)
+    {
+        return $return;
+    }
+
+    /**
+     * @dataProvider providePropertyData
+     */
+    public function testPropertyEnhance($property, string $originalMessage, string $enhancedMessage)
+    {
+        $this->nullProperty = $property;
+
+        $generatedError = null;
+        try {
+            $expectedLine = __LINE__ + 1;
+            $this->nullProperty->callMethod();
+        } catch (\Throwable $exception) {
+            $generatedError = $exception;
+        }
+
+        $this->checkAssertions($generatedError, $originalMessage, $enhancedMessage, $expectedLine);
+    }
+
+    public function providePropertyData()
+    {
+        return [
+            [
+                null,
+                'Call to a member function callMethod() on null',
+                'Attempted to call method "callMethod()" of expression "$this->nullProperty", which contains a non object, but a null.',
+            ],
+            [
+                [],
+                'Call to a member function callMethod() on array',
+                'Attempted to call method "callMethod()" of expression "$this->nullProperty", which contains a non object, but an array.',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideSelfMethodData
+     */
+    public function testSelfMethodEnhance($methodReturn, string $originalMessage, string $enhancedMessage)
+    {
+        $generatedError = null;
+        try {
+            $expectedLine = __LINE__ + 1;
+            self::method($methodReturn)->callMethod();
+        } catch (\Throwable $exception) {
+            $generatedError = $exception;
+        }
+
+        $this->checkAssertions($generatedError, $originalMessage, $enhancedMessage, $expectedLine);
+    }
+
+    public function provideSelfMethodData()
+    {
+        return [
+            [
+                null,
+                'Call to a member function callMethod() on null',
+                'Attempted to call method "callMethod()" of expression "self::method($methodReturn)", which contains a non object, but a null.',
+            ],
+            [
+                [],
+                'Call to a member function callMethod() on array',
+                'Attempted to call method "callMethod()" of expression "self::method($methodReturn)", which contains a non object, but an array.',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideStaticMethodData
+     */
+    public function testStaticMethodEnhance($methodReturn, string $originalMessage, string $enhancedMessage)
+    {
+        $generatedError = null;
+        try {
+            $expectedLine = __LINE__ + 1;
+            static::method($methodReturn)->callMethod();
+        } catch (\Throwable $exception) {
+            $generatedError = $exception;
+        }
+
+        $this->checkAssertions($generatedError, $originalMessage, $enhancedMessage, $expectedLine);
+    }
+
+    public function provideStaticMethodData()
+    {
+        return [
+            [
+                null,
+                'Call to a member function callMethod() on null',
+                'Attempted to call method "callMethod()" of expression "static::method($methodReturn)", which contains a non object, but a null.',
+            ],
+            [
+                [],
+                'Call to a member function callMethod() on array',
+                'Attempted to call method "callMethod()" of expression "static::method($methodReturn)", which contains a non object, but an array.',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideDefaultData
+     */
+    public function testDefaultEnhance($methodReturn, string $originalMessage)
+    {
+        $generatedError = null;
+        try {
+            static::method($methodReturn)
+                ->callMethod();
+        } catch (\Throwable $exception) {
+            $generatedError = $exception;
+        }
+
+        $this->assertSame($originalMessage, $generatedError->getMessage());
+
+        $enhancer = new NonObjectMethodErrorEnhancer();
+        $error = $enhancer->enhance($generatedError);
+
+        $this->assertNull($error);
+    }
+
+    public function provideDefaultData()
+    {
+        return [
+            [
+                null,
+                'Call to a member function callMethod() on null',
+            ],
+            [
+                [],
+                'Call to a member function callMethod() on array',
+            ],
+        ];
+    }
+
+    private function checkAssertions(\Throwable $generatedError, string $originalMessage, string $enhancedMessage, int $expectedLine)
+    {
+        $this->assertSame($originalMessage, $generatedError->getMessage());
+
+        $enhancer = new NonObjectMethodErrorEnhancer();
+        $error = $enhancer->enhance($generatedError);
+
+        $this->assertInstanceOf(NonObjectMethodError::class, $error);
+        $this->assertSame($enhancedMessage, $error->getMessage());
+        $this->assertSame(realpath(__FILE__), $error->getFile());
+        $this->assertSame($expectedLine, $error->getLine());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Hello!

This PR includes an error enhancer for call to a member function on non object (such as null or array). The new feature makes the text of error more clearly and understandable.

It supports only simple single-line expressions. For complex multi-line code snippets, a default error message is returned.

Before:
![image](https://user-images.githubusercontent.com/6825062/83569190-c75b1280-a52c-11ea-8943-e4cd96e0e961.png)


After:
![image](https://user-images.githubusercontent.com/6825062/83569224-d215a780-a52c-11ea-922f-7cd81049a1ca.png)


