### PR TITLE
[WebProfilerBundle] Fix error with custom function and web profiler routing tab

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
@@ -20,6 +20,8 @@
             <argument type="service" id="profiler" on-invalid="null" />
             <argument type="service" id="twig" />
             <argument type="service" id="router" on-invalid="null" />
+            <argument>null</argument>
+            <argument type="tagged_iterator" tag="routing.expression_language_provider" />
         </service>
 
         <service id="web_profiler.controller.exception" class="Symfony\Bundle\WebProfilerBundle\Controller\ExceptionController" public="true">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36985
| License       | MIT
| Doc PR        | no

Here is a simple solution for #36985 as it only concerns WebProfilerBundle.

Due to the limitation in the routing tab as explained in the footnote, the route in my repo did not match in profiler (no query string in the new context) but there is no more syntax error.