### PR TITLE
[Mailer] Mailjet Add ability to pass custom headers to API

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetApiTransportTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Symfony\Component\Mailer\Bridge\Mailjet\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetApiTransport;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+
+class MailjetApiTransportTest extends TestCase
+{
+    protected const USER = 'u$er';
+    protected const PASSWORD = 'pa$s';
+
+    /**
+     * @dataProvider getTransportData
+     */
+    public function testToString(MailjetApiTransport $transport, string $expected)
+    {
+        $this->assertSame($expected, (string) $transport);
+    }
+
+    public function getTransportData()
+    {
+        return [
+            [
+                new MailjetApiTransport(self::USER, self::PASSWORD),
+                'mailjet+api://api.mailjet.com',
+            ],
+            [
+                (new MailjetApiTransport(self::USER, self::PASSWORD))->setHost('example.com'),
+                'mailjet+api://example.com',
+            ],
+        ];
+    }
+
+    public function testPayloadFormat()
+    {
+        $email = (new Email())
+            ->subject('Sending email to mailjet API');
+        $email->getHeaders()
+            ->addTextHeader('X-authorized-header', 'authorized')
+            ->addTextHeader('X-MJ-TemplateLanguage', 'forbidden'); // This header is forbidden
+        $envelope = new Envelope(new Address('foo@example.com', 'Foo'), [new Address('bar@example.com', 'Bar'), new Address('baz@example.com', 'Baz')]);
+
+        $transport = new MailjetApiTransport(self::USER, self::PASSWORD);
+        $method = new \ReflectionMethod(MailjetApiTransport::class, 'getPayload');
+        $method->setAccessible(true);
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('Messages', $payload);
+        $this->assertNotEmpty($payload['Messages']);
+
+        $message = $payload['Messages'][0];
+        $this->assertArrayHasKey('Subject', $message);
+        $this->assertEquals('Sending email to mailjet API', $message['Subject']);
+
+        $this->assertArrayHasKey('Headers', $message);
+        $headers = $message['Headers'];
+        $this->assertArrayHasKey('X-authorized-header', $headers);
+        $this->assertEquals('authorized', $headers['X-authorized-header']);
+        $this->assertArrayNotHasKey('x-mj-templatelanguage', $headers);
+        $this->assertArrayNotHasKey('X-MJ-TemplateLanguage', $headers);
+
+        $this->assertArrayHasKey('From', $message);
+        $sender = $message['From'];
+        $this->assertArrayHasKey('Email', $sender);
+        $this->assertArrayHasKey('Name', $sender);
+        $this->assertEquals('foo@example.com', $sender['Email']);
+        $this->assertEquals('Foo', $sender['Name']);
+
+        $this->assertArrayHasKey('To', $message);
+        $recipients = $message['To'];
+        $this->assertIsArray($recipients);
+        $this->assertCount(2, $recipients);
+        $this->assertEquals('bar@example.com', $recipients[0]['Email']);
+        $this->assertEquals('', $recipients[0]['Name']); // For Recipients, even if the name is filled, it is empty
+        $this->assertEquals('baz@example.com', $recipients[1]['Email']);
+        $this->assertEquals('', $recipients[1]['Name']);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Tests/Transport/MailjetTransportFactoryTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Mailer\Bridge\Mailjet\Tests\Transport;
 
+use Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetApiTransport;
 use Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetSmtpTransport;
 use Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetTransportFactory;
 use Symfony\Component\Mailer\Test\TransportFactoryTestCase;
@@ -26,6 +27,11 @@ class MailjetTransportFactoryTest extends TransportFactoryTestCase
 
     public function supportsProvider(): iterable
     {
+        yield [
+            new Dsn('mailjet+api', 'default'),
+            true,
+        ];
+
         yield [
             new Dsn('mailjet', 'default'),
             true,
@@ -51,6 +57,16 @@ class MailjetTransportFactoryTest extends TransportFactoryTestCase
     {
         $dispatcher = $this->getDispatcher();
         $logger = $this->getLogger();
+
+        yield [
+            new Dsn('mailjet+api', 'default', self::USER, self::PASSWORD),
+            new MailjetApiTransport(self::USER, self::PASSWORD, $this->getClient(), $dispatcher, $logger),
+        ];
+
+        yield [
+            new Dsn('mailjet+api', 'example.com', self::USER, self::PASSWORD),
+            (new MailjetApiTransport(self::USER, self::PASSWORD, $this->getClient(), $dispatcher, $logger))->setHost('example.com'),
+        ];
 
         yield [
             new Dsn('mailjet', 'default', self::USER, self::PASSWORD),

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -26,6 +26,15 @@ class MailjetApiTransport extends AbstractApiTransport
 {
     private const HOST = 'api.mailjet.com';
     private const API_VERSION = '3.1';
+    private const FORBIDDEN_HEADERS = [
+        'Date', 'X-CSA-Complaints', 'Message-Id', 'X-Mailjet-Campaign', 'X-MJ-StatisticsContactsListID',
+        'DomainKey-Status', 'Received-SPF', 'Authentication-Results', 'Received', 'X-Mailjet-Prio',
+        'From', 'Sender', 'Subject', 'To', 'Cc', 'Bcc', 'Return-Path', 'Delivered-To', 'DKIM-Signature',
+        'X-Feedback-Id', 'X-Mailjet-Segmentation', 'List-Id', 'X-MJ-MID', 'X-MJ-ErrorMessage',
+        'X-MJ-TemplateErrorDeliver', 'X-MJ-TemplateErrorReporting', 'X-MJ-TemplateLanguage',
+        'X-Mailjet-Debug', 'User-Agent', 'X-Mailer', 'X-MJ-CustomID', 'X-MJ-EventPayload', 'X-MJ-Vars',
+        'X-Mailjet-TrackOpen', 'X-Mailjet-TrackClick', 'X-MJ-TemplateID', 'X-MJ-WorkflowID',
+    ];
 
     private $privateKey;
     private $publicKey;
@@ -102,6 +111,14 @@ class MailjetApiTransport extends AbstractApiTransport
         }
         if ($html) {
             $message['HTMLPart'] = $html;
+        }
+
+        foreach ($email->getHeaders()->all() as $header) {
+            if (\in_array($header->getName(), self::FORBIDDEN_HEADERS, true)) {
+                continue;
+            }
+
+            $message['Headers'][$header->getName()] = $header->getBodyAsString();
         }
 
         return [

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/composer.json
@@ -17,7 +17,8 @@
   ],
   "require": {
     "php": "^7.2.5",
-    "symfony/mailer": "^4.4|^5.0"
+    "symfony/mailer": "^4.4|^5.0",
+    "symfony/mime": "^5.2"
   },
   "require-dev": {
     "symfony/http-client": "^4.4|^5.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Mailjet mailer now forwards headers from original email removes forbidden headers, and sends them to Maijlet Api 

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
