### PR TITLE
The PHPUnit\Util\XML class has been removed in PHPUnit 9.3

### DIFF
--- a/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Resources;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Util\Xml\Loader;
 
 class TranslationFilesTest extends TestCase
 {
@@ -20,7 +21,11 @@ class TranslationFilesTest extends TestCase
      */
     public function testTranslationFileIsValid($filePath)
     {
-        \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
+        $loader = class_exists(Loader::class)
+            ? [new Loader(), 'loadFile']
+            : 'PHPUnit\Util\XML::loadfile';
+
+        $loader($filePath, false, false, true);
 
         $this->addToAssertionCount(1);
     }

--- a/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Resources;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Util\Xml\Loader;
 
 class TranslationFilesTest extends TestCase
 {
@@ -20,7 +21,11 @@ class TranslationFilesTest extends TestCase
      */
     public function testTranslationFileIsValid($filePath)
     {
-        \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
+        $loader = class_exists(Loader::class)
+            ? [new Loader(), 'loadFile']
+            : 'PHPUnit\Util\XML::loadfile';
+
+        $loader($filePath, false, false, true);
 
         $this->addToAssertionCount(1);
     }

--- a/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Resources;
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Util\Xml\Loader;
 
 class TranslationFilesTest extends TestCase
 {
@@ -20,7 +21,11 @@ class TranslationFilesTest extends TestCase
      */
     public function testTranslationFileIsValid($filePath)
     {
-        \PHPUnit\Util\XML::loadfile($filePath, false, false, true);
+        $loader = class_exists(Loader::class)
+            ? [new Loader(), 'loadFile']
+            : 'PHPUnit\Util\XML::loadfile';
+
+        $loader($filePath, false, false, true);
 
         $this->addToAssertionCount(1);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #37564
| License       | MIT
| Doc PR        | N/A

`PHPUnit\Util\XML`, an internal PHPUnit class, is used in a couple of tests. Those tests fail on PHPUnit 9.3 because that class has been removed. This PR fixes those tests by using the new class if it's available.

If this is too much C&P, we could consider having PhpUnitBridge polyfill this call.