### PR TITLE
[PhpUnitBridge] Internal classes are not legacy

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -143,6 +143,10 @@ class Deprecation
     public function isLegacy()
     {
         $class = $this->originatingClass();
+        if ((new \ReflectionClass($class))->isInternal()) {
+            return false;
+        }
+
         $method = $this->originatingMethod();
 
         return 0 === strpos($method, 'testLegacy')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #37564
| License       | MIT
| Doc PR        | N/A

This change works around the issue that we can observe in the failed Travis build of #38103.

We must not call PHPUnit's internal `Test::getGroups()` method with a built-in class, otherwise we will run into a TypeError. This won't be fixed on PHPUnit's side, so we need to prevent that call. Our DeprecationErrorHander might run into this case if a deprecation is triggered while autoloading a class.

And forgive me, I've had a really hard time trying to craft a test case for that. 🙈 