### PR TITLE
[Cache] Psr16Cache does not handle Proxy cache items

### DIFF
--- a/src/Symfony/Component/Cache/Psr16Cache.php
+++ b/src/Symfony/Component/Cache/Psr16Cache.php
@@ -44,6 +44,7 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
         $createCacheItem = \Closure::bind(
             static function ($key, $value, $allowInt = false) use (&$cacheItemPrototype) {
                 $item = clone $cacheItemPrototype;
+                $item->poolHash = $item->innerItem = null;
                 $item->key = $allowInt && \is_int($key) ? (string) $key : CacheItem::validateKey($key);
                 $item->value = $value;
                 $item->isHit = false;

--- a/src/Symfony/Component/Cache/Tests/Psr16CacheProxyTest.php
+++ b/src/Symfony/Component/Cache/Tests/Psr16CacheProxyTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Symfony\Component\Cache\Tests;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\ProxyAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+
+class Psr16CacheProxyTest extends SimpleCacheTest
+{
+    public function createSimpleCache(int $defaultLifetime = 0): CacheInterface
+    {
+        return new Psr16Cache(new ProxyAdapter(new ArrayAdapter($defaultLifetime), 'my-namespace.'));
+    }
+
+    public function testProxy()
+    {
+        $pool = new ArrayAdapter();
+        $cache = new Psr16Cache(new ProxyAdapter($pool, 'my-namespace.'));
+
+        $this->assertNull($cache->get('some-key'));
+        $this->assertTrue($cache->set('some-other-key', 'value'));
+
+        $item = $pool->getItem('my-namespace.some-other-key', 'value');
+        $this->assertTrue($item->isHit());
+        $this->assertSame('value', $item->get());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38006
| License       | MIT

Add test for Psr16Cache along with a ProxyAdapter
