### PR TITLE
httpfoundation: Add getArray & getString helpers

### DIFF
--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -42,6 +42,16 @@ final class InputBag extends ParameterBag
         return $this === $value ? $default : $value;
     }
 
+    public function getString(string $key, string $default = ''): string
+    {
+        return (string) parent::get($key, $default);
+    }
+
+    public function getArray(string $key, array $default = []): array
+    {
+        return (array) parent::get($key, $default);
+    }
+
     /**
      * Returns the inputs.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no 
| Tickets       | related to #34363
| License       | MIT
| Doc PR        | tbd. <!-- required for new features -->

#34363 deprecated working with arrays. For example, if you have form handling code like this:

```php
foreach ($request->request->get('tags', []) as $tag) {
    /* */
}
```

You'll get a deprecation notice starting in 5.1. The suggested workaround from the discussion in #34363 would make it look like this:

```php
foreach (($request->request->all()['tags'] ?? []) as $tag) {
    /* */
}
```

which is not only way uglier, but also incomplete, since `'tags'` could be a string at this point. So it would really have to look like this:

```php
foreach (((array) $request->request->all()['tags'] ?? []) as $tag) {
    /* */
}
```

(if that even works? I haven't tested it). 

So why not add a simple `getArray()` helper function? That also makes it easier for static analysis to verify that the code is actually correct.

Also, I added a `getString()` method for symmetry. Because I really think according to the logic in #34363 `get` should be deprecated or at least redirected to a `getString` function so that it's obvious what is going on, but I can also remove this part.

I know there are no tests and documentation, but I wanted to check if there is even interest in merging something like this before I go through all that (so consider this RFC)