### PR TITLE
[Mailer] Pass cloned message and envelope to MessageBus

### DIFF
--- a/src/Symfony/Component/Mailer/Mailer.php
+++ b/src/Symfony/Component/Mailer/Mailer.php
@@ -49,6 +49,9 @@ final class Mailer implements MailerInterface
             $clonedEnvelope = null !== $envelope ? clone $envelope : Envelope::create($clonedMessage);
             $event = new MessageEvent($clonedMessage, $clonedEnvelope, (string) $this->transport, true);
             $this->dispatcher->dispatch($event);
+
+            $message = $clonedMessage;
+            $envelope = $clonedEnvelope;
         }
 
         $this->bus->dispatch(new SendEmailMessage($message, $envelope));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Recent changes in https://github.com/symfony/mailer/commit/f62d7ebdc095f6a3e0922317d963765279be115c#diff-bb5be03f312bba64e0ce7d4cbbdbf7a8 (avoiding reuse of same var names when cloning) introduced an issue where, if an EventDispatcher is available, the cloned message is not dispatched to the MessageBus anymore.

Instead, the original message is dispatched, resulting in listener behaviour (e.g. `\Symfony\Component\Mailer\EventListener\MessageListener`) not affecting the message passed to the MessageBus.

This PR passes the cloned messages back to the original `$message` variable.

Alternatively, the original commit by @fabpot could be reverted. Changes in this PR however make it more explicit.