### PR TITLE
[Messenger] added support for Amazon SQS QueueUrl as DSN

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * Added support for an Amazon SQS QueueUrl to be used as DSN.
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportFactoryTest.php
@@ -21,6 +21,7 @@ class AmazonSqsTransportFactoryTest extends TestCase
         $factory = new AmazonSqsTransportFactory();
 
         $this->assertTrue($factory->supports('sqs://localhost', []));
+        $this->assertTrue($factory->supports('https://sqs.us-east-2.amazonaws.com/123456789012/ab1-MyQueue-A2BCDEF3GHI4', []));
         $this->assertFalse($factory->supports('redis://localhost', []));
         $this->assertFalse($factory->supports('invalid-dsn', []));
     }

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -88,6 +88,15 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testFromDsnAsQueueUrl()
+    {
+        $httpClient = $this->getMockBuilder(HttpClientInterface::class)->getMock();
+        $this->assertEquals(
+            new Connection(['queue_name' => 'ab1-MyQueue-A2BCDEF3GHI4', 'account' => '123456789012'], new SqsClient(['region' => 'us-east-2', 'endpoint' => 'https://sqs.us-east-2.amazonaws.com', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
+            Connection::fromDsn('https://sqs.us-east-2.amazonaws.com/123456789012/ab1-MyQueue-A2BCDEF3GHI4', [], $httpClient)
+        );
+    }
+
     public function testFromDsnWithCustomEndpoint()
     {
         $httpClient = $this->getMockBuilder(HttpClientInterface::class)->getMock();

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransportFactory.php
@@ -29,6 +29,6 @@ class AmazonSqsTransportFactory implements TransportFactoryInterface
 
     public function supports(string $dsn, array $options): bool
     {
-        return 0 === strpos($dsn, 'sqs://');
+        return 0 === strpos($dsn, 'sqs://') || preg_match('#^https://sqs\.[\w\-]+\.amazonaws\.com/.+#', $dsn);
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/TransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/TransportFactory.php
@@ -45,7 +45,7 @@ class TransportFactory implements TransportFactoryInterface
             $packageSuggestion = ' Run "composer require symfony/doctrine-messenger" to install Doctrine transport.';
         } elseif (0 === strpos($dsn, 'redis://')) {
             $packageSuggestion = ' Run "composer require symfony/redis-messenger" to install Redis transport.';
-        } elseif (0 === strpos($dsn, 'sqs://')) {
+        } elseif (0 === strpos($dsn, 'sqs://') || preg_match('#^https://sqs\.[\w\-]+\.amazonaws\.com/.+#', $dsn)) {
             $packageSuggestion = ' Run "composer require symfony/amazon-sqs-messenger" to install Amazon SQS transport.';
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #37305
| License       | MIT
| Doc PR        | N/A

This will allow to use an Amazon SQS QueueUrl as transport DSN