### PR TITLE
[Intl] Fix "Ivory Coast" English translation

### DIFF
--- a/src/Symfony/Component/Intl/Resources/data/regions/en.json
+++ b/src/Symfony/Component/Intl/Resources/data/regions/en.json
@@ -43,7 +43,7 @@
         "CF": "Central African Republic",
         "CG": "Congo - Brazzaville",
         "CH": "Switzerland",
-        "CI": "Côte d’Ivoire",
+        "CI": "Ivory Coast",
         "CK": "Cook Islands",
         "CL": "Chile",
         "CM": "Cameroon",


### PR DESCRIPTION
"Ivory Coast" appears as "Côte d’Ivoire" in most of the region files.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
-->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This is a fix for the "en.json" file only, but it should be fixed in all other languages too.