### PR TITLE
[HttpFoundation][Cache][Messenger] Replace redis "DEL" commands with "UNLINK"

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
@@ -149,7 +149,11 @@ class RedisTagAwareAdapter extends AbstractTagAwareAdapter
     {
         $lua = <<<'EOLUA'
             local v = redis.call('GET', KEYS[1])
-            redis.call('DEL', KEYS[1])
+            local e = redis.pcall('UNLINK', KEYS[1])
+
+            if type(e) ~= 'number' then
+                redis.call('DEL', KEYS[1])
+            end
 
             if not v or v:len() <= 13 or v:byte(1) ~= 0x9D or v:byte(6) ~= 0 or v:byte(10) ~= 0x5F then
                 return ''

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
@@ -89,6 +89,18 @@ class RedisSessionHandler extends AbstractSessionHandler
      */
     protected function doDestroy(string $sessionId): bool
     {
+        static $unlink = true;
+
+        if ($unlink) {
+            try {
+                $this->redis->unlink($this->prefix.$sessionId);
+
+                return true;
+            } catch (\Throwable $e) {
+                $unlink = false;
+            }
+        }
+
         $this->redis->del($this->prefix.$sessionId);
 
         return true;

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -460,6 +460,19 @@ class Connection
 
     public function cleanup(): void
     {
+        static $unlink = true;
+
+        if ($unlink) {
+            try {
+                $this->connection->unlink($this->stream);
+                $this->connection->unlink($this->queue);
+
+                return;
+            } catch (\Throwable $e) {
+                $unlink = false;
+            }
+        }
+
         $this->connection->del($this->stream);
         $this->connection->del($this->queue);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master |
| Bug fix?      | no
| New feature?  | no |
| Deprecations? | no |
| Tickets       | |
| License       | MIT|
| Doc PR        | |

This PR replaces DEL Command with UNLINK command.

Details about UNLINK can be found here https://redis.io/commands/unlink .

As noticed here redis/redis#1748 (comment) this will not change the behavior.

As there is no check of Redis version included, it will break Redis Versions < 4.0 through.

As Redis 4.0 was released on 2017-07-14 and Redis 3 went EOL with the Redis 5 on 2018-10-17, I don't expect this being an issue.

With redis 4.0 there is a new unlink command intruded ( https://redis.io/commands/unlink ) with is a smarter version of del() as it deletes keys in O(1) and frees the memory in background.

See also http://antirez.com/news/93 and redis/redis#1748

This won't change the behavior but only the memory usage as clarified here: redis/redis#1748 (comment) which shouldn't be an issue with most Magento instances

With this, I recommend replacing DEL operations with UNLINK operations.
