### PR TITLE
[Console] Fix undefined index for inconsistent command name definition

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -490,6 +490,11 @@ class Application
             throw new CommandNotFoundException(sprintf('The command "%s" does not exist.', $name));
         }
 
+        // When the command has a different name than the one used at the command loader level
+        if (!isset($this->commands[$name])) {
+            throw new CommandNotFoundException(sprintf('The "%s" command cannot be found because it is registered under multiple names. Make sure you don\'t set a different name via constructor or "setName()".', $name));
+        }
+
         $command = $this->commands[$name];
 
         if ($this->wantHelps) {

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1715,6 +1715,20 @@ class ApplicationTest extends TestCase
             $this->assertSame('Something went wrong.', $e->getMessage());
         }
     }
+
+    public function testCommandNameMismatchWithCommandLoaderKeyThrows()
+    {
+        $this->expectException(CommandNotFoundException::class);
+        $this->expectExceptionMessage('The "test" command cannot be found because it is registered under multiple names. Make sure you don\'t set a different name via constructor or "setName()".');
+
+        $app = new Application();
+        $loader = new FactoryCommandLoader([
+            'test' => static function () { return new Command('test-command'); },
+        ]);
+
+        $app->setCommandLoader($loader);
+        $app->get('test');
+    }
 }
 
 class CustomApplication extends Application


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fixes #38015 
| License       | MIT
| Doc PR        | -

The issue happens when the command name is set via construct/setName() and is routed via a command loader under a different name, which causes `Application::get(): Command` to return null (return type violation) with a notice. This makes it throws a proper CommandNotFoundException as expected.
 
