### PR TITLE
[Security] Pass Passport to LoginFailureEvent

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Added attributes on `Passport`
  * Changed `AuthorizationChecker` to call the access decision manager in unauthenticated sessions with a `NullToken`
  * [BC break] Removed `AccessListener::PUBLIC_ACCESS` in favor of `AuthenticatedVoter::PUBLIC_ACCESS`
+ * Added `Passport` to `LoginFailureEvent`.
 
 5.1.0
 -----

--- a/src/Symfony/Component/Security/Http/Event/LoginFailureEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/LoginFailureEvent.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
@@ -32,14 +33,16 @@ class LoginFailureEvent extends Event
     private $request;
     private $response;
     private $firewallName;
+    private $passport;
 
-    public function __construct(AuthenticationException $exception, AuthenticatorInterface $authenticator, Request $request, ?Response $response, string $firewallName)
+    public function __construct(AuthenticationException $exception, AuthenticatorInterface $authenticator, Request $request, ?Response $response, string $firewallName, ?PassportInterface $passport = null)
     {
         $this->exception = $exception;
         $this->authenticator = $authenticator;
         $this->request = $request;
         $this->response = $response;
         $this->firewallName = $firewallName;
+        $this->passport = $passport;
     }
 
     public function getException(): AuthenticationException
@@ -70,5 +73,10 @@ class LoginFailureEvent extends Event
     public function getResponse(): ?Response
     {
         return $this->response;
+    }
+
+    public function getPassport(): ?PassportInterface
+    {
+        return $this->passport;
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/RememberMeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/RememberMeListenerTest.php
@@ -86,6 +86,6 @@ class RememberMeListenerTest extends TestCase
 
     private function createLoginFailureEvent($providerKey)
     {
-        return new LoginFailureEvent(new AuthenticationException(), $this->createMock(AuthenticatorInterface::class), $this->request, null, $providerKey);
+        return new LoginFailureEvent(new AuthenticationException(), $this->createMock(AuthenticatorInterface::class), $this->request, null, $providerKey, null);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #37585
| License       | MIT
| Doc PR        | -

This changes pass a `Passport` to the `LoginFailureEvent`.