### PR TITLE
[Security] Use NullToken while checking authorization

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -43,3 +43,9 @@ Validator
     * })
     */
    ```
+
+Security
+--------
+
+ * [BC break] In the experimental authenticator-based system, * `TokenInterface::getUser()`
+   returns `null` in case of unauthenticated session.

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,7 +4,8 @@ CHANGELOG
 5.2.0
 -----
 
- * Added attributes on ``Passport``
+ * Added attributes on `Passport`
+ * Changed `AuthorizationChecker` to call the access decision manager in unauthenticated sessions with a `NullToken`
 
 5.1.0
 -----

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolver.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolver.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Authentication;
 
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -31,7 +32,7 @@ class AuthenticationTrustResolver implements AuthenticationTrustResolverInterfac
             return false;
         }
 
-        return $token instanceof AnonymousToken;
+        return $token instanceof AnonymousToken || $token instanceof NullToken;
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class NullToken implements TokenInterface
+{
+    public function __toString(): string
+    {
+        return '';
+    }
+
+    public function getRoleNames(): array
+    {
+        return [];
+    }
+
+    public function getCredentials()
+    {
+        return '';
+    }
+
+    public function getUser()
+    {
+        return null;
+    }
+
+    public function setUser($user)
+    {
+        throw new \BadMethodCallException('Cannot set user on a NullToken.');
+    }
+
+    public function getUsername()
+    {
+        return '';
+    }
+
+    public function isAuthenticated()
+    {
+        return true;
+    }
+
+    public function setAuthenticated(bool $isAuthenticated)
+    {
+        throw new \BadMethodCallException('Cannot change authentication state of NullToken.');
+    }
+
+    public function eraseCredentials()
+    {
+    }
+
+    public function getAttributes()
+    {
+        return [];
+    }
+
+    public function setAttributes(array $attributes)
+    {
+        throw new \BadMethodCallException('Cannot set attributes of NullToken.');
+    }
+
+    public function hasAttribute(string $name)
+    {
+        return false;
+    }
+
+    public function getAttribute(string $name)
+    {
+        return null;
+    }
+
+    public function setAttribute(string $name, $value)
+    {
+        throw new \BadMethodCallException('Cannot add attribute to NullToken.');
+    }
+
+    public function __serialize(): array
+    {
+        return [];
+    }
+
+    public function __unserialize(array $data): void
+    {
+    }
+
+    public function serialize()
+    {
+        return '';
+    }
+
+    public function unserialize($serialized)
+    {
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Authorization;
 
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
@@ -52,11 +53,11 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
                 throw new AuthenticationCredentialsNotFoundException('The token storage contains no authentication token. One possible reason may be that there is no firewall configured for this URL.');
             }
 
-            return false;
-        }
-
-        if ($this->alwaysAuthenticate || !$token->isAuthenticated()) {
-            $this->tokenStorage->setToken($token = $this->authenticationManager->authenticate($token));
+            $token = new NullToken();
+        } else {
+            if ($this->alwaysAuthenticate || !$token->isAuthenticated()) {
+                $this->tokenStorage->setToken($token = $this->authenticationManager->authenticate($token));
+            }
         }
 
         return $this->accessDecisionManager->decide($token, [$attribute], $subject);

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
@@ -77,7 +78,13 @@ class AuthorizationCheckerTest extends TestCase
     {
         $authorizationChecker = new AuthorizationChecker($this->tokenStorage, $this->authenticationManager, $this->accessDecisionManager, false, false);
 
-        $this->assertFalse($authorizationChecker->isGranted('ROLE_FOO'));
+        $this->accessDecisionManager
+            ->expects($this->once())
+            ->method('decide')
+            ->with($this->isInstanceOf(NullToken::class))
+            ->willReturn(true);
+
+        $this->assertTrue($authorizationChecker->isGranted('ANONYMOUS'));
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Http\Firewall;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
@@ -89,19 +90,7 @@ class AccessListener extends AbstractListener
                 throw new AuthenticationCredentialsNotFoundException('A Token was not found in the TokenStorage.');
             }
 
-            if ([AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY] === $attributes) {
-                trigger_deprecation('symfony/security-http', '5.1', 'Using "IS_AUTHENTICATED_ANONYMOUSLY" in your access_control rules when using the authenticator Security system is deprecated, use "PUBLIC_ACCESS" instead.');
-
-                return;
-            }
-
-            if ([self::PUBLIC_ACCESS] !== $attributes) {
-                throw $this->createAccessDeniedException($request, $attributes);
-            }
-        }
-
-        if ([self::PUBLIC_ACCESS] === $attributes) {
-            return;
+            $token = new NullToken();
         }
 
         if (!$token->isAuthenticated()) {

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/deprecation-contracts": "^2.1",
-        "symfony/security-core": "^5.1",
+        "symfony/security-core": "^5.2",
         "symfony/http-foundation": "^4.4.7|^5.0.7",
         "symfony/http-kernel": "^4.4|^5.0",
         "symfony/polyfill-php80": "^1.15",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #37523
| License       | MIT
| Doc PR        | tbd

This allows voters to grant access to unauthenticated users. E.g. some objects can be viewed by anyone, in this case the voter has to be able to grant access to unauthenticated users.

This *does break* the interface PHPdoc of `TokenInterface`: `getUser()` returns `null` instead of `string|UserInterface`. This is only true when using the new system, so not a real BC break. I think the only thing we can do to "guide" users is to add some custom handling for type errors related to `null` and `UserInterface` methods ("Did you forgot to check for `null` in the Voter?"). Is this something I should add to this PR?