### PR TITLE
[Workflow] Added Function (and Twig extension) to retrieve a specific transition

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * Added function `workflow_transition` to easily retrieve a specific transition object
+
 5.0.0
 -----
 
@@ -16,7 +21,7 @@ CHANGELOG
 
  * added a new `TwigErrorRenderer` for `html` format, integrated with the `ErrorHandler` component
  * marked all classes extending twig as `@final`
- * deprecated to pass `$rootDir` and `$fileLinkFormatter` as 5th and 6th argument respectively to the 
+ * deprecated to pass `$rootDir` and `$fileLinkFormatter` as 5th and 6th argument respectively to the
    `DebugCommand::__construct()` method, swap the variables position.
  * the `LintCommand` lints all the templates stored in all configured Twig paths if none argument is provided
  * deprecated accepting STDIN implicitly when using the `lint:twig` command, use `lint:twig -` (append a dash) instead to make it explicit.
@@ -29,7 +34,7 @@ CHANGELOG
 
  * added the `form_parent()` function that allows to reliably retrieve the parent form in Twig templates
  * added the `workflow_transition_blockers()` function
- * deprecated the `$requestStack` and `$requestContext` arguments of the 
+ * deprecated the `$requestStack` and `$requestContext` arguments of the
    `HttpFoundationExtension`, pass a `Symfony\Component\HttpFoundation\UrlHelper`
    instance as the only argument instead
 

--- a/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
@@ -39,6 +39,7 @@ final class WorkflowExtension extends AbstractExtension
         return [
             new TwigFunction('workflow_can', [$this, 'canTransition']),
             new TwigFunction('workflow_transitions', [$this, 'getEnabledTransitions']),
+            new TwigFunction('workflow_transition', [$this, 'getEnabledTransition']),
             new TwigFunction('workflow_has_marked_place', [$this, 'hasMarkedPlace']),
             new TwigFunction('workflow_marked_places', [$this, 'getMarkedPlaces']),
             new TwigFunction('workflow_metadata', [$this, 'getMetadata']),
@@ -62,6 +63,11 @@ final class WorkflowExtension extends AbstractExtension
     public function getEnabledTransitions(object $subject, string $name = null): array
     {
         return $this->workflowRegistry->get($subject, $name)->getEnabledTransitions($subject);
+    }
+
+    public function getEnabledTransition(object $subject, string $transition, string $name = null): ?Transition
+    {
+        return $this->workflowRegistry->get($subject, $name)->getEnabledTransition($subject, $transition);
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/WorkflowExtensionTest.php
@@ -81,6 +81,16 @@ class WorkflowExtensionTest extends TestCase
         $this->assertSame('t1', $transitions[0]->getName());
     }
 
+    public function testGetEnabledTransition()
+    {
+        $subject = new Subject();
+
+        $transition = $this->extension->getEnabledTransition($subject, 't1');
+
+        $this->assertInstanceOf(Transition::class, $transition);
+        $this->assertSame('t1', $transition->getName());
+    }
+
     public function testHasMarkedPlace()
     {
         $subject = new Subject(['ordered' => 1, 'waiting_for_payment' => 1]);

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -42,7 +42,7 @@
         "symfony/console": "^4.4|^5.0",
         "symfony/expression-language": "^4.4|^5.0",
         "symfony/web-link": "^4.4|^5.0",
-        "symfony/workflow": "^4.4|^5.0",
+        "symfony/workflow": "^5.2",
         "twig/cssinliner-extra": "^2.12",
         "twig/inky-extra": "^2.12",
         "twig/markdown-extra": "^2.12"
@@ -53,7 +53,7 @@
         "symfony/http-foundation": "<4.4",
         "symfony/http-kernel": "<4.4",
         "symfony/translation": "<5.0",
-        "symfony/workflow": "<4.4"
+        "symfony/workflow": "<5.2"
     },
     "suggest": {
         "symfony/finder": "",

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * Added function `getEnabledTransition` to easily retrieve a specific transition object
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -592,6 +592,21 @@ class WorkflowTest extends TestCase
         $this->assertSame('t5', $transitions[0]->getName());
     }
 
+    public function testGetEnabledTransition()
+    {
+        $definition = $this->createComplexWorkflowDefinition();
+        $subject = new Subject();
+        $workflow = new Workflow($definition, new MethodMarkingStore());
+
+        $subject->setMarking(['d' => 1]);
+        $transition = $workflow->getEnabledTransition($subject, 't3');
+        $this->assertInstanceOf(Transition::class, $transition);
+        $this->assertSame('t3', $transition->getName());
+
+        $transition = $workflow->getEnabledTransition($subject, 'does_not_exist');
+        $this->assertNull($transition);
+    }
+
     public function testGetEnabledTransitionsWithSameNameTransition()
     {
         $definition = $this->createWorkflowWithSameNameTransition();

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -235,6 +235,25 @@ class Workflow implements WorkflowInterface
         return $enabledTransitions;
     }
 
+    public function getEnabledTransition(object $subject, string $name): ?Transition
+    {
+        $marking = $this->getMarking($subject);
+
+        foreach ($this->definition->getTransitions() as $transition) {
+            if ($transition->getName() !== $name) {
+                continue;
+            }
+            $transitionBlockerList = $this->buildTransitionBlockerListForTransition($subject, $marking, $transition);
+            if (!$transitionBlockerList->isEmpty()) {
+                continue;
+            }
+
+            return $transition;
+        }
+
+        return null;
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
You can now easily retrieve a specific transition. Useful when you want the metadata of a specific transition.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | hmmmm, should I create a ticket first ?
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/13907

I needed to get the metadata of a transition, but in order to do that, you need the transition object. So here is a PR to easily get the transition object