### PR TITLE
[Config] Adding the "info" to a missing option error messages

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/Security/UserProvider/EntityFactory.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/Security/UserProvider/EntityFactory.php
@@ -52,7 +52,11 @@ class EntityFactory implements UserProviderFactoryInterface
     {
         $node
             ->children()
-                ->scalarNode('class')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('class')
+                    ->isRequired()
+                    ->info('The full entity class name of your user class.')
+                    ->cannotBeEmpty()
+                ->end()
                 ->scalarNode('property')->defaultNull()->end()
                 ->scalarNode('manager_name')->defaultNull()->end()
             ->end()

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -213,7 +213,11 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
         foreach ($this->children as $name => $child) {
             if (!\array_key_exists($name, $value)) {
                 if ($child->isRequired()) {
-                    $ex = new InvalidConfigurationException(sprintf('The child node "%s" at path "%s" must be configured.', $name, $this->getPath()));
+                    $message = sprintf('The child config "%s" under "%s" must be configured.', $name, $this->getPath());
+                    if ($child->getInfo()) {
+                        $message .= sprintf("\n\n Description: %s", $child->getInfo());
+                    }
+                    $ex = new InvalidConfigurationException($message);
                     $ex->setPath($this->getPath());
 
                     throw $ex;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Not needed

New error:

<img width="1063" alt="Screen Shot 2020-09-13 at 10 51 32 AM" src="https://user-images.githubusercontent.com/121003/93021186-6329ff00-f5af-11ea-83c6-98581b12ef75.png">

I used the missing `class` just as an example. I hit this while building a new feature in Symfony. It occurred to me that if, for example, you activate some feature in config and that feature has a required sub-key, why not print the `info()` for that sub key to make it discoverable?