### PR TITLE
[EventDispatcher] Add resumePropagation to events

### DIFF
--- a/src/Symfony/Contracts/EventDispatcher/Event.php
+++ b/src/Symfony/Contracts/EventDispatcher/Event.php
@@ -27,6 +27,7 @@ use Psr\EventDispatcher\StoppableEventInterface;
  * @author Roman Borschel <roman@code-factory.org>
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Nicolas Grekas <p@tchwork.com>
+ * @author Joshua Behrens <behrens@heptacom.de>
  */
 class Event implements StoppableEventInterface
 {
@@ -50,5 +51,13 @@ class Event implements StoppableEventInterface
     public function stopPropagation(): void
     {
         $this->propagationStopped = true;
+    }
+    
+    /**
+     * Resumes the propagation.
+     */
+    public function resumePropagation(): void
+    {
+        $this->propagationStopped = false;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix none
| License       | MIT
| Doc PR        | symfony/symfony-docs#none

It is useful when you want to dispatch an event twice but it has already been stopped by a listener. Current solution is to re-construct the event. As I am unsure about the acceptance I just publish this pull request for discussion. I will add tests and docs when this feature will be considered.