### PR TITLE
[VarDumper] Fix exception about abstract_arg

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.php
@@ -100,7 +100,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('var_dumper.server_connection', Connection::class)
             ->args([
-                abstract_arg('server host'),
+                '', // server host
                 [
                     'source' => inline_service(SourceContextProvider::class)->args([
                         param('kernel.charset'),
@@ -114,7 +114,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('var_dumper.dump_server', DumpServer::class)
             ->args([
-                abstract_arg('server host'),
+                '', // server host
                 service('logger')->nullOnInvalid(),
             ])
             ->tag('monolog.logger', ['channel' => 'debug'])

--- a/src/Symfony/Bundle/DebugBundle/Tests/DependencyInjection/DebugExtensionTest.php
+++ b/src/Symfony/Bundle/DebugBundle/Tests/DependencyInjection/DebugExtensionTest.php
@@ -15,7 +15,11 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\DebugBundle\DependencyInjection\DebugExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\VarDumper\Caster\ReflectionCaster;
+use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Server\Connection;
+use Symfony\Component\VarDumper\Server\DumpServer;
 
 class DebugExtensionTest extends TestCase
 {
@@ -70,12 +74,49 @@ class DebugExtensionTest extends TestCase
         $this->assertTrue($called);
     }
 
+    public function provideServicesUsingDumpDestinationCreation(): array
+    {
+        return [
+            ['tcp://localhost:1234', 'tcp://localhost:1234', null],
+            [null, '', null],
+            ['php://stderr', '', 'php://stderr'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideServicesUsingDumpDestinationCreation
+     */
+    public function testServicesUsingDumpDestinationCreation(?string $dumpDestination, string $expectedHost, ?string $expectedOutput)
+    {
+        $container = $this->createContainer();
+        $container->registerExtension(new DebugExtension());
+        $container->loadFromExtension('debug', ['dump_destination' => $dumpDestination]);
+        $container->setAlias('dump_server_public', 'var_dumper.dump_server')->setPublic(true);
+        $container->setAlias('server_conn_public', 'var_dumper.server_connection')->setPublic(true);
+        $container->setAlias('cli_dumper_public', 'var_dumper.cli_dumper')->setPublic(true);
+        $container->register('request_stack', RequestStack::class);
+        $this->compileContainer($container);
+
+        $dumpServer = $container->get('dump_server_public');
+        $this->assertInstanceOf(DumpServer::class, $dumpServer);
+        $this->assertSame($expectedHost, $container->findDefinition('dump_server_public')->getArgument(0));
+
+        $serverConn = $container->get('server_conn_public');
+        $this->assertInstanceOf(Connection::class, $serverConn);
+        $this->assertSame($expectedHost, $container->findDefinition('server_conn_public')->getArgument(0));
+
+        $cliDumper = $container->get('cli_dumper_public');
+        $this->assertInstanceOf(CliDumper::class, $cliDumper);
+        $this->assertSame($expectedOutput, $container->findDefinition('cli_dumper_public')->getArgument(0));
+    }
+
     private function createContainer()
     {
         $container = new ContainerBuilder(new ParameterBag([
             'kernel.cache_dir' => __DIR__,
             'kernel.charset' => 'UTF-8',
             'kernel.debug' => true,
+            'kernel.project_dir' => __DIR__,
             'kernel.bundles' => ['DebugBundle' => 'Symfony\\Bundle\\DebugBundle\\DebugBundle'],
         ]));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Related to #37237

Some empty args have been replaced by abstract args (server host, populated by `dump_destination` configuration value). But when `dump_destination` is not set (in test env for instance) or doesn't start by `tcp://`, `var_dumper.dump_server` and `var_dumper.server_connection` server host arg is not injected and an exception is thrown due to the abstract arg. 

This PR remove these abstract args.