### PR TITLE
[Workflow] make $registry->get(Entity::class) consistent with the doctrine way (by using class name)

### DIFF
--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Dispatch an event when the subject enters in the workflow for the very first time
  * Added a default context to the previous event
  * Added support for specifying which events should be dispatched when calling `workflow->apply()`
+ * It is now possible to retrieve a workflow by using a class name
 
 5.1.0
 -----

--- a/src/Symfony/Component/Workflow/Registry.php
+++ b/src/Symfony/Component/Workflow/Registry.php
@@ -51,8 +51,13 @@ class Registry
             }
         }
 
+        if (\is_string($subject)) {
+            $type = $subject;
+        } else {
+            $type = get_debug_type($subject);
+        }
         if (!$matched) {
-            throw new InvalidArgumentException(sprintf('Unable to find a workflow for class "%s".', get_debug_type($subject)));
+            throw new InvalidArgumentException(sprintf('Unable to find a workflow for class "%s".', $type));
         }
 
         if (2 <= \count($matched)) {
@@ -60,7 +65,7 @@ class Registry
                 return $workflow->getName();
             }, $matched);
 
-            throw new InvalidArgumentException(sprintf('Too many workflows (%s) match this subject (%s); set a different name on each and use the second (name) argument of this method.', implode(', ', $names), get_debug_type($subject)));
+            throw new InvalidArgumentException(sprintf('Too many workflows (%s) match this subject (%s); set a different name on each and use the second (name) argument of this method.', implode(', ', $names), $type));
         }
 
         return $matched[0];
