### PR TITLE
route matching improvement

### DIFF
--- a/src/Symfony/Component/Routing/Generator/CompiledUrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/CompiledUrlGenerator.php
@@ -33,17 +33,25 @@ class CompiledUrlGenerator extends UrlGenerator
 
     public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH)
     {
-        $locale = $parameters['_locale']
-            ?? $this->context->getParameter('_locale')
-            ?: $this->defaultLocale;
+        $routeName = null;
+        $locales = array_filter([
+            $parameters['_locale'] ?? null,
+            $this->context->getParameter('_locale') ?? null,
+            $this->defaultLocale ?? null,
+        ]);
 
-        if (null !== $locale) {
+        while(count($locales)>0) {
+            $locale = array_shift($locales);
             do {
                 if (($this->compiledRoutes[$name.'.'.$locale][1]['_canonical_route'] ?? null) === $name) {
-                    $name .= '.'.$locale;
+                    $routeName = $name.'.'.$locale;
                     break;
                 }
             } while (false !== $locale = strstr($locale, '_', true));
+            if ($routeName !== null) {
+                $name = $routeName;
+                break;
+            }
         }
 
         if (!isset($this->compiledRoutes[$name])) {

--- a/src/Symfony/Component/Routing/Generator/CompiledUrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/CompiledUrlGenerator.php
@@ -40,7 +40,7 @@ class CompiledUrlGenerator extends UrlGenerator
             $this->defaultLocale ?? null,
         ]);
 
-        while(\count($locales) > 0) {
+        while (\count($locales) > 0) {
             $locale = array_shift($locales);
             do {
                 if (($this->compiledRoutes[$name.'.'.$locale][1]['_canonical_route'] ?? null) === $name) {

--- a/src/Symfony/Component/Routing/Generator/CompiledUrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/CompiledUrlGenerator.php
@@ -40,7 +40,7 @@ class CompiledUrlGenerator extends UrlGenerator
             $this->defaultLocale ?? null,
         ]);
 
-        while(count($locales)>0) {
+        while(\count($locales)>0) {
             $locale = array_shift($locales);
             do {
                 if (($this->compiledRoutes[$name.'.'.$locale][1]['_canonical_route'] ?? null) === $name) {
@@ -48,7 +48,7 @@ class CompiledUrlGenerator extends UrlGenerator
                     break;
                 }
             } while (false !== $locale = strstr($locale, '_', true));
-            if ($routeName !== null) {
+            if (null !== $routeName) {
                 $name = $routeName;
                 break;
             }

--- a/src/Symfony/Component/Routing/Generator/CompiledUrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/CompiledUrlGenerator.php
@@ -40,7 +40,7 @@ class CompiledUrlGenerator extends UrlGenerator
             $this->defaultLocale ?? null,
         ]);
 
-        while(\count($locales)>0) {
+        while(\count($locales) > 0) {
             $locale = array_shift($locales);
             do {
                 if (($this->compiledRoutes[$name.'.'.$locale][1]['_canonical_route'] ?? null) === $name) {


### PR DESCRIPTION
Before , in the generate() function, if the locale doesn't match with a route a "Route Not Found" error was generated.
Now the function tries all "locales" before failing miserably.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |  Before , in the generate() function, if the locale doesn't match with a route a "Route Not Found" error was generated. Now the function tries all "locales" before failing miserably.
| License       | MIT

Before , in the generate() function, if the locale doesn't match with a route a "Route Not Found" error was generated.
Now the function tries all "locales" before failing miserably.
