### PR TITLE
[PhpUnitBridge] Fix expectDeprecation() in isolation

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/ExpectDeprecationTraitBeforeV8_4.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ExpectDeprecationTraitBeforeV8_4.php
@@ -23,6 +23,21 @@ trait ExpectDeprecationTraitBeforeV8_4
      */
     protected function expectDeprecation($message)
     {
+        // Expected deprecations set by isolated tests need to be written to a file
+        // so that the test running process can take account of them.
+        if ($file = getenv('SYMFONY_EXPECTED_DEPRECATIONS_SERIALIZE')) {
+            $this->getTestResultObject()->beStrictAboutTestsThatDoNotTestAnything(false);
+            $expectedDeprecations = file_get_contents($file);
+            if ($expectedDeprecations) {
+                $expectedDeprecations = array_merge(unserialize($expectedDeprecations), [$message]);
+            } else {
+                $expectedDeprecations = [$message];
+            }
+            file_put_contents($file, serialize($expectedDeprecations));
+
+            return;
+        }
+
         if (!SymfonyTestsListenerTrait::$previousErrorHandler) {
             SymfonyTestsListenerTrait::$previousErrorHandler = set_error_handler([SymfonyTestsListenerTrait::class, 'handleError']);
         }

--- a/src/Symfony/Bridge/PhpUnit/Legacy/ExpectDeprecationTraitForV8_4.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ExpectDeprecationTraitForV8_4.php
@@ -25,6 +25,21 @@ trait ExpectDeprecationTraitForV8_4
             throw new \InvalidArgumentException(sprintf('The "%s()" method requires the string $message argument.', __FUNCTION__));
         }
 
+        // Expected deprecations set by isolated tests need to be written to a file
+        // so that the test running process can take account of them.
+        if ($file = getenv('SYMFONY_EXPECTED_DEPRECATIONS_SERIALIZE')) {
+            $this->getTestResultObject()->beStrictAboutTestsThatDoNotTestAnything(false);
+            $expectedDeprecations = file_get_contents($file);
+            if ($expectedDeprecations) {
+                $expectedDeprecations = array_merge(unserialize($expectedDeprecations), [$message]);
+            } else {
+                $expectedDeprecations = [$message];
+            }
+            file_put_contents($file, serialize($expectedDeprecations));
+
+            return;
+        }
+
         if (!SymfonyTestsListenerTrait::$previousErrorHandler) {
             SymfonyTestsListenerTrait::$previousErrorHandler = set_error_handler([SymfonyTestsListenerTrait::class, 'handleError']);
         }

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -204,6 +204,7 @@ class SymfonyTestsListenerTrait
             if ($this->willBeIsolated($test)) {
                 $this->runsInSeparateProcess = tempnam(sys_get_temp_dir(), 'deprec');
                 putenv('SYMFONY_DEPRECATIONS_SERIALIZE='.$this->runsInSeparateProcess);
+                putenv('SYMFONY_EXPECTED_DEPRECATIONS_SERIALIZE='.tempnam(sys_get_temp_dir(), 'expectdeprec'));
             }
 
             $groups = Test::getGroups(\get_class($test), $test->getName(false));
