### PR TITLE
[DependencyInjection][CheckTypeDeclarationsPass] Always resolve parameters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -198,8 +198,7 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
             }
         } elseif (\is_string($value)) {
             if ('%' === ($value[0] ?? '') && preg_match('/^%([^%]+)%$/', $value, $match)) {
-                // Only array parameters are not inlined when dumped.
-                $value = [];
+                $value = $this->container->getParameter(substr($value, 1, -1));
             } elseif ($envPlaceholderUniquePrefix && false !== strpos($value, 'env_')) {
                 // If the value is an env placeholder that is either mixed with a string or with another env placeholder, then its resolved value will always be a string, so we don't need to resolve it.
                 // We don't need to change the value because it is already a string.

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -612,20 +612,6 @@ class CheckTypeDeclarationsPassTest extends TestCase
         $this->assertInstanceOf(\stdClass::class, $container->get('bar')->foo);
     }
 
-    public function testProcessResolveArrayParameters()
-    {
-        $container = new ContainerBuilder();
-        $container->setParameter('ccc', ['foobar']);
-
-        $container
-            ->register('foobar', BarMethodCall::class)
-            ->addMethodCall('setArray', ['%ccc%']);
-
-        (new CheckTypeDeclarationsPass(true))->process($container);
-
-        $this->addToAssertionCount(1);
-    }
-
     public function testProcessResolveExpressions()
     {
         $container = new ContainerBuilder();
@@ -788,6 +774,22 @@ class CheckTypeDeclarationsPassTest extends TestCase
             ->addArgument(new Expression('service("baz").getStdClass()'));
 
         (new CheckTypeDeclarationsPass())->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testProcessResolveParameters()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('array_param', ['foobar']);
+        $container->setParameter('string_param', 'ccc');
+
+        $container
+            ->register('foobar', BarMethodCall::class)
+            ->addMethodCall('setArray', ['%array_param%'])
+            ->addMethodCall('setString', ['%string_param%']);
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
 
         $this->addToAssertionCount(1);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/BarMethodCall.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/BarMethodCall.php
@@ -44,4 +44,8 @@ class BarMethodCall
     public function setClosure(\Closure $closure): void
     {
     }
+
+    public function setString(string $string)
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/37166
| License       | MIT
| Doc PR        | -

> Only array parameters are not inlined when dumped.

This is true only when the XML debug container is used, not on a live container that can contain unresolved parameters in the `%my_param%` form. That was my mistake. We have to resolve to get the parameter type.

`$value = [];` was just an improvement to avoid useless parameter resolve btw.