### PR TITLE
[Asset] Add missing PHPDoc type annotations

### DIFF
--- a/src/Symfony/Component/Asset/Context/RequestStackContext.php
+++ b/src/Symfony/Component/Asset/Context/RequestStackContext.php
@@ -20,8 +20,19 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class RequestStackContext implements ContextInterface
 {
+    /**
+     * @var RequestStack
+     */
     private $requestStack;
+
+    /**
+     * @var string
+     */
     private $basePath;
+
+    /**
+     * @var bool
+     */
     private $secure;
 
     /**

--- a/src/Symfony/Component/Asset/Package.php
+++ b/src/Symfony/Component/Asset/Package.php
@@ -23,7 +23,14 @@ use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
  */
 class Package implements PackageInterface
 {
+    /**
+     * @var VersionStrategyInterface
+     */
     private $versionStrategy;
+
+    /**
+     * @var ContextInterface
+     */
     private $context;
 
     public function __construct(VersionStrategyInterface $versionStrategy, ContextInterface $context = null)
@@ -68,6 +75,11 @@ class Package implements PackageInterface
         return $this->versionStrategy;
     }
 
+    /**
+     * @param string $url
+     *
+     * @return bool
+     */
     protected function isAbsoluteUrl($url)
     {
         return false !== strpos($url, '://') || '//' === substr($url, 0, 2);

--- a/src/Symfony/Component/Asset/Packages.php
+++ b/src/Symfony/Component/Asset/Packages.php
@@ -22,7 +22,14 @@ use Symfony\Component\Asset\Exception\LogicException;
  */
 class Packages
 {
+    /**
+     * @var PackageInterface|null
+     */
     private $defaultPackage;
+
+    /**
+     * @var PackageInterface[] Packages indexed by name
+     */
     private $packages = [];
 
     /**

--- a/src/Symfony/Component/Asset/PathPackage.php
+++ b/src/Symfony/Component/Asset/PathPackage.php
@@ -26,6 +26,9 @@ use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
  */
 class PathPackage extends Package
 {
+    /**
+     * @var string Base path to be prepended to relative paths
+     */
     private $basePath;
 
     /**
@@ -40,7 +43,7 @@ class PathPackage extends Package
         if (!$basePath) {
             $this->basePath = '/';
         } else {
-            if ('/' != $basePath[0]) {
+            if ('/' !== $basePath[0]) {
                 $basePath = '/'.$basePath;
             }
 

--- a/src/Symfony/Component/Asset/Tests/Context/RequestStackContextTest.php
+++ b/src/Symfony/Component/Asset/Tests/Context/RequestStackContextTest.php
@@ -13,12 +13,14 @@ namespace Symfony\Component\Asset\Tests\Context;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Asset\Context\RequestStackContext;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class RequestStackContextTest extends TestCase
 {
     public function testGetBasePathEmpty()
     {
-        $requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();
+        $requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
         $requestStackContext = new RequestStackContext($requestStack);
 
         $this->assertEmpty($requestStackContext->getBasePath());
@@ -28,10 +30,10 @@ class RequestStackContextTest extends TestCase
     {
         $testBasePath = 'test-path';
 
-        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
+        $request = $this->getMockBuilder(Request::class)->getMock();
         $request->method('getBasePath')
             ->willReturn($testBasePath);
-        $requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();
+        $requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
         $requestStack->method('getMasterRequest')
             ->willReturn($request);
 
@@ -42,7 +44,7 @@ class RequestStackContextTest extends TestCase
 
     public function testIsSecureFalse()
     {
-        $requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();
+        $requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
         $requestStackContext = new RequestStackContext($requestStack);
 
         $this->assertFalse($requestStackContext->isSecure());
@@ -50,10 +52,10 @@ class RequestStackContextTest extends TestCase
 
     public function testIsSecureTrue()
     {
-        $request = $this->getMockBuilder('Symfony\Component\HttpFoundation\Request')->getMock();
+        $request = $this->getMockBuilder(Request::class)->getMock();
         $request->method('isSecure')
             ->willReturn(true);
-        $requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();
+        $requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
         $requestStack->method('getMasterRequest')
             ->willReturn($request);
 
@@ -64,7 +66,7 @@ class RequestStackContextTest extends TestCase
 
     public function testDefaultContext()
     {
-        $requestStack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->getMock();
+        $requestStack = $this->getMockBuilder(RequestStack::class)->getMock();
         $requestStackContext = new RequestStackContext($requestStack, 'default-path', true);
 
         $this->assertSame('default-path', $requestStackContext->getBasePath());

--- a/src/Symfony/Component/Asset/Tests/PackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/PackageTest.php
@@ -20,6 +20,11 @@ class PackageTest extends TestCase
 {
     /**
      * @dataProvider getConfigs
+     *
+     * @param string|null $version
+     * @param string      $format
+     * @param string      $path
+     * @param string      $expected
      */
     public function testGetUrl($version, $format, $path, $expected)
     {
@@ -27,6 +32,9 @@ class PackageTest extends TestCase
         $this->assertSame($expected, $package->getUrl($path));
     }
 
+    /**
+     * @return array[]
+     */
     public function getConfigs()
     {
         return [

--- a/src/Symfony/Component/Asset/Tests/PackagesTest.php
+++ b/src/Symfony/Component/Asset/Tests/PackagesTest.php
@@ -12,7 +12,10 @@
 namespace Symfony\Component\Asset\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Asset\Exception\InvalidArgumentException;
+use Symfony\Component\Asset\Exception\LogicException;
 use Symfony\Component\Asset\Package;
+use Symfony\Component\Asset\PackageInterface;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
 
@@ -21,8 +24,8 @@ class PackagesTest extends TestCase
     public function testGetterSetters()
     {
         $packages = new Packages();
-        $packages->setDefaultPackage($default = $this->getMockBuilder('Symfony\Component\Asset\PackageInterface')->getMock());
-        $packages->addPackage('a', $a = $this->getMockBuilder('Symfony\Component\Asset\PackageInterface')->getMock());
+        $packages->setDefaultPackage($default = $this->getMockBuilder(PackageInterface::class)->getMock());
+        $packages->addPackage('a', $a = $this->getMockBuilder(PackageInterface::class)->getMock());
 
         $this->assertSame($default, $packages->getPackage());
         $this->assertSame($a, $packages->getPackage('a'));
@@ -57,14 +60,14 @@ class PackagesTest extends TestCase
 
     public function testNoDefaultPackage()
     {
-        $this->expectException('Symfony\Component\Asset\Exception\LogicException');
+        $this->expectException(LogicException::class);
         $packages = new Packages();
         $packages->getPackage();
     }
 
     public function testUndefinedPackage()
     {
-        $this->expectException('Symfony\Component\Asset\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         $packages = new Packages();
         $packages->getPackage('a');
     }

--- a/src/Symfony/Component/Asset/Tests/PathPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/PathPackageTest.php
@@ -11,14 +11,22 @@
 
 namespace Symfony\Component\Asset\Tests;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Asset\Context\ContextInterface;
 use Symfony\Component\Asset\PathPackage;
 use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
+use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
 
 class PathPackageTest extends TestCase
 {
     /**
      * @dataProvider getConfigs
+     *
+     * @param string $basePath
+     * @param string $format
+     * @param string $path
+     * @param string $expected
      */
     public function testGetUrl($basePath, $format, $path, $expected)
     {
@@ -26,6 +34,9 @@ class PathPackageTest extends TestCase
         $this->assertSame($expected, $package->getUrl($path));
     }
 
+    /**
+     * @return array[]
+     */
     public function getConfigs()
     {
         return [
@@ -50,6 +61,12 @@ class PathPackageTest extends TestCase
 
     /**
      * @dataProvider getContextConfigs
+     *
+     * @param string $basePathRequest
+     * @param string $basePath
+     * @param string $format
+     * @param string $path
+     * @param string $expected
      */
     public function testGetUrlWithContext($basePathRequest, $basePath, $format, $path, $expected)
     {
@@ -58,6 +75,9 @@ class PathPackageTest extends TestCase
         $this->assertSame($expected, $package->getUrl($path));
     }
 
+    /**
+     * @return array[]
+     */
     public function getContextConfigs()
     {
         return [
@@ -77,7 +97,7 @@ class PathPackageTest extends TestCase
 
     public function testVersionStrategyGivesAbsoluteURL()
     {
-        $versionStrategy = $this->getMockBuilder('Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface')->getMock();
+        $versionStrategy = $this->getMockBuilder(VersionStrategyInterface::class)->getMock();
         $versionStrategy->expects($this->any())
             ->method('applyVersion')
             ->willReturn('https://cdn.com/bar/main.css');
@@ -86,9 +106,14 @@ class PathPackageTest extends TestCase
         $this->assertSame('https://cdn.com/bar/main.css', $package->getUrl('main.css'));
     }
 
+    /**
+     * @param string $basePath
+     *
+     * @return MockObject&ContextInterface
+     */
     private function getContext($basePath)
     {
-        $context = $this->getMockBuilder('Symfony\Component\Asset\Context\ContextInterface')->getMock();
+        $context = $this->getMockBuilder(ContextInterface::class)->getMock();
         $context->expects($this->any())->method('getBasePath')->willReturn($basePath);
 
         return $context;

--- a/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
+++ b/src/Symfony/Component/Asset/Tests/UrlPackageTest.php
@@ -11,15 +11,25 @@
 
 namespace Symfony\Component\Asset\Tests;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Asset\Context\ContextInterface;
+use Symfony\Component\Asset\Exception\InvalidArgumentException;
+use Symfony\Component\Asset\Exception\LogicException;
 use Symfony\Component\Asset\UrlPackage;
 use Symfony\Component\Asset\VersionStrategy\EmptyVersionStrategy;
 use Symfony\Component\Asset\VersionStrategy\StaticVersionStrategy;
+use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
 
 class UrlPackageTest extends TestCase
 {
     /**
      * @dataProvider getConfigs
+     *
+     * @param string|string[] $baseUrls
+     * @param string          $format
+     * @param string          $path
+     * @param string          $expected
      */
     public function testGetUrl($baseUrls, $format, $path, $expected)
     {
@@ -27,6 +37,9 @@ class UrlPackageTest extends TestCase
         $this->assertSame($expected, $package->getUrl($path));
     }
 
+    /**
+     * @return array[]
+     */
     public function getConfigs()
     {
         return [
@@ -53,6 +66,12 @@ class UrlPackageTest extends TestCase
 
     /**
      * @dataProvider getContextConfigs
+     *
+     * @param bool            $secure
+     * @param string|string[] $baseUrls
+     * @param string          $format
+     * @param string          $path
+     * @param string          $expected
      */
     public function testGetUrlWithContext($secure, $baseUrls, $format, $path, $expected)
     {
@@ -61,6 +80,9 @@ class UrlPackageTest extends TestCase
         $this->assertSame($expected, $package->getUrl($path));
     }
 
+    /**
+     * @return array[]
+     */
     public function getContextConfigs()
     {
         return [
@@ -79,7 +101,7 @@ class UrlPackageTest extends TestCase
 
     public function testVersionStrategyGivesAbsoluteURL()
     {
-        $versionStrategy = $this->getMockBuilder('Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface')->getMock();
+        $versionStrategy = $this->getMockBuilder(VersionStrategyInterface::class)->getMock();
         $versionStrategy->expects($this->any())
             ->method('applyVersion')
             ->willReturn('https://cdn.com/bar/main.css');
@@ -90,19 +112,24 @@ class UrlPackageTest extends TestCase
 
     public function testNoBaseUrls()
     {
-        $this->expectException('Symfony\Component\Asset\Exception\LogicException');
+        $this->expectException(LogicException::class);
         new UrlPackage([], new EmptyVersionStrategy());
     }
 
     public function testWrongBaseUrl()
     {
-        $this->expectException('Symfony\Component\Asset\Exception\InvalidArgumentException');
+        $this->expectException(InvalidArgumentException::class);
         new UrlPackage(['not-a-url'], new EmptyVersionStrategy());
     }
 
+    /**
+     * @param bool $secure
+     *
+     * @return MockObject&ContextInterface
+     */
     private function getContext($secure)
     {
-        $context = $this->getMockBuilder('Symfony\Component\Asset\Context\ContextInterface')->getMock();
+        $context = $this->getMockBuilder(ContextInterface::class)->getMock();
         $context->expects($this->any())->method('isSecure')->willReturn($secure);
 
         return $context;

--- a/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
+++ b/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Asset\Tests\VersionStrategy;
 
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Symfony\Component\Asset\VersionStrategy\JsonManifestVersionStrategy;
 
 class JsonManifestVersionStrategyTest extends TestCase
@@ -39,19 +40,24 @@ class JsonManifestVersionStrategyTest extends TestCase
 
     public function testMissingManifestFileThrowsException()
     {
-        $this->expectException('RuntimeException');
+        $this->expectException(RuntimeException::class);
         $strategy = $this->createStrategy('non-existent-file.json');
         $strategy->getVersion('main.js');
     }
 
     public function testManifestFileWithBadJSONThrowsException()
     {
-        $this->expectException('RuntimeException');
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Error parsing JSON');
         $strategy = $this->createStrategy('manifest-invalid.json');
         $strategy->getVersion('main.js');
     }
 
+    /**
+     * @param string $manifestFilename File name in the fixtures directory
+     *
+     * @return JsonManifestVersionStrategy
+     */
     private function createStrategy($manifestFilename)
     {
         return new JsonManifestVersionStrategy(__DIR__.'/../fixtures/'.$manifestFilename);

--- a/src/Symfony/Component/Asset/Tests/VersionStrategy/StaticVersionStrategyTest.php
+++ b/src/Symfony/Component/Asset/Tests/VersionStrategy/StaticVersionStrategyTest.php
@@ -26,6 +26,10 @@ class StaticVersionStrategyTest extends TestCase
 
     /**
      * @dataProvider getConfigs
+     *
+     * @param string      $path
+     * @param string      $version
+     * @param string|null $format
      */
     public function testApplyVersion($path, $version, $format)
     {
@@ -34,6 +38,9 @@ class StaticVersionStrategyTest extends TestCase
         $this->assertSame($formatted, $staticVersionStrategy->applyVersion($path));
     }
 
+    /**
+     * @return array[]
+     */
     public function getConfigs()
     {
         return [

--- a/src/Symfony/Component/Asset/UrlPackage.php
+++ b/src/Symfony/Component/Asset/UrlPackage.php
@@ -35,7 +35,14 @@ use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
  */
 class UrlPackage extends Package
 {
+    /**
+     * @var string[]
+     */
     private $baseUrls = [];
+
+    /**
+     * @var self|null Package with only SSL URLs
+     */
     private $sslPackage;
 
     /**
@@ -85,7 +92,7 @@ class UrlPackage extends Package
             return $url;
         }
 
-        if ($url && '/' != $url[0]) {
+        if ($url && '/' !== $url[0]) {
             $url = '/'.$url;
         }
 
@@ -123,6 +130,11 @@ class UrlPackage extends Package
         return (int) fmod(hexdec(substr(hash('sha256', $path), 0, 10)), \count($this->baseUrls));
     }
 
+    /**
+     * @param string[] $urls Base assets URLs
+     *
+     * @return string[] Filtered URLs with SSL
+     */
     private function getSslUrls($urls)
     {
         $sslUrls = [];

--- a/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
@@ -24,7 +24,14 @@ namespace Symfony\Component\Asset\VersionStrategy;
  */
 class JsonManifestVersionStrategy implements VersionStrategyInterface
 {
+    /**
+     * @var string Absolute path to the manifest file
+     */
     private $manifestPath;
+
+    /**
+     * @var string[]|null
+     */
     private $manifestData;
 
     /**
@@ -50,6 +57,11 @@ class JsonManifestVersionStrategy implements VersionStrategyInterface
         return $this->getManifestPath($path) ?: $path;
     }
 
+    /**
+     * @param string $path
+     *
+     * @return string|null
+     */
     private function getManifestPath($path)
     {
         if (null === $this->manifestData) {

--- a/src/Symfony/Component/Asset/VersionStrategy/StaticVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/StaticVersionStrategy.php
@@ -18,7 +18,14 @@ namespace Symfony\Component\Asset\VersionStrategy;
  */
 class StaticVersionStrategy implements VersionStrategyInterface
 {
+    /**
+     * @var string
+     */
     private $version;
+
+    /**
+     * @var string
+     */
     private $format;
 
     /**
@@ -46,7 +53,7 @@ class StaticVersionStrategy implements VersionStrategyInterface
     {
         $versionized = sprintf($this->format, ltrim($path, '/'), $this->getVersion($path));
 
-        if ($path && '/' == $path[0]) {
+        if ($path && '/' === $path[0]) {
             return '/'.$versionized;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

This pull request mainly adds missing PHPDoc type annotations to the Asset component. 
The code is now compliant with Psalm level 2.