### PR TITLE
[MonologBridge] Added SwitchUserTokenProcessor to log the impersonator

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Processor;
+
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * The base class for security token processors.
+ *
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ * @author Igor Timoshenko <igor.timoshenko@i.ua>
+ */
+abstract class AbstractTokenProcessor
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    protected $tokenStorage;
+
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    abstract protected function getKey(): string;
+
+    abstract protected function getToken(): ?TokenInterface;
+
+    public function __invoke(array $record): array
+    {
+        $record['extra'][$this->getKey()] = null;
+
+        if (null !== $token = $this->getToken()) {
+            $record['extra'][$this->getKey()] = [
+                'username' => $token->getUsername(),
+                'authenticated' => $token->isAuthenticated(),
+                'roles' => $token->getRoleNames(),
+            ];
+        }
+
+        return $record;
+    }
+}

--- a/src/Symfony/Bridge/Monolog/Processor/SwitchUserTokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/SwitchUserTokenProcessor.php
@@ -11,22 +11,22 @@
 
 namespace Symfony\Bridge\Monolog\Processor;
 
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
- * Adds the current security token to the log entry.
+ * Adds the original security token to the log entry.
  *
- * @author Dany Maillard <danymaillard93b@gmail.com>
  * @author Igor Timoshenko <igor.timoshenko@i.ua>
  */
-class TokenProcessor extends AbstractTokenProcessor
+class SwitchUserTokenProcessor extends AbstractTokenProcessor
 {
     /**
      * {@inheritdoc}
      */
     protected function getKey(): string
     {
-        return 'token';
+        return 'impersonator_token';
     }
 
     /**
@@ -34,6 +34,12 @@ class TokenProcessor extends AbstractTokenProcessor
      */
     protected function getToken(): ?TokenInterface
     {
-        return $this->tokenStorage->getToken();
+        $token = $this->tokenStorage->getToken();
+
+        if ($token instanceof SwitchUserToken) {
+            return $token->getOriginalToken();
+        }
+
+        return null;
     }
 }

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/SwitchUserTokenProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/SwitchUserTokenProcessorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Monolog\Tests\Processor;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Monolog\Processor\SwitchUserTokenProcessor;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+/**
+ * Tests the SwitchUserTokenProcessor.
+ *
+ * @author Igor Timoshenko <igor.timoshenko@i.ua>
+ */
+class SwitchUserTokenProcessorTest extends TestCase
+{
+    public function testProcessor()
+    {
+        $originalToken = new UsernamePasswordToken('original_user', 'password', 'provider', ['ROLE_SUPER_ADMIN']);
+        $switchUserToken = new SwitchUserToken('user', 'passsword', 'provider', ['ROLE_USER'], $originalToken);
+        $tokenStorage = $this->getMockBuilder(TokenStorageInterface::class)->getMock();
+        $tokenStorage->method('getToken')->willReturn($switchUserToken);
+
+        $processor = new SwitchUserTokenProcessor($tokenStorage);
+        $record = ['extra' => []];
+        $record = $processor($record);
+
+        $this->assertArrayHasKey('original_token', $record['extra']);
+        $this->assertEquals($originalToken->getUsername(), $record['extra']['original_token']['username']);
+        $this->assertEquals($originalToken->isAuthenticated(), $record['extra']['original_token']['authenticated']);
+        $this->assertEquals(['ROLE_SUPER_ADMIN'], $record['extra']['original_token']['roles']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This pull request adds the ability to log the impersonator user in case of user impersonation feature usage. The current TokenProcessor logs only the current token and there are no ability to simply log the original token, so we need to copy-paste the TokenProcessor and change a few lines to log the original token