### PR TITLE
[PhpUnitBridge] Fix compatibility with phpunit 9.3

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/CommandForV9.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CommandForV9.php
@@ -12,9 +12,11 @@
 namespace Symfony\Bridge\PhpUnit\Legacy;
 
 use PHPUnit\TextUI\Command as BaseCommand;
-use PHPUnit\TextUI\Configuration\Configuration;
+use PHPUnit\TextUI\Configuration\Configuration as LegacyConfiguration;
 use PHPUnit\TextUI\Configuration\Registry;
 use PHPUnit\TextUI\TestRunner as BaseRunner;
+use PHPUnit\TextUI\XmlConfiguration\Configuration;
+use PHPUnit\TextUI\XmlConfiguration\Loader;
 use Symfony\Bridge\PhpUnit\SymfonyTestsListener;
 
 /**
@@ -43,9 +45,13 @@ class CommandForV9 extends BaseCommand
 
         if (isset($this->arguments['configuration'])) {
             $configuration = $this->arguments['configuration'];
-            if (!$configuration instanceof Configuration) {
+
+            if (!class_exists(Configuration::class) && !$configuration instanceof LegacyConfiguration) {
                 $configuration = Registry::getInstance()->get($this->arguments['configuration']);
+            } elseif (class_exists(Configuration::class) && !$configuration instanceof Configuration) {
+                $configuration = (new Loader())->load($this->arguments['configuration']);
             }
+
             foreach ($configuration->listeners() as $registeredListener) {
                 if ('Symfony\Bridge\PhpUnit\SymfonyTestsListener' === ltrim($registeredListener->className(), '\\')) {
                     $registeredLocally = true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | -<!-- required for new features -->

In PHPUnit 9.3 some Classes were moved or renamed, to make the PhpunitBridge compatible with PhpUnit 9.3 it necessary to call the new Loader instead of the Registry.
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
