### PR TITLE
[Mime] use fromString when creating a new Address

### DIFF
--- a/src/Symfony/Component/Mime/Address.php
+++ b/src/Symfony/Component/Mime/Address.php
@@ -89,7 +89,7 @@ final class Address
             return $address;
         }
         if (\is_string($address)) {
-            return new self($address);
+            return self::fromString($address);
         }
 
         throw new InvalidArgumentException(sprintf('An address can be an instance of Address or a string ("%s") given).', \is_object($address) ? \get_class($address) : \gettype($address)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | n/a

When creating an Address, there are two ways right now in 4.4: `Address::create()` which takes an email or an instance of Address and `Address::fromString()` which takes an email or an email+name.

In 4.4, I propose to make `create` supports everything possible. And in 5.2, I will probably propose to deprecate `fromString()`.
