### PR TITLE
[Messenger] Fix invalid option sslmode in AmazonSqs bridge

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -97,6 +97,24 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testFromDsnWithSslMode()
+    {
+        $httpClient = $this->getMockBuilder(HttpClientInterface::class)->getMock();
+        $this->assertEquals(
+            new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'endpoint' => 'http://localhost', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
+            Connection::fromDsn('sqs://localhost/queue?sslmode=disable', [], $httpClient)
+        );
+    }
+
+    public function testFromDsnWithSslModeOnDefault()
+    {
+        $httpClient = $this->getMockBuilder(HttpClientInterface::class)->getMock();
+        $this->assertEquals(
+            new Connection(['queue_name' => 'queue'], new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
+            Connection::fromDsn('sqs://default/queue?sslmode=disable', [], $httpClient)
+        );
+    }
+
     public function testFromDsnWithCustomEndpointAndPort()
     {
         $httpClient = $this->getMockBuilder(HttpClientInterface::class)->getMock();
@@ -147,6 +165,30 @@ class ConnectionTest extends TestCase
             new Connection(['account' => 12345], new SqsClient(['endpoint' => 'https://custom-endpoint.tld', 'region' => 'eu-west-1', 'accessKeyId' => null, 'accessKeySecret' => null], null, $httpClient)),
             Connection::fromDsn('sqs://default', ['endpoint' => 'https://custom-endpoint.tld', 'account' => 12345], $httpClient)
         );
+    }
+
+    public function testFromDsnWithInvalidQueryString()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown option found in DSN: [foo]. Allowed options are [buffer_size, wait_time, poll_timeout, visibility_timeout, auto_setup, access_key, secret_key, endpoint, region, queue_name, account, sslmode].');
+
+        Connection::fromDsn('sqs://default?foo=foo');
+    }
+
+    public function testFromDsnWithInvalidOption()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown option found: [bar]. Allowed options are [buffer_size, wait_time, poll_timeout, visibility_timeout, auto_setup, access_key, secret_key, endpoint, region, queue_name, account, sslmode].');
+
+        Connection::fromDsn('sqs://default', ['bar' => 'bar']);
+    }
+
+    public function testFromDsnWithInvalidQueryStringAndOption()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown option found: [bar]. Allowed options are [buffer_size, wait_time, poll_timeout, visibility_timeout, auto_setup, access_key, secret_key, endpoint, region, queue_name, account, sslmode].');
+
+        Connection::fromDsn('sqs://default?foo=foo', ['bar' => 'bar']);
     }
 
     public function testKeepGettingPendingMessages()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | />
| License       | MIT
| Doc PR        | /

The sslmode option allows people to use AmazonSqs with non-offical endpoint like the [asyncaws/testing-sqs](https://hub.docker.com/r/asyncaws/testing-sqs) docker image

By fixing precedence of DNS options in https://github.com/symfony/symfony/pull/37269 I introduced a bug that trigger an exception `Unknown option found: [sslmode]`. I apologize for this

This PR adds `sslmode` in list of allowed options