### PR TITLE
[SecurityBundle] Run functional tests for the authenticator system

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AbstractWebTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AbstractWebTestCase.php
@@ -33,6 +33,12 @@ abstract class AbstractWebTestCase extends BaseWebTestCase
         static::deleteTmpDir();
     }
 
+    public function provideSecuritySystems()
+    {
+        yield [['enable_authenticator_manager' => true]];
+        yield [['enable_authenticator_manager' => false]];
+    }
+
     protected static function deleteTmpDir()
     {
         if (!file_exists($dir = sys_get_temp_dir().'/'.static::getVarDir())) {
@@ -61,9 +67,10 @@ abstract class AbstractWebTestCase extends BaseWebTestCase
         return new $class(
             static::getVarDir(),
             $options['test_case'],
-            isset($options['root_config']) ? $options['root_config'] : 'config.yml',
-            isset($options['environment']) ? $options['environment'] : strtolower(static::getVarDir().$options['test_case']),
-            isset($options['debug']) ? $options['debug'] : false
+            $options['root_config'] ?? 'config.yml',
+            $options['environment'] ?? strtolower(static::getVarDir().$options['test_case']),
+            $options['debug'] ?? false,
+            $options['enable_authenticator_manager'] ?? false
         );
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticationCommencingTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticationCommencingTest.php
@@ -13,11 +13,20 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 class AuthenticationCommencingTest extends AbstractWebTestCase
 {
-    public function testAuthenticationIsCommencingIfAccessDeniedExceptionIsWrapped()
+    /**
+     * @dataProvider provideClientOptions
+     */
+    public function testAuthenticationIsCommencingIfAccessDeniedExceptionIsWrapped(array $options)
     {
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'config.yml']);
+        $client = $this->createClient($options);
 
         $client->request('GET', '/secure-but-not-covered-by-access-control');
         $this->assertRedirect($client->getResponse(), '/login');
+    }
+
+    public function provideClientOptions()
+    {
+        yield [['test_case' => 'StandardFormLogin', 'root_config' => 'config.yml', 'enable_authenticator_manager' => true]];
+        yield [['test_case' => 'StandardFormLogin', 'root_config' => 'legacy_config.yml', 'enable_authenticator_manager' => false]];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/ClearRememberMeTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/ClearRememberMeTest.php
@@ -19,9 +19,12 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class ClearRememberMeTest extends AbstractWebTestCase
 {
-    public function testUserChangeClearsCookie()
+    /**
+     * @dataProvider provideClientOptions
+     */
+    public function testUserChangeClearsCookie(array $options)
     {
-        $client = $this->createClient(['test_case' => 'ClearRememberMe', 'root_config' => 'config.yml']);
+        $client = $this->createClient($options);
 
         $client->request('POST', '/login', [
             '_username' => 'johannes',
@@ -35,6 +38,12 @@ class ClearRememberMeTest extends AbstractWebTestCase
         $client->request('GET', '/foo');
         $this->assertRedirect($client->getResponse(), '/login');
         $this->assertNull($cookieJar->get('REMEMBERME'));
+    }
+
+    public function provideClientOptions()
+    {
+        yield [['test_case' => 'ClearRememberMe', 'root_config' => 'config.yml', 'enable_authenticator_manager' => true]];
+        yield [['test_case' => 'ClearRememberMe', 'root_config' => 'legacy_config.yml', 'enable_authenticator_manager' => false]];
     }
 }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FirewallEntryPointTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FirewallEntryPointTest.php
@@ -31,9 +31,12 @@ class FirewallEntryPointTest extends AbstractWebTestCase
         );
     }
 
-    public function testItUsesTheConfiguredEntryPointFromTheExceptionListenerWithFormLoginAndNoCredentials()
+    /**
+     * @dataProvider provideSecuritySystems
+     */
+    public function testItUsesTheConfiguredEntryPointFromTheExceptionListenerWithFormLoginAndNoCredentials(array $options)
     {
-        $client = $this->createClient(['test_case' => 'FirewallEntryPoint', 'root_config' => 'config_form_login.yml']);
+        $client = $this->createClient($options + ['test_case' => 'FirewallEntryPoint', 'root_config' => 'config_form_login.yml']);
 
         $client->request('GET', '/secure/resource');
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
@@ -14,11 +14,11 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 class FormLoginTest extends AbstractWebTestCase
 {
     /**
-     * @dataProvider getConfigs
+     * @dataProvider provideClientOptions
      */
-    public function testFormLogin($config)
+    public function testFormLogin(array $options)
     {
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config]);
+        $client = $this->createClient($options);
 
         $form = $client->request('GET', '/login')->selectButton('login')->form();
         $form['_username'] = 'johannes';
@@ -33,11 +33,11 @@ class FormLoginTest extends AbstractWebTestCase
     }
 
     /**
-     * @dataProvider getConfigs
+     * @dataProvider provideClientOptions
      */
-    public function testFormLogout($config)
+    public function testFormLogout(array $options)
     {
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config]);
+        $client = $this->createClient($options);
 
         $form = $client->request('GET', '/login')->selectButton('login')->form();
         $form['_username'] = 'johannes';
@@ -66,11 +66,11 @@ class FormLoginTest extends AbstractWebTestCase
     }
 
     /**
-     * @dataProvider getConfigs
+     * @dataProvider provideClientOptions
      */
