### PR TITLE
[FrameworkBundle] Move default definitions outside the constructor

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -45,7 +45,7 @@ class Application extends BaseApplication
     protected function setDefaultDefinitions(): void
     {
         $inputDefinition = $this->getDefinition();
-        $inputDefinition->addOption(new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', $kernel->getEnvironment()));
+        $inputDefinition->addOption(new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', $this->kernel->getEnvironment()));
         $inputDefinition->addOption(new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode.'));
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -39,6 +39,11 @@ class Application extends BaseApplication
 
         parent::__construct('Symfony', Kernel::VERSION);
 
+        $this->setDefaultDefinitions();
+    }
+
+    protected function setDefaultDefinitions(): void
+    {
         $inputDefinition = $this->getDefinition();
         $inputDefinition->addOption(new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'The Environment name.', $kernel->getEnvironment()));
         $inputDefinition->addOption(new InputOption('--no-debug', null, InputOption::VALUE_NONE, 'Switches off debug mode.'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

By default there is 2 definitions, unfortunately the shortcut `-e` is used by default, which is really commonly used for user-land commands too.

I wanted to remove it but it's not possible to do it easily, the kernel is private in Application so I need to call the parent constructor, which set those definitions. I tried to replace the definitions after but that's not possible AFAIK.

With this PR it is possible to override those definitions easily, without BC.

Edit: Sorry if I target the wrong branch, I'm not exactly sure.