### PR TITLE
[HttpFoundation] add support for X_FORWARDED_PREFIX header

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+* added support for `X-Forwarded-Prefix` header
+
 5.2.0
 -----
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #36809 
| License       | MIT

Add support for `X-Forwarded-Prefix` header added by the popular Traefik HTTP LoadBalancer and Reverse Proxy. This ensures that the links rendered by symfony application deployed behind LB are valid even if the application is deployed via prefix URL.   

Example routing setup:
route `/admin/(.*)` => symfony backend `/$1`
in this case links rendered by symfony backend must start with `/admin/` 

To accept traefik prefix in your symfony app, you must modify index.php to allow accepting this header:

    Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_TRAEFIK ^ Request::HEADER_X_FORWARDED_HOST );`