-    public function testFormLoginWithCustomTargetPath($config)
+    public function testFormLoginWithCustomTargetPath(array $options)
     {
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config]);
+        $client = $this->createClient($options);
 
         $form = $client->request('GET', '/login')->selectButton('login')->form();
         $form['_username'] = 'johannes';
@@ -86,11 +86,11 @@ class FormLoginTest extends AbstractWebTestCase
     }
 
     /**
-     * @dataProvider getConfigs
+     * @dataProvider provideClientOptions
      */
-    public function testFormLoginRedirectsToProtectedResourceAfterLogin($config)
+    public function testFormLoginRedirectsToProtectedResourceAfterLogin(array $options)
     {
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config]);
+        $client = $this->createClient($options);
 
         $client->request('GET', '/protected_resource');
         $this->assertRedirect($client->getResponse(), '/login');
@@ -106,11 +106,11 @@ class FormLoginTest extends AbstractWebTestCase
         $this->assertStringContainsString('You\'re browsing to path "/protected_resource".', $text);
     }
 
-    public function getConfigs()
+    public function provideClientOptions()
     {
-        return [
-            ['config.yml'],
-            ['routes_as_path.yml'],
-        ];
+        yield [['test_case' => 'StandardFormLogin', 'root_config' => 'config.yml', 'enable_authenticator_manager' => true]];
+        yield [['test_case' => 'StandardFormLogin', 'root_config' => 'legacy_config.yml', 'enable_authenticator_manager' => false]];
+        yield [['test_case' => 'StandardFormLogin', 'root_config' => 'routes_as_path.yml', 'enable_authenticator_manager' => true]];
+        yield [['test_case' => 'StandardFormLogin', 'root_config' => 'legacy_routes_as_path.yml', 'enable_authenticator_manager' => false]];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/JsonLoginTest.php
@@ -18,9 +18,12 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  */
 class JsonLoginTest extends AbstractWebTestCase
 {
-    public function testDefaultJsonLoginSuccess()
+    /**
+     * @dataProvider provideSecuritySystems
+     */
+    public function testDefaultJsonLoginSuccess(array $options)
     {
-        $client = $this->createClient(['test_case' => 'JsonLogin', 'root_config' => 'config.yml']);
+        $client = $this->createClient($options + ['test_case' => 'JsonLogin', 'root_config' => 'config.yml']);
         $client->request('POST', '/chk', [], [], ['CONTENT_TYPE' => 'application/json'], '{"user": {"login": "dunglas", "password": "foo"}}');
         $response = $client->getResponse();
 
@@ -29,9 +32,12 @@ class JsonLoginTest extends AbstractWebTestCase
         $this->assertSame(['message' => 'Welcome @dunglas!'], json_decode($response->getContent(), true));
     }
 
-    public function testDefaultJsonLoginFailure()
+    /**
+     * @dataProvider provideSecuritySystems
+     */
+    public function testDefaultJsonLoginFailure(array $options)
     {
-        $client = $this->createClient(['test_case' => 'JsonLogin', 'root_config' => 'config.yml']);
+        $client = $this->createClient($options + ['test_case' => 'JsonLogin', 'root_config' => 'config.yml']);
         $client->request('POST', '/chk', [], [], ['CONTENT_TYPE' => 'application/json'], '{"user": {"login": "dunglas", "password": "bad"}}');
         $response = $client->getResponse();
 
@@ -40,9 +46,12 @@ class JsonLoginTest extends AbstractWebTestCase
         $this->assertSame(['error' => 'Invalid credentials.'], json_decode($response->getContent(), true));
     }
 
-    public function testCustomJsonLoginSuccess()
+    /**
+     * @dataProvider provideSecuritySystems
+     */
+    public function testCustomJsonLoginSuccess(array $options)
     {
-        $client = $this->createClient(['test_case' => 'JsonLogin', 'root_config' => 'custom_handlers.yml']);
+        $client = $this->createClient($options + ['test_case' => 'JsonLogin', 'root_config' => 'custom_handlers.yml']);
         $client->request('POST', '/chk', [], [], ['CONTENT_TYPE' => 'application/json'], '{"user": {"login": "dunglas", "password": "foo"}}');
         $response = $client->getResponse();
 
@@ -51,9 +60,12 @@ class JsonLoginTest extends AbstractWebTestCase
         $this->assertSame(['message' => 'Good game @dunglas!'], json_decode($response->getContent(), true));
     }
 
-    public function testCustomJsonLoginFailure()
+    /**
+     * @dataProvider provideSecuritySystems
+     */
+    public function testCustomJsonLoginFailure(array $options)
     {
-        $client = $this->createClient(['test_case' => 'JsonLogin', 'root_config' => 'custom_handlers.yml']);
+        $client = $this->createClient($options + ['test_case' => 'JsonLogin', 'root_config' => 'custom_handlers.yml']);
         $client->request('POST', '/chk', [], [], ['CONTENT_TYPE' => 'application/json'], '{"user": {"login": "dunglas", "password": "bad"}}');
         $response = $client->getResponse();
 
@@ -62,9 +74,12 @@ class JsonLoginTest extends AbstractWebTestCase
         $this->assertSame(['message' => 'Something went wrong'], json_decode($response->getContent(), true));
     }
 
-    public function testDefaultJsonLoginBadRequest()
+    /**
+     * @dataProvider provideSecuritySystems
+     */
+    public function testDefaultJsonLoginBadRequest(array $options)
     {
-        $client = $this->createClient(['test_case' => 'JsonLogin', 'root_config' => 'config.yml']);
+        $client = $this->createClient($options + ['test_case' => 'JsonLogin', 'root_config' => 'config.yml']);
         $client->request('POST', '/chk', [], [], ['CONTENT_TYPE' => 'application/json'], 'Not a json content');
         $response = $client->getResponse();
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LocalizedRoutesAsPathTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LocalizedRoutesAsPathTest.php
@@ -14,11 +14,11 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 class LocalizedRoutesAsPathTest extends AbstractWebTestCase
 {
     /**
-     * @dataProvider getLocales
+     * @dataProvider getLocalesAndClientConfig
      */
-    public function testLoginLogoutProcedure($locale)
+    public function testLoginLogoutProcedure($locale, array $options)
     {
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'localized_routes.yml']);
+        $client = $this->createClient(['test_case' => 'StandardFormLogin'] + $options);
 
         $crawler = $client->request('GET', '/'.$locale.'/login');
         $form = $crawler->selectButton('login')->form();
@@ -36,11 +36,11 @@ class LocalizedRoutesAsPathTest extends AbstractWebTestCase
 
     /**
      * @group issue-32995
-     * @dataProvider getLocales
+     * @dataProvider getLocalesAndClientConfig
      */
-    public function testLoginFailureWithLocalizedFailurePath($locale)
+    public function testLoginFailureWithLocalizedFailurePath($locale, array $options)
     {
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'localized_form_failure_handler.yml']);
+        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => ($options['enable_authenticator_manager'] ? '' : 'legacy_').'localized_form_failure_handler.yml'] + $options);
 
         $crawler = $client->request('GET', '/'.$locale.'/login');
         $form = $crawler->selectButton('login')->form();
