### PR TITLE
[HttpClient] make DNS resolution lazy with NativeHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -94,7 +94,7 @@ final class CurlResponse implements ResponseInterface
             if (0 < $duration) {
                 if ($execCounter === $multi->execCounter) {
                     $multi->execCounter = !\is_float($execCounter) ? 1 + $execCounter : PHP_INT_MIN;
-                    curl_multi_exec($multi->handle, $execCounter);
+                    curl_multi_remove_handle($multi->handle, $ch);
                 }
 
                 $lastExpiry = end($multi->pauseExpiries);
@@ -106,6 +106,7 @@ final class CurlResponse implements ResponseInterface
             } else {
                 unset($multi->pauseExpiries[(int) $ch]);
                 curl_pause($ch, CURLPAUSE_CONT);
+                curl_multi_add_handle($multi->handle, $ch);
             }
         };
 
@@ -335,6 +336,7 @@ final class CurlResponse implements ResponseInterface
 
                 unset($multi->pauseExpiries[$id]);
                 curl_pause($multi->openHandles[$id][0], CURLPAUSE_CONT);
+                curl_multi_add_handle($multi->handle, $multi->openHandles[$id][0]);
             }
         }
 

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpClient\Tests;
 
 use Symfony\Component\HttpClient\Exception\ClientException;
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\Response\StreamWrapper;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -236,6 +237,15 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
             'Unused pushed response: "https://127.0.0.1:3000/json/3"',
         ];
         $this->assertSame($expected, $logger->logs);
+    }
+
+    public function testDnsFailure()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://bad.host.test/');
+
+        $this->expectException(TransportException::class);
+        $response->getStatusCode();
     }
 
     private static function startVulcain(HttpClientInterface $client)

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -202,6 +202,10 @@ class MockHttpClientTest extends HttpClientTestCase
                 $this->markTestSkipped("MockHttpClient doesn't support pauses by default");
                 break;
 
+            case 'testDnsFailure':
+                $this->markTestSkipped("MockHttpClient doesn't use a DNS");
+                break;
+
             case 'testGetRequest':
                 array_unshift($headers, 'HTTP/1.1 200 OK');
                 $responses[] = new MockResponse($body, ['response_headers' => $headers]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Neither a bug nor a feature but still an improvement. This aligns the behavior of NativeHttpClient with the other adapters.