### PR TITLE
Allow Drupal to wrap the Symfony test listener

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 
 use PHPUnit\Util\Test;
-use Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerFor;
 
 /**
  * @internal
@@ -61,8 +60,8 @@ class Deprecation
         $line = $trace[$i];
         $this->triggeringFile = $file;
         if (isset($line['object']) || isset($line['class'])) {
-            if (isset($line['class']) && 0 === strpos($line['class'], SymfonyTestsListenerFor::class)) {
-                $parsedMsg = unserialize($this->message);
+            $parsedMsg = @unserialize($this->message);
+            if ($parsedMsg && isset($parsedMsg['deprecation'])) {
                 $this->message = $parsedMsg['deprecation'];
                 $this->originClass = $parsedMsg['class'];
                 $this->originMethod = $parsedMsg['method'];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | kinda
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Drupal has a test listener that wraps the Symfony listener as we need to manipulate deprecation testing to skip specific deprecations. We've managed to remove some how custom stuff and reaching into Symfony's privates via reflection recently (and fix a bug or two) but now we're getting output like:
```
  2x: a:4:{s:11:"deprecation";s:191:"Calling Drupal\Tests\WebAssert::responseNotMatches with more than one argument is deprecated in drupal:9.1.0 and will throw an exception in drupal:10.0.0. See https://www.drupal.org/node/TODO";s:5:"class";s:52:"Drupal\Tests\comment\Functional\CommentAnonymousTest";s:6:"method";s:13:"testAnonymous";s:15:"triggering_file";s:74:"/Users/alex/dev/sites/drupal8alt.dev/core/tests/Drupal/Tests/WebAssert.php";}
    2x in DrupalListener::endTest from Drupal\Tests\Listeners
```
instead of 
```
  2x: Calling Drupal\Tests\WebAssert::responseNotMatches with more than one argument is deprecated in drupal:9.1.0 and will throw an exception in drupal:10.0.0. See https://www.drupal.org/node/TODO
    2x in CommentAnonymousTest::testAnonymous from Drupal\Tests\comment\Functional
```

We can fix this by aliasing and copying the \Symfony\Bridge\PhpUnit\DeprecationErrorHandler\Deprecation class but ideally that class could be a bit more liberal in its implementation.
