### PR TITLE
[Notifier] Fixed base_uri while call auth/time API

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -88,7 +88,7 @@ final class OvhCloudTransport extends AbstractTransport
         if (200 !== $response->getStatusCode()) {
             $error = $response->toArray(false);
 
-            throw new TransportException(sprintf('Unable to send the SMS: %s.', $error['message']), $response);
+            throw new TransportException(sprintf('Unable to send the SMS: "%s".', $error['message']), $response);
         }
     }
 
@@ -97,7 +97,7 @@ final class OvhCloudTransport extends AbstractTransport
      */
     private function calculateTimeDelta(): int
     {
-        $endpoint = sprintf('%s/auth/time', $this->getEndpoint());
+        $endpoint = sprintf('https://%s/1.0/auth/time', $this->getEndpoint());
         $response = $this->client->request('GET', $endpoint);
 
         return $response->getContent() - time();


### PR DESCRIPTION
This patch fixed the base_uri missing while we call the auth/time OVH
API.

* Without this patch, the API call failed because the URL is wrong :
eu.api.ovh.com/auth/time

* With this patch, the API call successed, URL is :
https://eu.api.ovh.com/1.0/auth/time

| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fixed base_uri while call auth/time API
| License       | MIT