@@ -52,29 +52,32 @@ class LocalizedRoutesAsPathTest extends AbstractWebTestCase
     }
 
     /**
-     * @dataProvider getLocales
+     * @dataProvider getLocalesAndClientConfig
      */
-    public function testAccessRestrictedResource($locale)
+    public function testAccessRestrictedResource($locale, array $options)
     {
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'localized_routes.yml']);
+        $client = $this->createClient(['test_case' => 'StandardFormLogin'] + $options);
 
         $client->request('GET', '/'.$locale.'/secure/');
         $this->assertRedirect($client->getResponse(), '/'.$locale.'/login');
     }
 
     /**
-     * @dataProvider getLocales
+     * @dataProvider getLocalesAndClientConfig
      */
-    public function testAccessRestrictedResourceWithForward($locale)
+    public function testAccessRestrictedResourceWithForward($locale, array $options)
     {
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'localized_routes_with_forward.yml']);
+        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'localized_routes_with_forward.yml'] + $options);
 
         $crawler = $client->request('GET', '/'.$locale.'/secure/');
         $this->assertCount(1, $crawler->selectButton('login'), (string) $client->getResponse());
     }
 
-    public function getLocales()
+    public function getLocalesAndClientConfig()
     {
-        return [['en'], ['de']];
+        yield ['en', ['enable_authenticator_manager' => true, 'root_config' => 'localized_routes.yml']];
+        yield ['en', ['enable_authenticator_manager' => false, 'root_config' => 'legacy_localized_routes.yml']];
+        yield ['de', ['enable_authenticator_manager' => true, 'root_config' => 'localized_routes.yml']];
+        yield ['de', ['enable_authenticator_manager' => false, 'root_config' => 'legacy_localized_routes.yml']];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LogoutTest.php
@@ -13,9 +13,12 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
 class LogoutTest extends AbstractWebTestCase
 {
-    public function testSessionLessRememberMeLogout()
+    /**
+     * @dataProvider provideSecuritySystems
+     */
+    public function testSessionLessRememberMeLogout(array $options)
     {
-        $client = $this->createClient(['test_case' => 'RememberMeLogout', 'root_config' => 'config.yml']);
+        $client = $this->createClient($options + ['test_case' => 'RememberMeLogout', 'root_config' => 'config.yml']);
 
         $client->request('POST', '/login', [
             '_username' => 'johannes',
@@ -33,9 +36,12 @@ class LogoutTest extends AbstractWebTestCase
         $this->assertNull($cookieJar->get('REMEMBERME'));
     }
 
-    public function testCsrfTokensAreClearedOnLogout()
+    /**
+     * @dataProvider provideSecuritySystems
+     */
+    public function testCsrfTokensAreClearedOnLogout(array $options)
     {
-        $client = $this->createClient(['test_case' => 'LogoutWithoutSessionInvalidation', 'root_config' => 'config.yml']);
+        $client = $this->createClient($options + ['test_case' => 'LogoutWithoutSessionInvalidation', 'root_config' => 'config.yml']);
         static::$container->get('security.csrf.token_storage')->setToken('foo', 'bar');
 
         $client->request('POST', '/login', [
@@ -51,9 +57,12 @@ class LogoutTest extends AbstractWebTestCase
         $this->assertFalse(static::$container->get('security.csrf.token_storage')->hasToken('foo'));
     }
 
-    public function testAccessControlDoesNotApplyOnLogout()
+    /**
+     * @dataProvider provideSecuritySystems
+     */
+    public function testAccessControlDoesNotApplyOnLogout(array $options)
     {
-        $client = $this->createClient(['test_case' => 'LogoutAccess', 'root_config' => 'config.yml']);
+        $client = $this->createClient($options + ['test_case' => 'LogoutAccess', 'root_config' => 'config.yml']);
 
         $client->request('POST', '/login', ['_username' => 'johannes', '_password' => 'test']);
         $client->request('GET', '/logout');

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
@@ -14,33 +14,33 @@ namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 class SecurityRoutingIntegrationTest extends AbstractWebTestCase
 {
     /**
-     * @dataProvider getConfigs
+     * @dataProvider provideClientOptions
      */
-    public function testRoutingErrorIsNotExposedForProtectedResourceWhenAnonymous($config)
+    public function testRoutingErrorIsNotExposedForProtectedResourceWhenAnonymous(array $options)
     {
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config]);
+        $client = $this->createClient($options);
         $client->request('GET', '/protected_resource');
 
         $this->assertRedirect($client->getResponse(), '/login');
     }
 
     /**
-     * @dataProvider getConfigs
+     * @dataProvider provideClientOptions
      */
-    public function testRoutingErrorIsExposedWhenNotProtected($config)
+    public function testRoutingErrorIsExposedWhenNotProtected(array $options)
     {
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config]);
+        $client = $this->createClient($options);
         $client->request('GET', '/unprotected_resource');
 
         $this->assertEquals(404, $client->getResponse()->getStatusCode(), (string) $client->getResponse());
     }
 
     /**
-     * @dataProvider getConfigs
+     * @dataProvider provideClientOptions
      */
-    public function testRoutingErrorIsNotExposedForProtectedResourceWhenLoggedInWithInsufficientRights($config)
+    public function testRoutingErrorIsNotExposedForProtectedResourceWhenLoggedInWithInsufficientRights(array $options)
     {
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config]);
+        $client = $this->createClient($options);
 
         $form = $client->request('GET', '/login')->selectButton('login')->form();
         $form['_username'] = 'johannes';
@@ -53,38 +53,38 @@ class SecurityRoutingIntegrationTest extends AbstractWebTestCase
     }
 
     /**
-     * @dataProvider getConfigs
+     * @dataProvider provideClientOptions
      */
-    public function testSecurityConfigurationForSingleIPAddress($config)
+    public function testSecurityConfigurationForSingleIPAddress(array $options)
     {
-        $allowedClient = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], ['REMOTE_ADDR' => '10.10.10.10']);
+        $allowedClient = $this->createClient($options, ['REMOTE_ADDR' => '10.10.10.10']);
 
         $this->ensureKernelShutdown();
 
-        $barredClient = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], ['REMOTE_ADDR' => '10.10.20.10']);
+        $barredClient = $this->createClient($options, ['REMOTE_ADDR' => '10.10.20.10']);
 
         $this->assertAllowed($allowedClient, '/secured-by-one-ip');
         $this->assertRestricted($barredClient, '/secured-by-one-ip');
     }
 
     /**
-     * @dataProvider getConfigs
+     * @dataProvider provideClientOptions
      */
