### PR TITLE
[DI] deprecate Definition/Alias::setPrivate()

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 5.1 to 5.2
 =======================
 
+DependencyInjection
+-------------------
+
+ * Deprecated `Definition::setPrivate()` and `Alias::setPrivate()`, use `setPublic()` instead
+
 Mime
 ----
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -26,6 +26,7 @@ DependencyInjection
  * Removed `Alias::getDeprecationMessage()`, use `Alias::getDeprecation()` instead.
  * The `inline()` function from the PHP-DSL has been removed, use `inline_service()` instead.
  * The `ref()` function from the PHP-DSL has been removed, use `service()` instead.
+ * Removed `Definition::setPrivate()` and `Alias::setPrivate()`, use `setPublic()` instead
 
 Dotenv
 ------

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -296,7 +296,6 @@ abstract class AbstractDoctrineExtension extends Extension
                 $memcachedPort = !empty($cacheDriver['port']) ? $cacheDriver['port'] : '%'.$this->getObjectManagerElementName('cache.memcached_port').'%';
                 $cacheDef = new Definition($memcachedClass);
                 $memcachedInstance = new Definition($memcachedInstanceClass);
-                $memcachedInstance->setPrivate(true);
                 $memcachedInstance->addMethodCall('addServer', [
                     $memcachedHost, $memcachedPort,
                 ]);
@@ -310,7 +309,6 @@ abstract class AbstractDoctrineExtension extends Extension
                 $redisPort = !empty($cacheDriver['port']) ? $cacheDriver['port'] : '%'.$this->getObjectManagerElementName('cache.redis_port').'%';
                 $cacheDef = new Definition($redisClass);
                 $redisInstance = new Definition($redisInstanceClass);
