### PR TITLE
[Notifier][Slack] Use Slack Web API chat.postMessage instead of WebHooks

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Slack;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -30,16 +29,13 @@ final class SlackTransportFactory extends AbstractTransportFactory
     public function create(Dsn $dsn): TransportInterface
     {
         $scheme = $dsn->getScheme();
-        $id = ltrim($dsn->getPath(), '/');
+        $accessToken = $this->getUser($dsn);
+        $channel = $dsn->getOption('channel');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        if (!$id) {
-            throw new IncompleteDsnException('Missing path (maybe you haven\'t update the DSN when upgrading from 5.0).', $dsn->getOriginalDsn());
-        }
-
         if ('slack' === $scheme) {
-            return (new SlackTransport($id, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+            return (new SlackTransport($accessToken, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
         }
 
         throw new UnsupportedSchemeException($dsn, 'slack', $this->getSupportedSchemes());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

**TL;DR**: Revert changes introduced in 5.1 by #35828: Slack's Web API is much more flexible and easier to operate than Slack WebHooks are.

---

### Context

A valid choice was made to switch from Slack's Web API to Slack's WebHooks for a wrong reason: according to #35828, this was in reaction to the deprecation of Slack's Legacy Tokens.

The author cites:
> Legacy tokens are a deprecated method of generating tokens for testing and development.

[As far as I was able to understand](https://github.com/symfony/symfony/pull/35828#issuecomment-639465018
), from the author perspective, this deprecation was amalgamated with the (perceived) deprecation of the Web API itself.

According to [Slack documentation](https://api.slack.com/legacy/custom-integrations/legacy-tokens) cited by the author:

> If you were using a legacy token to make calls with the Web API, you'll need to generate a new one for your new Slack app.

**So Slack changing its credentials' policy didn't warrant changing how to use Slack's Web API.**

---

### Why Web API > WebHook?

While using Slack WebHooks as the underlying transport method for notification isn't inherently a bad choice, it does–on top of [the reasons cited by the author](#35828)–come with a major limitation: the need to setup (manually or programmatically) a Webhook per channel/recipient.

The Web API, with it's underlying OAuth Access Token, is much more flexible and allows for more diverse use case. Notifications can be sent on behalf of users for instance. Slack can also limit the use of the access tokens to a list of IP addresses and ranges.

**E.g. I want to notify the person who triggers a CD pipeline if the latter fails.** \
Assuming a team of 10 developer, using Slack WebHooks, I would need to setup 10 WebHooks, and manages as many secret in my Symfony app. Furthermore, I would need to create new WebHook each time a new member were to join the team. \
With the Web API, I would only need to manage a single access token for the whole Slack workspace, regardless of who as access to this workspace. 

Slack's Web API is much more flexible and easier to operate than Slack WebHooks are.