@@ -245,6 +246,17 @@ class SymfonyTestsListenerTrait
 
     public function endTest($test, $time)
     {
+        if ($file = getenv('SYMFONY_EXPECTED_DEPRECATIONS_SERIALIZE')) {
+            putenv('SYMFONY_EXPECTED_DEPRECATIONS_SERIALIZE');
+            $expectedDeprecations = file_get_contents($file);
+            if ($expectedDeprecations) {
+                self::$expectedDeprecations = array_merge(self::$expectedDeprecations, unserialize($expectedDeprecations));
+                if (!self::$previousErrorHandler) {
+                    self::$previousErrorHandler = set_error_handler([self::class, 'handleError']);
+                }
+            }
+        }
+
         if (class_exists(DebugClassLoader::class, false)) {
             DebugClassLoader::checkClasses();
         }

--- a/src/Symfony/Bridge/PhpUnit/Tests/ExpectDeprecationTraitTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/ExpectDeprecationTraitTest.php
@@ -33,6 +33,18 @@ final class ExpectDeprecationTraitTest extends TestCase
      * Do not remove this test in the next major version.
      *
      * @group legacy
+     * @runInSeparateProcess
+     */
+    public function testOneInIsolation()
+    {
+        $this->expectDeprecation('foo');
+        @trigger_error('foo', E_USER_DEPRECATED);
+    }
+
+    /**
+     * Do not remove this test in the next major version.
+     *
+     * @group legacy
      */
     public function testMany()
     {

--- a/src/Symfony/Bridge/PhpUnit/Tests/FailTests/ExpectDeprecationTraitTestFail.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/FailTests/ExpectDeprecationTraitTestFail.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Tests\FailTests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+
+/**
+ * Class ExpectDeprecationTraitTestFail.
+ *
+ * This class is deliberately suffixed with *TestFail.php so that it is ignored
+ * by PHPUnit. This test is designed to fail. See ../expectdeprecationfail.phpt.
+ */
+final class ExpectDeprecationTraitTestFail extends TestCase
+{
+    use ExpectDeprecationTrait;
+
+    /**
+     * Do not remove this test in the next major version.
+     *
+     * @group legacy
+     */
+    public function testOne()
+    {
+        $this->expectDeprecation('foo');
+        @trigger_error('bar', E_USER_DEPRECATED);
+    }
+
+    /**
+     * Do not remove this test in the next major version.
+     *
+     * @group legacy
+     * @runInSeparateProcess
+     */
+    public function testOneInIsolation()
+    {
+        $this->expectDeprecation('foo');
+        @trigger_error('bar', E_USER_DEPRECATED);
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/expectdeprecationfail.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/expectdeprecationfail.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test ExpectDeprecationTrait failing tests
+--FILE--
+<?php
+$test =  realpath(__DIR__ . '/FailTests/ExpectDeprecationTraitTestFail.php');
+passthru(getenv('SYMFONY_SIMPLE_PHPUNIT_BIN_DIR') . '/simple-phpunit --colors=never ' . $test);
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+Testing Symfony\Bridge\PhpUnit\Tests\FailTests\ExpectDeprecationTraitTestFail
+FF                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There were 2 failures:
+
+1) Symfony\Bridge\PhpUnit\Tests\FailTests\ExpectDeprecationTraitTestFail::testOne
+Failed asserting that string matches format description.
+--- Expected
++++ Actual
+@@ @@
+ @expectedDeprecation:
+-%A  foo
++  bar
+
+2) Symfony\Bridge\PhpUnit\Tests\FailTests\ExpectDeprecationTraitTestFail::testOneInIsolation
+Failed asserting that string matches format description.
+--- Expected
++++ Actual
+@@ @@
+ @expectedDeprecation:
+-%A  foo
++  bar
+
+FAILURES!
+Tests: 2, Assertions: 2, Failures: 2.

--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -134,6 +134,7 @@ $defaultEnvs = [
     'COMPOSER' => 'composer.json',
     'COMPOSER_VENDOR_DIR' => 'vendor',
     'COMPOSER_BIN_DIR' => 'bin',
+    'SYMFONY_SIMPLE_PHPUNIT_BIN_DIR' => __DIR__,
 ];
 
 foreach ($defaultEnvs as $envName => $envValue) {
@@ -193,7 +194,7 @@ if (!file_exists("$PHPUNIT_DIR/$PHPUNIT_VERSION_DIR/phpunit") || $configurationH
         'requires' => ['php' => '*'],
     ];
 
-    if (1 === \count($info['versions'])) {
+    if (1 === count($info['versions'])) {
         $passthruOrFail("$COMPOSER create-project --ignore-platform-reqs --no-install --prefer-dist --no-scripts --no-plugins --no-progress -s dev phpunit/phpunit $PHPUNIT_VERSION_DIR \"$PHPUNIT_VERSION.*\"");
     } else {
         $passthruOrFail("$COMPOSER create-project --ignore-platform-reqs --no-install --prefer-dist --no-scripts --no-plugins --no-progress phpunit/phpunit $PHPUNIT_VERSION_DIR \"$PHPUNIT_VERSION.*\"");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Tests like 
```
    /**
     * Do not remove this test in the next major version.
     *
     * @group legacy
     * @runInSeparateProcess
     */
    public function testOneInIsolation()
    {
        $this->expectDeprecation('foo');
        @trigger_error('foo', E_USER_DEPRECATED);
    }
```
will fail due to:

```
Testing Symfony\Bridge\PhpUnit\Tests\ExpectDeprecationTraitTest
R                                                                   1 / 1 (100%)R

Time: 111 ms, Memory: 6.00 MB

There were 2 risky tests:

1) Symfony\Bridge\PhpUnit\Tests\ExpectDeprecationTraitTest::testOneInIsolation
This test did not perform any assertions

/Users/alex/dev/symfony/src/Symfony/Bridge/PhpUnit/Tests/ExpectDeprecationTraitTest.php:38

2) Symfony\Bridge\PhpUnit\Tests\ExpectDeprecationTraitTest::testOneInIsolation
This test did not perform any assertions

OK, but incomplete, skipped, or risky tests!
Tests: 1, Assertions: 0, Risky: 2.
```
