### PR TITLE
[APP_CACHE_DIR] Ensure a split per environment when using that new variable

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -68,7 +68,11 @@ trait MicroKernelTrait
      */
     public function getCacheDir(): string
     {
-        return $_SERVER['APP_CACHE_DIR'] ?? parent::getCacheDir();
+        if (isset($_SERVER['APP_CACHE_DIR'])) {
+            return $_SERVER['APP_CACHE_DIR'].'/'.$this->environment;
+        }
+
+        return parent::getCacheDir();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/13819

All the explanation here: https://github.com/symfony/symfony-docs/pull/13819

