### PR TITLE
[ClassLoader][Routing] Fix namespace parsing on php 8

### DIFF
--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -216,6 +216,11 @@ REGEX;
         $inNamespace = false;
         $tokens = token_get_all($source);
 
+        $nsTokens = [T_WHITESPACE => true, T_NS_SEPARATOR => true, T_STRING => true];
+        if (\defined('T_NAME_QUALIFIED')) {
+            $nsTokens[T_NAME_QUALIFIED] = true;
+        }
+
         for ($i = 0; isset($tokens[$i]); ++$i) {
             $token = $tokens[$i];
             if (!isset($token[1]) || 'b"' === $token) {
@@ -230,7 +235,7 @@ REGEX;
                 $rawChunk .= $token[1];
 
                 // namespace name and whitespaces
-                while (isset($tokens[++$i][1]) && \in_array($tokens[$i][0], [T_WHITESPACE, T_NS_SEPARATOR, T_STRING])) {
+                while (isset($tokens[++$i][1], $nsTokens[$tokens[$i][0]])) {
                     $rawChunk .= $tokens[$i][1];
                 }
                 if ('{' === $tokens[$i]) {

--- a/src/Symfony/Component/ClassLoader/ClassMapGenerator.php
+++ b/src/Symfony/Component/ClassLoader/ClassMapGenerator.php
@@ -93,6 +93,11 @@ class ClassMapGenerator
         $contents = file_get_contents($path);
         $tokens = token_get_all($contents);
 
+        $nsTokens = [T_STRING => true, T_NS_SEPARATOR => true];
+        if (\defined('T_NAME_QUALIFIED')) {
+            $nsTokens[T_NAME_QUALIFIED] = true;
+        }
+
         $classes = [];
 
         $namespace = '';
@@ -110,7 +115,7 @@ class ClassMapGenerator
                     $namespace = '';
                     // If there is a namespace, extract it
                     while (isset($tokens[++$i][1])) {
-                        if (\in_array($tokens[$i][0], [T_STRING, T_NS_SEPARATOR])) {
+                        if (isset($nsTokens[$tokens[$i][0]])) {
                             $namespace .= $tokens[$i][1];
                         }
                     }

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -97,6 +97,11 @@ class AnnotationFileLoader extends FileLoader
             throw new \InvalidArgumentException(sprintf('The file "%s" does not contain PHP code. Did you forgot to add the "<?php" start tag at the beginning of the file?', $file));
         }
 
+        $nsTokens = [T_NS_SEPARATOR => true, T_STRING => true];
+        if (\defined('T_NAME_QUALIFIED')) {
+            $nsTokens[T_NAME_QUALIFIED] = true;
+        }
+
         for ($i = 0; isset($tokens[$i]); ++$i) {
             $token = $tokens[$i];
 
@@ -108,9 +113,9 @@ class AnnotationFileLoader extends FileLoader
                 return $namespace.'\\'.$token[1];
             }
 
-            if (true === $namespace && T_STRING === $token[0]) {
+            if (true === $namespace && isset($nsTokens[$token[0]])) {
                 $namespace = $token[1];
-                while (isset($tokens[++$i][1]) && \in_array($tokens[$i][0], [T_NS_SEPARATOR, T_STRING])) {
+                while (isset($tokens[++$i][1], $nsTokens[$tokens[$i][0]])) {
                     $namespace .= $tokens[$i][1];
                 }
                 $token = $tokens[$i];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The way namespace declarations are parsed has changed in php 8 (see php/php-src#5827). This PR should fix the corresponding issues in the ClassLoader and Routing components.

Note that Doctrine Annotations suffers from the same issue (doctrine/annotations#339). I had to run the Routing tests locally with doctrine/annotations#344 applied.