### PR TITLE
[Serializer] Support multiple levels of discriminator mapping

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -230,8 +230,9 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 throw new RuntimeException(sprintf('The type "%s" has no mapped class for the abstract object "%s".', $type, $class));
             }
 
-            $class = $mappedClass;
-            $reflectionClass = new \ReflectionClass($class);
+            if ($mappedClass !== $class) {
+                return $this->instantiateObject($data, $mappedClass, $context, new \ReflectionClass($mappedClass), $allowedAttributes, $format);
+            }
         }
 
         return parent::instantiateObject($data, $class, $context, $reflectionClass, $allowedAttributes, $format);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

When using multiple levels of discriminator mapping for denormalizing to a multiple level class hierarchy, only the top level discriminator mapping is considered, resulting in an error: **Cannot instantiate abstract class ...**

Example:
```php
/**
 * @DiscriminatorMap(typeProperty="type", mapping={"group"=GroupNode::class, "item"=ItemNode::class})
 */
abstract class Node {
    // ...
}

class GroupNode extends Node {
    // ...
}

/**
 * @DiscriminatorMap(typeProperty="item_type", mapping={"foo"=FooItemNode::class, "bar"=BarItemNode::class})
 */
abstract class ItemNode extends Node {
    // ...
}

class FooItemNode {
    // ...
}

class BarItemNode {
    // ...
}

$objectNormalizer = new ObjectNormalizer(new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader())));
$node = $objectNormalizer->denormalize(['type' => 'item', 'item_type' => 'foo']);
```

This results in an error: **Cannot instantiate abstract class ItemNode**. Expected is that `$node` is of type `FooItemNode` after denormalization.

The solution is to recursively call `AbstractObjectNormalizer::instantiateObject()` when a mapping is found, instead of always calling `parent::instantiateObject()`.


