### PR TITLE
[HttpClient] Allow to provide additional curl options  to CurlHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * added `StreamableInterface` to ease turning responses into PHP streams
  * added `MockResponse::getRequestMethod()` and `getRequestUrl()` to allow inspecting which request has been sent
  * added `EventSourceHttpClient` a Server-Sent events stream implementing the [EventSource specification](https://www.w3.org/TR/eventsource/#eventsource)
+ * added option "extra.curl" to allow setting additional curl options in `CurlHttpClient`
 
 5.1.0
 -----

--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpClient\Tests;
 
 use Symfony\Component\HttpClient\CurlHttpClient;
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -41,5 +42,50 @@ class CurlHttpClientTest extends HttpClientTestCase
         }
 
         parent::testTimeoutIsNotAFatalError();
+    }
+
+    public function testOverridingRefererUsingCurlOptions()
+    {
+        $httpClient = $this->getHttpClient(__FUNCTION__);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot set "CURLOPT_REFERER" with "extra.curl", use option "headers" instead.');
+
+        $httpClient->request('GET', 'http://localhost:8057/', [
+            'extra' => [
+                'curl' => [
+                    \CURLOPT_REFERER => 'Banana',
+                ],
+            ],
+        ]);
+    }
+
+    public function testOverridingHttpMethodUsingCurlOptions()
+    {
+        $httpClient = $this->getHttpClient(__FUNCTION__);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The HTTP method cannot be overridden using "extra.curl".');
+
+        $httpClient->request('POST', 'http://localhost:8057/', [
+            'extra' => [
+                'curl' => [
+                    \CURLOPT_HTTPGET => true,
+                ],
+            ],
+        ]);
+    }
+
+    public function testOverridingInternalAttributesUsingCurlOptions()
+    {
+        $httpClient = $this->getHttpClient(__FUNCTION__);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot set "CURLOPT_PRIVATE" with "extra.curl".');
+
+        $httpClient->request('POST', 'http://localhost:8057/', [
+            'extra' => [
+                'curl' => [
+                    \CURLOPT_PRIVATE => 'overriden private',
+                ],
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Fix #37798
| License       | MIT
| Doc PR        | symfony/symfony-docs#14195

~~**Tagging as a draft because:**~~
- ~~there is no Doc PR Ready yet~~
- probably there are better test cases required here.

This PR introduces an option to override default curl options defined in `CurlHttpClient`.  To override them, there is a special place in `$options` provided:

````php
$response = $httpClient->request('GET', 'http://your.url.here', [
            'extra' => [
                'curl' => [
                    CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4,
                ]
            ]
        ]);
````

This feature is available only in `CurlHttpClient` and would be ignored in another clients. 


