### PR TITLE
[Mime] skip test if guesser is not supported

### DIFF
--- a/src/Symfony/Component/Mime/Tests/AbstractMimeTypeGuesserTest.php
+++ b/src/Symfony/Component/Mime/Tests/AbstractMimeTypeGuesserTest.php
@@ -81,6 +81,10 @@ abstract class AbstractMimeTypeGuesserTest extends TestCase
 
     public function testGuessWithDuplicatedFileType()
     {
+        if (!$this->getGuesser()->isGuesserSupported()) {
+            $this->markTestSkipped('Guesser is not supported');
+        }
+
         $this->assertEquals('application/vnd.openxmlformats-officedocument.wordprocessingml.document', $this->getGuesser()->guessMimeType(__DIR__.'/Fixtures/test.docx'));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

fixes tests on AppVeyor