### PR TITLE
[PropertyAccess] Add support for static properties

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -418,7 +418,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                         throw $e;
                     }
                 } elseif (PropertyReadInfo::TYPE_PROPERTY === $type) {
-                    $result[self::VALUE] = $object->$name;
+                    $result[self::VALUE] = $access->isStatic() ? $object::${$name} : $object->$name;
 
                     if (isset($zval[self::REF]) && $access->canBeReference()) {
                         $result[self::REF] = &$object->$name;
@@ -522,7 +522,11 @@ class PropertyAccessor implements PropertyAccessorInterface
             if (PropertyWriteInfo::TYPE_METHOD === $type) {
                 $object->{$mutator->getName()}($value);
             } elseif (PropertyWriteInfo::TYPE_PROPERTY === $type) {
-                $object->{$mutator->getName()} = $value;
+                if ($mutator->isStatic()) {
+                    $object::${$mutator->getName()} = $value;
+                } else {
+                    $object->{$mutator->getName()} = $value;
+                }
             } elseif (PropertyWriteInfo::TYPE_ADDER_AND_REMOVER === $type) {
                 $this->writeCollection($zval, $property, $value, $mutator->getAdderInfo(), $mutator->getRemoverInfo());
             }

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/StaticProperty.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/StaticProperty.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+class StaticProperty
+{
+    public static $staticProperty = 'value';
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\ReturnTyped;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\StaticProperty;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestAdderRemoverInvalidArgumentLength;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestAdderRemoverInvalidMethods;
 use Symfony\Component\PropertyAccess\Tests\Fixtures\TestClass;
@@ -854,5 +855,16 @@ class PropertyAccessorTest extends TestCase
         $this->expectExceptionMessageMatches('/.*The method "setFoo" in class "Symfony\\\Component\\\PropertyAccess\\\Tests\\\Fixtures\\\TestClassSetValue" was found but does not have public access./');
         $object = new TestClassSetValue(0);
         $this->propertyAccessor->setValue($object, 'foo', 1);
+    }
+
+    public function testStaticProperty()
+    {
+        $object = new StaticProperty();
+
+        $this->assertEquals('value', $this->propertyAccessor->getValue($object, 'staticProperty'));
+
+        $this->propertyAccessor->setValue($object, 'staticProperty', 'new value');
+
+        $this->assertEquals('new value', $this->propertyAccessor->getValue($object, 'staticProperty'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #37334 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I'm not sure this is the good solution, the main issue can be in Doctrine or the Serializer component, but for now it fixes my problem. I'm using it in production with [cweagans/composer-patches](https://github.com/cweagans/composer-patches) and it's working fine.

I consider this as a new feature, but since this feature fix a bug.. I don't know what base branch I should use.

Thanks!