### PR TITLE
[Console] Do not check for "stty" using "exec" if that function is disabled

### DIFF
--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -66,6 +66,11 @@ class Terminal
             return self::$stty;
         }
 
+        // skip check if exec function is disabled
+        if (!\function_exists('exec')) {
+            return false;
+        }
+
         exec('stty 2>&1', $output, $exitcode);
 
         return self::$stty = 0 === $exitcode;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

fixes https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/5030