### PR TITLE
Allow array keys for collection types

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
  * Deprecated `Symfony\Component\Form\Extension\Validator\Util\ServerParams` in favor of its parent class `Symfony\Component\Form\Util\ServerParams`
  * Added the `html5` option to the `ColorType` to validate the input
  * Deprecated `NumberToLocalizedStringTransformer::ROUND_*` constants, use `\NumberFormatter::ROUND_*` instead
+ * Added `index_name` for `CollectionType` which allows submitting keys in collections
 
 5.0.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -45,7 +45,8 @@ class CollectionType extends AbstractType
             $options['entry_options'],
             $options['allow_add'],
             $options['allow_delete'],
-            $options['delete_empty']
+            $options['delete_empty'],
+            $options['index_name']
         );
 
         $builder->addEventSubscriber($resizeListener);
@@ -126,6 +127,7 @@ class CollectionType extends AbstractType
                     ? $previousValue
                     : 'The collection is invalid.';
             },
+            'index_name' => null,
         ]);
 
         $resolver->setNormalizer('entry_options', $entryOptionsNormalizer);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FooType.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FooType.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Component\Form\Tests\Extension\Core\EventListener;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Class FooType.
+ *
+ * @author Patrick Bußmann <patrick.bussmann@bussmann-it.de>
+ */
+class FooType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('foo', TextType::class)
+        ;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #7828
| License       | MIT
| Doc PR        | symfony/symfony-docs#13994

I found a bad mistake when I work with bigger symfony form objects.
The house example of @kokers is very good.
https://github.com/symfony/symfony/issues/7828#issuecomment-258818285

So the hidden `_id` field is now a `index_name` option 🙂