### PR TITLE
[PhpUnitBridge] Add ability to set a baseline for deprecation testing

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -129,6 +129,9 @@ class DeprecationErrorHandler
         if ($deprecation->isMuted()) {
             return null;
         }
+        if ($this->getConfiguration()->isBaselineDeprecation($deprecation)) {
+            return null;
+        }
         $group = 'other';
 
         if ($deprecation->originatesFromAnObject()) {
@@ -206,6 +209,10 @@ class DeprecationErrorHandler
 
             $isFailingAtShutdown = !$configuration->tolerates($this->deprecationGroups);
             $this->displayDeprecations($groups, $configuration, $isFailingAtShutdown);
+
+            if ($configuration->isGeneratingBaseline()) {
+                $configuration->writeBaseline();
+            }
 
             if ($isFailing || $isFailingAtShutdown) {
                 exit(1);

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/baseline.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/baseline.phpt
@@ -1,0 +1,80 @@
+--TEST--
+Test DeprecationErrorHandler in baseline mode
+--FILE--
+<?php
+$filename = tempnam(sys_get_temp_dir(), 'sf-');
+$baseline = [[
+  'location' => 'FooTestCase::testLegacyFoo',
+  'message' => 'silenced foo deprecation',
+  'count' => 1,
+],
+[
+  'location' => 'FooTestCase::testNonLegacyBar',
+  'message' => 'silenced bar deprecation',
+  'count' => 1,
+],
+[
+  'location' => 'procedural code',
+  'message' => 'root deprecation',
+  'count' => 1,
+]];
+file_put_contents($filename, json_encode($baseline, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+$k = 'SYMFONY_DEPRECATIONS_HELPER';
+unset($_SERVER[$k], $_ENV[$k]);
+putenv($k.'='.$_SERVER[$k] = $_ENV[$k] = 'baselineFile=' . urlencode($filename));
+putenv('ANSICON');
+putenv('ConEmuANSI');
+putenv('TERM');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+require_once __DIR__.'/../../bootstrap.php';
+
+@trigger_error('root deprecation', E_USER_DEPRECATED);
+
+eval(<<<'EOPHP'
+namespace PHPUnit\Util;
+
+class Test
+{
+    public static function getGroups()
+    {
+        return array();
+    }
+}
+EOPHP
+);
+
+class PHPUnit_Util_Test
+{
+    public static function getGroups()
+    {
+        return array();
+    }
+}
+
+class FooTestCase
+{
+    public function testLegacyFoo()
+    {
+        @trigger_error('silenced foo deprecation', E_USER_DEPRECATED);
+    }
+
+    public function testNonLegacyBar()
+    {
+        @trigger_error('silenced bar deprecation', E_USER_DEPRECATED);
+    }
+}
+
+$foo = new FooTestCase();
+$foo->testLegacyFoo();
+$foo->testNonLegacyBar();
+print "Cannot test baselineFile contents because it is generated in a shutdown function registered by another shutdown function."
+?>
+--EXPECT--
+Cannot test baselineFile contents because it is generated in a shutdown function registered by another shutdown function.

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/baseline2.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/baseline2.phpt
@@ -1,0 +1,74 @@
+--TEST--
+Test DeprecationErrorHandler in baseline mode
+--FILE--
+<?php
+$filename = tempnam(sys_get_temp_dir(), 'sf-');
+$baseline = [[
+  'location' => 'FooTestCase::testLegacyFoo',
+  'message' => 'silenced foo deprecation',
+  'count' => 1,
+]];
+file_put_contents($filename, json_encode($baseline, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+$k = 'SYMFONY_DEPRECATIONS_HELPER';
+unset($_SERVER[$k], $_ENV[$k]);
+putenv($k.'='.$_SERVER[$k] = $_ENV[$k] = 'baselineFile=' . urlencode($filename));
+putenv('ANSICON');
+putenv('ConEmuANSI');
+putenv('TERM');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+require_once __DIR__.'/../../bootstrap.php';
+
+@trigger_error('root deprecation', E_USER_DEPRECATED);
+
+eval(<<<'EOPHP'
+namespace PHPUnit\Util;
+
+class Test
+{
+    public static function getGroups()
+    {
+        return array();
+    }
+}
+EOPHP
+);
+
+class PHPUnit_Util_Test
+{
+    public static function getGroups()
+    {
+        return array();
+    }
+}
+
+class FooTestCase
+{
+    public function testLegacyFoo()
+    {
+        @trigger_error('silenced foo deprecation', E_USER_DEPRECATED);
+    }
+
+    public function testNonLegacyBar()
+    {
+        @trigger_error('silenced bar deprecation', E_USER_DEPRECATED);
+    }
+}
+
+$foo = new FooTestCase();
+$foo->testLegacyFoo();
+$foo->testNonLegacyBar();
+?>
+--EXPECTF--
+Other deprecation notices (2)
+
+  1x: root deprecation
+
+  1x: silenced bar deprecation
+    1x in FooTestCase::testNonLegacyBar

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/baseline3.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/baseline3.phpt
@@ -1,0 +1,79 @@
+--TEST--
+Test DeprecationErrorHandler in baseline mode
+--FILE--
+<?php
+$filename = tempnam(sys_get_temp_dir(), 'sf-');
+$baseline = [[
+  'location' => 'FooTestCase::testLegacyFoo',
+  'message' => 'silenced foo deprecation',
+  'count' => 1,
+]];
+file_put_contents($filename, json_encode($baseline, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES));
+
+$k = 'SYMFONY_DEPRECATIONS_HELPER';
+unset($_SERVER[$k], $_ENV[$k]);
+putenv($k.'='.$_SERVER[$k] = $_ENV[$k] = 'baselineFile=' . urlencode($filename));
+putenv('ANSICON');
+putenv('ConEmuANSI');
+putenv('TERM');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+require_once __DIR__.'/../../bootstrap.php';
+
+@trigger_error('root deprecation', E_USER_DEPRECATED);
+
+eval(<<<'EOPHP'
+namespace PHPUnit\Util;
+
+class Test
+{
+    public static function getGroups()
+    {
+        return array();
+    }
+}
+EOPHP
+);
+
+class PHPUnit_Util_Test
+{
+    public static function getGroups()
+    {
+        return array();
+    }
+}
+
+class FooTestCase
+{
+    public function testLegacyFoo()
+    {
+        @trigger_error('silenced foo deprecation', E_USER_DEPRECATED);
+        // This will cause a deprecation because the baseline only expects 1
+        // deprecation.
+        @trigger_error('silenced foo deprecation', E_USER_DEPRECATED);
+    }
+
+    public function testNonLegacyBar()
+    {
+        @trigger_error('silenced bar deprecation', E_USER_DEPRECATED);
+    }
+}
+
+$foo = new FooTestCase();
+$foo->testLegacyFoo();
+$foo->testNonLegacyBar();
+?>
+--EXPECTF--
+Legacy deprecation notices (1)
+
+Other deprecation notices (2)
+
+  1x: root deprecation
+
+  1x: silenced bar deprecation
+    1x in FooTestCase::testNonLegacyBar

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/generate_baseline.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/generate_baseline.phpt
@@ -1,0 +1,64 @@
+--TEST--
+Test DeprecationErrorHandler in baseline generation mode
+--FILE--
+<?php
+$filename = tempnam(sys_get_temp_dir(), 'sf-');
+
+$k = 'SYMFONY_DEPRECATIONS_HELPER';
+unset($_SERVER[$k], $_ENV[$k]);
+putenv($k.'='.$_SERVER[$k] = $_ENV[$k] = 'generateBaseline=true&baselineFile=' . urlencode($filename));
+putenv('ANSICON');
+putenv('ConEmuANSI');
+putenv('TERM');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+require_once __DIR__.'/../../bootstrap.php';
+
+@trigger_error('root deprecation', E_USER_DEPRECATED);
+
+eval(<<<'EOPHP'
+namespace PHPUnit\Util;
+
+class Test
+{
+    public static function getGroups()
+    {
+        return array();
+    }
+}
+EOPHP
+);
+
+class PHPUnit_Util_Test
+{
+    public static function getGroups()
+    {
+        return array();
+    }
+}
+
+class FooTestCase
+{
+    public function testLegacyFoo()
+    {
+        @trigger_error('silenced foo deprecation', E_USER_DEPRECATED);
+    }
+
+    public function testNonLegacyBar()
+    {
+        @trigger_error('silenced bar deprecation', E_USER_DEPRECATED);
+    }
+}
+
+$foo = new FooTestCase();
+$foo->testLegacyFoo();
+$foo->testNonLegacyBar();
+print "Cannot test baselineFile contents because it is generated in a shutdown function registered by another shutdown function."
+?>
+--EXPECT--
+Cannot test baselineFile contents because it is generated in a shutdown function registered by another shutdown function.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #37715, #34496
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This PR allows you set new options for `SYMFONY_DEPRECATIONS_HELPER` env var:
* `generateBaseline` - if this is set to TRUE any deprecations that occur will be written to the file defined in the `baselineFile` option
* `baselineFile` a path to a file that contains a json encoded array of deprecations that will be skipped.

### Questions
* If you set `generateBaseline` without also setting `baselineFile` an exception is thrown. We could use a default filename if one is not provided (like PHPStan).
* How much error checking should we do around the `baselineFile` variable - should we check if it is readable or should we rely on `file_get_contents`()?

### Still @todo
Add proper end-to-end testing using a .phpt test