### PR TITLE
Removed @internal from Composite

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Composite.php
+++ b/src/Symfony/Component/Validator/Constraints/Composite.php
@@ -25,8 +25,6 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  * contains the nested constraints.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
- *
- * @internal since Symfony 5.1
  */
 abstract class Composite extends Constraint
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #37348
| License       | MIT

I think that Composite should not be @internal. Even with the new @Compound constraint Composite is still useful for complex custom validators.

For example, I have @ExcelColumn(string $column, array $constraints) that checks that all cells in a column of an uploaded Excel file are valid. This cannot be expressed with @Compound.