### PR TITLE
[Console] Display errors even when --quiet is present

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -64,7 +64,8 @@ class SymfonyStyle extends OutputStyle
         $messages = \is_array($messages) ? array_values($messages) : [$messages];
 
         $this->autoPrependBlock();
-        $this->writeln($this->createBlock($messages, $type, $style, $prefix, $padding, $escape));
+        $this->writeln($this->createBlock($messages, $type, $style, $prefix, $padding, $escape),
+            self::OUTPUT_NORMAL|($type == 'ERROR' ? self::VERBOSITY_QUIET : 0));
         $this->newLine();
     }
 

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -65,7 +65,7 @@ class SymfonyStyle extends OutputStyle
 
         $this->autoPrependBlock();
         $this->writeln($this->createBlock($messages, $type, $style, $prefix, $padding, $escape),
-            self::OUTPUT_NORMAL|($type == 'ERROR' ? self::VERBOSITY_QUIET : 0));
+            self::OUTPUT_NORMAL | ('ERROR' == $type ? self::VERBOSITY_QUIET : 0));
         $this->newLine();
     }
 

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -127,9 +127,8 @@ class SymfonyStyleTest extends TestCase
             ->method('writeln')
             ->with(
                 $this->anything(),
-                $this->callback(function($type)
-                {
-                    return (($type & OutputInterface::VERBOSITY_QUIET) == OutputInterface::VERBOSITY_QUIET) ? true:false;
+                $this->callback(function ($type) {
+                    return (OutputInterface::VERBOSITY_QUIET == ($type & OutputInterface::VERBOSITY_QUIET)) ? true : false;
                 }
             ));
         $style = new SymfonyStyle($this->getMockBuilder(InputInterface::class)->getMock(), $output);

--- a/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Style/SymfonyStyleTest.php
@@ -115,4 +115,24 @@ class SymfonyStyleTest extends TestCase
 
         $this->assertInstanceOf(SymfonyStyle::class, $style->getErrorStyle());
     }
+
+    public function testPrintErrorIfWeRunInQuietMode()
+    {
+        $output = $this->getMockBuilder(OutputInterface::class)->getMock();
+        $output
+            ->method('getFormatter')
+            ->willReturn(new OutputFormatter());
+        $output
+            ->expects($this->once())
+            ->method('writeln')
+            ->with(
+                $this->anything(),
+                $this->callback(function($type)
+                {
+                    return (($type & OutputInterface::VERBOSITY_QUIET) == OutputInterface::VERBOSITY_QUIET) ? true:false;
+                }
+            ));
+        $style = new SymfonyStyle($this->getMockBuilder(InputInterface::class)->getMock(), $output);
+        $style->error('test');
+    }
 }


### PR DESCRIPTION
When using SymfonyStyle::error the message should be printed even when
the --quiet option is used.

| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |  Error messages should always be visible. The changes fix this problem at the first point where verbosity can be changed.