### PR TITLE
[Profiler] Add HttpClient copy as curl feature

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/http_client.html.twig
@@ -1,5 +1,7 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
+{% import _self as helper %}
+
 {% block toolbar %}
     {% if collector.requestCount %}
         {% set icon %}
@@ -88,6 +90,7 @@
                                             {% if trace.options is not empty %}
                                                 {{ profiler_dump(trace.options, maxDepth=1) }}
                                             {% endif %}
+                                            <button class="btn btn-sm" data-clipboard-text="{{ helper.render_curl(trace) }}">Copy-as-Curl</button>
                                         </th>
                                         {% if profiler_token and profiler_link %}
                                             <th>
@@ -121,6 +124,8 @@
                                     </tr>
                                     </tbody>
                                 </table>
+                                {# tmp: introspect the "trace" #}
+                                {{ dump(trace) }}
                             {% endfor %}
                         {% endif %}
                     </div>
@@ -128,4 +133,19 @@
             {% endfor %}
         {% endif %}
     </div>
+
+    <script type="text/javascript">//<![CDATA[
+
+        document.querySelectorAll('[data-clipboard-text]').forEach(function(button) {
+            button.addEventListener('click', function() {
+                navigator.clipboard.writeText(button.getAttribute('data-clipboard-text'));
+            })
+        });
+
+    //]]></script>
+
 {% endblock %}
+
+{% macro render_curl(trace) %}
+curl "{{ trace.url }}" --compressed -H "Connection: keep-alive" -v
+{% endmacro %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Part of https://github.com/symfony/symfony/issues/33311
| License       | MIT
| Doc PR        | none

**PR draft**

Folowing https://github.com/symfony/symfony/pull/37690
i wanted to see some issues on the httpclient and found this one https://github.com/symfony/symfony/issues/33311

i can work on both ping @nicolas-grekas 

```
- when a transport error occurs, (ie the "error" info is populated) we should maybe have a better display too?
```

what do you have in mind for `we should maybe have a better display too`?

```
- add a copy-as-curl button next to each request
```

`curl` request can be complex, what is the MVP wanted here?

Thanks :) 