### PR TITLE
[Validator] fix handling typed properties as constraint options

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -108,7 +108,7 @@ abstract class Constraint
         $defaultOption = $this->getDefaultOption();
         $invalidOptions = [];
         $missingOptions = array_flip((array) $this->getRequiredOptions());
-        $knownOptions = get_object_vars($this);
+        $knownOptions = get_class_vars(static::class);
 
         // The "groups" option is added to the object lazily
         $knownOptions['groups'] = true;

--- a/src/Symfony/Component/Validator/Tests/ConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintTest.php
@@ -13,10 +13,13 @@ namespace Symfony\Component\Validator\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\InvalidOptionsException;
 use Symfony\Component\Validator\Tests\Fixtures\ClassConstraint;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintB;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintC;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithStaticProperty;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithTypedProperty;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithValue;
 use Symfony\Component\Validator\Tests\Fixtures\ConstraintWithValueAsDefault;
 
@@ -244,5 +247,26 @@ class ConstraintTest extends TestCase
         $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $this->expectExceptionMessage('No default option is configured for constraint "Symfony\Component\Validator\Tests\Fixtures\ConstraintB".');
         new ConstraintB(['value' => 1]);
+    }
+
+    public function testStaticPropertiesAreNoOptions()
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        new ConstraintWithStaticProperty([
+            'foo' => 'bar',
+        ]);
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testSetTypedProperty()
+    {
+        $constraint = new ConstraintWithTypedProperty([
+            'foo' => 'bar',
+        ]);
+
+        $this->assertSame('bar', $constraint->foo);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithStaticProperty.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithStaticProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraint;
+
+class ConstraintWithStaticProperty extends Constraint
+{
+    public static $foo;
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithTypedProperty.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintWithTypedProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraint;
+
+class ConstraintWithTypedProperty extends Constraint
+{
+    public string $foo;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37387
| License       | MIT
| Doc PR        | 