### PR TITLE
Adds option to check EOL via about command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -57,7 +57,6 @@ EOT
             );
     }
 
-
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -68,6 +68,7 @@ EOT
 
         if ($input->getOption('is-maintained') && self::isExpired(Kernel::END_OF_MAINTENANCE)) {
             $io->error(sprintf('Symfony "%s" is not maintained anymore, see https://symfony.com/releases to upgrade.', Kernel::VERSION));
+
             return 1;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
+use \RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Helper\TableSeparator;
@@ -46,10 +47,16 @@ be different between web and CLI.
 
 The <info>Environment</info> section displays the current environment variables managed by Symfony Dotenv. It will not
 be shown if no variables were found. The values might be different between web and CLI.
+
+Passing <info>eolCheck</info> as an option you will get an error if the current symfony kernel is End of Maintenance and
+End of Life (can be used in CI as check `php bin/console about --eolCheck`
+
 EOT
-            )
-        ;
+            )->addOption(
+        'eolCheck'
+            );
     }
+
 
     /**
      * {@inheritdoc}
@@ -60,6 +67,12 @@ EOT
 
         /** @var KernelInterface $kernel */
         $kernel = $this->getApplication()->getKernel();
+
+        if ($input->getOption('eolCheck')) {
+            if(self::isExpired(Kernel::END_OF_MAINTENANCE) && self::isExpired(Kernel::END_OF_LIFE)) {
+                throw new RuntimeException(sprintf('Symfony %s is not maintained anymore, see https://symfony.com/releases to upgrade', Kernel::VERSION));
+            }
+        }
 
         $rows = [
             ['<info>Symfony</>'],

--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
-use \RuntimeException;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Helper\TableSeparator;
@@ -69,8 +69,8 @@ EOT
         $kernel = $this->getApplication()->getKernel();
 
         if ($input->getOption('eolCheck')) {
-            if(self::isExpired(Kernel::END_OF_MAINTENANCE) && self::isExpired(Kernel::END_OF_LIFE)) {
-                throw new RuntimeException(sprintf('Symfony %s is not maintained anymore, see https://symfony.com/releases to upgrade', Kernel::VERSION));
+            if (self::isExpired(Kernel::END_OF_MAINTENANCE) && self::isExpired(Kernel::END_OF_LIFE)) {
+                throw new RuntimeException(sprintf('Symfony "%s" is not maintained anymore, see https://symfony.com/releases to upgrade.', Kernel::VERSION));
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Slack discussion
| License       | MIT

This is an action on the slack discussion I had last week that ended up with this PR https://github.com/symfony/symfony/pull/37754 
Ideally I'd like to ran a command in my CI pipelines that can inform me automatically if the symfony I am running is EOL.
I thought the easiest, less invasive way is re-using the about command with an opt-in flag called `eolCheck`
