### PR TITLE
[PropertyAccess] Remove inflector component

### DIFF
--- a/src/Symfony/Component/PropertyAccess/composer.json
+++ b/src/Symfony/Component/PropertyAccess/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "symfony/inflector": "^4.4|^5.0",
         "symfony/polyfill-php80": "^1.15",
         "symfony/property-info": "^5.1.1"
     },


### PR DESCRIPTION
Remove inflector component as a requirements since the component is deprecated.

| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

I hope I didn't miss something. I could not find a use of inflector component inside the PropertyAccess component and the inflector contains only one class that is deprecated