### PR TITLE
fix: clarify parameter name to comply with deprecations from #34074

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -207,30 +207,30 @@ abstract class AbstractController implements ServiceSubscriberInterface
     }
 
     /**
-     * Checks if the attributes are granted against the current authentication token and optionally supplied subject.
+     * Checks if the attribute is granted against the current authentication token and optionally supplied subject.
      *
      * @throws \LogicException
      */
-    protected function isGranted($attributes, $subject = null): bool
+    protected function isGranted($attribute, $subject = null): bool
     {
         if (!$this->container->has('security.authorization_checker')) {
             throw new \LogicException('The SecurityBundle is not registered in your application. Try running "composer require symfony/security-bundle".');
         }
 
-        return $this->container->get('security.authorization_checker')->isGranted($attributes, $subject);
+        return $this->container->get('security.authorization_checker')->isGranted($attribute, $subject);
     }
 
     /**
-     * Throws an exception unless the attributes are granted against the current authentication token and optionally
+     * Throws an exception unless the attribute is granted against the current authentication token and optionally
      * supplied subject.
      *
      * @throws AccessDeniedException
      */
-    protected function denyAccessUnlessGranted($attributes, $subject = null, string $message = 'Access Denied.'): void
+    protected function denyAccessUnlessGranted($attribute, $subject = null, string $message = 'Access Denied.'): void
     {
-        if (!$this->isGranted($attributes, $subject)) {
+        if (!$this->isGranted($attribute, $subject)) {
             $exception = $this->createAccessDeniedException($message);
-            $exception->setAttributes($attributes);
+            $exception->setAttributes($attribute);
             $exception->setSubject($subject);
 
             throw $exception;

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Security\Core\Authorization;
 interface AuthorizationCheckerInterface
 {
     /**
-     * Checks if the attributes are granted against the current authentication token and optionally supplied subject.
+     * Checks if the attribute is granted against the current authentication token and optionally supplied subject.
      *
      * @param mixed $attribute A single attribute to vote on (can be of any type, string and instance of Expression are supported by the core)
      * @param mixed $subject


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37824 
| License       | MIT
| Doc PR        | 

[FrameworkBundle] Clarify parameter name from `$attributes` to `$attribute` in `AbstractController:denyUnlessGranted`