### PR TITLE
[Mailer] Support Amazon SES ConfigurationSetName

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -69,6 +69,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
             $this->assertSame('Hello There!', $content['Content']['Simple']['Body']['Text']['Data']);
             $this->assertSame('<b>Hello There!</b>', $content['Content']['Simple']['Body']['Html']['Data']);
             $this->assertSame(['replyto-1@example.com', 'replyto-2@example.com'], $content['ReplyToAddresses']);
+            $this->assertSame('aws-configuration-set-name', $content['ConfigurationSetName']);
 
             $json = '{"MessageId": "foobar"}';
 
@@ -86,6 +87,8 @@ class SesApiAsyncAwsTransportTest extends TestCase
             ->text('Hello There!')
             ->html('<b>Hello There!</b>')
             ->replyTo(new Address('replyto-1@example.com'), new Address('replyto-2@example.com'));
+
+        $mail->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', 'aws-configuration-set-name');
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
@@ -68,6 +68,7 @@ class SesHttpAsyncAwsTransportTest extends TestCase
             $this->assertStringContainsString('Saif Eddin <saif.gmati@symfony.com>', $content);
             $this->assertStringContainsString('Fabien <fabpot@symfony.com>', $content);
             $this->assertStringContainsString('Hello There!', $content);
+            $this->assertSame('aws-configuration-set-name', $body['ConfigurationSetName']);
 
             $json = '{"MessageId": "foobar"}';
 
@@ -83,6 +84,8 @@ class SesHttpAsyncAwsTransportTest extends TestCase
             ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
             ->from(new Address('fabpot@symfony.com', 'Fabien'))
             ->text('Hello There!');
+
+        $mail->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', 'aws-configuration-set-name');
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpTransportTest.php
@@ -70,6 +70,8 @@ class SesHttpTransportTest extends TestCase
             $this->assertStringContainsString('Fabien <fabpot@symfony.com>', $content);
             $this->assertStringContainsString('Hello There!', $content);
 
+            $this->assertSame('aws-configuration-set-name', $body['ConfigurationSetName']);
+
             $xml = '<SendEmailResponse xmlns="https://email.amazonaws.com/doc/2010-03-31/">
   <SendRawEmailResult>
     <MessageId>foobar</MessageId>
@@ -88,6 +90,8 @@ class SesHttpTransportTest extends TestCase
             ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
             ->from(new Address('fabpot@symfony.com', 'Fabien'))
             ->text('Hello There!');
+
+        $mail->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', 'aws-configuration-set-name');
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
@@ -89,6 +89,9 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
         if ($emails = $email->getReplyTo()) {
             $request['ReplyToAddresses'] = $this->stringifyAddresses($emails);
         }
+        if ($header = $email->getHeaders()->get('X-SES-CONFIGURATION-SET')) {
+            $request['ConfigurationSetName'] = $header->getBodyAsString();
+        }
 
         return new SendEmailRequest($request);
     }

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiTransport.php
@@ -90,10 +90,16 @@ class SesApiTransport extends AbstractApiTransport
     private function getPayload(Email $email, Envelope $envelope): array
     {
         if ($email->getAttachments()) {
-            return [
+            $payload = [
                 'Action' => 'SendRawEmail',
                 'RawMessage.Data' => base64_encode($email->toString()),
             ];
+
+            if ($header = $email->getHeaders()->get('X-SES-CONFIGURATION-SET')) {
+                $payload['ConfigurationSetName'] = $header->getBodyAsString();
+            }
+
+            return $payload;
         }
 
         $payload = [
@@ -117,6 +123,9 @@ class SesApiTransport extends AbstractApiTransport
         }
         if ($email->getReplyTo()) {
             $payload['ReplyToAddresses.member'] = $this->stringifyAddresses($email->getReplyTo());
+        }
+        if ($header = $email->getHeaders()->get('X-SES-CONFIGURATION-SET')) {
+            $payload['ConfigurationSetName'] = $header->getBodyAsString();
         }
 
         return $payload;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

In Amazon SES a Configuration Set can be used to monitor email sending
events (delivery, bounces, complaints etc.). In order to use this
feature the ConfigurationSetName needs to be sent along with the email.

Setting the `X-SES-CONFIGURATION-SET` header should accomplish this for
all SES Transports now.

Ref: https://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-configuration-sets-in-email.html
