### PR TITLE
[PhpUnitBridge] Fix ExpectDeprecationTrait::expectDeprecation() conflict

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ExpectDeprecationTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/ExpectDeprecationTrait.php
@@ -11,21 +11,20 @@
 
 namespace Symfony\Bridge\PhpUnit;
 
-use Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerTrait;
+use Symfony\Bridge\PhpUnit\Legacy\ExpectDeprecationTraitBeforeV8_4;
+use Symfony\Bridge\PhpUnit\Legacy\ExpectDeprecationTraitForV8_4;
 
-trait ExpectDeprecationTrait
-{
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    protected function expectDeprecation($message)
+if (version_compare(\PHPUnit\Runner\Version::id(), '8.4.0', '<')) {
+    trait ExpectDeprecationTrait
     {
-        if (!SymfonyTestsListenerTrait::$previousErrorHandler) {
-            SymfonyTestsListenerTrait::$previousErrorHandler = set_error_handler([SymfonyTestsListenerTrait::class, 'handleError']);
-        }
-
-        SymfonyTestsListenerTrait::$expectedDeprecations[] = $message;
+        use ExpectDeprecationTraitBeforeV8_4;
+    }
+} else {
+    /**
+     * @method void expectDeprecation(string $message)
+     */
+    trait ExpectDeprecationTrait
+    {
+        use ExpectDeprecationTraitForV8_4;
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/Legacy/ExpectDeprecationTraitBeforeV8_4.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ExpectDeprecationTraitBeforeV8_4.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Legacy;
+
+/**
+ * @internal, use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait instead.
+ */
+trait ExpectDeprecationTraitBeforeV8_4
+{
+    /**
+     * @param string $message
+     *
+     * @return void
+     */
+    protected function expectDeprecation($message)
+    {
+        if (!SymfonyTestsListenerTrait::$previousErrorHandler) {
+            SymfonyTestsListenerTrait::$previousErrorHandler = set_error_handler([SymfonyTestsListenerTrait::class, 'handleError']);
+        }
+
+        SymfonyTestsListenerTrait::$expectedDeprecations[] = $message;
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Legacy/ExpectDeprecationTraitForV8_4.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ExpectDeprecationTraitForV8_4.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Legacy;
+
+/**
+ * @internal use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait instead.
+ */
+trait ExpectDeprecationTraitForV8_4
+{
+    /**
+     * @param string $message
+     */
+    public function expectDeprecation(): void
+    {
+        if (1 > func_num_args() || !\is_string($message = func_get_arg(0))) {
+            throw new \InvalidArgumentException(sprintf('The "%s()" method requires the string $message argument.', __FUNCTION__));
+        }
+
+        if (!SymfonyTestsListenerTrait::$previousErrorHandler) {
+            SymfonyTestsListenerTrait::$previousErrorHandler = set_error_handler([SymfonyTestsListenerTrait::class, 'handleError']);
+        }
+
+        SymfonyTestsListenerTrait::$expectedDeprecations[] = $message;
+    }
+
+    /**
+     * @internal use expectDeprecation() instead.
+     */
+    public function expectDeprecationMessage(string $message): void
+    {
+        throw new \BadMethodCallException(sprintf('The "%s()" method is not supported by Symfony\'s PHPUnit Bridge ExpectDeprecationTrait, pass the message to expectDeprecation() instead.', __FUNCTION__));
+    }
+
+    /**
+     * @internal use expectDeprecation() instead.
+     */
+    public function expectDeprecationMessageMatches(string $regularExpression): void
+    {
+        throw new \BadMethodCallException(sprintf('The "%s()" method is not supported by Symfony\'s PHPUnit Bridge ExpectDeprecationTrait.', __FUNCTION__));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/37133
| License       | MIT
| Doc PR        | -

ExpectDeprecationTrait::expectDeprecation() must be compatible with TestCase::expectDeprecation(). I'm personally against a renaming on our side because this name is the best.