### PR TITLE
KernelBrowser::getContainer cannot return null anymore

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -45,7 +45,7 @@ class KernelBrowser extends HttpKernelBrowser
     /**
      * Returns the container.
      *
-     * @return ContainerInterface|null Returns null when the Kernel has been shutdown or not started yet
+     * @return ContainerInterface
      */
     public function getContainer()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

This is a pedantic change.

In symfony 4.4, getContainer could return null.
Since symfony 5.0, this is the implementation:
```
    public function getContainer()
    {
        if (!$this->container) {
            throw new \LogicException('Cannot retrieve the container from a non-booted kernel.');
        }

        return $this->container;
    }
```

So I updated the phpdoc.
