### PR TITLE
[Serializer] Add ability to collect denormalization errors

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * added `UidNormalizer`
  * added `FormErrorNormalizer`
  * added `MimeMessageNormalizer`
+ * added `DenormalizerInterface::COLLECT_INVARIANT_VIOLATIONS` context option to collect denormalization errors instead of throwing immediately
 
 5.1.0
 -----

--- a/src/Symfony/Component/Serializer/Exception/InvariantViolationException.php
+++ b/src/Symfony/Component/Serializer/Exception/InvariantViolationException.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+use Symfony\Component\Serializer\InvariantViolation;
+
+final class InvariantViolationException extends \RuntimeException implements ExceptionInterface
+{
+    /**
+     * @var array<string, array<InvariantViolation>>
+     */
+    private $violations;
+
+    /**
+     * @param array<string, array<InvariantViolation>> $violations
+     */
+    public function __construct(array $violations)
+    {
+        parent::__construct('Denormalization failed because some values were invalid.');
+
+        $this->violations = $violations;
+    }
+
+    /**
+     * @return array<string, array<InvariantViolation>>
+     */
+    public function getViolations(): array
+    {
+        return $this->violations;
+    }
+
+    /**
+     * @return array<string, array<InvariantViolation>>
+     */
+    public function getViolationsNestedIn(string $parentPath): array
+    {
+        if ('' === $parentPath) {
+            throw new \InvalidArgumentException('Parent path cannot be empty.');
+        }
+
+        $nestedViolations = [];
+
+        foreach ($this->violations as $path => $violations) {
+            $path = '' !== $path ? "{$parentPath}.{$path}" : $parentPath;
+
+            $nestedViolations[$path] = $violations;
+        }
+
+        return $nestedViolations;
+    }
+
+    /**
+     * @return array<string, array<string>>
+     */
+    public function getViolationMessages(): array
+    {
+        $messages = [];
+
+        foreach ($this->violations as $path => $violations) {
+            foreach ($violations as $violation) {
+                $messages[$path][] = $violation->getMessage();
+            }
+        }
+
+        return $messages;
+    }
+}

--- a/src/Symfony/Component/Serializer/Exception/InvariantViolationException.php
+++ b/src/Symfony/Component/Serializer/Exception/InvariantViolationException.php
@@ -15,9 +15,6 @@ use Symfony\Component\Serializer\InvariantViolation;
 
 final class InvariantViolationException extends \RuntimeException implements ExceptionInterface
 {
-    /**
-     * @var array<string, array<InvariantViolation>>
-     */
     private $violations;
 
     /**

--- a/src/Symfony/Component/Serializer/InvariantViolation.php
+++ b/src/Symfony/Component/Serializer/InvariantViolation.php
@@ -17,7 +17,7 @@ class InvariantViolation
     private $message;
     private $exception;
 
-    public function __construct($normalizedValue, string $message, ?\Throwable $exception = null)
+    public function __construct($normalizedValue, string $message, \Throwable $exception)
     {
         $this->normalizedValue = $normalizedValue;
         $this->message = $message;
@@ -34,7 +34,7 @@ class InvariantViolation
         return $this->message;
     }
 
-    public function getException(): ?\Throwable
+    public function getException(): \Throwable
     {
         return $this->exception;
     }

--- a/src/Symfony/Component/Serializer/InvariantViolation.php
+++ b/src/Symfony/Component/Serializer/InvariantViolation.php
@@ -13,19 +13,8 @@ namespace Symfony\Component\Serializer;
 
 class InvariantViolation
 {
-    /**
-     * @var mixed
-     */
     private $normalizedValue;
-
-    /**
-     * @var string
-     */
     private $message;
-
-    /**
-     * @var \Throwable|null
-     */
     private $exception;
 
     public function __construct($normalizedValue, string $message, ?\Throwable $exception = null)

--- a/src/Symfony/Component/Serializer/InvariantViolation.php
+++ b/src/Symfony/Component/Serializer/InvariantViolation.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer;
+
+class InvariantViolation
+{
+    /**
+     * @var mixed
+     */
+    private $normalizedValue;
+
+    /**
+     * @var string
+     */
+    private $message;
+
+    /**
+     * @var \Throwable|null
+     */
+    private $exception;
+
+    public function __construct($normalizedValue, string $message, ?\Throwable $exception = null)
+    {
+        $this->normalizedValue = $normalizedValue;
+        $this->message = $message;
+        $this->exception = $exception;
+    }
+
+    public function getNormalizedValue()
+    {
+        return $this->normalizedValue;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getException(): ?\Throwable
+    {
+        return $this->exception;
+    }
+}

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -335,14 +335,15 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             }
 
             try {
-                $denormalizedValue = $this->validateAndDenormalize($resolvedClass, $attribute, $value, $format, $context);
-                try {
-                    $this->setAttributeValue($object, $attribute, $denormalizedValue, $format, $context);
-                } catch (InvalidArgumentException $e) {
-                    throw new NotNormalizableValueException(sprintf('Failed to denormalize attribute "%s" value for class "%s": '.$e->getMessage(), $attribute, $type), $e->getCode(), $e);
-                }
+                $value = $this->validateAndDenormalize($resolvedClass, $attribute, $value, $format, $context);
             } catch (InvariantViolationException $exception) {
                 $invariantViolations += $exception->getViolationsNestedIn($attribute);
+            }
+
+            try {
+                $this->setAttributeValue($object, $attribute, $value, $format, $context);
+            } catch (InvalidArgumentException $e) {
+                throw new NotNormalizableValueException(sprintf('Failed to denormalize attribute "%s" value for class "%s": '.$e->getMessage(), $attribute, $type), $e->getCode(), $e);
             }
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -26,6 +26,8 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
  */
 interface DenormalizerInterface
 {
+    const COLLECT_INVARIANT_VIOLATIONS = 'collect_invariant_violations';
+
     /**
      * Denormalizes data back into an object of the given class.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #37419
| License       | MIT
| Doc PR        | -

This PR implements #37419 and replaces #27136 (and #28358 maybe).

With these changes, the feature would require all involved third party denormalizers to check the new `collect_invariant_violations` context option and transform any relevant domain error into an `InvariantViolationException` exception that contains information needed to build e.g. a nice `400 Bad Request` response.

Maybe I can go further with something similar to `ConstraintViolationBuilder` to ease creating `InvariantViolationException` instances with `symfony/translation` integration. But I'm not sure about the current direction so I'd like to get some feedback first :)

TODO:
- [ ] tests
- [ ] builder similar to `ConstraintViolationBuilder`?
- [ ] integration with `symfony/translation`?