### PR TITLE
[Form] Fix Guess phpdoc return type

### DIFF
--- a/src/Symfony/Component/Form/Guess/Guess.php
+++ b/src/Symfony/Component/Form/Guess/Guess.php
@@ -60,9 +60,9 @@ abstract class Guess
      * If there are multiple guesses with the same, highest confidence, the
      * returned guess is any of them.
      *
-     * @param Guess[] $guesses An array of guesses
+     * @param static[] $guesses An array of guesses
      *
-     * @return self|null
+     * @return static|null
      */
     public static function getBestGuess(array $guesses)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | -
| License       | MIT
| Doc PR        | -

Since `Guess` is abstract, `static` represents better the return type, so calling `TypeGuess::getBestGuess()` would return `TypeGuess` instead of `Guess`.
