### PR TITLE
[HttpClient] fix pausing AmpResponse

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,8 @@
         "symfony/yaml": "self.version"
     },
     "require-dev": {
-        "amphp/http-client": "^4.2",
+        "amphp/amp": "^2.5",
+        "amphp/http-client": "^4.2.1",
         "amphp/http-tunnel": "^1.0",
         "async-aws/ses": "^1.0",
         "async-aws/sqs": "^1.0",

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -201,6 +201,31 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $this->assertTrue(0.5 <= microtime(true) - $time);
     }
 
+    public function testPauseReplace()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://localhost:8057/');
+
+        $time = microtime(true);
+        $response->getInfo('pause_handler')(10);
+        $response->getInfo('pause_handler')(0.5);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertGreaterThanOrEqual(0.5, microtime(true) - $time);
+        $this->assertLessThanOrEqual(5, microtime(true) - $time);
+    }
+
+    public function testPauseDuringBody()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://localhost:8057/timeout-body');
+
+        $time = microtime(true);
+        $this->assertSame(200, $response->getStatusCode());
+        $response->getInfo('pause_handler')(1);
+        $response->getContent();
+        $this->assertGreaterThanOrEqual(1, microtime(true) - $time);
+    }
+
     public function testHttp2PushVulcainWithUnusedResponse()
     {
         $client = $this->getHttpClient(__FUNCTION__);

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -199,6 +199,8 @@ class MockHttpClientTest extends HttpClientTestCase
                 break;
 
             case 'testPause':
+            case 'testPauseReplace':
+            case 'testPauseDuringBody':
                 $this->markTestSkipped("MockHttpClient doesn't support pauses by default");
                 break;
 

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -23,12 +23,13 @@
     "require": {
         "php": ">=7.2.5",
         "psr/log": "^1.0",
-        "symfony/http-client-contracts": "^2.1.1",
+        "symfony/http-client-contracts": "^2.1.3",
         "symfony/polyfill-php73": "^1.11",
         "symfony/polyfill-php80": "^1.15",
         "symfony/service-contracts": "^1.0|^2"
     },
     "require-dev": {
+        "amphp/amp": "^2.5",
         "amphp/http-client": "^4.2.1",
         "amphp/http-tunnel": "^1.0",
         "amphp/socket": "^1.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | None

This fixes the pause handler while streaming bodies in `AmpHttpClient`.

Needs to be rebased onto the target branch and needs some test fixes. @nicolas-grekas FYI.