### PR TITLE
[Yaml Parser] fixed Parser to skip comments when inlining sequences

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -1244,7 +1244,13 @@ class Parser
             for ($i = 1; isset($this->currentLine[$i]) && ']' !== $this->currentLine[$i]; ++$i) {
             }
 
-            $value .= trim($this->currentLine);
+            $trimmedValue = trim($this->currentLine);
+
+            if ('' !== $trimmedValue && '#' === $trimmedValue[0]) {
+                continue;
+            }
+
+            $value .= $trimmedValue;
 
             if (isset($this->currentLine[$i]) && ']' === $this->currentLine[$i]) {
                 break;

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1898,6 +1898,30 @@ YAML
                 [new TaggedValue('foo', 'bar')],
                 '[ !foo bar ]',
             ],
+            'with-comments' => [
+                [
+                    [new TaggedValue('foo', ['foo', 'baz'])],
+                ],
+                <<<YAML
+- [!foo [
+    foo,
+    baz
+    #bar
+  ]]
+YAML
+            ],
+            'with-comments-trailing-comma' => [
+                [
+                    [new TaggedValue('foo', ['foo', 'baz'])],
+                ],
+                <<<YAML
+- [!foo [
+    foo,
+    baz,
+    #bar
+  ]]
+YAML
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37972
| License       | MIT

The parser didn't skip comments when parsing values in a sequence. This resulted in the YamlFileLoader trying to
parse a comment as a IteratorArgument which resulted in a InvalidArgumentException.

Consider the following valid yaml:

```yaml
- !foo [
    bar,
    #baz
  ]
```

The parser would generate the following array:
```php
['bar', '#baz']
```

After this fix the parser will generate the following array:
```php
['bar']
```

This  bug only appeared for me in 4.4