### PR TITLE
Translate failure messages of json authentication

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
@@ -143,6 +143,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('options'),
                 service('property_accessor')->nullOnInvalid(),
             ])
+            ->call('setTranslator', [service('translator')->ignoreOnInvalid()])
 
         ->set('security.authenticator.remember_me', RememberMeAuthenticator::class)
             ->abstract()

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.php
@@ -189,6 +189,7 @@ return static function (ContainerConfigurator $container) {
                 service('event_dispatcher')->nullOnInvalid(),
                 service('property_accessor')->nullOnInvalid(),
             ])
+            ->call('setTranslator', [service('translator')->ignoreOnInvalid()])
             ->tag('monolog.logger', ['channel' => 'security'])
 
         ->set('security.authentication.listener.remote_user', RemoteUserAuthenticationListener::class)

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -8,8 +8,9 @@ CHANGELOG
  * Changed `AuthorizationChecker` to call the access decision manager in unauthenticated sessions with a `NullToken`
  * [BC break] Removed `AccessListener::PUBLIC_ACCESS` in favor of `AuthenticatedVoter::PUBLIC_ACCESS`
  * Added `Passport` to `LoginFailureEvent`.
- * Deprecated `setProviderKey()`/`getProviderKey()` in favor of `setFirewallName()/getFirewallName()` in `PreAuthenticatedToken`, `RememberMeToken`, `SwitchUserToken`, `UsernamePasswordToken`, `DefaultAuthenticationSuccessHandler`; and deprecated the `AbstractRememberMeServices::$providerKey` property in favor of  `AbstractRememberMeServices::$firewallName`
+ * Deprecated `setProviderKey()`/`getProviderKey()` in favor of `setFirewallName()/getFirewallName()` in `PreAuthenticatedToken`, `RememberMeToken`, `SwitchUserToken`, `UsernamePasswordToken`, `DefaultAuthenticationSuccessHandler`; and deprecated the `AbstractRememberMeServices::$providerKey` property in favor of `AbstractRememberMeServices::$firewallName`
  * Added `FirewallListenerInterface` to make the execution order of firewall listeners configurable
+ * Added translator to `\Symfony\Component\Security\Http\Authenticator\JsonLoginAuthenticator` and `\Symfony\Component\Security\Http\Firewall\UsernamePasswordJsonAuthenticationListener` to translate authentication failure messages
 
 5.1.0
 -----

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordJsonAuthenticationListener.php
@@ -34,6 +34,7 @@ use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\SecurityEvents;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * UsernamePasswordJsonAuthenticationListener is a stateless implementation of
@@ -56,6 +57,11 @@ class UsernamePasswordJsonAuthenticationListener extends AbstractListener
     private $eventDispatcher;
     private $propertyAccessor;
     private $sessionStrategy;
+
+    /**
+     * @var TranslatorInterface|null
+     */
+    private $translator;
 
     public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, HttpUtils $httpUtils, string $providerKey, AuthenticationSuccessHandlerInterface $successHandler = null, AuthenticationFailureHandlerInterface $failureHandler = null, array $options = [], LoggerInterface $logger = null, EventDispatcherInterface $eventDispatcher = null, PropertyAccessorInterface $propertyAccessor = null)
     {
@@ -182,7 +188,13 @@ class UsernamePasswordJsonAuthenticationListener extends AbstractListener
         }
 
         if (!$this->failureHandler) {
-            return new JsonResponse(['error' => $failed->getMessageKey()], 401);
+            $errorMessage = $failed->getMessageKey();
+
+            if (null !== $this->translator) {
+                $errorMessage = $this->translator->trans($failed->getMessageKey(), $failed->getMessageData(), 'security');
+            }
+
+            return new JsonResponse(['error' => $errorMessage], 401);
         }
 
         $response = $this->failureHandler->onAuthenticationFailure($request, $failed);
@@ -202,6 +214,11 @@ class UsernamePasswordJsonAuthenticationListener extends AbstractListener
     public function setSessionAuthenticationStrategy(SessionAuthenticationStrategyInterface $sessionStrategy)
     {
         $this->sessionStrategy = $sessionStrategy;
+    }
+
+    public function setTranslator(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
     }
 
     private function migrateSession(Request $request, TokenInterface $token)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Resolves #33168
| License       | MIT
| Doc PR        | -

Until now the failure messages of the json authentication were not translated. I'm not sure if it's a bug or a new feature. The changes shouldn't be a BC.