### PR TITLE
[Validator] Allow a backslash in URL query string

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -35,7 +35,7 @@ class UrlValidator extends ConstraintValidator
             )
             (:[0-9]+)?                              # a port (optional)
             (?:/ (?:[\pL\pN\-._\~!$&\'()*+,;=:@]|%%[0-9A-Fa-f]{2})* )*      # a path
-            (?:\? (?:[\pL\pN\-._\~!$&\'()*+,;=:@/?]|%%[0-9A-Fa-f]{2})* )?   # a query (optional)
+            (?:\? (?:[\pL\pN\-._\~!$&\'()*+,;\\\=:@/?]|%%[0-9A-Fa-f]{2})* )?   # a query (optional)
             (?:\# (?:[\pL\pN\-._\~!$&\'()*+,;=:@/?]|%%[0-9A-Fa-f]{2})* )?   # a fragment (optional)
         $~ixu';
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -127,6 +127,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             ['http://symfony.com?'],
             ['http://symfony.com?query=1'],
             ['http://symfony.com/?query=1'],
+            ['http://symfony.com/?query=withslash\\'],
             ['http://symfony.com#'],
             ['http://symfony.com#fragment'],
             ['http://symfony.com/#fragment'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The format of query string isn't subject to any standard that I can find, but backslash `\` isn't a reserved character in URLs and seems to be valid and working in my limited tests.