### PR TITLE
[Security] In the new authenticator system, no auth listener is valid

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -588,7 +588,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
             }
         }
 
-        if (false === $hasListeners) {
+        if (false === $hasListeners && !$this->authenticatorManagerEnabled) {
             throw new InvalidConfigurationException(sprintf('No authentication listener registered for firewall "%s".', $id));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | not needed

In the new authenticator system, `anonymous` is gone and it IS now valid to have no authentication listeners. Before this PR, the following would trigger this error:

```
security:
    enable_authenticator_manager: true

    firewalls:
        main:
            lazy: true
```

But this IS valid (and would eventually be the "starting security.yaml" when the new system is the main system).

Cheers!