### PR TITLE
Release v4.4.13

### DIFF
--- a/CHANGELOG-4.4.md
+++ b/CHANGELOG-4.4.md
@@ -7,6 +7,15 @@ in 4.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v4.4.0...v4.4.1
 
+* 4.4.13 (2020-09-02)
+
+ * security #cve-2020-15094 Remove headers with internal meaning from HttpClient responses (mpdude)
+ * bug #38024 [Console] Fix undefined index for inconsistent command name definition (chalasr)
+ * bug #38023 [DI] fix inlining of non-shared services (nicolas-grekas)
+ * bug #38020 [PhpUnitBridge] swallow deprecations (xabbuh)
+ * bug #38010 [Cache] Psr16Cache does not handle Proxy cache items (alex-dev)
+ * bug #37937 [Serializer] fixed fix encoding of cache keys with anonymous classes (michaelzangerle)
+
 * 4.4.12 (2020-08-31)
 
  * bug #37966 [HttpClient][MockHttpClient][DX] Throw when the response factory callable does not return a valid response (fancyweb)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -76,12 +76,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     private static $freshCache = [];
 
-    const VERSION = '4.4.13-DEV';
+    const VERSION = '4.4.13';
     const VERSION_ID = 40413;
     const MAJOR_VERSION = 4;
     const MINOR_VERSION = 4;
     const RELEASE_VERSION = 13;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '11/2022';
     const END_OF_LIFE = '11/2023';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v4.4.12...v4.4.13)

 * security #cve-2020-15094 Remove headers with internal meaning from HttpClient responses (@mpdude)
 * bug #38024 [Console] Fix undefined index for inconsistent command name definition (@chalasr)
 * bug #38023 [DI] fix inlining of non-shared services (@nicolas-grekas)
 * bug #38020 [PhpUnitBridge] swallow deprecations (@xabbuh)
 * bug #38010 [Cache] Psr16Cache does not handle Proxy cache items (@alex-dev)
 * bug #37937 [Serializer] fixed fix encoding of cache keys with anonymous classes (@michaelzangerle)
