### PR TITLE
[Messenger] add redeliveredAt in RedeliveryStamp construct

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php
@@ -24,12 +24,12 @@ final class RedeliveryStamp implements StampInterface
     private $exceptionMessage;
     private $flattenException;
 
-    public function __construct(int $retryCount, string $exceptionMessage = null, FlattenException $flattenException = null)
+    public function __construct(int $retryCount, string $exceptionMessage = null, FlattenException $flattenException = null, \DateTimeImmutable $redeliveredAt = null)
     {
         $this->retryCount = $retryCount;
         $this->exceptionMessage = $exceptionMessage;
         $this->flattenException = $flattenException;
-        $this->redeliveredAt = new \DateTimeImmutable();
+        $this->redeliveredAt = $redeliveredAt ?? new \DateTimeImmutable();
     }
 
     public static function getRetryCountFromEnvelope(Envelope $envelope): int

--- a/src/Symfony/Component/Messenger/Tests/Stamp/RedeliveryStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/RedeliveryStampTest.php
@@ -33,4 +33,10 @@ class RedeliveryStampTest extends TestCase
         $this->assertSame('exception message', $stamp->getExceptionMessage());
         $this->assertSame($flattenException, $stamp->getFlattenException());
     }
+
+    public function testSerialization()
+    {
+        $stamp = new RedeliveryStamp(10, null, null, \DateTimeImmutable::createFromFormat(\DateTimeInterface::ISO8601, '2005-08-15T15:52:01+0000'));
+        $this->assertSame('2005-08-15T15:52:01+0000', $stamp->getRedeliveredAt()->format(\DateTimeInterface::ISO8601));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

---

this would allows one to correctly unserialize a RedeliveryStamp with a custom serializer not using the php serialize function