### PR TITLE
Bump ext-igbinary to 3.1.5 to fix compile error on php 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,7 +183,7 @@ before_install:
               tfold ext.redis tpecl redis-5.2.2 redis.so $INI "no"
           fi
 
-          tfold ext.igbinary tpecl igbinary-3.1.2 igbinary.so $INI
+          tfold ext.igbinary tpecl igbinary-3.1.5 igbinary.so $INI
       done
     - |
       # List all php extensions with versions


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872
| License       | MIT
| Doc PR        | N/A

Details: http://pecl.php.net/package-changelog.php?package=igbinary