### PR TITLE
[DoctrineBridge] add choice_translation_domain tests to prevent further regressions

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -138,6 +138,39 @@ class EntityTypeTest extends BaseTypeTest
         ]);
     }
 
+    /**
+     * @dataProvider choiceTranslationDomainProvider
+     */
+    public function testChoiceTranslationDomainIsDisabledByDefault($expanded)
+    {
+        $entity1 = new SingleIntIdEntity(1, 'Foo');
+
+        $this->persist([$entity1]);
+
+        $field = $this->factory->createNamed('name', static::TESTED_TYPE, null, [
+            'choices' => [
+                $entity1,
+            ],
+            'class' => SingleIntIdEntity::class,
+            'em' => 'default',
+            'expanded' => $expanded,
+        ]);
+
+        if ($expanded) {
+            $this->assertFalse($field->get('1')->getConfig()->getOption('translation_domain'));
+        } else {
+            $this->assertFalse($field->getConfig()->getOption('choice_translation_domain'));
+        }
+    }
+
+    public function choiceTranslationDomainProvider()
+    {
+        return [
+            [false],
+            [true],
+        ];
+    }
+
     public function testSetDataToUninitializedEntityWithNonRequired()
     {
         $entity1 = new SingleIntIdEntity(1, 'Foo');

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -25,7 +25,7 @@
         "doctrine/annotations": "~1.7",
         "symfony/stopwatch": "~2.8|~3.0|~4.0",
         "symfony/dependency-injection": "~3.4|~4.0",
-        "symfony/form": "^3.3.10|~4.0",
+        "symfony/form": "^3.4.43|~4.4.11",
         "symfony/http-kernel": "~2.8|~3.0|~4.0",
         "symfony/property-access": "~2.8|~3.0|~4.0",
         "symfony/property-info": "~2.8|3.0|~4.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #https://github.com/symfony/symfony/pull/37521#issuecomment-678247192
| License       | MIT
| Doc PR        | 