### PR TITLE
[HttpClient] Fix Array to string conversion notice when parsing JSON error body with non-scalar detail property

### DIFF
--- a/src/Symfony/Component/HttpClient/Exception/HttpExceptionTrait.php
+++ b/src/Symfony/Component/HttpClient/Exception/HttpExceptionTrait.php
@@ -60,7 +60,8 @@ trait HttpExceptionTrait
                 // see http://www.hydra-cg.com/spec/latest/core/#description-of-http-status-codes-and-errors
                 $separator = isset($body['hydra:title'], $body['hydra:description']) ? "\n\n" : '';
                 $message = ($body['hydra:title'] ?? '').$separator.($body['hydra:description'] ?? '');
-            } elseif (isset($body['title']) || isset($body['detail'])) {
+            } elseif ((isset($body['title']) || isset($body['detail']))
+                && (is_scalar($body['title'] ?? '') && is_scalar($body['detail'] ?? ''))) {
                 // see RFC 7807 and https://jsonapi.org/format/#error-objects
                 $separator = isset($body['title'], $body['detail']) ? "\n\n" : '';
                 $message = ($body['title'] ?? '').$separator.($body['detail'] ?? '');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38118 
| License       | MIT
| Doc PR        | no

An earlier commit added the ability to detect common API formats and extract a useful error message from the error response payload. To achieve this, if a `title` and `detail` property are found in the error response, the response is considered to be in a known format (RFC 7807) and these values are concatenated to form a helpful error message.

However, when either `title` or `detail` property are present, but the document is not intended to follow the RFC semantics, if the properties are not scalar (e.g. if the detail property is an array of field validation violations) then the concatenation of the strings causes a notice to be raised.

This pull request checks that the `title` and `detail` properties are scalar before attempting to concatenate them. If they are not, no enhanced error message is provided.