### PR TITLE
[Messenger] stop using the deprecated schema synchronizer API

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -17,7 +17,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\SchemaConfig;
-use Doctrine\DBAL\Schema\Synchronizer\SchemaSynchronizer;
 use Doctrine\DBAL\Statement;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
@@ -29,7 +28,6 @@ class ConnectionTest extends TestCase
     {
         $queryBuilder = $this->getQueryBuilderMock();
         $driverConnection = $this->getDBALConnectionMock();
-        $schemaSynchronizer = $this->getSchemaSynchronizerMock();
         $stmt = $this->getResultMock([
             'id' => 1,
             'body' => '{"message":"Hi"}',
@@ -52,7 +50,7 @@ class ConnectionTest extends TestCase
             ->method('executeQuery')
             ->willReturn($stmt);
 
-        $connection = new Connection([], $driverConnection, $schemaSynchronizer);
+        $connection = new Connection([], $driverConnection);
         $doctrineEnvelope = $connection->get();
         $this->assertEquals(1, $doctrineEnvelope['id']);
         $this->assertEquals('{"message":"Hi"}', $doctrineEnvelope['body']);
@@ -63,7 +61,6 @@ class ConnectionTest extends TestCase
     {
         $queryBuilder = $this->getQueryBuilderMock();
         $driverConnection = $this->getDBALConnectionMock();
-        $schemaSynchronizer = $this->getSchemaSynchronizerMock();
         $stmt = $this->getResultMock(false);
 
         $queryBuilder
@@ -81,7 +78,7 @@ class ConnectionTest extends TestCase
             ->method('executeQuery')
             ->willReturn($stmt);
 
-        $connection = new Connection([], $driverConnection, $schemaSynchronizer);
+        $connection = new Connection([], $driverConnection);
         $doctrineEnvelope = $connection->get();
         $this->assertNull($doctrineEnvelope);
     }
@@ -152,11 +149,6 @@ class ConnectionTest extends TestCase
             ->willReturn($expectedResult);
 
         return $stmt;
-    }
-
-    private function getSchemaSynchronizerMock(): SchemaSynchronizer
-    {
-        return $this->createMock(SchemaSynchronizer::class);
     }
 
     /**
@@ -261,7 +253,6 @@ class ConnectionTest extends TestCase
     {
         $queryBuilder = $this->getQueryBuilderMock();
         $driverConnection = $this->getDBALConnectionMock();
-        $schemaSynchronizer = $this->getSchemaSynchronizerMock();
         $id = 1;
         $stmt = $this->getResultMock([
             'id' => $id,
@@ -285,7 +276,7 @@ class ConnectionTest extends TestCase
             ->method('executeQuery')
             ->willReturn($stmt);
 
-        $connection = new Connection([], $driverConnection, $schemaSynchronizer);
+        $connection = new Connection([], $driverConnection);
         $doctrineEnvelope = $connection->find($id);
         $this->assertEquals(1, $doctrineEnvelope['id']);
         $this->assertEquals('{"message":"Hi"}', $doctrineEnvelope['body']);
@@ -296,7 +287,6 @@ class ConnectionTest extends TestCase
     {
         $queryBuilder = $this->getQueryBuilderMock();
         $driverConnection = $this->getDBALConnectionMock();
-        $schemaSynchronizer = $this->getSchemaSynchronizerMock();
         $message1 = [
             'id' => 1,
             'body' => '{"message":"Hi"}',
@@ -332,7 +322,7 @@ class ConnectionTest extends TestCase
             ->method('executeQuery')
             ->willReturn($stmt);
 
-        $connection = new Connection([], $driverConnection, $schemaSynchronizer);
+        $connection = new Connection([], $driverConnection);
         $doctrineEnvelopes = $connection->findAll();
 
         $this->assertEquals(1, $doctrineEnvelopes[0]['id']);

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -16,9 +16,9 @@ use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Synchronizer\SchemaSynchronizer;
-use Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
@@ -60,7 +60,7 @@ class Connection
     {
         $this->configuration = array_replace_recursive(self::DEFAULT_OPTIONS, $configuration);
         $this->driverConnection = $driverConnection;
-        $this->schemaSynchronizer = $schemaSynchronizer ?? new SingleDatabaseSynchronizer($this->driverConnection);
+        $this->schemaSynchronizer = $schemaSynchronizer;
         $this->autoSetup = $this->configuration['auto_setup'];
 
         if (null === self::$useDeprecatedConstants) {
@@ -233,7 +233,7 @@ class Connection
             $this->driverConnection->getConfiguration()->setFilterSchemaAssetsExpression(null);
         }
 
-        $this->schemaSynchronizer->updateSchema($this->getSchema(), true);
+        $this->updateSchema();
 
         if ($hasFilterCallback) {
             $this->driverConnection->getConfiguration()->setSchemaAssetsFilter($assetFilter);
@@ -389,5 +389,25 @@ class Connection
         $doctrineEnvelope['headers'] = json_decode($doctrineEnvelope['headers'], true);
 
         return $doctrineEnvelope;
+    }
+
+    private function updateSchema(): void
+    {
+        if (null !== $this->schemaSynchronizer) {
+            $this->schemaSynchronizer->updateSchema($this->getSchema(), true);
+
+            return;
+        }
+
+        $comparator = new Comparator();
+        $schemaDiff = $comparator->compare($this->driverConnection->getSchemaManager()->createSchema(), $this->getSchema());
+
+        foreach ($schemaDiff->toSaveSql($this->driverConnection->getDatabasePlatform()) as $sql) {
+            if (method_exists($this->driverConnection, 'executeStatement')) {
+                $this->driverConnection->executeStatement($sql);
+            } else {
+                $this->driverConnection->exec($sql);
+            }
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

see the failing tests and doctrine/dbal#4213