### PR TITLE
[FrameworkBundle] fail properly when the required service is not defined

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/MailerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/MailerAssertionsTrait.php
@@ -122,10 +122,10 @@ trait MailerAssertionsTrait
             static::fail('Unable to make email assertions. Did you forget to make an HTTP request?');
         }
 
-        if (!$logger = self::$container->get('mailer.logger_message_listener')) {
+        if (!self::$container->has('mailer.logger_message_listener')) {
             static::fail('A client must have Mailer enabled to make email assertions. Did you forget to require symfony/mailer?');
         }
 
-        return $logger->getEvents();
+        return self::$container->get('mailer.logger_message_listener')->getEvents();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Before:

```
Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: You have requested a non-existent service "mailer.logger_message_listener".
```

After:

```
A client must have Mailer enabled to make email assertions. Did you forget to require symfony/mailer?
```