### PR TITLE
Use hexadecimal numerals instead of hexadecimals in strings to repres…

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -25,9 +25,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class Connection extends AbstractConnection
 {
-    private const LDAP_INVALID_CREDENTIALS = '0x31';
-    private const LDAP_TIMEOUT = '0x55';
-    private const LDAP_ALREADY_EXISTS = '0x44';
+    private const LDAP_INVALID_CREDENTIALS = 0x31;
+    private const LDAP_TIMEOUT = 0x55;
+    private const LDAP_ALREADY_EXISTS = 0x44;
 
     /** @var bool */
     private $bound = false;


### PR DESCRIPTION
Use hexadecimal numerals instead of hexadecimals in strings to represent error codes.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #37577 , #36327
| License       | MIT

Class constants are now hexadecimal numerals instead of hexadecimals in strings.