### PR TITLE
[SecurityBundle] Fix UserCheckerListener registration with custom user checker

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -478,6 +478,12 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                 ->replaceArgument(0, new Reference($managerId))
             ;
 
+            // user checker listener
+            $container
+                ->setDefinition('security.listener.user_checker.'.$id, new ChildDefinition('security.listener.user_checker'))
+                ->replaceArgument(0, new Reference('security.user_checker.'.$id))
+                ->addTag('kernel.event_subscriber', ['dispatcher' => $firewallEventDispatcherId]);
+
             $listeners[] = new Reference('security.firewall.authenticator.'.$id);
         }
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.xml
@@ -54,9 +54,8 @@
             <argument type="service" id="security.encoder_factory" />
         </service>
 
-        <service id="security.listener.user_checker" class="Symfony\Component\Security\Http\EventListener\UserCheckerListener">
-            <tag name="kernel.event_subscriber" />
-            <argument type="service" id="Symfony\Component\Security\Core\User\UserCheckerInterface" />
+        <service id="security.listener.user_checker" class="Symfony\Component\Security\Http\EventListener\UserCheckerListener" abstract="true">
+            <argument type="abstract">user checker</argument>
         </service>
 
         <service id="security.listener.session"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37365 
| License       | MIT
| Doc PR        | -

The user checker listener was wrongly registered on the global event dispatcher, as it can be customized per firewall. This PR fixes that + correctly uses the configured user checker instead of always trying to use `UserCheckerInterface`.