### PR TITLE
[Cache] Move psr/simple-cache to require section

### DIFF
--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "php": ">=7.1.3",
         "psr/cache": "~1.0",
+        "psr/simple-cache": "^1.0",
         "psr/log": "~1.0",
         "symfony/cache-contracts": "^1.1.7|^2",
         "symfony/service-contracts": "^1.1|^2",
@@ -33,7 +34,6 @@
         "doctrine/cache": "^1.6",
         "doctrine/dbal": "^2.5|^3.0",
         "predis/predis": "^1.1",
-        "psr/simple-cache": "^1.0",
         "symfony/config": "^4.2|^5.0",
         "symfony/dependency-injection": "^3.4|^4.1|^5.0",
         "symfony/var-dumper": "^4.4|^5.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

It's not a dev dependency:
```
Fatal error: Interface 'Psr\SimpleCache\CacheInterface' not found in vendor/symfony/symfony/src/Symfony/Component/Cache/Psr16Cache.php on line 27
```
