### PR TITLE
[FrameworkBundle] fix filename being cleaned up at end of tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CacheClearCommand/CacheClearCommandTest.php
@@ -38,7 +38,7 @@ class CacheClearCommandTest extends TestCase
     protected function tearDown(): void
     {
         $this->fs->remove($this->kernel->getProjectDir());
-        $this->fs->remove(__DIR__.'/Fixture/preload.php');
+        $this->fs->remove(__DIR__.'/Fixture/.preload.php');
     }
 
     public function testCacheIsFreshAfterCacheClearedWithWarmup()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 