### PR TITLE
Silence stream_isatty and posix_isatty

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -512,11 +512,11 @@ class QuestionHelper extends Helper
         $inputStream = !$this->inputStream && \defined('STDIN') ? STDIN : $this->inputStream;
 
         if (\function_exists('stream_isatty')) {
-            return stream_isatty($inputStream);
+            return @stream_isatty($inputStream);
         }
 
         if (\function_exists('posix_isatty')) {
-            return posix_isatty($inputStream);
+            return @posix_isatty($inputStream);
         }
 
         return true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 

After https://github.com/symfony/symfony/pull/36696, I've got report that users get `XX bytes of buffered data lost during stream conversion` errors when validation of their first question fails. This can be seen at https://travis-ci.org/github/symfony/maker-bundle/jobs/693200010#L332

Simple reproducer:

```php
(new Application())
    ->register('app')
    ->setCode(function(InputInterface $input, OutputInterface $output) {
        (new QuestionHelper())->ask($input, $output, (new Question('Foo?'))->setValidator(function () {
            throw new InvalidArgumentException('Foo!');
        }));
    })
    ->getApplication()
    ->setDefaultCommand('app', true)
    ->run()
;
```
Runnning as:
`echo "foo\n" | php console-app.php`

These calls were actually silenced before already (and still are in 3.4), but we removed this later, thinking it's not needed anymore.

I would actually prefer to fix this differently if possible, but I would have to be able to reproduce issue mentioned in https://github.com/symfony/symfony/pull/36696/files#r420063328 first. I was unable to reproduce that issue with code similar as in https://github.com/symfony/symfony/blob/8ddaa20b29caa7aeb505681f12e86a7a444ae8b4/src/Symfony/Component/Console/Tests/phpt/uses_stdin_as_interactive_input.phpt, which should match scenario  that referenced comment describes

cc @weaverryan @nicolas-grekas 