### PR TITLE
[Yaml] fix more numeric cases changing in PHP 8

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -210,7 +210,7 @@ class Inline
                 return 'false';
             case ctype_digit($value):
                 return \is_string($value) ? "'$value'" : (int) $value;
-            case is_numeric($value) && false === strpos($value, "\n"):
+            case is_numeric($value) && false === strpos($value, "\f") && false === strpos($value, "\n") && false === strpos($value, "\r") && false === strpos($value, "\t") && false === strpos($value, "\v"):
                 $locale = setlocale(LC_NUMERIC, 0);
                 if (false !== $locale) {
                     setlocale(LC_NUMERIC, 'C');

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -570,6 +570,14 @@ class InlineTest extends TestCase
             ['[foo, \'@foo.baz\', { \'%foo%\': \'foo is %foo%\', bar: \'%foo%\' }, true, \'@service_container\']', ['foo', '@foo.baz', ['%foo%' => 'foo is %foo%', 'bar' => '%foo%'], true, '@service_container']],
 
             ['{ foo: { bar: { 1: 2, baz: 3 } } }', ['foo' => ['bar' => [1 => 2, 'baz' => 3]]]],
+
+            // numeric strings with trailing whitespaces
+            ["'0123 '", '0123 '],
+            ['"0123\f"', "0123\f"],
+            ['"0123\n"', "0123\n"],
+            ['"0123\r"', "0123\r"],
+            ['"0123\t"', "0123\t"],
+            ['"0123\v"', "0123\v"],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/yaml/commit/968ffcfa6554b05a38c69b5c20d351e5dc4a4f15#r41697638
| License       | MIT
| Doc PR        | 

see also https://wiki.php.net/rfc/saner-numeric-strings