### PR TITLE
[ErrorHandler] Parse "x not found" errors correctly on php 8

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorEnhancer/ClassNotFoundErrorEnhancerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorEnhancer/ClassNotFoundErrorEnhancerTest.php
@@ -82,12 +82,28 @@ class ClassNotFoundErrorEnhancerTest extends TestCase
 
         return [
             [
+                'Class "WhizBangFactory" not found',
+                "Attempted to load class \"WhizBangFactory\" from the global namespace.\nDid you forget a \"use\" statement?",
+            ],
+            [
                 'Class \'WhizBangFactory\' not found',
                 "Attempted to load class \"WhizBangFactory\" from the global namespace.\nDid you forget a \"use\" statement?",
             ],
             [
+                'Class "Foo\\Bar\\WhizBangFactory" not found',
+                "Attempted to load class \"WhizBangFactory\" from namespace \"Foo\\Bar\".\nDid you forget a \"use\" statement for another namespace?",
+            ],
+            [
                 'Class \'Foo\\Bar\\WhizBangFactory\' not found',
                 "Attempted to load class \"WhizBangFactory\" from namespace \"Foo\\Bar\".\nDid you forget a \"use\" statement for another namespace?",
+            ],
+            [
+                'Interface "Foo\\Bar\\WhizBangInterface" not found',
+                "Attempted to load interface \"WhizBangInterface\" from namespace \"Foo\\Bar\".\nDid you forget a \"use\" statement for another namespace?",
+            ],
+            [
+                'Trait "Foo\\Bar\\WhizBangTrait" not found',
+                "Attempted to load trait \"WhizBangTrait\" from namespace \"Foo\\Bar\".\nDid you forget a \"use\" statement for another namespace?",
             ],
             [
                 'Class \'UndefinedFunctionError\' not found',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

This PR is #38049 applied to the 4.4 branch.