### PR TITLE
[Process] Fix Permission Denied error when writing sf_proc_00 lock files on Windows

### DIFF
--- a/src/Symfony/Component/Process/Pipes/WindowsPipes.php
+++ b/src/Symfony/Component/Process/Pipes/WindowsPipes.php
@@ -56,6 +56,9 @@ class WindowsPipes extends AbstractPipes
                     $file = sprintf('%s\\sf_proc_%02X.%s', $tmpDir, $i, $name);
 
                     if (!$h = fopen($file.'.lock', 'w')) {
+                        if (file_exists($file.'.lock')) {
+                            continue 2;
+                        }
                         restore_error_handler();
                         throw new RuntimeException('A temporary file could not be opened to write the process output: '.$lastError);
                     }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  |no
| Deprecations? | no
| Tickets       | Fix #37294
| License       | MIT
| Doc PR        | 

Passes current Process unit tests.

On Windows systems, a new set of sf_proc_## files are generated in the system temp directory for each WindowsPipes object. These files are removed when the WindowsPipes object is destroyed.

This avoids receiving a permission denied error when attempting to write to sf_proc_## files between multiple sites running as different users, when the users do not have permissions to modify each others files.

Changes
- [Process] WindowsPipes always creates new sf_proc_## files in constructor
- [Process] WindowsPipes removes its sf_proc_## files in destructor