-    public function testSecurityConfigurationForMultipleIPAddresses($config)
+    public function testSecurityConfigurationForMultipleIPAddresses(array $options)
     {
-        $allowedClientA = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], ['REMOTE_ADDR' => '1.1.1.1']);
+        $allowedClientA = $this->createClient($options, ['REMOTE_ADDR' => '1.1.1.1']);
 
         $this->ensureKernelShutdown();
 
-        $allowedClientB = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], ['REMOTE_ADDR' => '2.2.2.2']);
+        $allowedClientB = $this->createClient($options, ['REMOTE_ADDR' => '2.2.2.2']);
 
         $this->ensureKernelShutdown();
 
-        $allowedClientC = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], ['REMOTE_ADDR' => '203.0.113.0']);
+        $allowedClientC = $this->createClient($options, ['REMOTE_ADDR' => '203.0.113.0']);
 
         $this->ensureKernelShutdown();
 
-        $barredClient = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], ['REMOTE_ADDR' => '192.168.1.1']);
+        $barredClient = $this->createClient($options, ['REMOTE_ADDR' => '192.168.1.1']);
 
         $this->assertAllowed($allowedClientA, '/secured-by-two-ips');
         $this->assertAllowed($allowedClientB, '/secured-by-two-ips');
@@ -97,19 +97,19 @@ class SecurityRoutingIntegrationTest extends AbstractWebTestCase
     }
 
     /**
-     * @dataProvider getConfigs
+     * @dataProvider provideConfigs
      */
