### PR TITLE
[Console] The message of "class not found" errors has changed in php 8

### DIFF
--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1367,8 +1367,8 @@ class ApplicationTest extends TestCase
         $application->setCatchExceptions(false);
         $application->setDispatcher(new EventDispatcher());
 
-        $application->register('dym')->setCode(function (InputInterface $input, OutputInterface $output) {
-            new \UnknownClass();
+        $application->register('dym')->setCode(function () {
+            throw new \Error('Something went wrong.');
         });
 
         $tester = new ApplicationTester($application);
@@ -1377,7 +1377,7 @@ class ApplicationTest extends TestCase
             $tester->run(['command' => 'dym']);
             $this->fail('->run() should rethrow PHP errors if not handled via ConsoleErrorEvent.');
         } catch (\Error $e) {
-            $this->assertSame($e->getMessage(), 'Class \'UnknownClass\' not found');
+            $this->assertSame('Something went wrong.', $e->getMessage());
         }
     }
 
@@ -1702,8 +1702,8 @@ class ApplicationTest extends TestCase
         $application->setAutoExit(false);
         $application->setDispatcher(new EventDispatcher());
 
-        $application->register('dym')->setCode(function (InputInterface $input, OutputInterface $output) {
-            new \UnknownClass();
+        $application->register('dym')->setCode(function () {
+            throw new \Error('Something went wrong.');
         });
 
         $tester = new ApplicationTester($application);
@@ -1712,7 +1712,7 @@ class ApplicationTest extends TestCase
             $tester->run(['command' => 'dym']);
             $this->fail('->run() should rethrow PHP errors if not handled via ConsoleErrorEvent.');
         } catch (\Error $e) {
-            $this->assertSame($e->getMessage(), 'Class \'UnknownClass\' not found');
+            $this->assertSame('Something went wrong.', $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The error message that php emits if an unknown class is accessed has changed in php 8. Two tests were failing because of this. But since those tests weren't really about missing classes, I tried to find a more resilient way to implement them.