### PR TITLE
HttpClient profiler error

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
@@ -15,7 +15,7 @@
             </div>
             <div class="sf-toolbar-info-piece">
                 <b>HTTP errors</b>
-                <span class="sf-toolbar-status sf-toolbar-status-red">{{ collector.errorCount }}</span>
+                <span class="sf-toolbar-status {{ collector.errorCount > 0 ? 'sf-toolbar-status-red' }}">{{ collector.errorCount }}</span>
             </div>
         {% endset %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix 
| License       | MIT
| Doc PR        | symfony/symfony-docs

When no error occurs making http request, the span was red, it is wierd
