### PR TITLE
[FrameworkBundle] Make AbstractPhpFileCacheWarmer public

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AbstractPhpFileCacheWarmer.php
@@ -17,9 +17,6 @@ use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Config\Resource\ClassExistenceResource;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
-/**
- * @internal
- */
 abstract class AbstractPhpFileCacheWarmer implements CacheWarmerInterface
 {
     private $phpArrayFile;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Introducing the PhpArrayAdapter was a great feature. It has proven itself well in the production.
Actually, using the adapter is closely related to warming up the cache for it. FrameworkBundle has an AbstractPhpFileCacheWarmer for conveniently creating a custom warmer.
But using it outside of the FrameworkBundle becomes more complicated because it is marked as internal.
I propose making it public and allow it to be used outside of the FrameworkBundle.

For example, I've proposed to cache Doctrine metadata using PhpArrayAdapter and the implementation uses AbstractPhpFileCacheWarmer https://github.com/doctrine/DoctrineBundle/pull/1196