### PR TITLE
[PhpUnitBridge] Fix assertDoesNotMatchRegularExpression() polyfill

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/PolyfillAssertTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/PolyfillAssertTrait.php
@@ -553,6 +553,6 @@ trait PolyfillAssertTrait
      */
     public static function assertDoesNotMatchRegularExpression($pattern, $string, $message = '')
     {
-        static::assertNotRegExp($message, $string, $message);
+        static::assertNotRegExp($pattern, $string, $message);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The `assertDoesNotMatchRegularExpression()` polyfill currently does not work because the `$pattern` argument is not passed down correctly.