### PR TITLE
[HttpClient][HttpClientTrait] don't calculate alternatives if option is auth_ntlm

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -111,7 +111,7 @@ trait HttpClientTrait
         }
 
         if (isset($options['auth_bearer']) && (!\is_string($options['auth_bearer']) || !preg_match('{^[-._=~+/0-9a-zA-Z]++$}', $options['auth_bearer']))) {
-            throw new InvalidArgumentException(sprintf('Option "auth_bearer" must be a string containing only characters from the base 64 alphabet, %s given.', \is_string($options['auth_bearer']) ? 'invalid string' : '"'.\gettype($options['auth_bearer']).'"'));
+            throw new InvalidArgumentException(sprintf('Option "auth_bearer" must be a string containing only characters from the base 64 alphabet, '.(\is_string($options['auth_bearer']) ? 'invalid string given.' : '"%s" given.'), \gettype($options['auth_bearer'])));
         }
 
         if (isset($options['auth_basic'], $options['auth_bearer'])) {
@@ -197,16 +197,22 @@ trait HttpClientTrait
                 continue;
             }
 
+            if ('auth_ntlm' === $name) {
+                if (!\extension_loaded('curl')) {
+                    $msg = 'try installing the "curl" extension to use "%s" instead.';
+                } else {
+                    $msg = 'try using "%s" instead.';
+                }
+
+                throw new InvalidArgumentException(sprintf('Option "auth_ntlm" is not supported by "%s", '.$msg, __CLASS__, CurlHttpClient::class));
+            }
+
             $alternatives = [];
 
             foreach ($defaultOptions as $key => $v) {
                 if (levenshtein($name, $key) <= \strlen($name) / 3 || false !== strpos($key, $name)) {
                     $alternatives[] = $key;
                 }
-            }
-
-            if ('auth_ntlm' === $name) {
-                throw new InvalidArgumentException(sprintf('Option "auth_ntlm" is not supported by "%s", try using CurlHttpClient instead.', __CLASS__));
             }
 
             throw new InvalidArgumentException(sprintf('Unsupported option "%s" passed to "%s", did you mean "%s"?', $name, __CLASS__, implode('", "', $alternatives ?: array_keys($defaultOptions))));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

If option is `auth_ntlm` an exception is thrown, `$alternatives` then is not used.
