### PR TITLE
[DI] disable preload.php on the CLI

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -319,6 +319,10 @@ EOF;
 
 use Symfony\Component\DependencyInjection\Dumper\Preloader;
 
+if (in_array(PHP_SAPI, ['cli', 'phpdbg'], true)) {
+    return;
+}
+
 require $autoloadFile;
 require __DIR__.'/Container{$hash}/{$options['class']}.php';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37152
| License       | MIT
| Doc PR        | -

See linked issue for a nasty side-effect of preloading on the CLI. Many hosting solutions do not provide a way to set different ini settings for CLI vs FPM. Let's skip preloading anything on the CLI.