### PR TITLE
Fix #37349

### DIFF
--- a/src/Symfony/Contracts/EventDispatcher/composer.json
+++ b/src/Symfony/Contracts/EventDispatcher/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php": "^7.1.3"
+        "php": "^7.1.3",
+        "psr/event-dispatcher": "^1.0"
     },
     "suggest": {
-        "psr/event-dispatcher": "",
         "symfony/event-dispatcher-implementation": ""
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37349
| License       | MIT
| Doc PR        |

Move psr/event-dispatcher dependency from suggest to require on symfony/event-dispatcher-contracts:^1.1