### PR TITLE
[ErrorHandler] Allow override of the default non-debug template

### DIFF
--- a/src/Symfony/Component/ErrorHandler/CHANGELOG.md
+++ b/src/Symfony/Component/ErrorHandler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * added the ability to set `HtmlErrorRenderer::$template` to a custom template to render when not in debug mode.
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
@@ -39,6 +39,8 @@ class HtmlErrorRenderer implements ErrorRendererInterface
     private $outputBuffer;
     private $logger;
 
+    private static $template = 'views/error.html.php';
+
     /**
      * @param bool|callable $debug        The debugging mode as a boolean or a callable that should return it
      * @param bool|callable $outputBuffer The output buffer as a string or a callable that should return it
@@ -134,7 +136,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
         $statusCode = $this->escape($exception->getStatusCode());
 
         if (!$debug) {
-            return $this->include('views/error.html.php', [
+            return $this->include(self::$template, [
                 'statusText' => $statusText,
                 'statusCode' => $statusCode,
             ]);
@@ -347,8 +349,19 @@ class HtmlErrorRenderer implements ErrorRendererInterface
     {
         extract($context, EXTR_SKIP);
         ob_start();
-        include __DIR__.'/../Resources/'.$name;
+
+        include file_exists($name) ? $name : __DIR__.'/../Resources/'.$name;
 
         return trim(ob_get_clean());
+    }
+
+    /**
+     * Allows overriding the default non-debug template.
+     *
+     * @param string $template path to the custom template file to render
+     */
+    public static function setTemplate(string $template): void
+    {
+        self::$template = $template;
     }
 }

--- a/src/Symfony/Component/ErrorHandler/README.md
+++ b/src/Symfony/Component/ErrorHandler/README.md
@@ -21,6 +21,9 @@ Debug::enable();
 //ErrorHandler::register();
 //DebugClassLoader::enable();
 
+// If you want a custom generic template when debug is not enabled
+// HtmlErrorRenderer::setTemplate('/path/to/custom/error.html.php');
+
 $data = ErrorHandler::call(static function () use ($filename, $datetimeFormat) {
     // if any code executed inside this anonymous function fails, a PHP exception
     // will be thrown, even if the code uses the '@' PHP silence operator


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes - a very tiny one
| Deprecations? | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Add new feature to allow the default hardcoded non-debug template to be overridden when `symfony/error-handler`used as a component in other projects. 

Currently, when used as a component, its not possible (that I could see) to override the standard default template of `views/error.html.php` therefore the look and feel, and text is hard coded. There is much written on how to customise the error pages when using the full symfony stack, but not when using individual `symfony/error-handler` component on its own.

This PR is related to the use of `symfony/error-handler` as a component in other projects - specifically the Joomla Content Management System, where, in non debug mode, a generic template **needs to be translatable, and customisable** even though most of the time when the error occurs will be at boot time and not much available to it. https://github.com/joomla/joomla-cms/issues/29968

This PR allows the use of code such as 

```php 
<?php

require 'vendor/autoload.php';

use Symfony\Component\ErrorHandler\ErrorHandler;
use Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer;

ErrorHandler::register();
HtmlErrorRenderer::setTemplate('/path/to/custom/mine.php');

throw new Exception('myException is this', 500);
``` 

and then for further customisation of the "look and feel" to be done in `mine.php`

Due to the unique way the error handler component is init'ed, the use of static calls has been employed rather than any DI approach, I hope this is ok. 