### PR TITLE
[Mailer] Fix reply-to functionality in the SendgridApiTransport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -166,4 +166,30 @@ class SendgridApiTransportTest extends TestCase
         $this->assertArrayHasKey('foo', $payload['headers']);
         $this->assertEquals('bar', $payload['headers']['foo']);
     }
+
+    public function testReplyTo()
+    {
+        $from = 'from@example.com';
+        $to = 'to@example.com';
+        $replyTo = 'replyto@example.com';
+        $email = new Email();
+        $email->from($from)
+            ->to($to)
+            ->replyTo($replyTo)
+            ->text('content');
+        $envelope = new Envelope(new Address($from), [new Address($to)]);
+
+        $transport = new SendgridApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(SendgridApiTransport::class, 'getPayload');
+        $method->setAccessible(true);
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('from', $payload);
+        $this->assertArrayHasKey('email', $payload['from']);
+        $this->assertSame($from, $payload['from']['email']);
+
+        $this->assertArrayHasKey('reply_to', $payload);
+        $this->assertArrayHasKey('email', $payload['reply_to']);
+        $this->assertSame($replyTo, $payload['reply_to']['email']);
+    }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -93,11 +93,16 @@ class SendgridApiTransport extends AbstractApiTransport
         if ($emails = array_map($addressStringifier, $email->getBcc())) {
             $personalization['bcc'] = $emails;
         }
+        if ($emails = array_map($addressStringifier, $email->getReplyTo())) {
+            // Email class supports an array of reply-to addresses,
+            // but SendGrid only supports a single address
+            $payload['reply_to'] = $emails[0];
+        }
 
         $payload['personalizations'][] = $personalization;
 
         // these headers can't be overwritten according to Sendgrid docs
-        // see https://developers.pepipost.com/migration-api/new-subpage/email-send
+        // see https://sendgrid.api-docs.io/v3.0/mail-send/mail-send-errors#-Headers-Errors
         $headersToBypass = ['x-sg-id', 'x-sg-eid', 'received', 'dkim-signature', 'content-transfer-encoding', 'from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'reply-to'];
         foreach ($email->getHeaders()->all() as $name => $header) {
             if (\in_array($name, $headersToBypass, true)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When sending a message using the `SendgridApiTransport`, the reply-to address was being ignored. In other transports, the reply to can be set using headers, but SendGrid requires that certain fields be added explicitly to the API payload. This is already handled for From, To, Cc, Bcc, and Subject, but was not handled for Reply-To. This change extracts the reply to address from the `Email` object and adds it to the payload.

Note that the `Email` object allows for multiple Reply-To addresses, but SendGrid only supports a single one, so I am just using the first element of the array.

I also fixed a link in a comment to SendGrid's documentation explaining the reserved headers that are not allowed.