### PR TITLE
[DI] Fix call to sprintf in ServicesConfigurator::stack()

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
@@ -151,7 +151,7 @@ class ServicesConfigurator extends AbstractConfigurator
 
                 $services[$i] = $definition;
             } elseif (!$service instanceof ReferenceConfigurator) {
-                throw new InvalidArgumentException(sprintf('"%s()" expects a list of definitions as returned by "%s()" or "%s()", "%s" given at index "%s" for service "%s".', __METHOD__, InlineServiceConfigurator::FACTORY, ReferenceConfigurator::FACTORY, $service instanceof AbstractConfigurator ? $service::FACTORY.'()' : get_debug_type($service)), $i, $id);
+                throw new InvalidArgumentException(sprintf('"%s()" expects a list of definitions as returned by "%s()" or "%s()", "%s" given at index "%s" for service "%s".', __METHOD__, InlineServiceConfigurator::FACTORY, ReferenceConfigurator::FACTORY, $service instanceof AbstractConfigurator ? $service::FACTORY.'()' : get_debug_type($service), $i, $id));
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This PR fixes a faulty call to `sprintf()` and prevents the following error:

```
Warning: sprintf(): Too few arguments in /Users/dunglas/workspace/activity-pub/vendor/symfony/dependency-injection/Loader/Configurator/ServicesConfigurator.php on line 154

Fatal error: Uncaught Error: Wrong parameters for Symfony\Component\DependencyInjection\Exception\InvalidArgumentException([string $message [, long $code [, Throwable $previous = NULL]]]) in /Users/dunglas/workspace/activity-pub/vendor/symfony/dependency-injection/Loader/Configurator/ServicesConfigurator.php:154 Stack trace: #0 /Users/dunglas/workspace/activity-pub/vendor/symfony/dependency-injection/Loader/Configurator/ServicesConfigurator.php(154): Exception->__construct('', 1, 'api_platform.js...') #1 /Users/dunglas/workspace/activity-pub/src/Bundle/Resources/config/services.php(12): Symfony\Component\DependencyInjection\Loader\Configurator\ServicesConfigurator->stack('api_platform.js...', Array) #2 /Users/dunglas/workspace/activity-pub/vendor/symfony/dependency-injection/Loader/PhpFileLoader.php(50): Symfony\Component\DependencyInjection\Loader\ProtectedPhpFileLoader::Symfony\Component\DependencyInjection\Loader\Configurator\{closure}(Object(Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurat in /Users/dunglas/workspace/activity-pub/vendor/symfony/dependency-injection/Loader/Configurator/ServicesConfigurator.php on line 154
```
