### PR TITLE
Use PHPUnit 9.3 on php 8

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -12,7 +12,11 @@ if (!getenv('SYMFONY_PHPUNIT_VERSION')) {
         if (false === getenv('SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT') && false !== strpos(@file_get_contents(__DIR__.'/src/Symfony/Component/HttpKernel/Kernel.php'), 'const MAJOR_VERSION = 3;')) {
             putenv('SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT=1');
         }
-        putenv('SYMFONY_PHPUNIT_VERSION=8.3');
+        if (\PHP_VERSION_ID >= 80000) {
+            putenv('SYMFONY_PHPUNIT_VERSION=9.3');
+        } else {
+            putenv('SYMFONY_PHPUNIT_VERSION=8.3');
+        }
     } elseif (\PHP_VERSION_ID >= 70000) {
         putenv('SYMFONY_PHPUNIT_VERSION=6.5');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #37564
| License       | MIT
| Doc PR        | N/A

Our CI for PHP 8 is currently a blind spot, mainly because the PHPUnit version 8.3 that we use for the test suite is incompatible with php 8. This PR changes the PHPUnit version used on Travis for php 8 to PHPUnit 9.3.

Our test suite might not be 100% compatible with that new PHPUnit release yet, but this change should allow us to run most tests on php 8 again and enable us to iteratively migrate to PHPUnit 9.3.