### PR TITLE
Require PHPUnit 9.3 on PHP 8

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -93,7 +93,10 @@ $passthruOrFail = function ($command) {
     }
 };
 
-if (PHP_VERSION_ID >= 70200) {
+if (PHP_VERSION_ID >= 80000) {
+    // PHP 8 requires PHPUnit 9.3+
+    $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '9.3');
+} elseif (PHP_VERSION_ID >= 70200) {
     // PHPUnit 8 requires PHP 7.2+
     $PHPUNIT_VERSION = $getEnvVar('SYMFONY_PHPUNIT_VERSION', '8.3');
 } elseif (PHP_VERSION_ID >= 70100) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The first version of PHPUnit to support PHP 8.0 is PHPUnit 9.3.

---

Depends on https://github.com/symfony/symfony/pull/37607. Related to https://github.com/composer/composer/pull/9054.