### PR TITLE
[Console] Make sure we pass a numeric array of arguments to call_user_func_array()

### DIFF
--- a/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/TextDescriptor.php
@@ -204,7 +204,7 @@ class TextDescriptor extends Descriptor
             // calculate max. width based on available commands per namespace
             $width = $this->getColumnWidth(\call_user_func_array('array_merge', array_map(function ($namespace) use ($commands) {
                 return array_intersect($namespace['commands'], array_keys($commands));
-            }, $namespaces)));
+            }, array_values($namespaces))));
 
             if ($describedNamespace) {
                 $this->writeText(sprintf('<comment>Available commands for the "%s" namespace:</comment>', $describedNamespace), $options);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

On php 8, the unit tests fail with the following error:

```
ArgumentCountError: array_merge() does not accept unknown named parameters
```

This PR should fix the issue.