-    public function testSecurityConfigurationForExpression($config)
+    public function testSecurityConfigurationForExpression(array $options)
     {
-        $allowedClient = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], ['HTTP_USER_AGENT' => 'Firefox 1.0']);
+        $allowedClient = $this->createClient($options, ['HTTP_USER_AGENT' => 'Firefox 1.0']);
         $this->assertAllowed($allowedClient, '/protected-via-expression');
         $this->ensureKernelShutdown();
 
-        $barredClient = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], []);
+        $barredClient = $this->createClient($options, []);
         $this->assertRestricted($barredClient, '/protected-via-expression');
         $this->ensureKernelShutdown();
 
-        $allowedClient = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => $config], []);
+        $allowedClient = $this->createClient($options, []);
 
         $allowedClient->request('GET', '/protected-via-expression');
         $form = $allowedClient->followRedirect()->selectButton('login')->form();
@@ -120,18 +120,24 @@ class SecurityRoutingIntegrationTest extends AbstractWebTestCase
         $this->assertAllowed($allowedClient, '/protected-via-expression');
     }
 
-    public function testInvalidIpsInAccessControl()
+    /**
+     * @dataProvider provideSecuritySystems
+     */
+    public function testInvalidIpsInAccessControl(array $options)
     {
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The given value "256.357.458.559" in the "security.access_control" config option is not a valid IP address.');
 
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'invalid_ip_access_control.yml']);
+        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'invalid_ip_access_control.yml'] + $options);
         $client->request('GET', '/unprotected_resource');
     }
 
