### PR TITLE
stop using the deprecated at() PHPUnit matcher

### DIFF
--- a/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Handler/ConsoleHandlerTest.php
@@ -112,14 +112,12 @@ class ConsoleHandlerTest extends TestCase
     {
         $output = $this->getMockBuilder('Symfony\Component\Console\Output\OutputInterface')->getMock();
         $output
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('getVerbosity')
-            ->willReturn(OutputInterface::VERBOSITY_QUIET)
-        ;
-        $output
-            ->expects($this->at(1))
-            ->method('getVerbosity')
-            ->willReturn(OutputInterface::VERBOSITY_DEBUG)
+            ->willReturnOnConsecutiveCalls(
+                OutputInterface::VERBOSITY_QUIET,
+                OutputInterface::VERBOSITY_DEBUG
+            )
         ;
         $handler = new ConsoleHandler($output);
         $this->assertFalse($handler->isHandling(['level' => Logger::NOTICE]),

--- a/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
@@ -57,17 +57,21 @@ class StopwatchExtensionTest extends TestCase
         $events = \is_array($events) ? $events : [$events];
         $stopwatch = $this->getMockBuilder('Symfony\Component\Stopwatch\Stopwatch')->getMock();
 
-        $i = -1;
+        $expectedCalls = 0;
+        $expectedStartCalls = [];
+        $expectedStopCalls = [];
         foreach ($events as $eventName) {
-            $stopwatch->expects($this->at(++$i))
-                ->method('start')
-                ->with($this->equalTo($eventName), 'template')
-            ;
-            $stopwatch->expects($this->at(++$i))
-                ->method('stop')
-                ->with($this->equalTo($eventName))
-            ;
+            ++$expectedCalls;
+            $expectedStartCalls[] = [$this->equalTo($eventName), 'template'];
+            $expectedStopCalls[] = [$this->equalTo($eventName)];
         }
+
+        $startInvocationMocker = $stopwatch->expects($this->exactly($expectedCalls))
+            ->method('start');
+        \call_user_func_array([$startInvocationMocker, 'withConsecutive'], $expectedStartCalls);
+        $stopInvocationMocker = $stopwatch->expects($this->exactly($expectedCalls))
+            ->method('stop');
+        \call_user_func_array([$stopInvocationMocker, 'withConsecutive'], $expectedStopCalls);
 
         return $stopwatch;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Controller;
 use Symfony\Bundle\FrameworkBundle\Controller\TemplateController;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -48,10 +49,8 @@ class TemplateControllerTest extends TestCase
         $twig = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
         $twig->expects($this->once())->method('render')->willReturn('bar');
 
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $container->expects($this->at(0))->method('has')->willReturn(false);
-        $container->expects($this->at(1))->method('has')->willReturn(true);
-        $container->expects($this->at(2))->method('get')->willReturn($twig);
+        $container = new ContainerBuilder();
+        $container->set('twig', $twig);
 
         $controller = new TemplateController();
         $controller->setContainer($container);
@@ -67,9 +66,8 @@ class TemplateControllerTest extends TestCase
         $templating = $this->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface')->getMock();
         $templating->expects($this->once())->method('render')->willReturn('bar');
 
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
-        $container->expects($this->at(0))->method('has')->willReturn(true);
-        $container->expects($this->at(1))->method('get')->willReturn($templating);
+        $container = new ContainerBuilder();
+        $container->set('templating', $templating);
 
         $controller = new TemplateController();
         $controller->setContainer($container);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/DelegatingEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/DelegatingEngineTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Templating;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Response;
 
 class DelegatingEngineTest extends TestCase
@@ -108,14 +109,10 @@ class DelegatingEngineTest extends TestCase
 
     private function getContainerMock($services)
     {
-        $container = $this->getMockBuilder('Symfony\Component\DependencyInjection\ContainerInterface')->getMock();
+        $container = new ContainerBuilder();
 
-        $i = 0;
         foreach ($services as $id => $service) {
-            $container->expects($this->at($i++))
-                ->method('get')
-                ->with($id)
-                ->willReturn($service);
+            $container->set($id, $service);
         }
 
         return $container;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -297,17 +297,18 @@ class TranslatorTest extends TestCase
 
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\LoaderInterface')->getMock();
 
-        $loader->expects($this->at(0))
+        $loader->expects($this->exactly(2))
             ->method('load')
-            /* The "messages.some_locale.loader" is passed via the resource_file option and shall be loaded first */
-            ->with('messages.some_locale.loader', 'some_locale', 'messages')
-            ->willReturn($someCatalogue);
-
-        $loader->expects($this->at(1))
-            ->method('load')
-            /* This resource is added by an addResource() call and shall be loaded after the resource_files */
-            ->with('second_resource.some_locale.loader', 'some_locale', 'messages')
-            ->willReturn($someCatalogue);
+            ->withConsecutive(
+                /* The "messages.some_locale.loader" is passed via the resource_file option and shall be loaded first */
+                ['messages.some_locale.loader', 'some_locale', 'messages'],
+                /* This resource is added by an addResource() call and shall be loaded after the resource_files */
+                ['second_resource.some_locale.loader', 'some_locale', 'messages']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $someCatalogue,
+                $someCatalogue
+            );
 
         $options = [
             'resource_files' => ['some_locale' => ['messages.some_locale.loader']],
@@ -352,55 +353,33 @@ class TranslatorTest extends TestCase
     {
         $loader = $this->getMockBuilder('Symfony\Component\Translation\Loader\LoaderInterface')->getMock();
         $loader
-            ->expects($this->at(0))
+            ->expects($this->exactly(7))
             ->method('load')
-            ->willReturn($this->getCatalogue('fr', [
-                'foo' => 'foo (FR)',
-            ]))
-        ;
-        $loader
-            ->expects($this->at(1))
-            ->method('load')
-            ->willReturn($this->getCatalogue('en', [
-                'foo' => 'foo (EN)',
-                'bar' => 'bar (EN)',
-                'choice' => '{0} choice 0 (EN)|{1} choice 1 (EN)|]1,Inf] choice inf (EN)',
-            ]))
-        ;
-        $loader
-            ->expects($this->at(2))
-            ->method('load')
-            ->willReturn($this->getCatalogue('es', [
-                'foobar' => 'foobar (ES)',
-            ]))
-        ;
-        $loader
-            ->expects($this->at(3))
-            ->method('load')
-            ->willReturn($this->getCatalogue('pt-PT', [
-                'foobarfoo' => 'foobarfoo (PT-PT)',
-            ]))
-        ;
-        $loader
-            ->expects($this->at(4))
-            ->method('load')
-            ->willReturn($this->getCatalogue('pt_BR', [
-                'other choice' => '{0} other choice 0 (PT-BR)|{1} other choice 1 (PT-BR)|]1,Inf] other choice inf (PT-BR)',
-            ]))
-        ;
-        $loader
-            ->expects($this->at(5))
-            ->method('load')
-            ->willReturn($this->getCatalogue('fr.UTF-8', [
-                'foobarbaz' => 'foobarbaz (fr.UTF-8)',
-            ]))
-        ;
-        $loader
-            ->expects($this->at(6))
-            ->method('load')
-            ->willReturn($this->getCatalogue('sr@latin', [
-                'foobarbax' => 'foobarbax (sr@latin)',
-            ]))
+            ->willReturnOnConsecutiveCalls(
+                $this->getCatalogue('fr', [
+                    'foo' => 'foo (FR)',
+                ]),
+                $this->getCatalogue('en', [
+                    'foo' => 'foo (EN)',
+                    'bar' => 'bar (EN)',
+                    'choice' => '{0} choice 0 (EN)|{1} choice 1 (EN)|]1,Inf] choice inf (EN)',
+                ]),
+                $this->getCatalogue('es', [
+                    'foobar' => 'foobar (ES)',
+                ]),
+                $this->getCatalogue('pt-PT', [
+                    'foobarfoo' => 'foobarfoo (PT-PT)',
+                ]),
+                $this->getCatalogue('pt_BR', [
+                    'other choice' => '{0} other choice 0 (PT-BR)|{1} other choice 1 (PT-BR)|]1,Inf] other choice inf (PT-BR)',
+                ]),
+                $this->getCatalogue('fr.UTF-8', [
+                    'foobarbaz' => 'foobarbaz (fr.UTF-8)',
+                ]),
+                $this->getCatalogue('sr@latin', [
+                    'foobarbax' => 'foobarbax (sr@latin)',
+                ])
+            )
         ;
 
         return $loader;

--- a/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Debug/TraceableEventDispatcherTest.php
@@ -174,8 +174,12 @@ class TraceableEventDispatcherTest extends TestCase
         $tdispatcher->addListener('foo', $listener1 = function () {});
         $tdispatcher->addListener('foo', $listener2 = function () {});
 
-        $logger->expects($this->at(0))->method('debug')->with('Notified event "{event}" to listener "{listener}".', ['event' => 'foo', 'listener' => 'closure']);
-        $logger->expects($this->at(1))->method('debug')->with('Notified event "{event}" to listener "{listener}".', ['event' => 'foo', 'listener' => 'closure']);
+        $logger->expects($this->exactly(2))
+            ->method('debug')
+            ->withConsecutive(
+                ['Notified event "{event}" to listener "{listener}".', ['event' => 'foo', 'listener' => 'closure']],
+                ['Notified event "{event}" to listener "{listener}".', ['event' => 'foo', 'listener' => 'closure']]
+            );
 
         $tdispatcher->dispatch('foo');
     }
@@ -189,9 +193,13 @@ class TraceableEventDispatcherTest extends TestCase
         $tdispatcher->addListener('foo', $listener1 = function (Event $event) { $event->stopPropagation(); });
         $tdispatcher->addListener('foo', $listener2 = function () {});
 
-        $logger->expects($this->at(0))->method('debug')->with('Notified event "{event}" to listener "{listener}".', ['event' => 'foo', 'listener' => 'closure']);
-        $logger->expects($this->at(1))->method('debug')->with('Listener "{listener}" stopped propagation of the event "{event}".', ['event' => 'foo', 'listener' => 'closure']);
-        $logger->expects($this->at(2))->method('debug')->with('Listener "{listener}" was not called for event "{event}".', ['event' => 'foo', 'listener' => 'closure']);
+        $logger->expects($this->exactly(3))
+            ->method('debug')
+            ->withConsecutive(
+                ['Notified event "{event}" to listener "{listener}".', ['event' => 'foo', 'listener' => 'closure']],
+                ['Listener "{listener}" stopped propagation of the event "{event}".', ['event' => 'foo', 'listener' => 'closure']],
+                ['Listener "{listener}" was not called for event "{event}".', ['event' => 'foo', 'listener' => 'closure']]
+            );
 
         $tdispatcher->dispatch('foo');
     }

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/CachingFactoryDecoratorTest.php
@@ -74,14 +74,13 @@ class CachingFactoryDecoratorTest extends TestCase
         $list1 = new ArrayChoiceList([]);
         $list2 = new ArrayChoiceList([]);
 
-        $this->decoratedFactory->expects($this->at(0))
+        $this->decoratedFactory->expects($this->exactly(2))
             ->method('createListFromChoices')
-            ->with($choices1)
-            ->willReturn($list1);
-        $this->decoratedFactory->expects($this->at(1))
-            ->method('createListFromChoices')
-            ->with($choices2)
-            ->willReturn($list2);
+            ->withConsecutive(
+                [$choices1],
+                [$choices2]
+            )
+            ->willReturnOnConsecutiveCalls($list1, $list2);
 
         $this->assertSame($list1, $this->factory->createListFromChoices($choices1));
         $this->assertSame($list2, $this->factory->createListFromChoices($choices2));
@@ -115,14 +114,13 @@ class CachingFactoryDecoratorTest extends TestCase
         $list1 = new ArrayChoiceList([]);
         $list2 = new ArrayChoiceList([]);
 
-        $this->decoratedFactory->expects($this->at(0))
+        $this->decoratedFactory->expects($this->exactly(2))
             ->method('createListFromChoices')
-            ->with($choices1)
-            ->willReturn($list1);
-        $this->decoratedFactory->expects($this->at(1))
-            ->method('createListFromChoices')
-            ->with($choices2)
-            ->willReturn($list2);
+            ->withConsecutive(
+                [$choices1],
+                [$choices2]
+            )
+            ->willReturnOnConsecutiveCalls($list1, $list2);
 
         $this->assertSame($list1, $this->factory->createListFromChoices($choices1));
         $this->assertSame($list2, $this->factory->createListFromChoices($choices2));
@@ -151,14 +149,13 @@ class CachingFactoryDecoratorTest extends TestCase
         $closure1 = function () {};
         $closure2 = function () {};
 
-        $this->decoratedFactory->expects($this->at(0))
+        $this->decoratedFactory->expects($this->exactly(2))
             ->method('createListFromChoices')
-            ->with($choices, $closure1)
-            ->willReturn($list1);
-        $this->decoratedFactory->expects($this->at(1))
-            ->method('createListFromChoices')
-            ->with($choices, $closure2)
-            ->willReturn($list2);
+            ->withConsecutive(
+                [$choices, $closure1],
+                [$choices, $closure2]
+            )
+            ->willReturnOnConsecutiveCalls($list1, $list2);
 
         $this->assertSame($list1, $this->factory->createListFromChoices($choices, $closure1));
         $this->assertSame($list2, $this->factory->createListFromChoices($choices, $closure2));
@@ -185,14 +182,13 @@ class CachingFactoryDecoratorTest extends TestCase
         $list1 = new ArrayChoiceList([]);
         $list2 = new ArrayChoiceList([]);
 
-        $this->decoratedFactory->expects($this->at(0))
+        $this->decoratedFactory->expects($this->exactly(2))
             ->method('createListFromLoader')
-            ->with($loader1)
-            ->willReturn($list1);
-        $this->decoratedFactory->expects($this->at(1))
-            ->method('createListFromLoader')
-            ->with($loader2)
-            ->willReturn($list2);
+            ->withConsecutive(
+                [$loader1],
+                [$loader2]
+            )
+            ->willReturnOnConsecutiveCalls($list1, $list2);
 
         $this->assertSame($list1, $this->factory->createListFromLoader($loader1));
         $this->assertSame($list2, $this->factory->createListFromLoader($loader2));
@@ -221,14 +217,13 @@ class CachingFactoryDecoratorTest extends TestCase
         $closure1 = function () {};
         $closure2 = function () {};
 
-        $this->decoratedFactory->expects($this->at(0))
+        $this->decoratedFactory->expects($this->exactly(2))
             ->method('createListFromLoader')
-            ->with($loader, $closure1)
-            ->willReturn($list1);
-        $this->decoratedFactory->expects($this->at(1))
-            ->method('createListFromLoader')
-            ->with($loader, $closure2)
-            ->willReturn($list2);
+            ->withConsecutive(
+                [$loader, $closure1],
+                [$loader, $closure2]
+            )
+            ->willReturnOnConsecutiveCalls($list1, $list2);
 
         $this->assertSame($list1, $this->factory->createListFromLoader($loader, $closure1));
         $this->assertSame($list2, $this->factory->createListFromLoader($loader, $closure2));
@@ -257,14 +252,13 @@ class CachingFactoryDecoratorTest extends TestCase
         $view1 = new ChoiceListView();
         $view2 = new ChoiceListView();
 
-        $this->decoratedFactory->expects($this->at(0))
+        $this->decoratedFactory->expects($this->exactly(2))
             ->method('createView')
-            ->with($list, $preferred1)
-            ->willReturn($view1);
-        $this->decoratedFactory->expects($this->at(1))
-            ->method('createView')
-            ->with($list, $preferred2)
-            ->willReturn($view2);
+            ->withConsecutive(
+                [$list, $preferred1],
+                [$list, $preferred2]
+            )
+            ->willReturnOnConsecutiveCalls($view1, $view2);
 
         $this->assertSame($view1, $this->factory->createView($list, $preferred1));
         $this->assertSame($view2, $this->factory->createView($list, $preferred2));
@@ -293,14 +287,13 @@ class CachingFactoryDecoratorTest extends TestCase
         $view1 = new ChoiceListView();
         $view2 = new ChoiceListView();
 
-        $this->decoratedFactory->expects($this->at(0))
+        $this->decoratedFactory->expects($this->exactly(2))
             ->method('createView')
-            ->with($list, $preferred1)
-            ->willReturn($view1);
-        $this->decoratedFactory->expects($this->at(1))
-            ->method('createView')
-            ->with($list, $preferred2)
-            ->willReturn($view2);
+            ->withConsecutive(
+                [$list, $preferred1],
+                [$list, $preferred2]
+            )
+            ->willReturnOnConsecutiveCalls($view1, $view2);
 
         $this->assertSame($view1, $this->factory->createView($list, $preferred1));
         $this->assertSame($view2, $this->factory->createView($list, $preferred2));
@@ -329,14 +322,13 @@ class CachingFactoryDecoratorTest extends TestCase
         $view1 = new ChoiceListView();
         $view2 = new ChoiceListView();
 
-        $this->decoratedFactory->expects($this->at(0))
+        $this->decoratedFactory->expects($this->exactly(2))
             ->method('createView')
-            ->with($list, null, $labels1)
-            ->willReturn($view1);
-        $this->decoratedFactory->expects($this->at(1))
-            ->method('createView')
-            ->with($list, null, $labels2)
-            ->willReturn($view2);
+            ->withConsecutive(
+                [$list, null, $labels1],
+                [$list, null, $labels2]
+            )
+            ->willReturnOnConsecutiveCalls($view1, $view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, $labels1));
         $this->assertSame($view2, $this->factory->createView($list, null, $labels2));
@@ -365,14 +357,13 @@ class CachingFactoryDecoratorTest extends TestCase
         $view1 = new ChoiceListView();
         $view2 = new ChoiceListView();
 
-        $this->decoratedFactory->expects($this->at(0))
+        $this->decoratedFactory->expects($this->exactly(2))
             ->method('createView')
-            ->with($list, null, null, $index1)
-            ->willReturn($view1);
-        $this->decoratedFactory->expects($this->at(1))
-            ->method('createView')
-            ->with($list, null, null, $index2)
-            ->willReturn($view2);
+            ->withConsecutive(
+                [$list, null, null, $index1],
+                [$list, null, null, $index2]
+            )
+            ->willReturnOnConsecutiveCalls($view1, $view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, null, $index1));
         $this->assertSame($view2, $this->factory->createView($list, null, null, $index2));
@@ -401,14 +392,13 @@ class CachingFactoryDecoratorTest extends TestCase
         $view1 = new ChoiceListView();
         $view2 = new ChoiceListView();
 
-        $this->decoratedFactory->expects($this->at(0))
+        $this->decoratedFactory->expects($this->exactly(2))
             ->method('createView')
-            ->with($list, null, null, null, $groupBy1)
-            ->willReturn($view1);
-        $this->decoratedFactory->expects($this->at(1))
-            ->method('createView')
-            ->with($list, null, null, null, $groupBy2)
-            ->willReturn($view2);
+            ->withConsecutive(
+                [$list, null, null, null, $groupBy1],
+                [$list, null, null, null, $groupBy2]
+            )
+            ->willReturnOnConsecutiveCalls($view1, $view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, null, null, $groupBy1));
         $this->assertSame($view2, $this->factory->createView($list, null, null, null, $groupBy2));
