### PR TITLE
[Messenger] unregister ConsumeMessagesCommand event subscribers

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -176,7 +176,9 @@ EOF
             $subscribers[] = new StopWorkerOnTimeLimitListener($timeLimit, $this->logger);
         }
 
-        foreach ($subscribers as $subscriber) $this->eventDispatcher->addSubscriber($subscriber);
+        foreach ($subscribers as $subscriber) {
+            $this->eventDispatcher->addSubscriber($subscriber);
+        }
 
         $stopsWhen[] = 'received a stop signal via the messenger:stop-workers command';
 
@@ -202,7 +204,9 @@ EOF
             'sleep' => $input->getOption('sleep') * 1000000,
         ]);
 
-        foreach ($subscribers as $subscriber) $this->eventDispatcher->removeSubscriber($subscriber);
+        foreach ($subscribers as $subscriber) {
+            $this->eventDispatcher->removeSubscriber($subscriber);
+        }
 
         return 0;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->


Current `ConsumeMessagesCommand` does not de-register event subscribers in the end which makes it hard to write integrational tests where you need to run different workers with different limits (e.g. message limit) as the previous limits are still stay.