-    public function testPublicHomepage()
+    /**
+     * @dataProvider provideSecuritySystems
+     */
+    public function testPublicHomepage(array $options)
     {
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'config.yml']);
+        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'config.yml'] + $options);
         $client->request('GET', '/en/');
 
         $this->assertEquals(200, $client->getResponse()->getStatusCode(), (string) $client->getResponse());
@@ -151,8 +157,17 @@ class SecurityRoutingIntegrationTest extends AbstractWebTestCase
         $this->assertEquals(302, $client->getResponse()->getStatusCode());
     }
 
-    public function getConfigs()
+    public function provideClientOptions()
     {
-        return [['config.yml'], ['routes_as_path.yml']];
+        yield [['test_case' => 'StandardFormLogin', 'root_config' => 'config.yml', 'enable_authenticator_manager' => true]];
+        yield [['test_case' => 'StandardFormLogin', 'root_config' => 'legacy_config.yml', 'enable_authenticator_manager' => false]];
+        yield [['test_case' => 'StandardFormLogin', 'root_config' => 'routes_as_path.yml', 'enable_authenticator_manager' => true]];
+        yield [['test_case' => 'StandardFormLogin', 'root_config' => 'legacy_routes_as_path.yml', 'enable_authenticator_manager' => false]];
+    }
+
+    public function provideConfigs()
+    {
+        yield [['test_case' => 'StandardFormLogin', 'root_config' => 'legacy_config.yml']];
+        yield [['test_case' => 'StandardFormLogin', 'root_config' => 'legacy_routes_as_path.yml']];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
@@ -25,8 +25,9 @@ class AppKernel extends Kernel
     private $varDir;
     private $testCase;
     private $rootConfig;
+    private $authenticatorManagerEnabled;
 
-    public function __construct($varDir, $testCase, $rootConfig, $environment, $debug)
+    public function __construct($varDir, $testCase, $rootConfig, $environment, $debug, $authenticatorManagerEnabled = false)
     {
         if (!is_dir(__DIR__.'/'.$testCase)) {
             throw new \InvalidArgumentException(sprintf('The test case "%s" does not exist.', $testCase));
@@ -39,6 +40,7 @@ class AppKernel extends Kernel
             throw new \InvalidArgumentException(sprintf('The root config "%s" does not exist.', $rootConfig));
         }
         $this->rootConfig = $rootConfig;
+        $this->authenticatorManagerEnabled = $authenticatorManagerEnabled;
 
         parent::__construct($environment, $debug);
     }
@@ -48,7 +50,7 @@ class AppKernel extends Kernel
      */
     public function getContainerClass(): string
     {
-        return parent::getContainerClass().substr(md5($this->rootConfig), -16);
+        return parent::getContainerClass().substr(md5($this->rootConfig.$this->authenticatorManagerEnabled), -16);
     }
 
     public function registerBundles(): iterable
@@ -78,6 +80,14 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
         $loader->load($this->rootConfig);
+
+        if ($this->authenticatorManagerEnabled) {
+            $loader->load(function ($container) {
+                $container->loadFromExtension('security', [
+                    'enable_authenticator_manager' => true,
+                ]);
+            });
+        }
     }
 
     public function serialize()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/ClearRememberMe/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/ClearRememberMe/config.yml
