### PR TITLE
[Router] allow to use \A and \z as regex start and end

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Added support for inline definition of requirements and defaults for host
+ * Added support for `\A` and `\z` as regex start and end for route requirement
 
 5.1.0
 -----

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -553,12 +553,18 @@ class Route implements \Serializable
 
     private function sanitizeRequirement(string $key, string $regex)
     {
-        if ('' !== $regex && '^' === $regex[0]) {
-            $regex = (string) substr($regex, 1); // returns false for a single character
+        if ('' !== $regex) {
+            if ('^' === $regex[0]) {
+                $regex = substr($regex, 1);
+            } elseif (0 === strpos($regex, '\\A')) {
+                $regex = substr($regex, 2);
+            }
         }
 
         if ('$' === substr($regex, -1)) {
             $regex = substr($regex, 0, -1);
+        } elseif (\strlen($regex) - 2 === strpos($regex, '\\z')) {
+            $regex = substr($regex, 0, -2);
         }
 
         if ('' === $regex) {

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -122,6 +122,14 @@ class RouteTest extends TestCase
         $this->assertTrue($route->hasRequirement('foo'), '->hasRequirement() return true if requirement is set');
     }
 
+    public function testRequirementAlternativeStartAndEndRegexSyntax()
+    {
+        $route = new Route('/{foo}');
+        $route->setRequirement('foo', '\A\d+\z');
+        $this->assertEquals('\d+', $route->getRequirement('foo'), '->setRequirement() removes \A and \z from the path');
+        $this->assertTrue($route->hasRequirement('foo'));
+    }
+
     /**
      * @dataProvider getInvalidRequirements
      */
@@ -139,6 +147,9 @@ class RouteTest extends TestCase
            ['^$'],
            ['^'],
            ['$'],
+           ['\A\z'],
+           ['\A'],
+           ['\z'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | —
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Some people are using `\A` and `\z` as alternative for `^` and `$` for route requirements.

E.g.: UUID pattern in ramsey/uuid (many routes broke after updating the lib):
https://github.com/ramsey/uuid/commit/569e93ac4e82410102d3431815cb65e701bef26a#diff-23c8536f7d61e7d839fd1c93ce0dd354L30-R31  

References:
https://www.rexegg.com/regex-anchors.html#A
https://www.rexegg.com/regex-anchors.html#z

P.S.: It is my first PR into Symfony. Maybe I should fix something, just let me know.