### PR TITLE
[Console] Reset question validator attempts only for actual stdin (bis)

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -104,7 +104,7 @@ class QuestionHelper extends Helper
     {
         $this->writePrompt($output, $question);
 
-        $inputStream = $this->inputStream ?: STDIN;
+        $inputStream = $this->inputStream ?: fopen('php://stdin', 'r');
         $autocomplete = $question->getAutocompleterCallback();
 
         if (null === $autocomplete || !self::$stty || !Terminal::hasSttyAvailable()) {
@@ -474,7 +474,7 @@ class QuestionHelper extends Helper
             } catch (\Exception $error) {
             }
 
-            $attempts = $attempts ?? -(int) $this->isTty();
+            $attempts = $attempts ?? -(int) $this->askForever();
         }
 
         throw $error;
@@ -507,18 +507,20 @@ class QuestionHelper extends Helper
         return self::$shell;
     }
 
-    private function isTty(): bool
+    private function askForever(): bool
     {
-        if (!\defined('STDIN')) {
+        $inputStream = $this->inputStream ?: fopen('php://stdin', 'r');
+
+        if ('php://stdin' !== (stream_get_meta_data($inputStream)['url'] ?? null)) {
             return true;
         }
 
         if (\function_exists('stream_isatty')) {
-            return stream_isatty(fopen('php://input', 'r'));
+            return stream_isatty($inputStream);
         }
 
         if (\function_exists('posix_isatty')) {
-            return posix_isatty(fopen('php://input', 'r'));
+            return posix_isatty($inputStream);
         }
 
         return true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

#37160 [fails](https://travis-ci.org/github/symfony/symfony/jobs/698492147), this should fix it by looking at the actual input stream.