### PR TITLE
[Security] Let security factories add firewall listeners

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * Added `FirewallListenerFactoryInterface`, which can be implemented by security factories to add firewall listeners
+
 5.1.0
 -----
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FirewallListenerFactoryInterface.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FirewallListenerFactoryInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Can be implemented by a security factory to add a listener to the firewall.
+ *
+ * @author Christian Scheb <me@christianscheb.de>
+ */
+interface FirewallListenerFactoryInterface
+{
+    /**
+     * Creates the firewall listener services for the provided configuration.
+     *
+     * @return string[] The listener service IDs to be used by the firewall
+     */
+    public function createListeners(ContainerBuilder $container, string $firewallName, array $config): array;
+}

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\EntryPointFactoryInterface;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FirewallListenerFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\RememberMeFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
@@ -570,6 +571,14 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                         $listeners[] = new Reference($listenerId);
                         $authenticationProviders[] = $provider;
                     }
+
+                    if ($factory instanceof FirewallListenerFactoryInterface) {
+                        $firewallListenerIds = $factory->createListeners($container, $id, $firewall[$key]);
+                        foreach ($firewallListenerIds as $firewallListenerId) {
+                            $listeners[] = new Reference($firewallListenerId);
+                        }
+                    }
+
                     $hasListeners = true;
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | n/a

Hello there, I'm the author of `scheb/two-factor-bundle`, which extends Symfony's security layer with two-factor authentication. I've been closely following the recent changes by @wouterj to rework the security layer with "authenticators" (great work!). While I managed to make my bundle work with authenticators, I see some limitations in the security layer that I'd like to address to make such extensions easier to implement.

With the new authenticator-based security system, it is no longer possible to add a authentication listener to the firewall. The only way to do it is a dirty compiler pass, which extends the argument on the `security.firewall.map.context.[firewallName]` service (like I do in: https://github.com/scheb/2fa/blob/ed2ce9804b6a78fe539894e77038ab96a52f5c56/src/bundle/DependencyInjection/Compiler/AccessListenerCompilerPass.php). This is quite ugly and hacky, so I believe there should be an easier and clean way to add firewall-level listeners. This PR adds an interface, which may be implemented by security factories and lets them add additional listeners to the firewall.

Why would you want to do that? There are certain use-cases that require extra logic to handle a request within the firewall. For example in my bundle, I need to handle the intermediate state between login and the completion of two-factor authentication. So ideally, I'm able to execute some code from the firewall right before `Symfony\Component\Security\Http\Firewall\AccessListener`. In the old security system, I could handle this in my authentication listener, which I had to implement anyways. With the new authenticator-based system this option is gone. In the ideal world, I could add a firewall listener and tell it to execute between `LogoutListener` and `AccessListener`.

This is a draft, so I'd like to hear your opinion on this :)

There's another issue, regarding the order of execution, which I'm addressing with #37337.