### PR TITLE
[Debug] Parse "x not found" errors correctly on php 8

### DIFF
--- a/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
@@ -29,50 +29,34 @@ class ClassNotFoundFatalErrorHandler implements FatalErrorHandlerInterface
      */
     public function handleError(array $error, FatalErrorException $exception)
     {
-        $messageLen = \strlen($error['message']);
-        $notFoundSuffix = '\' not found';
-        $notFoundSuffixLen = \strlen($notFoundSuffix);
-        if ($notFoundSuffixLen > $messageLen) {
+        if (!preg_match('/^(Class|Interface|Trait) [\'"]([^\'"]+)[\'"] not found$/', $error['message'], $matches)) {
             return null;
         }
+        $typeName = strtolower($matches[1]);
+        $fullyQualifiedClassName = $matches[2];
 
-        if (0 !== substr_compare($error['message'], $notFoundSuffix, -$notFoundSuffixLen)) {
-            return null;
+        if (false !== $namespaceSeparatorIndex = strrpos($fullyQualifiedClassName, '\\')) {
+            $className = substr($fullyQualifiedClassName, $namespaceSeparatorIndex + 1);
+            $namespacePrefix = substr($fullyQualifiedClassName, 0, $namespaceSeparatorIndex);
+            $message = sprintf('Attempted to load %s "%s" from namespace "%s".', $typeName, $className, $namespacePrefix);
+            $tail = ' for another namespace?';
+        } else {
+            $className = $fullyQualifiedClassName;
+            $message = sprintf('Attempted to load %s "%s" from the global namespace.', $typeName, $className);
+            $tail = '?';
         }
 
-        foreach (['class', 'interface', 'trait'] as $typeName) {
-            $prefix = ucfirst($typeName).' \'';
-            $prefixLen = \strlen($prefix);
-            if (0 !== strpos($error['message'], $prefix)) {
-                continue;
-            }
-
-            $fullyQualifiedClassName = substr($error['message'], $prefixLen, -$notFoundSuffixLen);
-            if (false !== $namespaceSeparatorIndex = strrpos($fullyQualifiedClassName, '\\')) {
-                $className = substr($fullyQualifiedClassName, $namespaceSeparatorIndex + 1);
-                $namespacePrefix = substr($fullyQualifiedClassName, 0, $namespaceSeparatorIndex);
-                $message = sprintf('Attempted to load %s "%s" from namespace "%s".', $typeName, $className, $namespacePrefix);
-                $tail = ' for another namespace?';
+        if ($candidates = $this->getClassCandidates($className)) {
+            $tail = array_pop($candidates).'"?';
+            if ($candidates) {
+                $tail = ' for e.g. "'.implode('", "', $candidates).'" or "'.$tail;
             } else {
-                $className = $fullyQualifiedClassName;
-                $message = sprintf('Attempted to load %s "%s" from the global namespace.', $typeName, $className);
-                $tail = '?';
+                $tail = ' for "'.$tail;
             }
-
-            if ($candidates = $this->getClassCandidates($className)) {
-                $tail = array_pop($candidates).'"?';
-                if ($candidates) {
-                    $tail = ' for e.g. "'.implode('", "', $candidates).'" or "'.$tail;
-                } else {
-                    $tail = ' for "'.$tail;
-                }
-            }
-            $message .= "\nDid you forget a \"use\" statement".$tail;
-
-            return new ClassNotFoundException($message, $exception);
         }
+        $message .= "\nDid you forget a \"use\" statement".$tail;
 
-        return null;
+        return new ClassNotFoundException($message, $exception);
     }
 
     /**

--- a/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
@@ -85,6 +85,15 @@ class ClassNotFoundFatalErrorHandlerTest extends TestCase
                     'type' => 1,
                     'line' => 12,
                     'file' => 'foo.php',
+                    'message' => 'Class "WhizBangFactory" not found',
+                ],
+                "/^Attempted to load class \"WhizBangFactory\" from the global namespace.\nDid you forget a \"use\" statement\?$/",
+            ],
+            [
+                [
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
                     'message' => 'Class \'WhizBangFactory\' not found',
                 ],
                 "/^Attempted to load class \"WhizBangFactory\" from the global namespace.\nDid you forget a \"use\" statement\?$/",
@@ -97,6 +106,33 @@ class ClassNotFoundFatalErrorHandlerTest extends TestCase
                     'message' => 'Class \'Foo\\Bar\\WhizBangFactory\' not found',
                 ],
                 "/^Attempted to load class \"WhizBangFactory\" from namespace \"Foo\\\\Bar\".\nDid you forget a \"use\" statement for another namespace\?$/",
+            ],
+            [
+                [
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => 'Class "Foo\\Bar\\WhizBangFactory" not found',
+                ],
+                "/^Attempted to load class \"WhizBangFactory\" from namespace \"Foo\\\\Bar\".\nDid you forget a \"use\" statement for another namespace\?$/",
+            ],
+            [
+                [
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => 'Interface "Foo\\Bar\\WhizBangInterface" not found',
+                ],
+                "/^Attempted to load interface \"WhizBangInterface\" from namespace \"Foo\\\\Bar\".\nDid you forget a \"use\" statement for another namespace\?$/",
+            ],
+            [
+                [
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => 'Trait "Foo\\Bar\\WhizBangTrait" not found',
+                ],
+                "/^Attempted to load trait \"WhizBangTrait\" from namespace \"Foo\\\\Bar\".\nDid you forget a \"use\" statement for another namespace\?$/",
             ],
             [
                 [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #36872
| License       | MIT
| Doc PR        | N/A

PHP 8 uses double quotes instead of single ones in error messages. This PR teaches `ClassNotFoundFatalErrorHandler` to parse the new format.

Depends on composer/composer#9183