### PR TITLE
[Form] Introduce validation events for forms

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Event/PostValidateEvent.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Event/PostValidateEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Validator\Event;
+
+use Symfony\Component\Form\FormEvent;
+
+/**
+ * This event is dispatched after validation completes.
+ *
+ * In this stage, the form will return a correct value to Form::isValid() and allow for
+ * further working with the form data.
+ */
+final class PostValidateEvent extends FormEvent
+{
+    public function isFormValid(): bool
+    {
+        return $this->getForm()->isValid();
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Validator/Event/PreValidateEvent.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Event/PreValidateEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Validator\Event;
+
+use Symfony\Component\Form\FormEvent;
+
+/**
+ * This event is dispatched before validation begins.
+ *
+ * In this stage the model and view data may have been denormalized. Otherwise the form
+ * is desynchronized because transformation failed during submission.
+ *
+ * It can be used to fetch data after denormalization.
+ *
+ * The event attaches the current view data. To know whether this is the renormalized data
+ * or the invalid request data, call Form::isSynchronized() first.
+ */
+final class PreValidateEvent extends FormEvent
+{
+}

--- a/src/Symfony/Component/Form/Extension/Validator/FormValidationEvents.php
+++ b/src/Symfony/Component/Form/Extension/Validator/FormValidationEvents.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Validator;
+
+final class FormValidationEvents
+{
+    /**
+     * @see Event\PreValidateEvent
+     * @Event(Event\PreValidateEvent::class)
+     */
+    const PRE_VALIDATE = 'form.pre_validate';
+
+    /**
+     * This event is dispatched after validation completes.
+     *
+     * In this stage, the form will return a correct value to Form::isValid() and allow for
+     * further working with the form data.
+     *
+     * @see Event\PostValidateEvent
+     * @Event(Event\PostValidateEvent::class)
+     */
+    const POST_VALIDATE = 'form.post_validate';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes (needs docs changes)
| Deprecations? | yes (adds a new parameter to the ValidationListener constructor)
| Tickets       | Related RFC: #37597
| License       | MIT
| Doc PR        | symfony/symfony-docs#... (yet to come)

This PR suggests the introduction of two new events related to form handling: `preValidate` and `postValidate`. These events are dispatched by the validation listener before starting validation and after validation has completed. They allow adding additional handling to the form submit process, e.g. writing changes from a DTO to a managed entity after validation succeeds. Consider the following DTO:

```php
use Symfony\Component\EventDispatcher\EventSubscriberInterface;
use Symfony\Component\Form\Extension\Validator\FormValidationEvents;
use Symfony\Component\Form\FormEvents;

final class RenameCategory implements EventSubscriberInterface
{
    public ?string $name;

    private Category $category;

    private function __construct() {}

    public static function fromCategory(Category $category): self
    {
        $instance = new self();
        $instance->category = $category;

        return $instance;
    }

    public static function getSubscribedEvents(): array
    {
        return [
            FormEvents::PRE_SET_DATA => 'initialize',
            FormValidationEvents::POST_VALIDATE => 'apply',
    }

    public function initialize()
    {
        $this->name = $this->category->getName();
    }

    public function apply()
    {
        $this->category->rename($this->name);
    }
}
```

Now, a controller can create the DTO, pass it to the form, then store the managed entity:
```php
public function renameCategory(Request $request, Category $category)
{
    $renameCategory = RenameCategory::fromCategory($category);

    $form = $this->createForm(EditCategoryForm::class, $renameCategory);
    $form->getConfig()->getEventDispatcher()->addSubscriber($renameCategory);
    $form->handleRequest($request);

    if ($form->isSubmitted() && $form->isValid()) {
        $entityManager->persist($category);
        $entityManager->flush();
    }

    // ...
}
```

Of course, this process could be further automated to fit one's needs, but I believe that for the time being, the addition of these events makes is a shortcut towards a better handling of DTOs in forms.