@@ -85,6 +90,12 @@ class Registry
     {
         if (null !== $workflowName && $workflowName !== $workflow->getName()) {
             return false;
+        }
+
+        if (\is_string($subject)) {
+            $stdClass = new \stdClass();
+            $stdClass->class = $subject;
+            $subject = $stdClass;
         }
 
         return $supportStrategy->supports($workflow, $subject);

--- a/src/Symfony/Component/Workflow/Registry.php
+++ b/src/Symfony/Component/Workflow/Registry.php
@@ -15,6 +15,7 @@ use Symfony\Component\Workflow\Exception\InvalidArgumentException;
 use Symfony\Component\Workflow\SupportStrategy\WorkflowSupportStrategyInterface;
 
 /**
+ * @author Carlos Pereira De Amorim <carlos@shauri.fr>
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
@@ -41,7 +42,7 @@ class Registry
     /**
      * @return Workflow
      */
-    public function get(object $subject, string $workflowName = null)
+    public function get($subject, string $workflowName = null)
     {
         $matched = [];
 
@@ -81,7 +82,7 @@ class Registry
         return $matched;
     }
 
-    private function supports(WorkflowInterface $workflow, WorkflowSupportStrategyInterface $supportStrategy, object $subject, ?string $workflowName): bool
+    private function supports(WorkflowInterface $workflow, WorkflowSupportStrategyInterface $supportStrategy, $subject, ?string $workflowName): bool
     {
         if (null !== $workflowName && $workflowName !== $workflow->getName()) {
             return false;

--- a/src/Symfony/Component/Workflow/Registry.php
+++ b/src/Symfony/Component/Workflow/Registry.php
@@ -15,7 +15,6 @@ use Symfony\Component\Workflow\Exception\InvalidArgumentException;
 use Symfony\Component\Workflow\SupportStrategy\WorkflowSupportStrategyInterface;
 
 /**
- * @author Carlos Pereira De Amorim <carlos@shauri.fr>
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */

--- a/src/Symfony/Component/Workflow/SupportStrategy/InstanceOfSupportStrategy.php
+++ b/src/Symfony/Component/Workflow/SupportStrategy/InstanceOfSupportStrategy.php
@@ -30,17 +30,13 @@ final class InstanceOfSupportStrategy implements WorkflowSupportStrategyInterfac
     /**
      * {@inheritdoc}
      */
-    public function supports(WorkflowInterface $workflow, $subject): bool
+    public function supports(WorkflowInterface $workflow, object $subject): bool
     {
-        if (\is_object($subject)) {
-            return $subject instanceof $this->className;
+        if ($subject instanceof \stdClass && property_exists($subject, 'class')) {
+            return $subject->class === $this->className;
         }
 
-        if (\is_string($subject)) {
-            return $subject === $this->className;
-        }
-
-        throw new \InvalidArgumentException(sprintf('"%s" is not a supported type.', \gettype($subject)));
+        return $subject instanceof $this->className;
     }
 
     public function getClassName(): string

--- a/src/Symfony/Component/Workflow/SupportStrategy/InstanceOfSupportStrategy.php
+++ b/src/Symfony/Component/Workflow/SupportStrategy/InstanceOfSupportStrategy.php
@@ -11,9 +11,11 @@
 
 namespace Symfony\Component\Workflow\SupportStrategy;
 
+use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Workflow\WorkflowInterface;
 
 /**
+ * @author Carlos Pereira De Amorim <carlos@shauri.fr>
  * @author Andreas Kleemann <akleemann@inviqa.com>
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
  */
@@ -29,9 +31,15 @@ final class InstanceOfSupportStrategy implements WorkflowSupportStrategyInterfac
     /**
      * {@inheritdoc}
      */
-    public function supports(WorkflowInterface $workflow, object $subject): bool
+    public function supports(WorkflowInterface $workflow, $subject): bool
     {
-        return $subject instanceof $this->className;
+        if (is_object($subject)) {
+            return $subject instanceof $this->className;
+        } elseif (is_string($subject)) {
+            return $subject === $this->className;
+        } else {
+            throw new Exception(sprintf('%s is not a supported type', gettype($subject)));
+        }
     }
 
     public function getClassName(): string

--- a/src/Symfony/Component/Workflow/SupportStrategy/InstanceOfSupportStrategy.php
+++ b/src/Symfony/Component/Workflow/SupportStrategy/InstanceOfSupportStrategy.php
@@ -35,11 +35,13 @@ final class InstanceOfSupportStrategy implements WorkflowSupportStrategyInterfac
     {
         if (\is_object($subject)) {
             return $subject instanceof $this->className;
-        } elseif (\is_string($subject)) {
-            return $subject === $this->className;
-        } else {
-            throw new Exception(sprintf('"%s" is not a supported type.', \gettype($subject)));
         }
+        
+        if (\is_string($subject)) {
+            return $subject === $this->className;
+        }
+
+        throw new \InvalidArgumentException(sprintf('"%s" is not a supported type.', \gettype($subject)));
     }
 
     public function getClassName(): string

--- a/src/Symfony/Component/Workflow/SupportStrategy/InstanceOfSupportStrategy.php
+++ b/src/Symfony/Component/Workflow/SupportStrategy/InstanceOfSupportStrategy.php
@@ -33,12 +33,12 @@ final class InstanceOfSupportStrategy implements WorkflowSupportStrategyInterfac
      */
     public function supports(WorkflowInterface $workflow, $subject): bool
     {
-        if (is_object($subject)) {
+        if (\is_object($subject)) {
             return $subject instanceof $this->className;
-        } elseif (is_string($subject)) {
+        } elseif (\is_string($subject)) {
             return $subject === $this->className;
         } else {
-            throw new Exception(sprintf('%s is not a supported type', gettype($subject)));
+            throw new Exception(sprintf('"%s" is not a supported type', \gettype($subject)));
         }
     }
 

--- a/src/Symfony/Component/Workflow/SupportStrategy/InstanceOfSupportStrategy.php
+++ b/src/Symfony/Component/Workflow/SupportStrategy/InstanceOfSupportStrategy.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Workflow\SupportStrategy;
 
-use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Workflow\WorkflowInterface;
 
 /**
@@ -36,7 +35,7 @@ final class InstanceOfSupportStrategy implements WorkflowSupportStrategyInterfac
         if (\is_object($subject)) {
             return $subject instanceof $this->className;
         }
-        
+
         if (\is_string($subject)) {
             return $subject === $this->className;
         }

--- a/src/Symfony/Component/Workflow/SupportStrategy/InstanceOfSupportStrategy.php
+++ b/src/Symfony/Component/Workflow/SupportStrategy/InstanceOfSupportStrategy.php
@@ -38,7 +38,7 @@ final class InstanceOfSupportStrategy implements WorkflowSupportStrategyInterfac
         } elseif (\is_string($subject)) {
             return $subject === $this->className;
         } else {
-            throw new Exception(sprintf('"%s" is not a supported type', \gettype($subject)));
+            throw new Exception(sprintf('"%s" is not a supported type.', \gettype($subject)));
         }
     }
 

--- a/src/Symfony/Component/Workflow/SupportStrategy/WorkflowSupportStrategyInterface.php
+++ b/src/Symfony/Component/Workflow/SupportStrategy/WorkflowSupportStrategyInterface.php
@@ -18,5 +18,5 @@ use Symfony\Component\Workflow\WorkflowInterface;
  */
 interface WorkflowSupportStrategyInterface
 {
-    public function supports(WorkflowInterface $workflow, $subject): bool;
+    public function supports(WorkflowInterface $workflow, object $subject): bool;
 }

--- a/src/Symfony/Component/Workflow/SupportStrategy/WorkflowSupportStrategyInterface.php
+++ b/src/Symfony/Component/Workflow/SupportStrategy/WorkflowSupportStrategyInterface.php
@@ -18,5 +18,5 @@ use Symfony\Component\Workflow\WorkflowInterface;
  */
 interface WorkflowSupportStrategyInterface
 {
-    public function supports(WorkflowInterface $workflow, object $subject): bool;
+    public function supports(WorkflowInterface $workflow, $subject): bool;
 }

--- a/src/Symfony/Component/Workflow/Tests/RegistryTest.php
+++ b/src/Symfony/Component/Workflow/Tests/RegistryTest.php
@@ -53,6 +53,13 @@ class RegistryTest extends TestCase
         $this->assertSame('workflow2', $workflow->getName());
     }
 
+    public function testGetWithSuccessFromClassName()
+    {
+        $workflow = $this->registry->get(Subject1::class);
+        $this->assertInstanceOf(Workflow::class, $workflow);
+        $this->assertSame('workflow1', $workflow->getName());
+
+    }
     public function testGetWithMultipleMatch()
     {
         $this->expectException('Symfony\Component\Workflow\Exception\InvalidArgumentException');
@@ -103,7 +110,11 @@ class RegistryTest extends TestCase
         $strategy = $this->getMockBuilder(WorkflowSupportStrategyInterface::class)->getMock();
         $strategy->expects($this->any())->method('supports')
             ->willReturnCallback(function ($workflow, $subject) use ($supportedClassName) {
-                return $subject instanceof $supportedClassName;
+                if (is_object($subject)) {
+                    return $subject instanceof $supportedClassName;
+                } else {
+                    return $subject === $supportedClassName;
+                }
             });
 
         return $strategy;

--- a/src/Symfony/Component/Workflow/Tests/RegistryTest.php
+++ b/src/Symfony/Component/Workflow/Tests/RegistryTest.php
@@ -109,12 +109,12 @@ class RegistryTest extends TestCase
     {
         $strategy = $this->getMockBuilder(WorkflowSupportStrategyInterface::class)->getMock();
         $strategy->expects($this->any())->method('supports')
-            ->willReturnCallback(function ($workflow, $subject) use ($supportedClassName) {
-                if (\is_object($subject)) {
-                    return $subject instanceof $supportedClassName;
+            ->willReturnCallback(function ($workflow, object $subject) use ($supportedClassName) {
+                if ($subject instanceof \stdClass && property_exists($subject, 'class')) {
+                    return $subject->class === $supportedClassName;
                 }
 
-                return $subject === $supportedClassName;
+                return $subject instanceof $supportedClassName;
             });
 
         return $strategy;

--- a/src/Symfony/Component/Workflow/Tests/RegistryTest.php
+++ b/src/Symfony/Component/Workflow/Tests/RegistryTest.php
@@ -58,8 +58,8 @@ class RegistryTest extends TestCase
         $workflow = $this->registry->get(Subject1::class);
         $this->assertInstanceOf(Workflow::class, $workflow);
         $this->assertSame('workflow1', $workflow->getName());
-
     }
+
     public function testGetWithMultipleMatch()
     {
         $this->expectException('Symfony\Component\Workflow\Exception\InvalidArgumentException');
@@ -110,7 +110,7 @@ class RegistryTest extends TestCase
         $strategy = $this->getMockBuilder(WorkflowSupportStrategyInterface::class)->getMock();
         $strategy->expects($this->any())->method('supports')
             ->willReturnCallback(function ($workflow, $subject) use ($supportedClassName) {
-                if (is_object($subject)) {
+                if (\is_object($subject)) {
                     return $subject instanceof $supportedClassName;
                 } else {
                     return $subject === $supportedClassName;

--- a/src/Symfony/Component/Workflow/Tests/RegistryTest.php
+++ b/src/Symfony/Component/Workflow/Tests/RegistryTest.php
@@ -112,9 +112,10 @@ class RegistryTest extends TestCase
             ->willReturnCallback(function ($workflow, $subject) use ($supportedClassName) {
                 if (\is_object($subject)) {
                     return $subject instanceof $supportedClassName;
-                } else {
-                    return $subject === $supportedClassName;
                 }
+
+                return $subject === $supportedClassName;
+
             });
 
         return $strategy;

--- a/src/Symfony/Component/Workflow/Tests/RegistryTest.php
+++ b/src/Symfony/Component/Workflow/Tests/RegistryTest.php
@@ -115,7 +115,6 @@ class RegistryTest extends TestCase
                 }
 
                 return $subject === $supportedClassName;
-
             });
 
         return $strategy;

--- a/src/Symfony/Component/Workflow/Tests/SupportStrategy/InstanceOfSupportStrategyTest.php
+++ b/src/Symfony/Component/Workflow/Tests/SupportStrategy/InstanceOfSupportStrategyTest.php
@@ -14,7 +14,9 @@ class InstanceOfSupportStrategyTest extends TestCase
 
         $this->assertTrue($strategy->supports($this->createWorkflow(), new Subject1()));
 
-        $this->assertTrue($strategy->supports($this->createWorkflow(), Subject1::class));
+        $stdClass = new \StdClass();
+        $stdClass->class = Subject1::class;
+        $this->assertTrue($strategy->supports($this->createWorkflow(), $stdClass));
     }
 
     public function testSupportsIfNotClassInstance()
@@ -23,7 +25,9 @@ class InstanceOfSupportStrategyTest extends TestCase
 
         $this->assertFalse($strategy->supports($this->createWorkflow(), new Subject1()));
 
-        $this->assertFalse($strategy->supports($this->createWorkflow(), Subject1::class));
+        $stdClass = new \StdClass();
+        $stdClass->class = Subject1::class;
+        $this->assertFalse($strategy->supports($this->createWorkflow(), $stdClass));
     }
 
     private function createWorkflow()

--- a/src/Symfony/Component/Workflow/Tests/SupportStrategy/InstanceOfSupportStrategyTest.php
+++ b/src/Symfony/Component/Workflow/Tests/SupportStrategy/InstanceOfSupportStrategyTest.php
@@ -13,6 +13,8 @@ class InstanceOfSupportStrategyTest extends TestCase
         $strategy = new InstanceOfSupportStrategy(Subject1::class);
 
         $this->assertTrue($strategy->supports($this->createWorkflow(), new Subject1()));
+
+        $this->assertTrue($strategy->supports($this->createWorkflow(), Subject1::class));
     }
 
     public function testSupportsIfNotClassInstance()
@@ -20,6 +22,8 @@ class InstanceOfSupportStrategyTest extends TestCase
         $strategy = new InstanceOfSupportStrategy(Subject2::class);
 
         $this->assertFalse($strategy->supports($this->createWorkflow(), new Subject1()));
+
+        $this->assertFalse($strategy->supports($this->createWorkflow(), Subject1::class));
     }
 
     private function createWorkflow()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | No
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/14106

For this, I had to change some Interface, but I don't think it causes BC Breaks

Now that I'm submitting it, I wonder if it's been submitted before :thinking: 

Anyway, I think it's more consistent to use the class name to retrieve a workflow. 

It's particularly convenient when you need the metadata of the workflow. In that case, you might not have an instance available and you have to do something like `$registry->get(new Entity())`.

With this PR, `$registry->get(Entity::class)` will work :)