### PR TITLE
[Console] allow cursor to be used even when STDIN is not defined

### DIFF
--- a/src/Symfony/Component/Console/Cursor.php
+++ b/src/Symfony/Component/Console/Cursor.php
@@ -21,10 +21,10 @@ final class Cursor
     private $output;
     private $input;
 
-    public function __construct(OutputInterface $output, $input = STDIN)
+    public function __construct(OutputInterface $output, $input = null)
     {
         $this->output = $output;
-        $this->input = $input;
+        $this->input = $input ?? (\defined('STDIN') ? STDIN : fopen('php://input', 'r+'));
     }
 
     public function moveUp(int $lines = 1): self


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37124
| License       | MIT
| Doc PR        | 

This allows to use the `Cursor` class introduced in Symfony 5.1 even when the `STDIN` constant is not defined. We did a similar bugfix in the past in the `QuestionHelper` class in #10798.