### PR TITLE
[Console] Fix Docblock for CommandTester::getExitCode

### DIFF
--- a/src/Symfony/Component/Console/Tester/TesterTrait.php
+++ b/src/Symfony/Component/Console/Tester/TesterTrait.php
@@ -29,6 +29,8 @@ trait TesterTrait
     /**
      * Gets the display returned by the last execution of the command or application.
      *
+     * @throws \RuntimeException If it's called before the execute method
+     *
      * @return string The display
      */
     public function getDisplay(bool $normalize = false)
@@ -95,10 +97,16 @@ trait TesterTrait
     /**
      * Gets the status code returned by the last execution of the command or application.
      *
+     * @throws \RuntimeException If it's called before the execute method
+     *
      * @return int The status code
      */
     public function getStatusCode()
     {
+        if (null === $this->statusCode) {
+            throw new \RuntimeException('Status code not initialized, did you execute the command before requesting the status code?');
+        }
+
         return $this->statusCode;
     }
 

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -67,9 +67,29 @@ class CommandTesterTest extends TestCase
         $this->assertEquals('foo'.PHP_EOL, $this->tester->getDisplay(), '->getDisplay() returns the display of the last execution');
     }
 
+    public function testGetDisplayWithoutCallingExecuteBefore()
+    {
+        $tester = new CommandTester(new Command());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Output not initialized');
+
+        $tester->getDisplay();
+    }
+
     public function testGetStatusCode()
     {
         $this->assertSame(0, $this->tester->getStatusCode(), '->getStatusCode() returns the status code');
+    }
+
+    public function testGetStatusCodeWithoutCallingExecuteBefore()
+    {
+        $tester = new CommandTester(new Command());
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Status code not initialized');
+
+        $tester->getStatusCode();
     }
 
     public function testCommandFromApplication()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT

While doing static analysis on my code, I found a false positive that led me to this little fix.