### PR TITLE
[HttpKernel] hide "_password" in request data collector raw content

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
  * made the public `http_cache` service handle requests when available
  * allowed enabling trusted hosts and proxies using new `kernel.trusted_hosts`,
    `kernel.trusted_proxies` and `kernel.trusted_headers` parameters
+ * content of request parameter `_password` is now also hidden
+   in the request profiler raw content section
 
 5.1.0
 -----

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -95,7 +95,6 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         $this->data = [
             'method' => $request->getMethod(),
             'format' => $request->getRequestFormat(),
-            'content' => $content,
             'content_type' => $response->headers->get('Content-Type', 'text/html'),
             'status_text' => isset(Response::$statusTexts[$statusCode]) ? Response::$statusTexts[$statusCode] : '',
             'status_code' => $statusCode,
@@ -129,8 +128,12 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
         }
 
         if (isset($this->data['request_request']['_password'])) {
+            $encodedPassword = rawurlencode($this->data['request_request']['_password']);
+            $content = str_replace('_password='.$encodedPassword, '_password=******', $content);
             $this->data['request_request']['_password'] = '******';
         }
+
+        $this->data['content'] = $content;
 
         foreach ($this->data as $key => $value) {
             if (!\is_array($value)) {

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -310,6 +310,27 @@ class RequestDataCollectorTest extends TestCase
         $this->assertTrue($collector->getStatelessCheck());
     }
 
+    public function testItHidesPassword()
+    {
+        $c = new RequestDataCollector();
+
+        $request = Request::create(
+            'http://test.com/login',
+            'POST',
+            ['_password' => ' _password@123'],
+            [],
+            [],
+            [],
+            '_password=%20_password%40123'
+        );
+
+        $c->collect($request, $this->createResponse());
+        $c->lateCollect();
+
+        $this->assertEquals('******', $c->getRequestRequest()->get('_password'));
+        $this->assertEquals('_password=******', $c->getContent());
+    }
+
     protected function createRequest($routeParams = ['name' => 'foo'])
     {
         $request = Request::create('http://test.com/foo?bar=baz');


### PR DESCRIPTION
The password was already hidden in POST parameters, but still remained visible in raw content.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

This is my first contribution, so I hope I did everything right :)

