### PR TITLE
Platform.sh populates  with real user IP even when reverse proxy is used

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -801,7 +801,7 @@ class Request
     {
         $ip = $this->server->get('REMOTE_ADDR');
 
-        if (!$this->isFromTrustedProxy()) {
+        if (!$this->isFromTrustedProxy() || $this->server->has('PLATFORM_PROJECT_ENTROPY')) {
             return [$ip];
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

[Symfony expects that if Varnish (or any other reverse proxy) is used then it's IP is stored as the value for `REMOTE_ADDR`](https://symfony.com/doc/current/deployment/proxies.html#but-what-if-the-ip-of-my-reverse-proxy-changes-constantly):

> For example, instead of reading the REMOTE_ADDR header (which will now be the IP address of your reverse proxy), the user’s true IP will be stored in a standard Forwarded: for="..." header or a X-Forwarded-For header.

But that is not true for Platform.sh. On Platform.sh `REMOTE_ADDR` variable contains the real user IP (Please ping @damz for details).
- So in Platform.sh case IP will be extracted from the `HTTP_X_FORWARDED_FOR ` header.
- `HTTP_X_FORWARDED_FOR` contains the real user IP (it is the same as `REMOTE_ADDR` and Varnish IP)
- Because Symfony assumes that `REMOTE_ADDR` is the Varnish IP (but not the real user IP, which it is) the another IP will be extracted as the real user IP from `HTTP_X_FORWARDED_FOR`

So Varnish IP is extracted as clean IP on all Symfony projects which run on Platform.sh and are using Varnish.

This PR adds "a special" check for Platform.sh, and returns `REMOTE_ADDR` instead of extracting the wrong IP from `HTTP_X_FORWARDED_FOR`.