@@ -19,7 +19,6 @@ security:
             remember_me:
                 always_remember_me: true
                 secret: key
-            anonymous: ~
 
     access_control:
         - { path: ^/foo, roles: ROLE_USER }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/ClearRememberMe/legacy_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/ClearRememberMe/legacy_config.yml
@@ -1,0 +1,7 @@
+imports:
+    - { resource: ./config.yml }
+
+security:
+    firewalls:
+        default:
+            anonymous: ~

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/base_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/base_config.yml
@@ -1,0 +1,44 @@
+imports:
+    - { resource: ./../config/default.yml }
+
+services:
+    csrf_form_login.form.type:
+        class: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\CsrfFormLoginBundle\Form\UserLoginType
+        arguments:
+            - '@request_stack'
+        tags:
+            - { name: form.type }
+
+security:
+    encoders:
+        Symfony\Component\Security\Core\User\User: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    johannes: { password: test, roles: [ROLE_USER] }
+
+    firewalls:
+        # This firewall doesn't make sense in combination with the rest of the
+        # configuration file, but it's here for testing purposes (do not use
+        # this file in a real world scenario though)
+        login_form:
+            pattern: ^/login$
+            security: false
+
+        default:
+            form_login:
+                check_path: /login_check
+                default_target_path: /profile
+                target_path_parameter: "user_login[_target_path]"
+                failure_path_parameter: "user_login[_failure_path]"
+                username_parameter: "user_login[username]"
+                password_parameter: "user_login[password]"
+            logout:
+                path: /logout_path
+                target: /
+                csrf_token_generator: security.csrf.token_manager
+
+    access_control:
+        - { path: .*, roles: IS_AUTHENTICATED_FULLY }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/legacy_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/legacy_config.yml
@@ -2,8 +2,9 @@ imports:
     - { resource: ./base_config.yml }
 
 security:
-    firewalls:
+  firewalls:
         default:
             form_login:
-                enable_csrf: true
+                csrf_token_generator: security.csrf.token_manager
                 csrf_parameter: "user_login[_token]"
+            anonymous: ~

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/legacy_routes_as_path.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/legacy_routes_as_path.yml
@@ -1,0 +1,13 @@
+imports:
+    - { resource: ./legacy_config.yml }
+
+security:
+    firewalls:
+        default:
+            form_login:
+                login_path: form_login
+                check_path: form_login_check
+                default_target_path: form_login_default_target_path
+            logout:
+                path: form_logout
+                target: form_login_homepage

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
@@ -19,8 +19,6 @@ security:
             pattern: ^/secure/
             http_basic: { realm: "Secure Gateway API" }
             entry_point: firewall_entry_point.entry_point.stub
-        default:
-            anonymous: ~
     access_control:
         - { path: ^/secure/, roles: ROLE_SECURE }
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/config.yml
@@ -17,7 +17,6 @@ security:
     firewalls:
         main:
             pattern: ^/
-            anonymous: true
             json_login:
                check_path:    /chk
                username_path: user.login

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/custom_handlers.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/custom_handlers.yml
@@ -14,7 +14,6 @@ security:
     firewalls:
         main:
             pattern: ^/
-            anonymous: true
             json_login:
                check_path:    /chk
                username_path: user.login

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutAccess/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutAccess/config.yml
@@ -18,7 +18,6 @@ security:
                 remember_me: true
                 require_previous_session: false
             logout: ~
-            anonymous: ~
             stateless: true
 
     access_control:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
@@ -22,5 +22,4 @@ security:
                 secret: secret
             logout:
                 invalidate_session: false
-            anonymous: ~
             stateless: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeLogout/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeLogout/config.yml
@@ -26,5 +26,4 @@ security:
                 always_remember_me: true
                 secret: key
             logout: ~
