### PR TITLE
Fix getTranslationNodeVisitor() return type

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -16,6 +16,11 @@ TwigBundle
 
  * Deprecated the public `twig` service to private.
 
+TwigBridge
+----------
+
+ * Changed 2nd argument type of `TranslationExtension::__construct()` to `TranslationNodeVisitor`
+
 Validator
 ---------
 

--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -18,7 +18,6 @@ use Symfony\Bridge\Twig\TokenParser\TransTokenParser;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\Contracts\Translation\TranslatorTrait;
 use Twig\Extension\AbstractExtension;
-use Twig\NodeVisitor\NodeVisitorInterface;
 use Twig\TwigFilter;
 
 // Help opcache.preload discover always-needed symbols
@@ -34,7 +33,7 @@ final class TranslationExtension extends AbstractExtension
     private $translator;
     private $translationNodeVisitor;
 
-    public function __construct(TranslatorInterface $translator = null, NodeVisitorInterface $translationNodeVisitor = null)
+    public function __construct(TranslatorInterface $translator = null, TranslationNodeVisitor $translationNodeVisitor = null)
     {
         $this->translator = $translator;
         $this->translationNodeVisitor = $translationNodeVisitor;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37686
| License       | MIT
| Doc PR        | -


When constructing the `TranslationExtension` with any `NodeVisitorInterface` other than `TranslationNodeVisitor`, you will get a type error when calling `getTranslationNodeVisitor()`. This PR fixes that by extracting a new `TranslationNodeVisitorInterface`.