### PR TITLE
[HttpFoundation] add `HeaderUtils::parseQuery()`: it does the same as `parse_str()` but preserves dots in variable names

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/dependency-injection": "^5.2",
         "symfony/event-dispatcher": "^5.1",
         "symfony/error-handler": "^4.4.1|^5.0.1",
-        "symfony/http-foundation": "^4.4|^5.0",
+        "symfony/http-foundation": "^5.2",
         "symfony/http-kernel": "^5.2",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php80": "^1.15",

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * added `HeaderUtils::parseQuery()`: it does the same as `parse_str()` but preserves dots in variable names
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -399,7 +399,7 @@ class Request
 
         $queryString = '';
         if (isset($components['query'])) {
-            parse_str(html_entity_decode($components['query']), $qs);
+            $qs = HeaderUtils::parseQuery(html_entity_decode($components['query']));
 
             if ($query) {
                 $query = array_replace($qs, $query);
@@ -660,7 +660,7 @@ class Request
             return '';
         }
 
-        parse_str($qs, $qs);
+        $qs = HeaderUtils::parseQuery($qs);
         ksort($qs);
 
         return http_build_query($qs, '', '&', PHP_QUERY_RFC3986);

--- a/src/Symfony/Component/HttpFoundation/Tests/HeaderUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HeaderUtilsTest.php
@@ -129,4 +129,41 @@ class HeaderUtilsTest extends TestCase
             ['attachment', 'föö.html'],
         ];
     }
+
+    /**
+     * @dataProvider provideParseQuery
+     */
+    public function testParseQuery(string $query, string $expected = null)
+    {
+        $this->assertSame($expected ?? $query, http_build_query(HeaderUtils::parseQuery($query), '', '&'));
+    }
+
+    public function provideParseQuery()
+    {
+        return [
+            ['a=b&c=d'],
+            ['a.b=c'],
+            ['a+b=c'],
+            ["a\0b=c", 'a='],
+            ['a%00b=c', 'a=c'],
+            ['a[b=c', 'a%5Bb=c'],
+            ['a]b=c', 'a%5Db=c'],
+            ['a[b]=c', 'a%5Bb%5D=c'],
+            ['a[b][c.d]=c', 'a%5Bb%5D%5Bc.d%5D=c'],
+            ['a%5Bb%5D=c'],
+        ];
+    }
+
+    public function testParseCookie()
+    {
+        $query = 'a.b=c; def%5Bg%5D=h';
+        $this->assertSame($query, http_build_query(HeaderUtils::parseQuery($query, false, ';'), '', '; '));
+    }
+
+    public function testParseQueryIgnoreBrackets()
+    {
+        $this->assertSame(['a.b' => ['A', 'B']], HeaderUtils::parseQuery('a.b=A&a.b=B', true));
+        $this->assertSame(['a.b[]' => ['A']], HeaderUtils::parseQuery('a.b[]=A', true));
+        $this->assertSame(['a.b[]' => ['A']], HeaderUtils::parseQuery('a.b%5B%5D=A', true));
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -807,7 +807,7 @@ class RequestTest extends TestCase
             ['foo=1&foo=2', 'foo=2', 'merges repeated parameters'],
             ['pa%3Dram=foo%26bar%3Dbaz&test=test', 'pa%3Dram=foo%26bar%3Dbaz&test=test', 'works with encoded delimiters'],
             ['0', '0=', 'allows "0"'],
-            ['Foo Bar&Foo%20Baz', 'Foo_Bar=&Foo_Baz=', 'normalizes encoding in keys'],
+            ['Foo Bar&Foo%20Baz', 'Foo%20Bar=&Foo%20Baz=', 'normalizes encoding in keys'],
             ['bar=Foo Bar&baz=Foo%20Baz', 'bar=Foo%20Bar&baz=Foo%20Baz', 'normalizes encoding in values'],
             ['foo=bar&&&test&&', 'foo=bar&test=', 'removes unneeded delimiters'],
             ['formula=e=m*c^2', 'formula=e%3Dm%2Ac%5E2', 'correctly treats only the first "=" as delimiter and the next as value'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Inspired by https://github.com/symfony/psr-http-message-bridge/pull/80
/cc @drupol 

Related to #9009, #29664, #26220 but also https://github.com/api-platform/core/issues/509 and https://www.drupal.org/project/drupal/issues/2984272
/cc @dunglas @alexpott 
