### PR TITLE
SerializedName based on Groups

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/LegacyBundle/Resources/config/serialization.yaml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/LegacyBundle/Resources/config/serialization.yaml
@@ -1,4 +1,4 @@
 Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\LegacyBundle\Entity\LegacyPerson:
     attributes:
         name:
-            serialized_name: 'full_name'
+            serialized_names: 'full_name'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/ModernBundle/config/serialization.yaml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/ModernBundle/config/serialization.yaml
@@ -1,4 +1,4 @@
 Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\ModernBundle\src\Entity\ModernPerson:
     attributes:
         name:
-            serialized_name: 'full_name'
+            serialized_names: 'full_name'

--- a/src/Symfony/Component/Serializer/Annotation/SerializedName.php
+++ b/src/Symfony/Component/Serializer/Annotation/SerializedName.php
@@ -28,6 +28,8 @@ final class SerializedName
      */
     private $serializedName;
 
+    private $groups = [];
+
     public function __construct(array $data)
     {
         if (!isset($data['value'])) {
@@ -39,10 +41,16 @@ final class SerializedName
         }
 
         $this->serializedName = $data['value'];
+        $this->groups = (array) ($data['groups'] ?? []);
     }
 
     public function getSerializedName(): string
     {
         return $this->serializedName;
+    }
+
+    public function getGroups(): array
+    {
+        return $this->groups;
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -57,9 +57,24 @@ interface AttributeMetadataInterface
     public function setSerializedName(string $serializedName = null);
 
     /**
+     * Adds the serialization name for this attribute.
+     */
+    public function addSerializedName(string $serializedName, array $groups = []);
+
+    /**
      * Gets the serialization name for this attribute.
      */
     public function getSerializedName(): ?string;
+
+    /**
+     * Gets the serialization names for this attribute.
+     */
+    public function getSerializedNames(): array;
+
+    /**
+     * Gets the serialization name for this attribute.
+     */
+    public function getSerializedNameForGroups(array $groups = []): ?string;
 
     /**
      * Sets if this attribute must be ignored or not.

--- a/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactoryCompiler.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactoryCompiler.php
@@ -47,7 +47,7 @@ EOF;
                 $attributesMetadata[$attributeMetadata->getName()] = [
                     $attributeMetadata->getGroups(),
                     $attributeMetadata->getMaxDepth(),
-                    $attributeMetadata->getSerializedName(),
+                    $attributeMetadata->getSerializedNames(),
                 ];
             }
 

--- a/src/Symfony/Component/Serializer/Mapping/Factory/CompiledClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/CompiledClassMetadataFactory.php
@@ -33,8 +33,9 @@ final class CompiledClassMetadataFactory implements ClassMetadataFactoryInterfac
         }
 
         $compiledClassMetadata = require $compiledClassMetadataFile;
+
         if (!\is_array($compiledClassMetadata)) {
-            throw new \RuntimeException(sprintf('Compiled metadata must be of the type array, %s given.', \gettype($compiledClassMetadata)));
+            throw new \RuntimeException(sprintf('Compiled metadata must be of the type array, "%s" given.', \gettype($compiledClassMetadata)));
         }
 
         $this->compiledClassMetadata = $compiledClassMetadata;
@@ -56,7 +57,7 @@ final class CompiledClassMetadataFactory implements ClassMetadataFactoryInterfac
             $classMetadata = new ClassMetadata($className);
             foreach ($this->compiledClassMetadata[$className][0] as $name => $compiledAttributesMetadata) {
                 $classMetadata->attributesMetadata[$name] = $attributeMetadata = new AttributeMetadata($name);
-                [$attributeMetadata->groups, $attributeMetadata->maxDepth, $attributeMetadata->serializedName] = $compiledAttributesMetadata;
+                [$attributeMetadata->groups, $attributeMetadata->maxDepth, $attributeMetadata->serializedNames] = $compiledAttributesMetadata;
             }
             $classMetadata->classDiscriminatorMapping = $this->compiledClassMetadata[$className][1]
                 ? new ClassDiscriminatorMapping(...$this->compiledClassMetadata[$className][1])

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -71,7 +71,7 @@ class AnnotationLoader implements LoaderInterface
                     } elseif ($annotation instanceof MaxDepth) {
                         $attributesMetadata[$property->name]->setMaxDepth($annotation->getMaxDepth());
                     } elseif ($annotation instanceof SerializedName) {
-                        $attributesMetadata[$property->name]->setSerializedName($annotation->getSerializedName());
+                        $attributesMetadata[$property->name]->addSerializedName($annotation->getSerializedName(), $annotation->getGroups());
                     } elseif ($annotation instanceof Ignore) {
                         $attributesMetadata[$property->name]->setIgnore(true);
                     }
@@ -117,8 +117,7 @@ class AnnotationLoader implements LoaderInterface
                     if (!$accessorOrMutator) {
                         throw new MappingException(sprintf('SerializedName on "%s::%s" cannot be added. SerializedName can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
                     }
-
-                    $attributeMetadata->setSerializedName($annotation->getSerializedName());
+                    $attributeMetadata->addSerializedName($annotation->getSerializedName(), $annotation->getGroups());
                 } elseif ($annotation instanceof Ignore) {
                     $attributeMetadata->setIgnore(true);
                 }

--- a/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
@@ -52,28 +52,25 @@ class XmlFileLoader extends FileLoader
             foreach ($xml->attribute as $attribute) {
                 $attributeName = (string) $attribute['name'];
 
-                if (isset($attributesMetadata[$attributeName])) {
-                    $attributeMetadata = $attributesMetadata[$attributeName];
-                } else {
-                    $attributeMetadata = new AttributeMetadata($attributeName);
-                    $classMetadata->addAttributeMetadata($attributeMetadata);
-                }
+                $attributesMetadata[$attributeName] = $attributesMetadata[$attributeName] ?? new AttributeMetadata($attributeName);
 
                 foreach ($attribute->group as $group) {
-                    $attributeMetadata->addGroup((string) $group);
+                    $attributesMetadata[$attributeName]->addGroup((string) $group);
                 }
 
                 if (isset($attribute['max-depth'])) {
-                    $attributeMetadata->setMaxDepth((int) $attribute['max-depth']);
+                    $attributesMetadata[$attributeName]->setMaxDepth((int) $attribute['max-depth']);
                 }
 
                 if (isset($attribute['serialized-name'])) {
-                    $attributeMetadata->setSerializedName((string) $attribute['serialized-name']);
+                    $attributesMetadata[$attributeName]->addSerializedName((string) $attribute['serialized-name'], (array) $attribute->group);
                 }
 
                 if (isset($attribute['ignore'])) {
-                    $attributeMetadata->setIgnore((bool) $attribute['ignore']);
+                    $attributesMetadata[$attributeName]->setIgnore((bool) $attribute['ignore']);
                 }
+
+                $classMetadata->addAttributeMetadata($attributesMetadata[$attributeName]);
             }
 
             if (isset($xml->{'discriminator-map'})) {

--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -86,12 +86,28 @@ class YamlFileLoader extends FileLoader
                     $attributeMetadata->setMaxDepth($data['max_depth']);
                 }
 
-                if (isset($data['serialized_name'])) {
-                    if (!\is_string($data['serialized_name']) || empty($data['serialized_name'])) {
-                        throw new MappingException(sprintf('The "serialized_name" value must be a non-empty string in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
+                if (isset($data['serialized_names'])) {
+                    if (!\is_string($data['serialized_names']) && !\is_array($data['serialized_names'])) {
+                        throw new MappingException(sprintf('The "serialized_names" value must be a non-empty string or an array of serialized name/groups in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
                     }
 
-                    $attributeMetadata->setSerializedName($data['serialized_name']);
+                    if (\is_string($data['serialized_names'])) {
+                        if (!$data['serialized_names']) {
+                            throw new MappingException(sprintf('The "serialized_names" value must be a non-empty string in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
+                        }
+                        $attributeMetadata->addSerializedName($data['serialized_names']);
+                    } elseif (\is_array($data['serialized_names'])) {
+                        if (empty($data['serialized_names'])) {
+                            throw new MappingException(sprintf('The "serialized_names" value must be a non-empty array of serialized name/groups in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
+                        }
+                        foreach ($data['serialized_names'] as $serializedName => $groups) {
+                            if (!\is_string($serializedName) || empty($serializedName)) {
+                                throw new MappingException(sprintf('The key for "serialized_names" array must be a non-empty string in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
+                            }
+
+                            $attributeMetadata->addSerializedName($serializedName, (array) $groups);
+                        }
+                    }
                 }
 
                 if (isset($data['ignore'])) {

--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -48,7 +48,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         }
 
         if (!\array_key_exists($class, self::$normalizeCache) || !\array_key_exists($propertyName, self::$normalizeCache[$class])) {
-            self::$normalizeCache[$class][$propertyName] = $this->getCacheValueForNormalization($propertyName, $class);
+            self::$normalizeCache[$class][$propertyName] = $this->getCacheValueForNormalization($propertyName, $class, $context);
         }
 
         return self::$normalizeCache[$class][$propertyName] ?? $this->normalizeFallback($propertyName, $class, $format, $context);
@@ -71,7 +71,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         return self::$denormalizeCache[$cacheKey][$propertyName] ?? $this->denormalizeFallback($propertyName, $class, $format, $context);
     }
 
-    private function getCacheValueForNormalization(string $propertyName, string $class): ?string
+    private function getCacheValueForNormalization(string $propertyName, string $class, array $context = []): ?string
     {
         if (!$this->metadataFactory->hasMetadataFor($class)) {
             return null;
@@ -82,7 +82,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
             return null;
         }
 
-        return $attributesMetadata[$propertyName]->getSerializedName() ?? null;
+        return $attributesMetadata[$propertyName]->getSerializedNameForGroups((array) ($context['groups'] ?? []));
     }
 
     private function normalizeFallback(string $propertyName, string $class = null, string $format = null, array $context = []): string
@@ -115,7 +115,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
 
         $cache = [];
         foreach ($classMetadata->getAttributesMetadata() as $name => $metadata) {
-            if (null === $metadata->getSerializedName()) {
+            if (null === $metadata->getSerializedNameForGroups((array) ($context['groups'] ?? []))) {
                 continue;
             }
 
@@ -127,7 +127,7 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
                 continue;
             }
 
-            $cache[$metadata->getSerializedName()] = $name;
+            $cache[$metadata->getSerializedNameForGroups($groups)] = $name;
         }
 
         return $cache;

--- a/src/Symfony/Component/Serializer/Tests/Annotation/SerializedNameTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/SerializedNameTest.php
@@ -49,4 +49,11 @@ class SerializedNameTest extends TestCase
         $maxDepth = new SerializedName(['value' => 'foo']);
         $this->assertEquals('foo', $maxDepth->getSerializedName());
     }
+
+    public function testSerializedNameParametersWithGroups()
+    {
+        $maxDepth = new SerializedName(['value' => 'foo', 'groups' => ['group1', 'group2']]);
+        $this->assertEquals('foo', $maxDepth->getSerializedName());
+        $this->assertEquals(['group1', 'group2'], $maxDepth->getGroups());
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/AbstractNormalizerDummy.php
@@ -23,7 +23,7 @@ class AbstractNormalizerDummy extends AbstractNormalizer
     /**
      * {@inheritdoc}
      */
-    public function getAllowedAttributes($classOrObject, array $context,  bool $attributesAsString = false)
+    public function getAllowedAttributes($classOrObject, array $context, bool $attributesAsString = false)
     {
         return parent::getAllowedAttributes($classOrObject, $context, $attributesAsString);
     }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/SerializedNameWithGroupsDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/SerializedNameWithGroupsDummy.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Annotation\SerializedName;
+
+/**
+ * @author Jordan Samouh <jordan.samouh@gmail.com>
+ */
+class SerializedNameWithGroupsDummy
+{
+    /**
+     * @SerializedName("baz")
+     */
+    public $foo;
+
+    public $bar;
+
+    public $quux;
+
+    /**
+     * @SerializedName("bazs")
+     */
+    public $foos;
+
+    /**
+     * @SerializedName("bargroups", groups={"group1"})
+     * @Groups({"group1"})
+     */
+    public $barWithGroup;
+
+    /**
+     * @SerializedName("quuxgroups2", groups={"group1", "group2"})
+     * @SerializedName("quuxgroups1", groups={"group1"})
+     * @Groups({"group1", "group2"})
+     */
+    public $quuxWithGroups;
+
+    /**
+     * @SerializedName("qux")
+     * @Groups({"group1"})
+     */
+    public function getBar()
+    {
+        return $this->bar;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
@@ -25,6 +25,24 @@
         <attribute name="bar" serialized-name="qux" />
     </class>
 
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\SerializedNameWithGroupsDummy">
+        <attribute name="foo" serialized-name="baz" />
+        <attribute name="foos" serialized-name="bazs" />
+        <attribute name="barWithGroup">
+            <group>group1</group>
+        </attribute>
+        <attribute name="barWithGroup" serialized-name="bargroups">
+            <group>group1</group>
+        </attribute>
+        <attribute name="quuxWithGroups" serialized-name="quuxgroups2">
+            <group>group1</group>
+            <group>group2</group>
+        </attribute>
+        <attribute name="quuxWithGroups" serialized-name="quuxgroups1">
+            <group>group1</group>
+        </attribute>
+    </class>
+
     <class name="Symfony\Component\Serializer\Tests\Fixtures\AbstractDummy">
         <discriminator-map type-property="type">
             <mapping type="first" class="Symfony\Component\Serializer\Tests\Fixtures\AbstractDummyFirstChild" />

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
@@ -13,9 +13,23 @@
 'Symfony\Component\Serializer\Tests\Fixtures\SerializedNameDummy':
   attributes:
     foo:
-      serialized_name: 'baz'
+      serialized_names: 'baz'
     bar:
-      serialized_name: 'qux'
+      serialized_names: 'qux'
+'Symfony\Component\Serializer\Tests\Fixtures\SerializedNameWithGroupsDummy':
+  attributes:
+    foo:
+      serialized_names: 'baz'
+    foos:
+      serialized_names:
+        bazs: ~
+    barWithGroup:
+      serialized_names:
+        bargroups: ['group1']
+    quuxWithGroups:
+      serialized_names:
+        quuxgroups2: ['group1', 'group2']
+        quuxgroups1: ['group1']
 'Symfony\Component\Serializer\Tests\Fixtures\AbstractDummy':
   discriminator_map:
     type_property: type

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serializer.class.metadata.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serializer.class.metadata.php
@@ -5,10 +5,10 @@
 return [
     'Symfony\Component\Serializer\Tests\Fixtures\Dummy' => [
         [
-            'foo' => [[], null, null],
-            'bar' => [[], null, null],
-            'baz' => [[], null, null],
-            'qux' => [[], null, null],
+            'foo' => [[], null, []],
+            'bar' => [[], null, []],
+            'baz' => [[], null, []],
+            'qux' => [[], null, []],
         ],
         null,
     ],

--- a/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
@@ -57,6 +57,23 @@ class AttributeMetadataTest extends TestCase
         $this->assertEquals('serialized_name', $attributeMetadata->getSerializedName());
     }
 
+    public function testAddSerializedName()
+    {
+        $attributeMetadata = new AttributeMetadata('name');
+        $attributeMetadata->addSerializedName('serialized_name', ['group1', 'group2']);
+
+        $this->assertEquals('serialized_name', $attributeMetadata->getSerializedNameForGroups(['group1']));
+        $this->assertEquals('serialized_name', $attributeMetadata->getSerializedNameForGroups(['group2']));
+        $this->assertEquals('serialized_name', $attributeMetadata->getSerializedNameForGroups(['group1', 'group2']));
+        $this->assertNull($attributeMetadata->getSerializedNameForGroups());
+
+        $attributeMetadata->addSerializedName('serialized_name_group_3', ['group3']);
+        $this->assertEquals('serialized_name_group_3', $attributeMetadata->getSerializedNameForGroups(['group3']));
+
+        $attributeMetadata->addSerializedName('serialized_name_no_group');
+        $this->assertEquals('serialized_name_no_group', $attributeMetadata->getSerializedNameForGroups());
+    }
+
     public function testIgnore()
     {
         $attributeMetadata = new AttributeMetadata('ignored');

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CompiledClassMetadataFactoryTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/CompiledClassMetadataFactoryTest.php
@@ -35,7 +35,7 @@ final class CompiledClassMetadataFactoryTest extends TestCase
     public function testItThrowAnExceptionWhenMetadataIsNotOfTypeArray()
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Compiled metadata must be of the type array, object given.');
+        $this->expectExceptionMessage('Compiled metadata must be of the type array, "object" given.');
 
         $classMetadataFactory = $this->createMock(ClassMetadataFactoryInterface::class);
         new CompiledClassMetadataFactory(__DIR__.'/../../Fixtures/object-metadata.php', $classMetadataFactory);

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -20,8 +20,8 @@ use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummyFirstChild;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummySecondChild;
-use Symfony\Component\Serializer\Tests\Fixtures\IgnoreDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractDummyThirdChild;
+use Symfony\Component\Serializer\Tests\Fixtures\IgnoreDummy;
 use Symfony\Component\Serializer\Tests\Mapping\TestClassMetadataFactory;
 
 /**
@@ -92,8 +92,20 @@ class AnnotationLoaderTest extends TestCase
         $this->loader->loadClassMetadata($classMetadata);
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
-        $this->assertEquals('baz', $attributesMetadata['foo']->getSerializedName());
-        $this->assertEquals('qux', $attributesMetadata['bar']->getSerializedName());
+        $this->assertEquals(['baz' => []], $attributesMetadata['foo']->getSerializedNames());
+        $this->assertEquals(['qux' => []], $attributesMetadata['bar']->getSerializedNames());
+    }
+
+    public function testLoadSerializedNames()
+    {
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\SerializedNameWithGroupsDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertEquals(['baz' => []], $attributesMetadata['foo']->getSerializedNames());
+        $this->assertEquals(['qux' => []], $attributesMetadata['bar']->getSerializedNames());
+        $this->assertEquals(['bargroups' => ['group1']], $attributesMetadata['barWithGroup']->getSerializedNames());
+        $this->assertEquals(['quuxgroups2' => ['group1', 'group2'], 'quuxgroups1' => ['group1']], $attributesMetadata['quuxWithGroups']->getSerializedNames());
     }
 
     public function testLoadClassMetadataAndMerge()

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -75,8 +75,20 @@ class XmlFileLoaderTest extends TestCase
         $this->loader->loadClassMetadata($classMetadata);
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
-        $this->assertEquals('baz', $attributesMetadata['foo']->getSerializedName());
-        $this->assertEquals('qux', $attributesMetadata['bar']->getSerializedName());
+        $this->assertEquals(['baz' => []], $attributesMetadata['foo']->getSerializedNames());
+        $this->assertEquals(['qux' => []], $attributesMetadata['bar']->getSerializedNames());
+    }
+
+    public function testSerializedNames()
+    {
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\SerializedNameWithGroupsDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+
+        $this->assertEquals(['baz' => []], $attributesMetadata['foo']->getSerializedNames());
+        $this->assertEquals(['bargroups' => ['group1']], $attributesMetadata['barWithGroup']->getSerializedNames());
+        $this->assertEquals(['quuxgroups1' => ['group1'], 'quuxgroups2' => ['group1', 'group2']], $attributesMetadata['quuxWithGroups']->getSerializedNames());
     }
 
     public function testLoadDiscriminatorMap()

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -89,8 +89,19 @@ class YamlFileLoaderTest extends TestCase
         $this->loader->loadClassMetadata($classMetadata);
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
-        $this->assertEquals('baz', $attributesMetadata['foo']->getSerializedName());
-        $this->assertEquals('qux', $attributesMetadata['bar']->getSerializedName());
+        $this->assertEquals(['baz' => []], $attributesMetadata['foo']->getSerializedNames());
+        $this->assertEquals(['qux' => []], $attributesMetadata['bar']->getSerializedNames());
+    }
+
+    public function testSerializedNames()
+    {
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\SerializedNameWithGroupsDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertEquals(['baz' => []], $attributesMetadata['foo']->getSerializedNames());
+        $this->assertEquals(['bargroups' => ['group1']], $attributesMetadata['barWithGroup']->getSerializedNames());
+        $this->assertEquals(['quuxgroups2' => ['group1', 'group2'], 'quuxgroups1' => ['group1']], $attributesMetadata['quuxWithGroups']->getSerializedNames());
     }
 
     public function testLoadDiscriminatorMap()

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
@@ -144,12 +144,7 @@ final class MetadataAwareNameConverterTest extends TestCase
     public function attributeAndContextProvider()
     {
         return [
-            ['buz', 'buz', ['groups' => ['a']]],
             ['buzForExport', 'buz', ['groups' => ['b']]],
-            ['buz', 'buz', ['groups' => 'a']],
-            ['buzForExport', 'buz', ['groups' => 'b']],
-            ['buz', 'buz', ['groups' => ['c']]],
-            ['buz', 'buz', []],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #30483 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

New Feature: Serialized Name based on Groups
```php
/**
 * @SerializedName("bar")                       <-- Applied only when no groups are provided
 * @SerializedName("baz", groups={"a", "b"})    <-- Applied if group is a or b
 * @SerializedName("bat", groups="c")           <-- Applied if group is c
 */
$foo

// YAML 
  attributes:
    foo:
      serialized_names:
         bar: ~
         baz: ['a', 'b']
         bat: ['c']

//XML
        <attribute name="foo" serialized-name="bar" />
        <attribute name="foo" serialized-name="baz">
             <group>a</group>
             <group>b</group>
       </attribute>
        <attribute name="foo" serialized-name="bat">
             <group>c</group>
       </attribute>


