### PR TITLE
[Ldap] Add comment about bind with empty password

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -50,6 +50,8 @@ class Connection extends AbstractConnection
 
     /**
      * {@inheritdoc}
+     *
+     * @param string $password WARNING: When the LDAP server allows unauthenticated binds, a blank $password will always be valid.
      */
     public function bind($dn = null, $password = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

When LDAP server allows unauthenticated binds, calling the method `bind` with a blank password will return a positive response.

This is not an issue when using High Level classes of Symfony, because this case is handled in `LdapBindAuthenticationProvider` and `CheckLdapCredentialsListener`.
And passing a blank password could be a valid use case for the low level class `Connection`.

This PR adds a comment on the parameter `$password` to let people Know about this