### PR TITLE
[Validator] ensure that the validator is a mock object for backwards-compatibility

### DIFF
--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -115,7 +115,7 @@ abstract class ConstraintValidatorTestCase extends TestCase
         $validator->expects($this->any())
             ->method('inContext')
             ->with($context)
-            ->willReturn(new AssertingContextualValidator());
+            ->willReturn($this->createMock(AssertingContextualValidator::class));
 
         return $context;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I accidentally broke the class in #37808. The validator was a mock object before (see the failing tests on the `5.1` branch).