### PR TITLE
[Messenger] Don't require doctrine/persistence when installing symfony/messenger

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "doctrine/persistence": "^1.3",
         "symfony/messenger": "^5.1",
         "symfony/service-contracts": "^1.1|^2"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #36790 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A

As of today, [installing `symfony/messenger` installs `symfony/doctrine-messenger`](https://github.com/symfony/symfony/blob/3867fb2489ef0d07dec4859cf461bb7bcc7618e0/src/Symfony/Component/Messenger/composer.json#L23) as well. Which means adding `doctrine/persistence` as a hard dep of the latest will install it for any user requiring `symfony/messenger` in 5.2.

I think it should stay a soft-dependency until we remove `symfony/doctrine-messenger` as a `symfony/messenger` dependency as of Symfony 6.0 (as mentioned in #35422).

---

related: #36785