### PR TITLE
make return type correct

### DIFF
--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -148,7 +148,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * Returns an iterator to iterate over children (implements \IteratorAggregate).
      *
-     * @return \ArrayIterator|FormView[] The iterator
+     * @return \ArrayIterator<string, FormView> The iterator
      */
     public function getIterator()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Since the real return type is `\ArrayIterator` AND array of `FormView` I've decided to change it. Also the other reason is that phpstan iks kind of failing because of this and I need to `assert` things in children of this class.
