### PR TITLE
[VarDumper] Fix caster for invalid SplFileInfo objects on php 8

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/SplCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/SplCaster.php
@@ -92,10 +92,24 @@ class SplCaster
         unset($a["\0SplFileInfo\0fileName"]);
         unset($a["\0SplFileInfo\0pathName"]);
 
-        if (false === $c->getPathname()) {
-            $a[$prefix.'⚠'] = 'The parent constructor was not called: the object is in an invalid state';
+        if (\PHP_VERSION_ID < 80000) {
+            if (false === $c->getPathname()) {
+                $a[$prefix.'⚠'] = 'The parent constructor was not called: the object is in an invalid state';
 
-            return $a;
+                return $a;
+            }
+        } else {
+            try {
+                $c->isReadable();
+            } catch (\RuntimeException $e) {
+                if ('Object not initialized' !== $e->getMessage()) {
+                    throw $e;
+                }
+
+                $a[$prefix.'⚠'] = 'The parent constructor was not called: the object is in an invalid state';
+
+                return $a;
+            }
         }
 
         foreach ($map as $key => $accessor) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

The behavior of uninitialized `SplFileInfo` classes has changed in php 8: https://3v4l.org/s4c4O

* `getPathname()` won't return `false` anymore.
* The error raised by most accessors is now recoverable. On php 7, it's fatal.

This PR adjusts the caster for those objects to the new behavior.