### PR TITLE
[Console] guard $argv + $token against null, preventing unnecessary exceptions

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -49,9 +49,7 @@ class ArgvInput extends Input
      */
     public function __construct(array $argv = null, InputDefinition $definition = null)
     {
-        if (null === $argv) {
-            $argv = $_SERVER['argv'];
-        }
+        $argv = $argv ?? $_SERVER['argv'] ?? [];
 
         // strip the application name
         array_shift($argv);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| Tickets       | Fix https://github.com/symfony/symfony/issues/38105
| License       | MIT

This issue was causing an unnecessary exception, leading to difficulty in locating the actual offending code as reported by many cases as detailed in #38105