### PR TITLE
[DependencyInjection][CheckTypeDeclarationsPass] Handle unresolved parameters pointing to environment variables

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -199,7 +199,9 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
         } elseif (\is_string($value)) {
             if ('%' === ($value[0] ?? '') && preg_match('/^%([^%]+)%$/', $value, $match)) {
                 $value = $this->container->getParameter(substr($value, 1, -1));
-            } elseif ($envPlaceholderUniquePrefix && false !== strpos($value, 'env_')) {
+            }
+
+            if ($envPlaceholderUniquePrefix && \is_string($value) && false !== strpos($value, 'env_')) {
                 // If the value is an env placeholder that is either mixed with a string or with another env placeholder, then its resolved value will always be a string, so we don't need to resolve it.
                 // We don't need to change the value because it is already a string.
                 if ('' === preg_replace('/'.$envPlaceholderUniquePrefix.'_\w+_[a-f0-9]{32}/U', '', $value, -1, $c) && 1 === $c) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Follow up to https://github.com/symfony/symfony/pull/37193

Unresolved parameters pointing to environment variables can be added to definitions after ResolveParameterPlaceHoldersPass execution. It is the case in the initial reported bug (RegisterListenersPass is executed after ResolveParameterPlaceHoldersPass). In this case, the parameter value is an env placeholder, so we need to try to resolve it.