### PR TITLE
[Mailer] Support reply-to in SesApiAsyncAwsTransport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -68,6 +68,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
             $this->assertSame('Fabien <fabpot@symfony.com>', $content['FromEmailAddress']);
             $this->assertSame('Hello There!', $content['Content']['Simple']['Body']['Text']['Data']);
             $this->assertSame('<b>Hello There!</b>', $content['Content']['Simple']['Body']['Html']['Data']);
+            $this->assertSame(['replyto-1@example.com', 'replyto-2@example.com'], $content['ReplyToAddresses']);
 
             $json = '{"MessageId": "foobar"}';
 
@@ -83,7 +84,8 @@ class SesApiAsyncAwsTransportTest extends TestCase
             ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
             ->from(new Address('fabpot@symfony.com', 'Fabien'))
             ->text('Hello There!')
-            ->html('<b>Hello There!</b>');
+            ->html('<b>Hello There!</b>')
+            ->replyTo(new Address('replyto-1@example.com'), new Address('replyto-2@example.com'));
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
@@ -86,6 +86,9 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
                 'Charset' => $email->getHtmlCharset(),
             ]);
         }
+        if ($emails = $email->getReplyTo()) {
+            $request['ReplyToAddresses'] = $this->stringifyAddresses($emails);
+        }
 
         return new SendEmailRequest($request);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Enable sending `SendEmailRequest`s with reply-to addresses with `SesApiAsyncAwsTransport`.
