### PR TITLE
[DI] Add check around class_alias for generated proxy classes

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -567,7 +567,7 @@ EOF;
             $proxyClass = explode(' ', $this->inlineRequires ? substr($proxyCode, \strlen($code)) : $proxyCode, 3)[1];
 
             if ($this->asFiles || $this->namespace) {
-                $proxyCode .= "\n\\class_alias(__NAMESPACE__.'\\\\$proxyClass', '$proxyClass', false);\n";
+                $proxyCode .= "\nif (!\\class_exists('$proxyClass', false)) {\n    \\class_alias(__NAMESPACE__.'\\\\$proxyClass', '$proxyClass', false);\n}\n";
             }
 
             $proxyClasses[$proxyClass.'.php'] = $proxyCode;
@@ -1086,7 +1086,7 @@ EOTXT
                 // If the class is a string we can optimize away
                 if (0 === strpos($class, "'") && false === strpos($class, '$')) {
                     if ("''" === $class) {
-                        throw new RuntimeException(sprintf('Cannot dump definition: %s service is defined to be created by a factory but is missing the service reference, did you forget to define the factory service id or class?', $id ? 'The "'.$id.'"' : 'inline'));
+                        throw new RuntimeException(sprintf('Cannot dump definition: "%s" service is defined to be created by a factory but is missing the service reference, did you forget to define the factory service id or class?', $id ? 'The "'.$id.'"' : 'inline'));
                     }
 
                     return $return.sprintf('%s::%s(%s)', $this->dumpLiteralClass($class), $callable[1], $arguments ? implode(', ', $arguments) : '').$tail;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -160,7 +160,9 @@ class FooClass_%s extends \Bar\FooClass implements \ProxyManager\Proxy\VirtualPr
 %A
 }
 
-\class_alias(__NAMESPACE__.'\\FooClass_%s', 'FooClass_%s', false);
+if (!\class_exists('FooClass_%s', false)) {
+    \class_alias(__NAMESPACE__.'\\FooClass_%s', 'FooClass_%s', false);
+}
 
     [ProjectServiceContainer.preload.php] => <?php
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | nofiles -->
| Tickets       | Fix #37059
| License       | MIT
| Doc PR        |

Here is the [requested](https://github.com/symfony/symfony/issues/37059#issuecomment-638633262) fix.

I'd like to note that I consider this kind of a workaround. I don't know why the issue only started to appear with Symfony 5.1 and not before. There might be some other problem hidden somewhere else.