### PR TITLE
[FrameworkBundle] generate preload.php in src/ to make opcache.preload predictable

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -170,6 +170,20 @@ EOF
             }
         }
 
+        $kernelDir = \dirname((new \ReflectionObject($kernel))->getFileName());
+        $preloadFile = $fs->makePathRelative(\dirname($containerFile, 2), $kernelDir);
+        $preloadFile .= substr_replace(basename($containerFile), '.preload', -4, 0);
+        $preloadFile = var_export('/'.$preloadFile, true);
+        @file_put_contents($kernelDir.'/preload.php', <<<EOPHP
+<?php
+
+if (file_exists(__DIR__.$preloadFile)) {
+    require __DIR__.$preloadFile;
+}
+
+EOPHP
+        );
+
         if ($output->isVerbose()) {
             $io->comment('Finished');
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -38,6 +38,7 @@ class CacheClearCommandTest extends TestCase
     protected function tearDown(): void
     {
         $this->fs->remove($this->kernel->getProjectDir());
+        $this->fs->remove(__DIR__.'/Fixture/preload.php');
     }
 
     public function testCacheIsFreshAfterCacheClearedWithWarmup()
@@ -82,5 +83,7 @@ class CacheClearCommandTest extends TestCase
         $containerRef = new \ReflectionClass(require $containerFile);
         $containerFile = str_replace('tes_'.\DIRECTORY_SEPARATOR, 'test'.\DIRECTORY_SEPARATOR, $containerRef->getFileName());
         $this->assertMatchesRegularExpression(sprintf('/\'kernel.container_class\'\s*=>\s*\'%s\'/', $containerClass), file_get_contents($containerFile), 'kernel.container_class is properly set on the dumped container');
+
+        $this->assertFileEquals(__DIR__.'/Fixture/preload.php.expected', __DIR__.'/Fixture/preload.php');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/preload.php.expected
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/Fixture/preload.php.expected
@@ -1,0 +1,5 @@
+<?php
+
+if (file_exists(__DIR__.'/test/var/cache/test/FixtureSymfony_Bundle_FrameworkBundle_Tests_Command_CacheClearCommand_Fixture_TestAppKernelTestDebugContainer.preload.php')) {
+    require __DIR__.'/test/var/cache/test/FixtureSymfony_Bundle_FrameworkBundle_Tests_Command_CacheClearCommand_Fixture_TestAppKernelTestDebugContainer.preload.php';
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As seen in https://github.com/symfonycorp/cloud-templates/pull/15, having the path of the preload file vary by env+debug makes configuring PHP.ini settings impossible.

This PR dump a new `preload.php` file in `src/` when `cache:clear` is called.
This makes the path predictable.

This is submitted as a bugfix because the current behavior is barely usable without this change.