### PR TITLE
Add no-store cache directive.

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -89,6 +89,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
                     ->setPrivate()
                     ->setMaxAge(0)
                     ->headers->addCacheControlDirective('must-revalidate');
+                $response->headers->addCacheControlDirective('no-store');
             }
         }
 


### PR DESCRIPTION
Prevents pages to be cached when using Back Button.

Here is explanation: https://engineering.mixmax.com/blog/chrome-back-button-cache-no-store

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

