### PR TITLE
[Messenger] fixed queue_name option on amazon sqs connection

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -124,6 +124,21 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testFromDsnWithQueueNameOption()
+    {
+        $httpClient = $this->getMockBuilder(HttpClientInterface::class)->getMock();
+
+        $this->assertEquals(
+            new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
+            Connection::fromDsn('sqs://default', ['queue_name' => 'queue'], $httpClient)
+        );
+
+        $this->assertEquals(
+            new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
+            Connection::fromDsn('sqs://default/queue', ['queue_name' => 'queue_ignored'], $httpClient)
+        );
+    }
+
     public function testKeepGettingPendingMessages()
     {
         $client = $this->createMock(SqsClient::class);

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -101,6 +101,7 @@ class Connection
             'poll_timeout' => $options['poll_timeout'],
             'visibility_timeout' => $options['visibility_timeout'],
             'auto_setup' => (bool) $options['auto_setup'],
+            'queue_name' => (string) $options['queue_name'],
         ];
 
         $clientConfiguration = [
@@ -119,8 +120,8 @@ class Connection
         }
 
         $parsedPath = explode('/', ltrim($parsedUrl['path'] ?? '/', '/'));
-        if (\count($parsedPath) > 0) {
-            $configuration['queue_name'] = end($parsedPath);
+        if (\count($parsedPath) > 0 && !empty($queueName = end($parsedPath))) {
+            $configuration['queue_name'] = $queueName;
         }
         $configuration['account'] = 2 === \count($parsedPath) ? $parsedPath[0] : null;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37293 
| License | MIT