### PR TITLE
[Validator] Fix PhpUnitBridge version constraint

### DIFF
--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -34,6 +34,7 @@
         "symfony/expression-language": "^5.1",
         "symfony/cache": "^4.4|^5.0",
         "symfony/mime": "^4.4|^5.0",
+        "symfony/phpunit-bridge": "^5.1",
         "symfony/property-access": "^4.4|^5.0",
         "symfony/property-info": "^4.4|^5.0",
         "symfony/translation": "^4.4|^5.0",
@@ -48,7 +49,6 @@
         "symfony/expression-language": "<5.1",
         "symfony/http-kernel": "<4.4",
         "symfony/intl": "<4.4",
-        "symfony/phpunit-bridge": "^5.1",
         "symfony/translation": "<4.4",
         "symfony/yaml": "<4.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR allows Validator 5.1 and PhpUnitBridge 5.1 to be installed alongside each other.