### PR TITLE
[Security] Renamed provider key to firewall name

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -74,3 +74,12 @@ Security
 
  * [BC break] `AccessListener::PUBLIC_ACCESS` has been removed in favor of
    `AuthenticatedVoter::PUBLIC_ACCESS`.
+
+ * Deprecated `setProviderKey()`/`getProviderKey()` in favor of `setFirewallName()/getFirewallName()`
+   in `PreAuthenticatedToken`, `RememberMeToken`, `SwitchUserToken`, `UsernamePasswordToken`,
+   `DefaultAuthenticationSuccessHandler`, the old methods will be removed in 6.0.
+
+ * Deprecated the `AbstractRememberMeServices::$providerKey` property in favor of
+   `AbstractRememberMeServices::$firewallName`, the old property will be removed
+   in 6.0.
+

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -133,6 +133,10 @@ Security
  * Removed `LogoutSuccessHandlerInterface` and `LogoutHandlerInterface`, register a listener on the `LogoutEvent` event instead.
  * Removed `DefaultLogoutSuccessHandler` in favor of `DefaultLogoutListener`.
  * Added a `logout(Request $request, Response $response, TokenInterface $token)` method to the `RememberMeServicesInterface`.
+ * Removed `setProviderKey()`/`getProviderKey()` in favor of `setFirewallName()/getFirewallName()`
+   in `PreAuthenticatedToken`, `RememberMeToken`, `SwitchUserToken`, `UsernamePasswordToken`,
+   `DefaultAuthenticationSuccessHandler`.
+ * Removed the `AbstractRememberMeServices::$providerKey` property in favor of `AbstractRememberMeServices::$firewallName`
 
 TwigBundle
 ----------

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -170,7 +170,7 @@ abstract class AbstractFactory implements SecurityFactoryInterface
         } else {
             $successHandler = $container->setDefinition($successHandlerId, new ChildDefinition('security.authentication.success_handler'));
             $successHandler->addMethodCall('setOptions', [$options]);
-            $successHandler->addMethodCall('setProviderKey', [$id]);
+            $successHandler->addMethodCall('setFirewallName', [$id]);
         }
 
         return $successHandlerId;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
