### PR TITLE
Upgrade PHPUnit to 8.5 (php 7.2) and 9.3 (php >= 7.3)

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -12,10 +12,10 @@ if (!getenv('SYMFONY_PHPUNIT_VERSION')) {
         if (false === getenv('SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT') && false !== strpos(@file_get_contents(__DIR__.'/src/Symfony/Component/HttpKernel/Kernel.php'), 'const MAJOR_VERSION = 3;')) {
             putenv('SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT=1');
         }
-        if (\PHP_VERSION_ID >= 80000) {
-            putenv('SYMFONY_PHPUNIT_VERSION=9.3');
+        if (\PHP_VERSION_ID < 70300) {
+            putenv('SYMFONY_PHPUNIT_VERSION=8.5');
         } else {
-            putenv('SYMFONY_PHPUNIT_VERSION=8.3');
+            putenv('SYMFONY_PHPUNIT_VERSION=9.3');
         }
     } elseif (\PHP_VERSION_ID >= 70000) {
         putenv('SYMFONY_PHPUNIT_VERSION=6.5');

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -49,8 +49,8 @@ class SymfonyTestsListenerTrait
             \PHPUnit_Util_Blacklist::$blacklistedClassNames[__CLASS__] = 2;
         } elseif (method_exists('PHPUnit\Util\Blacklist', 'addDirectory')) {
             eval(" // PHP 5.3 compat
-            (new BlackList())->getBlacklistedDirectories();
-            Blacklist::addDirectory(\dirname((new \ReflectionClass(__CLASS__))->getFileName(), 2));
+            (new \PHPUnit\Util\Blacklist())->getBlacklistedDirectories();
+            \PHPUnit\Util\Blacklist::addDirectory(\dirname(__FILE__, 2));
             ");
         } else {
             Blacklist::$blacklistedClassNames[__CLASS__] = 2;

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -25,7 +25,7 @@
         "symfony/debug": "~2.8|~3.0|~4.0",
         "symfony/event-dispatcher": "~3.4|~4.0",
         "symfony/http-foundation": "^3.4.38|^4.3",
-        "symfony/http-kernel": "^3.4.31|^4.3.4",
+        "symfony/http-kernel": "^3.4.44|^4.3.4",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/filesystem": "~2.8|~3.0|~4.0",
         "symfony/finder": "~2.8|~3.0|~4.0",

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "doctrine/collections": "~1.0",
-        "symfony/validator": "^3.4.3|^4.0.3",
+        "symfony/validator": "^3.4.44|^4.0.3",
         "symfony/dependency-injection": "~3.3|~4.0",
         "symfony/config": "~2.7|~3.0|~4.0",
         "symfony/expression-language": "~3.4|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes/no
| New feature?  | no
| Deprecations? | no
| Tickets       | #37564 
| License       | MIT
| Doc PR        | N/A

Our test suite on the 3.4 branch should be compatible with more recent versions of PHPUnit now. In order to make sure that it stays that way, I'm proposing to bump PHPUnit to 8.5 for the php 7.2 job and 9.3 for the php 7.3 and 7.4 jobs.