### PR TITLE
[WebProfilerBundle] Fix Tests for PHPUnit 9.3

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ProfilerControllerTest.php
@@ -382,10 +382,12 @@ class ProfilerControllerTest extends WebTestCase
             ->with($profile->getToken())
             ->willReturn($profile);
 
+        $collectorsNames = array_keys($profile->getCollectors());
+
         $profiler
             ->expects($this->atLeastOnce())
             ->method('has')
-            ->with($this->logicalXor($collectorsNames = array_keys($profile->getCollectors())))
+            ->with($this->logicalXor(...$collectorsNames))
             ->willReturn(true);
 
         $expectedTemplate = 'expected_template.html.twig';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #37564
| License       | MIT
| Doc PR        | N/A

PHPUnit's `logicalXor()` creates an XOR operation for one or multiple constraints. It expects the operands for that operation to be passed as variadic arguments, but this particullar test passes them in a single array.

This somewhat works on PHPUnit 8, but fails on PHPUnit 9. This PR fixes the failing test.