### PR TITLE
[HttpFoundation] Handle fallback filename

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -159,18 +159,8 @@ class BinaryFileResponse extends Response
             $filename = $this->file->getFilename();
         }
 
-        if ('' === $filenameFallback && (!preg_match('/^[\x20-\x7e]*$/', $filename) || false !== strpos($filename, '%'))) {
-            $encoding = mb_detect_encoding($filename, null, true) ?: '8bit';
-
-            for ($i = 0, $filenameLength = mb_strlen($filename, $encoding); $i < $filenameLength; ++$i) {
-                $char = mb_substr($filename, $i, 1, $encoding);
-
-                if ('%' === $char || \ord($char) < 32 || \ord($char) > 126) {
-                    $filenameFallback .= '_';
-                } else {
-                    $filenameFallback .= $char;
-                }
-            }
+        if ('' === $filenameFallback) {
+            $filenameFallback = HeaderUtils::getFilenameFallback($filename);
         }
 
         $dispositionHeader = $this->headers->makeDisposition($disposition, $filename, $filenameFallback);

--- a/src/Symfony/Component/HttpFoundation/HeaderUtils.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderUtils.php
@@ -167,7 +167,7 @@ class HeaderUtils
         }
 
         if ('' === $filenameFallback) {
-            $filenameFallback = $filename;
+            $filenameFallback = self::getFilenameFallback($filename);
         }
 
         // filenameFallback is not ASCII.
@@ -191,6 +191,27 @@ class HeaderUtils
         }
 
         return $disposition.'; '.self::toString($params, ';');
+    }
+
+    public static function getFilenameFallback(string $filename): string
+    {
+        if (preg_match('/^[\x20-\x7e]*$/', $filename) && false === strpos($filename, '%')) {
+            return $filename;
+        }
+        $filenameFallback = '';
+        $encoding = mb_detect_encoding($filename, null, true) ?: '8bit';
+
+        for ($i = 0, $filenameLength = mb_strlen($filename, $encoding); $i < $filenameLength; ++$i) {
+            $char = mb_substr($filename, $i, 1, $encoding);
+
+            if ('%' === $char || \ord($char) < 32 || \ord($char) > 126) {
+                $filenameFallback .= '_';
+            } else {
+                $filenameFallback .= $char;
+            }
+        }
+
+        return $filenameFallback;
     }
 
     private static function groupParts(array $matches, string $separators): array

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -46,6 +46,17 @@ class BinaryFileResponseTest extends ResponseTestCase
         $this->assertSame('fööö.html', $response->getFile()->getFilename());
     }
 
+    public function testConstructWithNonAscii8BitFilename()
+    {
+        touch(sys_get_temp_dir().'/Àáå.html');
+
+        $response = new BinaryFileResponse(sys_get_temp_dir().'/Àáå.html', 200, [], true, 'attachment');
+
+        @unlink(sys_get_temp_dir().'/Àáå.html');
+
+        $this->assertSame('Àáå.html', $response->getFile()->getFilename());
+    }
+
     public function testSetContent()
     {
         $this->expectException('LogicException');

--- a/src/Symfony/Component/HttpFoundation/Tests/HeaderUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HeaderUtilsTest.php
@@ -106,6 +106,7 @@ class HeaderUtilsTest extends TestCase
             ['attachment', 'foo "bar".html', '', 'attachment; filename="foo \\"bar\\".html"'],
             ['attachment', 'foo%20bar.html', 'foo bar.html', 'attachment; filename="foo bar.html"; filename*=utf-8\'\'foo%2520bar.html'],
             ['attachment', 'föö.html', 'foo.html', 'attachment; filename=foo.html; filename*=utf-8\'\'f%C3%B6%C3%B6.html'],
+            ['attachment', 'föö.html', '', 'attachment; filename=foo.html; filename*=utf-8\'\'f%C3%B6%C3%B6.html'],
         ];
     }
 
@@ -121,12 +122,10 @@ class HeaderUtilsTest extends TestCase
     public function provideMakeDispositionFail()
     {
         return [
-            ['attachment', 'foo%20bar.html'],
             ['attachment', 'foo/bar.html'],
             ['attachment', '/foo.html'],
             ['attachment', 'foo\bar.html'],
             ['attachment', '\foo.html'],
-            ['attachment', 'föö.html'],
         ];
     }
 }


### PR DESCRIPTION
- if passed a filename in an 8-bit encoding (e.g. Latin2), the original name doesn't contain (7-bit) ASCII and fails, despite being valid
- pass in an encoded version then

Signed-off-by: Jan Piskvor Martinec <github@piskvor.org>

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | n/a

If an attachment's filename contains characters that are beyond ASCII (`[\x20-\x7e]`), a fallback is not used, and an exception is thrown. There's already a method for generating a fallback filename - extracted that and used in both places.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
