### PR TITLE
Fix #37740: Cast all Request parameter values to string

### DIFF
--- a/src/Symfony/Component/BrowserKit/Request.php
+++ b/src/Symfony/Component/BrowserKit/Request.php
@@ -37,6 +37,11 @@ class Request
     {
         $this->uri = $uri;
         $this->method = $method;
+
+        array_walk_recursive($parameters, static function (&$value) {
+            $value = (string) $value;
+        });
+
         $this->parameters = $parameters;
         $this->files = $files;
         $this->cookies = $cookies;

--- a/src/Symfony/Component/BrowserKit/Tests/RequestTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/RequestTest.php
@@ -51,4 +51,24 @@ class RequestTest extends TestCase
         $request = new Request('http://www.example.com/', 'get', [], [], [], ['foo' => 'bar']);
         $this->assertEquals(['foo' => 'bar'], $request->getServer(), '->getServer() returns the server parameters of the request');
     }
+
+    public function testAllParameterValuesAreConvertedToString(): void
+    {
+        $parameters = [
+            'foo' => 1,
+            'bar' => [
+                'baz' => 2,
+            ],
+        ];
+
+        $expected = [
+            'foo' => '1',
+            'bar' => [
+                'baz' => '2',
+            ],
+        ];
+
+        $request = new Request('http://www.example.com/', 'get', $parameters);
+        $this->assertSame($expected, $request->getParameters());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37740| License       | MIT

This fix ensures that all parameter values in Browserkit\Request are received as strings on the receiving end.
