### PR TITLE
[FrameworkBundle] Remove unused form-resources complex type from XSD file

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -159,12 +159,6 @@
         <xsd:attribute name="json-manifest-path" type="xsd:string" />
     </xsd:complexType>
 
-    <xsd:complexType name="form-resources">
-        <xsd:choice minOccurs="1" maxOccurs="unbounded">
-            <xsd:element name="resource" type="xsd:string" />
-        </xsd:choice>
-    </xsd:complexType>
-
     <xsd:complexType name="translator">
         <xsd:sequence>
             <xsd:element name="fallback" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Unused since https://github.com/symfony/symfony/commit/d5be373cacc51c3bd5cdc7633d66c5505d3f43f3#diff-e7427ecf018e4434c1645712ebe715f6L165.