### PR TITLE
[Debug] Skip a test that was meant for HHVM

### DIFF
--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -558,6 +558,10 @@ class ErrorHandlerTest extends TestCase
      */
     public function testHandleFatalErrorOnHHVM()
     {
+        if (!\defined('HHVM_VERSION')) {
+            $this->markTestSkipped('This test requires HHVM.');
+        }
+
         try {
             $handler = ErrorHandler::register();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

This PR skips a test that fails on php 8. If I read the test correctly, it is meant to run on HHVM, so I assumed it's save to skip it if we're on PHP.