### PR TITLE
[HttpClient] unset activity list when creating CurlResponse

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -43,6 +43,7 @@ final class CurlResponse implements ResponseInterface
         $this->multi = $multi;
 
         if (\is_resource($ch)) {
+            unset($multi->handlesActivity[(int) $ch]);
             $this->handle = $ch;
             $this->debugBuffer = fopen('php://temp', 'w+');
             if (0x074000 === $curlVersion) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This might fix an error that looks like a race condition.
I've seen it, and @Toflar too, but we're unable to reproduce.

> Argument 2 passed to Symfony\Component\HttpClient\Chunk\DataChunk::__construct() must be of the type string, null given

This patch tentatively empties activity lists. If the issue is related to the PHP engine reusing resource ids, this will fix it. Otherwise, we'll know we'll have to look elsewhere.

> looking at https://github.com/symfony/http-client/blob/4.4/Response/ResponseTrait.php#L363 I don’t really see how this can happen other than inflate_add() returning null

> $response->inflate is true before becoming a resource; there must be a race condition in the curl client that ends up listing a data chunk before a FirstChunk in the activity list, which would explain why inflate_add is given a non-resource (`true`).