@@ -437,14 +427,13 @@ class CachingFactoryDecoratorTest extends TestCase
         $view1 = new ChoiceListView();
         $view2 = new ChoiceListView();
 
-        $this->decoratedFactory->expects($this->at(0))
+        $this->decoratedFactory->expects($this->exactly(2))
             ->method('createView')
-            ->with($list, null, null, null, null, $attr1)
-            ->willReturn($view1);
-        $this->decoratedFactory->expects($this->at(1))
-            ->method('createView')
-            ->with($list, null, null, null, null, $attr2)
-            ->willReturn($view2);
+            ->withConsecutive(
+                [$list, null, null, null, null, $attr1],
+                [$list, null, null, null, null, $attr2]
+            )
+            ->willReturnOnConsecutiveCalls($view1, $view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, null, null, null, $attr1));
         $this->assertSame($view2, $this->factory->createView($list, null, null, null, null, $attr2));
@@ -473,14 +462,13 @@ class CachingFactoryDecoratorTest extends TestCase
         $view1 = new ChoiceListView();
         $view2 = new ChoiceListView();
 
-        $this->decoratedFactory->expects($this->at(0))
+        $this->decoratedFactory->expects($this->exactly(2))
             ->method('createView')
-            ->with($list, null, null, null, null, $attr1)
-            ->willReturn($view1);
-        $this->decoratedFactory->expects($this->at(1))
-            ->method('createView')
-            ->with($list, null, null, null, null, $attr2)
-            ->willReturn($view2);
+            ->withConsecutive(
+                [$list, null, null, null, null, $attr1],
+                [$list, null, null, null, null, $attr2]
+            )
+            ->willReturnOnConsecutiveCalls($view1, $view2);
 
         $this->assertSame($view1, $this->factory->createView($list, null, null, null, null, $attr1));
         $this->assertSame($view2, $this->factory->createView($list, null, null, null, null, $attr2));

