### PR TITLE
[Mailer] Prevent MessageLoggerListener from leaking in env=prod

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
@@ -71,5 +71,6 @@ return static function (ContainerConfigurator $container) {
 
         ->set('mailer.logger_message_listener', MessageLoggerListener::class)
             ->tag('kernel.event_subscriber')
+            ->deprecate('symfony/framework-bundle', '5.2', 'The "%service_id%" service is deprecated, use "mailer.message_logger_listener" instead.')
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_debug.php
@@ -12,16 +12,21 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\Mailer\DataCollector\MessageDataCollector;
+use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('mailer.data_collector', MessageDataCollector::class)
             ->args([
-                service('mailer.logger_message_listener'),
+                service('mailer.message_logger_listener'),
             ])
-        ->tag('data_collector', [
-            'template' => '@WebProfiler/Collector/mailer.html.twig',
-            'id' => 'mailer',
-        ])
+            ->tag('data_collector', [
+                'template' => '@WebProfiler/Collector/mailer.html.twig',
+                'id' => 'mailer',
+            ])
+
+        ->set('mailer.message_logger_listener', MessageLoggerListener::class)
+            ->tag('kernel.event_subscriber')
+            ->tag('kernel.reset', ['method' => 'reset'])
     ;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| License       | MIT

I was trying to send a batch of emails with `--env=prod` when I noticed that `MessageLoggerListener` was still collecting all the messages and leaking the memory. I tried to do `$this->getApplication()->reset()`, but it didn't work because `MessageLoggerListener` was not tagged (now fixed in #37705).

In this PR I propose to move the declaration of `MessageLoggerListener` to `mailer_debug.php` since the only service depending on it is `mailer.data_collector` from `mailer_debug.php`. If a developer needs to collect sent emails, a custom listener could be implemented on the project side.

- [x] deprecate the service
- [x] add a new one to `mailer_debug.php`
- [ ] add a line to CHANGELOG.md
- [ ] add a line to UPGRADE-5.2.md