### PR TITLE
[FrameworkBundle] Remove reference to APP_SECRET in MicroKernelTrait

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -83,7 +83,6 @@ trait MicroKernelTrait
     {
         $loader->load(function (ContainerBuilder $container) use ($loader) {
             $container->loadFromExtension('framework', [
-                'secret' => '%env(APP_SECRET)%',
                 'router' => [
                     'resource' => 'kernel::loadRoutes',
                     'type' => 'service',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #37123
| License       | MIT
| Doc PR        | -

Needs https://github.com/symfony/recipes/pull/781