### PR TITLE
[Validator] Add valueNormalizer option to Unique Constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.2.0
 -----
 
+ * added the `valueNormalizer` option to `Unique` Constraint
  * added a `Cascade` constraint to ease validating nested typed object properties
  * deprecated the `allowEmptyString` option of the `Length` constraint
 

--- a/src/Symfony/Component/Validator/Constraints/Unique.php
+++ b/src/Symfony/Component/Validator/Constraints/Unique.php
@@ -28,4 +28,9 @@ class Unique extends Constraint
     ];
 
     public $message = 'This collection should contain only unique elements.';
+
+    /**
+     * @var string|callable
+     */
+    public $valueNormalizer;
 }

--- a/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
@@ -61,12 +61,12 @@ class UniqueValidator extends ConstraintValidator
         $normalizer = $unique->valueNormalizer;
 
         if (null === $normalizer) {
-            return static function($value) {
+            return static function ($value) {
                 return $value;
             };
         }
 
-        if (is_callable($normalizer)) {
+        if (\is_callable($normalizer)) {
             return $normalizer;
         }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -163,7 +163,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
 
     public function testExpectsInvalidNonStrictComparison()
     {
-        $callback = static function($item) {
+        $callback = static function ($item) {
             return (int) $item;
         };
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -160,4 +160,64 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
             yield 'callable with object' => [[new CallableClass(), 'execute']],
         ];
     }
+
+    public function testExpectsInvalidNonStrictComparison()
+    {
+        $callback = static function($item) {
+            return (int) $item;
+        };
+
+        $this->validator->validate([1, '1', 1.0, '1.0'], new Unique([
+            'message' => 'myMessage',
+            'valueNormalizer' => $callback,
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', 'array')
+            ->setCode(Unique::IS_NOT_UNIQUE)
+            ->assertRaised();
+    }
+
+    public function testExpectsValidNonStrictComparison()
+    {
+        $callback = static function ($item) {
+            return (int) $item;
+        };
+
+        $this->validator->validate([1, '2', 3, '4.0'], new Unique([
+            'valueNormalizer' => $callback,
+        ]));
+
+        $this->assertNoViolation();
+    }
+
+    public function testExpectsInvalidCaseInsensitiveComparison()
+    {
+        $callback = static function ($item) {
+            return mb_strtolower($item);
+        };
+
+        $this->validator->validate(['Hello', 'hello', 'HELLO', 'hellO'], new Unique([
+            'message' => 'myMessage',
+            'valueNormalizer' => $callback,
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', 'array')
+            ->setCode(Unique::IS_NOT_UNIQUE)
+            ->assertRaised();
+    }
+
+    public function testExpectsValidCaseInsensitiveComparison()
+    {
+        $callback = static function ($item) {
+            return mb_strtolower($item);
+        };
+
+        $this->validator->validate(['Hello', 'World'], new Unique([
+            'valueNormalizer' => $callback,
+        ]));
+
+        $this->assertNoViolation();
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -96,7 +96,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getCallback
      */
-    public function testExpectsUniqueObjects($closure)
+    public function testExpectsUniqueObjects($callback)
     {
         $object1 = new \stdClass();
         $object1->name = 'Foo';
@@ -113,7 +113,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
         $value = [$object1, $object2, $object3];
 
         $this->validator->validate($value, new Unique([
-            'valueNormalizer' => $closure,
+            'valueNormalizer' => $callback,
         ]));
 
         $this->assertNoViolation();
@@ -122,7 +122,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     /**
      * @dataProvider getCallback
      */
-    public function testExpectsNonUniqueObjects($closure)
+    public function testExpectsNonUniqueObjects($callback)
     {
         $object1 = new \stdClass();
         $object1->name = 'Foo';
@@ -136,12 +136,11 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
         $object3->name = 'Foo';
         $object3->email = 'foo@email.com';
 
-
         $value = [$object1, $object2, $object3];
 
         $this->validator->validate($value, new Unique([
             'message' => 'myMessage',
-            'valueNormalizer' => $closure,
+            'valueNormalizer' => $callback,
         ]));
 
         $this->buildViolation('myMessage')

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -152,7 +152,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     public function getCallback()
     {
         return [
-            yield 'static function' => [static function(\stdClass $object) {
+            yield 'static function' => [static function (\stdClass $object) {
                 return [$object->name, $object->email];
             }],
             yield 'callable with string notation' => ['Symfony\Component\Validator\Tests\Constraints\Closure::execute'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints\Unique;
 use Symfony\Component\Validator\Constraints\UniqueValidator;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
-class Closure
+class CallableClass
 {
     public static function execute(\stdClass $object)
     {
@@ -155,9 +155,9 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
             yield 'static function' => [static function (\stdClass $object) {
                 return [$object->name, $object->email];
             }],
-            yield 'callable with string notation' => ['Symfony\Component\Validator\Tests\Constraints\Closure::execute'],
-            yield 'callable with static notation' => [[Closure::class, 'execute']],
-            yield 'callable with object' => [[new Closure(), 'execute']],
+            yield 'callable with string notation' => ['Symfony\Component\Validator\Tests\Constraints\CallableClass::execute'],
+            yield 'callable with static notation' => [[CallableClass::class, 'execute']],
+            yield 'callable with object' => [[new CallableClass(), 'execute']],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #37451 
| License       | MIT
| Doc PR        | todo

Hello. This PR is about https://github.com/symfony/symfony/issues/37451. The idea is to make that constraint more flexible and able to process business rules, especially when working with objects. Please have a look to have an idea. We can think about it as the similar feature in UniqueEntity constraint, when we declare on which attributes we are applying the constraint. But in our case it is more general - we pass a callable with whatever logic we want to apply to collection elements before we apply 'uniqueness check' :)

Added some tests, but hopefully will have some extra time this week and will improve them :)

Looks like no BC breaks. Thanks! :)
