### PR TITLE
[VarDumper] Backport handler lock when using VAR_DUMPER_FORMAT

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -235,13 +235,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
                 --$i;
             }
 
-            if (isset($_SERVER['VAR_DUMPER_FORMAT'])) {
-                $html = 'html' === $_SERVER['VAR_DUMPER_FORMAT'];
-            } else {
-                $html = !\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && stripos($h[$i], 'html');
-            }
-
-            if ($html) {
+            if (!\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && stripos($h[$i], 'html')) {
                 $dumper = new HtmlDumper('php://output', $this->charset);
                 $dumper->setDisplayOptions(['fileLinkFormat' => $this->fileLinkFormat]);
             } else {

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -53,6 +53,12 @@ class VarDumper
     public static function setHandler(callable $callable = null)
     {
         $prevHandler = self::$handler;
+
+        // Prevent replacing the handler with expected format as soon as the env var was set:
+        if (isset($_SERVER['VAR_DUMPER_FORMAT'])) {
+            return $prevHandler;
+        }
+
         self::$handler = $callable;
 
         return $prevHandler;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A

Backport of the "lock" behavior from #35967, preventing unexpected handler change when using the `VAR_DUMPER_FORMAT` env var.

---

As a concrete example of this not working as expected: 
Start a PHPUnit test suite with this env var to the desired format. If a web test case is making a request (with debug enabled), the `DebugBundle` replaces the handler set initially by the `VAR_DUMPER_FORMAT`, will collect dumps into the profiler, but won't output these.
As well, for dumps made in between the the kernel is boot (`DebugBundle::build()` is called) and a request, the dumps are properly sent to the output with expected format, but looses colors.

IMHO, the use-cases of `VAR_DUMPER_FORMAT` justifies locking the handler for the whole process.