### PR TITLE
[Mailer] Fixed mandrill api header structure

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Tests/Transport/MandrillApiTransportTest.php
@@ -63,7 +63,7 @@ class MandrillApiTransportTest extends TestCase
         $this->assertArrayHasKey('message', $payload);
         $this->assertArrayHasKey('headers', $payload['message']);
         $this->assertCount(1, $payload['message']['headers']);
-        $this->assertEquals('foo: bar', $payload['message']['headers'][0]);
+        $this->assertEquals('bar', $payload['message']['headers']['foo']);
     }
 
     public function testSend()

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/Transport/MandrillApiTransport.php
@@ -111,7 +111,7 @@ class MandrillApiTransport extends AbstractApiTransport
                 continue;
             }
 
-            $payload['message']['headers'][] = $name.': '.$header->getBodyAsString();
+            $payload['message']['headers'][$name] = $header->getBodyAsString();
         }
 
         return $payload;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

When using the Mandrill API transport, it is not possible to set a reply-to address.

**How to reproduce**  
Create a new email and add a reply-to address:

```php
$email = (new Email())
    ->from('from@example.com')
    ->to('to@example.com')
    ->replyTo('replyto@example.com')
    ->subject('subject')
    ->text('text');
$mailer->send($email);
```

The expected result is a payload which contains the following headers:

```
"headers": {
    "reply-to": "replyto@example.com"
}
```

But instead, the `getPayload()` method produces these headers:

```
"headers": [
    "reply-to: replyto@example.com"
]
```

**Additional context**  
See https://mandrillapp.com/api/docs/messages.html.