### PR TITLE
[Worfklow] Add 'initiated' event which is dispatched upon entering inital place

### DIFF
--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Added function `getEnabledTransition` to easily retrieve a specific transition object
+ * Added and trigger `initiated` event for subject entering in the Workflow for the first time.
 
 5.1.0
 -----

--- a/src/Symfony/Component/Workflow/Event/InitiatedEvent.php
+++ b/src/Symfony/Component/Workflow/Event/InitiatedEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Event;
+
+final class InitiatedEvent extends Event
+{
+}

--- a/src/Symfony/Component/Workflow/EventListener/AuditTrailListener.php
+++ b/src/Symfony/Component/Workflow/EventListener/AuditTrailListener.php
@@ -31,9 +31,9 @@ class AuditTrailListener implements EventSubscriberInterface
     {
         foreach ($event->getMarking()->getPlaces() as $place => $nbToken) {
             $this->logger->info(sprintf('Initiated "%s" for subject of class "%s" in workflow "%s".', $place, \get_class($event->getSubject()), $event->getWorkflowName()));
-        }    
+        }
     }
-    
+
     public function onLeave(Event $event)
     {
         foreach ($event->getTransition()->getFroms() as $place) {

--- a/src/Symfony/Component/Workflow/EventListener/AuditTrailListener.php
+++ b/src/Symfony/Component/Workflow/EventListener/AuditTrailListener.php
@@ -27,6 +27,13 @@ class AuditTrailListener implements EventSubscriberInterface
         $this->logger = $logger;
     }
 
+    public function onInitiate(Event $event)
+    {
+        foreach ($event->getMarking()->getPlaces() as $place => $nbToken) {
+            $this->logger->info(sprintf('Initiated "%s" for subject of class "%s" in workflow "%s".', $place, \get_class($event->getSubject()), $event->getWorkflowName()));
+        }    
+    }
+    
     public function onLeave(Event $event)
     {
         foreach ($event->getTransition()->getFroms() as $place) {
@@ -49,6 +56,7 @@ class AuditTrailListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
+            'workflow.initiate' => ['onInitiate'],
             'workflow.leave' => ['onLeave'],
             'workflow.transition' => ['onTransition'],
             'workflow.enter' => ['onEnter'],

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -412,8 +412,10 @@ class Workflow implements WorkflowInterface
         $this->dispatcher->dispatch($event, WorkflowEvents::INITITATED);
         $this->dispatcher->dispatch($event, sprintf('workflow.%s.initiated', $this->name));
 
-        foreach ($marking->getPlaces() as $place => $nbToken) {
-            $this->dispatcher->dispatch($event, sprintf('workflow.%s.initiated.%s', $this->name, $place));
+        if (!empty($this->definition->getInitialPlaces())) {
+            foreach ($this->definition->getInitialPlaces() as $place) {
+                $this->dispatcher->dispatch($event, sprintf('workflow.%s.initiated.%s', $this->name, $place));
+            }
         }
     }
 

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -400,18 +400,18 @@ class Workflow implements WorkflowInterface
             }
         }
     }
-    
+
     private function initiated(object $subject, Marking $marking): void
     {
         if (null === $this->dispatcher) {
             return;
         }
-        
+
         $event = new InitiatedEvent($subject, $marking, null, $this);
-        
+
         $this->dispatcher->dispatch($event, WorkflowEvents::INITITATED);
         $this->dispatcher->dispatch($event, sprintf('workflow.%s.initiated', $this->name));
-        
+
         foreach ($marking->getPlaces() as $place => $nbToken) {
             $this->dispatcher->dispatch($event, sprintf('workflow.%s.initiated.%s', $this->name, $place));
         }

--- a/src/Symfony/Component/Workflow/WorkflowEvents.php
+++ b/src/Symfony/Component/Workflow/WorkflowEvents.php
@@ -16,6 +16,7 @@ use Symfony\Component\Workflow\Event\CompletedEvent;
 use Symfony\Component\Workflow\Event\EnteredEvent;
 use Symfony\Component\Workflow\Event\EnterEvent;
 use Symfony\Component\Workflow\Event\GuardEvent;
+use Symfony\Component\Workflow\Event\InitiatedEvent;
 use Symfony\Component\Workflow\Event\LeaveEvent;
 use Symfony\Component\Workflow\Event\TransitionEvent;
 
@@ -49,6 +50,11 @@ final class WorkflowEvents
      * @Event("Symfony\Component\Workflow\Event\EnteredEvent")
      */
     const ENTERED = 'workflow.entered';
+    
+    /**
+     * @Event("Symfony\Component\Workflow\Event\InitiatedEvent")
+     */
+    const ENTERED = 'workflow.initiated';
 
     /**
      * @Event("Symfony\Component\Workflow\Event\LeaveEvent")

--- a/src/Symfony/Component/Workflow/WorkflowEvents.php
+++ b/src/Symfony/Component/Workflow/WorkflowEvents.php
@@ -54,7 +54,7 @@ final class WorkflowEvents
     /**
      * @Event("Symfony\Component\Workflow\Event\InitiatedEvent")
      */
-    const ENTERED = 'workflow.initiated';
+    const INITIATED = 'workflow.initiated';
 
     /**
      * @Event("Symfony\Component\Workflow\Event\LeaveEvent")

--- a/src/Symfony/Component/Workflow/WorkflowEvents.php
+++ b/src/Symfony/Component/Workflow/WorkflowEvents.php
@@ -50,7 +50,7 @@ final class WorkflowEvents
      * @Event("Symfony\Component\Workflow\Event\EnteredEvent")
      */
     const ENTERED = 'workflow.entered';
-    
+
     /**
      * @Event("Symfony\Component\Workflow\Event\InitiatedEvent")
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | Master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #37421
| License       | MIT
| Doc PR        | symfony/symfony-docs#

Added new INITIATED event which is dispatched upon initiating a new subject with the initial place as currently the place name is missing from the entered even when the subject is marked with its initial marking.
