### PR TITLE
[Amqp] Add amqps support

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Add option to confirm message delivery
+ * DSN now support AMQPS out-of-the-box.
 
 5.1.0
 -----

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -53,6 +53,24 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testItCanBeConstructedWithAnAmqpsDsn()
+    {
+        $this->assertEquals(
+            new Connection([
+                'host' => 'localhost',
+                'port' => 5671,
+                'vhost' => '/',
+                'cacert' => '/etc/ssl/certs',
+            ], [
+                'name' => self::DEFAULT_EXCHANGE_NAME,
+            ], [
+                self::DEFAULT_EXCHANGE_NAME => [],
+            ]),
+            Connection::fromDsn('amqps://localhost?'.
+                'cacert=/etc/ssl/certs')
+        );
+    }
+
     public function testItGetsParametersFromTheDsn()
     {
         $this->assertEquals(
@@ -314,6 +332,45 @@ class ConnectionTest extends TestCase
         $connection->publish('body');
     }
 
+    public function testItSetupsTheTTLConnection()
+    {
+        $amqpConnection = $this->createMock(\AMQPConnection::class);
+        $amqpChannel = $this->createMock(\AMQPChannel::class);
+        $amqpExchange = $this->createMock(\AMQPExchange::class);
+        $amqpQueue0 = $this->createMock(\AMQPQueue::class);
+        $amqpQueue1 = $this->createMock(\AMQPQueue::class);
+
+        $factory = $this->createMock(AmqpFactory::class);
+        $factory->method('createConnection')->willReturn($amqpConnection);
+        $factory->method('createChannel')->willReturn($amqpChannel);
+        $factory->method('createExchange')->willReturn($amqpExchange);
+        $factory->method('createQueue')->will($this->onConsecutiveCalls($amqpQueue0, $amqpQueue1));
+
+        $amqpExchange->expects($this->once())->method('declareExchange');
+        $amqpExchange->expects($this->once())->method('publish')->with('body', 'routing_key', AMQP_NOPARAM, ['headers' => [], 'delivery_mode' => 2, 'timestamp' => time()]);
+        $amqpQueue0->expects($this->once())->method('declareQueue');
+        $amqpQueue0->expects($this->exactly(2))->method('bind')->withConsecutive(
+            [self::DEFAULT_EXCHANGE_NAME, 'binding_key0'],
+            [self::DEFAULT_EXCHANGE_NAME, 'binding_key1']
+        );
+        $amqpQueue1->expects($this->once())->method('declareQueue');
+        $amqpQueue1->expects($this->exactly(2))->method('bind')->withConsecutive(
+            [self::DEFAULT_EXCHANGE_NAME, 'binding_key2'],
+            [self::DEFAULT_EXCHANGE_NAME, 'binding_key3']
+        );
+
+        $dsn = 'amqps://localhost?'.
+            'cacert=/etc/ssl/certs&'.
+            'exchange[default_publish_routing_key]=routing_key&'.
+            'queues[queue0][binding_keys][0]=binding_key0&'.
+            'queues[queue0][binding_keys][1]=binding_key1&'.
+            'queues[queue1][binding_keys][0]=binding_key2&'.
+            'queues[queue1][binding_keys][1]=binding_key3';
+
+        $connection = Connection::fromDsn($dsn, [], $factory);
+        $connection->publish('body');
+    }
+
     public function testBindingArguments()
     {
         $amqpConnection = $this->createMock(\AMQPConnection::class);
@@ -504,6 +561,27 @@ class ConnectionTest extends TestCase
 
         $connection = Connection::fromDsn('amqp://user:secretpassword@localhost', [], $factory);
         $connection->channel();
+    }
+
+    public function testNoCaCertOnSslConnectionFromDsn()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('No CA certificate has been provided. Set "amqp.cacert" in your php.ini or pass the "cacert" parameter in the DSN to use SSL. Alternatively, you can use amqp:// to use without SSL.');
+
+        $factory = new TestAmqpFactory(
+            $amqpConnection = $this->createMock(\AMQPConnection::class),
+            $amqpChannel = $this->createMock(\AMQPChannel::class),
+            $amqpQueue = $this->createMock(\AMQPQueue::class),
+            $amqpExchange = $this->createMock(\AMQPExchange::class)
+        );
+
+        $oldCaCertValue = ini_set('amqp.cacert', '');
+
+        try {
+            Connection::fromDsn('amqps://', [], $factory);
+        } finally {
+            ini_set('amqp.cacert', $oldCaCertValue);
+        }
     }
 
     public function testAmqpStampHeadersAreUsed()

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransportFactory.php
@@ -29,7 +29,7 @@ class AmqpTransportFactory implements TransportFactoryInterface
 
     public function supports(string $dsn, array $options): bool
     {
-        return 0 === strpos($dsn, 'amqp://');
+        return 0 === strpos($dsn, 'amqp://') || 0 === strpos($dsn, 'amqps://');
     }
 }
 class_alias(AmqpTransportFactory::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpTransportFactory::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #37002
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/14250
### Cases

_Case 1 (simple):_ 
I want to set up my app with a locally installed amqp broker supporting SSL. No auth is needed, no vhost, only SSL certificate file located at /etc/ssl/cafile.
'amqps://'

_Case 2 (complex):_ 
I use a special port, special file locations for SSL. I pass it through php.ini or configuration.

### Questions

1) Actually AmqpTransportFactory use `supports` function to see if 'amqp://' is contained in dsn string and accept cacert argument to use SSL 
How are we supposed to cover AMQPS's case in your opinion?

cacert argument is settable through php.ini and code.

### Observations

I think this PR should aim at:

- Having correct defaults ssl values in case of 'amqps://' eg : case 1
- Being able to pass cacert file path and verify argument. eg : case 2
- Test: but test what?

#### EDIT
 
As discuted with @nicolas-grekas, we should check that cacert is existing in php.ini or is passed in configuration and throw an exception to give a nice feedback about what's wrong. Php amqp lib isn't actually precise about why it fails when you forget it.

### Steps

- [x] Ensure AMQPS can be used out of the box without DSN.
- [x] If not, try to modify vendor directly to fix it.
- [x] Modify vendor to make AMQPS works with DSN.
- [x] Check cacert to throw a better exception.
- [x] Add test related to last point.
- [x] Pass CI