### PR TITLE
[Notifier] Fix package rename when releasing

### DIFF
--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -50,9 +50,9 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Firebase\FirebaseTransportFactory::class,
             'package' => 'symfony/firebase-notifier',
         ],
-        'freemobile' => [
+        'free-mobile' => [
             'class' => Bridge\FreeMobile\FreeMobileTransportFactory::class,
-            'package' => 'symfony/freemobile-notifier',
+            'package' => 'symfony/free-mobile-notifier',
         ],
         'ovhcloud' => [
             'class' => Bridge\OvhCloud\OvhCloudTransportFactory::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix when upgrading my local project to use the package instead of my old code :)
| License       | MIT

---

Related to 
https://github.com/symfony/symfony/commit/a89a2a88935ae56961c71e4359961d4eb555cf90#diff-bd586be86489d3e4725496bf5d4caf23 friendly ping @fabpot 

The package is released at https://packagist.org/packages/symfony/free-mobile-notifier
And thus this needed to be fixed t give proper hint to devs

Thanks
