### PR TITLE
[Console] Make sure $maxAttempts is an int or null

### DIFF
--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -188,8 +188,11 @@ class Question
      */
     public function setMaxAttempts($attempts)
     {
-        if (null !== $attempts && $attempts < 1) {
-            throw new InvalidArgumentException('Maximum number of attempts must be a positive value.');
+        if (null !== $attempts) {
+            $attempts = (int) $attempts;
+            if ($attempts < 1) {
+                throw new InvalidArgumentException('Maximum number of attempts must be a positive value.');
+            }
         }
 
         $this->attempts = $attempts;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

The behavior of the "less than" operator for mixed types has changed in php 8. It is now possible to call `setMaxAttempts()` with a random string without raising the expected `InvalidArgumentException`. I've added an explicit type cast in order to restore the previous behavior.