### PR TITLE
[Lock] Add create table command for PDO store

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -39,6 +39,7 @@ use Symfony\Bundle\FrameworkBundle\Command\WorkflowDumpCommand;
 use Symfony\Bundle\FrameworkBundle\Command\YamlLintCommand;
 use Symfony\Bundle\FrameworkBundle\EventListener\SuggestMissingPackageSubscriber;
 use Symfony\Component\Console\EventListener\ErrorListener;
+use Symfony\Component\Lock\Command\PdoCreateTableCommand;
 use Symfony\Component\Messenger\Command\ConsumeMessagesCommand;
 use Symfony\Component\Messenger\Command\DebugCommand;
 use Symfony\Component\Messenger\Command\FailedMessagesRemoveCommand;
@@ -286,5 +287,11 @@ return static function (ContainerConfigurator $container) {
                 service('secrets.local_vault'),
             ])
             ->tag('console.command', ['command' => 'secrets:encrypt-from-local'])
+
+        ->set('console.command.pdo_lock_create_table', PdoCreateTableCommand::class)
+            ->args([
+                service('database_connection'),
+            ])
+            ->tag('console.command', ['command' => 'lock:pdo:create-table'])
     ;
 };

--- a/src/Symfony/Component/Lock/Command/PdoCreateTableCommand.php
+++ b/src/Symfony/Component/Lock/Command/PdoCreateTableCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Command;
+
+use Doctrine\DBAL\Driver\Connection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Lock\Store\PdoStore;
+
+/**
+ * @author Bartłomiej Zając <bzajacc@gmail.com>
+ */
+class PdoCreateTableCommand extends Command
+{
+    protected static $defaultName = 'lock:pdo:create-table';
+
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        parent::__construct();
+
+        $this->connection = $connection;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDefinition([])
+            ->setDescription('Create table for PDO lock store');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output);
+
+        $store = new PdoStore($this->connection);
+        $store->createTable();
+
+        $io->success('Table are successfully created!');
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | -
| License       | MIT
| Doc PR        | -

If you want to use PDO store lock, you need to create table first. So you need to run method `createTable()`, and add this a few line of code somewhere and run. After that you simply remove this code.

Now, this command is prevent this, and provide this functionality out of the box.

Not sure if I did this correctly, because this `database_connection` in service. I tested this on my app and it's working fine.

If you agree with this PR I will add Doc PR.
