### PR TITLE
Fix tests namespaces

### DIFF
--- a/src/Symfony/Component/Console/Tests/Formatter/NullOutputFormatterStyleTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/NullOutputFormatterStyleTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Console\Tests\Output;
+namespace Symfony\Component\Console\Tests\Formatter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Formatter\NullOutputFormatterStyle;

--- a/src/Symfony/Component/Console/Tests/Formatter/NullOutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/NullOutputFormatterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Console\Tests\Output;
+namespace Symfony\Component\Console\Tests\Formatter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Formatter\NullOutputFormatter;

--- a/src/Symfony/Component/Validator/Tests/ValidationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Validator\Tests\Validator;
+namespace Symfony\Component\Validator\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\Email;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A

Fixes namespaces for tests introduced in #34869 & #31466, spotted by travis generating Composer warnings:

```
Deprecation Notice: Class Symfony\Component\Console\Tests\Output\NullOutputFormatterStyleTest located in ./src/Symfony/Component/Console/Tests/Formatter/NullOutputFormatterStyleTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/travis/.phpenv/versions/7.4.9/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Symfony\Component\Console\Tests\Output\NullOutputFormatterTest located in ./src/Symfony/Component/Console/Tests/Formatter/NullOutputFormatterTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/travis/.phpenv/versions/7.4.9/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Symfony\Component\Validator\Tests\Validator\ValidationTest located in ./src/Symfony/Component/Validator/Tests/ValidationTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/travis/.phpenv/versions/7.4.9/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
```
