### PR TITLE
Fix for: Third argument in addResource can not be null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ composer.phar
 package.tar
 /packages.json
 /.phpunit
+.idea/symfony.iml
+.idea/misc.xml
+.idea/modules.xml

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -145,6 +145,8 @@ class Translator extends BaseTranslator implements WarmableInterface
         }
         foreach ($this->resources as $key => $params) {
             list($format, $resource, $locale, $domain) = $params;
+            if($locale==null)
+                $locale="";
             parent::addResource($format, $resource, $locale, $domain);
         }
         $this->resources = [];


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | yes
| Tickets       |
| License       | MIT
| Doc PR        | 

Deprecation message:

Passing "null" to the third argument of the "Symfony\Component\Translation\Translator::addResource" method has been deprecated since Symfony 4.4 and will throw an error in 5.0.


