### PR TITLE
Fix a typo in UPGRADE-5.1.md

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -4,8 +4,8 @@ UPGRADE FROM 5.0 to 5.1
 Config
 ------
 
- * The signature of method `NodeDefinition::setDeprecated()` has been updated to `NodeDefinition::setDeprecation(string $package, string $version, string $message)`.
- * The signature of method `BaseNode::setDeprecated()` has been updated to `BaseNode::setDeprecation(string $package, string $version, string $message)`.
+ * The signature of method `NodeDefinition::setDeprecated()` has been updated to `NodeDefinition::setDeprecated(string $package, string $version, string $message)`.
+ * The signature of method `BaseNode::setDeprecated()` has been updated to `BaseNode::setDeprecated(string $package, string $version, string $message)`.
  * Passing a null message to `BaseNode::setDeprecated()` to un-deprecate a node is deprecated
  * Deprecated `BaseNode::getDeprecationMessage()`, use `BaseNode::getDeprecation()` instead
 


### PR DESCRIPTION
I guess there was a mistake on the Config upgrade.

The method's name which signature has changed is `NodeDefinition::setDeprecated(...)` (instead of `NodeDefinition::setDeprecation(...)`). Same thing goes for `BaseNode::setDeprecated(...).

Thanks :)

| Q             | A
| ------------- | ---
| Branch?       |  5.1
| Bug fix?      | kinda
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | none
| License       | MIT
| Doc PR        | none
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
