### PR TITLE
[Console] added TableCellStyle

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Added support for signals:
     * Added `Application::getSignalRegistry()` and `Application::setSignalsToDispatchEvent()` methods
     * Added `SignalableCommandInterface` interface
+ * Added `TableCellStyle` class to customize table cell
 
 5.1.0
 -----

--- a/src/Symfony/Component/Console/Helper/TableCell.php
+++ b/src/Symfony/Component/Console/Helper/TableCell.php
@@ -22,6 +22,7 @@ class TableCell
     private $options = [
         'rowspan' => 1,
         'colspan' => 1,
+        'style' => null,
     ];
 
     public function __construct(string $value = '', array $options = [])
@@ -31,6 +32,10 @@ class TableCell
         // check option names
         if ($diff = array_diff(array_keys($options), array_keys($this->options))) {
             throw new InvalidArgumentException(sprintf('The TableCell does not support the following options: \'%s\'.', implode('\', \'', $diff)));
+        }
+
+        if (isset($options['style']) && !$options['style'] instanceof TableCellStyle) {
+            throw new InvalidArgumentException('The style option must be an instance of "TableCellStyle".');
         }
 
         $this->options = array_merge($this->options, $options);
@@ -64,5 +69,10 @@ class TableCell
     public function getRowspan()
     {
         return (int) $this->options['rowspan'];
+    }
+
+    public function getStyle(): ?TableCellStyle
+    {
+        return $this->options['style'];
     }
 }

