### PR TITLE
[PhpunitBridge] Fix deprecation type detection (when several autoload files are used)

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -264,7 +264,10 @@ class Deprecation
                     if (file_exists($v.'/composer/installed.json')) {
                         self::$vendors[] = $v;
                         $loader = require $v.'/autoload.php';
-                        $paths = self::getSourcePathsFromPrefixes(array_merge($loader->getPrefixes(), $loader->getPrefixesPsr4()));
+                        $paths = self::addSourcePathsFromPrefixes(
+                            array_merge($loader->getPrefixes(), $loader->getPrefixesPsr4()),
+                            $paths
+                        );
                     }
                 }
             }
@@ -280,15 +283,17 @@ class Deprecation
         return self::$vendors;
     }
 
-    private static function getSourcePathsFromPrefixes(array $prefixesByNamespace)
+    private static function addSourcePathsFromPrefixes(array $prefixesByNamespace, array $paths)
     {
         foreach ($prefixesByNamespace as $prefixes) {
             foreach ($prefixes as $prefix) {
                 if (false !== realpath($prefix)) {
-                    yield realpath($prefix);
+                    $paths[] = realpath($prefix);
                 }
             }
         }
+
+        return $paths;
     }
 
     /**

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/fake_app/AppService.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/fake_app/AppService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services;
+
+use acme\lib\SomeService;
+use foo\lib\SomeOtherService;
+
+final class AppService
+{
+    public function directDeprecations()
+    {
+        $service1 = new SomeService();
+        $service1->deprecatedApi();
+
+        $service2 = new SomeOtherService();
+        $service2->deprecatedApi();
+    }
+}
+

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/fake_vendor_bis/autoload.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/fake_vendor_bis/autoload.php
@@ -1,0 +1,5 @@
+<?php
+
+require_once __DIR__.'/composer/autoload_real.php';
+
+return ComposerAutoloaderInitFakeBis::getLoader();

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/fake_vendor_bis/composer/autoload_real.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/fake_vendor_bis/composer/autoload_real.php
@@ -1,6 +1,6 @@
 <?php
 
-class ComposerLoaderFake
+class ComposerLoaderFakeBis
 {
     public function getPrefixes()
     {
@@ -10,8 +10,7 @@ class ComposerLoaderFake
     public function getPrefixesPsr4()
     {
         return [
-            'App\\Services\\' => [__DIR__.'/../../fake_app/'],
-            'acme\\lib\\' => [__DIR__.'/../acme/lib/'],
+            'foo\\lib\\' => [__DIR__.'/../foo/lib/'],
         ];
     }
 
@@ -32,14 +31,14 @@ class ComposerLoaderFake
     }
 }
 
-class ComposerAutoloaderInitFake
+class ComposerAutoloaderInitFakeBis
 {
     private static $loader;
 
     public static function getLoader()
     {
         if (null === self::$loader) {
-            self::$loader = new ComposerLoaderFake();
+            self::$loader = new ComposerLoaderFakeBis();
             spl_autoload_register([self::$loader, 'loadClass']);
         }
 

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/fake_vendor_bis/composer/installed.json
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/fake_vendor_bis/composer/installed.json
@@ -1,0 +1,1 @@
+{"just here": "for the detection"}

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/fake_vendor_bis/foo/lib/SomeOtherService.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/fake_vendor_bis/foo/lib/SomeOtherService.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace foo\lib;
+
+class SomeOtherService
+{
+    public function deprecatedApi()
+    {
+        @trigger_error(
+            __FUNCTION__.' from foo is deprecated! You should stop relying on it!',
+            E_USER_DEPRECATED
+        );
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/multiple_autoloads.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/multiple_autoloads.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Test DeprecationErrorHandler with multiple autoload files
+--FILE--
+<?php
+
+$k = 'SYMFONY_DEPRECATIONS_HELPER';
+putenv($k.'='.$_SERVER[$k] = $_ENV[$k] = 'max[self]=0');
+putenv('ANSICON');
+putenv('ConEmuANSI');
+putenv('TERM');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+require_once __DIR__.'/../../bootstrap.php';
+
+eval(<<<'EOPHP'
+namespace PHPUnit\Util;
+
+class Test
+{
+    public static function getGroups()
+    {
+        return array();
+    }
+}
+EOPHP
+);
+
+require __DIR__.'/fake_vendor/autoload.php';
+require __DIR__.'/fake_vendor_bis/autoload.php';
+
+(new \App\Services\AppService())->directDeprecations();
+?>
+--EXPECTF--
+Remaining direct deprecation notices (2)
+
+  1x: deprecatedApi is deprecated! You should stop relying on it!
+    1x in AppService::directDeprecations from App\Services
+
+  1x: deprecatedApi from foo is deprecated! You should stop relying on it!
+    1x in AppService::directDeprecations from App\Services


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Several autoload files are supported by the PHPUnit Bridge but when the internal paths are registered (for deprecation type detection), the paths (from prefixes) of the last autoload file override the paths previously registered. This PR fixes this bug.