### PR TITLE
[HttpClient] Fix bad testRetryTransportError in AsyncDecoratorTraitTest

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/AsyncDecoratorTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/AsyncDecoratorTraitTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpClient\Response\AsyncContext;
 use Symfony\Component\HttpClient\Response\AsyncResponse;
 use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -68,11 +69,10 @@ class AsyncDecoratorTraitTest extends NativeHttpClientTest
                 if ($chunk->isFirst()) {
                     $this->assertSame(200, $context->getStatusCode());
                 }
-
-                yield $chunk;
             } catch (TransportExceptionInterface $e) {
                 $context->getResponse()->cancel();
                 $context->replaceRequest('GET', 'http://localhost:8057/');
+                $context->passthru();
             }
         });
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Issues in the test:
1. `TransportExceptionInterface` is not `use`d (imported)
2. The catch block will not be executed (even the above 1 is fixed) because
the exception (of `chunked-broken`) will be thrown only when `getContent()` is called
The header is OK, status is 200, and we only asserted `getStatusCode()`
So this test made no sense.
