### PR TITLE
[RFC][lock] Introduce Shared Lock (or Read/Write Lock)

### DIFF
--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * `MongoDbStore` does not implement `BlockingStoreInterface` anymore, typehint against `PersistingStoreInterface` instead.
+ * added support for shared locks
 
 5.1.0
 -----

--- a/src/Symfony/Component/Lock/SharedLockInterface.php
+++ b/src/Symfony/Component/Lock/SharedLockInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock;
+
+use Symfony\Component\Lock\Exception\LockAcquiringException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+
+/**
+ * SharedLockInterface defines an interface to manipulate the status of a shared lock.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+interface SharedLockInterface extends LockInterface
+{
+    /**
+     * Acquires the lock for reading. If the lock is acquired by someone else in write mode, the parameter `blocking`
+     * determines whether or not the call should block until the release of the lock.
+     *
+     * @return bool whether or not the lock had been acquired
+     *
+     * @throws LockConflictedException If the lock is acquired by someone else in blocking mode
+     * @throws LockAcquiringException  If the lock can not be acquired
+     */
+    public function acquireRead(bool $blocking = false);
+}

--- a/src/Symfony/Component/Lock/SharedLockStoreInterface.php
+++ b/src/Symfony/Component/Lock/SharedLockStoreInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock;
+
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Exception\NotSupportedException;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+interface SharedLockStoreInterface extends PersistingStoreInterface
+{
+    /**
+     * Stores the resource if it's not locked for reading by someone else.
+     *
+     * @throws NotSupportedException
+     * @throws LockConflictedException
+     */
+    public function saveRead(Key $key);
+
+    /**
+     * Waits until a key becomes free for reading, then stores the resource.
+     *
+     * @throws LockConflictedException
+     */
+    public function waitAndSaveRead(Key $key);
+}

