### PR TITLE
Add %translator.enabled_locales% parameter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1095,10 +1095,9 @@ class FrameworkExtension extends Extension
         $defaultOptions['cache_dir'] = $config['cache_dir'];
         $translator->setArgument(4, $defaultOptions);
 
-        $translator->setArgument(5, $config['enabled_locales']);
-
         $container->setParameter('translator.logging', $config['logging']);
         $container->setParameter('translator.default_path', $config['default_path']);
+        $container->setParameter('translator.enabled_locales', $config['enabled_locales']);
 
         // Discover translation directories
         $dirs = [];

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -16,7 +16,7 @@
                 <argument key="cache_dir">%kernel.cache_dir%/translations</argument>
                 <argument key="debug">%kernel.debug%</argument>
             </argument>
-            <argument type="collection" /> <!-- enabled locales -->
+            <argument>%translator.enabled_locales%</argument>
             <call method="setConfigCacheFactory">
                 <argument type="service" id="config_cache_factory" />
             </call>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Added a new parameter named `translator.enabled_locales` to expose the `framework.translator.enabled_locales` configuration. This can be used to avoid listing the enabled locales in other libraries (eg. php-translations)
