### PR TITLE
[DependencyInjection] Display alternatives when a service is not found in CheckExceptionOnInvalidReferenceBehaviorPass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php
@@ -64,7 +64,7 @@ class CheckExceptionOnInvalidReferenceBehaviorPass extends AbstractRecursivePass
                     if ($k !== $id) {
                         $currentId = $k.'" in the container provided to "'.$currentId;
                     }
-                    throw new ServiceNotFoundException($id, $currentId);
+                    throw new ServiceNotFoundException($id, $currentId, null, $this->getAlternatives($id));
                 }
             }
         }
@@ -83,6 +83,23 @@ class CheckExceptionOnInvalidReferenceBehaviorPass extends AbstractRecursivePass
             }
         }
 
-        throw new ServiceNotFoundException($id, $currentId);
+        throw new ServiceNotFoundException($id, $currentId, null, $this->getAlternatives($id));
+    }
+
+    private function getAlternatives(string $id): array
+    {
+        $alternatives = [];
+        foreach ($this->container->getServiceIds() as $knownId) {
+            if ('' === $knownId || '.' === $knownId[0]) {
+                continue;
+            }
+
+            $lev = levenshtein($id, $knownId);
+            if ($lev <= \strlen($id) / 3 || false !== strpos($knownId, $id)) {
+                $alternatives[] = $knownId;
+            }
+        }
+
+        return $alternatives;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckExceptionOnInvalidReferenceBehaviorPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckExceptionOnInvalidReferenceBehaviorPassTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\Compiler\InlineServiceDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\Reference;
 
 class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
@@ -104,6 +105,22 @@ class CheckExceptionOnInvalidReferenceBehaviorPassTest extends TestCase
 
         (new AnalyzeServiceReferencesPass())->process($container);
         (new InlineServiceDefinitionsPass())->process($container);
+        $this->process($container);
+    }
+
+    public function testProcessThrowsExceptionOnInvalidReferenceWithAlternatives()
+    {
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('The service "a" has a dependency on a non-existent service "@ccc". Did you mean this: "ccc"?');
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('a', '\stdClass')
+            ->addArgument(new Reference('@ccc'));
+
+        $container
+            ->register('ccc', '\stdClass');
+
         $this->process($container);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I often see the mistake of using `@my_service` instead of `my_service` in bundles configurations in YAML (on entries that are then turned into references). Since we don't currently display alternatives, the message content is just that the service don't exist which is hard to understand for new users of the framework.