### PR TITLE
[VarExporter] unserialize() might throw an Exception on php 8

### DIFF
--- a/src/Symfony/Component/VarExporter/Exception/NotInstantiableTypeException.php
+++ b/src/Symfony/Component/VarExporter/Exception/NotInstantiableTypeException.php
@@ -13,8 +13,8 @@ namespace Symfony\Component\VarExporter\Exception;
 
 class NotInstantiableTypeException extends \Exception implements ExceptionInterface
 {
-    public function __construct(string $type)
+    public function __construct(string $type, \Throwable $previous = null)
     {
-        parent::__construct(sprintf('Type "%s" is not instantiable.', $type));
+        parent::__construct(sprintf('Type "%s" is not instantiable.', $type), 0, $previous);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

VarExporter attempts a deserialization in order to check if a given object can be exported in serialized form. On php 8, the `unserialize` call might throw an exception that needs to be caught and converted to the expected `NotInstantiableTypeException`.