### PR TITLE
[Console] allow multiline responses to console questions

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 -----
 
  * Added `SingleCommandApplication::setAutoExit()` to allow testing via `CommandTester`
+ * added support for multiline responses to questions through `Question::setMultiline()`
+   and `Question::isMultiline()`
 
 5.1.0
 -----

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -129,7 +129,7 @@ class QuestionHelper extends Helper
             }
 
             if (false === $ret) {
-                $ret = fgets($inputStream, 4096);
+                $ret = $this->readInput($inputStream, $question);
                 if (false === $ret) {
                     throw new MissingInputException('Aborted.');
                 }
@@ -501,5 +501,27 @@ class QuestionHelper extends Helper
         exec('stty 2> /dev/null', $output, $status);
 
         return self::$stdinIsInteractive = 1 !== $status;
+    }
+
+    /**
+     * Reads one or more lines of input and returns what is read.
+     *
+     * @param resource $inputStream The handler resource
+     * @param Question $question    The question being asked
+     *
+     * @return string|bool The input received, false in case input could not be read
+     */
+    private function readInput($inputStream, Question $question)
+    {
+        if (!$question->isMultiline()) {
+            return fgets($inputStream, 4096);
+        }
+
+        $ret = '';
+        while (false !== ($char = fgetc($inputStream))) {
+            $ret .= $char;
+        }
+
+        return $ret;
     }
 }

--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -33,6 +33,10 @@ class SymfonyQuestionHelper extends QuestionHelper
         $text = OutputFormatter::escapeTrailingBackslash($question->getQuestion());
         $default = $question->getDefault();
 
+        if ($question->isMultiline()) {
+            $text .= sprintf(' (press %s to continue)', $this->getEofShortcut());
+        }
+
         switch (true) {
             case null === $default:
                 $text = sprintf(' <info>%s</info>:', $text);
@@ -92,5 +96,14 @@ class SymfonyQuestionHelper extends QuestionHelper
         }
 
         parent::writeError($output, $error);
+    }
+
+    private function getEofShortcut(): string
+    {
+        if (false !== strpos(PHP_OS, 'WIN')) {
+            return '<comment>Ctrl+Z</comment> then <comment>Enter</comment>';
+        }
+
+        return '<comment>Ctrl+D</comment>';
     }
 }

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -30,6 +30,7 @@ class Question
     private $default;
     private $normalizer;
     private $trimmable = true;
+    private $multiline = false;
 
     /**
      * @param string $question The question to ask to the user
@@ -59,6 +60,26 @@ class Question
     public function getDefault()
     {
         return $this->default;
+    }
+
+    /**
+     * Returns whether the user response accepts newline characters.
+     */
+    public function isMultiline(): bool
+    {
+        return $this->multiline;
+    }
+
+    /**
+     * Sets whether the user response should accept newline characters.
+     *
+     * @return $this
+     */
+    public function setMultiline(bool $multiline): self
+    {
+        $this->multiline = $multiline;
+
+        return $this;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -442,6 +442,40 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
         $this->assertEquals(' 8AM', $dialog->ask($this->createStreamableInputInterfaceMock($this->getInputStream(' 8AM')), $this->createOutputInterface(), $question));
     }
 
+    public function testAskMultilineResponseWithEOF()
+    {
+        $essay = <<<'EOD'
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque pretium lectus quis suscipit porttitor. Sed pretium bibendum vestibulum.
+
+Etiam accumsan, justo vitae imperdiet aliquet, neque est sagittis mauris, sed interdum massa leo id leo.
+
+Aliquam rhoncus, libero ac blandit convallis, est sapien hendrerit nulla, vitae aliquet tellus orci a odio. Aliquam gravida ante sit amet massa lacinia, ut condimentum purus venenatis.
+
+Vivamus et erat dictum, euismod neque in, laoreet odio. Aenean vitae tellus at leo vestibulum auctor id eget urna.
+EOD;
+
+        $response = $this->getInputStream($essay);
+
+        $dialog = new QuestionHelper();
+
+        $question = new Question('Write an essay');
+        $question->setMultiline(true);
+
+        $this->assertEquals($essay, $dialog->ask($this->createStreamableInputInterfaceMock($response), $this->createOutputInterface(), $question));
+    }
+
+    public function testAskMultilineResponseWithSingleNewline()
+    {
+        $response = $this->getInputStream("\n");
+
+        $dialog = new QuestionHelper();
+
+        $question = new Question('Write an essay');
+        $question->setMultiline(true);
+
+        $this->assertEquals('', $dialog->ask($this->createStreamableInputInterfaceMock($response), $this->createOutputInterface(), $question));
+    }
+
     /**
      * @dataProvider getAskConfirmationData
      */

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -211,4 +211,22 @@ EOT
 
         $this->assertStringContainsString($expected, $stream);
     }
+
+    public function testAskMultilineQuestionIncludesHelpText()
+    {
+        $expected = 'Write an essay (press Ctrl+D to continue)';
+
+        if (false !== strpos(PHP_OS, 'WIN')) {
+            $expected = 'Write an essay (press Ctrl+Z then Enter to continue)';
+        }
+
+        $question = new Question('Write an essay');
+        $question->setMultiline(true);
+
+        $helper = new SymfonyQuestionHelper();
+        $input = $this->createStreamableInputInterfaceMock($this->getInputStream('\\'));
+        $helper->ask($input, $output = $this->createOutputInterface(), $question);
+
+        $this->assertOutputContains($expected, $output);
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Question/QuestionTest.php
+++ b/src/Symfony/Component/Console/Tests/Question/QuestionTest.php
@@ -297,4 +297,18 @@ class QuestionTest extends TestCase
     {
         self::assertNull($this->question->getNormalizer());
     }
+
+    /**
+     * @dataProvider providerTrueFalse
+     */
+    public function testSetMultiline(bool $multiline)
+    {
+        self::assertSame($this->question, $this->question->setMultiline($multiline));
+        self::assertSame($multiline, $this->question->isMultiline());
+    }
+
+    public function testIsMultilineDefault()
+    {
+        self::assertFalse($this->question->isMultiline());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | symfony/symfony-docs#14002

By default, the question helper stops reading user input when it receives a newline character (i.e., when the user hits `ENTER` once). However, with this feature, developers may specify that the response to a question should allow multiline answers by passing `true` to `setMultiline()`.

Multiline questions stop reading user input after receiving three newline characters in a row (i.e., the user hits `ENTER` three times) or an end-of-transmission control character (`Ctrl-D` on Unix systems or `Ctrl-Z` on Windows).

If a user enters a newline character without input, control is returned to the question class, where the input may be validated to prompt the user again (in the case of a required question), or control may be passed along to the rest of the script.
