### PR TITLE
[HttpFoundation] Allow `null` in InputBag@set

### DIFF
--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -72,7 +72,7 @@ final class InputBag extends ParameterBag
     /**
      * Sets an input by name.
      *
-     * @param string|array $value
+     * @param string|array|null $value
      */
     public function set(string $key, $value)
     {

--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -76,7 +76,7 @@ final class InputBag extends ParameterBag
      */
     public function set(string $key, $value)
     {
-        if (!is_scalar($value) && !\is_array($value) && !method_exists($value, '__toString')) {
+        if (null !== $value && !is_scalar($value) && !\is_array($value) && !method_exists($value, '__toString')) {
             trigger_deprecation('symfony/http-foundation', '5.1', 'Passing "%s" as a 2nd Argument to "%s()" is deprecated, pass a string or an array instead.', get_debug_type($value), __METHOD__);
         }
 

--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -77,7 +77,7 @@ final class InputBag extends ParameterBag
     public function set(string $key, $value)
     {
         if (null !== $value && !is_scalar($value) && !\is_array($value) && !method_exists($value, '__toString')) {
-            trigger_deprecation('symfony/http-foundation', '5.1', 'Passing "%s" as a 2nd Argument to "%s()" is deprecated, pass a string or an array instead.', get_debug_type($value), __METHOD__);
+            trigger_deprecation('symfony/http-foundation', '5.1', 'Passing "%s" as a 2nd Argument to "%s()" is deprecated, pass a string, array, or null instead.', get_debug_type($value), __METHOD__);
         }
 
         $this->parameters[$key] = $value;


### PR DESCRIPTION
This allows `null` to be passed to InputBag's `set` method.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes?
| Deprecations? | no
| License       | MIT

Previously, `null` was an allowed value to the InputBag's `set` method. At some point this was deprecated. It would be very nice for us to be able to set this to `null`. For example, this ability drives a very popular feature of Laravel where we ship a middleware that converts all empty strings to `null` on incoming requests.

Note that the `get` method already specifically allows `null` and `null` is a valid decoded JSON value.