### PR TITLE
[Cache] Fix CacheCollectorPass with decorated cache pools

### DIFF
--- a/src/Symfony/Component/Cache/DependencyInjection/CacheCollectorPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CacheCollectorPass.php
@@ -47,15 +47,13 @@ class CacheCollectorPass implements CompilerPassInterface
         }
 
         foreach ($container->findTaggedServiceIds($this->cachePoolTag) as $id => $attributes) {
-            $this->addToCollector($id, $container);
+            $poolName = $attributes[0]['name'] ?? $id;
 
-            if (($attributes[0]['name'] ?? $id) !== $id) {
-                $this->addToCollector($attributes[0]['name'], $container);
-            }
+            $this->addToCollector($id, $poolName, $container);
         }
     }
 
-    private function addToCollector(string $id, ContainerBuilder $container)
+    private function addToCollector(string $id, string $name, ContainerBuilder $container)
     {
         $definition = $container->getDefinition($id);
         if ($definition->isAbstract()) {
@@ -77,7 +75,7 @@ class CacheCollectorPass implements CompilerPassInterface
         $container->setDefinition($id, $recorder);
 
         // Tell the collector to add the new instance
-        $collectorDefinition->addMethodCall('addInstance', [$id, new Reference($id)]);
+        $collectorDefinition->addMethodCall('addInstance', [$name, new Reference($id)]);
         $collectorDefinition->setPublic(false);
     }
 }

--- a/src/Symfony/Component/Cache/Tests/DependencyInjection/CacheCollectorPassTest.php
+++ b/src/Symfony/Component/Cache/Tests/DependencyInjection/CacheCollectorPassTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Cache\Adapter\TraceableAdapter;
 use Symfony\Component\Cache\Adapter\TraceableTagAwareAdapter;
 use Symfony\Component\Cache\DataCollector\CacheDataCollector;
 use Symfony\Component\Cache\DependencyInjection\CacheCollectorPass;
+use Symfony\Component\Cache\Tests\Fixtures\ArrayCache;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -48,16 +50,51 @@ class CacheCollectorPassTest extends TestCase
         $this->assertEquals([
             ['addInstance', ['fs', new Reference('fs')]],
             ['addInstance', ['tagged_fs', new Reference('tagged_fs')]],
-            ['addInstance', ['.php.inner', new Reference('.php.inner')]],
-            ['addInstance', ['php', new Reference('php')]],
+            ['addInstance', ['php', new Reference('.php.inner')]],
         ], $collector->getMethodCalls());
 
         $this->assertSame(TraceableAdapter::class, $container->findDefinition('fs')->getClass());
         $this->assertSame(TraceableTagAwareAdapter::class, $container->getDefinition('tagged_fs')->getClass());
 
         $this->assertSame(TraceableAdapter::class, $container->findDefinition('.php.inner')->getClass());
-        $this->assertSame(TraceableTagAwareAdapter::class, $container->getDefinition('php')->getClass());
+        $this->assertSame(TagAwareAdapter::class, $container->getDefinition('php')->getClass());
 
         $this->assertFalse($collector->isPublic(), 'The "data_collector.cache" should be private after processing');
+    }
+
+    public function testProcessCacheObjectsAreDecorated()
+    {
+        $container = new ContainerBuilder();
+        $collector = $container->register('data_collector.cache', CacheDataCollector::class);
+
+        $container
+            ->register('cache.object', ArrayCache::class)
+            ->addTag('cache.pool', ['name' => 'cache.object']);
+
+        $container
+            ->register('something_is_decorating_cache_object', TagAwareAdapter::class)
+            ->setPublic(true)
+            ->setDecoratedService('cache.object');
+
+        $container->register('some_service_using_cache_object', TraceableAdapter::class)
+            ->setPublic(true)
+            ->addArgument(new Reference('cache.object'));
+
+        $container->addCompilerPass(new CacheCollectorPass(), PassConfig::TYPE_BEFORE_REMOVING);
+
+        $container->compile();
+        $this->assertCount(1, $collector->getMethodCalls());
+        $this->assertEquals(
+            [
+                [
+                    'addInstance',
+                    [
+                        'cache.object',
+                        new Reference('something_is_decorating_cache_object'),
+                    ],
+                ],
+            ],
+            $collector->getMethodCalls()
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38055 
| License       | MIT
| Doc PR        | 

The `getDefinition` call in `addToCollector` does not work when the service is decorated. Also instances will be added with the decoration name. This looks weird in the profiler. I have changed it to prefer the attribute name.

Before:
![image](https://user-images.githubusercontent.com/6224096/92225243-3be27c00-eea3-11ea-8bd5-2ae69212e658.png)

After: (`\Shopware\Storefront\Framework\Cache\CacheDecorator` did go into `cache.object`)
![image](https://user-images.githubusercontent.com/6224096/92225284-47ce3e00-eea3-11ea-885f-cdba95b89302.png)