-                $redisInstance->setPrivate(true);
                 $redisInstance->addMethodCall('connect', [
                     $redisHost, $redisPort,
                 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -781,7 +781,6 @@ class FrameworkExtension extends Extension
             // Enable the AuditTrail
             if ($workflow['audit_trail']['enabled']) {
                 $listener = new Definition(Workflow\EventListener\AuditTrailListener::class);
-                $listener->setPrivate(true);
                 $listener->addTag('monolog.logger', ['channel' => 'workflow']);
                 $listener->addTag('kernel.event_listener', ['event' => sprintf('workflow.%s.leave', $name), 'method' => 'onLeave']);
                 $listener->addTag('kernel.event_listener', ['event' => sprintf('workflow.%s.transition', $name), 'method' => 'onTransition']);
@@ -801,7 +800,6 @@ class FrameworkExtension extends Extension
                 }
 
                 $guard = new Definition(Workflow\EventListener\GuardListener::class);
-                $guard->setPrivate(true);
 
                 $guard->setArguments([
                     $guardsConfiguration,
@@ -829,7 +827,6 @@ class FrameworkExtension extends Extension
         if (class_exists(Stopwatch::class)) {
             $container->register('debug.stopwatch', Stopwatch::class)
                 ->addArgument(true)
-                ->setPrivate(true)
                 ->addTag('kernel.reset', ['method' => 'reset']);
             $container->setAlias(Stopwatch::class, new Alias('debug.stopwatch', false));
         }
@@ -938,7 +935,7 @@ class FrameworkExtension extends Extension
         $loader->load('session.php');
 
         // session storage
-        $container->setAlias('session.storage', $config['storage_id'])->setPrivate(true);
+        $container->setAlias('session.storage', $config['storage_id']);
         $options = ['cache_limiter' => '0'];
         foreach (['name', 'cookie_lifetime', 'cookie_path', 'cookie_domain', 'cookie_secure', 'cookie_httponly', 'cookie_samesite', 'use_cookies', 'gc_maxlifetime', 'gc_probability', 'gc_divisor', 'sid_length', 'sid_bits_per_character'] as $key) {
             if (isset($config[$key])) {
@@ -970,9 +967,9 @@ class FrameworkExtension extends Extension
                 $container->getDefinition('session.abstract_handler')
                     ->replaceArgument(0, $container->hasDefinition($id) ? new Reference($id) : $config['handler_id']);
 
-                $container->setAlias('session.handler', 'session.abstract_handler')->setPrivate(true);
+                $container->setAlias('session.handler', 'session.abstract_handler');
             } else {
-                $container->setAlias('session.handler', $config['handler_id'])->setPrivate(true);
+                $container->setAlias('session.handler', $config['handler_id']);
             }
         }
 
@@ -1375,7 +1372,7 @@ class FrameworkExtension extends Extension
                 ->addTag('annotations.cached_reader')
             ;
 
-            $container->setAlias('annotation_reader', 'annotations.cached_reader')->setPrivate(true);
+            $container->setAlias('annotation_reader', 'annotations.cached_reader');
             $container->setAlias(Reader::class, new Alias('annotations.cached_reader', false));
         } else {
             $container->removeDefinition('annotations.cached_reader');
@@ -1559,7 +1556,6 @@ class FrameworkExtension extends Extension
 
         if (interface_exists('phpDocumentor\Reflection\DocBlockFactoryInterface')) {
             $definition = $container->register('property_info.php_doc_extractor', 'Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor');
-            $definition->setPrivate(true);
             $definition->addTag('property_info.description_extractor', ['priority' => -1000]);
             $definition->addTag('property_info.type_extractor', ['priority' => -1001]);
         }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -154,7 +154,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('security.authentication.session_strategy.strategy', $config['session_fixation_strategy']);
 
         if (isset($config['access_decision_manager']['service'])) {
-            $container->setAlias('security.access.decision_manager', $config['access_decision_manager']['service'])->setPrivate(true);
+            $container->setAlias('security.access.decision_manager', $config['access_decision_manager']['service']);
         } else {
             $container
                 ->getDefinition('security.access.decision_manager')

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/TwigLoaderPass.php
@@ -43,7 +43,7 @@ class TwigLoaderPass implements CompilerPassInterface
         }
 
         if (1 === $found) {
-            $container->setAlias('twig.loader', $id)->setPrivate(true);
+            $container->setAlias('twig.loader', $id);
         } else {
             $chainLoader = $container->getDefinition('twig.loader.chain');
             krsort($prioritizedLoaders);
@@ -54,7 +54,7 @@ class TwigLoaderPass implements CompilerPassInterface
                 }
             }
 
-            $container->setAlias('twig.loader', 'twig.loader.chain')->setPrivate(true);
+            $container->setAlias('twig.loader', 'twig.loader.chain');
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Alias.php
+++ b/src/Symfony/Component/DependencyInjection/Alias.php
@@ -17,16 +17,14 @@ class Alias
 {
     private $id;
     private $public;
-    private $private;
     private $deprecation = [];
 
     private static $defaultDeprecationTemplate = 'The "%alias_id%" service alias is deprecated. You should stop using it, as it will be removed in the future.';
 
-    public function __construct(string $id, bool $public = true)
+    public function __construct(string $id, bool $public = false)
     {
         $this->id = $id;
         $this->public = $public;
-        $this->private = 2 > \func_num_args();
     }
 
     /**
@@ -47,7 +45,6 @@ class Alias
     public function setPublic(bool $boolean)
     {
         $this->public = $boolean;
-        $this->private = false;
 
         return $this;
     }
@@ -55,18 +52,15 @@ class Alias
     /**
      * Sets if this Alias is private.
      *
-     * When set, the "private" state has a higher precedence than "public".
-     * In version 3.4, a "private" alias always remains publicly accessible,
-     * but triggers a deprecation notice when accessed from the container,
-     * so that the alias can be made really private in 4.0.
-     *
      * @return $this
+     *
+     * @deprecated since Symfony 5.2, use setPublic() instead
      */
     public function setPrivate(bool $boolean)
     {
-        $this->private = $boolean;
+        trigger_deprecation('symfony/dependency-injection', '5.2', 'The "%s()" method is deprecated, use "setPublic()" instead.', __METHOD__);
 
-        return $this;
+        return $this->setPublic(!$boolean);
     }
 
     /**
@@ -76,7 +70,7 @@ class Alias
      */
     public function isPrivate()
     {
-        return $this->private;
+        return !$this->public;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added `param()` and `abstract_arg()` in the PHP-DSL
+ * deprecated `Definition::setPrivate()` and `Alias::setPrivate()`, use `setPublic()` instead
 
 5.1.0
 -----

--- a/src/Symfony/Component/DependencyInjection/ChildDefinition.php
+++ b/src/Symfony/Component/DependencyInjection/ChildDefinition.php
@@ -29,7 +29,6 @@ class ChildDefinition extends Definition
     public function __construct(string $parent)
     {
         $this->parent = $parent;
-        $this->setPrivate(false);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -104,7 +104,7 @@ class DecoratorServicePass extends AbstractRecursivePass
                 $decoratingDefinitions[$inner] = $definition;
             }
 
-            $container->setAlias($inner, $id)->setPublic($public)->setPrivate($private);
+            $container->setAlias($inner, $id)->setPublic($public);
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -74,12 +74,6 @@ class PassConfig
             new CheckArgumentsValidityPass(false),
         ]];
 
-        $this->beforeRemovingPasses = [
-            -100 => [
-                new ResolvePrivatesPass(),
-            ],
-        ];
-
         $this->removingPasses = [[
             new RemovePrivateAliasesPass(),
             new ReplaceAliasByActualDefinitionPass(),

--- a/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
@@ -44,7 +44,7 @@ class ReplaceAliasByActualDefinitionPass extends AbstractRecursivePass
             }
             // Check if target needs to be replaces
             if (isset($replacements[$targetId])) {
-                $container->setAlias($definitionId, $replacements[$targetId])->setPublic($target->isPublic())->setPrivate($target->isPrivate());
+                $container->setAlias($definitionId, $replacements[$targetId])->setPublic($target->isPublic());
             }
             // No need to process the same target twice
             if (isset($seenAliasTargets[$targetId])) {
@@ -65,8 +65,7 @@ class ReplaceAliasByActualDefinitionPass extends AbstractRecursivePass
                 continue;
             }
             // Remove private definition and schedule for replacement
-            $definition->setPublic(!$target->isPrivate());
-            $definition->setPrivate($target->isPrivate());
+            $definition->setPublic($target->isPublic());
             $container->setDefinition($definitionId, $definition);
             $container->removeDefinition($targetId);
             $replacements[$targetId] = $definitionId;

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveChildDefinitionsPass.php
@@ -132,7 +132,7 @@ class ResolveChildDefinitionsPass extends AbstractRecursivePass
         if (isset($changes['public'])) {
             $def->setPublic($definition->isPublic());
         } else {
-            $def->setPrivate($definition->isPrivate() || $parentDef->isPrivate());
+            $def->setPublic($parentDef->isPublic());
         }
         if (isset($changes['lazy'])) {
             $def->setLazy($definition->isLazy());

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolvePrivatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolvePrivatesPass.php
@@ -11,10 +11,14 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
+trigger_deprecation('symfony/dependency-injection', '5.2', 'The "%s" class is deprecated.', ResolvePrivatesPass::class);
+
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @deprecated since Symfony 5.2
  */
 class ResolvePrivatesPass implements CompilerPassInterface
 {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
@@ -34,7 +34,7 @@ class ResolveReferencesToAliasesPass extends AbstractRecursivePass
             $this->currentId = $id;
 
             if ($aliasId !== $defId = $this->getDefinitionId($aliasId, $container)) {
-                $container->setAlias($id, $defId)->setPublic($alias->isPublic())->setPrivate($alias->isPrivate());
+                $container->setAlias($id, $defId)->setPublic($alias->isPublic());
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceLocatorTagPass.php
@@ -106,7 +106,6 @@ final class ServiceLocatorTagPass extends AbstractRecursivePass
 
         $locator = (new Definition(ServiceLocator::class))
             ->addArgument($refMap)
-            ->setPublic(false)
             ->addTag('container.service_locator');
 
         if (null !== $callerId && $container->hasDefinition($callerId)) {
@@ -123,7 +122,6 @@ final class ServiceLocatorTagPass extends AbstractRecursivePass
             // to have them specialized per consumer service, we use a cloning factory
             // to derivate customized instances from the prototype one.
             $container->register($id .= '.'.$callerId, ServiceLocator::class)
-                ->setPublic(false)
                 ->setFactory([new Reference($locatorId), 'withContext'])
                 ->addTag('container.service_locator_context', ['id' => $callerId])
                 ->addArgument($callerId)

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -33,8 +33,7 @@ class Definition
     private $autoconfigured = false;
     private $configurator;
     private $tags = [];
-    private $public = true;
-    private $private = true;
+    private $public = false;
     private $synthetic = false;
     private $abstract = false;
     private $lazy = false;
@@ -586,7 +585,6 @@ class Definition
         $this->changes['public'] = true;
 
         $this->public = $boolean;
-        $this->private = false;
 
         return $this;
     }
@@ -604,18 +602,15 @@ class Definition
     /**
      * Sets if this service is private.
      *
-     * When set, the "private" state has a higher precedence than "public".
-     * In version 3.4, a "private" service always remains publicly accessible,
-     * but triggers a deprecation notice when accessed from the container,
-     * so that the service can be made really private in 4.0.
-     *
      * @return $this
+     *
+     * @deprecated since Symfony 5.2, use setPublic() instead
      */
     public function setPrivate(bool $boolean)
     {
-        $this->private = $boolean;
+        trigger_deprecation('symfony/dependency-injection', '5.2', 'The "%s()" method is deprecated, use "setPublic()" instead.', __METHOD__);
 
-        return $this;
+        return $this->setPublic(!$boolean);
     }
 
     /**
@@ -625,7 +620,7 @@ class Definition
      */
     public function isPrivate()
     {
-        return $this->private;
+        return !$this->public;
     }
 
     /**
@@ -661,6 +656,10 @@ class Definition
     public function setSynthetic(bool $boolean)
     {
         $this->synthetic = $boolean;
+
+        if (!isset($this->changes['public'])) {
+            $this->setPublic(true);
+        }
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -108,8 +108,8 @@ class XmlDumper extends Dumper
         if (!$definition->isShared()) {
             $service->setAttribute('shared', 'false');
         }
-        if (!$definition->isPrivate()) {
-            $service->setAttribute('public', $definition->isPublic() ? 'true' : 'false');
+        if ($definition->isPublic()) {
+            $service->setAttribute('public', 'true');
         }
         if ($definition->isSynthetic()) {
             $service->setAttribute('synthetic', 'true');
@@ -227,8 +227,8 @@ class XmlDumper extends Dumper
         $service = $this->document->createElement('service');
         $service->setAttribute('id', $alias);
         $service->setAttribute('alias', $id);
-        if (!$id->isPrivate()) {
-            $service->setAttribute('public', $id->isPublic() ? 'true' : 'false');
+        if ($id->isPublic()) {
+            $service->setAttribute('public', 'true');
         }
 
         if ($id->isDeprecated()) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -183,7 +183,11 @@ class YamlDumper extends Dumper
             return sprintf("    %s: '@%s'\n", $alias, $id);
         }
 
-        return sprintf("    %s:\n        alias: %s\n        public: %s\n%s", $alias, $id, $id->isPublic() ? 'true' : 'false', $deprecated);
+        if ($id->isPublic()) {
+            $deprecated = "        public: true\n".$deprecated;
+        }
+
+        return sprintf("    %s:\n        alias: %s\n%s", $alias, $id, $deprecated);
     }
 
     private function addServices(): string

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
@@ -81,7 +81,6 @@ class ServicesConfigurator extends AbstractConfigurator
             }
 
             $id = sprintf('.%d_%s', ++$this->anonymousCount, preg_replace('/^.*\\\\/', '', $class).'~'.$this->anonymousHash);
-            $definition->setPublic(false);
         } elseif (!$defaults->isPublic() || !$defaults->isPrivate()) {
             $definition->setPublic($defaults->isPublic() && !$defaults->isPrivate());
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/FileLoader.php
@@ -125,7 +125,7 @@ abstract class FileLoader extends BaseFileLoader
     {
         foreach ($this->interfaces as $interface) {
             if (!empty($this->singlyImplemented[$interface]) && !$this->container->has($interface)) {
-                $this->container->setAlias($interface, $this->singlyImplemented[$interface])->setPublic(false);
+                $this->container->setAlias($interface, $this->singlyImplemented[$interface]);
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -848,7 +848,7 @@ class YamlFileLoader extends FileLoader
                     throw new InvalidArgumentException(sprintf('Creating an alias using the tag "!service" is not allowed in "%s".', $file));
                 }
 
-                $this->container->getDefinition($id)->setPublic(false);
+                $this->container->getDefinition($id);
 
                 $this->isLoadingInstanceof = $isLoadingInstanceof;
                 $this->instanceof = $instanceof;

--- a/src/Symfony/Component/DependencyInjection/Tests/AliasTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/AliasTest.php
@@ -24,7 +24,7 @@ class AliasTest extends TestCase
         $alias = new Alias('foo');
 
         $this->assertEquals('foo', (string) $alias);
-        $this->assertTrue($alias->isPublic());
+        $this->assertFalse($alias->isPublic());
     }
 
     public function testCanConstructANonPublicAlias()
@@ -41,7 +41,7 @@ class AliasTest extends TestCase
 
         $this->assertEquals('foo', (string) $alias);
         $this->assertFalse($alias->isPublic());
-        $this->assertFalse($alias->isPrivate());
+        $this->assertTrue($alias->isPrivate());
     }
 
     public function testCanSetPublic()

--- a/src/Symfony/Component/DependencyInjection/Tests/ChildDefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ChildDefinitionTest.php
@@ -54,9 +54,9 @@ class ChildDefinitionTest extends TestCase
     {
         $def = new ChildDefinition('foo');
 
-        $this->assertTrue($def->isPublic());
-        $this->assertSame($def, $def->setPublic(false));
         $this->assertFalse($def->isPublic());
+        $this->assertSame($def, $def->setPublic(true));
+        $this->assertTrue($def->isPublic());
         $this->assertSame(['public' => true], $def->getChanges());
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AliasDeprecatedPublicServicesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AliasDeprecatedPublicServicesPassTest.php
@@ -65,7 +65,6 @@ final class AliasDeprecatedPublicServicesPassTest extends TestCase
         $container = new ContainerBuilder();
         $container
             ->register('foo')
-            ->setPublic(false)
             ->addTag('container.private', ['package' => 'foo/bar', 'version' => '1.2']);
 
         (new AliasDeprecatedPublicServicesPass())->process($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/DecoratorServicePassTest.php
@@ -25,7 +25,6 @@ class DecoratorServicePassTest extends TestCase
         $container = new ContainerBuilder();
         $fooDefinition = $container
             ->register('foo')
-            ->setPublic(false)
         ;
         $fooExtendedDefinition = $container
             ->register('foo.extended')
@@ -90,7 +89,6 @@ class DecoratorServicePassTest extends TestCase
         $container = new ContainerBuilder();
         $fooDefinition = $container
             ->register('foo')
-            ->setPublic(false)
         ;
         $barDefinition = $container
             ->register('bar')

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/InlineServiceDefinitionsPassTest.php
@@ -27,7 +27,6 @@ class InlineServiceDefinitionsPassTest extends TestCase
         $container = new ContainerBuilder();
         $inlineable = $container
             ->register('inlinable.service')
-            ->setPublic(false)
         ;
 
         $container
@@ -46,11 +45,10 @@ class InlineServiceDefinitionsPassTest extends TestCase
     public function testProcessDoesNotInlinesWhenAliasedServiceIsShared()
     {
         $container = new ContainerBuilder();
-        $container
-            ->register('foo')
-            ->setPublic(false)
+        $container->register('foo');
+        $container->setAlias('moo', 'foo')
+            ->setPublic(true)
         ;
-        $container->setAlias('moo', 'foo');
 
         $container
             ->register('service')
@@ -68,11 +66,11 @@ class InlineServiceDefinitionsPassTest extends TestCase
         $container = new ContainerBuilder();
         $container
             ->register('foo')
+            ->setPublic(true)
             ->setShared(false)
         ;
         $bar = $container
             ->register('bar')
-            ->setPublic(false)
             ->setShared(false)
         ;
         $container->setAlias('moo', 'bar');
@@ -98,12 +96,13 @@ class InlineServiceDefinitionsPassTest extends TestCase
         $container = new ContainerBuilder();
         $container
             ->register('foo')
+            ->setPublic(true)
             ->addArgument(new Reference('bar'))
             ->setShared(false)
         ;
         $container
             ->register('bar')
-            ->setPublic(false)
+            ->setPublic(true)
             ->addMethodCall('setFoo', [new Reference('foo')])
         ;
 
@@ -151,6 +150,7 @@ class InlineServiceDefinitionsPassTest extends TestCase
         ;
         $container
             ->register('baz')
+            ->setPublic(true)
             ->setShared(false)
         ;
 
@@ -168,7 +168,7 @@ class InlineServiceDefinitionsPassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $a = $container->register('a')->setPublic(false);
+        $a = $container->register('a');
         $b = $container
             ->register('b')
             ->addArgument(new Reference('a'))
@@ -188,15 +188,15 @@ class InlineServiceDefinitionsPassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $container->register('a')->setPublic(false);
+        $container->register('a');
         $b = $container
             ->register('b')
-            ->setPublic(false)
             ->setFactory([new Reference('a'), 'a'])
         ;
 
         $container
             ->register('foo')
+            ->setPublic(true)
             ->setArguments([
                 $ref = new Reference('b'),
             ]);
@@ -215,12 +215,12 @@ class InlineServiceDefinitionsPassTest extends TestCase
         ;
         $container
             ->register('b')
-            ->setPublic(false)
             ->setFactory([new Reference('a'), 'a'])
         ;
 
         $container
             ->register('foo')
+            ->setPublic(true)
             ->setArguments([
                     $ref1 = new Reference('b'),
                     $ref2 = new Reference('b'),
@@ -241,16 +241,15 @@ class InlineServiceDefinitionsPassTest extends TestCase
         ;
         $container
             ->register('b')
-            ->setPublic(false)
             ->setFactory([new Reference('a'), 'a'])
         ;
 
         $inlineFactory = new Definition();
-        $inlineFactory->setPublic(false);
         $inlineFactory->setFactory([new Reference('b'), 'b']);
 
         $container
             ->register('foo')
+            ->setPublic(true)
             ->setArguments([
                     $ref = new Reference('b'),
                     $inlineFactory,
@@ -267,12 +266,12 @@ class InlineServiceDefinitionsPassTest extends TestCase
         $container = new ContainerBuilder();
         $container
             ->register('foo')
-            ->setPublic(false)
             ->setLazy(true)
         ;
 
         $container
             ->register('service')
+            ->setPublic(true)
             ->setArguments([$ref = new Reference('foo')])
         ;
 
@@ -287,7 +286,6 @@ class InlineServiceDefinitionsPassTest extends TestCase
         $container = new ContainerBuilder();
         $container
             ->register('foo')
-            ->setPublic(false)
             ->addMethodCall('foo', [$ref = new Reference('foo')])
         ;
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -55,12 +55,10 @@ class IntegrationTest extends TestCase
         $container
             ->register('b', '\stdClass')
             ->addArgument(new Reference('c'))
-            ->setPublic(false)
         ;
 
         $c = $container
             ->register('c', '\stdClass')
-            ->setPublic(false)
         ;
 
         $container->compile();
@@ -87,7 +85,6 @@ class IntegrationTest extends TestCase
 
         $c = $container
             ->register('c', '\stdClass')
-            ->setPublic(false)
         ;
 
         $container->compile();
@@ -114,12 +111,10 @@ class IntegrationTest extends TestCase
         $container
             ->register('b', '\stdClass')
             ->addArgument(new Reference('c'))
-            ->setPublic(false)
         ;
 
         $container
             ->register('c', '\stdClass')
-            ->setPublic(false)
         ;
 
         $container->compile();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RemoveUnusedDefinitionsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RemoveUnusedDefinitionsPassTest.php
@@ -25,14 +25,13 @@ class RemoveUnusedDefinitionsPassTest extends TestCase
         $container = new ContainerBuilder();
         $container
             ->register('foo')
-            ->setPublic(false)
         ;
         $container
             ->register('bar')
-            ->setPublic(false)
         ;
         $container
             ->register('moo')
+            ->setPublic(true)
             ->setArguments([new Reference('bar')])
         ;
 
@@ -48,12 +47,10 @@ class RemoveUnusedDefinitionsPassTest extends TestCase
         $container = new ContainerBuilder();
         $container
             ->register('foo')
-            ->setPublic(false)
         ;
         $container
             ->register('bar')
             ->setArguments([new Reference('foo')])
-            ->setPublic(false)
         ;
 
         $this->process($container);
@@ -67,10 +64,10 @@ class RemoveUnusedDefinitionsPassTest extends TestCase
         $container = new ContainerBuilder();
         $container
             ->register('foo')
-            ->setPublic(false)
         ;
         $container
             ->register('bar')
+            ->setPublic(true)
             ->setArguments([new Definition(null, [new Reference('foo')])])
         ;
 
@@ -87,15 +84,17 @@ class RemoveUnusedDefinitionsPassTest extends TestCase
         $container
             ->register('foo', 'stdClass')
             ->setFactory(['stdClass', 'getInstance'])
-            ->setPublic(false);
+            ->setPublic(true)
+        ;
 
         $container
             ->register('bar', 'stdClass')
             ->setFactory([new Reference('foo'), 'getInstance'])
-            ->setPublic(false);
+        ;
 
         $container
             ->register('foobar')
+            ->setPublic(true)
             ->addArgument(new Reference('bar'));
 
         $this->process($container);
@@ -112,7 +111,6 @@ class RemoveUnusedDefinitionsPassTest extends TestCase
         $container
             ->register('foo')
             ->setArguments(['%env(FOOBAR)%'])
-            ->setPublic(false)
         ;
 
         $resolvePass = new ResolveParameterPlaceHoldersPass();
@@ -152,7 +150,6 @@ class RemoveUnusedDefinitionsPassTest extends TestCase
         $container = new ContainerBuilder();
         $container
             ->setDefinition('foo', $definition)
-            ->setPublic(false)
         ;
 
         $this->process($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ReplaceAliasByActualDefinitionPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ReplaceAliasByActualDefinitionPassTest.php
@@ -25,15 +25,14 @@ class ReplaceAliasByActualDefinitionPassTest extends TestCase
     {
         $container = new ContainerBuilder();
 
-        $aDefinition = $container->register('a', '\stdClass');
+        $aDefinition = $container->register('a', '\stdClass')->setPublic(true);
         $aDefinition->setFactory([new Reference('b'), 'createA']);
 
         $bDefinition = new Definition('\stdClass');
-        $bDefinition->setPublic(false);
         $container->setDefinition('b', $bDefinition);
 
-        $container->setAlias('a_alias', 'a');
-        $container->setAlias('b_alias', 'b');
+        $container->setAlias('a_alias', 'a')->setPublic(true);
+        $container->setAlias('b_alias', 'b')->setPublic(true);
 
         $container->setAlias('container', 'service_container');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolvePrivatesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolvePrivatesPassTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Compiler\ResolvePrivatesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * @group legacy
+ */
 class ResolvePrivatesPassTest extends TestCase
 {
     public function testPrivateHasHigherPrecedenceThanPublic()
@@ -34,6 +37,6 @@ class ResolvePrivatesPassTest extends TestCase
         (new ResolvePrivatesPass())->process($container);
 
         $this->assertFalse($container->getDefinition('foo')->isPublic());
-        $this->assertFalse($container->getAlias('bar')->isPublic());
+        $this->assertTrue($container->getAlias('bar')->isPublic());
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -316,7 +316,7 @@ class ContainerBuilderTest extends TestCase
     public function testGetAliases()
     {
         $builder = new ContainerBuilder();
-        $builder->setAlias('bar', 'foo');
+        $builder->setAlias('bar', 'foo')->setPublic(true);
         $builder->setAlias('foobar', 'foo');
         $builder->setAlias('moo', new Alias('foo', false));
 
@@ -1099,8 +1099,6 @@ class ContainerBuilderTest extends TestCase
         $container = new ContainerBuilder();
         $container->setResourceTracking(false);
 
-        $fooDefinition->setPublic(false);
-
         $container->addDefinitions([
             'bar' => $fooDefinition,
             'bar_user' => $fooUserDefinition->setPublic(true),
@@ -1350,7 +1348,7 @@ class ContainerBuilderTest extends TestCase
             ])
         ;
         $container->register('bar_service', 'stdClass')->setArguments([new Reference('baz_service')])->setPublic(true);
-        $container->register('baz_service', 'stdClass')->setPublic(false);
+        $container->register('baz_service', 'stdClass');
         $container->compile();
 
         $this->assertInstanceOf(ServiceLocator::class, $foo = $container->get('foo_service'));
@@ -1458,7 +1456,7 @@ class ContainerBuilderTest extends TestCase
     {
         $container = new ContainerBuilder();
         $container->register('foo', 'stdClass')->setPublic(true);
-        $container->register('Foo', 'stdClass')->setProperty('foo', new Reference('foo'))->setPublic(false);
+        $container->register('Foo', 'stdClass')->setProperty('foo', new Reference('foo'));
         $container->register('fOO', 'stdClass')->setProperty('Foo', new Reference('Foo'))->setPublic(true);
 
         $this->assertSame(['service_container', 'foo', 'Foo', 'fOO', 'Psr\Container\ContainerInterface', 'Symfony\Component\DependencyInjection\ContainerInterface'], $container->getServiceIds());
@@ -1582,10 +1580,8 @@ class ContainerBuilderTest extends TestCase
     {
         $container = new ContainerBuilder();
         $container->register('foo', 'stdClass')
-            ->setPublic(false)
             ->setProperty('bar', new Reference('foo'));
         $container->register('baz', 'stdClass')
-            ->setPublic(false)
             ->setProperty('inner', new Reference('baz.inner'))
             ->setDecoratedService('foo');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -144,9 +144,9 @@ class DefinitionTest extends TestCase
     public function testSetIsPublic()
     {
         $def = new Definition('stdClass');
-        $this->assertTrue($def->isPublic(), '->isPublic() returns true by default');
-        $this->assertSame($def, $def->setPublic(false), '->setPublic() implements a fluent interface');
-        $this->assertFalse($def->isPublic(), '->isPublic() returns false if the instance must not be public.');
+        $this->assertFalse($def->isPublic(), '->isPublic() returns false by default');
+        $this->assertSame($def, $def->setPublic(true), '->setPublic() implements a fluent interface');
+        $this->assertTrue($def->isPublic(), '->isPublic() returns true if the service is public.');
     }
 
     public function testSetIsSynthetic()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -699,7 +699,7 @@ class PhpDumperTest extends TestCase
     public function testInlinedDefinitionReferencingServiceContainer()
     {
         $container = new ContainerBuilder();
-        $container->register('foo', 'stdClass')->addMethodCall('add', [new Reference('service_container')])->setPublic(false);
+        $container->register('foo', 'stdClass')->addMethodCall('add', [new Reference('service_container')]);
         $container->register('bar', 'stdClass')->addArgument(new Reference('foo'))->setPublic(true);
         $container->compile();
 
@@ -833,7 +833,7 @@ class PhpDumperTest extends TestCase
         $container = new ContainerBuilder();
         $container->register('foo_service', 'stdClass')->setArguments([new Reference('baz_service')])->setPublic(true);
         $container->register('bar_service', 'stdClass')->setArguments([new Reference('baz_service')])->setPublic(true);
-        $container->register('baz_service', 'stdClass')->setPublic(false);
+        $container->register('baz_service', 'stdClass');
         $container->compile();
 
         $dumper = new PhpDumper($container);
@@ -856,7 +856,6 @@ class PhpDumperTest extends TestCase
         // no method calls
         $container->register('translator.loader_1', 'stdClass')->setPublic(true);
         $container->register('translator.loader_1_locator', ServiceLocator::class)
-            ->setPublic(false)
             ->addArgument([
                 'translator.loader_1' => new ServiceClosureArgument(new Reference('translator.loader_1')),
             ]);
@@ -867,7 +866,6 @@ class PhpDumperTest extends TestCase
         // one method calls
         $container->register('translator.loader_2', 'stdClass')->setPublic(true);
         $container->register('translator.loader_2_locator', ServiceLocator::class)
-            ->setPublic(false)
             ->addArgument([
                 'translator.loader_2' => new ServiceClosureArgument(new Reference('translator.loader_2')),
             ]);
@@ -879,7 +877,6 @@ class PhpDumperTest extends TestCase
         // two method calls
         $container->register('translator.loader_3', 'stdClass')->setPublic(true);
         $container->register('translator.loader_3_locator', ServiceLocator::class)
-            ->setPublic(false)
             ->addArgument([
                 'translator.loader_3' => new ServiceClosureArgument(new Reference('translator.loader_3')),
             ]);
@@ -891,7 +888,7 @@ class PhpDumperTest extends TestCase
 
         $nil->setValues([null]);
         $container->register('bar_service', 'stdClass')->setArguments([new Reference('baz_service')])->setPublic(true);
-        $container->register('baz_service', 'stdClass')->setPublic(false);
+        $container->register('baz_service', 'stdClass');
         $container->compile();
 
         $dumper = new PhpDumper($container);
@@ -913,8 +910,7 @@ class PhpDumperTest extends TestCase
         ;
         $container->register(TestServiceSubscriber::class, TestServiceSubscriber::class)->setPublic(true);
 
-        $container->register(CustomDefinition::class, CustomDefinition::class)
-            ->setPublic(false);
+        $container->register(CustomDefinition::class, CustomDefinition::class);
 
         $container->register(TestDefinition1::class, TestDefinition1::class)->setPublic(true);
 
@@ -924,8 +920,8 @@ class PhpDumperTest extends TestCase
              */
             public function process(ContainerBuilder $container)
             {
-                $container->setDefinition('late_alias', new Definition(TestDefinition1::class));
-                $container->setAlias(TestDefinition1::class, 'late_alias');
+                $container->setDefinition('late_alias', new Definition(TestDefinition1::class))->setPublic(true);
+                $container->setAlias(TestDefinition1::class, 'late_alias')->setPublic(true);
             }
         }, PassConfig::TYPE_AFTER_REMOVING);
 
@@ -941,8 +937,7 @@ class PhpDumperTest extends TestCase
         require_once self::$fixturesPath.'/includes/classes.php';
 
         $container = new ContainerBuilder();
-        $container->register('not_invalid', 'BazClass')
-            ->setPublic(false);
+        $container->register('not_invalid', 'BazClass');
         $container->register('bar', 'BarClass')
             ->setPublic(true)
             ->addMethodCall('setBaz', [new Reference('not_invalid', SymfonyContainerInterface::IGNORE_ON_INVALID_REFERENCE)]);
@@ -973,10 +968,8 @@ class PhpDumperTest extends TestCase
     public function testExpressionReferencingPrivateService()
     {
         $container = new ContainerBuilder();
-        $container->register('private_bar', 'stdClass')
-            ->setPublic(false);
-        $container->register('private_foo', 'stdClass')
-            ->setPublic(false);
+        $container->register('private_bar', 'stdClass');
+        $container->register('private_foo', 'stdClass');
         $container->register('public_foo', 'stdClass')
             ->setPublic(true)
             ->addArgument(new Expression('service("private_foo").bar'));
@@ -1219,7 +1212,6 @@ class PhpDumperTest extends TestCase
         $this->expectDeprecation('The "foo" service is deprecated. You should stop using it, as it will be removed in the future.');
         $container = new ContainerBuilder();
         $container->register('foo', 'stdClass')
-            ->setPublic(false)
             ->setDeprecated(true);
         $container->register('bar', 'stdClass')
             ->setPublic(true)

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -88,10 +88,10 @@ class XmlDumperTest extends TestCase
         </service>
       </argument>
     </service>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+    <service id="Psr\Container\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
   </services>
@@ -111,10 +111,10 @@ class XmlDumperTest extends TestCase
       <tag name=\"foo&quot;bar\bar\" foo=\"foo&quot;barřž€\"/>
       <argument>foo&lt;&gt;&amp;bar</argument>
     </service>
-    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\">
+    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\">
       <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
-    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\">
+    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\">
       <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
   </services>
@@ -141,10 +141,10 @@ class XmlDumperTest extends TestCase
   <services>
     <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" public=\"true\" synthetic=\"true\"/>
     <service id=\"foo\" class=\"FooClass\Foo\" public=\"true\" decorates=\"bar\" decoration-inner-name=\"bar.woozy\"/>
-    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\">
+    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\">
       <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
-    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\">
+    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\">
       <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
   </services>
@@ -155,10 +155,10 @@ class XmlDumperTest extends TestCase
   <services>
     <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" public=\"true\" synthetic=\"true\"/>
     <service id=\"foo\" class=\"FooClass\Foo\" public=\"true\" decorates=\"bar\"/>
-    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\">
+    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\">
       <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
-    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\">
+    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\">
       <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
   </services>
@@ -169,10 +169,10 @@ class XmlDumperTest extends TestCase
   <services>
     <service id=\"service_container\" class=\"Symfony\Component\DependencyInjection\ContainerInterface\" public=\"true\" synthetic=\"true\"/>
     <service id=\"decorator\" decorates=\"decorated\" decoration-on-invalid=\"null\" decoration-inner-name=\"decorated.inner\" decoration-priority=\"1\"/>
-    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\" public=\"false\">
+    <service id=\"Psr\Container\ContainerInterface\" alias=\"service_container\">
       <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
-    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\" public=\"false\">
+    <service id=\"Symfony\Component\DependencyInjection\ContainerInterface\" alias=\"service_container\">
       <deprecated package=\"symfony/dependency-injection\" version=\"5.1\">The \"%alias_id%\" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/anonymous.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/anonymous.expected.yml
@@ -10,10 +10,9 @@ services:
         arguments: [!tagged_iterator listener]
     .2_stdClass~%s:
         class: stdClass
-        public: false
         tags:
             - listener
     decorated:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\StdClassDecorator
         public: true
-        arguments: [!service { class: stdClass, public: false }]
+        arguments: [!service { class: stdClass }]

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/child.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/child.expected.yml
@@ -9,7 +9,7 @@ services:
         public: true
         file: file.php
         lazy: true
-        arguments: [!service { class: Class1, public: false }]
+        arguments: [!service { class: Class1 }]
     bar:
         alias: foo
         public: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container9.php
@@ -68,7 +68,6 @@ $container
     ->register('inlined', 'Bar')
     ->setProperty('pub', 'pub')
     ->addMethodCall('setBaz', [new Reference('baz')])
-    ->setPublic(false)
 ;
 $container
     ->register('baz', 'Baz')
@@ -82,7 +81,6 @@ $container
 ;
 $container
     ->register('configurator_service', 'ConfClass')
-    ->setPublic(false)
     ->addMethodCall('setFoo', [new Reference('baz')])
 ;
 $container
@@ -93,7 +91,6 @@ $container
 $container
     ->register('configurator_service_simple', 'ConfClass')
     ->addArgument('bar')
-    ->setPublic(false)
 ;
 $container
     ->register('configured_service_simple', 'stdClass')
@@ -122,7 +119,6 @@ $container
 $container
     ->register('new_factory', 'FactoryClass')
     ->setProperty('foo', 'bar')
-    ->setPublic(false)
 ;
 $container
     ->register('factory_service', 'Bar')
@@ -144,7 +140,6 @@ $container
     ->register('factory_simple', 'SimpleFactoryClass')
     ->addArgument('foo')
     ->setDeprecated('vendor/package', '1.1', 'The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.')
-    ->setPublic(false)
 ;
 $container
     ->register('factory_service_simple', 'Bar')
@@ -171,7 +166,6 @@ $container->register('BAR2', 'stdClass')->setPublic(true);
 $container
     ->register('tagged_iterator_foo', 'Bar')
     ->addTag('foo')
-    ->setPublic(false)
 ;
 $container
     ->register('tagged_iterator', 'Bar')

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_env_in_id.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container_env_in_id.php
@@ -16,7 +16,7 @@ $container->register('foo', 'stdClass')->setPublic(true)
 $container->register('bar', 'stdClass')->setPublic(true)
    ->addArgument(new Reference('bar_%env(BAR)%'));
 
-$container->register('bar_%env(BAR)%', 'stdClass')->setPublic(false);
-$container->register('baz_%env(BAR)%', 'stdClass')->setPublic(false);
+$container->register('bar_%env(BAR)%', 'stdClass');
+$container->register('baz_%env(BAR)%', 'stdClass');
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
@@ -44,7 +44,7 @@ class Symfony_DI_PhpDumper_Test_Rot13Parameters extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.PnIy5ic' => true,
+            '.service_locator.PWbaRiJ' => true,
             'Psr\\Container\\ContainerInterface' => true,
             'Symfony\\Component\\DependencyInjection\\ContainerInterface' => true,
         ];

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_service_locator_argument.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_service_locator_argument.php
@@ -45,7 +45,7 @@ class Symfony_DI_PhpDumper_Service_Locator_Argument extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.VAwNRfI' => true,
+            '.service_locator.ZP1tNYN' => true,
             'Psr\\Container\\ContainerInterface' => true,
             'Symfony\\Component\\DependencyInjection\\ContainerInterface' => true,
             'foo2' => true,

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_subscriber.php
@@ -44,13 +44,11 @@ class ProjectServiceContainer extends Container
     public function getRemovedIds(): array
     {
         return [
-            '.service_locator.dZze14t' => true,
-            '.service_locator.dZze14t.foo_service' => true,
+            '.service_locator.DlIAmAe' => true,
+            '.service_locator.DlIAmAe.foo_service' => true,
             'Psr\\Container\\ContainerInterface' => true,
             'Symfony\\Component\\DependencyInjection\\ContainerInterface' => true,
             'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CustomDefinition' => true,
-            'Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\TestDefinition1' => true,
-            'late_alias' => true,
         ];
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services1.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services1.xml
@@ -2,10 +2,10 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service class="Symfony\Component\DependencyInjection\ContainerInterface" id="service_container" public="true" synthetic="true"/>
-        <service alias="service_container" id="Psr\Container\ContainerInterface" public="false">
+        <service alias="service_container" id="Psr\Container\ContainerInterface">
           <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
         </service>
-        <service alias="service_container" id="Symfony\Component\DependencyInjection\ContainerInterface" public="false">
+        <service alias="service_container" id="Symfony\Component\DependencyInjection\ContainerInterface">
           <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
         </service>
     </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services14.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services14.xml
@@ -3,13 +3,13 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="monolog.logger" parent="monolog.logger_prototype" public="false">
+        <service id="monolog.logger" parent="monolog.logger_prototype">
             <argument index="0">app</argument>
         </service>
 
         <service id="logger" alias="monolog.logger" />
 
-        <service id="monolog.logger" parent="monolog.logger_prototype" public="false">
+        <service id="monolog.logger" parent="monolog.logger_prototype">
             <argument index="0">app</argument>
         </service>
         <service id="monolog.logger_prototype" class="Symfony\Bridge\Monolog\Logger" abstract="true">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services21.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services21.xml
@@ -18,10 +18,10 @@
         </service>
       </configurator>
     </service>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+    <service id="Psr\Container\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services24.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services24.xml
@@ -3,10 +3,10 @@
   <services>
     <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
     <service id="foo" class="Foo" public="true" autowire="true"/>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+    <service id="Psr\Container\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services28.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services28.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <defaults public="false" autowire="true">
+        <defaults autowire="true">
             <tag name="foo" />
         </defaults>
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
@@ -64,7 +64,7 @@
       <factory service="baz" />
     </service>
     <service id="alias_for_foo" alias="foo" />
-    <service id="another_alias_for_foo" alias="foo" public="false" />
+    <service id="another_alias_for_foo" alias="foo" public="true"/>
     <service id="0" class="FooClass" />
     <service id="1" class="FooClass">
       <argument type="service" id="0" />

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services8.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services8.xml
@@ -34,10 +34,10 @@
   </parameters>
   <services>
     <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+    <service id="Psr\Container\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services9.xml
@@ -68,7 +68,7 @@
         <argument type="service" id="inlined"/>
       </call>
     </service>
-    <service id="inlined" class="Bar" public="false">
+    <service id="inlined" class="Bar">
       <property name="pub">pub</property>
       <call method="setBaz">
         <argument type="service" id="baz"/>
@@ -80,7 +80,7 @@
       </call>
     </service>
     <service id="request" class="Request" public="true" synthetic="true"/>
-    <service id="configurator_service" class="ConfClass" public="false">
+    <service id="configurator_service" class="ConfClass">
       <call method="setFoo">
         <argument type="service" id="baz"/>
       </call>
@@ -88,7 +88,7 @@
     <service id="configured_service" class="stdClass" public="true">
       <configurator service="configurator_service" method="configureStdClass"/>
     </service>
-    <service id="configurator_service_simple" class="ConfClass" public="false">
+    <service id="configurator_service_simple" class="ConfClass">
       <argument>bar</argument>
     </service>
     <service id="configured_service_simple" class="stdClass" public="true">
@@ -100,7 +100,7 @@
     <service id="deprecated_service" class="stdClass" public="true">
       <deprecated package="vendor/package" version="1.1">The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.</deprecated>
     </service>
-    <service id="new_factory" class="FactoryClass" public="false">
+    <service id="new_factory" class="FactoryClass">
       <property name="foo">bar</property>
     </service>
     <service id="factory_service" class="Bar" public="true">
@@ -113,7 +113,7 @@
     <service id="service_from_static_method" class="Bar\FooClass" public="true">
       <factory class="Bar\FooClass" method="getInstance"/>
     </service>
-    <service id="factory_simple" class="SimpleFactoryClass" public="false">
+    <service id="factory_simple" class="SimpleFactoryClass">
       <argument>foo</argument>
       <deprecated package="vendor/package" version="1.1">The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.</deprecated>
     </service>
@@ -139,7 +139,7 @@
     </service>
     <service id="bar2" class="stdClass" public="true"/>
     <service id="BAR2" class="stdClass" public="true"/>
-    <service id="tagged_iterator_foo" class="Bar" public="false">
+    <service id="tagged_iterator_foo" class="Bar">
       <tag name="foo"/>
     </service>
     <service id="tagged_iterator" class="Bar" public="true">
@@ -153,10 +153,10 @@
       <tag name="container.preload" class="Some\Sidekick1"/>
       <tag name="container.preload" class="Some\Sidekick2"/>
     </service>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+    <service id="Psr\Container\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
     <service id="alias_for_foo" alias="foo" public="true"/>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_abstract.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_abstract.xml
@@ -3,10 +3,10 @@
   <services>
     <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
     <service id="foo" class="Foo" public="true" abstract="true"/>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+    <service id="Psr\Container\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_dump_load.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_dump_load.xml
@@ -5,10 +5,10 @@
     <service id="foo" autoconfigure="true" abstract="true">
       <argument type="service" id="bar" on-invalid="ignore_uninitialized"/>
     </service>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+    <service id="Psr\Container\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_tsantos.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_tsantos.xml
@@ -4,25 +4,25 @@
     <service id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true"/>
     <service id="tsantos_serializer" class="TSantos\Serializer\EventEmitterSerializer" public="true">
       <argument type="service">
-        <service class="TSantos\Serializer\Encoder\JsonEncoder" public="false">
+        <service class="TSantos\Serializer\Encoder\JsonEncoder">
           <tag name="tsantos_serializer.encoder" format="json"/>
         </service>
       </argument>
       <argument type="service">
-        <service class="TSantos\Serializer\NormalizerRegistry" public="false">
+        <service class="TSantos\Serializer\NormalizerRegistry">
           <call method="add">
             <argument type="service">
-              <service class="TSantos\Serializer\Normalizer\ObjectNormalizer" public="false">
+              <service class="TSantos\Serializer\Normalizer\ObjectNormalizer">
                 <tag name="tsantos_serializer.normalizer" priority="-800"/>
                 <argument type="service">
-                  <service class="TSantos\SerializerBundle\Serializer\CircularReferenceHandler" public="false"/>
+                  <service class="TSantos\SerializerBundle\Serializer\CircularReferenceHandler"/>
                 </argument>
               </service>
             </argument>
           </call>
           <call method="add">
             <argument type="service">
-              <service class="TSantos\Serializer\Normalizer\CollectionNormalizer" public="false">
+              <service class="TSantos\Serializer\Normalizer\CollectionNormalizer">
                 <tag name="tsantos_serializer.normalizer" priority="-900"/>
                 <call method="setSerializer">
                   <argument type="service" id="tsantos_serializer"/>
@@ -32,7 +32,7 @@
           </call>
           <call method="add">
             <argument type="service">
-              <service class="TSantos\Serializer\Normalizer\JsonNormalizer" public="false">
+              <service class="TSantos\Serializer\Normalizer\JsonNormalizer">
                 <tag name="tsantos_serializer.normalizer" priority="-1000"/>
                 <call method="setSerializer">
                   <argument type="service" id="tsantos_serializer"/>
@@ -43,13 +43,13 @@
         </service>
       </argument>
       <argument type="service">
-        <service class="TSantos\Serializer\EventDispatcher\EventDispatcher" public="false">
+        <service class="TSantos\Serializer\EventDispatcher\EventDispatcher">
           <call method="addSubscriber">
             <argument type="service">
-              <service class="TSantos\SerializerBundle\EventListener\StopwatchListener" public="false">
+              <service class="TSantos\SerializerBundle\EventListener\StopwatchListener">
                 <tag name="tsantos_serializer.event_subscriber"/>
                 <argument type="service">
-                  <service class="Symfony\Component\Stopwatch\Stopwatch" public="false">
+                  <service class="Symfony\Component\Stopwatch\Stopwatch">
                     <tag name="kernel.reset" method="reset"/>
                     <argument>true</argument>
                   </service>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_abstract_argument.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_abstract_argument.xml
@@ -6,10 +6,10 @@
       <argument key="$baz" type="abstract">should be defined by Pass</argument>
       <argument key="$bar">test</argument>
     </service>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+    <service id="Psr\Container\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_arguments.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_tagged_arguments.xml
@@ -11,10 +11,10 @@
     <service id="foo_tagged_locator" class="Bar" public="true">
       <argument type="tagged_locator" tag="foo_tag" index-by="barfoo" default-index-method="foobar" default-priority-method="getPriority"/>
     </service>
-    <service id="Psr\Container\ContainerInterface" alias="service_container" public="false">
+    <service id="Psr\Container\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
-    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container" public="false">
+    <service id="Symfony\Component\DependencyInjection\ContainerInterface" alias="service_container">
       <deprecated package="symfony/dependency-injection" version="5.1">The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.</deprecated>
     </service>
   </services>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/bad_alias.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/bad_alias.yml
@@ -1,7 +1,6 @@
 services:
     foo:
         class: stdClass
-        public: false
 
     bar:
         alias: foo

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/child_parent/main.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/child_parent/main.yml
@@ -3,7 +3,6 @@ services:
         abstract: true
         lazy: true
         autowire: false
-        public: false
         tags: [from_parent]
 
     child_service:

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/defaults_instanceof_importance/main.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/integration/defaults_instanceof_importance/main.yml
@@ -9,7 +9,6 @@ services:
         Symfony\Component\DependencyInjection\Tests\Compiler\IntegrationTestStubParent:
             autowire: false
             shared: false
-            public: false
             tags:
                 - { name: foo_tag, tag_option: from_instanceof }
             calls:

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services1.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services1.yml
@@ -5,14 +5,12 @@ services:
         synthetic: true
     Psr\Container\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1
             message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services24.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services24.yml
@@ -10,14 +10,12 @@ services:
         autowire: true
     Psr\Container\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1
             message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services28.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services28.yml
@@ -1,6 +1,5 @@
 services:
     _defaults:
-        public: false
         autowire: true
         tags:
             - name: foo

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services34.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services34.yml
@@ -11,14 +11,12 @@ services:
         decoration_on_invalid: null
     Psr\Container\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1
             message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
@@ -44,6 +44,4 @@ services:
     alias_for_foo: '@foo'
     another_alias_for_foo:
         alias: foo
-        public: false
-    another_third_alias_for_foo:
-        alias: foo
+        public: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services8.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services8.yml
@@ -25,14 +25,12 @@ services:
         synthetic: true
     Psr\Container\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1
             message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services9.yml
@@ -57,7 +57,6 @@ services:
 
     inlined:
         class: Bar
-        public: false
         properties: { pub: pub }
         calls:
             - [setBaz, ['@baz']]
@@ -74,7 +73,6 @@ services:
         public: true
     configurator_service:
         class: ConfClass
-        public: false
         calls:
             - [setFoo, ['@baz']]
 
@@ -84,7 +82,6 @@ services:
         public: true
     configurator_service_simple:
         class: ConfClass
-        public: false
         arguments: ['bar']
     configured_service_simple:
         class: stdClass
@@ -111,7 +108,6 @@ services:
         public: true
     new_factory:
         class: FactoryClass
-        public: false
         properties: { foo: bar }
     factory_service:
         class: Bar
@@ -132,7 +128,6 @@ services:
             message: The "%service_id%" service is deprecated. You should stop using it, as it will be removed in the future.
             package: vendor/package
             version: 1.1
-        public: false
         arguments: ['foo']
     factory_service_simple:
         class: Bar
@@ -160,7 +155,6 @@ services:
         class: Bar
         tags:
             - foo
-        public: false
     tagged_iterator:
         class: Bar
         arguments:
@@ -168,14 +162,12 @@ services:
         public: true
     Psr\Container\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1
             message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_dump_load.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_dump_load.yml
@@ -10,14 +10,12 @@ services:
         arguments: ['@!bar']
     Psr\Container\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1
             message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_inline.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_inline.yml
@@ -10,14 +10,12 @@ services:
         arguments: [!service { class: Class2, arguments: [!service { class: Class2 }] }]
     Psr\Container\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1
             message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_abstract_argument.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_abstract_argument.yml
@@ -9,14 +9,12 @@ services:
         arguments: { $baz: !abstract 'should be defined by Pass', $bar: test }
     Psr\Container\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1
             message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_argument.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services_with_tagged_argument.yml
@@ -19,14 +19,12 @@ services:
         arguments: [!tagged_locator foo]
     Psr\Container\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1
             message: The "%alias_id%" autowiring alias is deprecated. Define it explicitly in your app if you want to keep using it.
     Symfony\Component\DependencyInjection\ContainerInterface:
         alias: service_container
-        public: false
         deprecated:
             package: symfony/dependency-injection
             version: 5.1

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/FileLoaderTest.php
@@ -171,7 +171,6 @@ class FileLoaderTest extends TestCase
         $loader = new TestFileLoader($container, new FileLocator(self::$fixturesPath.'/Fixtures'));
 
         $prototype = new Definition();
-        $prototype->setPublic(true)->setPrivate(true);
         $loader->registerClasses($prototype, 'Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\\', 'Prototype/*');
 
         $this->assertTrue($container->has(Bar::class));
@@ -190,7 +189,7 @@ class FileLoaderTest extends TestCase
         $alias = $container->getAlias(FooInterface::class);
         $this->assertSame(Foo::class, (string) $alias);
         $this->assertFalse($alias->isPublic());
-        $this->assertFalse($alias->isPrivate());
+        $this->assertTrue($alias->isPrivate());
     }
 
     public function testMissingParentClass()

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -310,10 +310,10 @@ class XmlFileLoaderTest extends TestCase
         $aliases = $container->getAliases();
         $this->assertArrayHasKey('alias_for_foo', $aliases, '->load() parses <service> elements');
         $this->assertEquals('foo', (string) $aliases['alias_for_foo'], '->load() parses aliases');
-        $this->assertTrue($aliases['alias_for_foo']->isPublic());
+        $this->assertFalse($aliases['alias_for_foo']->isPublic());
         $this->assertArrayHasKey('another_alias_for_foo', $aliases);
         $this->assertEquals('foo', (string) $aliases['another_alias_for_foo']);
-        $this->assertFalse($aliases['another_alias_for_foo']->isPublic());
+        $this->assertTrue($aliases['another_alias_for_foo']->isPublic());
 
         $this->assertEquals(['decorated', null, 0], $services['decorator_service']->getDecoratedService());
         $this->assertEquals(['decorated', 'decorated.pif-pouf', 0], $services['decorator_service_with_name']->getDecoratedService());

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -194,13 +194,10 @@ class YamlFileLoaderTest extends TestCase
         $aliases = $container->getAliases();
         $this->assertArrayHasKey('alias_for_foo', $aliases, '->load() parses aliases');
         $this->assertEquals('foo', (string) $aliases['alias_for_foo'], '->load() parses aliases');
-        $this->assertTrue($aliases['alias_for_foo']->isPublic());
+        $this->assertFalse($aliases['alias_for_foo']->isPublic());
         $this->assertArrayHasKey('another_alias_for_foo', $aliases);
         $this->assertEquals('foo', (string) $aliases['another_alias_for_foo']);
-        $this->assertFalse($aliases['another_alias_for_foo']->isPublic());
-        $this->assertTrue(isset($aliases['another_third_alias_for_foo']));
-        $this->assertEquals('foo', (string) $aliases['another_third_alias_for_foo']);
-        $this->assertTrue($aliases['another_third_alias_for_foo']->isPublic());
+        $this->assertTrue($aliases['another_alias_for_foo']->isPublic());
 
         $this->assertEquals(['decorated', null, 0], $services['decorator_service']->getDecoratedService());
         $this->assertEquals(['decorated', 'decorated.pif-pouf', 0], $services['decorator_service_with_name']->getDecoratedService());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Right now, there is a very subtle difference between `setPublic()` and `setPrivate()` that dates back to the FC/BC layer we created to turn services private by default.

We kept this difference to help third party bundles provide support for a wide range of versions of Symfony, but since 5.2 will be released at the same time as 3.4 will enter EOM, we should remove this behavior and deprecate `setPrivate()` to signal the change.

This is what this PR does.