### PR TITLE
[Notifier] Add notification property to SmsMessage class

### DIFF
--- a/src/Symfony/Component/Notifier/Message/SmsMessage.php
+++ b/src/Symfony/Component/Notifier/Message/SmsMessage.php
@@ -25,6 +25,7 @@ final class SmsMessage implements MessageInterface
     private $transport;
     private $subject;
     private $phone;
+    private $notification;
 
     public function __construct(string $phone, string $subject)
     {
@@ -38,7 +39,15 @@ final class SmsMessage implements MessageInterface
 
     public static function fromNotification(Notification $notification, SmsRecipientInterface $recipient): self
     {
-        return new self($recipient->getPhone(), $notification->getSubject());
+        $message = new self($recipient->getPhone(), $notification->getSubject());
+        $message->notification = $notification;
+
+        return $message;
+    }
+
+    public function getNotification(): ?Notification
+    {
+        return $this->notification;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |  none
| License       | MIT
| Doc PR        | none

This PR is a follow up from the discussion there: https://github.com/symfony/symfony/pull/36648#discussion_r469100871

The idea is to allow SmsTransports to get the notification level in order to use or set some advanced parameters in the transport.

Work case: MobytTransport, added in PR #36648, has a parameter to choose between 3 levels of delivery quality(and costs).

Depending on the notification importance we should be able to set the parameter. 

I'm open to any suggestion to make it as generic as possible.
