### PR TITLE
Release v5.1.2

### DIFF
--- a/CHANGELOG-5.1.md
+++ b/CHANGELOG-5.1.md
@@ -7,6 +7,16 @@ in 5.1 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v5.1.0...v5.1.1
 
+* 5.1.2 (2020-06-15)
+
+ * bug #37265 [HttpFoundation] use InputBag for Request::$request only if data is coming from a form (nicolas-grekas)
+ * bug #37283 [SecurityBundle] Fix CookieClearingLogoutListener DI configuration (wouterj)
+ * bug #37160 Reset question validator attempts only for actual stdin (ostrolucky)
+ * bug #36975 [PropertyInfo] Make PhpDocExtractor compatible with phpDocumentor v5 (DerManoMann)
+ * bug #37279 [Form] Fixed prototype block prefixes hierarchy of the CollectionType (yceruto)
+ * bug #37276 [Form] Fixed block prefixes hierarchy of the CollectionType (yceruto)
+ * bug #37261 Fix register csrf protection listener (Ne-Lexa)
+
 * 5.1.1 (2020-06-12)
 
  * bug #37227 [DependencyInjection][CheckTypeDeclarationsPass] Handle unresolved parameters pointing to environment variables (fancyweb)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -73,12 +73,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     private static $freshCache = [];
 
-    const VERSION = '5.1.2-DEV';
+    const VERSION = '5.1.2';
     const VERSION_ID = 50102;
     const MAJOR_VERSION = 5;
     const MINOR_VERSION = 1;
     const RELEASE_VERSION = 2;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '01/2021';
     const END_OF_LIFE = '01/2021';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v5.1.1...v5.1.2)

 * bug #37265 [HttpFoundation] use InputBag for Request::$request only if data is coming from a form (@nicolas-grekas)
 * bug #37283 [SecurityBundle] Fix CookieClearingLogoutListener DI configuration (@wouterj)
 * bug #37160 Reset question validator attempts only for actual stdin (@ostrolucky)
 * bug #36975 [PropertyInfo] Make PhpDocExtractor compatible with phpDocumentor v5 (@DerManoMann)
 * bug #37279 [Form] Fixed prototype block prefixes hierarchy of the CollectionType (@yceruto)
 * bug #37276 [Form] Fixed block prefixes hierarchy of the CollectionType (@yceruto)
 * bug #37261 Fix register csrf protection listener (@Ne-Lexa)
