### PR TITLE
[Translation] Add support for calling 'trans' with ICU formatted messages

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.2.0
 -----
 
+ * added support for calling `trans` with ICU formatted messages
  * added `PseudoLocalizationTranslator`
 
 5.1.0

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -369,6 +369,14 @@ class TranslatorTest extends TestCase
     }
 
     /**
+     * @dataProvider getTransICUTests
+     */
+    public function testTransICU(...$args)
+    {
+        $this->testTrans(...$args);
+    }
+
+    /**
      * @dataProvider getInvalidLocalesTests
      */
     public function testTransInvalidLocale($locale)
@@ -441,6 +449,17 @@ class TranslatorTest extends TestCase
             ['Symfony est awesome !', 'Symfony is %what%!', 'Symfony est %what% !', ['%what%' => 'awesome'], 'fr', ''],
             ['Symfony est super !', new StringClass('Symfony is great!'), 'Symfony est super !', [], 'fr', ''],
             ['', null, '', [], 'fr', ''],
+        ];
+    }
+
+    public function getTransICUTests()
+    {
+        $id = '{apples, plural, =0 {There are no apples} one {There is one apple} other {There are # apples}}';
+
+        return [
+            ['There are no apples', $id, $id, ['{apples}' => 0], 'en', 'test'.MessageCatalogue::INTL_DOMAIN_SUFFIX],
+            ['There is one apple',  $id, $id, ['{apples}' => 1], 'en', 'test'.MessageCatalogue::INTL_DOMAIN_SUFFIX],
+            ['There are 3 apples',  $id, $id, ['{apples}' => 3], 'en', 'test'.MessageCatalogue::INTL_DOMAIN_SUFFIX],
         ];
     }
 

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -214,7 +214,10 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
             }
         }
 
-        if ($this->hasIntlFormatter && $catalogue->defines($id, $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX)) {
+        $len = \strlen(MessageCatalogue::INTL_DOMAIN_SUFFIX);
+        if ($this->hasIntlFormatter
+            && ($catalogue->defines($id, $domain.MessageCatalogue::INTL_DOMAIN_SUFFIX)
+                || 0 == substr_compare($domain, MessageCatalogue::INTL_DOMAIN_SUFFIX, -$len, $len))) {
             return $this->formatter->formatIntl($catalogue->get($id, $domain), $locale, $parameters);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | maybe, see https://github.com/symfony/symfony/issues/37228
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #37228
| License       | MIT
| Doc PR        | symfony/symfony-docs#13875

Motivation:

```
$apples = [0 => 'No apples', 1 => '1 apple', '# apples'];
echo _m($apples, ['count' => 0]); // Outputs 'No apples'
echo _m($apples, ['count' => 2]); // Outputs '2 apples'
```

where `_m` is a wrapper my application is using, but we obviously don't want to replicate many of the effort of the translation component, so it relies on `trans`.

This wrapper itself could be integrated into Symfony, if deemed appropriate.

See #37228
