### PR TITLE
Directly use the driverConnection executeUpdate method

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -126,7 +126,7 @@ class Connection
                 'available_at' => '?',
             ]);
 
-        $this->executeQuery($queryBuilder->getSQL(), [
+        $this->executeUpdate($queryBuilder->getSQL(), [
             $body,
             json_encode($headers),
             $this->configuration['queue_name'],
@@ -179,7 +179,7 @@ class Connection
                 ->set('delivered_at', '?')
                 ->where('id = ?');
             $now = new \DateTime();
-            $this->executeQuery($queryBuilder->getSQL(), [
+            $this->executeUpdate($queryBuilder->getSQL(), [
                 $now,
                 $doctrineEnvelope['id'],
             ], [
@@ -324,6 +324,25 @@ class Connection
                 $this->setup();
             }
             $stmt = $this->driverConnection->executeQuery($sql, $parameters, $types);
+        }
+
+        return $stmt;
+    }
+
+    private function executeUpdate(string $sql, array $parameters = [], array $types = [])
+    {
+        try {
+            $stmt = $this->driverConnection->executeUpdate($sql, $parameters, $types);
+        } catch (TableNotFoundException $e) {
+            if ($this->driverConnection->isTransactionActive()) {
+                throw $e;
+            }
+
+            // create table
+            if ($this->autoSetup) {
+                $this->setup();
+            }
+            $stmt = $this->driverConnection->executeUpdate($sql, $parameters, $types);
         }
 
         return $stmt;


### PR DESCRIPTION
executeUpdate & executeQuery methods do not throw a TableNotFoundException. No need for the try/catch as it is done for executeQuery

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix https://github.com/symfony/symfony/issues/37355
| License       | MIT

As explained in https://github.com/symfony/symfony/issues/37355, when doing a write operation, one should avoid using the `executeQuery` method of a Connection, as Doctrine's MasterSlaveConnection can pick a slave instance (usually read-only) for these operations.

