### PR TITLE
[PropertyAccess] fix return value

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -465,7 +465,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         if ($this->cacheItemPool) {
             $item = $this->cacheItemPool->getItem(self::CACHE_PREFIX_READ.rawurlencode($key));
             if ($item->isHit()) {
-                return $this->readPropertyCache[$key] = unserialize($item->get())?:null;
+                return $this->readPropertyCache[$key] = unserialize($item->get()) ?: null;
             }
         }
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -467,7 +467,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             if ($item->isHit()) {
                 $unserialized = @unserialize($item->get());
                 
-                return $this->readPropertyCache[$key] = $unserialized !== false ? $unserialized : null;
+                return $this->readPropertyCache[$key] = false !== $unserialized ? $unserialized : null;
             }
         }
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -466,7 +466,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             $item = $this->cacheItemPool->getItem(self::CACHE_PREFIX_READ.rawurlencode($key));
             if ($item->isHit()) {
                 $unserialized = @unserialize($item->get());
-                
+
                 return $this->readPropertyCache[$key] = false !== $unserialized ? $unserialized : null;
             }
         }

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -465,7 +465,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         if ($this->cacheItemPool) {
             $item = $this->cacheItemPool->getItem(self::CACHE_PREFIX_READ.rawurlencode($key));
             if ($item->isHit()) {
-                return $this->readPropertyCache[$key] = unserialize($item->get());
+                return $this->readPropertyCache[$key] = unserialize($item->get())?:null;
             }
         }
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -465,7 +465,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         if ($this->cacheItemPool) {
             $item = $this->cacheItemPool->getItem(self::CACHE_PREFIX_READ.rawurlencode($key));
             if ($item->isHit()) {
-                return $this->readPropertyCache[$key] = $item->get();
+                return $this->readPropertyCache[$key] = unserialize($item->get());
             }
         }
 
@@ -476,7 +476,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         ]);
 
         if (isset($item)) {
-            $this->cacheItemPool->save($item->set($accessor));
+            $this->cacheItemPool->save($item->set(serialize($accessor)));
         }
 
         return $this->readPropertyCache[$key] = $accessor;

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -465,7 +465,9 @@ class PropertyAccessor implements PropertyAccessorInterface
         if ($this->cacheItemPool) {
             $item = $this->cacheItemPool->getItem(self::CACHE_PREFIX_READ.rawurlencode($key));
             if ($item->isHit()) {
-                return $this->readPropertyCache[$key] = @unserialize($item->get()) ?: null;
+                $unserialized = @unserialize($item->get());
+                
+                return $this->readPropertyCache[$key] = $unserialized !== false ? $unserialized : null;
             }
         }
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -465,7 +465,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         if ($this->cacheItemPool) {
             $item = $this->cacheItemPool->getItem(self::CACHE_PREFIX_READ.rawurlencode($key));
             if ($item->isHit()) {
-                return $this->readPropertyCache[$key] = unserialize($item->get()) ?: null;
+                return $this->readPropertyCache[$key] = @unserialize($item->get()) ?: null;
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #37101
| License       | MIT

The added return type for the function **getReadInfo** **_?PropertyReadInfo_** is not working if the readInfo is cached. Because it is automatically saved as array.
