### PR TITLE
[Intl] Skip test cases that produce a TypeError on php 8

### DIFF
--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -377,14 +377,16 @@ abstract class AbstractNumberFormatterTest extends TestCase
 
     public function formatFractionDigitsProvider()
     {
-        return [
-            [1.123, '1.123', null, 0],
-            [1.123, '1', 0, 0],
-            [1.123, '1.1', 1, 1],
-            [1.123, '1.12', 2, 2],
-            [1.123, '1.123', -1, 0],
-            [1.123, '1', 'abc', 0],
-        ];
+        yield [1.123, '1.123', null, 0];
+        yield [1.123, '1', 0, 0];
+        yield [1.123, '1.1', 1, 1];
+        yield [1.123, '1.12', 2, 2];
+        yield [1.123, '1.123', -1, 0];
+
+        if (\PHP_VERSION_ID < 80000) {
+            // This dataset will produce a TypeError on php 8.
+            yield [1.123, '1', 'abc', 0];
+        }
     }
 
     /**
@@ -410,14 +412,16 @@ abstract class AbstractNumberFormatterTest extends TestCase
 
     public function formatGroupingUsedProvider()
     {
-        return [
-            [1000, '1,000', null, 1],
-            [1000, '1000', 0, 0],
-            [1000, '1,000', 1, 1],
-            [1000, '1,000', 2, 1],
-            [1000, '1000', 'abc', 0],
-            [1000, '1,000', -1, 1],
-        ];
+        yield [1000, '1,000', null, 1];
+        yield [1000, '1000', 0, 0];
+        yield [1000, '1,000', 1, 1];
+        yield [1000, '1,000', 2, 1];
+        yield [1000, '1,000', -1, 1];
+
+        if (\PHP_VERSION_ID < 80000) {
+            // This dataset will produce a TypeError on php 8.
+            yield [1000, '1000', 'abc', 0];
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

On php 8, `NumberFormatter::setAttribute()` will throw a type error if the provided value is not of type `int|float`. This is why I'm skipping the corresponding tests for now. Alternatively, we could check for the PHP version in Symfony's implementation of that class and throw the `TypeError` as well, if we're on php 8. But since this is a breaking change, I'm was unsure if I sould go that way.