--- a/src/Symfony/Component/Form/Tests/ChoiceList/LazyChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/LazyChoiceListTest.php
@@ -67,15 +67,10 @@ class LazyChoiceListTest extends TestCase
      */
     public function testGetChoicesUsesLoadedListWhenLoaderDoesNotCacheChoiceListOnFirstCall()
     {
-        $this->loader->expects($this->at(0))
+        $this->loader->expects($this->exactly(2))
             ->method('loadChoiceList')
             ->with($this->value)
-            ->willReturn($this->loadedList);
-
-        $this->loader->expects($this->at(1))
-            ->method('loadChoiceList')
-            ->with($this->value)
-            ->willReturn(new ArrayChoiceList(['a', 'b']));
+            ->willReturnOnConsecutiveCalls($this->loadedList, new ArrayChoiceList(['a', 'b']));
 
         // The same list is returned by the lazy choice list
         $this->loadedList->expects($this->exactly(2))

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
@@ -92,32 +92,38 @@ class FormDataCollectorTest extends TestCase
     {
         $this->form->add($this->childForm);
 
-        $this->dataExtractor->expects($this->at(0))
+        $this->dataExtractor->expects($this->exactly(2))
             ->method('extractConfiguration')
-            ->with($this->form)
-            ->willReturn(['config' => 'foo']);
-        $this->dataExtractor->expects($this->at(1))
-            ->method('extractConfiguration')
-            ->with($this->childForm)
-            ->willReturn(['config' => 'bar']);
+            ->withConsecutive(
+                [$this->form],
+                [$this->childForm]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['config' => 'foo'],
+                ['config' => 'bar']
+            );
 
-        $this->dataExtractor->expects($this->at(2))
+        $this->dataExtractor->expects($this->exactly(2))
             ->method('extractDefaultData')
-            ->with($this->form)
-            ->willReturn(['default_data' => 'foo']);
-        $this->dataExtractor->expects($this->at(3))
-            ->method('extractDefaultData')
-            ->with($this->childForm)
-            ->willReturn(['default_data' => 'bar']);
+            ->withConsecutive(
+                [$this->form],
+                [$this->childForm]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['default_data' => 'foo'],
+                ['default_data' => 'bar']
+            );
 
-        $this->dataExtractor->expects($this->at(4))
+        $this->dataExtractor->expects($this->exactly(2))
             ->method('extractSubmittedData')
-            ->with($this->form)
-            ->willReturn(['submitted_data' => 'foo']);
-        $this->dataExtractor->expects($this->at(5))
-            ->method('extractSubmittedData')
-            ->with($this->childForm)
-            ->willReturn(['submitted_data' => 'bar']);
+            ->withConsecutive(
+                [$this->form],
+                [$this->childForm]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['submitted_data' => 'foo'],
+                ['submitted_data' => 'bar']
+            );
 
         $this->dataCollector->collectConfiguration($this->form);
         $this->dataCollector->collectDefaultData($this->form);
@@ -158,14 +164,16 @@ class FormDataCollectorTest extends TestCase
         $form1 = $this->createForm('form1');
         $form2 = $this->createForm('form2');
 
-        $this->dataExtractor->expects($this->at(0))
+        $this->dataExtractor->expects($this->exactly(2))
             ->method('extractConfiguration')
-            ->with($form1)
-            ->willReturn(['config' => 'foo']);
-        $this->dataExtractor->expects($this->at(1))
-            ->method('extractConfiguration')
-            ->with($form2)
-            ->willReturn(['config' => 'bar']);
+            ->withConsecutive(
+                [$form1],
+                [$form2]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['config' => 'foo'],
+                ['config' => 'bar']
+            );
 
         $this->dataCollector->collectConfiguration($form1);
         $this->dataCollector->collectConfiguration($form2);
@@ -208,12 +216,12 @@ class FormDataCollectorTest extends TestCase
 
     public function testBuildSamePreliminaryFormTreeMultipleTimes()
     {
-        $this->dataExtractor->expects($this->at(0))
+        $this->dataExtractor
             ->method('extractConfiguration')
             ->with($this->form)
             ->willReturn(['config' => 'foo']);
 
-        $this->dataExtractor->expects($this->at(1))
+        $this->dataExtractor
             ->method('extractDefaultData')
             ->with($this->form)
             ->willReturn(['default_data' => 'foo']);
@@ -280,42 +288,49 @@ class FormDataCollectorTest extends TestCase
         $this->form->add($this->childForm);
         $this->view->children['child'] = $this->childView;
 
-        $this->dataExtractor->expects($this->at(0))
+        $this->dataExtractor->expects($this->exactly(2))
             ->method('extractConfiguration')
-            ->with($this->form)
-            ->willReturn(['config' => 'foo']);
-        $this->dataExtractor->expects($this->at(1))
-            ->method('extractConfiguration')
-            ->with($this->childForm)
-            ->willReturn(['config' => 'bar']);
+            ->withConsecutive(
+                [$this->form],
+                [$this->childForm]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['config' => 'foo'],
+                ['config' => 'bar']
+            );
 
-        $this->dataExtractor->expects($this->at(2))
+        $this->dataExtractor->expects($this->exactly(2))
             ->method('extractDefaultData')
-            ->with($this->form)
-            ->willReturn(['default_data' => 'foo']);
-        $this->dataExtractor->expects($this->at(3))
-            ->method('extractDefaultData')
-            ->with($this->childForm)
-            ->willReturn(['default_data' => 'bar']);
+            ->withConsecutive(
+                [$this->form],
+                [$this->childForm]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['default_data' => 'foo'],
+                ['default_data' => 'bar']
+            );
 
-        $this->dataExtractor->expects($this->at(4))
+        $this->dataExtractor->expects($this->exactly(2))
             ->method('extractSubmittedData')
-            ->with($this->form)
-            ->willReturn(['submitted_data' => 'foo']);
-        $this->dataExtractor->expects($this->at(5))
-            ->method('extractSubmittedData')
-            ->with($this->childForm)
-            ->willReturn(['submitted_data' => 'bar']);
+            ->withConsecutive(
+                [$this->form],
+                [$this->childForm]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['submitted_data' => 'foo'],
+                ['submitted_data' => 'bar']
+            );
 
-        $this->dataExtractor->expects($this->at(6))
+        $this->dataExtractor->expects($this->exactly(2))
             ->method('extractViewVariables')
-            ->with($this->view)
-            ->willReturn(['view_vars' => 'foo']);
-
-        $this->dataExtractor->expects($this->at(7))
-            ->method('extractViewVariables')
-            ->with($this->childView)
-            ->willReturn(['view_vars' => 'bar']);
+            ->withConsecutive(
+                [$this->view],
+                [$this->childView]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['view_vars' => 'foo'],
+                ['view_vars' => 'bar']
+            );
 
         $this->dataCollector->collectConfiguration($this->form);
         $this->dataCollector->collectDefaultData($this->form);
@@ -373,79 +388,65 @@ class FormDataCollectorTest extends TestCase
         $form1View->children['child1'] = $child1View;
         $form2View->children['child1'] = $child1View;
 
-        $this->dataExtractor->expects($this->at(0))
+        $this->dataExtractor->expects($this->exactly(4))
             ->method('extractConfiguration')
-            ->with($form1)
-            ->willReturn(['config' => 'foo']);
-        $this->dataExtractor->expects($this->at(1))
-            ->method('extractConfiguration')
-            ->with($child1)
-            ->willReturn(['config' => 'bar']);
+            ->withConsecutive(
+                [$form1],
+                [$child1],
+                [$form2],
+                [$child1]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['config' => 'foo'],
+                ['config' => 'bar'],
+                ['config' => 'foo'],
+                ['config' => 'bar']
+            );
 
-        $this->dataExtractor->expects($this->at(2))
+        $this->dataExtractor->expects($this->exactly(4))
             ->method('extractDefaultData')
-            ->with($form1)
-            ->willReturn(['default_data' => 'foo']);
-        $this->dataExtractor->expects($this->at(3))
-            ->method('extractDefaultData')
-            ->with($child1)
-            ->willReturn(['default_data' => 'bar']);
+            ->withConsecutive(
+                [$form1],
+                [$child1],
+                [$form2],
+                [$child1]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['default_data' => 'foo'],
+                ['default_data' => 'bar'],
+                ['default_data' => 'foo'],
+                ['default_data' => 'bar']
+            );
 
-        $this->dataExtractor->expects($this->at(4))
+        $this->dataExtractor->expects($this->exactly(4))
             ->method('extractSubmittedData')
-            ->with($form1)
-            ->willReturn(['submitted_data' => 'foo']);
-        $this->dataExtractor->expects($this->at(5))
-            ->method('extractSubmittedData')
-            ->with($child1)
-            ->willReturn(['submitted_data' => 'bar']);
+            ->withConsecutive(
+                [$form1],
+                [$child1],
+                [$form2],
+                [$child1]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['submitted_data' => 'foo'],
+                ['submitted_data' => 'bar'],
+                ['submitted_data' => 'foo'],
+                ['submitted_data' => 'bar']
+            );
 
-        $this->dataExtractor->expects($this->at(6))
+        $this->dataExtractor->expects($this->exactly(4))
             ->method('extractViewVariables')
-            ->with($form1View)
-            ->willReturn(['view_vars' => 'foo']);
-
-        $this->dataExtractor->expects($this->at(7))
-            ->method('extractViewVariables')
-            ->with($child1View)
-            ->willReturn(['view_vars' => $child1View->vars]);
-
-        $this->dataExtractor->expects($this->at(8))
-            ->method('extractConfiguration')
-            ->with($form2)
-            ->willReturn(['config' => 'foo']);
-        $this->dataExtractor->expects($this->at(9))
-            ->method('extractConfiguration')
-            ->with($child1)
-            ->willReturn(['config' => 'bar']);
-
-        $this->dataExtractor->expects($this->at(10))
-            ->method('extractDefaultData')
-            ->with($form2)
-            ->willReturn(['default_data' => 'foo']);
-        $this->dataExtractor->expects($this->at(11))
-            ->method('extractDefaultData')
-            ->with($child1)
-            ->willReturn(['default_data' => 'bar']);
-
-        $this->dataExtractor->expects($this->at(12))
-            ->method('extractSubmittedData')
-            ->with($form2)
-            ->willReturn(['submitted_data' => 'foo']);
-        $this->dataExtractor->expects($this->at(13))
-            ->method('extractSubmittedData')
-            ->with($child1)
-            ->willReturn(['submitted_data' => 'bar']);
-
-        $this->dataExtractor->expects($this->at(14))
-            ->method('extractViewVariables')
-            ->with($form2View)
-            ->willReturn(['view_vars' => 'foo']);
-
-        $this->dataExtractor->expects($this->at(15))
-            ->method('extractViewVariables')
-            ->with($child1View)
-            ->willReturn(['view_vars' => $child1View->vars]);
+            ->withConsecutive(
+                [$form1View],
+                [$child1View],
+                [$form2View],
+                [$child1View]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['view_vars' => 'foo'],
+                ['view_vars' => $child1View->vars],
+                ['view_vars' => 'foo'],
+                ['view_vars' => $child1View->vars]
+            );
 
         $this->dataCollector->collectConfiguration($form1);
         $this->dataCollector->collectDefaultData($form1);
@@ -526,14 +527,16 @@ class FormDataCollectorTest extends TestCase
 
         $this->view->children['child'] = $this->childView;
 
-        $this->dataExtractor->expects($this->at(0))
+        $this->dataExtractor->expects($this->exactly(2))
             ->method('extractConfiguration')
-            ->with($this->form)
-            ->willReturn(['config' => 'foo']);
-        $this->dataExtractor->expects($this->at(1))
-            ->method('extractConfiguration')
-            ->with($this->childForm)
-            ->willReturn(['config' => 'bar']);
+            ->withConsecutive(
+                [$this->form],
+                [$this->childForm]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['config' => 'foo'],
+                ['config' => 'bar']
+            );
 
         // explicitly call collectConfiguration(), since $this->childForm is not
         // contained in the form tree
@@ -574,14 +577,16 @@ class FormDataCollectorTest extends TestCase
         // but associate the two
         $this->dataCollector->associateFormWithView($this->childForm, $this->childView);
 
-        $this->dataExtractor->expects($this->at(0))
+        $this->dataExtractor->expects($this->exactly(2))
             ->method('extractConfiguration')
-            ->with($this->form)
-            ->willReturn(['config' => 'foo']);
-        $this->dataExtractor->expects($this->at(1))
-            ->method('extractConfiguration')
-            ->with($this->childForm)
-            ->willReturn(['config' => 'bar']);
+            ->withConsecutive(
+                [$this->form],
+                [$this->childForm]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['config' => 'foo'],
+                ['config' => 'bar']
+            );
 
         // explicitly call collectConfiguration(), since $this->childForm is not
         // contained in the form tree
@@ -626,18 +631,18 @@ class FormDataCollectorTest extends TestCase
         $this->dataExtractor
              ->method('extractDefaultData')
              ->willReturn([]);
-        $this->dataExtractor->expects($this->at(4))
+        $this->dataExtractor->expects($this->exactly(3))
             ->method('extractSubmittedData')
-            ->with($form1)
-            ->willReturn(['errors' => ['foo']]);
-        $this->dataExtractor->expects($this->at(5))
-            ->method('extractSubmittedData')
-            ->with($childForm1)
-            ->willReturn(['errors' => ['bar', 'bam']]);
-        $this->dataExtractor->expects($this->at(8))
-            ->method('extractSubmittedData')
-            ->with($form2)
-            ->willReturn(['errors' => ['baz']]);
+            ->withConsecutive(
+                [$form1],
+                [$childForm1],
+                [$form2]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['errors' => ['foo']],
+                ['errors' => ['bar', 'bam']],
+                ['errors' => ['baz']]
+            );
 
         $this->dataCollector->collectSubmittedData($form1);
 
@@ -668,26 +673,22 @@ class FormDataCollectorTest extends TestCase
         $this->dataExtractor
             ->method('extractDefaultData')
             ->willReturn([]);
-        $this->dataExtractor->expects($this->at(10))
+        $this->dataExtractor->expects($this->exactly(5))
             ->method('extractSubmittedData')
-            ->with($this->form)
-            ->willReturn(['errors' => []]);
-        $this->dataExtractor->expects($this->at(11))
-            ->method('extractSubmittedData')
-            ->with($child1Form)
-            ->willReturn(['errors' => []]);
-        $this->dataExtractor->expects($this->at(12))
-            ->method('extractSubmittedData')
-            ->with($child11Form)
-            ->willReturn(['errors' => ['foo']]);
-        $this->dataExtractor->expects($this->at(13))
-            ->method('extractSubmittedData')
-            ->with($child2Form)
-            ->willReturn(['errors' => []]);
-        $this->dataExtractor->expects($this->at(14))
-            ->method('extractSubmittedData')
-            ->with($child21Form)
-            ->willReturn(['errors' => []]);
+            ->withConsecutive(
+                [$this->form],
+                [$child1Form],
+                [$child11Form],
+                [$child2Form],
+                [$child21Form]
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['errors' => []],
+                ['errors' => []],
+                ['errors' => ['foo']],
+                ['errors' => []],
+                ['errors' => []]
+            );
 
         $this->dataCollector->collectSubmittedData($this->form);
         $this->dataCollector->buildPreliminaryFormTree($this->form);

--- a/src/Symfony/Component/Form/Tests/FormRegistryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRegistryTest.php
@@ -144,15 +144,13 @@ class FormRegistryTest extends TestCase
         $this->extension1->addType($parentType);
         $this->extension2->addType($type);
 
-        $this->resolvedTypeFactory->expects($this->at(0))
+        $this->resolvedTypeFactory->expects($this->exactly(2))
             ->method('createResolvedType')
-            ->with($parentType)
-            ->willReturn($parentResolvedType);
-
-        $this->resolvedTypeFactory->expects($this->at(1))
-            ->method('createResolvedType')
-            ->with($type, [], $parentResolvedType)
-            ->willReturn($resolvedType);
+            ->withConsecutive(
+                [$parentType],
+                [$type, [], $parentResolvedType]
+            )
+            ->willReturnOnConsecutiveCalls($parentResolvedType, $resolvedType);
 
         $this->assertSame($resolvedType, $this->registry->getType(\get_class($type)));
     }

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -117,13 +117,26 @@ class SimpleFormTest extends AbstractFormTest
     // https://github.com/symfony/symfony/commit/d4f4038f6daf7cf88ca7c7ab089473cce5ebf7d8#commitcomment-1632879
     public function testDataIsInitializedFromSubmit()
     {
+        $preSetData = false;
+        $preSubmit = false;
+
         $mock = $this->getMockBuilder('\stdClass')
             ->setMethods(['preSetData', 'preSubmit'])
             ->getMock();
-        $mock->expects($this->at(0))
-            ->method('preSetData');
-        $mock->expects($this->at(1))
-            ->method('preSubmit');
+        $mock->expects($this->once())
+            ->method('preSetData')
+            ->with($this->callback(function () use (&$preSetData, $preSubmit) {
+                $preSetData = true;
+
+                return false === $preSubmit;
+            }));
+        $mock->expects($this->once())
+            ->method('preSubmit')
+            ->with($this->callback(function () use ($preSetData, &$preSubmit) {
+                $preSubmit = true;
+
+                return false === $preSetData;
+            }));
 
         $config = new FormConfigBuilder('name', null, $this->dispatcher);
         $config->addEventListener(FormEvents::PRE_SET_DATA, [$mock, 'preSetData']);

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -461,12 +461,12 @@ class ResponseTest extends ResponseTestCase
     public function testDefaultContentType()
     {
         $headerMock = $this->getMockBuilder('Symfony\Component\HttpFoundation\ResponseHeaderBag')->setMethods(['set'])->getMock();
-        $headerMock->expects($this->at(0))
+        $headerMock->expects($this->exactly(2))
             ->method('set')
-            ->with('Content-Type', 'text/html');
-        $headerMock->expects($this->at(1))
-            ->method('set')
-            ->with('Content-Type', 'text/html; charset=UTF-8');
+            ->withConsecutive(
+                ['Content-Type', 'text/html'],
+                ['Content-Type', 'text/html; charset=UTF-8']
+            );
 
         $response = new Response('foo');
         $response->headers = $headerMock;

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ContainerControllerResolverTest.php
@@ -15,6 +15,7 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Debug\ErrorHandler;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ContainerControllerResolver;
 
@@ -117,16 +118,10 @@ class ContainerControllerResolverTest extends ControllerResolverTest
         $this->expectException('LogicException');
         $this->expectExceptionMessage('Controller "Symfony\Component\HttpKernel\Tests\Controller\ImpossibleConstructController" cannot be fetched from the container because it is private. Did you forget to tag the service with "controller.service_arguments"?');
         $container = $this->getMockBuilder(Container::class)->getMock();
-        $container->expects($this->at(0))
+        $container->expects($this->exactly(2))
             ->method('has')
             ->with(ImpossibleConstructController::class)
-            ->willReturn(true)
-        ;
-
-        $container->expects($this->at(1))
-            ->method('has')
-            ->with(ImpossibleConstructController::class)
-            ->willReturn(false)
+            ->willReturnOnConsecutiveCalls(true, false)
         ;
 
         $container->expects($this->atLeastOnce())
@@ -181,18 +176,10 @@ class ContainerControllerResolverTest extends ControllerResolverTest
     {
         $this->expectException('LogicException');
         $this->expectExceptionMessage('Controller "app.my_controller" cannot be fetched from the container because it is private. Did you forget to tag the service with "controller.service_arguments"?');
-        $container = $this->getMockBuilder(Container::class)->getMock();
-        $container->expects($this->at(0))
-            ->method('has')
-            ->with('app.my_controller')
-            ->willReturn(false)
-        ;
 
-        $container->expects($this->atLeastOnce())
-            ->method('getRemovedIds')
-            ->with()
-            ->willReturn(['app.my_controller' => true])
-        ;
+        $container = new ContainerBuilder();
+        $container->register('app.my_controller');
+        $container->removeDefinition('app.my_controller');
 
         $resolver = $this->createControllerResolver(null, $container);
 

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TranslatorListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TranslatorListenerTest.php
@@ -45,13 +45,15 @@ class TranslatorListenerTest extends TestCase
     public function testDefaultLocaleIsUsedOnExceptionsInOnKernelRequest()
     {
         $this->translator
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('setLocale')
-            ->willThrowException(new \InvalidArgumentException());
-        $this->translator
-            ->expects($this->at(1))
-            ->method('setLocale')
-            ->with($this->equalTo('en'));
+            ->withConsecutive(
+                ['fr'],
+                ['en']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new \InvalidArgumentException())
+            );
 
         $event = new GetResponseEvent($this->createHttpKernel(), $this->createRequest('fr'), HttpKernelInterface::MASTER_REQUEST);
         $this->listener->onKernelRequest($event);
@@ -82,13 +84,15 @@ class TranslatorListenerTest extends TestCase
     public function testDefaultLocaleIsUsedOnExceptionsInOnKernelFinishRequest()
     {
         $this->translator
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('setLocale')
-            ->willThrowException(new \InvalidArgumentException());
-        $this->translator
-            ->expects($this->at(1))
-            ->method('setLocale')
-            ->with($this->equalTo('en'));
+            ->withConsecutive(
+                ['fr'],
+                ['en']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new \InvalidArgumentException())
+            );
 
         $this->setMasterRequest($this->createRequest('fr'));
         $event = new FinishRequestEvent($this->createHttpKernel(), $this->createRequest('de'), HttpKernelInterface::SUB_REQUEST);

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -314,8 +314,8 @@ class HttpKernelTest extends TestCase
         $request = new Request();
 
         $stack = $this->getMockBuilder('Symfony\Component\HttpFoundation\RequestStack')->setMethods(['push', 'pop'])->getMock();
-        $stack->expects($this->at(0))->method('push')->with($this->equalTo($request));
-        $stack->expects($this->at(1))->method('pop');
+        $stack->expects($this->once())->method('push')->with($this->equalTo($request));
+        $stack->expects($this->once())->method('pop');
 
         $dispatcher = new EventDispatcher();
         $kernel = $this->getHttpKernel($dispatcher, null, $stack);

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -219,9 +220,12 @@ class KernelTest extends TestCase
     public function testShutdownGivesNullContainerToAllBundles()
     {
         $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\Bundle')->getMock();
-        $bundle->expects($this->at(3))
+        $bundle->expects($this->exactly(2))
             ->method('setContainer')
-            ->with(null);
+            ->withConsecutive(
+                [$this->isInstanceOf(ContainerInterface::class)],
+                [null]
+            );
 
         $kernel = $this->getKernel(['getBundles']);
         $kernel->expects($this->any())

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
@@ -80,15 +80,13 @@ class BundleEntryReaderTest extends TestCase
 
     public function testReadEntireDataFileIfNoIndicesGiven()
     {
-        $this->readerImpl->expects($this->at(0))
+        $this->readerImpl->expects($this->exactly(2))
             ->method('read')
-            ->with(self::RES_DIR, 'en')
-            ->willReturn(self::$data);
-
-        $this->readerImpl->expects($this->at(1))
-            ->method('read')
-            ->with(self::RES_DIR, 'root')
-            ->willReturn(self::$fallbackData);
+            ->withConsecutive(
+                [self::RES_DIR, 'en'],
+                [self::RES_DIR, 'root']
+            )
+            ->willReturnOnConsecutiveCalls(self::$data, self::$fallbackData);
 
         $this->assertSame(self::$mergedData, $this->reader->readEntry(self::RES_DIR, 'en', []));
     }
@@ -116,15 +114,13 @@ class BundleEntryReaderTest extends TestCase
 
     public function testFallbackIfEntryDoesNotExist()
     {
-        $this->readerImpl->expects($this->at(0))
+        $this->readerImpl->expects($this->exactly(2))
             ->method('read')
-            ->with(self::RES_DIR, 'en_GB')
-            ->willReturn(self::$data);
-
-        $this->readerImpl->expects($this->at(1))
-            ->method('read')
-            ->with(self::RES_DIR, 'en')
-            ->willReturn(self::$fallbackData);
+            ->withConsecutive(
+                [self::RES_DIR, 'en_GB'],
+                [self::RES_DIR, 'en']
+            )
+            ->willReturnOnConsecutiveCalls(self::$data, self::$fallbackData);
 
         $this->assertSame('Lah', $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam']));
     }
@@ -142,15 +138,13 @@ class BundleEntryReaderTest extends TestCase
 
     public function testFallbackIfLocaleDoesNotExist()
     {
-        $this->readerImpl->expects($this->at(0))
+        $this->readerImpl->expects($this->exactly(2))
             ->method('read')
-            ->with(self::RES_DIR, 'en_GB')
-            ->willThrowException(new ResourceBundleNotFoundException());
-
-        $this->readerImpl->expects($this->at(1))
-            ->method('read')
-            ->with(self::RES_DIR, 'en')
-            ->willReturn(self::$fallbackData);
+            ->withConsecutive(
+                [self::RES_DIR, 'en_GB'],
+                [self::RES_DIR, 'en']
+            )
+            ->willReturnOnConsecutiveCalls(self::$data, self::$fallbackData);
 
         $this->assertSame('Lah', $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam']));
     }
@@ -185,15 +179,13 @@ class BundleEntryReaderTest extends TestCase
     public function testMergeDataWithFallbackData($childData, $parentData, $result)
     {
         if (null === $childData || \is_array($childData)) {
-            $this->readerImpl->expects($this->at(0))
+            $this->readerImpl->expects($this->exactly(2))
                 ->method('read')
-                ->with(self::RES_DIR, 'en')
-                ->willReturn($childData);
-
-            $this->readerImpl->expects($this->at(1))
-                ->method('read')
-                ->with(self::RES_DIR, 'root')
-                ->willReturn($parentData);
+                ->withConsecutive(
+                    [self::RES_DIR, 'en'],
+                    [self::RES_DIR, 'root']
+                )
+                ->willReturnOnConsecutiveCalls($childData, $parentData);
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')
@@ -223,15 +215,16 @@ class BundleEntryReaderTest extends TestCase
     public function testMergeExistingEntryWithExistingFallbackEntry($childData, $parentData, $result)
     {
         if (null === $childData || \is_array($childData)) {
-            $this->readerImpl->expects($this->at(0))
+            $this->readerImpl->expects($this->exactly(2))
                 ->method('read')
-                ->with(self::RES_DIR, 'en')
-                ->willReturn(['Foo' => ['Bar' => $childData]]);
-
-            $this->readerImpl->expects($this->at(1))
-                ->method('read')
-                ->with(self::RES_DIR, 'root')
-                ->willReturn(['Foo' => ['Bar' => $parentData]]);
+                ->withConsecutive(
+                    [self::RES_DIR, 'en'],
+                    [self::RES_DIR, 'root']
+                )
+                ->willReturnOnConsecutiveCalls(
+                    ['Foo' => ['Bar' => $childData]],
+                    ['Foo' => ['Bar' => $parentData]]
+                );
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')
@@ -247,15 +240,13 @@ class BundleEntryReaderTest extends TestCase
      */
     public function testMergeNonExistingEntryWithExistingFallbackEntry($childData, $parentData, $result)
     {
-        $this->readerImpl->expects($this->at(0))
+        $this->readerImpl
             ->method('read')
-            ->with(self::RES_DIR, 'en_GB')
-            ->willReturn(['Foo' => 'Baz']);
-
-        $this->readerImpl->expects($this->at(1))
-            ->method('read')
-            ->with(self::RES_DIR, 'en')
-            ->willReturn(['Foo' => ['Bar' => $parentData]]);
+            ->withConsecutive(
+                [self::RES_DIR, 'en_GB'],
+                [self::RES_DIR, 'en']
+            )
+            ->willReturnOnConsecutiveCalls(['Foo' => 'Baz'], ['Foo' => ['Bar' => $parentData]]);
 
         $this->assertSame($parentData, $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true));
     }
@@ -266,15 +257,13 @@ class BundleEntryReaderTest extends TestCase
     public function testMergeExistingEntryWithNonExistingFallbackEntry($childData, $parentData, $result)
     {
         if (null === $childData || \is_array($childData)) {
-            $this->readerImpl->expects($this->at(0))
+            $this->readerImpl
                 ->method('read')
-                ->with(self::RES_DIR, 'en_GB')
-                ->willReturn(['Foo' => ['Bar' => $childData]]);
-
-            $this->readerImpl->expects($this->at(1))
-                ->method('read')
-                ->with(self::RES_DIR, 'en')
-                ->willReturn(['Foo' => 'Bar']);
+                ->withConsecutive(
+                    [self::RES_DIR, 'en_GB'],
+                    [self::RES_DIR, 'en']
+                )
+                ->willReturnOnConsecutiveCalls(['Foo' => ['Bar' => $childData]], ['Foo' => 'Bar']);
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')
@@ -288,15 +277,13 @@ class BundleEntryReaderTest extends TestCase
     public function testFailIfEntryFoundNeitherInParentNorChild()
     {
         $this->expectException('Symfony\Component\Intl\Exception\MissingResourceException');
-        $this->readerImpl->expects($this->at(0))
+        $this->readerImpl
             ->method('read')
-            ->with(self::RES_DIR, 'en_GB')
-            ->willReturn(['Foo' => 'Baz']);
-
-        $this->readerImpl->expects($this->at(1))
-            ->method('read')
-            ->with(self::RES_DIR, 'en')
-            ->willReturn(['Foo' => 'Bar']);
+            ->withConsecutive(
+                [self::RES_DIR, 'en_GB'],
+                [self::RES_DIR, 'en']
+            )
+            ->willReturnOnConsecutiveCalls(['Foo' => 'Baz'], ['Foo' => 'Baz']);
 
         $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true);
     }
@@ -310,15 +297,13 @@ class BundleEntryReaderTest extends TestCase
         $childData = \is_array($childData) ? new \ArrayObject($childData) : $childData;
 
         if (null === $childData || $childData instanceof \ArrayObject) {
-            $this->readerImpl->expects($this->at(0))
+            $this->readerImpl
                 ->method('read')
-                ->with(self::RES_DIR, 'en_GB')
-                ->willReturn(['Foo' => ['Bar' => $childData]]);
-
-            $this->readerImpl->expects($this->at(1))
-                ->method('read')
-                ->with(self::RES_DIR, 'en')
-                ->willReturn(['Foo' => ['Bar' => $parentData]]);
+                ->withConsecutive(
+                    [self::RES_DIR, 'en_GB'],
+                    [self::RES_DIR, 'en']
+                )
+                ->willReturnOnConsecutiveCalls(['Foo' => ['Bar' => $childData]], ['Foo' => ['Bar' => $parentData]]);
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')
@@ -337,16 +322,14 @@ class BundleEntryReaderTest extends TestCase
         $this->reader->setLocaleAliases(['mo' => 'ro_MD']);
 
         if (null === $childData || \is_array($childData)) {
-            $this->readerImpl->expects($this->at(0))
+            $this->readerImpl
                 ->method('read')
-                ->with(self::RES_DIR, 'ro_MD')
-                ->willReturn(['Foo' => ['Bar' => $childData]]);
-
-            // Read fallback locale of aliased locale ("ro_MD" -> "ro")
-            $this->readerImpl->expects($this->at(1))
-                ->method('read')
-                ->with(self::RES_DIR, 'ro')
-                ->willReturn(['Foo' => ['Bar' => $parentData]]);
+                ->withConsecutive(
+                    [self::RES_DIR, 'ro_MD'],
+                    // Read fallback locale of aliased locale ("ro_MD" -> "ro")
+                    [self::RES_DIR, 'ro']
+                )
+                ->willReturnOnConsecutiveCalls(['Foo' => ['Bar' => $childData]], ['Foo' => ['Bar' => $parentData]]);
         } else {
             $this->readerImpl->expects($this->once())
                 ->method('read')

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCollectionTest.php
@@ -130,18 +130,18 @@ abstract class PropertyAccessorCollectionTest extends PropertyAccessorArrayAcces
             ->method('getStructure')
             ->willReturn($structure);
 
-        $structure->expects($this->at(0))
+        $structure->expects($this->once())
             ->method('getAxes')
             ->willReturn($axesBefore);
-        $structure->expects($this->at(1))
+        $structure->expects($this->once())
             ->method('removeAxis')
             ->with('fourth');
-        $structure->expects($this->at(2))
+        $structure->expects($this->exactly(2))
             ->method('addAxis')
-            ->with('first');
-        $structure->expects($this->at(3))
-            ->method('addAxis')
-            ->with('third');
+            ->withConsecutive(
+                ['first'],
+                ['third']
+            );
 
         $this->propertyAccessor->setValue($car, 'structure.axes', $axesAfter);
     }

--- a/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
@@ -76,7 +76,7 @@ class FirewallTest extends TestCase
             ->getMock()
         ;
         $event
-            ->expects($this->at(0))
+            ->expects($this->once())
             ->method('hasResponse')
             ->willReturn(true)
         ;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -37,15 +37,16 @@ class ArrayDenormalizerTest extends TestCase
 
     public function testDenormalize()
     {
-        $this->serializer->expects($this->at(0))
+        $this->serializer->expects($this->exactly(2))
             ->method('denormalize')
-            ->with(['foo' => 'one', 'bar' => 'two'])
-            ->willReturn(new ArrayDummy('one', 'two'));
-
-        $this->serializer->expects($this->at(1))
-            ->method('denormalize')
-            ->with(['foo' => 'three', 'bar' => 'four'])
-            ->willReturn(new ArrayDummy('three', 'four'));
+            ->withConsecutive(
+                [['foo' => 'one', 'bar' => 'two']],
+                [['foo' => 'three', 'bar' => 'four']]
+            )
+            ->willReturnOnConsecutiveCalls(
+                new ArrayDummy('one', 'two'),
+                new ArrayDummy('three', 'four')
+            );
 
         $result = $this->denormalizer->denormalize(
             [

--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -12,15 +12,22 @@
 namespace Symfony\Component\Validator\Test;
 
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Constraint\IsIdentical;
+use PHPUnit\Framework\Constraint\IsInstanceOf;
+use PHPUnit\Framework\Constraint\IsNull;
+use PHPUnit\Framework\Constraint\LogicalOr;
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\Context\ExecutionContext;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\PropertyMetadata;
+use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
 
 /**
  * A test case to ease testing Constraint Validators.
@@ -99,7 +106,6 @@ abstract class ConstraintValidatorTestCase extends TestCase
     {
         $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')->getMock();
         $validator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ValidatorInterface')->getMock();
-        $contextualValidator = $this->getMockBuilder('Symfony\Component\Validator\Validator\ContextualValidatorInterface')->getMock();
 
         $context = new ExecutionContext($validator, $this->root, $translator);
         $context->setGroup($this->group);
@@ -109,7 +115,7 @@ abstract class ConstraintValidatorTestCase extends TestCase
         $validator->expects($this->any())
             ->method('inContext')
             ->with($context)
-            ->willReturn($contextualValidator);
+            ->willReturn(new AssertingContextualValidator());
 
         return $context;
     }
@@ -162,36 +168,26 @@ abstract class ConstraintValidatorTestCase extends TestCase
     protected function expectNoValidate()
     {
         $validator = $this->context->getValidator()->inContext($this->context);
-        $validator->expects($this->never())
-            ->method('atPath');
-        $validator->expects($this->never())
-            ->method('validate');
+        $validator->expectNoValidate();
     }
 
     protected function expectValidateAt($i, $propertyPath, $value, $group)
     {
         $validator = $this->context->getValidator()->inContext($this->context);
-        $validator->expects($this->at(2 * $i))
-            ->method('atPath')
-            ->with($propertyPath)
-            ->willReturn($validator);
-        $validator->expects($this->at(2 * $i + 1))
-            ->method('validate')
-            ->with($value, $this->logicalOr(null, [], $this->isInstanceOf('\Symfony\Component\Validator\Constraints\Valid')), $group)
-            ->willReturn($validator);
+        $validator->expectValidation($i, $propertyPath, $value, $group, function ($passedConstraints) {
+            $expectedConstraints = new LogicalOr();
+            $expectedConstraints->setConstraints([new IsNull(), new IsIdentical([]), new IsInstanceOf(Valid::class)]);
+
+            Assert::assertThat($passedConstraints, $expectedConstraints);
+        });
     }
 
     protected function expectValidateValueAt($i, $propertyPath, $value, $constraints, $group = null)
     {
         $contextualValidator = $this->context->getValidator()->inContext($this->context);
-        $contextualValidator->expects($this->at(2 * $i))
-            ->method('atPath')
-            ->with($propertyPath)
-            ->willReturn($contextualValidator);
-        $contextualValidator->expects($this->at(2 * $i + 1))
-            ->method('validate')
-            ->with($value, $constraints, $group)
-            ->willReturn($contextualValidator);
+        $contextualValidator->expectValidation($i, $propertyPath, $value, $group, function ($passedConstraints) use ($constraints) {
+            Assert::assertEquals($constraints, $passedConstraints);
+        });
     }
 
     protected function assertNoViolation()
@@ -342,5 +338,65 @@ class ConstraintViolationAssertion
             $this->constraint,
             $this->cause
         );
+    }
+}
+
+class AssertingContextualValidator implements ContextualValidatorInterface
+{
+    private $expectNoValidate = false;
+    private $atPathCalls = -1;
+    private $expectedAtPath = [];
+    private $validateCalls = -1;
+    private $expectedValidate = [];
+
+    public function atPath($path)
+    {
+        Assert::assertFalse($this->expectNoValidate, 'No validation calls have been expected.');
+
+        if (!isset($this->expectedAtPath[++$this->atPathCalls])) {
+            throw new ExpectationFailedException(sprintf('Validation for property path "%s" was not expected.', $path));
+        }
+
+        Assert::assertSame($this->expectedAtPath[$this->atPathCalls], $path);
+
+        return $this;
+    }
+
+    public function validate($value, $constraints = null, $groups = null)
+    {
+        Assert::assertFalse($this->expectNoValidate, 'No validation calls have been expected.');
+
+        list($expectedValue, $expectedGroup, $expectedConstraints) = $this->expectedValidate[++$this->validateCalls];
+
+        Assert::assertSame($expectedValue, $value);
+        $expectedConstraints($constraints);
+        Assert::assertSame($expectedGroup, $groups);
+
+        return $this;
+    }
+
+    public function validateProperty($object, $propertyName, $groups = null)
+    {
+        return $this;
+    }
+
+    public function validatePropertyValue($objectOrClass, $propertyName, $value, $groups = null)
+    {
+        return $this;
+    }
+
+    public function getViolations()
+    {
+    }
+
+    public function expectNoValidate()
+    {
+        $this->expectNoValidate = true;
+    }
+
+    public function expectValidation($call, $propertyPath, $value, $group, $constraints)
+    {
+        $this->expectedAtPath[$call] = $propertyPath;
+        $this->expectedValidate[$call] = [$value, $group, $constraints];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37780
| License       | MIT
| Doc PR        | 