### PR TITLE
[Messenger] - Add option to confirm message delivery in Amqp connection

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
@@ -6,3 +6,8 @@ CHANGELOG
 
  * Introduced the AMQP bridge.
  * Deprecated use of invalid options
+
+5.2.0
+-----
+
+ * Add option to confirm message delivery

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Fixtures/long_receiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Fixtures/long_receiver.php
@@ -13,12 +13,12 @@ if (!file_exists($autoload)) {
 require_once $autoload;
 
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceiver;
+use Symfony\Component\Messenger\Bridge\Amqp\Transport\Connection;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\EventListener\DispatchPcntlSignalListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnSigtermSignalListener;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceiver;
-use Symfony\Component\Messenger\Bridge\Amqp\Transport\Connection;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
 use Symfony\Component\Messenger\Worker;
 use Symfony\Component\Serializer as SerializerComponent;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | -
| License       | MIT
| Doc PR        | -

Hello! My first PR here. 

Sometimes we need to be sure that messages are delivered to Amqp. To make it work we need to wait for the confirmation from the Amqp server. So let's wait for it confirmation if confirmation timeout is defined. Default behaviour are not modified - waiting for confirmation will impact performance of sending message. 