### PR TITLE
[ExpressionLanguage] fix passing arguments to call_user_func_array() on PHP 8

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
+++ b/src/Symfony/Component/ExpressionLanguage/Node/GetAttrNode.php
@@ -86,7 +86,13 @@ class GetAttrNode extends Node
                     throw new \RuntimeException(sprintf('Unable to call method "%s" of object "%s".', $this->nodes['attribute']->attributes['value'], \get_class($obj)));
                 }
 
-                return \call_user_func_array($toCall, $this->nodes['arguments']->evaluate($functions, $values));
+                $arguments = $this->nodes['arguments']->evaluate($functions, $values);
+
+                if (\PHP_VERSION_ID >= 80000) {
+                    $arguments = array_values($arguments);
+                }
+
+                return \call_user_func_array($toCall, $arguments);
 
             case self::ARRAY_CALL:
                 $array = $this->nodes['node']->evaluate($functions, $values);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 