### PR TITLE
[Translation] Fix caching of parent locales file in translator

### DIFF
--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -460,7 +460,7 @@ EOF
     protected function computeFallbackLocales($locale)
     {
         if (null === $this->parentLocales) {
-            $parentLocales = json_decode(file_get_contents(__DIR__.'/Resources/data/parents.json'), true);
+            $this->parentLocales = json_decode(file_get_contents(__DIR__.'/Resources/data/parents.json'), true);
         }
 
         $locales = [];
@@ -473,7 +473,7 @@ EOF
         }
 
         while ($locale) {
-            $parent = $parentLocales[$locale] ?? null;
+            $parent = $this->parentLocales[$locale] ?? null;
 
             if ($parent) {
                 $locale = 'root' !== $parent ? $parent : null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 (this is the lowest maintained branch with this code)
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |
| License       | MIT
| Doc PR        |

The `parentLocales` property was probably meant as a cache for the content of the `parents.json` file but instead the content is stored in a local variable and the property stays `null`. This means the file is read on each call to `computeFallbackLocales`.

This PR update the code to what was probably meant to be.

(Ref https://github.com/symfony/symfony/pull/28070)