### PR TITLE
Add multiple badges into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
     <img src="https://symfony.com/logos/symfony_black_02.svg">
 </a></p>
 
+![GitHub tests status](https://github.com/symfony/symfony/workflows/Tests/badge.svg)
+[![Travis Status](https://travis-ci.org/symfony/symfony.svg?branch=master)](https://travis-ci.org/symfony/symfony)
+[![AppVeyor status](https://img.shields.io/appveyor/build/fabpot/symfony/master)](https://ci.appveyor.com/project/fabpot/symfony)
+[![GitHub forks](https://img.shields.io/github/forks/symfony/symfony)](https://github.com/symfony/symfony/network)
+[![GitHub stars](https://img.shields.io/github/stars/symfony/symfony)](https://github.com/symfony/symfony/stargazers)
+[![Packagist Downloads](https://img.shields.io/packagist/dm/symfony/symfony)](https://packagist.org/packages/symfony/symfony)
+[![Packagist Version](https://img.shields.io/packagist/v/symfony/symfony)](https://packagist.org/packages/symfony/symfony)
+[![GitHub license](https://img.shields.io/github/license/symfony/symfony)](https://github.com/symfony/symfony/blob/master/LICENSE)
+
 [Symfony][1] is a **PHP framework** for web and console applications and a set of reusable
 **PHP components**. Symfony is used by thousands of web applications (including
 BlaBlaCar.com and Spotify.com) and most of the [popular PHP projects][2] (including


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR adds multiple badges into the README. Direct badge sources are Travis, and GitHub, and other badges are provided by http://shields.io/ and rely on data sources provided by GitHub, Appveyor and Packagist

Badges are really beautiful 🤩 but also can provide useful informations for people quickly browsing GitHub repositories. They provide popularity and usage KPI and links to the CI tools.

Other possible useful badges I could add in the PR (just tell me):
- link to the Symfony slack
- link to Symfony documentation
- link to Symfony website
But these would be static badges, not indicating a status / number, just clickable items.

You can see how it would look like by clicking on this link: https://github.com/symfony/symfony/blob/21a6fc51c0e8c412d5c46e341ce6d7f433ce66a4/README.md