### PR TITLE
[TwigBridge] allow null for $message of filter method `trans`

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -92,8 +92,12 @@ final class TranslationExtension extends AbstractExtension
         return $this->translationNodeVisitor ?: $this->translationNodeVisitor = new TranslationNodeVisitor();
     }
 
-    public function trans(string $message, array $arguments = [], string $domain = null, string $locale = null, int $count = null): string
+    public function trans(?string $message, array $arguments = [], string $domain = null, string $locale = null, int $count = null): string
     {
+        if (null === $message || '' === $message) {
+            return '';
+        }
+
         if (null !== $count) {
             $arguments['%count%'] = $count;
         }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/TranslationExtensionTest.php
@@ -118,6 +118,10 @@ class TranslationExtensionTest extends TestCase
             ['{{ "{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples"|trans(count=count) }}', 'There is 5 apples', ['count' => 5]],
             ['{{ text|trans(count=5, arguments={\'%name%\': \'Symfony\'}) }}', 'There is 5 apples (Symfony)', ['text' => '{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%)']],
             ['{{ "{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples"|trans({}, "messages", "fr", count) }}', 'There is 5 apples', ['count' => 5]],
+
+            // trans filter with null message
+            ['{{ null|trans }}', ''],
+            ['{{ foo|trans }}', '', ['foo' => null]],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37931
| License       | MIT

With Symfony 5.0, filter method `trans` of Symfony Twig Bridge does not allow null values for `$message` parameter anymore, breaking backward compatibility. See also #37931. The included commit provides a fix to this BC break by allowing null values again.