### PR TITLE
Provides a way to override cache and log folders from the ENV

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -66,6 +66,22 @@ trait MicroKernelTrait
     /**
      * {@inheritdoc}
      */
+    public function getCacheDir(): string
+    {
+        return $_SERVER['APP_CACHE_DIR'] ?? parent::getCacheDir();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLogDir(): string
+    {
+        return $_SERVER['APP_LOG_DIR'] ?? parent::getLogDir();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function registerBundles(): iterable
     {
         $contents = require $this->getProjectDir().'/config/bundles.php';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

When using Docker and especially on Mac OS X, performances are terrible when using a "mount" on the host inside the container. (which happens by default)

To optimize the performances, one of the tricks is to change where the application is going to write the cache and the logs.

This PR provides a new env variables `APP_CACHE_DIR` and `APP_LOG_DIR` which can be set to change where will be saved the caches and the logs.

I know we can do it per project BUT:
- I think that is a good addition to Symfony
- it would allow project like eZ Platform and eZ Launchpad to automate that optimization
https://github.com/ezsystems/ezplatform/pull/543

Let me know
