### PR TITLE
Removed redundant strtolower in ConsumeMessagesCommand

### DIFF
--- a/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php
@@ -208,7 +208,7 @@ EOF
     private function convertToBytes(string $memoryLimit): int
     {
         $memoryLimit = strtolower($memoryLimit);
-        $max = strtolower(ltrim($memoryLimit, '+'));
+        $max = ltrim($memoryLimit, '+');
         if (0 === strpos($max, '0x')) {
             $max = \intval($max, 16);
         } elseif (0 === strpos($max, '0')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no
