### PR TITLE
[Mailer] Fixed 'verify_peer' option in mailer DSN being ignored

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/EsmtpTransportFactoryTest.php
@@ -81,5 +81,22 @@ class EsmtpTransportFactoryTest extends TransportFactoryTestCase
             new Dsn('smtps', 'example.com', '', '', 465, ['verify_peer' => false]),
             $transport,
         ];
+
+        yield [
+            new Dsn('smtps', 'example.com', '', '', 465, ['verify_peer' => 'false']),
+            $transport,
+        ];
+
+        yield [
+            Dsn::fromString('smtps://:@example.com?verify_peer=0'),
+            $transport,
+        ];
+
+        $transport = new EsmtpTransport('example.com', 465, true, $eventDispatcher, $logger);
+
+        yield [
+            Dsn::fromString('smtps://:@example.com?verify_peer='),
+            $transport,
+        ];
     }
 }

--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransportFactory.php
@@ -29,7 +29,7 @@ final class EsmtpTransportFactory extends AbstractTransportFactory
 
         $transport = new EsmtpTransport($host, $port, $tls, $this->dispatcher, $this->logger);
 
-        if (!$dsn->getOption('verify_peer', true)) {
+        if ('' !== $dsn->getOption('verify_peer') && !filter_var($dsn->getOption('verify_peer', true), FILTER_VALIDATE_BOOLEAN)) {
             /** @var SocketStream $stream */
             $stream = $transport->getStream();
             $streamOptions = $stream->getStreamOptions();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->

The mailer DSN option 'verify_peer' was being ignored because `$dsn->getOption('verify_peer', true)` was returning a string and thus NOT operator on it was always resulting in false. I propose changing the line where it is used with a `filter_var` call with the `FILTER_VALIDATE_BOOLEAN` as the filter parameter to overcome this issue.
