### PR TITLE
[Lock] MongoDbStore deprecated extracting database/collection from MongoDB connection URI

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 5.1 to 5.2
 =======================
 
+Lock
+----
+
+ * Deprecated passing of `database` or `collection` to `MongoDbStore` via connection URI, use `$options` instead.
+
 Mime
 ----
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -73,6 +73,11 @@ Inflector
 
  * The component has been removed, use `EnglishInflector` from the String component instead.
 
+Lock
+----
+
+* `MongoDbStore` can no longer be constructed by passing `database` or `collection` via connection URI, use `$options` instead.
+
 Mailer
 ------
 

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * deprecated passing of `database` or `collection` to `MongoDbStore` via connection URI, use `$options` instead.
+
 5.1.0
 -----
 
@@ -19,10 +24,10 @@ CHANGELOG
  * added InvalidTtlException
  * deprecated `StoreInterface` in favor of `BlockingStoreInterface` and `PersistingStoreInterface`
  * `Factory` is deprecated, use `LockFactory` instead
- * `StoreFactory::createStore` allows PDO and Zookeeper DSN. 
- * deprecated services `lock.store.flock`, `lock.store.semaphore`, `lock.store.memcached.abstract` and `lock.store.redis.abstract`, 
+ * `StoreFactory::createStore` allows PDO and Zookeeper DSN.
+ * deprecated services `lock.store.flock`, `lock.store.semaphore`, `lock.store.memcached.abstract` and `lock.store.redis.abstract`,
    use `StoreFactory::createStore` instead.
-    
+
 4.2.0
 -----
 

--- a/src/Symfony/Component/Lock/Store/StoreFactory.php
+++ b/src/Symfony/Component/Lock/Store/StoreFactory.php
@@ -81,6 +81,8 @@ class StoreFactory
                 return new $storeClass($connection);
 
             case 0 === strpos($connection, 'mongodb'):
+                trigger_deprecation('symfony/lock', '5.2', 'Using "%s" to construct a "%s" with a connection URI string is deprecated. Use a "%s" instead.', __CLASS__, MongoDbStore::class, Collection::class);
+
                 return new MongoDbStore($connection);
 
             case 0 === strpos($connection, 'mssql://'):

--- a/src/Symfony/Component/Lock/composer.json
+++ b/src/Symfony/Component/Lock/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "psr/log": "~1.0",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/polyfill-php80": "^1.15"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #37180
| License       | MIT
| Doc PR        | 

We should not overload the MongoDB connection URI with a non-standard querysting like `collection`.

The `/path` component should only be used for the authentication database, never the default database.

see https://docs.mongodb.com/manual/reference/connection-string/

see https://github.com/symfony/symfony/pull/37140#issuecomment-641665443