### PR TITLE
[Console] Rework the signal integration

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -7,6 +7,10 @@ CHANGELOG
  * Added `SingleCommandApplication::setAutoExit()` to allow testing via `CommandTester`
  * added support for multiline responses to questions through `Question::setMultiline()`
    and `Question::isMultiline()`
+ * Added `SignalRegistry` class to stack signals handlers
+ * Added support for signals:
+    * Added `Application::getSignalRegistry()` and `Application::setSignalsToDispatchEvent()` methods
+    * Added `SignalableCommandInterface` interface
 
 5.1.0
 -----

--- a/src/Symfony/Component/Console/Command/SignalableCommandInterface.php
+++ b/src/Symfony/Component/Console/Command/SignalableCommandInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Command;
+
+/**
+ * Interface for command reacting to signal.
+ *
+ * @author Grégoire Pineau <lyrixx@lyrix.info>
+ */
+interface SignalableCommandInterface
+{
+    /**
+     * Returns the list of signals to subscribe.
+     */
+    public function getSubscribedSignals(): array;
+
+    /**
+     * The method will be called when the application is signaled.
+     */
+    public function handleSignal(int $signal): void;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | refs https://github.com/symfony/symfony/pull/33729 
| License       | MIT
| Doc PR        |

I updated the code to have a better design and DX:

* `SignalRegistry::$handlingSignals` is gone. This was a temporary data store to
  bind signal to symfony event. This does not belong to the `SignalRegistry`. It
  has been replaced by `Application::$signalsToDispatchEvent`. A method has been
  added to edit this list `Application::setSignalsToDispatchEvent()`
* The default value for `Application::$signalsToDispatchEvent` is `SIGINT,
  SIGTERM, SIGUSR1, SIGUSR2`. Theses defaults seems good enough for most of
  application. for recall:
    * `SIGINT`: CTRL+C
    * `SIGTERM`: `kill PID`, this is what occurs when stopping a process with SystemD, upstart & co
    * `SIGUSR1` and `SIGUSR2`: Signal for user space
* `Application::setSignalRegistry()` is gone. Now the Application always owns a
  signal registry. Since it's a CLI, it's legit to always have support for
  signals. A method has been added for convenience, and to register signal
  handler manually from the command:

    ```php
        $application->getSignalRegistry()->register(SIGINT, function ($signal) {
            dump("Signal ($signal) caught");
        });
    ```
* The interface `SignalableCommandInterface` has been added. When a command
  implements this interface, the command is automatically called when a
  registered signal has been caught


A note about the BC:

* If one register an handler before the Symfony ones, the Signal Registry keeps
   existing registered handlers. The BC is kept ✅
* If one register an handler after the Symfony ones, it overrides the Symfony
  behavior. Since the feature is new. the BC is kept ✅

---

So now, If one want to listen a signal, they have few options depending on the context:

* A global action is common to all commands (such as logging, enabling a
  profiler (👋 blackfire.io)): Use a listener. With autoconfigure, the following
  code is enough:
    ```php
    class SignalSubscriber implements EventSubscriberInterface
    {
        private $logger;

        public function __construct(LoggerInterface $logger = null)
        {
            $this->logger = $logger ?: new NullLogger();
        }

        public function handleSignal(ConsoleSignalEvent $event)
        {
            $signal = $event->getHandlingSignal();

            $this->logger->debug('The application has been signaled', [
                'signal' => $signal,
            ]);
        }

        public static function getSubscribedEvents()
        {
            return [
                ConsoleEvents::SIGNAL => 'handleSignal',
            ];
        }
    }
    ```

* The command should react to a signal: Implements the interface:
    ```php
    class SignalCommand extends Command implements SignalableCommandInterface
    {
        protected static $defaultName = 'signal';

        private $shouldStop = false;

        protected function execute(InputInterface $input, OutputInterface $output): int
        {
            $output->writeln('hello, I am '. getmypid());

            for ($i=0; $i < 60; $i++) {
                if ($this->shouldStop) {
                    break;
                }

                $output->write('.');

                sleep(1);
            }
            $output->writeln('');

            $output->writeln('bye');

            return 0;
        }

        public function handleSignal(int $signal)
        {
            dump([__METHOD__, $signal]);

            $this->shouldStop = true;
        }

        public function getSubscribedSignals(): array
        {
            return [SIGINT];
        }
    }
    ```

* The command should react differently to many event and/or one wants a full control on name of the method called

    ```php
    class SignalCommand extends Command
    {
        protected static $defaultName = 'signal';

        private $shouldStop = false;

        protected function execute(InputInterface $input, OutputInterface $output): int
        {
            $this->getApplication()->getSignalRegistry()->register(SIGINT, [$this, 'stop']);
            $this->getApplication()->getSignalRegistry()->register(SIGUSR1, [$this, 'enableBlackfire']);

            $output->writeln('hello, I am '. getmypid());

            for ($i=0; $i < 60; $i++) {
                if ($this->shouldStop) {
                    break;
                }

                $output->write('.');

                sleep(1);
            }
            $output->writeln('');

            $output->writeln('bye');

            return 0;
        }

        public function stop()
        {
            $this->shouldStop = true;
        }

        public function enableBlackfire()
        {
            // ...
        }
    }
    ```

ping @marie 