### PR TITLE
[Console] added info method to symfony style

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -164,7 +164,9 @@ class SymfonyStyle extends OutputStyle
     }
 
     /**
-     * {@inheritdoc}
+     * Formats an info message.
+     *
+     * @param string|array $message
      */
     public function info($message)
     {

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -166,6 +166,14 @@ class SymfonyStyle extends OutputStyle
     /**
      * {@inheritdoc}
      */
+    public function info($message)
+    {
+        $this->block($message, 'INFO', 'fg=green', ' ', true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function caution($message)
     {
         $this->block($message, 'CAUTION', 'fg=white;bg=red', ' ! ', true);

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_2.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_2.php
@@ -12,5 +12,6 @@ return function (InputInterface $input, OutputInterface $output) {
     $output->error('Error');
     $output->success('Success');
     $output->note('Note');
+    $output->info('Info');
     $output->block('Custom block', 'CUSTOM', 'fg=white;bg=green', 'X ', true);
 };

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_2.txt
@@ -9,5 +9,7 @@
 
  ! [NOTE] Note                                                                                                          
 
+ [INFO] Info                                                                                                            
+
 X [CUSTOM] Custom block                                                                                                 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

It would be nice to have an info method as part of the SymfonyStyle class. This would prevent having to use the \<INFO\> tag, and it is consistent with other methods like warning and error (similar to the types available in monolog)
