### PR TITLE
Postpone Range BC layer removal to 6.0.

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Range.php
+++ b/src/Symfony/Component/Validator/Constraints/Range.php
@@ -46,7 +46,6 @@ class Range extends Constraint
     public $max;
     public $maxPropertyPath;
 
-    // BC layer, to be removed in 5.0
     /**
      * @internal
      */
@@ -76,8 +75,9 @@ class Range extends Constraint
                 $this->deprecatedMinMessageSet = isset($options['minMessage']);
                 $this->deprecatedMaxMessageSet = isset($options['maxMessage']);
 
+                // BC layer, should throw a ConstraintDefinitionException in 6.0
                 if ($this->deprecatedMinMessageSet || $this->deprecatedMaxMessageSet) {
-                    @trigger_error('Since symfony/validator 4.4: "minMessage" and "maxMessage" are deprecated when the "min" and "max" options are both set. Use "notInRangeMessage" instead.', E_USER_DEPRECATED);
+                    trigger_deprecation('symfony/validator', '4.4', '"minMessage" and "maxMessage" are deprecated when the "min" and "max" options are both set. Use "notInRangeMessage" instead.');
                 }
             }
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RangeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RangeTest.php
@@ -3,10 +3,13 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Validator\Constraints\Range;
 
 class RangeTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testThrowsConstraintExceptionIfBothMinLimitAndPropertyPath()
     {
         $this->expectException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
@@ -52,11 +55,12 @@ class RangeTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation Since symfony/validator 4.4: "minMessage" and "maxMessage" are deprecated when the "min" and "max" options are both set. Use "notInRangeMessage" instead.
      * @dataProvider provideDeprecationTriggeredIfMinMaxAndMinMessageOrMaxMessageSet
      */
     public function testDeprecationTriggeredIfMinMaxAndMinMessageOrMaxMessageSet(array $options, bool $expectedDeprecatedMinMessageSet, bool $expectedDeprecatedMaxMessageSet)
     {
+        $this->expectDeprecation('Since symfony/validator 4.4: "minMessage" and "maxMessage" are deprecated when the "min" and "max" options are both set. Use "notInRangeMessage" instead.');
+
         $sut = new Range($options);
         $this->assertEquals($expectedDeprecatedMinMessageSet, $sut->deprecatedMinMessageSet);
         $this->assertEquals($expectedDeprecatedMaxMessageSet, $sut->deprecatedMaxMessageSet);

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -20,7 +20,8 @@
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php80": "^1.15",
-        "symfony/translation-contracts": "^1.1|^2"
+        "symfony/translation-contracts": "^1.1|^2",
+        "symfony/deprecation-contracts": "^2.0"
     },
     "require-dev": {
         "symfony/http-client": "^4.4|^5.0",
@@ -47,6 +48,7 @@
         "symfony/expression-language": "<5.1",
         "symfony/http-kernel": "<4.4",
         "symfony/intl": "<4.4",
+        "symfony/phpunit-bridge": "^5.1",
         "symfony/translation": "<4.4",
         "symfony/yaml": "<4.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This BC layer triggers a deprecation message when using `minMessage`/`maxMessage` and `min` and `max` are both set.
Since users on 5.0 and 5.1 hasn't have the deprecation, removing the BC layer (and so throwing an exception) in 5.x would be a big BC break.

Also updated trigger_error to trigger_deprecation and `@deprecationMessage` to `ExpectDeprecationTrait::expectDeprecation`.