### PR TITLE
[HttpClient][MockHttpClient][DX] Throw when the response factory callable does not return a valid response

### DIFF
--- a/src/Symfony/Component/HttpClient/MockHttpClient.php
+++ b/src/Symfony/Component/HttpClient/MockHttpClient.php
@@ -68,6 +68,10 @@ class MockHttpClient implements HttpClientInterface
             $this->responseFactory->next();
         }
 
+        if (!$response instanceof ResponseInterface) {
+            throw new TransportException(\sprintf('The response factory passed to MockHttpClient must return/yield an instance of ResponseInterface, "%s" given.', \is_object($response) ? \get_class($response) : \gettype($response)));
+        }
+
         return MockResponse::fromRequest($method, $url, $options, $response);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The current message is `TypeError: Argument 4 passed to Symfony\Component\HttpClient\Response\MockResponse::fromRequest() must implement interface Symfony\Contracts\HttpClient\ResponseInterface, instance of Generator given`.

I lost some time with this because I was passing a callable that returns a \Generator instead of passing the resulting \Generator directly. We could support that case but I guess with the added exception message, it is clear we don't support it at all.