### PR TITLE
[Messenger] Fix precedence of DSN options for 4.4

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -209,7 +209,7 @@ class ConnectionTest extends TestCase
             'expectedAutoSetup' => false,
         ];
 
-        yield 'options from options array wins over options from dsn' => [
+        yield 'options from dsn array wins over options from options' => [
             'dsn' => 'doctrine://default?table_name=name_from_dsn&redeliver_timeout=1200&queue_name=normal&auto_setup=true',
             'options' => [
                 'table_name' => 'name_from_options',
@@ -218,10 +218,10 @@ class ConnectionTest extends TestCase
                 'auto_setup' => false,
             ],
             'expectedConnection' => 'default',
-            'expectedTableName' => 'name_from_options',
-            'expectedRedeliverTimeout' => 1800,
-            'expectedQueue' => 'important',
-            'expectedAutoSetup' => false,
+            'expectedTableName' => 'name_from_dsn',
+            'expectedRedeliverTimeout' => 1200,
+            'expectedQueue' => 'normal',
+            'expectedAutoSetup' => true,
         ];
 
         yield 'options from dsn with falsey boolean' => [

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -85,7 +85,7 @@ class Connection
         }
 
         $configuration = ['connection' => $components['host']];
-        $configuration += $options + $query + self::DEFAULT_OPTIONS;
+        $configuration += $query + $options + self::DEFAULT_OPTIONS;
 
         $configuration['auto_setup'] = filter_var($configuration['auto_setup'], FILTER_VALIDATE_BOOLEAN);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/37218#discussion_r438779225
| License       | MIT
| Doc PR        | N/A

This PR fix précédence of DSN options over constructor options in all component on branch 4.4