### PR TITLE
[Security\Http] Skip remember-me logout on empty token

### DIFF
--- a/src/Symfony/Component/Security/Http/EventListener/RememberMeLogoutListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/RememberMeLogoutListener.php
@@ -40,6 +40,10 @@ class RememberMeLogoutListener implements EventSubscriberInterface
             return;
         }
 
+        if (!$event->getToken()) {
+            return;
+        }
+
         if (null === $event->getResponse()) {
             throw new LogicException(sprintf('No response was set for this logout action. Make sure the DefaultLogoutListener or another listener has set the response before "%s" is called.', __CLASS__));
         }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/RememberMeLogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/RememberMeLogoutListenerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+use Symfony\Component\Security\Http\EventListener\RememberMeLogoutListener;
+use Symfony\Component\Security\Http\RememberMe\AbstractRememberMeServices;
+
+class RememberMeLogoutListenerTest extends TestCase
+{
+    public function testOnLogoutDoesNothingIfNoToken()
+    {
+        $rememberMeServices = $this->createMock(AbstractRememberMeServices::class);
+        $rememberMeServices->expects($this->never())->method('logout');
+
+        $rememberMeLogoutListener = new RememberMeLogoutListener($rememberMeServices);
+        $rememberMeLogoutListener->onLogout(new LogoutEvent(new Request(), null));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37501 
| License       | MIT
| Doc PR        | -


