### PR TITLE
Prevent parsing invalid octal digits as octal numbers

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -759,16 +759,16 @@ class Inline
 
                 switch (true) {
                     case ctype_digit($scalar):
-                        if ('0' === $scalar[0]) {
-                            return octdec(preg_replace('/[^0-7]/', '', $scalar));
+                        if (preg_match('/^0[0-7]+$/', $scalar)) {
+                            return octdec($scalar);
                         }
 
                         $cast = (int) $scalar;
 
                         return ($scalar === (string) $cast) ? $cast : $scalar;
                     case '-' === $scalar[0] && ctype_digit(substr($scalar, 1)):
-                        if ('0' === $scalar[1]) {
-                            return -octdec(preg_replace('/[^0-7]/', '', substr($scalar, 1)));
+                        if (preg_match('/^-0[0-7]+$/', $scalar)) {
+                            return -octdec(substr($scalar, 1));
                         }
 
                         $cast = (int) $scalar;

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -853,11 +853,11 @@ class InlineTest extends TestCase
 
     public function testParsePositiveOctalNumberContainingInvalidDigits()
     {
-        self::assertSame(342391, Inline::parse('0123456789'));
+        self::assertSame('0123456789', Inline::parse('0123456789'));
     }
 
     public function testParseNegativeOctalNumberContainingInvalidDigits()
     {
-        self::assertSame(-342391, Inline::parse('-0123456789'));
+        self::assertSame('-0123456789', Inline::parse('-0123456789'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Values starting with `0` but containing `8` or `9` such as `0123456789` are not valid octal numbers, therefore they should be parsed as regular strings. This is consistent with how other invalid octal values are parsed, e.g. `01234567ab` already gets parsed as the string `"01234567ab"`.