### PR TITLE
[Security] Fix infinite loop when token storage has no token

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -47,16 +47,16 @@ class AccessListener implements ListenerInterface
      */
     public function handle(GetResponseEvent $event)
     {
-        if (null === $token = $this->tokenStorage->getToken()) {
-            throw new AuthenticationCredentialsNotFoundException('A Token was not found in the TokenStorage.');
-        }
-
         $request = $event->getRequest();
 
         list($attributes) = $this->map->getPatterns($request);
 
         if (null === $attributes) {
             return;
+        }
+
+        if (null === $token = $this->tokenStorage->getToken()) {
+            throw new AuthenticationCredentialsNotFoundException('A Token was not found in the TokenStorage.');
         }
 
         if (!$token->isAuthenticated()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When token storage is empty (anonymous not enabled in the config of the fullstack framework) and when we try to access to a page covered by an access control rule, an infinite loop is triggered:
- AccessListener throws an AuthenticationException because TokenStorage has no token
- ExceptionListener intercept the exception and redirects to the login page
- AccessListener catches the request and throws an AuthenticationException because TokenStorage has no token etc...

This PR aims to fix that behavior.