### PR TITLE
[Security] Add missing NullToken vote

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -60,3 +60,6 @@ Security
 
  * [BC break] In the experimental authenticator-based system, * `TokenInterface::getUser()`
    returns `null` in case of unauthenticated session.
+
+ * [BC break] `AccessListener::PUBLIC_ACCESS` has been removed in favor of
+   `AuthenticatedVoter::PUBLIC_ACCESS`.

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Added attributes on `Passport`
  * Changed `AuthorizationChecker` to call the access decision manager in unauthenticated sessions with a `NullToken`
+ * [BC break] Removed `AccessListener::PUBLIC_ACCESS` in favor of `AuthenticatedVoter::PUBLIC_ACCESS`
 
 5.1.0
 -----

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
@@ -32,6 +32,7 @@ class AuthenticatedVoter implements VoterInterface
     const IS_ANONYMOUS = 'IS_ANONYMOUS';
     const IS_IMPERSONATOR = 'IS_IMPERSONATOR';
     const IS_REMEMBERED = 'IS_REMEMBERED';
+    const PUBLIC_ACCESS = 'PUBLIC_ACCESS';
 
     private $authenticationTrustResolver;
 
@@ -45,6 +46,10 @@ class AuthenticatedVoter implements VoterInterface
      */
     public function vote(TokenInterface $token, $subject, array $attributes)
     {
+        if ($attributes === [self::PUBLIC_ACCESS]) {
+            return VoterInterface::ACCESS_GRANTED;
+        }
+
         $result = VoterInterface::ACCESS_ABSTAIN;
         foreach ($attributes as $attribute) {
             if (null === $attribute || (self::IS_AUTHENTICATED_FULLY !== $attribute

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -32,8 +32,6 @@ use Symfony\Component\Security\Http\Event\LazyResponseEvent;
  */
 class AccessListener extends AbstractListener
 {
-    const PUBLIC_ACCESS = 'PUBLIC_ACCESS';
-
     private $tokenStorage;
     private $accessDecisionManager;
     private $map;
@@ -57,7 +55,7 @@ class AccessListener extends AbstractListener
         [$attributes] = $this->map->getPatterns($request);
         $request->attributes->set('_access_control_attributes', $attributes);
 
-        return $attributes && ([AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY] !== $attributes && [self::PUBLIC_ACCESS] !== $attributes) ? true : null;
+        return $attributes && ([AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY] !== $attributes && [AuthenticatedVoter::PUBLIC_ACCESS] !== $attributes) ? true : null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While playing with 5.2-dev, I discovered I forgot to add a granted vote for `PUBLIC_ACCESS`.

I also think it makes more sense now to move the constant from `AccessListener` to `AuthenticatedVoter` (to not have a dependency on Http constants in a Core voter). This is however a BC break, should we do anything more to facility our early-adapters?