### PR TITLE
[Notifier] Use notifications as services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier.php
@@ -23,6 +23,7 @@ use Symfony\Component\Notifier\EventListener\SendFailedMessageToNotifierListener
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Messenger\MessageHandler;
+use Symfony\Component\Notifier\Notification\ServiceNotification;
 use Symfony\Component\Notifier\Notifier;
 use Symfony\Component\Notifier\NotifierInterface;
 use Symfony\Component\Notifier\Texter;
@@ -101,5 +102,10 @@ return static function (ContainerConfigurator $container) {
         ->set('texter.messenger.sms_handler', MessageHandler::class)
             ->args([service('texter.transports')])
             ->tag('messenger.message_handler', ['handles' => SmsMessage::class])
+
+        ->instanceof(ServiceNotification::class)
+            ->call('setNotifier', [service('notifier')])
+            ->tag('notifier.notification')
+            ->private()
     ;
 };

--- a/src/Symfony/Component/Notifier/Notification/ServiceNotification.php
+++ b/src/Symfony/Component/Notifier/Notification/ServiceNotification.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Notification;
+
+use Symfony\Component\Notifier\NotifierInterface;
+use Symfony\Component\Notifier\Recipient\Recipient;
+use Symfony\Contracts\Service\ResetInterface;
+
+abstract class ServiceNotification extends Notification implements ResetInterface
+{
+    protected $subject;
+    private $notifier;
+
+    protected function __construct(string $subject = '', array $channels = [])
+    {
+        parent::__construct($subject, $channels);
+    }
+
+    public function __invoke($subject)
+    {
+        $this->subject = $subject;
+
+        try {
+            foreach ($this->recipients() as $recipient) {
+                $this->notifier->send($this, $recipient);
+            }
+        } finally {
+            $this->reset();
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public function setNotifier(NotifierInterface $notifier): void
+    {
+        $this->notifier = $notifier;
+    }
+
+    public function reset()
+    {
+        $this->subject = null;
+    }
+
+    /**
+     * @return iterable|Recipient[]
+     */
+    abstract protected function recipients(): iterable;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

The current Notifier doc explains that a notification has to be explicitly instantiated and then passed to the notifier send() method.

In this PR, I suggest a complementary design using notifications as private services, being able to be sent by themselves, and which can be directly connected to domain events via a message subscriber in a Messenger component context, an event subscriber in an EventDispatcher component context or whatever else. Thanks to this design, each notification exists through a dedicated class and doesn't need be instantiated in userland.

Thus, they can be all listed thanks to the `debug:container --tag notifier.notification` command. We could also see to what they are connected thanks to the `debug:event-dispatcher` / `debug:messenger` commands.

```php
/**
 * @property InvoiceCreated $subject
 */
class InvoiceCreatedNotification extends ServiceNotification implements MessageSubscriberInterface
{
    protected function __construct()
    {
        parent::__construct('New invoice', ['email']);
    }

    public static function getHandledMessages(): iterable
    {
        yield InvoiceCreated::class;
    }

    protected function recipients(): iterable
    {
        yield $this->subject->invoice()->debtor();
    }
}
```