### PR TITLE
[Form] Fix ChoiceType translation domain

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -386,7 +386,7 @@ class ChoiceType extends AbstractType
             'value' => $choiceView->value,
             'label' => $choiceView->label,
             'attr' => $choiceView->attr,
-            'translation_domain' => $options['translation_domain'],
+            'translation_domain' => $options['choice_translation_domain'],
             'block_name' => 'entry',
         ];
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1994,6 +1994,24 @@ class ChoiceTypeTest extends BaseTypeTest
         $this->assertEquals('_09name', $view->vars['full_name']);
     }
 
+    public function testSubFormTranslationDomain()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'label' => 'label',
+            'translation_domain' => 'label_translation_domain',
+            'choices' => [
+                'choice1' => true,
+                'choice2' => false,
+            ],
+            'choice_translation_domain' => 'choice_translation_domain',
+            'expanded' => true,
+        ])->createView();
+
+        $this->assertCount(2, $form->children);
+        $this->assertSame('choice_translation_domain', $form->children[0]->vars['translation_domain']);
+        $this->assertSame('choice_translation_domain', $form->children[1]->vars['translation_domain']);
+    }
+
     /**
      * @dataProvider provideTrimCases
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Tickets       | Fix #...
| License       | MIT
| Doc PR        | symfony/symfony-docs#...

When using
```
->add('foo', ChoiceType::class, [
    'label'       => 'label',
    'translation_domain' => false,
    'choices'     => [
        'choice.no'  => false,
        'choice.yes' => true,
    ],
    'choice_translation_domain' => 'messages',
    'expanded'    => true,
    'required'    => false,
    'placeholder' => false,
]);
```

I discovered that the choices was not translated.

Seems like it's because the subForm is using the `translation_domain` instead of the `choice_translation_domain`.