--- a/src/Symfony/Component/Console/Helper/TableCellStyle.php
+++ b/src/Symfony/Component/Console/Helper/TableCellStyle.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Helper;
+
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+
+/**
+ * @author Yewhen Khoptynskyi <khoptynskyi@gmail.com>
+ */
+class TableCellStyle
+{
+    const DEFAULT_ALIGN = 'left';
+
+    private $options = [
+        'fg' => 'default',
+        'bg' => 'default',
+        'options' => null,
+        'align' => self::DEFAULT_ALIGN,
+        'cellFormat' => null,
+    ];
+
+    private $tagOptions = [
+        'fg',
+        'bg',
+        'options',
+    ];
+
+    private $alignMap = [
+        'left' => STR_PAD_RIGHT,
+        'center' => STR_PAD_BOTH,
+        'right' => STR_PAD_LEFT,
+    ];
+
+    public function __construct(array $options = [])
+    {
+        if ($diff = array_diff(array_keys($options), array_keys($this->options))) {
+            throw new InvalidArgumentException(sprintf('The TableCellStyle does not support the following options: \'%s\'.', implode('\', \'', $diff)));
+        }
+
+        if (isset($options['align']) && !\array_key_exists($options['align'], $this->alignMap)) {
+            throw new InvalidArgumentException(sprintf('Wrong align value. Value must be following: \'%s\'.', implode('\', \'', array_keys($this->alignMap))));
+        }
+
+        $this->options = array_merge($this->options, $options);
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * Gets options we need for tag for example fg, bg.
+     *
+     * @return string[]
+     */
+    public function getTagOptions()
+    {
+        return array_filter(
+            $this->getOptions(),
+            function ($key) {
+                return \in_array($key, $this->tagOptions) && isset($this->options[$key]);
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+    }
+
+    public function getPadByAlign()
+    {
+        return $this->alignMap[$this->getOptions()['align']];
+    }
+
+    public function getCellFormat(): ?string
+    {
+        return $this->getOptions()['cellFormat'];
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Helper/TableCellStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableCellStyleTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Helper\TableCellStyle;
+
+class TableCellStyleTest extends TestCase
+{
+    public function testCreateTableCellStyle()
+    {
+        $tableCellStyle = new TableCellStyle(['fg' => 'red']);
+        $this->assertEquals('red', $tableCellStyle->getOptions()['fg']);
+
+        $this->expectException('Symfony\Component\Console\Exception\InvalidArgumentException');
+        new TableCellStyle(['wrong_key' => null]);
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableCell;
+use Symfony\Component\Console\Helper\TableCellStyle;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Helper\TableStyle;
 use Symfony\Component\Console\Output\ConsoleSectionOutput;
@@ -624,6 +625,212 @@ TABLE
             ,
                 true,
             ],
+            'TabeCellStyle with align. Also with rowspan and colspan > 1' => [
+               [
+                   new TableCell(
+                       'ISBN',
+                       [
+                           'style' => new TableCellStyle([
+                               'align' => 'right',
+                           ]),
+                       ]
+                   ),
+                   'Title',
+                   new TableCell(
+                       'Author',
+                       [
+                           'style' => new TableCellStyle([
+                               'align' => 'center',
+                           ]),
+                       ]
+                   ),
+               ],
+               [
+                   [
+                       new TableCell(
+                           '<fg=red>978</>',
+                           [
+                               'style' => new TableCellStyle([
+                                   'align' => 'center',
+                               ]),
+                           ]
+                       ),
+                       'De Monarchia',
+                       new TableCell(
+                           "Dante Alighieri \nspans multiple rows rows Dante Alighieri \nspans multiple rows rows",
+                           [
+                               'rowspan' => 2,
+                               'style' => new TableCellStyle([
+                                   'align' => 'center',
+                               ]),
+                           ]
+                       ),
+                   ],
+                   [
+                       '<info>99921-58-10-7</info>',
+                       'Divine Comedy',
+                   ],
+                   new TableSeparator(),
+                   [
+                       new TableCell(
+                           '<error>test</error>',
+                           [
+                               'colspan' => 2,
+                               'style' => new TableCellStyle([
+                                   'align' => 'center',
+                               ]),
+                           ]
+                       ),
+                       new TableCell(
+                           'tttt',
+                           [
+                               'style' => new TableCellStyle([
+                                   'align' => 'right',
+                               ]),
+                           ]
+                       ),
+                   ],
+               ],
+               'default',
+<<<'TABLE'
++---------------+---------------+-------------------------------------------+
+|          ISBN | Title         |                  Author                   |
++---------------+---------------+-------------------------------------------+
+|      978      | De Monarchia  |             Dante Alighieri               |
+| 99921-58-10-7 | Divine Comedy | spans multiple rows rows Dante Alighieri  |
+|               |               |         spans multiple rows rows          |
++---------------+---------------+-------------------------------------------+
+|             test              |                                      tttt |
++---------------+---------------+-------------------------------------------+
+
+TABLE
+               ,
+           ],
+            'TabeCellStyle with fg,bg. Also with rowspan and colspan > 1' => [
+                [],
+                [
+                   [
+                       new TableCell(
+                           '<fg=red>978</>',
+                           [
+                               'style' => new TableCellStyle([
+                                   'fg' => 'black',
+                                   'bg' => 'green',
+                               ]),
+                           ]
+                       ),
+                       'De Monarchia',
+                       new TableCell(
+                           "Dante Alighieri \nspans multiple rows rows Dante Alighieri \nspans multiple rows rows",
+                           [
+                               'rowspan' => 2,
+                               'style' => new TableCellStyle([
+                                   'fg' => 'red',
+                                   'bg' => 'green',
+                                   'align' => 'center',
+                               ]),
+                           ]
+                       ),
+                   ],
+
+                   [
+                       '<info>99921-58-10-7</info>',
+                       'Divine Comedy',
+                   ],
+                   new TableSeparator(),
+                   [
+                       new TableCell(
+                           '<error>test</error>',
+                           [
+                               'colspan' => 2,
+                               'style' => new TableCellStyle([
+                                   'fg' => 'red',
+                                   'bg' => 'green',
+                                   'align' => 'center',
+                               ]),
+                           ]
+                       ),
+                       new TableCell(
+                           'tttt',
+                           [
+                               'style' => new TableCellStyle([
+                                   'fg' => 'red',
+                                   'bg' => 'green',
+                                   'align' => 'right',
+                               ]),
+                           ]
+                       ),
+                   ],
+                ],
+                'default',
+<<<'TABLE'
++---------------+---------------+-------------------------------------------+
+[39;49m| [39;49m[31m978[39m[39;49m           | De Monarchia  |[39;49m[31;42m             Dante Alighieri               [39;49m[39;49m|[39;49m
+[39;49m| [39;49m[32m99921-58-10-7[39m[39;49m | Divine Comedy |[39;49m[31;42m spans multiple rows rows Dante Alighieri  [39;49m[39;49m|[39;49m
+|               |               |[31;42m         spans multiple rows rows          [39;49m|
++---------------+---------------+-------------------------------------------+
+|             [37;41mtest[39;49m              |[31;42m                                      tttt [39;49m|
++---------------+---------------+-------------------------------------------+
+
+TABLE
+            ,
+            true,
+           ],
+            'TabeCellStyle with cellFormat. Also with rowspan and colspan > 1' => [
+                [
+                    new TableCell(
+                        'ISBN',
+                        [
+                            'style' => new TableCellStyle([
+                                'cellFormat' => '<fg=black;bg=cyan>%s</>',
+                            ]),
+                        ]
+                    ),
+                    'Title',
+                    'Author',
+                ],
+                [
+                    [
+                        '978-0521567817',
+                        'De Monarchia',
+                        new TableCell(
+                            "Dante Alighieri\nspans multiple rows",
+                            [
+                                'rowspan' => 2,
+                                'style' => new TableCellStyle([
+                                    'cellFormat' => '<info>%s</info>',
+                                ]),
+                            ]
+                        ),
+                    ],
+                    ['978-0804169127', 'Divine Comedy'],
+                    [
+                        new TableCell(
+                            'test',
+                            [
+                                'colspan' => 2,
+                                'style' => new TableCellStyle([
+                                    'cellFormat' => '<error>%s</error>',
+                                ]),
+                            ]
+                        ),
+                        'tttt',
+                    ],
+                ],
+                'default',
+<<<'TABLE'
++----------------+---------------+---------------------+
+|[30;46m ISBN           [39;49m|[32m Title         [39m|[32m Author              [39m|
++----------------+---------------+---------------------+
+[39;49m| 978-0521567817 | De Monarchia  |[39;49m[32m Dante Alighieri     [39m[39;49m|[39;49m
+| 978-0804169127 | Divine Comedy |[32m spans multiple rows [39m|
+|[37;41m test                           [39;49m| tttt                |
++----------------+---------------+---------------------+
+
+TABLE
+                ,
+                true,
+           ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #13370 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Added an opportunity to customize a table cell via TableCellStyle object.

It can be used as

```php
new TableCell(
  'content',
  [
    'style' => new TableCellStyle([
        'align' => 'center',                            
        'fg' => 'red',
        'bg' => 'green',
        
        // or
        'cellFormat' => '<info>%s</info>',
    ])
  ]
)
```

See #13370
