### PR TITLE
[TwigBundle] Fix translator argument for twig.extension.trans

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
@@ -98,7 +98,7 @@ return static function (ContainerConfigurator $container) {
             ->tag('data_collector', ['template' => '@WebProfiler/Collector/twig.html.twig', 'id' => 'twig', 'priority' => 257])
 
         ->set('twig.extension.trans', TranslationExtension::class)
-            ->args([service('translation')->nullOnInvalid()])
+            ->args([service('translator')->nullOnInvalid()])
             ->tag('twig.extension')
 
         ->set('twig.extension.assets', AssetExtension::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I fixed the Translator service argument for Translation Twig Extension, which was a bit hard to debug, because of `nullOnInvalid` and the anonymous class created in the Extension if Translator is null (https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php#L50).
