### PR TITLE
[BrowserKit] update cookie test for cookie values with double quotes

### DIFF
--- a/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
@@ -47,6 +47,7 @@ class CookieTest extends TestCase
         return [
             ['foo=bar; path=/'],
             ['foo=bar; path=/foo'],
+            ['foo="Test"; path=/'],
             ['foo=bar; domain=example.com; path=/'],
             ['foo=bar; domain=example.com; path=/; secure', 'https://example.com/'],
             ['foo=bar; path=/; httponly'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0 
| Bug fix?      | no
| New feature?  | noâ
| Deprecations? | no 
| Tickets       | Fix #37161
| License       | MIT
| Doc PR        | symfony/symfony-docs#

Provide a test for cookie values with double quotes