### PR TITLE
Don't call createMock with an array of interfaces

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Security/User/EntityUserProviderTest.php
@@ -70,7 +70,7 @@ class EntityUserProviderTest extends TestCase
     {
         $user = new User(1, 1, 'user1');
 
-        $repository = $this->createMock([ObjectRepository::class, UserLoaderInterface::class]);
+        $repository = $this->createMock(UserLoaderRepository::class);
         $repository
             ->expects($this->once())
             ->method('loadUserByUsername')
@@ -156,7 +156,7 @@ class EntityUserProviderTest extends TestCase
 
     public function testLoadUserByUserNameShouldLoadUserWhenProperInterfaceProvided()
     {
-        $repository = $this->createMock([ObjectRepository::class, UserLoaderInterface::class]);
+        $repository = $this->createMock(UserLoaderRepository::class);
         $repository->expects($this->once())
             ->method('loadUserByUsername')
             ->with('name')
@@ -189,7 +189,7 @@ class EntityUserProviderTest extends TestCase
     {
         $user = new User(1, 1, 'user1');
 
-        $repository = $this->createMock([interface_exists(ObjectRepository::class) ? ObjectRepository::class : LegacyObjectRepository::class, PasswordUpgraderInterface::class]);
+        $repository = $this->createMock(PasswordUpgraderRepository::class);
         $repository->expects($this->once())
             ->method('upgradePassword')
             ->with($user, 'foobar');
@@ -232,4 +232,12 @@ class EntityUserProviderTest extends TestCase
             $em->getClassMetadata('Symfony\Bridge\Doctrine\Tests\Fixtures\User'),
         ]);
     }
+}
+
+abstract class UserLoaderRepository implements ObjectRepository, UserLoaderInterface
+{
+}
+
+abstract class PasswordUpgraderRepository implements ObjectRepository, PasswordUpgraderInterface
+{
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -16,8 +16,8 @@ use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\ChainAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
-use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\Tests\Fixtures\ExternalAdapter;
+use Symfony\Component\Cache\Tests\Fixtures\PrunableAdapter;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -189,7 +189,7 @@ class ChainAdapterTest extends AdapterTestCase
 
     private function getPruneableMock(): AdapterInterface
     {
-        $pruneable = $this->createMock([PruneableInterface::class, AdapterInterface::class]);
+        $pruneable = $this->createMock(PrunableAdapter::class);
 
         $pruneable
             ->expects($this->atLeastOnce())
@@ -201,7 +201,7 @@ class ChainAdapterTest extends AdapterTestCase
 
     private function getFailingPruneableMock(): AdapterInterface
     {
-        $pruneable = $this->createMock([PruneableInterface::class, AdapterInterface::class]);
+        $pruneable = $this->createMock(PrunableAdapter::class);
 
         $pruneable
             ->expects($this->atLeastOnce())

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
-use Symfony\Component\Cache\PruneableInterface;
+use Symfony\Component\Cache\Tests\Fixtures\PrunableAdapter;
 use Symfony\Component\Cache\Tests\Traits\TagAwareTestTrait;
 
 /**
@@ -204,7 +204,7 @@ class TagAwareAdapterTest extends AdapterTestCase
      */
     private function getPruneableMock(): AdapterInterface
     {
-        $pruneable = $this->createMock([PruneableInterface::class, AdapterInterface::class]);
+        $pruneable = $this->createMock(PrunableAdapter::class);
 
         $pruneable
             ->expects($this->atLeastOnce())
@@ -216,7 +216,7 @@ class TagAwareAdapterTest extends AdapterTestCase
 
     private function getFailingPruneableMock(): AdapterInterface
     {
-        $pruneable = $this->createMock([PruneableInterface::class, AdapterInterface::class]);
+        $pruneable = $this->createMock(PrunableAdapter::class);
 
         $pruneable
             ->expects($this->atLeastOnce())

--- a/src/Symfony/Component/Cache/Tests/Fixtures/PrunableAdapter.php
+++ b/src/Symfony/Component/Cache/Tests/Fixtures/PrunableAdapter.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Fixtures;
+
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+use Symfony\Component\Cache\PruneableInterface;
+
+abstract class PrunableAdapter implements AdapterInterface, PruneableInterface
+{
+}

--- a/src/Symfony/Component/Cache/Tests/Fixtures/PrunableCache.php
+++ b/src/Symfony/Component/Cache/Tests/Fixtures/PrunableCache.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Fixtures;
+
+use Psr\SimpleCache\CacheInterface;
+use Symfony\Component\Cache\PruneableInterface;
+
+abstract class PrunableCache implements CacheInterface, PruneableInterface
+{
+}

--- a/src/Symfony/Component/Cache/Tests/Simple/ChainCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/ChainCacheTest.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\Cache\Tests\Simple;
 
 use Psr\SimpleCache\CacheInterface;
-use Symfony\Component\Cache\PruneableInterface;
 use Symfony\Component\Cache\Simple\ArrayCache;
 use Symfony\Component\Cache\Simple\ChainCache;
 use Symfony\Component\Cache\Simple\FilesystemCache;
+use Symfony\Component\Cache\Tests\Fixtures\PrunableCache;
 
 /**
  * @group time-sensitive
@@ -65,7 +65,7 @@ class ChainCacheTest extends CacheTestCase
 
     private function getPruneableMock(): CacheInterface
     {
-        $pruneable = $this->createMock([CacheInterface::class, PruneableInterface::class]);
+        $pruneable = $this->createMock(PrunableCache::class);
 
         $pruneable
             ->expects($this->atLeastOnce())
@@ -77,7 +77,7 @@ class ChainCacheTest extends CacheTestCase
 
     private function getFailingPruneableMock(): CacheInterface
     {
-        $pruneable = $this->createMock([CacheInterface::class, PruneableInterface::class]);
+        $pruneable = $this->createMock(PrunableCache::class);
 
         $pruneable
             ->expects($this->atLeastOnce())


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #37564 
| License       | MIT
| Doc PR        | N/A

PHPUnit 8 allows us to pass an array of interfaces to `createMock()`. The result was a mock object that implemented all of the given interfaces. This feature has sadly been removed (see sebastianbergmann/phpunit#3955), which forces us to create dummy classes that can be mocked instead. I've done this already on the 3.4 branch with #37566.

This PR fixes all affected tests (that I could find) on the 4.4 branch.