### PR TITLE
[Notifier] fix factory definition of notifier transports

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier.php
@@ -73,7 +73,7 @@ return static function (ContainerConfigurator $container) {
         ->alias(ChatterInterface::class, 'chatter')
 
         ->set('chatter.transports', Transports::class)
-            ->factory(['chatter.transport_factory', 'fromStrings'])
+            ->factory([service('chatter.transport_factory'), 'fromStrings'])
             ->args([[]])
 
         ->set('chatter.transport_factory', Transport::class)
@@ -93,7 +93,7 @@ return static function (ContainerConfigurator $container) {
         ->alias(TexterInterface::class, 'texter')
 
         ->set('texter.transports', Transports::class)
-            ->factory(['texter.transport_factory', 'fromStrings'])
+            ->factory([service('texter.transport_factory'), 'fromStrings'])
             ->args([[]])
 
         ->set('texter.transport_factory', Transport::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | #37298<!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

With a fresh install of Symfony `symfony new --version=next` and after adding the Notifier component `composer req symfony/notifier` I got the following errors:

```
In PhpDumper.php line 1843:
                                                                                       
  Cannot dump definition because of invalid class name ('chatter.transport_factory').  
```

and

```
In PhpDumper.php line 1843:
                                                                                       
  Cannot dump definition because of invalid class name ('texter.transport_factory').  
```

This PR fixes this bug.