### PR TITLE
Add getFlashBag to SessionInterface

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -1,6 +1,12 @@
 UPGRADE FROM 5.1 to 5.2
 =======================
 
+
+HttpFoundation
+---------
+
+* Deprecated `SessionInterface` implementations without a `getFlashBag(): FlashBagInterface` method.
+
 Validator
 ---------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -61,6 +61,8 @@ HttpFoundation
  * Removed `Response::create()`, `JsonResponse::create()`,
    `RedirectResponse::create()`, and `StreamedResponse::create()` methods (use
    `__construct()` instead)
+ * Added `getFlashBag(): FlashBagInterface` to `SessionInterface`.
+
 
 HttpKernel
 ----------

--- a/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
@@ -11,12 +11,15 @@
 
 namespace Symfony\Component\HttpFoundation\Session;
 
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
 
 /**
  * Interface for the session.
  *
  * @author Drak <drak@zikula.org>
+ *
+ * @method FlashBagInterface getFlashBag() Gets the flashbag interface. - not implementing it is deprecated since Symfony 5.2
  */
 interface SessionInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes(ish)
| New feature?  | no
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

As mentioned in issue #36273, the `SessionInterface` does not implement this method, but users are expected to hint agains it when injection the `Session`. Since 5.1 the expected method of getting the flashbag is to inject the `Session` instead, and get the flashbag from that.

This change should make it possible to inject the interface, but still be sure that the `getFlashBag` method is available.

