### PR TITLE
[PHPUnitBridge] deprecations not disabled anymore when disabled=0

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -49,8 +49,9 @@ class DeprecationErrorHandler
      * Registers and configures the deprecation handler.
      *
      * The mode is a query string with options:
-     *  - "disabled" to disable the deprecation handler
+     *  - "disabled" to enable/disable the deprecation handler
      *  - "verbose" to enable/disable displaying the deprecation report
+     *  - "quiet" to disable displaying the deprecation report only for some groups (i.e. quiet[]=other)
      *  - "max" to configure the number of deprecations to allow before exiting with a non-zero
      *    status code; it's an array with keys "total", "self", "direct" and "indirect"
      *

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Configuration.php
@@ -166,30 +166,29 @@ class Configuration
             }
         }
 
-        if (isset($normalizedConfiguration['disabled'])) {
+        $normalizedConfiguration += [
+            'max' => [],
+            'disabled' => false,
+            'verbose' => true,
+            'quiet' => [],
+        ];
+
+        if ('' === $normalizedConfiguration['disabled'] || filter_var($normalizedConfiguration['disabled'], FILTER_VALIDATE_BOOLEAN)) {
             return self::inDisabledMode();
         }
 
         $verboseOutput = [];
-        if (!isset($normalizedConfiguration['verbose'])) {
-            $normalizedConfiguration['verbose'] = true;
-        }
-
         foreach (['unsilenced', 'direct', 'indirect', 'self', 'other'] as $group) {
-            $verboseOutput[$group] = (bool) $normalizedConfiguration['verbose'];
+            $verboseOutput[$group] = filter_var($normalizedConfiguration['verbose'], FILTER_VALIDATE_BOOLEAN);
         }
 
-        if (isset($normalizedConfiguration['quiet']) && \is_array($normalizedConfiguration['quiet'])) {
+        if (\is_array($normalizedConfiguration['quiet'])) {
             foreach ($normalizedConfiguration['quiet'] as $shushedGroup) {
                 $verboseOutput[$shushedGroup] = false;
             }
         }
 
-        return new self(
-            isset($normalizedConfiguration['max']) ? $normalizedConfiguration['max'] : [],
-            '',
-            $verboseOutput
-        );
+        return new self($normalizedConfiguration['max'], '', $verboseOutput);
     }
 
     /**

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/ConfigurationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/ConfigurationTest.php
@@ -176,10 +176,22 @@ class ConfigurationTest extends TestCase
         $this->assertTrue($configuration->shouldDisplayStackTrace('interesting'));
     }
 
-    public function testItCanBeDisabled()
+    public function provideItCanBeDisabled(): array
     {
-        $configuration = Configuration::fromUrlEncodedString('disabled');
-        $this->assertFalse($configuration->isEnabled());
+        return [
+            ['disabled', false],
+            ['disabled=1', false],
+            ['disabled=0', true]
+        ];
+    }
+
+    /**
+     * @dataProvider provideItCanBeDisabled
+     */
+    public function testItCanBeDisabled(string $encodedString, bool $expectedEnabled)
+    {
+        $configuration = Configuration::fromUrlEncodedString($encodedString);
+        $this->assertSame($expectedEnabled, $configuration->isEnabled());
     }
 
     public function testItCanBeShushed()

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/disabled_1.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/disabled_1.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test DeprecationErrorHandler in default mode
+--FILE--
+<?php
+
+$k = 'SYMFONY_DEPRECATIONS_HELPER';
+putenv($k.'='.$_SERVER[$k] = $_ENV[$k] = 'disabled=1');
+putenv($k);
+putenv('ANSICON');
+putenv('ConEmuANSI');
+putenv('TERM');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+require_once __DIR__.'/../../bootstrap.php';
+
+@trigger_error('root deprecation', E_USER_DEPRECATED);
+
+eval(<<<'EOPHP'
+namespace PHPUnit\Util;
+
+class Test
+{
+    public static function getGroups()
+    {
+        return array();
+    }
+}
+EOPHP
+);
+?>
+--EXPECTF--
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | 
| Tickets       | 
| License       | MIT
| Doc PR        | 

According to the [docs](https://symfony.com/doc/current/components/phpunit_bridge.html#disabling-the-deprecation-helper), `disabled=1` turns off deprecations mode on phpunit-bridge. It's not totally true since deprecations are disabled as soon as `disabled` key is present in `SYMFONY_DEPRECATIONS_HELPER`. So if `disabled=0` deprecations are still disabled.

Instead of updating the doc, this PR suggest to make `disabled` behavior consistent with `verbose` behavior, so:
- `disabled` => deprecations disabled
- `disabled=0` => deprecations enabled
- `disabled=1` => deprecations disabled