### PR TITLE
[Lock] Fix wrong interface for MongoDbStore

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -16,6 +16,11 @@ FrameworkBundle
    used to be added by default to the seed, which is not the case anymore. This allows sharing caches between
    apps or different environments.
 
+Lock
+----
+
+ * `MongoDbStore` does not implement `BlockingStoreInterface` anymore, typehint against `PersistingStoreInterface` instead.
+
 Mime
 ----
 

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * `MongoDbStore` does not implement `BlockingStoreInterface` anymore, typehint against `PersistingStoreInterface` instead.
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -19,15 +19,14 @@ use MongoDB\Driver\ReadPreference;
 use MongoDB\Exception\DriverRuntimeException;
 use MongoDB\Exception\InvalidArgumentException as MongoInvalidArgumentException;
 use MongoDB\Exception\UnsupportedException;
-use Symfony\Component\Lock\BlockingStoreInterface;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Exception\LockAcquiringException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Exception\LockExpiredException;
 use Symfony\Component\Lock\Exception\LockStorageException;
-use Symfony\Component\Lock\Exception\NotSupportedException;
 use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistingStoreInterface;
 
 /**
  * MongoDbStore is a StoreInterface implementation using MongoDB as a storage
@@ -46,7 +45,7 @@ use Symfony\Component\Lock\Key;
  *
  * @author Joe Bennett <joe@assimtech.com>
  */
-class MongoDbStore implements BlockingStoreInterface
+class MongoDbStore implements PersistingStoreInterface
 {
     private $collection;
     private $client;
@@ -222,14 +221,6 @@ class MongoDbStore implements BlockingStoreInterface
         }
 
         $this->checkNotExpired($key);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function waitAndSave(Key $key)
-    {
-        throw new NotSupportedException(sprintf('The store "%s" does not support blocking locks.', __CLASS__));
     }
 
     /**

--- a/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MongoDbStoreTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Lock\Tests\Store;
 use MongoDB\Client;
 use MongoDB\Driver\Exception\ConnectionTimeoutException;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
-use Symfony\Component\Lock\Exception\NotSupportedException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\MongoDbStore;
@@ -79,17 +78,6 @@ class MongoDbStoreTest extends AbstractStoreTest
             $indexes[] = $index->getName();
         }
         $this->assertContains('expires_at_1', $indexes);
-    }
-
-    public function testNonBlocking()
-    {
-        $this->expectException(NotSupportedException::class);
-
-        $store = $this->getStore();
-
-        $key = new Key(uniqid(__METHOD__, true));
-
-        $store->waitAndSave($key);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

The MongoDbStore is not a `BlockingStore` because does not "really" implements  the method `waitAndSave`.

This PR changes the interface of `MongoDbStore` and remove the dummy implementation of `waitAndSave`.