### PR TITLE
Console ProgressBar: Change redraw default value to 25fps

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -56,7 +56,7 @@ final class ProgressBar
     /**
      * @param int $max Maximum steps (0 if unknown)
      */
-    public function __construct(OutputInterface $output, int $max = 0, float $minSecondsBetweenRedraws = 0.1)
+    public function __construct(OutputInterface $output, int $max = 0, float $minSecondsBetweenRedraws = 1 / 25)
     {
         if ($output instanceof ConsoleOutputInterface) {
             $output = $output->getErrorOutput();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | 

`ProgressBar` has a default value of `0.1` for `$minSecondsBetweenRedraws` which works out to 10 fps, so below the threshhold at which the human eye perceives it as a moving image instead of a series of individual images. Of course, the console's progress bar is not really an animation tool, but it seems like a low-hanging fruit to change the redraw frequency to something that can be perceived as a fluid motion. So I'm proposing to change `$minSecondsBetweenRedraws` to `0.016666666666667`, i.e. 60 fps, which is a fairly typical refresh rate for computer screens, so redrawing more often than that would be pointless. It means of course to redraw six times more often than currently, but i guess performance is not such a big concern here, right?