### PR TITLE
[Mailer] Added the missing reset tag to mailer.logger_message_listener

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.xml
@@ -41,6 +41,7 @@
 
         <service id="mailer.logger_message_listener" class="Symfony\Component\Mailer\EventListener\MessageLoggerListener">
             <tag name="kernel.event_subscriber"/>
+            <tag name="kernel.reset" method="reset" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | 