### PR TITLE
[String] We cannot have a "provides" function in test cases

### DIFF
--- a/src/Symfony/Component/String/Tests/FunctionsTest.php
+++ b/src/Symfony/Component/String/Tests/FunctionsTest.php
@@ -20,14 +20,14 @@ use function Symfony\Component\String\s;
 final class FunctionsTest extends TestCase
 {
     /**
-     * @dataProvider provideS
+     * @dataProvider provideStrings
      */
     public function testS(AbstractString $expected, string $input)
     {
         $this->assertEquals($expected, s($input));
     }
 
-    public function provideS()
+    public function provideStrings(): array
     {
         return [
             [new UnicodeString('foo'), 'foo'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #37564
| License       | MIT
| Doc PR        | N/A

Because of a change in PHPUnit 9.3 (see sebastianbergmann/phpunit#3936), we cannot have define a method named `provides` in test cases. And since php is case-insensitive regarding method calls, the method `provideS` used by the String component's `FunctionTest` will cause a fatal error. I have renamed it to work around that issue.

cc @fancyweb