### PR TITLE
[FrameworkBundle] Add days before expiration in "about" command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -66,8 +66,8 @@ EOT
             new TableSeparator(),
             ['Version', Kernel::VERSION],
             ['Long-Term Support', 4 === Kernel::MINOR_VERSION ? 'Yes' : 'No'],
-            ['End of maintenance', Kernel::END_OF_MAINTENANCE.(self::isExpired(Kernel::END_OF_MAINTENANCE) ? ' <error>Expired</>' : '')],
-            ['End of life', Kernel::END_OF_LIFE.(self::isExpired(Kernel::END_OF_LIFE) ? ' <error>Expired</>' : '')],
+            ['End of maintenance', Kernel::END_OF_MAINTENANCE.(self::isExpired(Kernel::END_OF_MAINTENANCE) ? ' <error>Expired</>' : ' (<comment>'.self::daysBeforeExpiration(Kernel::END_OF_MAINTENANCE).'</>)')],
+            ['End of life', Kernel::END_OF_LIFE.(self::isExpired(Kernel::END_OF_LIFE) ? ' <error>Expired</>' : ' (<comment>'.self::daysBeforeExpiration(Kernel::END_OF_LIFE).'</>)')],
             new TableSeparator(),
             ['<info>Kernel</>'],
             new TableSeparator(),
@@ -118,5 +118,12 @@ EOT
         $date = \DateTime::createFromFormat('d/m/Y', '01/'.$date);
 
         return false !== $date && new \DateTime() > $date->modify('last day of this month 23:59:59');
+    }
+
+    private static function daysBeforeExpiration(string $date): string
+    {
+        $date = \DateTime::createFromFormat('d/m/Y', '01/'.$date);
+
+        return (new \DateTime())->diff($date->modify('last day of this month 23:59:59'))->format('in %R%a days');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes (with RFC)
| Deprecations? | no
| Tickets       | Slack discussion + see RFC below 
| License       | MIT
| Doc PR        | 

Maybe this can be usefull in the `bin/console about` output.
Following a small discussion on Slack
<details>
<summary>See discussion </summary>

<img width="910" alt="sf_slack" src="https://user-images.githubusercontent.com/13205768/89516646-029dea00-d7d9-11ea-8ff5-eed5ae72fc77.png">

</details>


---

Symfony 5.1 output:
<img width="681" alt="sf51" src="https://user-images.githubusercontent.com/13205768/89515902-067d3c80-d7d8-11ea-8676-1f90dd0a3418.png">

---

Symfony 5.foo_bar output:
With:
```php
    // symfony/http-kernel/Kernel.php
    const END_OF_MAINTENANCE = '08/2020'; // this month
    const END_OF_LIFE = '09/2020'; // next month
```
<img width="680" alt="sf51_fake" src="https://user-images.githubusercontent.com/13205768/89516056-375d7180-d7d8-11ea-9345-83db200a693d.png">

---

## RFC <a href="#rfc" id="rfc">#</a>

Is there a way in Symfony land packages to have such info or/and in Composer in general? the EOL of a package version.

Like for example the https://github.com/FriendsOfPHP/security-advisories `Security Advisories` feature,
but for `End Of Life Advisories` where packages maintainers can add their packages, and this data can be read by `composer` or an other command

~Or maybe directly inside the `composer.json`, like an `"eol": "true"` // and `false` by default if not defined~ (not possible, see below)

Thanks