### PR TITLE
Removed comments and requirements relative to php <5.5 (not supported anymore)

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -437,8 +437,6 @@ class Command
      * This feature should be used only when creating a long process command,
      * like a daemon.
      *
-     * PHP 5.5+ or the proctitle PECL library is required
-     *
      * @param string $title The process title
      *
      * @return $this

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToHtml5LocalDateTimeTransformerTest.php
@@ -63,7 +63,6 @@ class DateTimeToHtml5LocalDateTimeTransformerTest extends TestCase
 
     /**
      * @dataProvider transformProvider
-     * @requires PHP 5.5
      */
     public function testTransformDateTimeImmutable($fromTz, $toTz, $from, $to)
     {

--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -115,9 +115,6 @@ class CookieTest extends TestCase
         $this->assertEquals($expire->format('U'), $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date');
     }
 
-    /**
-     * @requires PHP 5.5
-     */
     public function testConstructorWithDateTimeImmutable()
     {
         $expire = new \DateTimeImmutable();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.43.43.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

---

There is also https://github.com/symfony/symfony/blob/3.4/src/Symfony/Component/EventDispatcher/Tests/AbstractEventDispatcherTest.php#L270-L276 but I think we could let it in place (and this file does not exist on master)