### PR TITLE
[Router] added \Z as regex end for route requirement

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 -----
 
  * Added support for inline definition of requirements and defaults for host
- * Added support for `\A` and `\z` as regex start and end for route requirement
+ * Added support for `\A` as regex start and `\Z` or `\z` as end for route requirement
 
 5.1.0
 -----

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -563,7 +563,7 @@ class Route implements \Serializable
 
         if ('$' === substr($regex, -1)) {
             $regex = substr($regex, 0, -1);
-        } elseif (\strlen($regex) - 2 === strpos($regex, '\\z')) {
+        } elseif (\in_array(\strlen($regex) - 2, [strpos($regex, '\\z'), strpos($regex, '\\Z')], true)) {
             $regex = substr($regex, 0, -2);
         }
 

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -128,6 +128,10 @@ class RouteTest extends TestCase
         $route->setRequirement('foo', '\A\d+\z');
         $this->assertEquals('\d+', $route->getRequirement('foo'), '->setRequirement() removes \A and \z from the path');
         $this->assertTrue($route->hasRequirement('foo'));
+
+        $route->setRequirement('bar', '\A\d+\Z');
+        $this->assertEquals('\d+', $route->getRequirement('bar'), '->setRequirement() removes \A and \Z from the path');
+        $this->assertTrue($route->hasRequirement('bar'));
     }
 
     /**
@@ -147,8 +151,10 @@ class RouteTest extends TestCase
            ['^$'],
            ['^'],
            ['$'],
+           ['\A\Z'],
            ['\A\z'],
            ['\A'],
+           ['\Z'],
            ['\z'],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | —
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

In previous PR (#37711) I added `/A` and `/z`, but `$` in regex is `/z` + `/Z`.

Thanks @rvitaliy: https://github.com/symfony/symfony/pull/37711#issuecomment-666984916

References:
^ and $: https://www.pcre.org/original/doc/html/pcrepattern.html#TOC1
\A, \z, \Z: https://www.pcre.org/original/doc/html/pcrepattern.html#SEC5

> The \A, \Z, and \z assertions differ from the traditional circumflex and dollar (described in the next section) in that they only ever match at the very start and end of the subject string, whatever options are set. Thus, they are independent of multiline mode. These three assertions are not affected by the PCRE_NOTBOL or PCRE_NOTEOL options, which affect only the behaviour of the circumflex and dollar metacharacters. However, if the startoffset argument of pcre_exec() is non-zero, indicating that matching is to start at a point other than the beginning of the subject, \A can never match. The difference between \Z and \z is that \Z matches before a newline at the end of the string as well as at the very end, whereas \z matches only at the end.

