### PR TITLE
[DependencyInjection] Resolve parameters in tag arguments

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added `param()` and `abstract_arg()` in the PHP-DSL
  * deprecated `Definition::setPrivate()` and `Alias::setPrivate()`, use `setPublic()` instead
+ * added support for parameters in service tag arguments
 
 5.1.0
 -----

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1250,7 +1250,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                 if ($throwOnAbstract && $definition->isAbstract()) {
                     throw new InvalidArgumentException(sprintf('The service "%s" tagged "%s" must not be abstract.', $id, $name));
                 }
-                $tags[$id] = $definition->getTag($name);
+                $tags[$id] = $this->parameterBag->resolveValue($definition->getTag($name));
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -911,6 +911,22 @@ class ContainerBuilderTest extends TestCase
         $this->assertEquals([], $builder->findTaggedServiceIds('foobar'), '->findTaggedServiceIds() returns an empty array if there is annotated services');
     }
 
+    public function testResolveTagAttributtes()
+    {
+        $builder = new ContainerBuilder();
+        $builder->getParameterBag()->add(['foo_argument' => 'foo']);
+
+        $builder
+            ->register('foo', 'Bar\FooClass')
+            ->addTag('foo', ['foo' => '%foo_argument%'])
+        ;
+        $this->assertEquals($builder->findTaggedServiceIds('foo'), [
+            'foo' => [
+                ['foo' => 'foo'],
+            ],
+        ], '->findTaggedServiceIds() replaces parameters in tag attributes');
+    }
+
     public function testFindUnusedTags()
     {
         $builder = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #35337
| License       | MIT
| Doc PR        | None, yet, will follow if this is accepted

Arguably this could be a BC break if people are actively relying on parameters not being resolved in tag parameters, although I can't come up with a sensible use case for that scenario.