### PR TITLE
[Form] Fixed prototype block prefixes hierarchy of the CollectionType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -93,7 +93,7 @@ class CollectionType extends AbstractType
                 $view->vars['multipart'] = true;
             }
 
-            if ($prefixOffset > -2 && $prototype->getConfig()->getOption('block_prefix')) {
+            if ($prefixOffset > -3 && $prototype->getConfig()->getOption('block_prefix')) {
                 --$prefixOffset;
             }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -428,37 +428,66 @@ class CollectionTypeTest extends BaseTypeTest
     public function testEntriesBlockPrefixesWithCustomBlockPrefix()
     {
         $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, [''], [
+            'allow_add' => true,
             'entry_options' => ['block_prefix' => 'field'],
         ])
             ->createView()
         ;
 
-        $this->assertCount(1, $collectionView);
-        $this->assertSame([
+        $expectedBlockPrefixes = [
             'form',
             'collection_entry',
             'text',
             'field',
             '_fields_entry',
-        ], $collectionView[0]->vars['block_prefixes']);
+        ];
+
+        $this->assertCount(1, $collectionView);
+        $this->assertSame($expectedBlockPrefixes, $collectionView[0]->vars['block_prefixes']);
+        $this->assertSame($expectedBlockPrefixes, $collectionView->vars['prototype']->vars['block_prefixes']);
     }
 
     public function testEntriesBlockPrefixesWithCustomBlockPrefixedType()
     {
         $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, [''], [
+            'allow_add' => true,
             'entry_type' => BlockPrefixedFooTextType::class,
         ])
             ->createView()
         ;
 
-        $this->assertCount(1, $collectionView);
-        $this->assertSame([
+        $expectedBlockPrefixes = [
             'form',
             'collection_entry',
             'block_prefixed_foo_text',
             'foo',
             '_fields_entry',
-        ], $collectionView[0]->vars['block_prefixes']);
+        ];
+
+        $this->assertCount(1, $collectionView);
+        $this->assertSame($expectedBlockPrefixes, $collectionView[0]->vars['block_prefixes']);
+        $this->assertSame($expectedBlockPrefixes, $collectionView->vars['prototype']->vars['block_prefixes']);
+    }
+
+    public function testPrototypeBlockPrefixesWithCustomBlockPrefix()
+    {
+        $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, [], [
+            'allow_add' => true,
+            'entry_options' => ['block_prefix' => 'field'],
+        ])
+            ->createView()
+        ;
+
+        $expectedBlockPrefixes = [
+            'form',
+            'collection_entry',
+            'text',
+            'field',
+            '_fields_entry',
+        ];
+
+        $this->assertCount(0, $collectionView);
+        $this->assertSame($expectedBlockPrefixes, $collectionView->vars['prototype']->vars['block_prefixes']);
     }
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37024
| License       | MIT
| Doc PR        | 

Following https://github.com/symfony/symfony/pull/37276