### PR TITLE
Add tests for translated error messages of json authentication

### DIFF
--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -27,6 +27,7 @@
     "require-dev": {
         "symfony/routing": "^4.4|^5.0",
         "symfony/security-csrf": "^4.4|^5.0",
+        "symfony/translation": "^4.4|^5.0",
         "psr/log": "~1.0"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #33168
| License       | MIT
| Doc PR        | -

In PR #38037 i added the translator to the json authenticator but there are some tests missing. I added some now.