@@ -110,7 +110,7 @@ class AbstractFactoryTest extends TestCase
         if ($defaultHandlerInjection) {
             $this->assertEquals('setOptions', $methodCalls[0][0]);
             $this->assertEquals(['default_target_path' => '/bar'], $methodCalls[0][1][0]);
-            $this->assertEquals('setProviderKey', $methodCalls[1][0]);
+            $this->assertEquals('setFirewallName', $methodCalls[1][0]);
             $this->assertEquals(['foo'], $methodCalls[1][1]);
         } else {
             $this->assertCount(0, $methodCalls);

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Changed `AuthorizationChecker` to call the access decision manager in unauthenticated sessions with a `NullToken`
  * [BC break] Removed `AccessListener::PUBLIC_ACCESS` in favor of `AuthenticatedVoter::PUBLIC_ACCESS`
  * Added `Passport` to `LoginFailureEvent`.
+ * Deprecated `setProviderKey()`/`getProviderKey()` in favor of `setFirewallName()/getFirewallName()` in `PreAuthenticatedToken`, `RememberMeToken`, `SwitchUserToken`, `UsernamePasswordToken`, `DefaultAuthenticationSuccessHandler`; and deprecated the `AbstractRememberMeServices::$providerKey` property in favor of  `AbstractRememberMeServices::$firewallName`
 
 5.1.0
 -----

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProvider.php
@@ -69,6 +69,6 @@ class PreAuthenticatedAuthenticationProvider implements AuthenticationProviderIn
      */
     public function supports(TokenInterface $token)
     {
-        return $token instanceof PreAuthenticatedToken && $this->providerKey === $token->getProviderKey();
+        return $token instanceof PreAuthenticatedToken && $this->providerKey === $token->getFirewallName();
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/RememberMeAuthenticationProvider.php
@@ -69,6 +69,6 @@ class RememberMeAuthenticationProvider implements AuthenticationProviderInterfac
      */
     public function supports(TokenInterface $token)
     {
-        return $token instanceof RememberMeToken && $token->getProviderKey() === $this->providerKey;
+        return $token instanceof RememberMeToken && $token->getFirewallName() === $this->providerKey;
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -103,7 +103,7 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
      */
     public function supports(TokenInterface $token)
     {
-        return $token instanceof UsernamePasswordToken && $this->providerKey === $token->getProviderKey();
+        return $token instanceof UsernamePasswordToken && $this->providerKey === $token->getFirewallName();
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
@@ -21,24 +21,24 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class PreAuthenticatedToken extends AbstractToken
 {
     private $credentials;
-    private $providerKey;
+    private $firewallName;
 
     /**
      * @param string|\Stringable|UserInterface $user
      * @param mixed                            $credentials
      * @param string[]                         $roles
      */
-    public function __construct($user, $credentials, string $providerKey, array $roles = [])
+    public function __construct($user, $credentials, string $firewallName, array $roles = [])
     {
         parent::__construct($roles);
 
-        if (empty($providerKey)) {
-            throw new \InvalidArgumentException('$providerKey must not be empty.');
+        if ('' === $firewallName) {
+            throw new \InvalidArgumentException('$firewallName must not be empty.');
         }
 
         $this->setUser($user);
         $this->credentials = $credentials;
-        $this->providerKey = $providerKey;
+        $this->firewallName = $firewallName;
 
         if ($roles) {
             $this->setAuthenticated(true);
@@ -49,10 +49,21 @@ class PreAuthenticatedToken extends AbstractToken
      * Returns the provider key.
      *
      * @return string The provider key
+     *
+     * @deprecated since 5.2, use getFirewallName() instead
      */
     public function getProviderKey()
     {
-        return $this->providerKey;
+        if (1 !== \func_num_args() || true !== func_get_arg(0)) {
+            trigger_deprecation('symfony/security-core', '5.2', 'Method "%s" is deprecated, use "getFirewallName()" instead.', __METHOD__);
+        }
+
+        return $this->firewallName;
+    }
+
+    public function getFirewallName(): string
+    {
+        return $this->getProviderKey(true);
     }
 
     /**
@@ -78,7 +89,7 @@ class PreAuthenticatedToken extends AbstractToken
      */
     public function __serialize(): array
     {
-        return [$this->credentials, $this->providerKey, parent::__serialize()];
+        return [$this->credentials, $this->firewallName, parent::__serialize()];
     }
 
     /**
@@ -86,7 +97,7 @@ class PreAuthenticatedToken extends AbstractToken
      */
     public function __unserialize(array $data): void
     {
-        [$this->credentials, $this->providerKey, $parentData] = $data;
+        [$this->credentials, $this->firewallName, $parentData] = $data;
         $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -21,14 +21,14 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class RememberMeToken extends AbstractToken
 {
     private $secret;
-    private $providerKey;
+    private $firewallName;
 
     /**
      * @param string $secret A secret used to make sure the token is created by the app and not by a malicious client
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(UserInterface $user, string $providerKey, string $secret)
+    public function __construct(UserInterface $user, string $firewallName, string $secret)
     {
         parent::__construct($user->getRoles());
 
@@ -36,11 +36,11 @@ class RememberMeToken extends AbstractToken
             throw new \InvalidArgumentException('$secret must not be empty.');
         }
 
-        if (empty($providerKey)) {
-            throw new \InvalidArgumentException('$providerKey must not be empty.');
+        if ('' === $firewallName) {
+            throw new \InvalidArgumentException('$firewallName must not be empty.');
         }
 
-        $this->providerKey = $providerKey;
+        $this->firewallName = $firewallName;
         $this->secret = $secret;
 
         $this->setUser($user);
@@ -63,10 +63,21 @@ class RememberMeToken extends AbstractToken
      * Returns the provider secret.
      *
      * @return string The provider secret
+     *
+     * @deprecated since 5.2, use getFirewallName() instead
      */
     public function getProviderKey()
     {
-        return $this->providerKey;
+        if (1 !== \func_num_args() || true !== func_get_arg(0)) {
+            trigger_deprecation('symfony/security-core', '5.2', 'Method "%s" is deprecated, use "getFirewallName()" instead.', __METHOD__);
+        }
+
+        return $this->firewallName;
+    }
+
+    public function getFirewallName(): string
+    {
+        return $this->getProviderKey(true);
     }
 
     /**
@@ -92,7 +103,7 @@ class RememberMeToken extends AbstractToken
      */
     public function __serialize(): array
     {
-        return [$this->secret, $this->providerKey, parent::__serialize()];
+        return [$this->secret, $this->firewallName, parent::__serialize()];
     }
 
     /**
@@ -100,7 +111,7 @@ class RememberMeToken extends AbstractToken
      */
     public function __unserialize(array $data): void
     {
-        [$this->secret, $this->providerKey, $parentData] = $data;
+        [$this->secret, $this->firewallName, $parentData] = $data;
         $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/SwitchUserToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/SwitchUserToken.php
@@ -23,14 +23,12 @@ class SwitchUserToken extends UsernamePasswordToken
     /**
      * @param string|object $user        The username (like a nickname, email address, etc.), or a UserInterface instance or an object implementing a __toString method
      * @param mixed         $credentials This usually is the password of the user
-     * @param string        $providerKey The provider key
-     * @param string[]      $roles       An array of roles
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($user, $credentials, string $providerKey, array $roles, TokenInterface $originalToken)
+    public function __construct($user, $credentials, string $firewallName, array $roles, TokenInterface $originalToken)
     {
-        parent::__construct($user, $credentials, $providerKey, $roles);
+        parent::__construct($user, $credentials, $firewallName, $roles);
 
         $this->originalToken = $originalToken;
     }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 class UsernamePasswordToken extends AbstractToken
 {
     private $credentials;
-    private $providerKey;
+    private $firewallName;
 
     /**
      * @param string|\Stringable|UserInterface $user        The username (like a nickname, email address, etc.) or a UserInterface instance
@@ -30,17 +30,17 @@ class UsernamePasswordToken extends AbstractToken
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($user, $credentials, string $providerKey, array $roles = [])
+    public function __construct($user, $credentials, string $firewallName, array $roles = [])
     {
         parent::__construct($roles);
 
-        if (empty($providerKey)) {
-            throw new \InvalidArgumentException('$providerKey must not be empty.');
+        if ('' === $firewallName) {
+            throw new \InvalidArgumentException('$firewallName must not be empty.');
         }
 
         $this->setUser($user);
         $this->credentials = $credentials;
-        $this->providerKey = $providerKey;
+        $this->firewallName = $firewallName;
 
         parent::setAuthenticated(\count($roles) > 0);
     }
@@ -69,10 +69,21 @@ class UsernamePasswordToken extends AbstractToken
      * Returns the provider key.
      *
      * @return string The provider key
+     *
+     * @deprecated since 5.2, use getFirewallName() instead
      */
     public function getProviderKey()
     {
-        return $this->providerKey;
+        if (1 !== \func_num_args() || true !== func_get_arg(0)) {
+            trigger_deprecation('symfony/security-core', '5.2', 'Method "%s" is deprecated, use "getFirewallName()" instead.', __METHOD__);
+        }
+
+        return $this->firewallName;
+    }
+
+    public function getFirewallName(): string
+    {
+        return $this->getProviderKey(true);
     }
 
     /**
@@ -90,7 +101,7 @@ class UsernamePasswordToken extends AbstractToken
      */
     public function __serialize(): array
     {
-        return [$this->credentials, $this->providerKey, parent::__serialize()];
+        return [$this->credentials, $this->firewallName, parent::__serialize()];
     }
 
     /**
@@ -98,7 +109,7 @@ class UsernamePasswordToken extends AbstractToken
      */
     public function __unserialize(array $data): void
     {
-        [$this->credentials, $this->providerKey, $parentData] = $data;
+        [$this->credentials, $this->firewallName, $parentData] = $data;
         $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
         parent::__unserialize($parentData);
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
@@ -30,7 +30,7 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
         ;
         $token
             ->expects($this->once())
-            ->method('getProviderKey')
+            ->method('getFirewallName')
             ->willReturn('foo')
         ;
         $this->assertFalse($provider->supports($token));
@@ -65,7 +65,7 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
         $token = $provider->authenticate($this->getSupportedToken('fabien', 'pass'));
         $this->assertInstanceOf('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken', $token);
         $this->assertEquals('pass', $token->getCredentials());
-        $this->assertEquals('key', $token->getProviderKey());
+        $this->assertEquals('key', $token->getFirewallName());
         $this->assertEquals([], $token->getRoleNames());
         $this->assertEquals(['foo' => 'bar'], $token->getAttributes(), '->authenticate() copies token attributes');
         $this->assertSame($user, $token->getUser());
@@ -89,7 +89,7 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
 
     protected function getSupportedToken($user = false, $credentials = false)
     {
-        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken')->setMethods(['getUser', 'getCredentials', 'getProviderKey'])->disableOriginalConstructor()->getMock();
+        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken')->setMethods(['getUser', 'getCredentials', 'getFirewallName'])->disableOriginalConstructor()->getMock();
         if (false !== $user) {
             $token->expects($this->once())
                   ->method('getUser')
@@ -105,7 +105,7 @@ class PreAuthenticatedAuthenticationProviderTest extends TestCase
 
         $token
             ->expects($this->any())
-            ->method('getProviderKey')
+            ->method('getFirewallName')
             ->willReturn('key')
         ;
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/RememberMeAuthenticationProviderTest.php
@@ -99,10 +99,10 @@ class RememberMeAuthenticationProviderTest extends TestCase
                 ->willReturn([]);
         }
 
-        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')->setMethods(['getProviderKey'])->setConstructorArgs([$user, 'foo', $secret])->getMock();
+        $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')->setMethods(['getFirewallName'])->setConstructorArgs([$user, 'foo', $secret])->getMock();
         $token
             ->expects($this->once())
-            ->method('getProviderKey')
+            ->method('getFirewallName')
             ->willReturn('foo');
 
         return $token;

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -202,10 +202,10 @@ class UserAuthenticationProviderTest extends TestCase
 
     protected function getSupportedToken()
     {
-        $mock = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')->setMethods(['getCredentials', 'getProviderKey', 'getRoles'])->disableOriginalConstructor()->getMock();
+        $mock = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')->setMethods(['getCredentials', 'getFirewallName', 'getRoles'])->disableOriginalConstructor()->getMock();
         $mock
             ->expects($this->any())
-            ->method('getProviderKey')
+            ->method('getFirewallName')
             ->willReturn('key')
         ;
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/PreAuthenticatedTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/PreAuthenticatedTokenTest.php
@@ -24,7 +24,7 @@ class PreAuthenticatedTokenTest extends TestCase
         $token = new PreAuthenticatedToken('foo', 'bar', 'key', ['ROLE_FOO']);
         $this->assertTrue($token->isAuthenticated());
         $this->assertEquals(['ROLE_FOO'], $token->getRoleNames());
-        $this->assertEquals('key', $token->getProviderKey());
+        $this->assertEquals('key', $token->getFirewallName());
     }
 
     public function testGetCredentials()

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
@@ -21,7 +21,7 @@ class RememberMeTokenTest extends TestCase
         $user = $this->getUser();
         $token = new RememberMeToken($user, 'fookey', 'foo');
 
-        $this->assertEquals('fookey', $token->getProviderKey());
+        $this->assertEquals('fookey', $token->getFirewallName());
         $this->assertEquals('foo', $token->getSecret());
         $this->assertEquals(['ROLE_FOO'], $token->getRoleNames());
         $this->assertSame($user, $token->getUser());

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/SwitchUserTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/SwitchUserTokenTest.php
@@ -28,7 +28,7 @@ class SwitchUserTokenTest extends TestCase
         $this->assertInstanceOf(SwitchUserToken::class, $unserializedToken);
         $this->assertSame('admin', $unserializedToken->getUsername());
         $this->assertSame('bar', $unserializedToken->getCredentials());
-        $this->assertSame('provider-key', $unserializedToken->getProviderKey());
+        $this->assertSame('provider-key', $unserializedToken->getFirewallName());
         $this->assertEquals(['ROLE_USER'], $unserializedToken->getRoleNames());
 
         $unserializedOriginalToken = $unserializedToken->getOriginalToken();
@@ -36,7 +36,7 @@ class SwitchUserTokenTest extends TestCase
         $this->assertInstanceOf(UsernamePasswordToken::class, $unserializedOriginalToken);
         $this->assertSame('user', $unserializedOriginalToken->getUsername());
         $this->assertSame('foo', $unserializedOriginalToken->getCredentials());
-        $this->assertSame('provider-key', $unserializedOriginalToken->getProviderKey());
+        $this->assertSame('provider-key', $unserializedOriginalToken->getFirewallName());
         $this->assertEquals(['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'], $unserializedOriginalToken->getRoleNames());
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/UsernamePasswordTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/UsernamePasswordTokenTest.php
@@ -24,7 +24,7 @@ class UsernamePasswordTokenTest extends TestCase
         $token = new UsernamePasswordToken('foo', 'bar', 'key', ['ROLE_FOO']);
         $this->assertEquals(['ROLE_FOO'], $token->getRoleNames());
         $this->assertTrue($token->isAuthenticated());
-        $this->assertEquals('key', $token->getProviderKey());
+        $this->assertEquals('key', $token->getFirewallName());
     }
 
     public function testSetAuthenticatedToTrue()

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/ExpressionLanguageTest.php
@@ -53,8 +53,8 @@ class ExpressionLanguageTest extends TestCase
 
         $noToken = null;
         $anonymousToken = new AnonymousToken('firewall', 'anon.');
-        $rememberMeToken = new RememberMeToken($user, 'providerkey', 'firewall');
-        $usernamePasswordToken = new UsernamePasswordToken('username', 'password', 'providerkey', $roles);
+        $rememberMeToken = new RememberMeToken($user, 'firewall-name', 'firewall');
+        $usernamePasswordToken = new UsernamePasswordToken('username', 'password', 'firewall-name', $roles);
 
         return [
             [$noToken, 'is_anonymous()', false],

--- a/src/Symfony/Component/Security/Http/Authentication/CustomAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/CustomAuthenticationSuccessHandler.php
@@ -22,17 +22,21 @@ class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler
     private $handler;
 
     /**
-     * @param array  $options     Options for processing a successful authentication attempt
-     * @param string $providerKey The provider key
+     * @param array $options Options for processing a successful authentication attempt
      */
-    public function __construct(AuthenticationSuccessHandlerInterface $handler, array $options, string $providerKey)
+    public function __construct(AuthenticationSuccessHandlerInterface $handler, array $options, string $firewallName)
     {
         $this->handler = $handler;
         if (method_exists($handler, 'setOptions')) {
             $this->handler->setOptions($options);
         }
-        if (method_exists($handler, 'setProviderKey')) {
-            $this->handler->setProviderKey($providerKey);
+
+        if (method_exists($handler, 'setFirewallName')) {
+            $this->handler->setFirewallName($firewallName);
+        } elseif (method_exists($handler, 'setProviderKey')) {
+            trigger_deprecation('symfony/security-http', '5.2', 'Method "%s::setProviderKey()" is deprecated, rename the method to "setFirewallName()" instead.', \get_class($handler));
+
+            $this->handler->setProviderKey($firewallName);
         }
     }
 

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -30,7 +30,9 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
 
     protected $httpUtils;
     protected $options;
+    /** @deprecated since 5.2, use $firewallName instead */
     protected $providerKey;
+    protected $firewallName;
     protected $defaultOptions = [
         'always_use_default_target_path' => false,
         'default_target_path' => '/',
@@ -75,15 +77,43 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
      * Get the provider key.
      *
      * @return string
+     *
+     * @deprecated since 5.2, use getFirewallName() instead
      */
     public function getProviderKey()
     {
-        return $this->providerKey;
+        if (1 !== \func_num_args() || true !== func_get_arg(0)) {
+            trigger_deprecation('symfony/security-core', '5.2', 'Method "%s()" is deprecated, use "getFirewallName()" instead.', __METHOD__);
+        }
+
+        if ($this->providerKey !== $this->firewallName) {
+            trigger_deprecation('symfony/security-core', '5.2', 'The "%1$s::$providerKey" property is deprecated, use "%1$s::$firewallName" instead.', __CLASS__);
+
+            return $this->providerKey;
+        }
+
+        return $this->firewallName;
     }
 
     public function setProviderKey(string $providerKey)
     {
+        if (2 !== \func_num_args() || true !== func_get_arg(1)) {
+            trigger_deprecation('symfony/security-http', '5.2', 'Method "%s" is deprecated, use "setFirewallName()" instead.', __METHOD__);
+        }
+
         $this->providerKey = $providerKey;
+    }
+
+    public function getFirewallName(): ?string
+    {
+        return $this->getProviderKey(true);
+    }
+
+    public function setFirewallName(string $firewallName): void
+    {
+        $this->setProviderKey($firewallName, true);
+
+        $this->firewallName = $firewallName;
     }
 
     /**
@@ -101,8 +131,9 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
             return $targetUrl;
         }
 
-        if (null !== $this->providerKey && $targetUrl = $this->getTargetPath($request->getSession(), $this->providerKey)) {
-            $this->removeTargetPath($request->getSession(), $this->providerKey);
+        $firewallName = $this->getFirewallName();
+        if (null !== $firewallName && $targetUrl = $this->getTargetPath($request->getSession(), $firewallName)) {
+            $this->removeTargetPath($request->getSession(), $firewallName);
 
             return $targetUrl;
         }

--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractPreAuthenticatedAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractPreAuthenticatedAuthenticator.php
@@ -117,7 +117,7 @@ abstract class AbstractPreAuthenticatedAuthenticator implements InteractiveAuthe
     private function clearToken(AuthenticationException $exception): void
     {
         $token = $this->tokenStorage->getToken();
-        if ($token instanceof PreAuthenticatedToken && $this->firewallName === $token->getProviderKey()) {
+        if ($token instanceof PreAuthenticatedToken && $this->firewallName === $token->getFirewallName()) {
             $this->tokenStorage->setToken(null);
 
             if (null !== $this->logger) {

--- a/src/Symfony/Component/Security/Http/Authenticator/Token/PostAuthenticationToken.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Token/PostAuthenticationToken.php
@@ -27,7 +27,7 @@ class PostAuthenticationToken extends AbstractToken
     {
         parent::__construct($roles);
 
-        if (empty($firewallName)) {
+        if ('' === $firewallName) {
             throw new \InvalidArgumentException('$firewallName must not be empty.');
         }
 

--- a/src/Symfony/Component/Security/Http/Event/LoginSuccessEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/LoginSuccessEvent.php
@@ -38,7 +38,7 @@ class LoginSuccessEvent extends Event
     private $authenticatedToken;
     private $request;
     private $response;
-    private $providerKey;
+    private $firewallName;
 
     public function __construct(AuthenticatorInterface $authenticator, PassportInterface $passport, TokenInterface $authenticatedToken, Request $request, ?Response $response, string $firewallName)
     {
@@ -47,7 +47,7 @@ class LoginSuccessEvent extends Event
         $this->authenticatedToken = $authenticatedToken;
         $this->request = $request;
         $this->response = $response;
-        $this->providerKey = $firewallName;
+        $this->firewallName = $firewallName;
     }
 
     public function getAuthenticator(): AuthenticatorInterface
@@ -81,7 +81,7 @@ class LoginSuccessEvent extends Event
 
     public function getFirewallName(): string
     {
-        return $this->providerKey;
+        return $this->firewallName;
     }
 
     public function setResponse(?Response $response): void

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -179,7 +179,7 @@ abstract class AbstractAuthenticationListener extends AbstractListener
         }
 
         $token = $this->tokenStorage->getToken();
-        if ($token instanceof UsernamePasswordToken && $this->providerKey === $token->getProviderKey()) {
+        if ($token instanceof UsernamePasswordToken && $this->providerKey === $token->getFirewallName()) {
             $this->tokenStorage->setToken(null);
         }
 

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -83,7 +83,7 @@ abstract class AbstractPreAuthenticatedListener extends AbstractListener
         }
 
         if (null !== $token = $this->tokenStorage->getToken()) {
-            if ($token instanceof PreAuthenticatedToken && $this->providerKey == $token->getProviderKey() && $token->isAuthenticated() && $token->getUsername() === $user) {
+            if ($token instanceof PreAuthenticatedToken && $this->providerKey == $token->getFirewallName() && $token->isAuthenticated() && $token->getUsername() === $user) {
                 return;
             }
         }
@@ -128,7 +128,7 @@ abstract class AbstractPreAuthenticatedListener extends AbstractListener
     private function clearToken(AuthenticationException $exception)
     {
         $token = $this->tokenStorage->getToken();
-        if ($token instanceof PreAuthenticatedToken && $this->providerKey === $token->getProviderKey()) {
+        if ($token instanceof PreAuthenticatedToken && $this->providerKey === $token->getFirewallName()) {
             $this->tokenStorage->setToken(null);
 
             if (null !== $this->logger) {

--- a/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
@@ -90,7 +90,7 @@ class BasicAuthenticationListener extends AbstractListener
             $this->tokenStorage->setToken($token);
         } catch (AuthenticationException $e) {
             $token = $this->tokenStorage->getToken();
-            if ($token instanceof UsernamePasswordToken && $this->providerKey === $token->getProviderKey()) {
+            if ($token instanceof UsernamePasswordToken && $this->providerKey === $token->getFirewallName()) {
                 $this->tokenStorage->setToken(null);
             }
 

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -47,7 +47,7 @@ class ExceptionListener
     use TargetPathTrait;
 
     private $tokenStorage;
-    private $providerKey;
+    private $firewallName;
     private $accessDeniedHandler;
     private $authenticationEntryPoint;
     private $authenticationTrustResolver;
@@ -56,12 +56,12 @@ class ExceptionListener
     private $httpUtils;
     private $stateless;
 
-    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationTrustResolverInterface $trustResolver, HttpUtils $httpUtils, string $providerKey, AuthenticationEntryPointInterface $authenticationEntryPoint = null, string $errorPage = null, AccessDeniedHandlerInterface $accessDeniedHandler = null, LoggerInterface $logger = null, bool $stateless = false)
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationTrustResolverInterface $trustResolver, HttpUtils $httpUtils, string $firewallName, AuthenticationEntryPointInterface $authenticationEntryPoint = null, string $errorPage = null, AccessDeniedHandlerInterface $accessDeniedHandler = null, LoggerInterface $logger = null, bool $stateless = false)
     {
         $this->tokenStorage = $tokenStorage;
         $this->accessDeniedHandler = $accessDeniedHandler;
         $this->httpUtils = $httpUtils;
-        $this->providerKey = $providerKey;
+        $this->firewallName = $firewallName;
         $this->authenticationEntryPoint = $authenticationEntryPoint;
         $this->authenticationTrustResolver = $trustResolver;
         $this->errorPage = $errorPage;
@@ -230,7 +230,7 @@ class ExceptionListener
     {
         // session isn't required when using HTTP basic authentication mechanism for example
         if ($request->hasSession() && $request->isMethodSafe() && !$request->isXmlHttpRequest()) {
-            $this->saveTargetPath($request->getSession(), $this->providerKey, $request->getUri());
+            $this->saveTargetPath($request->getSession(), $this->firewallName, $request->getUri());
         }
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -44,7 +44,7 @@ class SwitchUserListener extends AbstractListener
     private $tokenStorage;
     private $provider;
     private $userChecker;
-    private $providerKey;
+    private $firewallName;
     private $accessDecisionManager;
     private $usernameParameter;
     private $role;
@@ -52,16 +52,16 @@ class SwitchUserListener extends AbstractListener
     private $dispatcher;
     private $stateless;
 
-    public function __construct(TokenStorageInterface $tokenStorage, UserProviderInterface $provider, UserCheckerInterface $userChecker, string $providerKey, AccessDecisionManagerInterface $accessDecisionManager, LoggerInterface $logger = null, string $usernameParameter = '_switch_user', string $role = 'ROLE_ALLOWED_TO_SWITCH', EventDispatcherInterface $dispatcher = null, bool $stateless = false)
+    public function __construct(TokenStorageInterface $tokenStorage, UserProviderInterface $provider, UserCheckerInterface $userChecker, string $firewallName, AccessDecisionManagerInterface $accessDecisionManager, LoggerInterface $logger = null, string $usernameParameter = '_switch_user', string $role = 'ROLE_ALLOWED_TO_SWITCH', EventDispatcherInterface $dispatcher = null, bool $stateless = false)
     {
-        if (empty($providerKey)) {
-            throw new \InvalidArgumentException('$providerKey must not be empty.');
+        if ('' === $firewallName) {
+            throw new \InvalidArgumentException('$firewallName must not be empty.');
         }
 
         $this->tokenStorage = $tokenStorage;
         $this->provider = $provider;
         $this->userChecker = $userChecker;
-        $this->providerKey = $providerKey;
+        $this->firewallName = $firewallName;
         $this->accessDecisionManager = $accessDecisionManager;
         $this->usernameParameter = $usernameParameter;
         $this->role = $role;
@@ -181,7 +181,7 @@ class SwitchUserListener extends AbstractListener
 
         $roles = $user->getRoles();
         $roles[] = 'ROLE_PREVIOUS_ADMIN';
-        $token = new SwitchUserToken($user, $user->getPassword(), $this->providerKey, $roles, $token);
+        $token = new SwitchUserToken($user, $user->getPassword(), $this->firewallName, $roles, $token);
 
         if (null !== $this->dispatcher) {
             $switchEvent = new SwitchUserEvent($request, $token->getUser(), $token);

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
@@ -177,7 +177,7 @@ class UsernamePasswordJsonAuthenticationListener extends AbstractListener
         }
 
         $token = $this->tokenStorage->getToken();
-        if ($token instanceof UsernamePasswordToken && $this->providerKey === $token->getProviderKey()) {
+        if ($token instanceof UsernamePasswordToken && $this->providerKey === $token->getFirewallName()) {
             $this->tokenStorage->setToken(null);
         }
 

--- a/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
@@ -136,8 +136,14 @@ class LogoutUrlGenerator
                 throw new \InvalidArgumentException('Unable to generate a logout url for an anonymous token.');
             }
 
-            if (null !== $token && method_exists($token, 'getProviderKey')) {
-                $key = $token->getProviderKey();
+            if (null !== $token) {
+                if (method_exists($token, 'getFirewallName')) {
+                    $key = $token->getFirewallName();
+                } elseif (method_exists($token, 'getProviderKey')) {
+                    trigger_deprecation('symfony/security-http', '5.2', 'Method "%s::getProviderKey()" has been deprecated, rename it to "getFirewallName()" instead.', \get_class($token));
+
+                    $key = $token->getProviderKey();
+                }
 
                 if (isset($this->listeners[$key])) {
                     return $this->listeners[$key];

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -41,20 +41,20 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
         'httponly' => true,
         'samesite' => null,
     ];
-    private $providerKey;
+    private $firewallName;
     private $secret;
     private $userProviders;
 
     /**
      * @throws \InvalidArgumentException
      */
-    public function __construct(iterable $userProviders, string $secret, string $providerKey, array $options = [], LoggerInterface $logger = null)
+    public function __construct(iterable $userProviders, string $secret, string $firewallName, array $options = [], LoggerInterface $logger = null)
     {
         if (empty($secret)) {
             throw new \InvalidArgumentException('$secret must not be empty.');
         }
-        if (empty($providerKey)) {
-            throw new \InvalidArgumentException('$providerKey must not be empty.');
+        if ('' === $firewallName) {
+            throw new \InvalidArgumentException('$firewallName must not be empty.');
         }
         if (!\is_array($userProviders) && !$userProviders instanceof \Countable) {
             $userProviders = iterator_to_array($userProviders, false);
@@ -65,7 +65,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
 
         $this->userProviders = $userProviders;
         $this->secret = $secret;
-        $this->providerKey = $providerKey;
+        $this->firewallName = $firewallName;
         $this->options = array_merge($this->options, $options);
         $this->logger = $logger;
     }
@@ -123,7 +123,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
                 $this->logger->info('Remember-me cookie accepted.');
             }
 
-            return new RememberMeToken($user, $this->providerKey, $this->secret);
+            return new RememberMeToken($user, $this->firewallName, $this->secret);
         } catch (CookieTheftException $e) {
             $this->loginFail($request, $e);
 

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/AuthenticatorManagerTest.php
@@ -239,8 +239,8 @@ class AuthenticatorManagerTest extends TestCase
         return $authenticator;
     }
 
-    private function createManager($authenticators, $providerKey = 'main', $eraseCredentials = true)
+    private function createManager($authenticators, $firewallName = 'main', $eraseCredentials = true)
     {
-        return new AuthenticatorManager($authenticators, $this->tokenStorage, $this->eventDispatcher, $providerKey, null, $eraseCredentials);
+        return new AuthenticatorManager($authenticators, $this->tokenStorage, $this->eventDispatcher, $firewallName, null, $eraseCredentials);
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -29,7 +29,7 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
         $token = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
         $handler = new DefaultAuthenticationSuccessHandler($httpUtils, $options);
         if ($request->hasSession()) {
-            $handler->setProviderKey('admin');
+            $handler->setFirewallName('admin');
         }
         $this->assertSame('http://localhost'.$redirectedUrl, $handler->onAuthenticationSuccess($request, $token)->getTargetUrl());
     }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/RememberMeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/RememberMeListenerTest.php
@@ -75,17 +75,17 @@ class RememberMeListenerTest extends TestCase
         $this->listener->onFailedLogin($event);
     }
 
-    private function createLoginSuccessfulEvent($providerKey, $response, PassportInterface $passport = null)
+    private function createLoginSuccessfulEvent($firewallName, $response, PassportInterface $passport = null)
     {
         if (null === $passport) {
             $passport = new SelfValidatingPassport(new User('test', null), [new RememberMeBadge()]);
         }
 
-        return new LoginSuccessEvent($this->createMock(AuthenticatorInterface::class), $passport, $this->token, $this->request, $response, $providerKey);
+        return new LoginSuccessEvent($this->createMock(AuthenticatorInterface::class), $passport, $this->token, $this->request, $response, $firewallName);
     }
 
-    private function createLoginFailureEvent($providerKey)
+    private function createLoginFailureEvent($firewallName)
     {
-        return new LoginFailureEvent(new AuthenticationException(), $this->createMock(AuthenticatorInterface::class), $this->request, null, $providerKey, null);
+        return new LoginFailureEvent(new AuthenticationException(), $this->createMock(AuthenticatorInterface::class), $this->request, null, $firewallName, null);
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/SessionStrategyListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/SessionStrategyListenerTest.php
@@ -60,9 +60,9 @@ class SessionStrategyListenerTest extends TestCase
         $listener->onSuccessfulLogin($this->createEvent('api_firewall'));
     }
 
-    private function createEvent($providerKey)
+    private function createEvent($firewallName)
     {
-        return new LoginSuccessEvent($this->createMock(AuthenticatorInterface::class), new SelfValidatingPassport(new User('test', null)), $this->token, $this->request, null, $providerKey);
+        return new LoginSuccessEvent($this->createMock(AuthenticatorInterface::class), new SelfValidatingPassport(new User('test', null)), $this->token, $this->request, null, $firewallName);
     }
 
     private function configurePreviousSession()

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -49,10 +49,10 @@ class SwitchUserListenerTest extends TestCase
         $this->event = new RequestEvent($this->getMockBuilder(HttpKernelInterface::class)->getMock(), $this->request, HttpKernelInterface::MASTER_REQUEST);
     }
 
-    public function testProviderKeyIsRequired()
+    public function testFirewallNameIsRequired()
     {
         $this->expectException('InvalidArgumentException');
-        $this->expectExceptionMessage('$providerKey must not be empty');
+        $this->expectExceptionMessage('$firewallName must not be empty');
         new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, '', $this->accessDecisionManager);
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Logout/LogoutUrlGeneratorTest.php
@@ -88,7 +88,7 @@ class LogoutUrlGeneratorTest extends TestCase
         $this->assertSame('/logout', $this->generator->getLogoutPath());
     }
 
-    public function testGuessFromTokenWithoutProviderKeyFallbacksToCurrentFirewall()
+    public function testGuessFromTokenWithoutFirewallNameFallbacksToCurrentFirewall()
     {
         $this->tokenStorage->setToken(new UsernamePasswordToken('username', 'password', 'provider'));
         $this->generator->registerListener('secured_area', '/logout', null, null);

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
@@ -89,7 +89,7 @@ class AbstractRememberMeServicesTest extends TestCase
 
         $this->assertSame($user, $returnedToken->getUser());
         $this->assertSame('foosecret', $returnedToken->getSecret());
-        $this->assertSame('fookey', $returnedToken->getProviderKey());
+        $this->assertSame('fookey', $returnedToken->getFirewallName());
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Tests/Util/TargetPathTraitTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Util/TargetPathTraitTest.php
@@ -60,18 +60,18 @@ class TestClassWithTargetPathTrait
 {
     use TargetPathTrait;
 
-    public function doSetTargetPath(SessionInterface $session, $providerKey, $uri)
+    public function doSetTargetPath(SessionInterface $session, $firewallName, $uri)
     {
-        $this->saveTargetPath($session, $providerKey, $uri);
+        $this->saveTargetPath($session, $firewallName, $uri);
     }
 
-    public function doGetTargetPath(SessionInterface $session, $providerKey)
+    public function doGetTargetPath(SessionInterface $session, $firewallName)
     {
-        return $this->getTargetPath($session, $providerKey);
+        return $this->getTargetPath($session, $firewallName);
     }
 
-    public function doRemoveTargetPath(SessionInterface $session, $providerKey)
+    public function doRemoveTargetPath(SessionInterface $session, $firewallName)
     {
-        $this->removeTargetPath($session, $providerKey);
+        $this->removeTargetPath($session, $firewallName);
     }
 }

--- a/src/Symfony/Component/Security/Http/Util/TargetPathTrait.php
+++ b/src/Symfony/Component/Security/Http/Util/TargetPathTrait.php
@@ -23,24 +23,24 @@ trait TargetPathTrait
      *
      * Usually, you do not need to set this directly.
      */
-    private function saveTargetPath(SessionInterface $session, string $providerKey, string $uri)
+    private function saveTargetPath(SessionInterface $session, string $firewallName, string $uri)
     {
-        $session->set('_security.'.$providerKey.'.target_path', $uri);
+        $session->set('_security.'.$firewallName.'.target_path', $uri);
     }
 
     /**
      * Returns the URL (if any) the user visited that forced them to login.
      */
-    private function getTargetPath(SessionInterface $session, string $providerKey): ?string
+    private function getTargetPath(SessionInterface $session, string $firewallName): ?string
     {
-        return $session->get('_security.'.$providerKey.'.target_path');
+        return $session->get('_security.'.$firewallName.'.target_path');
     }
 
     /**
      * Removes the target path from the session.
      */
-    private function removeTargetPath(SessionInterface $session, string $providerKey)
+    private function removeTargetPath(SessionInterface $session, string $firewallName)
     {
-        $session->remove('_security.'.$providerKey.'.target_path');
+        $session->remove('_security.'.$firewallName.'.target_path');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #15207 
| License       | MIT
| Doc PR        | tbd

This fixes the `$providerKey` argument names on the classes that will remain in use, even when the new Security system will take over. @fabpot do you think these changes are worth it?

Officially, all token classes are not marked as `@final`. Do I need to take into account when someone is overriding the `getProviderKey()` method? Also, I couldn't find a way to trigger a deprecation notice for deprecated properties, is this a problem?