### PR TITLE
[DoctrineBridge] Bump doctrine/data-fixtures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
         "cache/integration-tests": "dev-master",
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.6",
-        "doctrine/data-fixtures": "1.0.*",
+        "doctrine/data-fixtures": "^1.1",
         "doctrine/dbal": "~2.4",
         "doctrine/orm": "~2.4,>=2.4.5",
         "doctrine/doctrine-bundle": "~1.4",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -34,7 +34,7 @@
         "symfony/expression-language": "~2.8|~3.0|~4.0",
         "symfony/validator": "^3.2.5|~4.0",
         "symfony/translation": "~2.8|~3.0|~4.0",
-        "doctrine/data-fixtures": "1.0.*",
+        "doctrine/data-fixtures": "^1.1",
         "doctrine/dbal": "~2.4",
         "doctrine/orm": "^2.4.5"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Discovered while working on #37639: DoctrineBridge is locked to an old an unmaintained branch of `doctrine/data-fixtures`. This is going to be a problem as soon as we want to support `doctrine/persistence` 2.