### PR TITLE
[DI] dump OS-indepent paths in the preload file

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/Preloader.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/Preloader.php
@@ -27,7 +27,7 @@ final class Preloader
 
         foreach ($list as $item) {
             if (0 === strpos($item, $cacheDir)) {
-                file_put_contents($file, sprintf("require_once __DIR__.%s;\n", var_export(substr($item, \strlen($cacheDir)), true)), \FILE_APPEND);
+                file_put_contents($file, sprintf("require_once __DIR__.%s;\n", var_export(strtr(substr($item, \strlen($cacheDir)), \DIRECTORY_SEPARATOR, '/'), true)), \FILE_APPEND);
                 continue;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38123
| License       | MIT
| Doc PR        | -

This allows generating the file on Windows and running it on Linux (Docker).
