### PR TITLE
[HttpClient] added support for pausing responses with a new `pause_handler` callable exposed as an info item

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added `AsyncDecoratorTrait` to ease processing responses without breaking async
+ * added support for pausing responses with a new `pause_handler` callable exposed as an info item
 
 5.1.0
 -----

--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -26,6 +26,9 @@ final class CurlClientState extends ClientState
     public $pushedResponses = [];
     /** @var DnsCache */
     public $dnsCache;
+    /** @var float[] */
+    public $pauseExpiries = [];
+    public $execCounter = PHP_INT_MIN;
 
     public function __construct()
     {

--- a/src/Symfony/Component/HttpClient/Internal/NativeClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/NativeClientState.php
@@ -30,6 +30,8 @@ final class NativeClientState extends ClientState
     public $dnsCache = [];
     /** @var bool */
     public $sleep = false;
+    /** @var int[] */
+    public $hosts = [];
 
     public function __construct()
     {

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -198,6 +198,10 @@ class MockHttpClientTest extends HttpClientTestCase
                 $this->markTestSkipped("MockHttpClient doesn't timeout on destruct");
                 break;
 
+            case 'testPause':
+                $this->markTestSkipped("MockHttpClient doesn't support pauses by default");
+                break;
+
             case 'testGetRequest':
                 array_unshift($headers, 'HTTP/1.1 200 OK');
                 $responses[] = new MockResponse($body, ['response_headers' => $headers]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This code sample will delay sending the request by 2 seconds:
```php
$response = $client->request('GET', 'https://symfony.com/');
$response->getInfo('pause_handler')(2);
```

Unlike "competing" HTTP clients written in PHP, this one works while streaming a request/response. This means this PR allows implementing delays before retries but it also enables throttling the streams while still maintaining async/multiplexing.

Returning the handler as an info item saves adding a new method and thus plays well with decorators, without requiring a new dedicated interface.

While this can be used directly, the target use case is within an async-decorator, by using [the `AsyncContext::pause()` method](https://github.com/symfony/symfony/pull/36779/files#diff-1d1f61631f4f5e84634e7c3dac6f208cR89).

As a  bonus, this PR improves `NativeHttpClient` by making it able to count the maximum number of open connections *per-host*.