### PR TITLE
[Sendgrid-Mailer] Fixed envelope recipients on sendgridApiTransport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -84,7 +84,7 @@ class SendgridApiTransport extends AbstractApiTransport
         }
 
         $personalization = [
-            'to' => array_map($addressStringifier, $email->getTo()),
+            'to' => array_map($addressStringifier, $this->getRecipients($email, $envelope)),
             'subject' => $email->getSubject(),
         ];
         if ($emails = array_map($addressStringifier, $email->getCc())) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37870 
| License       | MIT
| Doc PR        | no

Fixes #37870

The SendgridApiTransport was not using the envelope to get the
recipients, so overriding the recipients with the EnvelopeListener was
not working.