### PR TITLE
[FrameworkBundle] allow configuring trusted proxies using semantic configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Added `framework.http_cache` configuration tree
+ * Added `framework.trusted_proxies` and `framework.trusted_headers` configuration options
 
 5.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -85,6 +85,20 @@ class Configuration implements ConfigurationInterface
                     ->beforeNormalization()->ifString()->then(function ($v) { return [$v]; })->end()
                     ->prototype('scalar')->end()
                 ->end()
+                ->scalarNode('trusted_proxies')->end()
+                ->arrayNode('trusted_headers')
+                    ->fixXmlConfig('trusted_header')
+                    ->performNoDeepMerging()
+                    ->defaultValue(['x-forwarded-all', '!x-forwarded-host', '!x-forwarded-prefix'])
+                    ->beforeNormalization()->ifString()->then(function ($v) { return $v ? array_map('trim', explode(',', $v)) : []; })->end()
+                    ->enumPrototype()
+                        ->values([
+                            'forwarded',
+                            'x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-forwarded-port',
+                            'x-forwarded-all', '!x-forwarded-host', '!x-forwarded-prefix',
+                        ])
+                    ->end()
+                ->end()
                 ->scalarNode('error_controller')
                     ->defaultValue('error_controller')
                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -95,10 +95,6 @@ class FrameworkBundle extends Bundle
         if ($this->container->getParameter('kernel.http_method_override')) {
             Request::enableHttpMethodParameterOverride();
         }
-
-        if ($trustedHosts = $this->container->getParameter('kernel.trusted_hosts')) {
-            Request::setTrustedHosts($trustedHosts);
-        }
     }
 
     public function build(ContainerBuilder $container)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -42,6 +42,9 @@
         <xsd:attribute name="default-locale" type="xsd:string" />
         <xsd:attribute name="test" type="xsd:boolean" />
         <xsd:attribute name="error-controller" type="xsd:string" />
+        <xsd:attribute name="trusted_hosts" type="xsd:string" />
+        <xsd:attribute name="trusted_proxies" type="xsd:string" />
+        <xsd:attribute name="trusted_headers" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="form">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -132,9 +132,9 @@ return static function (ContainerConfigurator $container) {
             ->tag('container.hot_path')
 
         ->set('http_cache.store', Store::class)
-        ->args([
-            param('kernel.cache_dir').'/http_cache',
-        ])
+            ->args([
+                param('kernel.cache_dir').'/http_cache',
+            ])
 
         ->set('url_helper', UrlHelper::class)
             ->args([

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -30,10 +30,7 @@ class ConfigurationTest extends TestCase
         $processor = new Processor();
         $config = $processor->processConfiguration(new Configuration(true), [['secret' => 's3cr3t']]);
 
-        $this->assertEquals(
-            array_merge(['secret' => 's3cr3t', 'trusted_hosts' => []], self::getBundleDefaultConfig()),
-            $config
-        );
+        $this->assertEquals(self::getBundleDefaultConfig(), $config);
     }
 
     public function getTestValidSessionName()
@@ -341,6 +338,13 @@ class ConfigurationTest extends TestCase
             'http_method_override' => true,
             'ide' => null,
             'default_locale' => 'en',
+            'secret' => 's3cr3t',
+            'trusted_hosts' => [],
+            'trusted_headers' => [
+                'x-forwarded-all',
+                '!x-forwarded-host',
+                '!x-forwarded-prefix',
+            ],
             'csrf_protection' => [
                 'enabled' => false,
             ],

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 -----
 
  * made the public `http_cache` service handle requests when available
+ * allowed enabling trusted hosts and proxies using new `kernel.trusted_hosts`,
+   `kernel.trusted_proxies` and `kernel.trusted_headers` parameters
 
 5.1.0
 -----

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -764,7 +764,17 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $this->initializeBundles();
         $this->initializeContainer();
 
-        return $this->container;
+        $container = $this->container;
+
+        if ($container->hasParameter('kernel.trusted_hosts') && $trustedHosts = $container->getParameter('kernel.trusted_hosts')) {
+            Request::setTrustedHosts($trustedHosts);
+        }
+
+        if ($container->hasParameter('kernel.trusted_proxies') && $container->hasParameter('kernel.trusted_headers') && $trustedProxies = $container->getParameter('kernel.trusted_proxies')) {
+            Request::setTrustedProxies(\is_array($trustedProxies) ? $trustedProxies : array_map('trim', explode(',', $trustedProxies)), $container->getParameter('kernel.trusted_headers'));
+        }
+
+        return $container;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | -
| Tickets       | -
| License       | MIT
| Doc PR        | -

On top of the improved DX this should provide, this PR (and #37351) will allow [removing the corresponding lines](https://github.com/symfony/recipes/pull/790) from `index.php` & recipes.

Using values:
```yaml
framework:
    trusted_proxies: '127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16'
#or
    trusted_proxies: '%env(TRUSTED_PROXIES)%'
```

`trusted_headers` is similar but is an array of headers to trust.
```yaml
framework:
    # that's the defaults already
    trusted_headers: ['x-forwarded-all', '!x-forwarded-host', '!x-forwarded-prefix']
```
