### PR TITLE
[Mailer] Implement additional mailer transport options

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 -----
 
  * added `NativeTransportFactory` to configure a transport based on php.ini settings
+ * added `local_domain`, `restart_threshold`, `restart_threshold_sleep` and `ping_threshold` options for `smtp`
+ * added `command` option for `sendmail`
 
 4.4.0
 -----

--- a/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/SendmailTransportFactoryTest.php
@@ -38,6 +38,11 @@ class SendmailTransportFactoryTest extends TransportFactoryTestCase
             new Dsn('sendmail+smtp', 'default'),
             new SendmailTransport(null, $this->getDispatcher(), $this->getLogger()),
         ];
+
+        yield [
+            new Dsn('sendmail+smtp', 'default', null, null, null, ['command' => '/usr/sbin/sendmail -oi -t']),
+            new SendmailTransport('/usr/sbin/sendmail -oi -t', $this->getDispatcher(), $this->getLogger()),
+        ];
     }
 
     public function unsupportedSchemeProvider(): iterable

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
@@ -81,5 +81,29 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
             new Dsn('smtps', 'example.com', '', '', 465, ['verify_peer' => false]),
             $transport,
         ];
+
+        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
+        $transport->setLocalDomain('example.com');
+
+        yield [
+            new Dsn('smtps', 'example.com', '', '', 465, ['local_domain' => 'example.com']),
+            $transport,
+        ];
+
+        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
+        $transport->setRestartThreshold(10, 1);
+
+        yield [
+            new Dsn('smtps', 'example.com', '', '', 465, ['restart_threshold' => '10', 'restart_threshold_sleep' => '1']),
+            $transport,
+        ];
+
+        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
+        $transport->setPingThreshold(10);
+
+        yield [
+            new Dsn('smtps', 'example.com', '', '', 465, ['ping_threshold' => '10']),
+            $transport,
+        ];
     }
 }

--- a/src/Symfony/Component/Mailer/Transport/SendmailTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransportFactory.php
@@ -21,7 +21,7 @@ final class SendmailTransportFactory extends AbstractTransportFactory
     public function create(Dsn $dsn): TransportInterface
     {
         if ('sendmail+smtp' === $dsn->getScheme() || 'sendmail' === $dsn->getScheme()) {
-            return new SendmailTransport(null, $this->dispatcher, $this->logger);
+            return new SendmailTransport($dsn->getOption('command'), $this->dispatcher, $this->logger);
         }
 
         throw new UnsupportedSchemeException($dsn, 'sendmail', $this->getSupportedSchemes());

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
@@ -48,6 +48,18 @@ final class EsmtpTransportFactory extends AbstractTransportFactory
             $transport->setPassword($password);
         }
 
+        if (null !== ($localDomain = $dsn->getOption('local_domain'))) {
+            $transport->setLocalDomain($localDomain);
+        }
+
+        if (null !== ($restartThreshold = $dsn->getOption('restart_threshold'))) {
+            $transport->setRestartThreshold((int) $restartThreshold, (int) $dsn->getOption('restart_threshold_sleep', 0));
+        }
+
+        if (null !== ($pingThreshold = $dsn->getOption('ping_threshold'))) {
+            $transport->setPingThreshold((int) $pingThreshold);
+        }
+
         return $transport;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #37300
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/13911

This implements additional transport configuration options mentioned in #37300. It also adds a `command` option to be able to define the command used by the `sendmail` transport.

Examples:

```yml
framework:
  mailer:
    transports:
      sendmail: sendmail://default?command=/usr/sbin/sendmail%%20-oi%%20-t
      local_domain: smtps://smtp.example.com?local_domain=example.org
      restart_threshold: smtps://smtp.example.com?restart_threshold=10&restart_threshold_sleep=1
      ping_threshold: smtps://smtp.example.com?ping_threshold=200
```
