### PR TITLE
Update AbstractTransport.php

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -52,7 +52,7 @@ abstract class AbstractTransport implements TransportInterface
         return $this;
     }
 
-    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, Envelope $envelope = null): SentMessage
     {
         $message = clone $message;
         $envelope = null !== $envelope ? clone $envelope : Envelope::create($message);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

Removing ? from return type.
According to line 66, a SentMessage is returned in any case, isn't it?

If you agree, this change should be reflected in extending classes as well, e.g. https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php#L129

Question: What's the recommended way to check if the mail has been sent successfully? I didn't find anything better than $sentMessage->getDebug() yet...
