### PR TITLE
[PhpUnitBridge] Polyfill new phpunit 9.1 assertions

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
+++ b/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * polyfill new phpunit 9.1 assertions
+
 5.1.0
 -----
 
@@ -25,7 +30,7 @@ CHANGELOG
 -----
 
  * added `ClassExistsMock`
- * bumped PHP version from 5.3.3 to 5.5.9 
+ * bumped PHP version from 5.3.3 to 5.5.9
  * split simple-phpunit bin into php file with code and a shell script
 
 4.1.0

--- a/src/Symfony/Bridge/PhpUnit/Legacy/PolyfillAssertTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/PolyfillAssertTrait.php
@@ -282,6 +282,17 @@ trait PolyfillAssertTrait
      *
      * @return void
      */
+    public static function assertIsNotReadable($filename, $message = '')
+    {
+        static::assertNotIsReadable($filename, $message);
+    }
+
+    /**
+     * @param string $filename
+     * @param string $message
+     *
+     * @return void
+     */
     public static function assertIsWritable($filename, $message = '')
     {
         static::assertInternalType('string', $filename, $message);
@@ -298,6 +309,17 @@ trait PolyfillAssertTrait
     {
         static::assertInternalType('string', $filename, $message);
         static::assertFalse(is_writable($filename), $message ? $message : "Failed asserting that $filename is not writable.");
+    }
+
+    /**
+     * @param string $filename
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertIsNotWritable($filename, $message = '')
+    {
+        static::assertNotIsWritable($filename, $message);
     }
 
     /**
@@ -330,6 +352,17 @@ trait PolyfillAssertTrait
      *
      * @return void
      */
+    public static function assertDirectoryDoesNotExist($directory, $message = '')
+    {
+        static::assertDirectoryNotExists($directory, $message);
+    }
+
+    /**
+     * @param string $directory
+     * @param string $message
+     *
+     * @return void
+     */
     public static function assertDirectoryIsReadable($directory, $message = '')
     {
         static::assertDirectoryExists($directory, $message);
@@ -354,6 +387,17 @@ trait PolyfillAssertTrait
      *
      * @return void
      */
+    public static function assertDirectoryIsNotReadable($directory, $message = '')
+    {
+        static::assertDirectoryNotIsReadable($directory, $message);
+    }
+
+    /**
+     * @param string $directory
+     * @param string $message
+     *
+     * @return void
+     */
     public static function assertDirectoryIsWritable($directory, $message = '')
     {
         static::assertDirectoryExists($directory, $message);
@@ -370,6 +414,17 @@ trait PolyfillAssertTrait
     {
         static::assertDirectoryExists($directory, $message);
         static::assertNotIsWritable($directory, $message);
+    }
+
+    /**
+     * @param string $directory
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertDirectoryIsNotWritable($directory, $message = '')
+    {
+        static::assertDirectoryNotIsWritable($directory, $message);
     }
 
     /**
@@ -402,6 +457,17 @@ trait PolyfillAssertTrait
      *
      * @return void
      */
+    public static function assertFileDoesNotExist($filename, $message = '')
+    {
+        static::assertFileNotExists($filename, $message);
+    }
+
+    /**
+     * @param string $filename
+     * @param string $message
+     *
+     * @return void
+     */
     public static function assertFileIsReadable($filename, $message = '')
     {
         static::assertFileExists($filename, $message);
@@ -426,6 +492,17 @@ trait PolyfillAssertTrait
      *
      * @return void
      */
+    public static function assertFileIsNotReadable($filename, $message = '')
+    {
+        static::assertFileNotIsReadable($filename, $message);
+    }
+
+    /**
+     * @param string $filename
+     * @param string $message
+     *
+     * @return void
+     */
     public static function assertFileIsWritable($filename, $message = '')
     {
         static::assertFileExists($filename, $message);
@@ -442,5 +519,40 @@ trait PolyfillAssertTrait
     {
         static::assertFileExists($filename, $message);
         static::assertNotIsWritable($filename, $message);
+    }
+
+    /**
+     * @param string $filename
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertFileIsNotWritable($filename, $message = '')
+    {
+        static::assertFileNotIsWritable($filename, $message);
+    }
+
+    /**
+     * @param string $pattern
+     * @param string $string
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertMatchesRegularExpression($pattern, $string, $message = '')
+    {
+        static::assertRegExp($pattern, $string, $message);
+    }
+
+    /**
+     * @param string $pattern
+     * @param string $string
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function assertDoesNotMatchRegularExpression($pattern, $string, $message = '')
+    {
+        static::assertNotRegExp($message, $string, $message);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #37320
| License       | MIT
| Doc PR        | n/a

This PR adds the following new assertions that was added to PhpUnit 9.1:

- Implement **`assertIsNotReadable()`** as alternative for `assertNotIsReadable()`
- Implement **`assertIsNotWritable()`** as alternative for `assertNotIsWritable()`
- Implement **`assertDirectoryDoesNotExist()`** as alternative for `assertDirectoryNotExists()`
- Implement **`assertDirectoryIsNotReadable()`** as alternative for `assertDirectoryNotIsReadable()`
- Implement **`assertDirectoryIsNotWritable()`** as alternative for `assertDirectoryNotIsWritable()`
- Implement **`assertFileDoesNotExist()`** as alternative for `assertFileNotExists()`
- Implement **`assertFileIsNotReadable()`** as alternative for `assertFileNotIsReadable()`
- Implement **`assertFileIsNotWritable()`** as alternative for `assertFileNotIsWritable()`
- Implement **`assertMatchesRegularExpression()`** as alternative for `assertRegExp()`
- Implement **`assertDoesNotMatchRegularExpression()`** as alternative for `assertNotRegExp()`
