### PR TITLE
[Mailer] Reorder headers used to determine Sender

### DIFF
--- a/src/Symfony/Component/Mailer/DelayedEnvelope.php
+++ b/src/Symfony/Component/Mailer/DelayedEnvelope.php
@@ -83,14 +83,14 @@ final class DelayedEnvelope extends Envelope
 
     private static function getSenderFromHeaders(Headers $headers): Address
     {
-        if ($return = $headers->get('Return-Path')) {
-            return $return->getAddress();
-        }
         if ($sender = $headers->get('Sender')) {
             return $sender->getAddress();
         }
         if ($from = $headers->get('From')) {
             return $from->getAddresses()[0];
+        }
+        if ($return = $headers->get('Return-Path')) {
+            return $return->getAddress();
         }
 
         throw new LogicException('Unable to determine the sender of the message.');

--- a/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EnvelopeTest.php
@@ -81,6 +81,24 @@ class EnvelopeTest extends TestCase
         $this->assertEquals($from, $e->getSender());
     }
 
+    public function testSenderFromHeadersWithMulitpleHeaders()
+    {
+        $headers = new Headers();
+        $headers->addMailboxListHeader('From', [$from = new Address('from@symfony.com', 'from'), 'some@symfony.com']);
+        $headers->addPathHeader('Return-Path', $return = new Address('return@symfony.com', 'return'));
+        $headers->addMailboxHeader('Sender', $sender = new Address('sender@symfony.com', 'sender'));
+        $headers->addMailboxListHeader('To', ['to@symfony.com']);
+        $e = Envelope::create(new Message($headers));
+        $this->assertEquals($sender, $e->getSender());
+
+        $headers = new Headers();
+        $headers->addMailboxListHeader('From', [$from = new Address('from@symfony.com', 'from'), 'some@symfony.com']);
+        $headers->addPathHeader('Return-Path', $return = new Address('return@symfony.com', 'return'));
+        $headers->addMailboxListHeader('To', ['to@symfony.com']);
+        $e = Envelope::create(new Message($headers));
+        $this->assertEquals($from, $e->getSender());
+    }
+
     public function testRecipientsFromHeaders()
     {
         $headers = new Headers();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Use the `Return-Path` header as the last candidate to determine the Envelope's sender address.

The `Return-Path` is usually configured _in addition_ to the `Sender` and/or `From` header: it allows for email bounces and complaints to be sent to a dedicated email address. It should therefor not be used as the first candidate header to determine the sender.