### PR TITLE
Remove outdated references from base_js.html.twig file

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -1,5 +1,5 @@
-{# This file is partially duplicated in TwigBundle/Resources/views/base_js.html.twig. If you
-   make any change in this file, verify the same change is needed in the other file. #}
+{# This file is partially duplicated in src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js.
+   If you make any change in this file, verify the same change is needed in the other file. #}
 <script{% if csp_script_nonce is defined and csp_script_nonce %} nonce="{{ csp_script_nonce }}"{% endif %}>/*<![CDATA[*/
     {# Caution: the contents of this file are processed by Twig before loading
                 them as JavaScript source code. Always use '/*' comments instead


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  5.1
| Bug fix?      | yes
| New feature?  |no
| Deprecations? | no
| License       | MIT

It looks like TwigBundle/Resources/views/base_js.html.twig file has been removed.
