### PR TITLE
[Mime] Keep Sender full address when used by non-SMTP transports

### DIFF
--- a/src/Symfony/Component/Mailer/Envelope.php
+++ b/src/Symfony/Component/Mailer/Envelope.php
@@ -44,9 +44,13 @@ class Envelope
 
     public function setSender(Address $sender): void
     {
-        $this->sender = new Address($sender->getAddress());
+        $this->sender = $sender;
     }
 
+    /**
+     * @return Address Returns a "mailbox" as specified by RFC 2822
+     *                 Must be converted to an "addr-spec" when used as a "MAIL FROM" value in SMTP (use getAddress())
+     */
     public function getSender(): Address
     {
         return $this->sender;

--- a/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
@@ -29,8 +29,8 @@ class EnvelopeTest extends TestCase
 
     public function testConstructorWithNamedAddressSender()
     {
-        $e = new Envelope(new Address('fabien@symfony.com', 'Fabien'), [new Address('thomas@symfony.com')]);
-        $this->assertEquals(new Address('fabien@symfony.com'), $e->getSender());
+        $e = new Envelope($sender = new Address('fabien@symfony.com', 'Fabien'), [new Address('thomas@symfony.com')]);
+        $this->assertEquals($sender, $e->getSender());
     }
 
     public function testConstructorWithAddressRecipients()
@@ -54,31 +54,31 @@ class EnvelopeTest extends TestCase
     public function testSenderFromHeaders()
     {
         $headers = new Headers();
-        $headers->addPathHeader('Return-Path', new Address('return@symfony.com', 'return'));
-        $headers->addMailboxListHeader('To', ['from@symfony.com']);
+        $headers->addPathHeader('Return-Path', $return = new Address('return@symfony.com', 'return'));
+        $headers->addMailboxListHeader('To', ['to@symfony.com']);
         $e = Envelope::create(new Message($headers));
-        $this->assertEquals(new Address('return@symfony.com', 'return'), $e->getSender());
+        $this->assertEquals($return, $e->getSender());
 
         $headers = new Headers();
-        $headers->addMailboxHeader('Sender', new Address('sender@symfony.com', 'sender'));
-        $headers->addMailboxListHeader('To', ['from@symfony.com']);
+        $headers->addMailboxHeader('Sender', $sender = new Address('sender@symfony.com', 'sender'));
+        $headers->addMailboxListHeader('To', ['to@symfony.com']);
         $e = Envelope::create(new Message($headers));
-        $this->assertEquals(new Address('sender@symfony.com', 'sender'), $e->getSender());
+        $this->assertEquals($sender, $e->getSender());
 
         $headers = new Headers();
-        $headers->addMailboxListHeader('From', [new Address('from@symfony.com', 'from'), 'some@symfony.com']);
-        $headers->addMailboxListHeader('To', ['from@symfony.com']);
+        $headers->addMailboxListHeader('From', [$from = new Address('from@symfony.com', 'from'), 'some@symfony.com']);
+        $headers->addMailboxListHeader('To', ['to@symfony.com']);
         $e = Envelope::create(new Message($headers));
-        $this->assertEquals(new Address('from@symfony.com', 'from'), $e->getSender());
+        $this->assertEquals($from, $e->getSender());
     }
 
     public function testSenderFromHeadersWithoutFrom()
     {
         $headers = new Headers();
-        $headers->addMailboxListHeader('To', ['from@symfony.com']);
+        $headers->addMailboxListHeader('To', ['to@symfony.com']);
         $e = Envelope::create($message = new Message($headers));
-        $message->getHeaders()->addMailboxListHeader('From', [new Address('from@symfony.com', 'from')]);
-        $this->assertEquals(new Address('from@symfony.com', 'from'), $e->getSender());
+        $message->getHeaders()->addMailboxListHeader('From', [$from = new Address('from@symfony.com', 'from')]);
+        $this->assertEquals($from, $e->getSender());
     }
 
     public function testRecipientsFromHeaders()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a

refs #36178

The `Envelope` is an SMTP concept. The Sender is used in the `MAIL FROM` SMTP command, where only an address is supported. But we are also supporting non-SMTP transports, where the Sender might also be used as the `From` header, where a full mailbox is supported.

To take into account the 2 usages, this PR keeps the full mailbox in the Envelope and let the SMTP class only use the address (which was already the case anyway).
