### PR TITLE
[DoctrineBridge] Ulid and Uuid as Doctrine Types

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * added support for symfony/uid as `UlidType`, `UuidType`, `UlidBinaryType` and `UuidBinaryType` as Doctrine types
+ * added `UlidGenerator`, `UUidV1Generator`, `UuidV4Generator` and `UuidV6Generator`
+
 5.0.0
 -----
 

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterUidTypePass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterUidTypePass.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass;
+
+use Symfony\Bridge\Doctrine\Types\UlidType;
+use Symfony\Bridge\Doctrine\Types\UuidType;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Uid\AbstractUid;
+
+final class RegisterUidTypePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!class_exists(AbstractUid::class)) {
+            return;
+        }
+
+        $typeDefinition = $container->getParameter('doctrine.dbal.connection_factory.types');
+
+        if (!isset($typeDefinition['uuid'])) {
+            $typeDefinition['uuid'] = ['class' => UuidType::class];
+        }
+
+        if (!isset($typeDefinition['ulid'])) {
+            $typeDefinition['ulid'] = ['class' => UlidType::class];
+        }
+
+        $container->setParameter('doctrine.dbal.connection_factory.types', $typeDefinition);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Id/UlidGenerator.php
+++ b/src/Symfony/Bridge/Doctrine/Id/UlidGenerator.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Types;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\AbstractIdGenerator;
+use Symfony\Component\Uid\Ulid;
+
+final class UlidGenerator extends AbstractIdGenerator
+{
+    public function generate(EntityManager $em, $entity): Ulid
+    {
+        return new Ulid();
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Id/UuidV1Generator.php
+++ b/src/Symfony/Bridge/Doctrine/Id/UuidV1Generator.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Types;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\AbstractIdGenerator;
+use Symfony\Component\Uid\UuidV1;
+
+final class UuidV1Generator extends AbstractIdGenerator
+{
+    public function generate(EntityManager $em, $entity): UuidV1
+    {
+        return new UuidV1();
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Id/UuidV4Generator.php
+++ b/src/Symfony/Bridge/Doctrine/Id/UuidV4Generator.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Types;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\AbstractIdGenerator;
+use Symfony\Component\Uid\UuidV4;
+
+final class UuidV4Generator extends AbstractIdGenerator
+{
+    public function generate(EntityManager $em, $entity): UuidV4
+    {
+        return new UuidV4();
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Id/UuidV6Generator.php
+++ b/src/Symfony/Bridge/Doctrine/Id/UuidV6Generator.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Types;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Id\AbstractIdGenerator;
+use Symfony\Component\Uid\UuidV6;
+
+final class UuidV6Generator extends AbstractIdGenerator
+{
+    public function generate(EntityManager $em, $entity): UuidV6
+    {
+        return new UuidV6();
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Types/UlidBinaryTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/UlidBinaryTypeTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Types\UlidBinaryType;
+use Symfony\Component\Uid\Ulid;
+
+class UlidBinaryTypeTest extends TestCase
+{
+    private const DUMMY_ULID = '01EEDQEK6ZAZE93J8KG5B4MBJC';
+
+    private $platform;
+
+    /** @var UlidBinaryType */
+    private $type;
+
+    public static function setUpBeforeClass(): void
+    {
+        Type::addType('ulid_binary', UlidBinaryType::class);
+    }
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform
+            ->method('getBinaryTypeDeclarationSQL')
+            ->willReturn('DUMMYBINARY(16)');
+
+        $this->type = Type::getType('ulid_binary');
+    }
+
+    public function testUlidConvertsToDatabaseValue()
+    {
+        $uuid = Ulid::fromString(self::DUMMY_ULID);
+
+        $expected = $uuid->toBinary();
+        $actual = $this->type->convertToDatabaseValue($uuid, $this->platform);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testStringUlidConvertsToDatabaseValue()
+    {
+        $expected = Ulid::fromString(self::DUMMY_ULID)->toBinary();
+        $actual = $this->type->convertToDatabaseValue(self::DUMMY_ULID, $this->platform);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testInvalidUlidConversionForDatabaseValue()
+    {
+        $this->expectException(ConversionException::class);
+
+        $this->type->convertToDatabaseValue('abcdefg', $this->platform);
+    }
+
+    public function testNotSupportedTypeConversionForDatabaseValue()
+    {
+        $this->assertNull($this->type->convertToDatabaseValue(new \stdClass(), $this->platform));
+    }
+
+    public function testNullConversionForDatabaseValue()
+    {
+        $this->assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    public function testUlidConvertsToPHPValue()
+    {
+        $uuid = $this->type->convertToPHPValue(self::DUMMY_ULID, $this->platform);
+
+        $this->assertEquals(self::DUMMY_ULID, $uuid->__toString());
+    }
+
+    public function testInvalidUlidConversionForPHPValue()
+    {
+        $this->expectException(ConversionException::class);
+
+        $this->type->convertToPHPValue('abcdefg', $this->platform);
+    }
+
+    public function testNullConversionForPHPValue()
+    {
+        $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    public function testReturnValueIfUlidForPHPValue()
+    {
+        $uuid = new Ulid();
+        $this->assertSame($uuid, $this->type->convertToPHPValue($uuid, $this->platform));
+    }
+
+    public function testGetName()
+    {
+        $this->assertEquals('ulid_binary', $this->type->getName());
+    }
+
+    public function testGetGuidTypeDeclarationSQL()
+    {
+        $this->assertEquals('DUMMYBINARY(16)', $this->type->getSqlDeclaration(['length' => 36], $this->platform));
+    }
+
+    public function testRequiresSQLCommentHint()
+    {
+        $this->assertTrue($this->type->requiresSQLCommentHint($this->platform));
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Types/UlidTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/UlidTypeTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Types\UlidType;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\Ulid;
+
+final class UlidTypeTest extends TestCase
+{
+    private const DUMMY_ULID = '01EEDQEK6ZAZE93J8KG5B4MBJC';
+
+    /** @var AbstractPlatform */
+    private $platform;
+
+    /** @var UlidType */
+    private $type;
+
+    public static function setUpBeforeClass(): void
+    {
+        Type::addType('ulid', UlidType::class);
+    }
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform
+            ->method('getGuidTypeDeclarationSQL')
+            ->willReturn('DUMMYVARCHAR()');
+
+        $this->type = Type::getType('ulid');
+    }
+
+    public function testUlidConvertsToDatabaseValue(): void
+    {
+        $ulid = Ulid::fromString(self::DUMMY_ULID);
+
+        $expected = $ulid->__toString();
+        $actual = $this->type->convertToDatabaseValue($ulid, $this->platform);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testUlidInterfaceConvertsToDatabaseValue(): void
+    {
+        $ulid = $this->createMock(AbstractUid::class);
+
+        $ulid
+            ->expects($this->once())
+            ->method('__toString')
+            ->willReturn('foo');
+
+        $actual = $this->type->convertToDatabaseValue($ulid, $this->platform);
+
+        $this->assertEquals('foo', $actual);
+    }
+
+    public function testUlidStringConvertsToDatabaseValue(): void
+    {
+        $actual = $this->type->convertToDatabaseValue(self::DUMMY_ULID, $this->platform);
+
+        $this->assertEquals(self::DUMMY_ULID, $actual);
+    }
+
+    public function testInvalidUlidConversionForDatabaseValue(): void
+    {
+        $this->expectException(ConversionException::class);
+
+        $this->type->convertToDatabaseValue('abcdefg', $this->platform);
+    }
+
+    public function testNotSupportedTypeConversionForDatabaseValue()
+    {
+        $this->assertNull($this->type->convertToDatabaseValue(new \stdClass(), $this->platform));
+    }
+
+    public function testNullConversionForDatabaseValue(): void
+    {
+        $this->assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    public function testUlidInterfaceConvertsToPHPValue(): void
+    {
+        $ulid = $this->createMock(AbstractUid::class);
+        $actual = $this->type->convertToPHPValue($ulid, $this->platform);
+
+        $this->assertSame($ulid, $actual);
+    }
+
+    public function testUlidConvertsToPHPValue(): void
+    {
+        $ulid = $this->type->convertToPHPValue(self::DUMMY_ULID, $this->platform);
+
+        $this->assertInstanceOf(Ulid::class, $ulid);
+        $this->assertEquals(self::DUMMY_ULID, $ulid->__toString());
+    }
+
+    public function testInvalidUlidConversionForPHPValue(): void
+    {
+        $this->expectException(ConversionException::class);
+
+        $this->type->convertToPHPValue('abcdefg', $this->platform);
+    }
+
+    public function testNullConversionForPHPValue(): void
+    {
+        $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    public function testReturnValueIfUlidForPHPValue(): void
+    {
+        $ulid = new Ulid();
+
+        $this->assertSame($ulid, $this->type->convertToPHPValue($ulid, $this->platform));
+    }
+
+    public function testGetName(): void
+    {
+        $this->assertEquals('ulid', $this->type->getName());
+    }
+
+    public function testGetGuidTypeDeclarationSQL(): void
+    {
+        $this->assertEquals('DUMMYVARCHAR()', $this->type->getSqlDeclaration(['length' => 36], $this->platform));
+    }
+
+    public function testRequiresSQLCommentHint(): void
+    {
+        $this->assertTrue($this->type->requiresSQLCommentHint($this->platform));
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Types/UuidBinaryTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/UuidBinaryTypeTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Types\UuidBinaryType;
+use Symfony\Component\Uid\Uuid;
+
+class UuidBinaryTypeTest extends TestCase
+{
+    private const DUMMY_UUID = '9f755235-5a2d-4aba-9605-e9962b312e50';
+
+    private $platform;
+
+    /** @var UuidBinaryType */
+    private $type;
+
+    public static function setUpBeforeClass(): void
+    {
+        Type::addType('uuid_binary', UuidBinaryType::class);
+    }
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform
+            ->method('getBinaryTypeDeclarationSQL')
+            ->willReturn('DUMMYBINARY(16)');
+
+        $this->type = Type::getType('uuid_binary');
+    }
+
+    public function testUuidConvertsToDatabaseValue()
+    {
+        $uuid = Uuid::fromString(self::DUMMY_UUID);
+
+        $expected = uuid_parse(self::DUMMY_UUID);
+        $actual = $this->type->convertToDatabaseValue($uuid, $this->platform);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testStringUuidConvertsToDatabaseValue()
+    {
+        $uuid = self::DUMMY_UUID;
+
+        $expected = uuid_parse(self::DUMMY_UUID);
+        $actual = $this->type->convertToDatabaseValue($uuid, $this->platform);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testInvalidUuidConversionForDatabaseValue()
+    {
+        $this->expectException(ConversionException::class);
+
+        $this->type->convertToDatabaseValue('abcdefg', $this->platform);
+    }
+
+    public function testNullConversionForDatabaseValue()
+    {
+        $this->assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    public function testUuidConvertsToPHPValue()
+    {
+        $uuid = $this->type->convertToPHPValue(uuid_parse(self::DUMMY_UUID), $this->platform);
+
+        $this->assertEquals(self::DUMMY_UUID, $uuid->__toString());
+    }
+
+    public function testInvalidUuidConversionForPHPValue()
+    {
+        $this->expectException(ConversionException::class);
+
+        $this->type->convertToPHPValue('abcdefg', $this->platform);
+    }
+
+    public function testNotSupportedTypeConversionForDatabaseValue()
+    {
+        $this->assertNull($this->type->convertToDatabaseValue(new \stdClass(), $this->platform));
+    }
+
+    public function testNullConversionForPHPValue()
+    {
+        $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    public function testReturnValueIfUuidForPHPValue()
+    {
+        $uuid = Uuid::v4();
+        $this->assertSame($uuid, $this->type->convertToPHPValue($uuid, $this->platform));
+    }
+
+    public function testGetName()
+    {
+        $this->assertEquals('uuid_binary', $this->type->getName());
+    }
+
+    public function testGetGuidTypeDeclarationSQL()
+    {
+        $this->assertEquals('DUMMYBINARY(16)', $this->type->getSqlDeclaration(['length' => 36], $this->platform));
+    }
+
+    public function testRequiresSQLCommentHint()
+    {
+        $this->assertTrue($this->type->requiresSQLCommentHint($this->platform));
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Types/UuidTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/UuidTypeTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Types\UuidType;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Component\Uid\Uuid;
+
+final class UuidTypeTest extends TestCase
+{
+    private const DUMMY_UUID = '9f755235-5a2d-4aba-9605-e9962b312e50';
+
+    /** @var AbstractPlatform */
+    private $platform;
+
+    /** @var UuidType */
+    private $type;
+
+    public static function setUpBeforeClass(): void
+    {
+        Type::addType('uuid', UuidType::class);
+    }
+
+    protected function setUp(): void
+    {
+        $this->platform = $this->createMock(AbstractPlatform::class);
+        $this->platform
+            ->method('getGuidTypeDeclarationSQL')
+            ->willReturn('DUMMYVARCHAR()');
+
+        $this->type = Type::getType('uuid');
+    }
+
+    public function testUuidConvertsToDatabaseValue(): void
+    {
+        $uuid = Uuid::fromString(self::DUMMY_UUID);
+
+        $expected = $uuid->__toString();
+        $actual = $this->type->convertToDatabaseValue($uuid, $this->platform);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testUuidInterfaceConvertsToDatabaseValue(): void
+    {
+        $uuid = $this->createMock(AbstractUid::class);
+
+        $uuid
+            ->expects($this->once())
+            ->method('__toString')
+            ->willReturn('foo');
+
+        $actual = $this->type->convertToDatabaseValue($uuid, $this->platform);
+
+        $this->assertEquals('foo', $actual);
+    }
+
+    public function testUuidStringConvertsToDatabaseValue(): void
+    {
+        $actual = $this->type->convertToDatabaseValue(self::DUMMY_UUID, $this->platform);
+
+        $this->assertEquals(self::DUMMY_UUID, $actual);
+    }
+
+    public function testInvalidUuidConversionForDatabaseValue(): void
+    {
+        $this->expectException(ConversionException::class);
+
+        $this->type->convertToDatabaseValue('abcdefg', $this->platform);
+    }
+
+    public function testNotSupportedTypeConversionForDatabaseValue()
+    {
+        $this->assertNull($this->type->convertToDatabaseValue(new \stdClass(), $this->platform));
+    }
+
+    public function testNullConversionForDatabaseValue(): void
+    {
+        $this->assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+    }
+
+    public function testUuidInterfaceConvertsToPHPValue(): void
+    {
+        $uuid = $this->createMock(AbstractUid::class);
+        $actual = $this->type->convertToPHPValue($uuid, $this->platform);
+
+        $this->assertSame($uuid, $actual);
+    }
+
+    public function testUuidConvertsToPHPValue(): void
+    {
+        $uuid = $this->type->convertToPHPValue(self::DUMMY_UUID, $this->platform);
+
+        $this->assertInstanceOf(Uuid::class, $uuid);
+        $this->assertEquals(self::DUMMY_UUID, $uuid->__toString());
+    }
+
+    public function testInvalidUuidConversionForPHPValue(): void
+    {
+        $this->expectException(ConversionException::class);
+
+        $this->type->convertToPHPValue('abcdefg', $this->platform);
+    }
+
+    public function testNullConversionForPHPValue(): void
+    {
+        $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+
+    public function testReturnValueIfUuidForPHPValue(): void
+    {
+        $uuid = Uuid::v4();
+
+        $this->assertSame($uuid, $this->type->convertToPHPValue($uuid, $this->platform));
+    }
+
+    public function testGetName(): void
+    {
+        $this->assertEquals('uuid', $this->type->getName());
+    }
+
+    public function testGetGuidTypeDeclarationSQL(): void
+    {
+        $this->assertEquals('DUMMYVARCHAR()', $this->type->getSqlDeclaration(['length' => 36], $this->platform));
+    }
+
+    public function testRequiresSQLCommentHint(): void
+    {
+        $this->assertTrue($this->type->requiresSQLCommentHint($this->platform));
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Types/AbstractBinaryUidType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/AbstractBinaryUidType.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\GuidType;
+use Symfony\Component\Uid\AbstractUid;
+
+abstract class AbstractBinaryUidType extends GuidType
+{
+    abstract protected function getUidClass(): string;
+
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
+    {
+        return $platform->getBinaryTypeDeclarationSQL(
+            [
+                'length' => '16',
+                'fixed' => true,
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws ConversionException
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?AbstractUid
+    {
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        if ($value instanceof AbstractUid) {
+            return $value;
+        }
+
+        try {
+            $uuid = $this->getUidClass()::fromString($value);
+        } catch (\InvalidArgumentException $e) {
+            throw ConversionException::conversionFailed($value, $this->getName());
+        }
+
+        return $uuid;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws ConversionException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        if ($value instanceof AbstractUid) {
+            return $value->toBinary();
+        }
+
+        if (!\is_string($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
+            return null;
+        }
+
+        try {
+            return $this->getUidClass()::fromString((string) $value)->toBinary();
+        } catch (\InvalidArgumentException $e) {
+            throw ConversionException::conversionFailed($value, $this->getName());
+        }
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Types/AbstractUidType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/AbstractUidType.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Types;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\GuidType;
+use Symfony\Component\Uid\AbstractUid;
+
+abstract class AbstractUidType extends GuidType
+{
+    abstract protected function getUidClass(): string;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws ConversionException
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): ?AbstractUid
+    {
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        if ($value instanceof AbstractUid) {
+            return $value;
+        }
+
+        try {
+            $uuid = $this->getUidClass()::fromString($value);
+        } catch (\InvalidArgumentException $e) {
+            throw ConversionException::conversionFailed($value, $this->getName());
+        }
+
+        return $uuid;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws ConversionException
+     */
+    public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
+    {
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        if ($value instanceof AbstractUid) {
+            return $value;
+        }
+
+        if (!\is_string($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
+            return null;
+        }
+
+        if ($this->getUidClass()::isValid((string) $value)) {
+            return (string) $value;
+        }
+
+        throw ConversionException::conversionFailed($value, $this->getName());
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Types/UlidBinaryType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/UlidBinaryType.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Types;
+
+use Symfony\Component\Uid\Ulid;
+
+final class UlidBinaryType extends AbstractBinaryUidType
+{
+    public function getName(): string
+    {
+        return 'ulid_binary';
+    }
+
+    protected function getUidClass(): string
+    {
+        return Ulid::class;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Types/UlidType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/UlidType.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Types;
+
+use Symfony\Component\Uid\Ulid;
+
+final class UlidType extends AbstractUidType
+{
+    public function getName(): string
+    {
+        return 'ulid';
+    }
+
+    protected function getUidClass(): string
+    {
+        return Ulid::class;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Types/UuidBinaryType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/UuidBinaryType.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Types;
+
+use Symfony\Component\Uid\Uuid;
+
+final class UuidBinaryType extends AbstractBinaryUidType
+{
+    public function getName(): string
+    {
+        return 'uuid_binary';
+    }
+
+    protected function getUidClass(): string
+    {
+        return Uuid::class;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Types/UuidType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/UuidType.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Types;
+
+use Symfony\Component\Uid\Uuid;
+
+final class UuidType extends AbstractUidType
+{
+    public function getName(): string
+    {
+        return 'uuid';
+    }
+
+    protected function getUidClass(): string
+    {
+        return Uuid::class;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -39,6 +39,7 @@
         "symfony/proxy-manager-bridge": "^4.4|^5.0",
         "symfony/security-core": "^5.0",
         "symfony/expression-language": "^4.4|^5.0",
+        "symfony/uid": "^5.1",
         "symfony/validator": "^5.0.2",
         "symfony/translation": "^4.4|^5.0",
         "symfony/var-dumper": "^4.4|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | #36102 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

This Types Implementations are basically copies from https://github.com/ramsey/uuid-doctrine, with minor tweaks to use Symfonys Uid classes. 

I am not done yet. I'm going to implement some UnitTests and I also do need to add the Changelog Entries.

And I do ask my self if the Types should be registered automatically (with the recipe?), cause it would collide with Ramseys uuids implementation.