--- a/src/Symfony/Component/Lock/Store/BlockingSharedLockStoreTrait.php
+++ b/src/Symfony/Component/Lock/Store/BlockingSharedLockStoreTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Store;
+
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Key;
+
+trait BlockingSharedLockStoreTrait
+{
+    abstract public function saveRead(Key $key);
+
+    public function waitAndSaveRead(Key $key)
+    {
+        while (true) {
+            try {
+                $this->saveRead($key);
+
+                return;
+            } catch (LockConflictedException $e) {
+                usleep((100 + random_int(-10, 10)) * 1000);
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Lock/Store/RedisStore.php
+++ b/src/Symfony/Component/Lock/Store/RedisStore.php
@@ -11,25 +11,31 @@
 
 namespace Symfony\Component\Lock\Store;
 
+use Predis\Response\ServerException;
 use Symfony\Component\Cache\Traits\RedisClusterProxy;
 use Symfony\Component\Cache\Traits\RedisProxy;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Exception\LockStorageException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\SharedLockStoreInterface;
 
 /**
  * RedisStore is a PersistingStoreInterface implementation using Redis as store engine.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
-class RedisStore implements PersistingStoreInterface
+class RedisStore implements SharedLockStoreInterface
 {
     use ExpiringStoreTrait;
+    use BlockingSharedLockStoreTrait;
 
     private $redis;
     private $initialTtl;
+    private $supportTime;
 
     /**
      * @param \Redis|\RedisArray|\RedisCluster|RedisProxy|RedisClusterProxy|\Predis\ClientInterface $redisClient
@@ -55,17 +61,82 @@ class RedisStore implements PersistingStoreInterface
     public function save(Key $key)
     {
         $script = '
-            if redis.call("GET", KEYS[1]) == ARGV[1] then
-                return redis.call("PEXPIRE", KEYS[1], ARGV[2])
-            elseif redis.call("SET", KEYS[1], ARGV[1], "NX", "PX", ARGV[2]) then
-                return 1
-            else
-                return 0
+            local key = KEYS[1]
+            local uniqueToken = ARGV[2]
+            local ttl = tonumber(ARGV[3])
+
+            -- asserts the KEY is compatible with current version (old Symfony <5.2 BC)
+            if redis.call("TYPE", key).ok == "string" then
+                return false
             end
+
+            '.$this->getNowCode().'
+
+            -- Remove expired values
+            redis.call("ZREMRANGEBYSCORE", key, "-inf", now)
+
+            -- is already acquired
+            if redis.call("ZSCORE", key, uniqueToken) then
+                -- is not WRITE lock and cannot be promoted
+                if not redis.call("ZSCORE", key, "__write__") and redis.call("ZCOUNT", key, "-inf", "+inf") > 1  then
+                    return false
+                end
+            elseif redis.call("ZCOUNT", key, "-inf", "+inf") > 0  then
+                return false
+            end
+
+            redis.call("ZADD", key, now + ttl, uniqueToken)
+            redis.call("ZADD", key, now + ttl, "__write__")
+
+            -- Extend the TTL of the key
+            local maxExpiration = redis.call("ZREVRANGE", key, 0, 0, "WITHSCORES")[2]
+            redis.call("PEXPIREAT", key, maxExpiration)
+
+            return true
         ';
 
         $key->reduceLifetime($this->initialTtl);
-        if (!$this->evaluate($script, (string) $key, [$this->getUniqueToken($key), (int) ceil($this->initialTtl * 1000)])) {
+        if (!$this->evaluate($script, (string) $key, [microtime(true), $this->getUniqueToken($key), (int) ceil($this->initialTtl * 1000)])) {
+            throw new LockConflictedException();
+        }
+
+        $this->checkNotExpired($key);
+    }
+
+    public function saveRead(Key $key)
+    {
+        $script = '
+            local key = KEYS[1]
+            local uniqueToken = ARGV[2]
+            local ttl = tonumber(ARGV[3])
+
+            -- asserts the KEY is compatible with current version (old Symfony <5.2 BC)
+            if redis.call("TYPE", key).ok == "string" then
+                return false
+            end
+
+            '.$this->getNowCode().'
+
+            -- Remove expired values
+            redis.call("ZREMRANGEBYSCORE", key, "-inf", now)
+
+            -- lock not already acquired and a WRITE lock exists?
+            if not redis.call("ZSCORE", key, uniqueToken) and redis.call("ZSCORE", key, "__write__") then
+                return false
+            end
+
+            redis.call("ZADD", key, now + ttl, uniqueToken)
+            redis.call("ZREM", key, "__write__")
+
+            -- Extend the TTL of the key
+            local maxExpiration = redis.call("ZREVRANGE", key, 0, 0, "WITHSCORES")[2]
+            redis.call("PEXPIREAT", key, maxExpiration)
+
+            return true
+        ';
+
+        $key->reduceLifetime($this->initialTtl);
+        if (!$this->evaluate($script, (string) $key, [microtime(true), $this->getUniqueToken($key), (int) ceil($this->initialTtl * 1000)])) {
             throw new LockConflictedException();
         }
 
@@ -78,15 +149,37 @@ class RedisStore implements PersistingStoreInterface
     public function putOffExpiration(Key $key, float $ttl)
     {
         $script = '
-            if redis.call("GET", KEYS[1]) == ARGV[1] then
-                return redis.call("PEXPIRE", KEYS[1], ARGV[2])
-            else
-                return 0
+            local key = KEYS[1]
+            local uniqueToken = ARGV[2]
+            local ttl = tonumber(ARGV[3])
+
+            -- asserts the KEY is compatible with current version (old Symfony <5.2 BC)
+            if redis.call("TYPE", key).ok == "string" then
+                return false
             end
+
+            '.$this->getNowCode().'
+
+            -- lock already acquired acquired?
+            if not redis.call("ZSCORE", key, uniqueToken) then
+                return false
+            end
+
+            redis.call("ZADD", key, now + ttl, uniqueToken)
+            -- if the lock is also a WRITE lock, increase the TTL
+            if redis.call("ZSCORE", key, "__write__") then
+                redis.call("ZADD", key, now + ttl, "__write__")
+            end
+
+            -- Extend the TTL of the key
+            local maxExpiration = redis.call("ZREVRANGE", key, 0, 0, "WITHSCORES")[2]
+            redis.call("PEXPIREAT", key, maxExpiration)
+
+            return true
         ';
 
         $key->reduceLifetime($ttl);
-        if (!$this->evaluate($script, (string) $key, [$this->getUniqueToken($key), (int) ceil($ttl * 1000)])) {
+        if (!$this->evaluate($script, (string) $key, [microtime(true), $this->getUniqueToken($key), (int) ceil($ttl * 1000)])) {
             throw new LockConflictedException();
         }
 
@@ -99,11 +192,28 @@ class RedisStore implements PersistingStoreInterface
     public function delete(Key $key)
     {
         $script = '
-            if redis.call("GET", KEYS[1]) == ARGV[1] then
-                return redis.call("DEL", KEYS[1])
-            else
-                return 0
+            local key = KEYS[1]
+            local uniqueToken = ARGV[1]
+
+            -- asserts the KEY is compatible with current version (old Symfony <5.2 BC)
+            if redis.call("TYPE", key).ok == "string" then
+                return false
             end
+
+            -- lock not already acquired
+            if not redis.call("ZSCORE", key, uniqueToken) then
+                return false
+            end
+
+            redis.call("ZREM", key, uniqueToken)
+            redis.call("ZREM", key, "__write__")
+
+            local maxExpiration = redis.call("ZREVRANGE", key, 0, 0, "WITHSCORES")[2]
+            if nil ~= maxExpiration then
+                redis.call("PEXPIREAT", key, maxExpiration)
+            end
+
+            return true
         ';
 
         $this->evaluate($script, (string) $key, [$this->getUniqueToken($key)]);
@@ -114,7 +224,28 @@ class RedisStore implements PersistingStoreInterface
      */
     public function exists(Key $key)
     {
-        return $this->redis->get((string) $key) === $this->getUniqueToken($key);
+        $script = '
+            local key = KEYS[1]
+            local uniqueToken = ARGV[2]
+
+            -- asserts the KEY is compatible with current version (old Symfony <5.2 BC)
+            if redis.call("TYPE", key).ok == "string" then
+                return false
+            end
+
+            '.$this->getNowCode().'
+
+            -- Remove expired values
+            redis.call("ZREMRANGEBYSCORE", key, "-inf", now)
+
+            if redis.call("ZSCORE", key, uniqueToken) then
+                return true
+            end
+
+            return false
+        ';
+
+        return (bool) $this->evaluate($script, (string) $key, [microtime(true), $this->getUniqueToken($key)]);
     }
 
     /**
@@ -130,15 +261,34 @@ class RedisStore implements PersistingStoreInterface
             $this->redis instanceof RedisProxy ||
             $this->redis instanceof RedisClusterProxy
         ) {
-            return $this->redis->eval($script, array_merge([$resource], $args), 1);
+            $this->redis->clearLastError();
+            $result = $this->redis->eval($script, array_merge([$resource], $args), 1);
+            if (null !== $err = $this->redis->getLastError()) {
+                throw new LockStorageException($err);
+            }
+
+            return $result;
         }
 
         if ($this->redis instanceof \RedisArray) {
+            $client = $this->redis->_instance($this->redis->_target($resource));
+            $client->clearLastError();
+            $result = $client->eval($script, array_merge([$resource], $args), 1);
+            if (null !== $err = $client->getLastError()) {
+                throw new LockStorageException($err);
+            }
+
+            return $result;
+
             return $this->redis->_instance($this->redis->_target($resource))->eval($script, array_merge([$resource], $args), 1);
         }
 
         if ($this->redis instanceof \Predis\ClientInterface) {
-            return $this->redis->eval(...array_merge([$script, 1, $resource], $args));
+            try {
+                return $this->redis->eval(...array_merge([$script, 1, $resource], $args));
+            } catch (ServerException $e) {
+                throw new LockStorageException($e->getMessage(), $e->getCode(), $e);
+            }
         }
 
         throw new InvalidArgumentException(sprintf('"%s()" expects being initialized with a Redis, RedisArray, RedisCluster or Predis\ClientInterface, "%s" given.', __METHOD__, get_debug_type($this->redis)));
@@ -152,5 +302,40 @@ class RedisStore implements PersistingStoreInterface
         }
 
         return $key->getState(__CLASS__);
+    }
+
+    private function getNowCode(): string
+    {
+        if (null === $this->supportTime) {
+            // Redis < 5.0 does not support TIME (not deterministic) in script.
+            // https://redis.io/commands/eval#replicating-commands-instead-of-scripts
+            // This code asserts TIME can be use, otherwise will fallback to a timestamp generated by the PHP process.
+            $script = '
+                local now = redis.call("TIME")
+                redis.call("SET", KEYS[1], "1", "PX", 1)
+
+	            return 1
+            ';
+            try {
+                $this->supportTime = 1 === $this->evaluate($script, 'symfony_check_support_time', []);
+            } catch (LockStorageException $e) {
+                if (false === strpos($e->getMessage(), 'commands not allowed after non deterministic')) {
+                    throw $e;
+                }
+                $this->supportTime = false;
+            }
+        }
+
+        if ($this->supportTime) {
+            return '
+                local now = redis.call("TIME")
+                now = now[1] * 1000 + math.floor(now[2] / 1000)
+            ';
+        }
+
+        return '
+            local now = tonumber(ARGV[1])
+            now = math.floor(now * 1000)
+        ';
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/AbstractRedisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/AbstractRedisStoreTest.php
@@ -11,6 +11,11 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use Symfony\Component\Cache\Traits\RedisClusterProxy;
+use Symfony\Component\Cache\Traits\RedisProxy;
+use Symfony\Component\Lock\Exception\InvalidArgumentException;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\RedisStore;
 
@@ -42,5 +47,84 @@ abstract class AbstractRedisStoreTest extends AbstractStoreTest
     public function getStore(): PersistingStoreInterface
     {
         return new RedisStore($this->getRedisConnection());
+    }
+
+    public function testBackwardCompatibility()
+    {
+        $resource = uniqid(__METHOD__, true);
+        $key1 = new Key($resource);
+        $key2 = new Key($resource);
+
+        $oldStore = new Symfony51Store($this->getRedisConnection());
+        $newStore = $this->getStore();
+
+        $oldStore->save($key1);
+        $this->assertTrue($oldStore->exists($key1));
+
+        $this->expectException(LockConflictedException::class);
+        $newStore->save($key2);
+    }
+}
+
+class Symfony51Store
+{
+    private $redis;
+
+    public function __construct($redis)
+    {
+        $this->redis = $redis;
+    }
+
+    public function save(Key $key)
+    {
+        $script = '
+            if redis.call("GET", KEYS[1]) == ARGV[1] then
+                return redis.call("PEXPIRE", KEYS[1], ARGV[2])
+            elseif redis.call("SET", KEYS[1], ARGV[1], "NX", "PX", ARGV[2]) then
+                return 1
+            else
+                return 0
+            end
+        ';
+        if (!$this->evaluate($script, (string) $key, [$this->getUniqueToken($key), (int) ceil(5 * 1000)])) {
+            throw new LockConflictedException();
+        }
+    }
+
+    public function exists(Key $key)
+    {
+        return $this->redis->get((string) $key) === $this->getUniqueToken($key);
+    }
+
+    private function evaluate(string $script, string $resource, array $args)
+    {
+        if (
+            $this->redis instanceof \Redis ||
+            $this->redis instanceof \RedisCluster ||
+            $this->redis instanceof RedisProxy ||
+            $this->redis instanceof RedisClusterProxy
+        ) {
+            return $this->redis->eval($script, array_merge([$resource], $args), 1);
+        }
+
+        if ($this->redis instanceof \RedisArray) {
+            return $this->redis->_instance($this->redis->_target($resource))->eval($script, array_merge([$resource], $args), 1);
+        }
+
+        if ($this->redis instanceof \Predis\ClientInterface) {
+            return $this->redis->eval(...array_merge([$script, 1, $resource], $args));
+        }
+
+        throw new InvalidArgumentException(sprintf('"%s()" expects being initialized with a Redis, RedisArray, RedisCluster or Predis\ClientInterface, "%s" given.', __METHOD__, get_debug_type($this->redis)));
+    }
+
+    private function getUniqueToken(Key $key): string
+    {
+        if (!$key->hasState(__CLASS__)) {
+            $token = base64_encode(random_bytes(32));
+            $key->setState(__CLASS__, $token);
+        }
+
+        return $key->getState(__CLASS__);
     }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/AbstractStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/AbstractStoreTest.php
@@ -109,4 +109,20 @@ abstract class AbstractStoreTest extends TestCase
 
         $store->delete($key);
     }
+
+    public function testDeleteIsolated()
+    {
+        $store = $this->getStore();
+
+        $key1 = new Key(uniqid(__METHOD__, true));
+        $key2 = new Key(uniqid(__METHOD__, true));
+
+        $store->save($key1);
+        $this->assertTrue($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+
+        $store->delete($key2);
+        $this->assertTrue($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+    }
 }

--- a/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Lock\Store\FlockStore;
 class FlockStoreTest extends AbstractStoreTest
 {
     use BlockingStoreTestTrait;
+    use SharedLockStoreTestTrait;
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
@@ -21,6 +21,8 @@ use Symfony\Component\Lock\Store\RedisStore;
  */
 class RedisStoreTest extends AbstractRedisStoreTest
 {
+    use SharedLockStoreTestTrait;
+
     public static function setUpBeforeClass(): void
     {
         try {

--- a/src/Symfony/Component/Lock/Tests/Store/SharedLockStoreTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/SharedLockStoreTestTrait.php
@@ -1,0 +1,177 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Store;
+
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistingStoreInterface;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+trait SharedLockStoreTestTrait
+{
+    /**
+     * @see AbstractStoreTest::getStore()
+     *
+     * @return PersistingStoreInterface
+     */
+    abstract protected function getStore();
+
+    public function testSharedLockReadFirst()
+    {
+        $store = $this->getStore();
+
+        $resource = uniqid(__METHOD__, true);
+        $key1 = new Key($resource);
+        $key2 = new Key($resource);
+        $key3 = new Key($resource);
+
+        $store->saveRead($key1);
+        $this->assertTrue($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+        $this->assertFalse($store->exists($key3));
+
+        // assert we can store multiple keys in read mode
+        $store->saveRead($key2);
+        $this->assertTrue($store->exists($key1));
+        $this->assertTrue($store->exists($key2));
+        $this->assertFalse($store->exists($key3));
+
+        try {
+            $store->save($key3);
+            $this->fail('The store shouldn\'t save the second key');
+        } catch (LockConflictedException $e) {
+        }
+
+        // The failure of previous attempt should not impact the state of current locks
+        $this->assertTrue($store->exists($key1));
+        $this->assertTrue($store->exists($key2));
+        $this->assertFalse($store->exists($key3));
+
+        $store->delete($key1);
+        $this->assertFalse($store->exists($key1));
+        $this->assertTrue($store->exists($key2));
+        $this->assertFalse($store->exists($key3));
+
+        $store->delete($key2);
+        $this->assertFalse($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+        $this->assertFalse($store->exists($key3));
+
+        $store->save($key3);
+        $this->assertFalse($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+        $this->assertTrue($store->exists($key3));
+
+        $store->delete($key3);
+        $this->assertFalse($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+        $this->assertFalse($store->exists($key3));
+    }
+
+    public function testSharedLockWriteFirst()
+    {
+        $store = $this->getStore();
+
+        $resource = uniqid(__METHOD__, true);
+        $key1 = new Key($resource);
+        $key2 = new Key($resource);
+
+        $store->save($key1);
+        $this->assertTrue($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+
+        try {
+            $store->saveRead($key2);
+            $this->fail('The store shouldn\'t save the second key');
+        } catch (LockConflictedException $e) {
+        }
+
+        // The failure of previous attempt should not impact the state of current locks
+        $this->assertTrue($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+
+        $store->delete($key1);
+        $this->assertFalse($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+
+        $store->save($key2);
+        $this->assertFalse($store->exists($key1));
+        $this->assertTrue($store->exists($key2));
+
+        $store->delete($key2);
+        $this->assertFalse($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+    }
+
+    public function testSharedLockPromote()
+    {
+        $store = $this->getStore();
+
+        $resource = uniqid(__METHOD__, true);
+        $key1 = new Key($resource);
+        $key2 = new Key($resource);
+
+        $store->saveRead($key1);
+        $store->saveRead($key2);
+        $this->assertTrue($store->exists($key1));
+        $this->assertTrue($store->exists($key2));
+
+        try {
+            $store->save($key1);
+            $this->fail('The store shouldn\'t save the second key');
+        } catch (LockConflictedException $e) {
+        }
+    }
+
+    public function testSharedLockPromoteAllowed()
+    {
+        $store = $this->getStore();
+
+        $resource = uniqid(__METHOD__, true);
+        $key1 = new Key($resource);
+        $key2 = new Key($resource);
+
+        $store->saveRead($key1);
+        $store->save($key1);
+
+        try {
+            $store->saveRead($key2);
+            $this->fail('The store shouldn\'t save the second key');
+        } catch (LockConflictedException $e) {
+        }
+        $this->assertTrue($store->exists($key1));
+        $this->assertFalse($store->exists($key2));
+
+        $store->delete($key1);
+        $store->saveRead($key2);
+        $this->assertFalse($store->exists($key1));
+        $this->assertTrue($store->exists($key2));
+    }
+
+    public function testSharedLockDemote()
+    {
+        $store = $this->getStore();
+
+        $resource = uniqid(__METHOD__, true);
+        $key1 = new Key($resource);
+        $key2 = new Key($resource);
+
+        $store->save($key1);
+        $store->saveRead($key1);
+        $store->saveRead($key2);
+
+        $this->assertTrue($store->exists($key1));
+        $this->assertTrue($store->exists($key2));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | TODO

This PR adds a new method "acquireRead" to the Lock class in order to solve the [single writer multiple readers](https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock) problem.

usage:
```php
$aliceLock = $factory->createLock('invoice');
$bobLock = $factory->createLock('invoice');
$oscarLock = $factory->createLock('invoice');

$aliceLock->acquireRead(); // true
$bobLock->acquireRead(); // true
$oscarLock->acquire(); // false
```
## next steps

### add more stores

- pdo
- memcached
- zookeeper
- mongodb

### Priority policies

Priority policy (read-preffering or write preffering) is not covered by this PR.

## Promote/Demote

Converting a Read lock to Write Lock (promote) or Write lock to Read lock (demote) is covered by calling `acquireRead` / `acquired` method. 
```php
// demote
$lock->acquire();
...
$lock->acquireRead(); 

// promote
$lock->acquireRead();
...
$lock->acquire(); 
```