### PR TITLE
[Ldap] fix refreshUser() ignoring extra_fields

### DIFF
--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -108,7 +108,7 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', \get_class($user)));
         }
 
-        return new LdapUser($user->getEntry(), $user->getUsername(), $user->getPassword(), $user->getRoles());
+        return new LdapUser($user->getEntry(), $user->getUsername(), $user->getPassword(), $user->getRoles(), $user->getExtraFields());
     }
 
     /**

--- a/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Security/LdapUserProviderTest.php
@@ -330,4 +330,14 @@ class LdapUserProviderTest extends TestCase
         $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})', 'userpassword', ['email']);
         $this->assertInstanceOf(LdapUser::class, $provider->loadUserByUsername('foo'));
     }
+
+    public function testRefreshUserShouldReturnUserWithSameProperties()
+    {
+        $ldap = $this->createMock(LdapInterface::class);
+        $provider = new LdapUserProvider($ldap, 'ou=MyBusiness,dc=symfony,dc=com', null, null, [], 'sAMAccountName', '({uid_key}={username})', 'userpassword', ['email']);
+
+        $user = new LdapUser(new Entry('foo'), 'foo', 'bar', ['ROLE_DUMMY'], ['email' => 'foo@symfony.com']);
+
+        $this->assertEquals($user, $provider->refreshUser($user));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While #31532 introduced `extra_fields` in general, #32824 later added `LdapUser` & `LdapUserProvider` and ignored `extra_fields` on `refreshUser()`. 

This PR fixes `refreshUser()` and adds a test which makes sure, that the refreshed ldap user doesn't lose its default values.