### PR TITLE
[Filesystem] Adds "tempfile" method

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -23,6 +23,7 @@ use Symfony\Component\Filesystem\Exception\IOException;
 class Filesystem
 {
     private static $lastError;
+    private $temporaryFiles;
 
     /**
      * Copies a file.
@@ -693,6 +694,26 @@ class Filesystem
         if (false === @file_put_contents($filename, $content, FILE_APPEND)) {
             throw new IOException(sprintf('Failed to write file "%s".', $filename), 0, null, $filename);
         }
+    }
+
+    /**
+     * Creates a temporary file with support for custom stream wrappers
+     * which will be automatically deleted after the end of the execution.
+     *
+     * @param string $prefix The prefix of the generated temporary filename
+     *                       Note: Windows uses only the first three characters of prefix
+     * @param string $suffix The suffix of the generated temporary filename
+     *
+     * @return string The new temporary filename (with path), or throw an exception on failure
+     */
+    public function tempfile(string $dir, string $prefix, string $suffix = '')
+    {
+        return $this->temporaryFiles[] = $this->tempnam($dir, $prefix, $suffix);
+    }
+
+    public function __destruct()
+    {
+        $this->remove($this->temporaryFiles);
     }
 
     private function toIterable($files): iterable

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1724,6 +1724,18 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFilePermissions(767, $targetFilePath);
     }
 
+    public function testTempfile()
+    {
+        $dirname = $this->workspace;
+        $filesystem = clone $this->filesystem;
+
+        $filename = $filesystem->tempfile($dirname, 'foo');
+        $this->assertFileExists($filename);
+
+        $filesystem->__destruct();
+        $this->assertFileNotExists($filename);
+    }
+
     /**
      * Normalize the given path (transform each blackslash into a real directory separator).
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #31692 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | `TODO`
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->

This pull request adds a method called `tempfile` to the Filesystem Component which is an alternative to `tempnam`. This method after the end of the execution deletes all temporary files created with this method.