### PR TITLE
[Console] Parse '--version' when it is in default def and no other command is specified

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -183,7 +183,6 @@ class Application implements ResetInterface
 
     /**
      * Checks if the current application has the parameter in the default option.
-     *
      */
     protected function hasDefaultOption(string $option): bool
     {

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -199,7 +199,7 @@ class Application implements ResetInterface
     public function doRun(InputInterface $input, OutputInterface $output)
     {
         // If no command was used, and the default version option was not overriden, print current version and return.
-        if ($this->hasDefaultOption('version') && true === $input->hasParameterOption(['--version', '-V'], true)) {
+        if ($this->hasDefaultOption('version') && $input->hasParameterOption(['--version', '-V'], true)) {
             $output->writeln($this->getLongVersion());
 
             return 0;
@@ -214,7 +214,7 @@ class Application implements ResetInterface
 
         $name = $this->getCommandName($input);
 
-        if ($this->hasDefaultOption('help') && true === $input->hasParameterOption(['--help', '-h'], true)) {
+        if ($this->hasDefaultOption('help') && $input->hasParameterOption(['--help', '-h'], true)) {
             if (!$name) {
                 $name = 'help';
                 $input = new ArrayInput(['command_name' => $this->defaultCommand]);
@@ -860,13 +860,13 @@ class Application implements ResetInterface
      */
     protected function configureIO(InputInterface $input, OutputInterface $output)
     {
-        if ($this->hasDefaultOption('ansi') && true === $input->hasParameterOption(['--ansi'], true)) {
+        if ($this->hasDefaultOption('ansi') && $input->hasParameterOption(['--ansi'], true)) {
             $output->setDecorated(true);
-        } elseif ($this->hasDefaultOption('no-ansi') && true === $input->hasParameterOption(['--no-ansi'], true)) {
+        } elseif ($this->hasDefaultOption('no-ansi') && $input->hasParameterOption(['--no-ansi'], true)) {
             $output->setDecorated(false);
         }
 
-        if ($this->hasDefaultOption('no-interaction') && true === $input->hasParameterOption(['--no-interaction', '-n'], true)) {
+        if ($this->hasDefaultOption('no-interaction') && $input->hasParameterOption(['--no-interaction', '-n'], true)) {
             $input->setInteractive(false);
         }
 
@@ -878,7 +878,7 @@ class Application implements ResetInterface
             default: $shellVerbosity = 0; break;
         }
 
-        if ($this->hasDefaultOption('quiet') && true === $input->hasParameterOption(['--quiet', '-q'], true)) {
+        if ($this->hasDefaultOption('quiet') && $input->hasParameterOption(['--quiet', '-q'], true)) {
             $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
             $shellVerbosity = -1;
         } elseif ($this->hasDefaultOption('verbose')) {

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -214,7 +214,7 @@ class Application implements ResetInterface
 
         $name = $this->getCommandName($input);
 
-        if (true === $input->hasParameterOption(['--help', '-h'], true)) {
+        if ($this->hasDefaultOption('help') && true === $input->hasParameterOption(['--help', '-h'], true)) {
             if (!$name) {
                 $name = 'help';
                 $input = new ArrayInput(['command_name' => $this->defaultCommand]);
@@ -860,13 +860,13 @@ class Application implements ResetInterface
      */
     protected function configureIO(InputInterface $input, OutputInterface $output)
     {
-        if (true === $input->hasParameterOption(['--ansi'], true)) {
+        if ($this->hasDefaultOption('ansi') && true === $input->hasParameterOption(['--ansi'], true)) {
             $output->setDecorated(true);
-        } elseif (true === $input->hasParameterOption(['--no-ansi'], true)) {
+        } elseif ($this->hasDefaultOption('no-ansi') && true === $input->hasParameterOption(['--no-ansi'], true)) {
             $output->setDecorated(false);
         }
 
-        if (true === $input->hasParameterOption(['--no-interaction', '-n'], true)) {
+        if ($this->hasDefaultOption('no-interaction') && true === $input->hasParameterOption(['--no-interaction', '-n'], true)) {
             $input->setInteractive(false);
         }
 
@@ -878,10 +878,10 @@ class Application implements ResetInterface
             default: $shellVerbosity = 0; break;
         }
 
-        if (true === $input->hasParameterOption(['--quiet', '-q'], true)) {
+        if ($this->hasDefaultOption('quiet') && true === $input->hasParameterOption(['--quiet', '-q'], true)) {
             $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
             $shellVerbosity = -1;
-        } else {
+        } elseif ($this->hasDefaultOption('verbose')) {
             if ($input->hasParameterOption('-vvv', true) || $input->hasParameterOption('--verbose=3', true) || 3 === $input->getParameterOption('--verbose', false, true)) {
                 $output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
                 $shellVerbosity = 3;

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -182,18 +182,24 @@ class Application implements ResetInterface
     }
 
     /**
+     * Checks if the current application has the parameter in the default option.
+     *
+     * @param string $option Option to check.
+     *
+     * @return bool True if the default definition contains the option, false otherwise.
+     */
+    protected function hasDefaultOption( $option ) {
+        $defaultDefinition = $this->getDefaultInputDefinition();
+        return $defaultDefinition->hasOption( $option );
+    }
+
+    /**
      * Runs the current application.
      *
      * @return int 0 if everything went fine, or an error code
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
-        if (true === $input->hasParameterOption(['--version', '-V'], true)) {
-            $output->writeln($this->getLongVersion());
-
-            return 0;
-        }
-
         try {
             // Makes ArgvInput::getFirstArgument() able to distinguish an option from an argument.
             $input->bind($this->getDefinition());
@@ -202,6 +208,14 @@ class Application implements ResetInterface
         }
 
         $name = $this->getCommandName($input);
+
+        // If no command was used, and the default version option was not overriden, print current version and return.
+        if ( ! $name && $this->hasDefaultOption( 'version' ) && true === $input->hasParameterOption(['--version', '-V'], true)) {
+            $output->writeln($this->getLongVersion());
+
+            return 0;
+        }
+
         if (true === $input->hasParameterOption(['--help', '-h'], true)) {
             if (!$name) {
                 $name = 'help';

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -184,7 +184,7 @@ class Application implements ResetInterface
     /**
      * Checks if the current application has the parameter in the default option.
      */
-    protected final function hasDefaultOption(string $option): bool
+    final protected function hasDefaultOption(string $option): bool
     {
         $defaultDefinition = $this->getDefaultInputDefinition();
 

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -184,11 +184,8 @@ class Application implements ResetInterface
     /**
      * Checks if the current application has the parameter in the default option.
      *
-     * @param string $option Option to check
-     *
-     * @return bool True if the default definition contains the option, false otherwise
      */
-    protected function hasDefaultOption($option)
+    protected function hasDefaultOption(string $option): bool
     {
         $defaultDefinition = $this->getDefaultInputDefinition();
 

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -199,6 +199,13 @@ class Application implements ResetInterface
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
+        // If no command was used, and the default version option was not overriden, print current version and return.
+        if ($this->hasDefaultOption('version') && true === $input->hasParameterOption(['--version', '-V'], true)) {
+            $output->writeln($this->getLongVersion());
+
+            return 0;
+        }
+
         try {
             // Makes ArgvInput::getFirstArgument() able to distinguish an option from an argument.
             $input->bind($this->getDefinition());
@@ -207,13 +214,6 @@ class Application implements ResetInterface
         }
 
         $name = $this->getCommandName($input);
-
-        // If no command was used, and the default version option was not overriden, print current version and return.
-        if (!$name && $this->hasDefaultOption('version') && true === $input->hasParameterOption(['--version', '-V'], true)) {
-            $output->writeln($this->getLongVersion());
-
-            return 0;
-        }
 
         if (true === $input->hasParameterOption(['--help', '-h'], true)) {
             if (!$name) {
@@ -1098,7 +1098,7 @@ class Application implements ResetInterface
         $this->defaultCommand = $commandName;
 
         if ($isSingleCommand) {
-            // Ensure the command exist
+            // Ensure the command exists
             $this->find($commandName);
 
             $this->singleCommand = true;

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -184,13 +184,15 @@ class Application implements ResetInterface
     /**
      * Checks if the current application has the parameter in the default option.
      *
-     * @param string $option Option to check.
+     * @param string $option Option to check
      *
-     * @return bool True if the default definition contains the option, false otherwise.
+     * @return bool True if the default definition contains the option, false otherwise
      */
-    protected function hasDefaultOption( $option ) {
+    protected function hasDefaultOption($option)
+    {
         $defaultDefinition = $this->getDefaultInputDefinition();
-        return $defaultDefinition->hasOption( $option );
+
+        return $defaultDefinition->hasOption($option);
     }
 
     /**
@@ -210,7 +212,7 @@ class Application implements ResetInterface
         $name = $this->getCommandName($input);
 
         // If no command was used, and the default version option was not overriden, print current version and return.
-        if ( ! $name && $this->hasDefaultOption( 'version' ) && true === $input->hasParameterOption(['--version', '-V'], true)) {
+        if (!$name && $this->hasDefaultOption('version') && true === $input->hasParameterOption(['--version', '-V'], true)) {
             $output->writeln($this->getLongVersion());
 
             return 0;

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -184,7 +184,7 @@ class Application implements ResetInterface
     /**
      * Checks if the current application has the parameter in the default option.
      */
-    protected function hasDefaultOption(string $option): bool
+    protected final function hasDefaultOption(string $option): bool
     {
         $defaultDefinition = $this->getDefaultInputDefinition();
 

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -184,11 +184,9 @@ class Application implements ResetInterface
     /**
      * Checks if the current application has the parameter in the default option.
      */
-    final protected function hasDefaultOption(string $option): bool
+    private function hasDefaultOption(string $option): bool
     {
-        $defaultDefinition = $this->getDefaultInputDefinition();
-
-        return $defaultDefinition->hasOption($option);
+        return $this->getDefaultInputDefinition()->hasOption($option);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1842,21 +1842,7 @@ class CustomApplicationWithCommand extends Application
      */
     protected function getDefaultInputDefinition(): InputDefinition
     {
-        return new InputDefinition([
-            new InputArgument('command', InputArgument::REQUIRED, 'The command to execute'),
-
-            new InputOption('--custom', '-c', InputOption::VALUE_NONE, 'Set the custom input definition.'),
-        ]);
-    }
-
-    /**
-     * Gets the default helper set with the helpers that should always be available.
-     *
-     * @return HelperSet A HelperSet instance
-     */
-    protected function getDefaultHelperSet(): HelperSet
-    {
-        return new HelperSet([new FormatterHelper()]);
+        return new InputDefinition([new InputArgument('command', InputArgument::REQUIRED, 'The command to execute')]);
     }
 }
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1317,7 +1317,7 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'foo:version', '--version' => '1.2.3']);
 
-        $this->assertEquals('called'.PHP_EOL.'1.2.3'.PHP_EOL, $tester->getDisplay(), 'Application parses the version option properly for the command');
+        $this->assertSame('called'.PHP_EOL.'1.2.3'.PHP_EOL, $tester->getDisplay(), 'Application parses the version option properly for the command');
     }
 
     public function testRunWithDispatcher()

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1268,7 +1268,7 @@ class ApplicationTest extends TestCase
         $inputDefinition = $application->getDefinition();
 
         // check whether the default arguments and options are not returned any more
-        $this->assertTrue($inputDefinition->hasArgument('command'));
+        $this->assertFalse($inputDefinition->hasArgument('command'));
 
         $this->assertFalse($inputDefinition->hasOption('help'));
         $this->assertFalse($inputDefinition->hasOption('quiet'));
@@ -1309,7 +1309,7 @@ class ApplicationTest extends TestCase
     {
         $command = new \FooVersionCommand();
 
-        $application = new CustomApplication();
+        $application = new CustomApplicationWithCommand();
         $application->setAutoExit(false);
         $application->add($command);
         $application->setDefaultCommand($command->getName());
@@ -1811,6 +1811,29 @@ class ApplicationTest extends TestCase
 }
 
 class CustomApplication extends Application
+{
+    /**
+     * Overwrites the default input definition.
+     *
+     * @return InputDefinition An InputDefinition instance
+     */
+    protected function getDefaultInputDefinition(): InputDefinition
+    {
+        return new InputDefinition([new InputOption('--custom', '-c', InputOption::VALUE_NONE, 'Set the custom input definition.')]);
+    }
+
+    /**
+     * Gets the default helper set with the helpers that should always be available.
+     *
+     * @return HelperSet A HelperSet instance
+     */
+    protected function getDefaultHelperSet(): HelperSet
+    {
+        return new HelperSet([new FormatterHelper()]);
+    }
+}
+
+class CustomApplicationWithCommand extends Application
 {
     /**
      * Overwrites the default input definition.

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1317,7 +1317,7 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'foo:version', '--version' => '1.2.3']);
 
-        $this->assertEquals('called'.PHP_EOL.'1.2.3'.PHP_EOL, $tester->getDisplay(), 'Application runs the default set command if different from \'list\' command');
+        $this->assertEquals('called'.PHP_EOL.'1.2.3'.PHP_EOL, $tester->getDisplay(), 'Application parses the version option properly for the command');
     }
 
     public function testRunWithDispatcher()

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1305,7 +1305,7 @@ class ApplicationTest extends TestCase
         $this->assertTrue($inputDefinition->hasOption('custom'));
     }
 
-    public function testRemovedVersionFromCustomInputDefinitionWorksWithCommand()
+    public function testRemovedDefaultValuesFromInputDefinitionWorksWithCommand()
     {
         $command = new \FooVersionCommand();
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/FooVersionCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/FooVersionCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class FooVersionCommand extends Command
+{
+    public $input;
+    public $output;
+
+    protected function configure()
+    {
+        $this
+            ->setName('foo:version')
+            ->setDescription('The foo:version command')
+            ->setAliases(['afooversion'])
+            ->addOption('version', null, InputOption::VALUE_OPTIONAL, 'fooopt version')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->input = $input;
+        $this->output = $output;
+
+        $output->writeln('called');
+        $output->writeln($this->input->getOption('version'));
+
+        return 0;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Fixtures/FooVersionCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/FooVersionCommand.php
@@ -7,9 +7,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class FooVersionCommand extends Command
 {
-    public $input;
-    public $output;
-
     protected function configure()
     {
         $this
@@ -22,11 +19,8 @@ class FooVersionCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->input = $input;
-        $this->output = $output;
-
         $output->writeln('called');
-        $output->writeln($this->input->getOption('version'));
+        $output->writeln($input->getOption('version'));
 
         return 0;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | Fixing this bug means that we allow this "new" option to be used, so I don't know if this is a yes or a no :)
| Deprecations? | no
| Tickets       | Fix #37459 
| License       | MIT
| Doc PR        |

This PR allows you to use the option `--version` in commands. See the original issue for minimal application setup and how to reproduce it.