### PR TITLE
Increase HttpBrowser::getHeaders() visibility to protected

### DIFF
--- a/src/Symfony/Component/BrowserKit/HttpBrowser.php
+++ b/src/Symfony/Component/BrowserKit/HttpBrowser.php
@@ -94,7 +94,7 @@ class HttpBrowser extends AbstractBrowser
         return [http_build_query($fields, '', '&', \PHP_QUERY_RFC1738), ['Content-Type' => 'application/x-www-form-urlencoded']];
     }
 
-    private function getHeaders(Request $request): array
+    protected function getHeaders(Request $request): array
     {
         $headers = [];
         foreach ($request->getServer() as $key => $value) {


### PR DESCRIPTION
Resolves symfony/symfony#38051

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #38051
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Increases visibility to allow for oddball header overrides; see #38051 for more detail.

If this looks good, let me know if this is worth adding docs/changelog entries and I'll do so.