-            anonymous: ~
             stateless: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/config.yml
@@ -27,13 +27,11 @@ security:
                 check_path: /login_check
                 default_target_path: /profile
             logout: ~
-            anonymous: ~
             lazy: true
 
         # This firewall is here just to check its the logout functionality
         second_area:
             http_basic: ~
-            anonymous: ~
             logout:
                 target: /second/target
                 path: /second/logout

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/invalid_ip_access_control.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/invalid_ip_access_control.yml
@@ -15,7 +15,6 @@ security:
         default:
             form_login: ~
             logout: ~
-            anonymous: ~
 
     access_control:
         # the '256.357.458.559' IP is wrong on purpose, to check invalid IP errors

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/legacy_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/legacy_config.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: ./config.yml }
+
+security:
+    firewalls:
+        default:
+            anonymous: ~
+        second_area:
+            anonymous: ~

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/legacy_localized_form_failure_handler.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/legacy_localized_form_failure_handler.yml
@@ -1,0 +1,7 @@
+imports:
+    - { resource: ./localized_form_failure_handler.yml }
+
+security:
+    firewalls:
+        default:
+            anonymous: ~

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/legacy_localized_routes.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/legacy_localized_routes.yml
@@ -1,0 +1,7 @@
+imports:
+    - { resource: ./localized_routes.yml }
+
+security:
+    firewalls:
+        default:
+            anonymous: ~

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/legacy_routes_as_path.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/legacy_routes_as_path.yml
@@ -1,0 +1,13 @@
+imports:
+    - { resource: ./legacy_config.yml }
+
+security:
+    firewalls:
+        default:
+            form_login:
+                login_path: form_login
+                check_path: form_login_check
+                default_target_path: form_login_default_target_path
+            logout:
+                path: form_logout
+                target: form_login_homepage

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_form_failure_handler.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_form_failure_handler.yml
@@ -17,4 +17,3 @@ security:
                 login_path: localized_login_path
                 check_path: localized_check_path
                 failure_handler: localized_form_failure_handler
-            anonymous: ~

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_routes.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_routes.yml
@@ -20,7 +20,6 @@ security:
             logout:
                 path: localized_logout_path
                 target: localized_logout_target_path
-            anonymous: ~
 
     access_control:
         - { path: '^/(?:[a-z]{2})/secure/.*', roles: ROLE_USER }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -26,7 +26,7 @@
         "symfony/security-core": "^5.1",
         "symfony/security-csrf": "^4.4|^5.0",
         "symfony/security-guard": "^5.1",
-        "symfony/security-http": "^5.1"
+        "symfony/security-http": "^5.1,>=5.1.2"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.0",

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -79,7 +79,14 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
 
     public function authenticate(Request $request): PassportInterface
     {
-        $credentials = $this->getCredentials($request);
+        try {
+            $credentials = $this->getCredentials($request);
+        } catch (BadRequestHttpException $e) {
+            $request->setRequestFormat('json');
+
+            throw $e;
+        }
+
         $user = $this->userProvider->loadUserByUsername($credentials['username']);
         if (!$user instanceof UserInterface) {
             throw new AuthenticationServiceException('The user provider must return a UserInterface object.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

<s>Includes https://github.com/symfony/symfony/pull/37261 until it's merged.</s>

This runs all relevant functional tests in the security bundle for both the traditional and the authenticator system. This will hopefully avoid breaking more code in further releases.

deps=high builds will be green once this has been merged up into master.

---

During the functional tests, some inconsistencies were fixed. Three tests revealed larger inconsistencies that couldn't be fixed easily. These are not run for the new system as of now, we need to investigate further how to proceed with them. I'll create a separate issue/discussion for these:

* `Symfony\Bundle\SecurityBundle\Tests\Functional\FirewallEntryPointTest::testItUsesTheConfiguredEntryPointWhenUsingUnknownCredentials`
* `Symfony\Bundle\SecurityBundle\Tests\Functional\CsrfFormLoginTest::testFormLoginWithInvalidCsrfToken`
* `Symfony\Bundle\SecurityBundle\Tests\Functional\SecurityRoutingIntegrationTest::testSecurityConfigurationForExpression`