### PR TITLE
[Lock][Cache] Fix Redis tests

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
@@ -33,9 +33,10 @@ abstract class AbstractRedisAdapterTest extends AdapterTestCase
         if (!\extension_loaded('redis')) {
             self::markTestSkipped('Extension redis required.');
         }
-        if (!@((new \Redis())->connect(getenv('REDIS_HOST')))) {
-            $e = error_get_last();
-            self::markTestSkipped($e['message']);
+        try {
+            (new \Redis())->connect(getenv('REDIS_HOST'));
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
@@ -33,9 +33,10 @@ abstract class AbstractRedisCacheTest extends CacheTestCase
         if (!\extension_loaded('redis')) {
             self::markTestSkipped('Extension redis required.');
         }
-        if (!@((new \Redis())->connect(getenv('REDIS_HOST')))) {
-            $e = error_get_last();
-            self::markTestSkipped($e['message']);
+        try {
+            (new \Redis())->connect(getenv('REDIS_HOST'));
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/RedisArrayStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisArrayStoreTest.php
@@ -23,9 +23,10 @@ class RedisArrayStoreTest extends AbstractRedisStoreTest
         if (!class_exists('RedisArray')) {
             self::markTestSkipped('The RedisArray class is required.');
         }
-        if (!@((new \Redis())->connect(getenv('REDIS_HOST')))) {
-            $e = error_get_last();
-            self::markTestSkipped($e['message']);
+        try {
+            (new \Redis())->connect(getenv('REDIS_HOST'));
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
@@ -20,9 +20,10 @@ class RedisStoreTest extends AbstractRedisStoreTest
 {
     public static function setUpBeforeClass()
     {
-        if (!@((new \Redis())->connect(getenv('REDIS_HOST')))) {
-            $e = error_get_last();
-            self::markTestSkipped($e['message']);
+        try {
+            (new \Redis())->connect(getenv('REDIS_HOST'));
+        } catch (\Exception $e) {
+            self::markTestSkipped($e->getMessage());
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

In branch 3.4, travis started a redis-server container and tests run correctly.

Starting from 4.4, the travis test suite don't start the server anymore, which is not an issue for 4.4's tests because tests are skiped.

The issue is when branch 4.4 run the 3.4's test suite to check if component changes in 4.4 does not affect 3.4. in that case, the 3.4 tests suite is run without redise-server.
see https://travis-ci.org/github/symfony/symfony/jobs/711062047 for example

This PR replace the error handler (didn't worked) by catching the exception in a similar way than https://github.com/symfony/symfony/pull/36647