### PR TITLE
[Messenger] Added factory methods to DelayStamp for better DX

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
 * Added `FlattenExceptionNormalizer` to give more information about the exception on Messenger background processes. The `FlattenExceptionNormalizer` has a higher priority than `ProblemNormalizer` and it is only used when the Messenger serialization context is set.
+* Added factory methods to `DelayStamp`.
 
 5.1.0
 -----

--- a/src/Symfony/Component/Messenger/Stamp/DelayStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/DelayStamp.php
@@ -30,4 +30,19 @@ final class DelayStamp implements StampInterface
     {
         return $this->delay;
     }
+
+    public static function delayForSeconds(int $seconds): self
+    {
+        return new self($seconds * 1000);
+    }
+
+    public static function delayForMinutes(int $minutes): self
+    {
+        return self::delayForSeconds($minutes * 60);
+    }
+
+    public static function delayForHours(int $hours): self
+    {
+        return self::delayForMinutes($hours * 60);
+    }
 }

--- a/src/Symfony/Component/Messenger/Tests/Stamp/DelayStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/DelayStampTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Stamp;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+
+/**
+ * @author Yanick Witschi <yanick.witschi@terminal42.ch>
+ */
+class DelayStampTest extends TestCase
+{
+    public function testSeconds()
+    {
+        $stamp = DelayStamp::delayForSeconds(30);
+        $this->assertSame(30000, $stamp->getDelay());
+    }
+
+    public function testMinutes()
+    {
+        $stamp = DelayStamp::delayForMinutes(30);
+        $this->assertSame(1800000, $stamp->getDelay());
+    }
+
+    public function testHours()
+    {
+        $stamp = DelayStamp::delayForHours(30);
+        $this->assertSame(108000000, $stamp->getDelay());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | not necessary imho

I often find myself delaying messages for a few minutes or so and I always have to remember the `DelayStamp` uses milliseconds. I guess these simple factories could improve DX quite a bit :) 