### PR TITLE
Small update in our internal terminology

### DIFF
--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -81,7 +81,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
         $options['on_progress'] = function (int $dlNow, int $dlSize, array $info) use ($onProgress, $subnets, &$lastPrimaryIp): void {
             if ($info['primary_ip'] !== $lastPrimaryIp) {
                 if (IpUtils::checkIp($info['primary_ip'], $subnets ?? self::PRIVATE_SUBNETS)) {
-                    throw new TransportException(sprintf('IP "%s" is blacklisted for "%s".', $info['primary_ip'], $info['url']));
+                    throw new TransportException(sprintf('IP "%s" is blocked for "%s".', $info['primary_ip'], $info['url']));
                 }
 
                 $lastPrimaryIp = $info['primary_ip'];

--- a/src/Symfony/Component/HttpClient/Tests/NoPrivateNetworkHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/NoPrivateNetworkHttpClientTest.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class NoPrivateNetworkHttpClientTest extends TestCase
 {
-    public function getBlacklistData(): array
+    public function getExcludeData(): array
     {
         return [
             // private
@@ -63,16 +63,16 @@ class NoPrivateNetworkHttpClientTest extends TestCase
     }
 
     /**
-     * @dataProvider getBlacklistData
+     * @dataProvider getExcludeData
      */
-    public function testBlacklist(string $ipAddr, $subnets, bool $mustThrow)
+    public function testExclude(string $ipAddr, $subnets, bool $mustThrow)
     {
         $content = 'foo';
         $url = sprintf('http://%s/', 0 < substr_count($ipAddr, ':') ? sprintf('[%s]', $ipAddr) : $ipAddr);
 
         if ($mustThrow) {
             $this->expectException(TransportException::class);
-            $this->expectExceptionMessage(sprintf('IP "%s" is blacklisted for "%s".', $ipAddr, $url));
+            $this->expectExceptionMessage(sprintf('IP "%s" is blocked for "%s".', $ipAddr, $url));
         }
 
         $previousHttpClient = $this->getHttpClientMock($url, $ipAddr, $content);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I would like us to use the term "blocklist" instead of "blacklist". I've updated all the internal uses I could find. There are no BC breaks. 

We still use some "blacklist" when we relate to `PHPUnit\Util\Blacklist`
