### PR TITLE
[Messenger] fix forward compatibility with Doctrine DBAL 2.11+

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/ConnectionTest.php
@@ -13,13 +13,13 @@ namespace Symfony\Component\Messenger\Bridge\Doctrine\Tests\Transport;
 
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\ResultStatement;
-use Doctrine\DBAL\ForwardCompatibility\Driver\ResultStatement as ForwardCompatibleResultStatement;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaConfig;
 use Doctrine\DBAL\Schema\Synchronizer\SchemaSynchronizer;
+use Doctrine\DBAL\Statement;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Doctrine\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Bridge\Doctrine\Transport\Connection;
@@ -146,14 +146,10 @@ class ConnectionTest extends TestCase
 
     private function getStatementMock($expectedResult): ResultStatement
     {
-        $mockedInterface = interface_exists(ForwardCompatibleResultStatement::class)
-            ? ForwardCompatibleResultStatement::class
-            : ResultStatement::class;
-
-        $stmt = $this->createMock($mockedInterface);
+        $stmt = $this->createMock(Statement::class);
 
         $stmt->expects($this->once())
-            ->method(method_exists($mockedInterface, 'fetchAssociative') ? 'fetchAssociative' : 'fetch')
+            ->method(method_exists(Statement::class, 'fetchAssociative') ? 'fetchAssociative' : 'fetch')
             ->willReturn($expectedResult);
 
         return $stmt;
@@ -315,12 +311,9 @@ class ConnectionTest extends TestCase
             'headers' => json_encode(['type' => DummyMessage::class]),
         ];
 
-        $mockedInterface = interface_exists(ForwardCompatibleResultStatement::class)
-            ? ForwardCompatibleResultStatement::class
-            : ResultStatement::class;
-        $stmt = $this->createMock($mockedInterface);
+        $stmt = $this->createMock(Statement::class);
         $stmt->expects($this->once())
-            ->method(method_exists($mockedInterface, 'fetchAllAssociative') ? 'fetchAllAssociative' : 'fetchAll')
+            ->method(method_exists(Statement::class, 'fetchAllAssociative') ? 'fetchAllAssociative' : 'fetchAll')
             ->willReturn([$message1, $message2]);
 
         $driverConnection


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

The methods will be deprecated in 2.11 (see doctrine/dbal#4019), but the forward compatibility layer is only present in 3.0 (see doctrine/dbal#4007).