### PR TITLE
[Messenger] Don't prevent dispatch out of another bus

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
 * Added `FlattenExceptionNormalizer` to give more information about the exception on Messenger background processes. The `FlattenExceptionNormalizer` has a higher priority than `ProblemNormalizer` and it is only used when the Messenger serialization context is set.
 * Added factory methods to `DelayStamp`.
+* Removed the exception when dispatching a message with a `DispatchAfterCurrentBusStamp` and not in a context of another dispatch call
 
 5.1.0
 -----

--- a/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
@@ -44,12 +44,13 @@ class DispatchAfterCurrentBusMiddleware implements MiddlewareInterface
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         if (null !== $envelope->last(DispatchAfterCurrentBusStamp::class)) {
-            if (!$this->isRootDispatchCallRunning) {
-                throw new \LogicException(sprintf('You can only use a "%s" stamp in the context of a message handler.', DispatchAfterCurrentBusStamp::class));
-            }
-            $this->queue[] = new QueuedEnvelope($envelope, $stack);
+            if ($this->isRootDispatchCallRunning) {
+                $this->queue[] = new QueuedEnvelope($envelope, $stack);
 
-            return $envelope;
+                return $envelope;
+            }
+
+            $envelope = $envelope->withoutAll(DispatchAfterCurrentBusStamp::class);
         }
 
         if ($this->isRootDispatchCallRunning) {

--- a/src/Symfony/Component/Messenger/Tests/Middleware/DispatchAfterCurrentBusMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/DispatchAfterCurrentBusMiddlewareTest.php
@@ -256,6 +256,28 @@ class DispatchAfterCurrentBusMiddlewareTest extends TestCase
         $messageBus->dispatch($message);
     }
 
+    public function testDispatchOutOfAnotherHandlerDispatchesAndRemoveStamp()
+    {
+        $event = new DummyEvent('First event');
+
+        $middleware = new DispatchAfterCurrentBusMiddleware();
+        $handlingMiddleware = $this->createMock(MiddlewareInterface::class);
+
+        $handlingMiddleware
+            ->method('handle')
+            ->with($this->expectHandledMessage($event))
+            ->will($this->willHandleMessage());
+
+        $eventBus = new MessageBus([
+            $middleware,
+            $handlingMiddleware,
+        ]);
+
+        $enveloppe = $eventBus->dispatch($event, [new DispatchAfterCurrentBusStamp()]);
+
+        self::assertNull($enveloppe->last(DispatchAfterCurrentBusStamp::class));
+    }
+
     private function expectHandledMessage($message): Callback
     {
         return $this->callback(function (Envelope $envelope) use ($message) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | https://github.com/symfony/symfony/issues/35814#issuecomment-682433541 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A