### PR TITLE
[Console] Fixes question input encoding on Windows

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -158,6 +158,11 @@ class QuestionHelper extends Helper
         $inputStream = $this->inputStream ?: STDIN;
         $autocomplete = $question->getAutocompleterValues();
 
+        if (\function_exists('sapi_windows_cp_set')) {
+            // Codepage used by cmd.exe on Windows to allow special characters (éàüñ).
+            sapi_windows_cp_set(1252);
+        }
+
         if (null === $autocomplete || !self::$stty || !Terminal::hasSttyAvailable()) {
             $ret = false;
             if ($question->isHidden()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #35842, Fix #36324, Fix #37495 and Fix #37278 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | no <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->

To ask a question to a user, the [QuestionHelper](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Helper/QuestionHelper.php) use [`fgets`](https://www.php.net/manual/en/function.fgets.php). However, special characters are not supported on Windows with this function (like accents: `é`, `à`, `ö`). The solution is to set a special encoding with [`sapi_windows_cp_get`](https://www.php.net/manual/en/function.sapi-windows-cp-get).

> Before
```php
$stream = fopen('php://stdin', 'r');
$input = fgets($stream);
echo $input;

// input: "Bonjour à tous"
// output: 'Bonjour \ tous" or "Bonjour   tous"
```

> After
```php
// Check if the function exists because it only exists on Windows
if(function_exists('sapi_windows_cp_set')) {
    sapi_windows_cp_get(437);
}

$stream = fopen('php://stdin', 'r');
$input = fgets($stream);
echo $input;

// input: "Bonjour à tous"
// output: 'Bonjour à tous"
```

*Thanks to @bnjmnfnk for the solution 😉*