### PR TITLE
[HttpFoundation] Added File::getContent()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added `HeaderUtils::parseQuery()`: it does the same as `parse_str()` but preserves dots in variable names
+ * added `File::getContent()`
 
 5.1.0
 -----

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -104,6 +104,17 @@ class File extends \SplFileInfo
         return $target;
     }
 
+    public function getContent(): string
+    {
+        $content = file_get_contents($this->getPathname());
+
+        if (false === $content) {
+            throw new FileException(sprintf('Could not get the content of the file "%s".', $this->getPathname()));
+        }
+
+        return $content;
+    }
+
     /**
      * @return self
      */

--- a/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/FileTest.php
@@ -85,6 +85,13 @@ class FileTest extends TestCase
         @unlink($targetPath);
     }
 
+    public function testGetContent()
+    {
+        $file = new File(__FILE__);
+
+        $this->assertStringEqualsFile(__FILE__, $file->getContent());
+    }
+
     public function getFilenameFixtures()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

---

This is a very simple PR but I think it increases the DX when working
with uploaded files: I looked at for this method and I did not found it.
So I had to check witch method returns the "pathname" or to remember I
can cast the object to string to get its pathname.

It's a small detail, but IMHO it's better with it.

About file_get_contents vs stream: let's be simple here. If one want a
stream, they can use the code they always used for it :)