### PR TITLE
Fix register csrf protection listener

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterCsrfFeaturesPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterCsrfFeaturesPass.php
@@ -27,29 +27,25 @@ class RegisterCsrfFeaturesPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!$container->has('security.csrf.token_storage')) {
-            return;
-        }
-
         $this->registerCsrfProtectionListener($container);
         $this->registerLogoutHandler($container);
     }
 
     private function registerCsrfProtectionListener(ContainerBuilder $container)
     {
-        if (!$container->has('security.authenticator.manager')) {
+        if (!$container->has('security.authenticator.manager') || !$container->has('security.csrf.token_manager')) {
             return;
         }
 
         $container->register('security.listener.csrf_protection', CsrfProtectionListener::class)
-            ->addArgument(new Reference('security.csrf.token_storage'))
+            ->addArgument(new Reference('security.csrf.token_manager'))
             ->addTag('kernel.event_subscriber')
             ->setPublic(false);
     }
 
     protected function registerLogoutHandler(ContainerBuilder $container)
     {
-        if (!$container->has('security.logout_listener')) {
+        if (!$container->has('security.logout_listener') || !$container->has('security.csrf.token_storage')) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | np
| Tickets       | #37254
| License       | MIT

Fix TypeError. Expected instance `CsrfTokenManagerInterface`, but `SessionTokenStorage` was given.

```
Uncaught Error: Argument 1 passed to Symfony\Component\Security\Http\EventListener\CsrfProtectionListener::__construct() must implement interface Symfony\Component\Security\Csrf\CsrfTokenManagerInterface, instance of Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage given

Uncaught PHP Exception TypeError: "Argument 1 passed to Symfony\Component\Security\Http\EventListener\CsrfProtectionListener::__construct() must implement interface Symfony\Component\Security\Csrf\CsrfTokenManagerInterface, instance of Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage given
```
 