### PR TITLE
[PhpUnitBridge] Move assertMatchesRegularExpression in PolyfillAssertTrait

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/PolyfillAssertTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/PolyfillAssertTrait.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\PhpUnit\Legacy;
 
 use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\Constraint\LogicalNot;
+use PHPUnit\Framework\Constraint\RegularExpression;
 use PHPUnit\Framework\Constraint\StringContains;
 use PHPUnit\Framework\Constraint\TraversableContains;
 
@@ -442,5 +443,25 @@ trait PolyfillAssertTrait
     {
         static::assertFileExists($filename, $message);
         static::assertNotIsWritable($filename, $message);
+    }
+
+    /**
+     * Asserts that a string matches a given regular expression.
+     *
+     * @param string $pattern
+     * @param string $string
+     * @param string $message
+     *
+     * @return void
+     */
+    public function assertMatchesRegularExpression($pattern, $string, $message = '')
+    {
+        static::assertThat(
+            $string,
+            new LogicalNot(
+                new RegularExpression($pattern)
+            ),
+            $message
+        );
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/Legacy/PolyfillTestCaseTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/PolyfillTestCaseTrait.php
@@ -11,10 +11,8 @@
 
 namespace Symfony\Bridge\PhpUnit\Legacy;
 
-use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use SebastianBergmann\RecursionContext\InvalidArgumentException;
 
 /**
  * This trait is @internal.
@@ -117,19 +115,5 @@ trait PolyfillTestCaseTrait
         $property = new \ReflectionProperty(TestCase::class, 'expectedExceptionMessageRegExp');
         $property->setAccessible(true);
         $property->setValue($this, $messageRegExp);
-    }
-
-    /**
-     * Asserts that a string matches a given regular expression.
-     *
-     * @param string $pattern
-     * @param string $string
-     * @param string $message
-     *
-     * @return void
-     */
-    public function assertMatchesRegularExpression($pattern, $string, $message = '')
-    {
-        $this->assertRegExp($pattern, $string, $message);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a

Move the polyfill method introduced in #37960 in the `Assert` trait. Sorry I noticed this trait later.