### PR TITLE
[PhpUnitBridge] Adjust output parsing of CoverageListenerTrait for PHPUnit 9.3

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/CoverageListenerTrait.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\PhpUnit\Legacy;
 
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Warning;
+use PHPUnit\Util\Annotation\Registry;
 
 /**
  * PHP 5.3 compatible trait-like shared implementation.
@@ -70,9 +71,6 @@ class CoverageListenerTrait
             $testClass = \PHPUnit_Util_Test::class;
         }
 
-        $r = new \ReflectionProperty($testClass, 'annotationCache');
-        $r->setAccessible(true);
-
         $covers = $sutFqcn;
         if (!\is_array($sutFqcn)) {
             $covers = array($sutFqcn);
@@ -82,6 +80,20 @@ class CoverageListenerTrait
             }
         }
 
+        if (class_exists(Registry::class)) {
+            $this->addCoversForDocBlockInsideRegistry($test, $covers);
+
+            return;
+        }
+
+        $this->addCoversForClassToAnnotationCache($testClass, $test, $covers);
+    }
+
+    private function addCoversForClassToAnnotationCache($testClass, $test, $covers)
+    {
+        $r = new \ReflectionProperty($testClass, 'annotationCache');
+        $r->setAccessible(true);
+
         $cache = $r->getValue();
         $cache = array_replace_recursive($cache, array(
             \get_class($test) => array(
@@ -89,6 +101,18 @@ class CoverageListenerTrait
             ),
         ));
         $r->setValue($testClass, $cache);
+    }
+
+    private function addCoversForDocBlockInsideRegistry($test, $covers)
+    {
+        $docBlock = Registry::getInstance()->forClassName(\get_class($test));
+
+        $symbolAnnotations = new \ReflectionProperty($docBlock, 'symbolAnnotations');
+        $symbolAnnotations->setAccessible(true);
+
+        $symbolAnnotations->setValue($docBlock, array_replace($docBlock->symbolAnnotations(), array(
+            'covers' => $covers,
+        )));
     }
 
     private function findSutFqcn($test)

--- a/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
@@ -31,13 +31,19 @@ class CoverageListenerTest extends TestCase
         $dir = __DIR__.'/../Tests/Fixtures/coverage';
         $phpunit = $_SERVER['argv'][0];
 
-        exec("$php $phpunit -c $dir/phpunit-without-listener.xml.dist $dir/tests/ --coverage-text 2> /dev/null", $output);
+        exec("$php $phpunit -c $dir/phpunit-without-listener.xml.dist $dir/tests/ --coverage-text --colors=never 2> /dev/null", $output);
         $output = implode("\n", $output);
-        $this->assertStringContainsString('FooCov', $output);
+        $this->assertMatchesRegularExpression('/FooCov\n\s*Methods:\s+100.00%[^\n]+Lines:\s+100.00%/', $output);
 
-        exec("$php $phpunit -c $dir/phpunit-with-listener.xml.dist $dir/tests/ --coverage-text 2> /dev/null", $output);
+        exec("$php $phpunit -c $dir/phpunit-with-listener.xml.dist $dir/tests/ --coverage-text --colors=never 2> /dev/null", $output);
         $output = implode("\n", $output);
-        $this->assertStringNotContainsString('FooCov', $output);
+
+        if (false === strpos($output, 'FooCov')) {
+            $this->addToAssertionCount(1);
+        } else {
+            $this->assertMatchesRegularExpression('/FooCov\n\s*Methods:\s+0.00%[^\n]+Lines:\s+0.00%/', $output);
+        }
+
         $this->assertStringContainsString("SutNotFoundTest::test\nCould not find the tested class.", $output);
         $this->assertStringNotContainsString("CoversTest::test\nCould not find the tested class.", $output);
         $this->assertStringNotContainsString("CoversDefaultClassTest::test\nCould not find the tested class.", $output);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #37637, #37564
| License       | MIT
| Doc PR        | N/A

This PR makes `CoverageListenerTrait` pass with PHPUnit 9.3. It contains a backport of #38054.

The problem that is addressed here is that a one of the fixture classes is now included in the output despite having a coverage of zero. The test now accepts both cases:

* The class is omitted from the output
* The class appears with 0.00% coverage.
