### PR TITLE
[DI] fix parsing of argument type=binary in xml

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -265,6 +265,7 @@
       <xsd:enumeration value="expression" />
       <xsd:enumeration value="string" />
       <xsd:enumeration value="constant" />
+      <xsd:enumeration value="binary" />
       <xsd:enumeration value="iterator" />
       <xsd:enumeration value="service_locator" />
       <!-- "tagged" is an alias of "tagged_iterator", using "tagged_iterator" is preferred. -->


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        |

Parameters and arguments can be of type="binary" since #25928. But the XSD forgot to be updated for arguments.
So if you try to run `bin/console debug:container` you'd get an error like

```
In XmlFileLoader.php line 385:

  Unable to parse file "var/cache/dev/App_KernelDevDebugContainer.xml": [ERROR 1840] Element '{ht
  tp://symfony.com/schema/dic/services}argument', attribute 'type': [facet 'enumeration'] The value 'binary' is not a
  n element of the set {'abstract', 'collection', 'service', 'expression', 'string', 'constant', 'iterator', 'service
  _locator', 'tagged', 'tagged_iterator', 'tagged_locator'}. (in /home/benny/project/ - line 505, column 0)
  [ERROR 1824] Element '{http://symfony.com/schema/dic/services}argument', attribute 'type': 'binary' is not a valid
  value of the atomic type '{http://symfony.com/schema/dic/services}argument_type'. (in /home/benny/project/ - line 5
  05, column 0)`
```
