### PR TITLE
[Serializer] Support for getters without get/has/is prefix in ObjectNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,11 +1,6 @@
 CHANGELOG
 =========
 
-5.2.0
------
-
- * added support for properties without mutator method to `ObjectNormalizer`
-
 5.1.0
 -----
 
@@ -13,6 +8,7 @@ CHANGELOG
  * added support for `\stdClass` to `ObjectNormalizer`
  * added the ability to ignore properties using metadata (e.g. `@Symfony\Component\Serializer\Annotation\Ignore`)
  * added an option to serialize constraint violations payloads (e.g. severity)
+ * added support for properties without mutator method to `ObjectNormalizer`
 
 5.0.0
 -----

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * added support for properties without mutator method to `ObjectNormalizer`
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -16,6 +16,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Exception\MissingMutatorMethodException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
@@ -100,6 +101,10 @@ class ObjectNormalizer extends AbstractObjectNormalizer
                 if (!$reflClass->hasProperty($attributeName)) {
                     $attributeName = lcfirst($attributeName);
                 }
+            } elseif ($reflClass->hasProperty($name)) {
+                @trigger_error('Missing mutator method for property ['.$name.']', E_USER_NOTICE);
+
+                $attributeName = $name;
             }
 
             if (null !== $attributeName && $this->isAllowedAttribute($object, $attributeName, $format, $context)) {

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -16,7 +16,6 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Exception\LogicException;
-use Symfony\Component\Serializer\Exception\MissingMutatorMethodException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -12,12 +12,10 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
-use Symfony\Component\Serializer\Exception\MissingMutatorMethodException;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -12,10 +12,12 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
+use Symfony\Component\Serializer\Exception\MissingMutatorMethodException;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
@@ -296,6 +298,16 @@ class ObjectNormalizerTest extends TestCase
             'foo' => 'b',
             'inner' => ['foo' => 'foo', 'bar' => 'bar'],
         ], DummyWithConstructorObjectAndDefaultValue::class, null, $context));
+    }
+
+    public function testAttributesWithoutAccessor()
+    {
+        $normalizer = new ObjectNormalizer(null, null, null, new ReflectionExtractor());
+        $obj = new DummyWithoutAccessor();
+
+        $normalizedObj = $normalizer->normalize($obj);
+
+        $this->assertArrayHasKey('email', $normalizedObj);
     }
 
     public function testNormalizeSameObjectWithDifferentAttributes()
@@ -981,5 +993,15 @@ class DummyWithNullableConstructorObject
     public function getInner()
     {
         return $this->inner;
+    }
+}
+
+class DummyWithoutAccessor
+{
+    private $email = 'dummy@example.com';
+
+    public function email(): string
+    {
+        return $this->email;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | master
| Bug fix      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #37605
| License       | MIT
| Doc PR        | TODO - symfony/symfony-docs#... <!-- required for new features -->

Adding support for Objects without mutator methods. I think for projects with legacy code, it is quite realistic to work without setter and getter. That's why I opened this pull request. But I also think it's not a good code. therefore a notice is thrown.

