### PR TITLE
[Security/Http] Remove unnecessary null check

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -171,9 +171,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
                 $authenticatedToken->eraseCredentials();
             }
 
-            if (null !== $this->eventDispatcher) {
-                $this->eventDispatcher->dispatch(new AuthenticationSuccessEvent($authenticatedToken), AuthenticationEvents::AUTHENTICATION_SUCCESS);
-            }
+            $this->eventDispatcher->dispatch(new AuthenticationSuccessEvent($authenticatedToken), AuthenticationEvents::AUTHENTICATION_SUCCESS);
 
             if (null !== $this->logger) {
                 $this->logger->info('Authenticator successful!', ['token' => $authenticatedToken, 'authenticator' => \get_class($authenticator)]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Just found this piece of code, it checks if `$this->eventDispatcher` is null, but actually it cannot be null. The constructor argument is non-nullable and a few lines further up it is used without the null check. So I'd recommend to remove the statement.