### PR TITLE
[PhpUnitBridge] CoverageListenerTrait update for PHPUnit 8.5/9.x

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerTrait.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\PhpUnit\Legacy;
 
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Warning;
+use PHPUnit\Util\Annotation\Registry;
 use PHPUnit\Util\Test;
 
 /**
@@ -66,9 +67,6 @@ class CoverageListenerTrait
             return;
         }
 
-        $r = new \ReflectionProperty(Test::class, 'annotationCache');
-        $r->setAccessible(true);
-
         $covers = $sutFqcn;
         if (!\is_array($sutFqcn)) {
             $covers = [$sutFqcn];
@@ -78,13 +76,40 @@ class CoverageListenerTrait
             }
         }
 
+        if (class_exists(Registry::class)) {
+            $this->addCoversForDocBlockInsideRegistry($test, $covers);
+
+            return;
+        }
+
+        $this->addCoversForClassToAnnotationCache($test, $covers);
+    }
+
+    private function addCoversForClassToAnnotationCache($test, $covers)
+    {
+        $r = new \ReflectionProperty(Test::class, 'annotationCache');
+        $r->setAccessible(true);
+
         $cache = $r->getValue();
         $cache = array_replace_recursive($cache, [
             \get_class($test) => [
                 'covers' => $covers,
             ],
         ]);
+
         $r->setValue(Test::class, $cache);
+    }
+
+    private function addCoversForDocBlockInsideRegistry($test, $covers)
+    {
+        $docBlock = Registry::getInstance()->forClassName(\get_class($test));
+
+        $symbolAnnotations = new \ReflectionProperty($docBlock, 'symbolAnnotations');
+        $symbolAnnotations->setAccessible(true);
+
+        $symbolAnnotations->setValue($docBlock, array_replace($docBlock->symbolAnnotations(), [
+            'covers' => $covers,
+        ]));
     }
 
     private function findSutFqcn($test)


### PR DESCRIPTION
Updated to use `PHPUnit\Util\Annotation\Registry` and related classes.

Fixes #37637

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Fix #37637
| License       | MIT
| Doc PR        | n/a

- [x] Fixes the issue under PHPUnit 8.5+
- [x] Tests TBD

If this is a sensible approach, I will try to add a test for this addition. 
