### PR TITLE
[POC] [Form] Support get/set accessors for form fields

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\ChoiceList\Factory\CachingFactoryDecorator;
 use Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface;
 use Symfony\Component\Form\ChoiceList\Factory\DefaultChoiceListFactory;
 use Symfony\Component\Form\ChoiceList\Factory\PropertyAccessDecorator;
+use Symfony\Component\Form\Extension\Core\Type\AccessorMapperExtension;
 use Symfony\Component\Form\Extension\Core\Type\TransformationFailureExtension;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -84,6 +85,7 @@ class CoreExtension extends AbstractExtension
     {
         return [
             new TransformationFailureExtension($this->translator),
+            new AccessorMapperExtension(),
         ];
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/AccessorMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/AccessorMapper.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Symfony\Component\Form\Extension\Core\DataMapper;
+
+use Symfony\Component\Form\DataMapperInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
+class AccessorMapper implements DataMapperInterface
+{
+    private $get;
+    private $set;
+    private $fallbackMapper;
+
+    public function __construct(?\Closure $get, ?\Closure $set, DataMapperInterface $fallbackMapper)
+    {
+        $this->get = $get;
+        $this->set = $set;
+        $this->fallbackMapper = $fallbackMapper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapDataToForms($data, iterable $forms)
+    {
+        $empty = null === $data || [] === $data;
+
+        if (!$empty && !\is_array($data) && !\is_object($data)) {
+            throw new UnexpectedTypeException($data, 'object, array or empty');
+        }
+
+        if (!$this->get) {
+            $this->fallbackMapper->mapDataToForms($data, $forms);
+            return;
+        }
+
+        foreach ($forms as $form) {
+            $config = $form->getConfig();
+
+            if (!$empty && $config->getMapped()) {
+                $form->setData($this->getPropertyValue($data));
+            } else {
+                $form->setData($config->getData());
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mapFormsToData(iterable $forms, &$data)
+    {
+        if (null === $data) {
+            return;
+        }
+
+        if (!\is_array($data) && !\is_object($data)) {
+            throw new UnexpectedTypeException($data, 'object, array or empty');
+        }
+
+        if (!$this->set) {
+            $this->fallbackMapper->mapFormsToData($forms, $data);
+            return;
+        }
+
+        foreach ($forms as $form) {
+            $config = $form->getConfig();
+
+            // Write-back is disabled if the form is not synchronized (transformation failed),
+            // if the form was not submitted and if the form is disabled (modification not allowed)
+            if (null !== $this->set && $config->getMapped() && $form->isSubmitted() && $form->isSynchronized() && !$form->isDisabled()) {
+                ($this->set)($data, $form->getData());
+            }
+        }
+    }
+
+    private function getPropertyValue($data)
+    {
+        return $this->get ? ($this->get)($data) : null;
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/AccessorMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/AccessorMapper.php
@@ -3,7 +3,10 @@
 namespace Symfony\Component\Form\Extension\Core\DataMapper;
 
 use Symfony\Component\Form\DataMapperInterface;
+use Symfony\Component\Form\Exception\ExceptionInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\FormError;
+use TypeError;
 
 class AccessorMapper implements DataMapperInterface
 {
@@ -69,7 +72,13 @@ class AccessorMapper implements DataMapperInterface
             // Write-back is disabled if the form is not synchronized (transformation failed),
             // if the form was not submitted and if the form is disabled (modification not allowed)
             if (null !== $this->set && $config->getMapped() && $form->isSubmitted() && $form->isSynchronized() && !$form->isDisabled()) {
-                $returnValue = ($this->set)($data, $form->getData());
+                try {
+                    $returnValue = ($this->set)($data, $form->getData());
+                } catch (ExceptionInterface | TypeError $e) {
+                    $form->addError(new FormError($e->getMessage()));
+                    continue;
+                }
+
                 $type = is_object($returnValue) ? get_class($returnValue) : gettype($returnValue);
 
                 if (

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/AccessorMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/AccessorMapper.php
@@ -69,7 +69,15 @@ class AccessorMapper implements DataMapperInterface
             // Write-back is disabled if the form is not synchronized (transformation failed),
             // if the form was not submitted and if the form is disabled (modification not allowed)
             if (null !== $this->set && $config->getMapped() && $form->isSubmitted() && $form->isSynchronized() && !$form->isDisabled()) {
-                ($this->set)($data, $form->getData());
+                $returnValue = ($this->set)($data, $form->getData());
+                $type = is_object($returnValue) ? get_class($returnValue) : gettype($returnValue);
+
+                if (
+                    (is_scalar($data) && gettype($data) === $type)
+                    || (is_array($data) && is_array($returnValue))
+                    || (is_object($data) && $returnValue instanceof $type)) {
+                    $data = $returnValue;
+                }
             }
         }
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/AccessorMapperExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/AccessorMapperExtension.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Closure;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\DataMapper\AccessorMapper;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AccessorMapperExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        if (!$options['get'] && !$options['set']) {
+            return;
+        }
+
+        if (!$dataMapper = $builder->getDataMapper()) {
+            return;
+        }
+
+        $builder->setDataMapper(new AccessorMapper($options['get'], $options['set'], $dataMapper));
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'get' => null,
+            'set' => null,
+        ]);
+
+        $resolver->setAllowedTypes('get', ['null', Closure::class]);
+        $resolver->setAllowedTypes('set', ['null', Closure::class]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getExtendedTypes(): iterable
+    {
+        return [FormType::class];
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/CoreExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/CoreExtensionTest.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Symfony\Component\Form\Extension\Core\CoreExtension;
+use Symfony\Component\Form\Extension\Core\DataMapper\AccessorMapper;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormFactoryBuilder;
 
 class CoreExtensionTest extends TestCase
@@ -29,5 +33,33 @@ class CoreExtensionTest extends TestCase
         $form->submit('foo');
 
         $this->assertFalse($form->isValid());
+    }
+
+    public function testMapperExtensionIsLoaded()
+    {
+        $formFactoryBuilder = new FormFactoryBuilder();
+        $formFactory = $formFactoryBuilder->addExtension(new CoreExtension())
+            ->getFormFactory();
+
+        $mock = $this->getMockBuilder(stdClass::class)->addMethods(['get', 'set'])->getMock();
+        $mock->expects($this->once())->method('get')->willReturn('foo');
+        $mock->expects($this->once())->method('set')->with('bar');
+
+        $formBuilder = $formFactory->createBuilder();
+        $form = $formBuilder
+            ->add(
+                'foo',
+                TextType::class
+            )
+            ->setDataMapper(new AccessorMapper(
+                function (MockObject $data) { return $data->get(); },
+                function (MockObject $data, $value) { return $data->set($value); },
+                $formBuilder->getDataMapper()
+            ))
+            ->setData($mock)
+            ->getForm();
+
+        $this->assertInstanceOf(AccessorMapper::class, $form->getConfig()->getDataMapper());
+        $form->submit(['foo' => 'bar']);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/AccessorMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/AccessorMapperTest.php
@@ -1,0 +1,224 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\DataMapper;
+
+use PHPUnit\Framework\MockObject\Matcher\Invocation;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\DataMapperInterface;
+use Symfony\Component\Form\Extension\Core\DataMapper\AccessorMapper;
+use Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormConfigBuilder;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\PropertyAccess\PropertyPath;
+
+class AccessorMapperTest extends TestCase
+{
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var PropertyPathMapper
+     */
+    private $propertyPathMapper;
+
+    /**
+     * @var PropertyAccessorInterface
+     */
+    private $propertyAccessor;
+
+    protected function setUp(): void
+    {
+        $this->dispatcher = new EventDispatcher();
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+        $this->propertyPathMapper = $this->getMockBuilder(DataMapperInterface::class)->getMock();
+    }
+
+    public function testGetUsesFallbackIfNoAccessor()
+    {
+        $this->setupPropertyPathMapper($this->once(), $this->never());
+
+        $data = $this->getMockBuilder(stdClass::class)->addMethods(['getEngine', 'getEngineClosure'])->getMock();
+        $data
+            ->expects($this->never())
+            ->method('getEngineClosure');
+        $data
+            ->expects($this->once())
+            ->method('getEngine')
+            ->willReturn('electric');
+
+        $propertyPath = new PropertyPath('engine');
+
+        $config = new FormConfigBuilder('name', null, $this->dispatcher);
+        $config->setByReference(true);
+        $config->setPropertyPath($propertyPath);
+        $form = new Form($config);
+
+        $mapper = $this->createMapper(false, false);
+        $mapper->mapDataToForms($data, [$form]);
+
+        $this->assertSame('electric', $form->getData());
+    }
+
+    public function testGetUsesAccessor()
+    {
+        $this->setupPropertyPathMapper($this->never(), $this->never());
+
+        $data = $this->getMockBuilder(stdClass::class)->addMethods(['getEngine', 'getEngineClosure'])->getMock();
+        $data
+            ->expects($this->once())
+            ->method('getEngineClosure')
+            ->willReturn('electric');
+        $data
+            ->expects($this->never())
+            ->method('getEngine');
+
+        $propertyPath = new PropertyPath('engine');
+
+        $config = new FormConfigBuilder('name', null, $this->dispatcher);
+        $config->setByReference(true);
+        $config->setPropertyPath($propertyPath);
+        $form = new Form($config);
+
+        $mapper = $this->createMapper(true, false);
+        $mapper->mapDataToForms($data, [$form]);
+
+        $this->assertSame('electric', $form->getData());
+    }
+
+    public function testSetUsesAccessor()
+    {
+        $this->setupPropertyPathMapper($this->never(), $this->never());
+
+        $data = new class() {
+            private $engine;
+
+            public function setEngineClosure($engine)
+            {
+                $this->engine = $engine;
+            }
+
+            public function getEngine()
+            {
+                return $this->engine;
+            }
+        };
+
+        $propertyPath = new PropertyPath('engine');
+
+        $config = new FormConfigBuilder('name', null, $this->dispatcher);
+        $config->setByReference(true);
+        $config->setPropertyPath($propertyPath);
+        $form = new Form($config);
+
+        $form->submit('electric');
+        $mapper = $this->createMapper(false, true);
+        $mapper->mapFormsToData([$form], $data);
+
+        $this->assertSame('electric', $data->getEngine());
+    }
+
+    public function testSetUsesAccessorForCompoundFields()
+    {
+        $this->setupPropertyPathMapper($this->any(), $this->any());
+
+        $data = new class() {
+            private $foo;
+            private $bar;
+
+            public function setEngineClosure($data)
+            {
+                if (!$data) {
+                    return;
+                }
+
+                foreach ($data as $key => $value) {
+                    $this->$key = $value;
+                }
+            }
+
+            public function getEngineClosure()
+            {
+                return [
+                    'foo' => $this->foo,
+                    'bar' => $this->bar,
+                ];
+            }
+
+            public function getFoo()
+            {
+                return $this->foo;
+            }
+
+            public function getBar()
+            {
+                return $this->bar;
+            }
+        };
+
+        $config = new FormConfigBuilder('address', null, $this->dispatcher);
+        $config->setCompound(true);
+        $config->setDataMapper(new PropertyPathMapper($this->propertyAccessor));
+        $addressForm = new Form($config);
+        $addressForm
+            ->add(new Form(new FormConfigBuilder('foo', null, $this->dispatcher)))
+            ->add(new Form(new FormConfigBuilder('bar', null, $this->dispatcher)));
+
+        $mapper = $this->createMapper(true, true);
+
+        $config = new FormConfigBuilder('name', null, $this->dispatcher);
+        $config->setCompound(true);
+        $config->setDataMapper($mapper);
+        $config->setData($data);
+        $form = new Form($config);
+        $form->add($addressForm);
+
+        $form->submit(['address' => ['foo' => 'foo', 'bar' => 'bar']]);
+        $this->assertNull($form->getTransformationFailure());
+
+        $this->assertSame('foo', $data->getFoo());
+        $this->assertSame('bar', $data->getBar());
+    }
+
+    private function setupPropertyPathMapper(Invocation $dataToFormsMatcher, Invocation $formsToDataMatcher): void
+    {
+        $propertyPathMapper = new PropertyPathMapper($this->propertyAccessor);
+
+        $this->propertyPathMapper
+            ->expects($dataToFormsMatcher)
+            ->method('mapDataToForms')
+            ->willReturnCallback(function (...$args) use ($propertyPathMapper) {
+                $propertyPathMapper->mapDataToForms(...$args);
+            });
+        $this->propertyPathMapper
+            ->expects($formsToDataMatcher)
+            ->method('mapFormsToData')
+            ->willReturnCallback(function (...$args) use ($propertyPathMapper) {
+                $propertyPathMapper->mapFormsToData(...$args);
+            });
+    }
+
+    private function createMapper(bool $useGetClosure, bool $useSetClosure)
+    {
+        return new AccessorMapper(
+            $useGetClosure ? function ($object) { return $object->getEngineClosure(); } : null,
+            $useSetClosure ? function ($object, $value) { $object->setEngineClosure($value); } : null,
+            $this->propertyPathMapper
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #37597 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This is a proof of concept PR based on the original idea in the RFC above, but already incorporating feedback from the community.

# Brief overview

This adds a new form type extension that defines 'get' and 'set' options for forms. If provided, the extension wraps the existing data mapper (usually a PropertyPathMapper) in an AccessorMapper with the provided accessors. If an accessor is left undefined, this falls back to the wrapped data mapper for compatibility.

# Why?

To explain why we do this, let's consider the following gist: https://gist.github.com/alcaeus/0b66968ee505ab24bdb71fe7c88325a7

The `Category` entity has a non-standard accessor to rename the category. While this is expressive, it does not play nice with the form component out of the box. To remedy this problem, one could use the RichModelFormsBundle, which allows for changing the write access property path separate from the read property path.
Alternatively, one can create a `EditCategoryProxy` DTO, which maps a `setName` call (that the PropertyAccess component will seek out) to the `rename` method in the `Category` entity.
A more complex solution uses the `EditCategoryTwoStep` DTO, which contains public properties for all fields, then maps them to the `Category` entity in a special `apply` method which needs to called after the form has been validated. The advantage of this is that it does not leave an entity in an invalid state, since constraints on the DTO are evaluated before `apply` is called (typically by the user before flushing the entity to the manager). It also reduces boilerplate code by doing away with setters and getters and using public properties (since it's just a data holder).

Both DTOs have a significant problem in my view: they are tightly coupled to a specific form, but are separate classes that contain lots of usual boilerplate code. This is where the addition of accessor closures comes into play.

# Basic usage

Forms where you don't specify an accessor (all current forms) behave exactly like before, with no code being changed. They still use a PropertyPathMapper or whatever the user provided. However, upon specifying either 'get' or 'set' option causes cool things to happen. For all examples, please consider the following entity:
```php
final class Category
{
  private string $name;

  public static function fromName(string $name): self
  {
    return new self($name);
  }

  private function __construct(string $name)
  {
    $this->name = $name;
  }

  public function getName(): string
  {
    return $this->name;
  }

  public function rename(string $name): void
  {
    $this->name = $name;
  }
}
```

This class has no typical `setName` accessor as the property access component would expect, so using this entity in a form was previously coupled to using a DTO or a custom data mapper **on the embedding form** to handle this API. With form accessors, the form is defined like this:

```php
$builder->add('name', null, ['set' => function(Category $category, string $name) { $category->rename($value); }]);
```

In this case, getting the value is handled through the PropertyPathMapper, while the value is changed using our closure.

# Advanced usage
Apart from this basic usage, the mapper contains a few features that are nice for people who are more familiar with complex and rich models.

## Using immutable objects

A typical example is storing dates, as it's recommended to always handle `DateTimeImmutable` objects. These return a new instance of themselves with the value applied. The old object is discarded or can be kept for auditing purposes. Let's change the category we had above to being immutable:
```php
final class Category
{
  private string $name;

  public static function fromName(string $name): self
  {
    return new self($name);
  }

  private function __construct(string $name)
  {
    $this->name = $name;
  }

  public function getName(): string
  {
    return $this->name;
  }

  public function rename(string $name): self
  {
    return self::fromName($name);
  }
}
```

Again, the form framework does not support this. With accessors, this becomes increasingly simple:

```php
$builder->add('name', null, ['set' => function(Category $category, string $name) { return $category->rename($value); }]);
```

If the setter returns a non-null value, the mapper behaves as follows:
* If the original data is a scalar value, a scalar value replaces the form data. Otherwise, it is discarded.
* If the original data is an array, returning another array also replaces the form data. Otherwise, it is discarded.
* If the original data is an object, and the returned object is an instance of the same class, this replaces form data. Otherwise, it is discarded.

The form data is overwritten after each step, so any subsequent calls to accessors already operate on the new object.

## Basic validation

Any `TypeError` or `Symfony\Component\Form\Exception\ExceptionInterface` from a 'set' accessor are caught and the exception message added as a form error. This causes the form to fail validation before any changes are applied. However, the exception does not stop the processing of form fields, so this can serve as a sanity check before doing more significant validation (e.g. uniqueness checks).

## Compound fields

Example: we have a checkout form that contains address fields. The fields are added as single form fields, but should all map to a single accessor. The RichModelFormsBundle mentioned in the RFC makes this possible by defining the same `write_property_path` multiple times (from [the documentation](https://github.com/sensiolabs-de/rich-model-forms-bundle/blob/main/docs/mapping.md#mapping-several-form-fields-to-a-single-method)):
```php
$builder
    ->add('address', AddressType::class, [
        'read_property_path' => 'shippingAddress',
        'write_property_path' => 'ship',
    ])
    ->add('trackingNumber', TextType::class, [
        'read_property_path' => 'trackingNumber',
        'write_property_path' => 'ship',
    ])
 ;
```

With closures being used for accessors, this is no longer feasible. It is thus suggested to set your own set accessor:

```php
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        parent::buildForm($builder, $options);

        $builder
            ->add('address', AddressType::class)
            ->add('trackingNumber', TextType::class)
        ;
    }

    public function configureOptions(OptionsResolver $resolver)
    {
        parent::configureOptions($resolver);

        $resolver->setDefault('set', function (Order $order, array $data) { $order->ship($data['address'], $data['trackingNumber']);
    }
```

This use case is also tested in the `testSetUsesAccessorForCompoundFields` test for the access mapper itself.