### PR TITLE
[Workflow] Added Context to Workflow Event

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/WorkflowExtension.php
@@ -21,6 +21,7 @@ use Twig\TwigFunction;
  * WorkflowExtension.
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ * @author Carlos Pereira De Amorim <carlos@shauri.fr>
  */
 final class WorkflowExtension extends AbstractExtension
 {

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 -----
 
  * Added `Workflow::getEnabledTransition()` to easily retrieve a specific transition object
+ * Added context to the event dispatched
+ * Added default context to the Initial Marking
 
 5.1.0
 -----

--- a/src/Symfony/Component/Workflow/Event/Event.php
+++ b/src/Symfony/Component/Workflow/Event/Event.php
@@ -19,20 +19,23 @@ use Symfony\Contracts\EventDispatcher\Event as BaseEvent;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ * @author Carlos Pereira De Amorim <carlos@shauri.fr>
  */
 class Event extends BaseEvent
 {
+    protected $context;
     private $subject;
     private $marking;
     private $transition;
     private $workflow;
 
-    public function __construct(object $subject, Marking $marking, Transition $transition = null, WorkflowInterface $workflow = null)
+    public function __construct(object $subject, Marking $marking, Transition $transition = null, WorkflowInterface $workflow = null, array $context = [])
     {
         $this->subject = $subject;
         $this->marking = $marking;
         $this->transition = $transition;
         $this->workflow = $workflow;
+        $this->context = $context;
     }
 
     public function getMarking()
@@ -63,5 +66,10 @@ class Event extends BaseEvent
     public function getMetadata(string $key, $subject)
     {
         return $this->workflow->getMetadataStore()->getMetadata($key, $subject);
+    }
+
+    public function getContext(): array
+    {
+        return $this->context;
     }
 }

--- a/src/Symfony/Component/Workflow/Event/TransitionEvent.php
+++ b/src/Symfony/Component/Workflow/Event/TransitionEvent.php
@@ -13,15 +13,8 @@ namespace Symfony\Component\Workflow\Event;
 
 final class TransitionEvent extends Event
 {
-    private $context;
-
     public function setContext(array $context): void
     {
         $this->context = $context;
-    }
-
-    public function getContext(): array
-    {
-        return $this->context;
     }
 }


### PR DESCRIPTION
There's also a default context for the initial marking event.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #37421 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/13947

This time, I need context in the events, because, sometimes, the transition is automatic and sometimes, it is manual. I want to be able to make the difference. I figured using the context for that is a good idea. I hope you do too :)

By the way, I believe it also fixes #37421 . I took @pluk77 request to be able to differentiate an initial marking by having a default context in that case