### PR TITLE
Permissive event dispatcher contracts for 4.4

### DIFF
--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "symfony/event-dispatcher-contracts": "^1.1"
+        "symfony/event-dispatcher-contracts": "^1.1|^2"
     },
     "require-dev": {
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Allows the event-dispatcher component to be used on PHP 8.