### PR TITLE
Register welcome event only on debug mode

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+ * Added the configuration for welcome page inside the file `welcome.php`
+
 5.1.0
 -----
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -178,6 +178,10 @@ class FrameworkExtension extends Extension
         $phpLoader->load('fragment_renderer.php');
         $phpLoader->load('error_renderer.php');
 
+        if (true === $container->getParameter('kernel.debug')) {
+            $phpLoader->load('welcome.php');
+        }
+
         if (interface_exists(PsrEventDispatcherInterface::class)) {
             $container->setAlias(PsrEventDispatcherInterface::class, 'event_dispatcher');
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.php
@@ -151,8 +151,6 @@ return static function (ContainerConfigurator $container) {
                 service('request_stack'),
                 service('router.request_context')->ignoreOnInvalid(),
                 service('logger')->ignoreOnInvalid(),
-                param('kernel.project_dir'),
-                param('kernel.debug'),
             ])
             ->tag('kernel.event_subscriber')
             ->tag('monolog.logger', ['channel' => 'request'])

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/welcome.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/welcome.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\HttpKernel\EventListener\WelcomeListener;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('welcome.listener', WelcomeListener::class)
+            ->args([
+                param('kernel.project_dir'),
+            ])
+            ->tag('kernel.event_subscriber')
+    ;
+};

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+ * Removed from `RouterListener` the function `onKernelException` and unsubscribed the
+'kernel.exception' from the `RouterListener`
+ * Added a `WelcomeListener` and subscribed the 'kernel.exception'
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/HttpKernel/EventListener/WelcomeListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/WelcomeListener.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\Exception\NoConfigurationException;
+
+/**
+ * @internal
+ */
+final class WelcomeListener implements EventSubscriberInterface
+{
+    private $projectDir;
+
+    public function __construct(string $projectDir = null)
+    {
+        $this->projectDir = $projectDir;
+    }
+
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        if (!($e = $event->getThrowable()) instanceof NotFoundHttpException) {
+            return;
+        }
+
+        if ($e->getPrevious() instanceof NoConfigurationException) {
+            $event->setResponse($this->createWelcomeResponse());
+        }
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::EXCEPTION => ['onKernelException', -64],
+        ];
+    }
+
+    private function createWelcomeResponse(): Response
+    {
+        $version = Kernel::VERSION;
+        $projectDir = realpath($this->projectDir).\DIRECTORY_SEPARATOR;
+        $docVersion = substr(Kernel::VERSION, 0, 3);
+
+        ob_start();
+        include \dirname(__DIR__).'/Resources/welcome.html.php';
+
+        return new Response(ob_get_clean(), Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Hi. I was reviewing the events that are running at my application. I saw this event that is running everytime even on prod-non-debug mode. I tried to unregistered it with a compiler pass but I could not.

Many can argue that this is a micro-optimization and the benefits are not that great. Still though it might worth a try.. since I don't see any reason why on every 404 I must do a check if my debug mode is on.

 - [ ] add tests and ensure they pass.
 - [x] Wait for routing.xml to convert to php
 - [x] Update CHANGELOG

Until I complete the above maybe you would like to provide some feedback about it :)