### PR TITLE
[FrameworkBundle] Allow to leverage autoconfiguration for DataCollectors with template

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Added `framework.trusted_proxies` and `framework.trusted_headers` configuration options
  * Deprecated the public `form.factory`, `form.type.file`, `translator`, `security.csrf.token_manager`, `serializer`,
    `cache_clearer`, `filesystem` and `validator` services to private.
+ * Added `TemplateAwareDataCollectorInterface` and `AbstractDataCollector` to simplify custom data collector creation and leverage autoconfiguration
 
 5.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DataCollector/AbstractDataCollector.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DataCollector/AbstractDataCollector.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DataCollector;
+
+/**
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ */
+abstract class AbstractDataCollector implements TemplateAwareDataCollectorInterface
+{
+    /**
+     * @var array
+     */
+    protected $data = [];
+
+    public function getName(): string
+    {
+        return static::class;
+    }
+
+    public function reset(): void
+    {
+        $this->data = [];
+    }
+
+    public static function getTemplate(): ?string
+    {
+        return null;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DataCollector/TemplateAwareDataCollectorInterface.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DataCollector/TemplateAwareDataCollectorInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DataCollector;
+
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+
+/**
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ */
+interface TemplateAwareDataCollectorInterface extends DataCollectorInterface
+{
+    public static function getTemplate(): ?string;
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ProfilerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ProfilerPass.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
 
+use Symfony\Bundle\FrameworkBundle\DataCollector\TemplateAwareDataCollectorInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
@@ -37,11 +38,14 @@ class ProfilerPass implements CompilerPassInterface
             $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
             $template = null;
 
-            if (isset($attributes[0]['template'])) {
-                if (!isset($attributes[0]['id'])) {
+            $collectorClass = $container->findDefinition($id)->getClass();
+            $isTemplateAware = is_subclass_of($collectorClass, TemplateAwareDataCollectorInterface::class);
+            if (isset($attributes[0]['template']) || $isTemplateAware) {
+                $idForTemplate = $attributes[0]['id'] ?? $collectorClass;
+                if (!$idForTemplate) {
                     throw new InvalidArgumentException(sprintf('Data collector service "%s" must have an id attribute in order to specify a template.', $id));
                 }
-                $template = [$attributes[0]['id'], $attributes[0]['template']];
+                $template = [$idForTemplate, $attributes[0]['template'] ?? $collectorClass::getTemplate()];
             }
 
             $collectors->insert([$id, $template], [$priority, --$order]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
@@ -12,8 +12,15 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DataCollector\AbstractDataCollector;
+use Symfony\Bundle\FrameworkBundle\DataCollector\TemplateAwareDataCollectorInterface;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveInstanceofConditionalsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 
 class ProfilerPassTest extends TestCase
 {
@@ -53,5 +60,65 @@ class ProfilerPassTest extends TestCase
         $methodCalls = $profilerDefinition->getMethodCalls();
         $this->assertCount(1, $methodCalls);
         $this->assertEquals('add', $methodCalls[0][0]); // grab the method part of the first call
+    }
+
+    public function provideValidCollectorWithTemplateUsingAutoconfigure(): \Generator
+    {
+        yield [new class() implements TemplateAwareDataCollectorInterface {
+            public function collect(Request $request, Response $response, \Throwable $exception = null)
+            {
+            }
+
+            public function getName(): string
+            {
+                return static::class;
+            }
+
+            public function reset()
+            {
+            }
+
+            public static function getTemplate(): string
+            {
+                return 'foo';
+            }
+        }];
+
+        yield [new class() extends AbstractDataCollector {
+            public function collect(Request $request, Response $response, \Throwable $exception = null)
+            {
+            }
+
+            public static function getTemplate(): string
+            {
+                return 'foo';
+            }
+        }];
+    }
+
+    /**
+     * @dataProvider provideValidCollectorWithTemplateUsingAutoconfigure
+     */
+    public function testValidCollectorWithTemplateUsingAutoconfigure(TemplateAwareDataCollectorInterface $dataCollector)
+    {
+        $container = new ContainerBuilder();
+        $profilerDefinition = $container->register('profiler', 'ProfilerClass');
+
+        $container->registerForAutoconfiguration(DataCollectorInterface::class)->addTag('data_collector');
+        $container->register('mydatacollector', \get_class($dataCollector))->setAutoconfigured(true);
+
+        (new ResolveInstanceofConditionalsPass())->process($container);
+        (new ProfilerPass())->process($container);
+
+        $idForTemplate = \get_class($dataCollector);
+        $this->assertSame(['mydatacollector' => [$idForTemplate, 'foo']], $container->getParameter('data_collector.templates'));
+
+        // grab the method calls off of the "profiler" definition
+        $methodCalls = $profilerDefinition->getMethodCalls();
+        $this->assertCount(1, $methodCalls);
+        $this->assertEquals('add', $methodCalls[0][0]); // grab the method part of the first call
+
+        (new ResolveChildDefinitionsPass())->process($container);
+        $this->assertSame($idForTemplate, $container->get('mydatacollector')->getName());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#14085

When creating a datacollector with a template for the profiler display, an id must be set in the `data_collector` tag and must be the same as this returned by `DataCollectorInterface::getName`. A template path can also be added to the tag. We lose in this case the ability to use autoconfigure. This PR suggests:
- To guess the id configured in the `data_collector` tag. To follow the principle already used for services ids or events names, if not specified, the id is the data collector class name.
- To allow data collectors to provide the template path from the code. Note that the template path configuration via the `data_collector` tags still takes precedence over configuration from the code.

This PR also provides an `AbstractDataCollector` to avoid to implement methods that might be considered as boilerplate: `reset` and `getName`.
