### PR TITLE
Adding a keyword for Packagist

### DIFF
--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -2,7 +2,7 @@
     "name": "symfony/console",
     "type": "library",
     "description": "Symfony Console Component",
-    "keywords": ["console", "cli", "command line"],
+    "keywords": ["console", "cli", "command line", "terminal"],
     "homepage": "https://symfony.com",
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Thank you @javiereguiluz for the suggestion.
https://github.com/symfony/symfony/pull/37273

| Q             | A
| ------------- | ---
| Branch?       | N/A
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

So project will appear here:
https://packagist.org/search/?tags=terminal

