### PR TITLE
[Translator] modify attributes and method accessibility

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added support for `name` attribute on `unit` element from xliff2 to be used as a translation key instead of always the `source` element
+ * updated attributes `cacheVary`, `cacheDir` and method `getCatalogueCachePath`  accessibility in Translator to allow functionality extension.
 
 5.0.0
 -----

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -65,14 +65,14 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
     /**
      * @var string
      */
-    private $cacheDir;
+    protected $cacheDir;
 
     /**
      * @var bool
      */
     private $debug;
 
-    private $cacheVary;
+    protected $cacheVary;
 
     /**
      * @var ConfigCacheFactoryInterface|null
@@ -350,7 +350,7 @@ EOF
         return $fallbackContent;
     }
 
-    private function getCatalogueCachePath(string $locale): string
+    protected function getCatalogueCachePath(string $locale): string
     {
         return $this->cacheDir.'/catalogue.'.$locale.'.'.strtr(substr(base64_encode(hash('sha256', serialize($this->cacheVary), true)), 0, 7), '/', '_').'.php';
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #37914
| License       | MIT
| Doc PR        | no

Modify accessibility on getCatalogueCachePath and attributes used on it to allow customization of cache file names by extending the translator.
