### PR TITLE
[Voter][RFC] Allow any type for attribute

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php
@@ -49,8 +49,8 @@ abstract class Voter implements VoterInterface
     /**
      * Determines if the attribute and subject are supported by this voter.
      *
-     * @param string $attribute An attribute
-     * @param mixed  $subject   The subject to secure, e.g. an object the user wants to access or any other PHP type
+     * @param mixed $attribute An attribute
+     * @param mixed $subject   The subject to secure, e.g. an object the user wants to access or any other PHP type
      *
      * @return bool True if the attribute and subject are supported, false otherwise
      */
@@ -60,8 +60,8 @@ abstract class Voter implements VoterInterface
      * Perform a single access check operation on a given attribute, subject and token.
      * It is safe to assume that $attribute and $subject already passed the "supports()" method check.
      *
-     * @param string $attribute
-     * @param mixed  $subject
+     * @param mixed $attribute
+     * @param mixed $subject
      *
      * @return bool
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | I'd love 4.4 but I understand this can be considered a feature instead
| Bug fix?      | no
| New feature?  | not necessarily
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

In our app we heavily utilize enums (https://github.com/marc-mabe/php-enum) and that includes attributes we vote on. This is working just fine since forever but sadly PHPStan complains that the attribute should be `string` and any comparisons we make between attribute and enums are "pointless". For a full picture we are not using annotations for requiring roles but rather plain PHP:

```
$this->denyAccessUnlessGranted(PermissionNameEnum::view(), ApplicationFeatureEnum::catalogProduct());
```

Given using objects as attributes works just fine and I wasn't able to find any places that would require `string` explicitly I'd like to ask to widen parameter type for the attribute.


