### PR TITLE
[Mailer] Fixed Mailgun API bridge JsonException when API response is not applicaton/json

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -64,15 +64,17 @@ class MailgunApiTransport extends AbstractApiTransport
             'body' => $body->bodyToIterable(),
         ]);
 
-        $result = $response->toArray(false);
         if (200 !== $response->getStatusCode()) {
             if ('application/json' === $response->getHeaders(false)['content-type'][0]) {
+                $result = $response->toArray(false);
                 throw new HttpTransportException('Unable to send an email: '.$result['message'].sprintf(' (code %d).', $response->getStatusCode()), $response);
             }
 
             throw new HttpTransportException('Unable to send an email: '.$response->getContent(false).sprintf(' (code %d).', $response->getStatusCode()), $response);
         }
 
+        // The assumption here is that all 200 responses are "application/json", so it's safe to call "toArray".
+        $result = $response->toArray(false);
         $sentMessage->setMessageId($result['id']);
 
         return $response;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38146 
| License       | MIT
| Doc PR        | -

Handles gracefully cases in which the Mailgun API does not return JSON responses.