### PR TITLE
Avoid accessibility errors on symfony web debug toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -1,4 +1,4 @@
-<div id="sfwdt{{ token }}" class="sf-toolbar sf-display-none"></div>
+<div id="sfwdt{{ token }}" class="sf-toolbar sf-display-none" role="region" aria-label="Symfony Web Debug Toolbar"></div>
 {{ include('@WebProfiler/Profiler/base_js.html.twig') }}
 <style{% if csp_style_nonce %} nonce="{{ csp_style_nonce }}"{% endif %}>
     {{ include('@WebProfiler/Profiler/toolbar.css.twig', { 'position': position, 'floatable': true }) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

When for example using the [axe](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd) to test the website for accessibility. Axe will fail because a div element without a role or a parent [landmark](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/HTML5.html) is rendered. To avoid this errors I think we should define it as a specific region.