### PR TITLE
Fix the parameter names in the SecurityFactoryInterface::create() method

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SecurityFactoryInterface.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SecurityFactoryInterface.php
@@ -24,17 +24,17 @@ interface SecurityFactoryInterface
     /**
      * Configures the container services required to use the authentication listener.
      *
-     * @param string      $id                The unique id of the firewall
-     * @param array       $config            The options array for the listener
-     * @param string      $userProvider      The service id of the user provider
-     * @param string|null $defaultEntryPoint
+     * @param string      $id                  The unique id of the firewall
+     * @param array       $config              The options array for the listener
+     * @param string      $userProviderId      The service id of the user provider
+     * @param string|null $defaultEntryPointId
      *
      * @return array containing three values:
      *               - the provider id
      *               - the listener id
      *               - the entry point id
      */
-    public function create(ContainerBuilder $container, $id, $config, $userProvider, $defaultEntryPoint);
+    public function create(ContainerBuilder $container, $id, $config, $userProviderId, $defaultEntryPointId);
 
     /**
      * Defines the position at which the provider is called.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

With regard to PHP 8, Psalm has added a named arguments check:
https://psalm.dev/articles/getting-ready-for-named-arguments

This check currently fails, because the `SecurityFactoryInterface` uses different parameter names than the `AbstractFactory`. You can see for yourselves at https://psalm.dev/r/81413a1c96.
