### PR TITLE
[BrowserKit] KernelBrowser supports now "json" key in parameters of "KernelBrowser"

### DIFF
--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * Added support of `json` key in parameters of `KernelBrowser::request()`
+   to encode an array to JSON
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/BrowserKit/Request.php
+++ b/src/Symfony/Component/BrowserKit/Request.php
@@ -38,6 +38,10 @@ class Request
         $this->uri = $uri;
         $this->method = $method;
 
+        if (null === $content && isset($parameters['json'])) {
+            $content = json_encode($parameters['json']);
+        }
+
         array_walk_recursive($parameters, static function (&$value) {
             $value = (string) $value;
         });

--- a/src/Symfony/Component/BrowserKit/Tests/RequestTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/RequestTest.php
@@ -71,4 +71,13 @@ class RequestTest extends TestCase
         $request = new Request('http://www.example.com/', 'get', $parameters);
         $this->assertSame($expected, $request->getParameters());
     }
+
+    public function testJsonParametersContent()
+    {
+        $request = new Request('http://www.example.com/', 'get', ['json' => ['foo' => 'bar']]);
+        $this->assertSame('{"foo":"bar"}', $request->getContent());
+
+        $request = new Request('http://www.example.com/', 'get', ['json' => ['foo' => 'bar']], [], [], [], 'baz');
+        $this->assertSame('baz', $request->getContent());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #37608 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | `TODO` <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->

This pull request adds the ability to give an array to the parameters of `KernelBrowser::request` to the `json` key and parse it into a JSON format in the content.

```php
$client->request('GET', 'https://example.com', [
    'json' => ['foo' => 'bar']
]);

// The content request will have:
// {"foo":"bar"}