### PR TITLE
[HttpFoundation] Skip the cookie_max_age fixture on PHP 8

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
@@ -45,6 +45,10 @@ class ResponseFunctionalTest extends TestCase
      */
     public function testCookie($fixture)
     {
+        if (\PHP_VERSION_ID >= 80000 && 'cookie_max_age' === $fixture) {
+            $this->markTestSkipped('This fixture produces a fatal error on PHP 8.');
+        }
+
         $result = file_get_contents(sprintf('http://localhost:8054/%s.php', $fixture));
         $this->assertStringMatchesFormatFile(__DIR__.sprintf('/Fixtures/response-functional/%s.expected', $fixture), $result);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

This PR suggest to skip a certain integration test on php 8. The integration test in question triggers a warning by setting a way too high expiration date when calling `setcookie()`. Apparently, this warning has been upgraded to a fatal error on php 8.

Since the integration test is run in a separate process, we might as well adjust the expectation of that test case, but I don't really see the point in asserting fatal error behavior, to be honest.