### PR TITLE
Fix checks for phpunit releases on Composer 2

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit
@@ -117,7 +117,11 @@ if (!file_exists("$PHPUNIT_DIR/phpunit-$PHPUNIT_VERSION/phpunit") || md5_file(__
         'requires' => array('php' => '*'),
     );
 
-    if (1 === count($info['versions'])) {
+    $stableVersions = array_filter($info['versions'], function($v) {
+        return !preg_match('/-dev$|^dev-/', $v);
+    });
+
+    if (!$stableVersions) {
         $passthruOrFail("$COMPOSER create-project --ignore-platform-reqs --no-install --prefer-dist --no-scripts --no-plugins --no-progress -s dev phpunit/phpunit phpunit-$PHPUNIT_VERSION \"$PHPUNIT_VERSION.*\"");
     } else {
         $passthruOrFail("$COMPOSER create-project --ignore-platform-reqs --no-install --prefer-dist --no-scripts --no-plugins --no-progress phpunit/phpunit phpunit-$PHPUNIT_VERSION \"$PHPUNIT_VERSION.*\"");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37601
| License       | MIT
| Doc PR        | n/a

`simple-phpunit` has a core assumption that any version of PHPUnit without a stable release will only have one dev version returned by Composer.  Per https://github.com/symfony/symfony/issues/37601, it's possible for Composer 2 to list **more than one dev version**.  This breaks that assumption and therefore prevents the installation of 9.3.* ([which is needed for testing on PHP 8](https://github.com/sebastianbergmann/phpunit/pull/4374#issuecomment-657029594)).

The fix implemented here is to remove any versions containing `dev-` or `-dev` from the list of possible versions to see if any stable versions remain.