### PR TITLE
[Security] Magic login link authentication

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -74,6 +74,7 @@ class UnusedTagsPass implements CompilerPassInterface
         'routing.route_loader',
         'security.expression_language_provider',
         'security.remember_me_aware',
+        'security.authenticator.login_linker',
         'security.voter',
         'serializer.encoder',
         'serializer.normalizer',

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/EntryPointFactoryInterface.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/EntryPointFactoryInterface.php
@@ -26,5 +26,5 @@ interface EntryPointFactoryInterface
      * This does not mean that the entry point is also used. This is managed
      * by the "entry_point" firewall setting.
      */
-    public function registerEntryPoint(ContainerBuilder $container, string $id, array $config): ?string;
+    public function registerEntryPoint(ContainerBuilder $container, string $firewallName, array $config): ?string;
 }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
@@ -97,9 +97,9 @@ class FormLoginFactory extends AbstractFactory implements AuthenticatorFactoryIn
         return $this->registerEntryPoint($container, $id, $config);
     }
 
-    public function registerEntryPoint(ContainerBuilder $container, string $id, array $config): string
+    public function registerEntryPoint(ContainerBuilder $container, string $firewallName, array $config): string
     {
-        $entryPointId = 'security.authentication.form_entry_point.'.$id;
+        $entryPointId = 'security.authentication.form_entry_point.'.$firewallName;
         $container
             ->setDefinition($entryPointId, new ChildDefinition('security.authentication.form_entry_point'))
             ->addArgument(new Reference('security.http_utils'))

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/GuardAuthenticationFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/GuardAuthenticationFactory.php
@@ -114,7 +114,7 @@ class GuardAuthenticationFactory implements SecurityFactoryInterface, Authentica
         return $authenticatorIds;
     }
 
-    public function registerEntryPoint(ContainerBuilder $container, string $id, array $config): ?string
+    public function registerEntryPoint(ContainerBuilder $container, string $firewallName, array $config): ?string
     {
         try {
             return $this->determineEntryPoint(null, $config);

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
@@ -82,9 +82,9 @@ class HttpBasicFactory implements SecurityFactoryInterface, AuthenticatorFactory
         ;
     }
 
-    public function registerEntryPoint(ContainerBuilder $container, string $id, array $config): string
+    public function registerEntryPoint(ContainerBuilder $container, string $firewallName, array $config): string
     {
-        $entryPointId = 'security.authentication.basic_entry_point.'.$id;
+        $entryPointId = 'security.authentication.basic_entry_point.'.$firewallName;
         $container
             ->setDefinition($entryPointId, new ChildDefinition('security.authentication.basic_entry_point'))
             ->addArgument($config['realm'])

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginLinkFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginLinkFactory.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory;
+
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkHandler;
+
+/**
+ * @internal
+ * @experimental in 5.2
+ */
+class LoginLinkFactory extends AbstractFactory implements AuthenticatorFactoryInterface
+{
+    public function addConfiguration(NodeDefinition $node)
+    {
+        /** @var NodeBuilder $builder */
+        $builder = $node->children();
+
+        $builder
+            ->scalarNode('check_route')
+                ->isRequired()
+                ->info('Route that will validate the login link - e.g. app_login_link_verify')
+            ->end()
+            ->arrayNode('signature_properties')
+                ->prototype('scalar')->end()
+                ->requiresAtLeastOneElement()
+                ->info('An array of properties on your User that are used to sign the link. If any of these change, all existing links will become invalid')
+                ->example(['email', 'password'])
+            ->end()
+            ->integerNode('lifetime')
+                ->defaultValue(600)
+                ->info('The lifetime of the login link in seconds')
+            ->end()
+            ->integerNode('max_uses')
+                ->defaultNull()
+                ->info('Max number of times a login link can be used - null means unlimited within lifetime.')
+            ->end()
+            ->scalarNode('used_link_cache')
+                ->info('Cache service id used to expired links of max_uses is set')
+            ->end()
+            ->scalarNode('success_handler')
+                ->info(sprintf('A service id that implements %s', AuthenticationSuccessHandlerInterface::class))
+            ->end()
+            ->scalarNode('failure_handler')
+                ->info(sprintf('A service id that implements %s', AuthenticationFailureHandlerInterface::class))
+            ->end()
+            ->scalarNode('provider')
+                ->info('the user provider to load users from.')
+            ->end()
+        ;
+
+        foreach (array_merge($this->defaultSuccessHandlerOptions, $this->defaultFailureHandlerOptions) as $name => $default) {
+            if (\is_bool($default)) {
+                $builder->booleanNode($name)->defaultValue($default);
+            } else {
+                $builder->scalarNode($name)->defaultValue($default);
+            }
+        }
+    }
+
+    public function getKey()
+    {
+        return 'login-link';
+    }
+
+    public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId): string
+    {
+        if (!class_exists(LoginLinkHandler::class)) {
+            throw new \LogicException('Login login link requires symfony/security-http:^5.2.');
+        }
+
+        if (!$container->hasDefinition('security.authenticator.login_link')) {
+            $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__).'/../../Resources/config'));
+            $loader->load('security_authenticator_login_link.php');
+        }
+
+        if (null !== $config['max_uses'] && !isset($config['used_link_cache'])) {
+            $config['used_link_cache'] = 'security.authenticator.cache.expired_links';
+        }
+
+        $expiredStorageId = null;
+        if (isset($config['used_link_cache'])) {
+            $expiredStorageId = 'security.authenticator.expired_login_link_storage.'.$firewallName;
+            $container
+                ->setDefinition($expiredStorageId, new ChildDefinition('security.authenticator.expired_login_link_storage'))
+                ->replaceArgument(0, new Reference($config['used_link_cache']))
+                ->replaceArgument(1, $config['lifetime']);
+        }
+
+        $linkerId = 'security.authenticator.login_link_handler.'.$firewallName;
+        $linkerOptions = [
+            'route_name' => $config['check_route'],
+            'lifetime' => $config['lifetime'],
+            'max_uses' => $config['max_uses'] ?? null,
+        ];
+        $container
+            ->setDefinition($linkerId, new ChildDefinition('security.authenticator.abstract_login_link_handler'))
+            ->replaceArgument(1, new Reference($userProviderId))
+            ->replaceArgument(3, $config['signature_properties'])
+            ->replaceArgument(5, $linkerOptions)
+            ->replaceArgument(6, $expiredStorageId ? new Reference($expiredStorageId) : null)
+            ->addTag('security.authenticator.login_linker', ['firewall' => $firewallName])
+        ;
+
+        $authenticatorId = 'security.authenticator.login_link.'.$firewallName;
+        $container
+            ->setDefinition($authenticatorId, new ChildDefinition('security.authenticator.login_link'))
+            ->replaceArgument(0, new Reference($linkerId))
+            ->replaceArgument(2, new Reference($this->createAuthenticationSuccessHandler($container, $firewallName, $config)))
+            ->replaceArgument(3, new Reference($this->createAuthenticationFailureHandler($container, $firewallName, $config)))
+            ->replaceArgument(4, [
+                'check_route' => $config['check_route'],
+            ]);
+
+        return $authenticatorId;
+    }
+
+    public function getPosition()
+    {
+        return 'form';
+    }
+
+    protected function createAuthProvider(ContainerBuilder $container, string $id, array $config, string $userProviderId)
+    {
+        throw new \Exception('The old authentication system is not supported with login_link.');
+    }
+
+    protected function getListenerId()
+    {
+        throw new \Exception('The old authentication system is not supported with login_link.');
+    }
+
+    protected function createListener(ContainerBuilder $container, string $id, array $config, string $userProvider)
+    {
+        throw new \Exception('The old authentication system is not supported with login_link.');
+    }
+
+    protected function createEntryPoint(ContainerBuilder $container, string $id, array $config, ?string $defaultEntryPointId)
+    {
+        throw new \Exception('The old authentication system is not supported with login_link.');
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/LoginLink/FirewallAwareLoginLinkHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/LoginLink/FirewallAwareLoginLinkHandler.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\LoginLink;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkDetails;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
+
+/**
+ * Decorates the login link handler for the current firewall.
+ *
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ */
+class FirewallAwareLoginLinkHandler implements LoginLinkHandlerInterface
+{
+    private $firewallMap;
+    private $loginLinkHandlerLocator;
+    private $requestStack;
+
+    public function __construct(FirewallMap $firewallMap, ContainerInterface $loginLinkHandlerLocator, RequestStack $requestStack)
+    {
+        $this->firewallMap = $firewallMap;
+        $this->loginLinkHandlerLocator = $loginLinkHandlerLocator;
+        $this->requestStack = $requestStack;
+    }
+
+    public function createLoginLink(UserInterface $user): LoginLinkDetails
+    {
+        return $this->getLoginLinkHandler()->createLoginLink($user);
+    }
+
+    public function consumeLoginLink(Request $request): UserInterface
+    {
+        return $this->getLoginLinkHandler()->consumeLoginLink($request);
+    }
+
+    private function getLoginLinkHandler(): LoginLinkHandlerInterface
+    {
+        if (null === $request = $this->requestStack->getCurrentRequest()) {
+            throw new \LogicException('Cannot determine the correct LoginLinkHandler to use: there is no active Request and so, the firewall cannot be determined. Try using the specific login link handler service.');
+        }
+
+        $firewallName = $this->firewallMap->getFirewallConfig($request)->getName();
+        if (!$this->loginLinkHandlerLocator->has($firewallName)) {
+            throw new \InvalidArgumentException(sprintf('No login link handler found. Did you add a login_link key under your "%s" firewall?', $firewallName));
+        }
+
+        return $this->loginLinkHandlerLocator->get($firewallName);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_login_link.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator_login_link.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\SecurityBundle\LoginLink\FirewallAwareLoginLinkHandler;
+use Symfony\Component\Security\Http\Authenticator\LoginLinkAuthenticator;
+use Symfony\Component\Security\Http\LoginLink\ExpiredLoginLinkStorage;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkHandler;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('security.authenticator.login_link', LoginLinkAuthenticator::class)
+            ->abstract()
+            ->args([
+                abstract_arg('the login link handler instance'),
+                service('security.http_utils'),
+                abstract_arg('authentication success handler'),
+                abstract_arg('authentication failure handler'),
+                abstract_arg('options'),
+            ])
+
+        ->set('security.authenticator.abstract_login_link_handler', LoginLinkHandler::class)
+            ->abstract()
+            ->args([
+                service('router'),
+                abstract_arg('user provider'),
+                service('property_accessor'),
+                abstract_arg('signature properties'),
+                '%kernel.secret%',
+                abstract_arg('options'),
+                abstract_arg('expired login link storage'),
+            ])
+
+        ->set('security.authenticator.expired_login_link_storage', ExpiredLoginLinkStorage::class)
+            ->abstract()
+            ->args([
+                abstract_arg('cache pool service'),
+                abstract_arg('expired login link storage'),
+            ])
+
+        ->set('security.authenticator.cache.expired_links')
+            ->parent('cache.app')
+            ->private()
+            ->tag('cache.pool')
+
+        ->set('security.authenticator.firewall_aware_login_link_handler', FirewallAwareLoginLinkHandler::class)
+            ->args([
+                service('security.firewall.map'),
+                tagged_locator('security.authenticator.login_linker', 'firewall'),
+                service('request_stack'),
+            ])
+        ->alias(LoginLinkHandlerInterface::class, 'security.authenticator.firewall_aware_login_link_handler')
+
+        ->set('security.authenticator.entity_login_link_user_handler', EntityLoginLinkUserHandler::class)
+            ->abstract()
+            ->args([
+                service('doctrine'),
+                abstract_arg('user entity class name'),
+            ])
+
+    ;
+};

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -28,6 +28,7 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\HttpBasic
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\HttpBasicLdapFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\JsonLoginFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\JsonLoginLdapFactory;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\LoginLinkFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\LoginThrottlingFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\RememberMeFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\RemoteUserFactory;
@@ -66,6 +67,7 @@ class SecurityBundle extends Bundle
         $extension->addSecurityListenerFactory(new AnonymousFactory());
         $extension->addSecurityListenerFactory(new CustomAuthenticatorFactory());
         $extension->addSecurityListenerFactory(new LoginThrottlingFactory());
+        $extension->addSecurityListenerFactory(new LoginLinkFactory());
 
         $extension->addUserProviderFactory(new InMemoryFactory());
         $extension->addUserProviderFactory(new LdapFactory());

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/LoginLinkFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/LoginLinkFactoryTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection\Security\Factory;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\LoginLinkFactory;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class LoginLinkFactoryTest extends TestCase
+{
+    public function testBasicServiceConfiguration()
+    {
+        $container = new ContainerBuilder();
+
+        $config = [
+            'check_route' => 'app_check_login_link',
+            'lifetime' => 500,
+            'signature_properties' => ['email', 'password'],
+            'success_handler' => 'success_handler_service_id',
+            'failure_handler' => 'failure_handler_service_id',
+        ];
+
+        $factory = new LoginLinkFactory();
+        $finalizedConfig = $this->processConfig($config, $factory);
+        $factory->createAuthenticator($container, 'firewall1', $finalizedConfig, 'userprovider');
+
+        $this->assertTrue($container->hasDefinition('security.authenticator.login_link'));
+        $this->assertTrue($container->hasDefinition('security.authenticator.login_link_handler.firewall1'));
+    }
+
+    private function processConfig(array $config, LoginLinkFactory $factory)
+    {
+        $nodeDefinition = new ArrayNodeDefinition('login-link');
+        $factory->addConfiguration($nodeDefinition);
+
+        $node = $nodeDefinition->getNode();
+        $normalizedConfig = $node->normalize($config);
+
+        return $node->finalize($normalizedConfig);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/LoginLink/TestCustomLoginLinkSuccessHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/LoginLink/TestCustomLoginLinkSuccessHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\LoginLink;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+
+class TestCustomLoginLinkSuccessHandler implements AuthenticationSuccessHandlerInterface
+{
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token)
+    {
+        return new JsonResponse(['message' => sprintf('Welcome %s!', $token->getUsername())]);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LoginLinkAuthenticationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/LoginLinkAuthenticationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkHandler;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
+
+/**
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ */
+class LoginLinkAuthenticationTest extends AbstractWebTestCase
+{
+    public function testLoginLinkSuccess()
+    {
+        if (!class_exists(LoginLinkHandler::class)) {
+            $this->markTestSkipped('Login link auth requires symfony/security-http:^5.2');
+        }
+
+        $client = $this->createClient(['test_case' => 'LoginLink', 'root_config' => 'config.yml']);
+
+        // we need an active request that is under the firewall to use the linker
+        $request = Request::create('/get-login-link');
+        self::$container->get(RequestStack::class)->push($request);
+
+        /** @var LoginLinkHandlerInterface $loginLinkHandler */
+        $loginLinkHandler = self::$container->get(LoginLinkHandlerInterface::class);
+        $user = new User('weaverryan', 'foo');
+        $loginLink = $loginLinkHandler->createLoginLink($user);
+        $this->assertStringContainsString('user=weaverryan', $loginLink);
+        $this->assertStringContainsString('hash=', $loginLink);
+        $this->assertStringContainsString('expires=', $loginLink);
+        $client->request('GET', $loginLink->getUrl());
+        $response = $client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['message' => 'Welcome weaverryan!'], json_decode($response->getContent(), true));
+
+        $client->request('GET', $loginLink->getUrl());
+        $response = $client->getResponse();
+        $this->assertSame(200, $response->getStatusCode());
+
+        $client->request('GET', $loginLink->getUrl());
+        $response = $client->getResponse();
+        $this->assertSame(302, $response->getStatusCode(), 'Should redirect with an error because max uses are only 2');
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LoginLink/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LoginLink/bundles.php
@@ -1,0 +1,15 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+    new Symfony\Bundle\SecurityBundle\SecurityBundle(),
+    new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+];

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LoginLink/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LoginLink/config.yml
@@ -1,0 +1,28 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+security:
+    enable_authenticator_manager: true
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    weaverryan: { password: foo, roles: [ROLE_USER] }
+
+    firewalls:
+        main:
+            pattern: ^/
+            login_link:
+                check_route:    login_link_check
+                signature_properties: ['password']
+                max_uses: 2
+                success_handler: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\LoginLink\TestCustomLoginLinkSuccessHandler
+
+services:
+    Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\LoginLink\TestCustomLoginLinkSuccessHandler: null
+    # needed so LoginLinkHandlerInterface has *some* reference, and so isn't
+    # entirely removed from the container (so we can fetch it in the test container)
+    login_link_handler:
+        alias: 'Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface'
+        public: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LoginLink/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LoginLink/routing.yml
@@ -1,0 +1,2 @@
+login_link_check:
+    path: /login-link-check

--- a/src/Symfony/Bundle/SecurityBundle/Tests/LoginLink/FirewallAwareLoginLinkHandlerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/LoginLink/FirewallAwareLoginLinkHandlerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\LoginLink;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Bundle\SecurityBundle\LoginLink\FirewallAwareLoginLinkHandler;
+use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkDetails;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
+
+class FirewallAwareLoginLinkHandlerTest extends TestCase
+{
+    public function testSuccessfulDecoration()
+    {
+        $user = $this->createMock(UserInterface::class);
+        $linkDetails = new LoginLinkDetails('http://example.com', new \DateTimeImmutable());
+        $request = Request::create('http://example.com/verify');
+
+        $firewallMap = $this->createFirewallMap('main_firewall');
+        $loginLinkHandler = $this->createMock(LoginLinkHandlerInterface::class);
+        $loginLinkHandler->expects($this->once())
+            ->method('createLoginLink')
+            ->with($user)
+            ->willReturn($linkDetails);
+        $loginLinkHandler->expects($this->once())
+            ->method('consumeLoginLink')
+            ->with($request)
+            ->willReturn($user);
+        $locator = $this->createLocator([
+            'main_firewall' => $loginLinkHandler,
+        ]);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        $linker = new FirewallAwareLoginLinkHandler($firewallMap, $locator, $requestStack);
+        $actualLinkDetails = $linker->createLoginLink($user);
+        $this->assertSame($linkDetails, $actualLinkDetails);
+
+        $actualUser = $linker->consumeLoginLink($request);
+        $this->assertSame($user, $actualUser);
+    }
+
+    private function createFirewallMap(string $firewallName)
+    {
+        $map = $this->createMock(FirewallMap::class);
+        $map->expects($this->any())
+            ->method('getFirewallConfig')
+            ->willReturn($config = new FirewallConfig($firewallName, 'user_checker'));
+
+        return $map;
+    }
+
+    private function createLocator(array $linkers)
+    {
+        $locator = $this->createMock(ContainerInterface::class);
+        $locator->expects($this->any())
+            ->method('has')
+            ->willReturnCallback(function ($firewallName) use ($linkers) {
+                return isset($linkers[$firewallName]);
+            });
+        $locator->expects($this->any())
+            ->method('get')
+            ->willReturnCallback(function ($firewallName) use ($linkers) {
+                return $linkers[$firewallName];
+            });
+
+        return $locator;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.en.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.en.xlf
@@ -66,6 +66,10 @@
                 <source>Too many failed login attempts, please try again later.</source>
                 <target>Too many failed login attempts, please try again later.</target>
             </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Invalid or expired login link.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\LoginLink\Exception\InvalidLoginLinkAuthenticationException;
+use Symfony\Component\Security\Http\LoginLink\Exception\InvalidLoginLinkExceptionInterface;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
+
+/**
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ * @experimental in 5.2
+ */
+final class LoginLinkAuthenticator extends AbstractAuthenticator implements InteractiveAuthenticatorInterface
+{
+    private $loginLinkHandler;
+    private $httpUtils;
+    private $successHandler;
+    private $failureHandler;
+    private $options;
+
+    public function __construct(LoginLinkHandlerInterface $loginLinkHandler, HttpUtils $httpUtils, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options)
+    {
+        $this->loginLinkHandler = $loginLinkHandler;
+        $this->httpUtils = $httpUtils;
+        $this->successHandler = $successHandler;
+        $this->failureHandler = $failureHandler;
+        $this->options = $options;
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        return $this->httpUtils->checkRequestPath($request, $this->options['check_route']);
+    }
+
+    public function authenticate(Request $request): PassportInterface
+    {
+        $username = $request->get('user');
+
+        if (!$username) {
+            throw new InvalidLoginLinkAuthenticationException('Missing user from link.');
+        }
+
+        return new SelfValidatingPassport(
+            new UserBadge($username, function () use ($request) {
+                try {
+                    $user = $this->loginLinkHandler->consumeLoginLink($request);
+                } catch (InvalidLoginLinkExceptionInterface $e) {
+                    throw new InvalidLoginLinkAuthenticationException('Login link could not be validated.', 0, $e);
+                }
+
+                return $user;
+            }),
+            []
+        );
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return $this->successHandler->onAuthenticationSuccess($request, $token);
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    {
+        return $this->failureHandler->onAuthenticationFailure($request, $exception);
+    }
+
+    public function isInteractive(): bool
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/Security/Http/LoginLink/Exception/ExpiredLoginLinkException.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/Exception/ExpiredLoginLinkException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\LoginLink\Exception;
+
+/**
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ * @experimental in 5.2
+ */
+class ExpiredLoginLinkException extends \Exception implements InvalidLoginLinkExceptionInterface
+{
+}

--- a/src/Symfony/Component/Security/Http/LoginLink/Exception/InvalidLoginLinkAuthenticationException.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/Exception/InvalidLoginLinkAuthenticationException.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\LoginLink\Exception;
+
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * Thrown when a login link is invalid.
+ *
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ * @experimental in 5.2
+ */
+class InvalidLoginLinkAuthenticationException extends AuthenticationException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageKey()
+    {
+        return 'Invalid or expired login link.';
+    }
+}

--- a/src/Symfony/Component/Security/Http/LoginLink/Exception/InvalidLoginLinkException.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/Exception/InvalidLoginLinkException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\LoginLink\Exception;
+
+/**
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ * @experimental in 5.2
+ */
+class InvalidLoginLinkException extends \Exception implements InvalidLoginLinkExceptionInterface
+{
+}

--- a/src/Symfony/Component/Security/Http/LoginLink/Exception/InvalidLoginLinkExceptionInterface.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/Exception/InvalidLoginLinkExceptionInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\LoginLink\Exception;
+
+/**
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ * @experimental in 5.2
+ */
+interface InvalidLoginLinkExceptionInterface extends \Throwable
+{
+}

--- a/src/Symfony/Component/Security/Http/LoginLink/ExpiredLoginLinkStorage.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/ExpiredLoginLinkStorage.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\LoginLink;
+
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * @final
+ */
+class ExpiredLoginLinkStorage
+{
+    private $cache;
+    private $lifetime;
+
+    public function __construct(CacheItemPoolInterface $cache, int $lifetime)
+    {
+        $this->cache = $cache;
+        $this->lifetime = $lifetime;
+    }
+
+    public function countUsages(string $hash): int
+    {
+        $key = rawurlencode($hash);
+        if (!$this->cache->hasItem($key)) {
+            return 0;
+        }
+
+        return $this->cache->getItem($key)->get();
+    }
+
+    public function incrementUsages(string $hash): void
+    {
+        $item = $this->cache->getItem(rawurlencode($hash));
+
+        if (!$item->isHit()) {
+            $item->expiresAfter($this->lifetime);
+        }
+
+        $item->set($this->countUsages($hash) + 1);
+        $this->cache->save($item);
+    }
+}

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkDetails.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkDetails.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\LoginLink;
+
+/**
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ * @experimental in 5.2
+ */
+class LoginLinkDetails
+{
+    private $url;
+    private $expiresAt;
+
+    public function __construct(string $url, \DateTimeImmutable $expiresAt)
+    {
+        $this->url = $url;
+        $this->expiresAt = $expiresAt;
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getExpiresAt(): \DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function __toString()
+    {
+        return $this->url;
+    }
+}

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\LoginLink;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\LoginLink\Exception\ExpiredLoginLinkException;
+use Symfony\Component\Security\Http\LoginLink\Exception\InvalidLoginLinkException;
+
+/**
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ * @experimental in 5.2
+ */
+final class LoginLinkHandler implements LoginLinkHandlerInterface
+{
+    private $urlGenerator;
+    private $userProvider;
+    private $propertyAccessor;
+    private $signatureProperties;
+    private $secret;
+    private $options;
+    private $expiredStorage;
+
+    public function __construct(UrlGeneratorInterface $urlGenerator, UserProviderInterface $userProvider, PropertyAccessorInterface $propertyAccessor, array $signatureProperties, string $secret, array $options, ?ExpiredLoginLinkStorage $expiredStorage)
+    {
+        $this->urlGenerator = $urlGenerator;
+        $this->userProvider = $userProvider;
+        $this->propertyAccessor = $propertyAccessor;
+        $this->signatureProperties = $signatureProperties;
+        $this->secret = $secret;
+        $this->options = array_merge([
+            'route_name' => null,
+            'lifetime' => 600,
+            'max_uses' => null,
+        ], $options);
+        $this->expiredStorage = $expiredStorage;
+    }
+
+    public function createLoginLink(UserInterface $user): LoginLinkDetails
+    {
+        $expiresAt = new \DateTimeImmutable(sprintf('+%d seconds', $this->options['lifetime']));
+
+        $expires = $expiresAt->format('U');
+        $parameters = [
+            'user' => $user->getUsername(),
+            'expires' => $expires,
+            'hash' => $this->computeSignatureHash($user, $expires),
+        ];
+
+        $url = $this->urlGenerator->generate(
+            $this->options['route_name'],
+            $parameters,
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+
+        return new LoginLinkDetails($url, $expiresAt);
+    }
+
+    public function consumeLoginLink(Request $request): UserInterface
+    {
+        $username = $request->get('user');
+
+        try {
+            $user = $this->userProvider->loadUserByUsername($username);
+        } catch (UsernameNotFoundException $exception) {
+            throw new InvalidLoginLinkException('User not found.', 0, $exception);
+        }
+
+        $hash = $request->get('hash');
+        $expires = $request->get('expires');
+        if (false === hash_equals($hash, $this->computeSignatureHash($user, $expires))) {
+            throw new InvalidLoginLinkException('Invalid or expired signature.');
+        }
+
+        if ($expires < time()) {
+            throw new ExpiredLoginLinkException('Login link has expired.');
+        }
+
+        if ($this->expiredStorage && $this->options['max_uses']) {
+            $hash = $request->get('hash');
+            if ($this->expiredStorage->countUsages($hash) >= $this->options['max_uses']) {
+                throw new ExpiredLoginLinkException(sprintf('Login link can only be used "%d" times.', $this->options['max_uses']));
+            }
+
+            $this->expiredStorage->incrementUsages($hash);
+        }
+
+        return $user;
+    }
+
+    private function computeSignatureHash(UserInterface $user, int $expires): string
+    {
+        $signatureFields = [base64_encode($user->getUsername()), $expires];
+
+        foreach ($this->signatureProperties as $property) {
+            $value = $this->propertyAccessor->getValue($user, $property);
+            if (!is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
+                throw new \InvalidArgumentException(sprintf('The property path "%s" on the user object "%s" must return a value that can be cast to a string, but "%s" was returned.', $property, \get_class($user), get_debug_type($value)));
+            }
+            $signatureFields[] = base64_encode($value);
+        }
+
+        return base64_encode(hash_hmac('sha256', implode(':', $signatureFields), $this->secret));
+    }
+}

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\LoginLink;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * A class that is able to create and handle "magic" login links.
+ *
+ * @author Ryan Weaver <ryan@symfonycasts.com>
+ * @experimental in 5.2
+ */
+interface LoginLinkHandlerInterface
+{
+    /**
+     * Generate a link that can be used to authenticate as the given user.
+     */
+    public function createLoginLink(UserInterface $user): LoginLinkDetails;
+
+    /**
+     * Validates if this request contains a login link and returns the associated User.
+     *
+     * Throw InvalidLoginLinkExceptionInterface if the link is invalid.
+     */
+    public function consumeLoginLink(Request $request): UserInterface;
+}

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/LoginLinkAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/LoginLinkAuthenticatorTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\LoginLinkAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\LoginLink\Exception\ExpiredLoginLinkException;
+use Symfony\Component\Security\Http\LoginLink\Exception\InvalidLoginLinkAuthenticationException;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
+
+class LoginLinkAuthenticatorTest extends TestCase
+{
+    private $loginLinkHandler;
+    private $successHandler;
+    private $failureHandler;
+    /** @var LoginLinkAuthenticator */
+    private $authenticator;
+
+    protected function setUp(): void
+    {
+        $this->loginLinkHandler = $this->createMock(LoginLinkHandlerInterface::class);
+        $this->successHandler = $this->createMock(AuthenticationSuccessHandlerInterface::class);
+        $this->failureHandler = $this->createMock(AuthenticationFailureHandlerInterface::class);
+    }
+
+    public function testSuccessfulAuthenticate()
+    {
+        $this->setUpAuthenticator();
+
+        $request = Request::create('/login/link/check?stuff=1&user=weaverryan');
+        $user = $this->createMock(UserInterface::class);
+        $this->loginLinkHandler->expects($this->once())
+            ->method('consumeLoginLink')
+            ->with($request)
+            ->willReturn($user);
+
+        $passport = $this->authenticator->authenticate($request);
+        $this->assertInstanceOf(SelfValidatingPassport::class, $passport);
+        /** @var UserBadge $userBadge */
+        $userBadge = $passport->getBadge(UserBadge::class);
+        $this->assertSame($user, $userBadge->getUser());
+        $this->assertSame('weaverryan', $userBadge->getUserIdentifier());
+    }
+
+    public function testUnsuccessfulAuthenticate()
+    {
+        $this->expectException(InvalidLoginLinkAuthenticationException::class);
+        $this->setUpAuthenticator();
+
+        $request = Request::create('/login/link/check?stuff=1&user=weaverryan');
+        $this->loginLinkHandler->expects($this->once())
+            ->method('consumeLoginLink')
+            ->with($request)
+            ->willThrowException(new ExpiredLoginLinkException());
+
+        $passport = $this->authenticator->authenticate($request);
+        // trigger the user loader to try to load the user
+        $passport->getBadge(UserBadge::class)->getUser();
+    }
+
+    public function testMissingUser()
+    {
+        $this->expectException(InvalidLoginLinkAuthenticationException::class);
+        $this->setUpAuthenticator();
+
+        $request = Request::create('/login/link/check?stuff=1');
+        $this->createMock(UserInterface::class);
+        $this->loginLinkHandler->expects($this->never())
+            ->method('consumeLoginLink');
+
+        $this->authenticator->authenticate($request);
+    }
+
+    private function setUpAuthenticator(array $options = [])
+    {
+        $this->authenticator = new LoginLinkAuthenticator($this->loginLinkHandler, new HttpUtils(), $this->successHandler, $this->failureHandler, $options);
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/ExpiredLoginLinkStorageTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/ExpiredLoginLinkStorageTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\LoginLink;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Security\Http\LoginLink\ExpiredLoginLinkStorage;
+
+class ExpiredLoginLinkStorageTest extends TestCase
+{
+    public function testUsage()
+    {
+        $cache = new ArrayAdapter();
+        $storage = new ExpiredLoginLinkStorage($cache, 600);
+
+        $this->assertSame(0, $storage->countUsages('hash+more'));
+        $storage->incrementUsages('hash+more');
+        $this->assertSame(1, $storage->countUsages('hash+more'));
+    }
+}

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -1,0 +1,217 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\LoginLink;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\LoginLink\Exception\ExpiredLoginLinkException;
+use Symfony\Component\Security\Http\LoginLink\Exception\InvalidLoginLinkException;
+use Symfony\Component\Security\Http\LoginLink\ExpiredLoginLinkStorage;
+use Symfony\Component\Security\Http\LoginLink\LoginLinkHandler;
+
+class LoginLinkHandlerTest extends TestCase
+{
+    /** @var MockObject|UrlGeneratorInterface */
+    private $router;
+    /** @var MockObject|UserProviderInterface */
+    private $userProvider;
+    /** @var PropertyAccessorInterface */
+    private $propertyAccessor;
+    /** @var MockObject|ExpiredLoginLinkStorage */
+    private $expiredLinkStorage;
+
+    protected function setUp(): void
+    {
+        $this->router = $this->createMock(UrlGeneratorInterface::class);
+        $this->userProvider = $this->createMock(UserProviderInterface::class);
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+        $this->expiredLinkStorage = $this->createMock(ExpiredLoginLinkStorage::class);
+    }
+
+    public function testCreateLoginLink()
+    {
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+
+        $this->router->expects($this->once())
+            ->method('generate')
+            ->with(
+                'app_check_login_link_route',
+                $this->callback(function ($parameters) {
+                    return 'weaverryan' == $parameters['user']
+                        && isset($parameters['expires'])
+                        && isset($parameters['hash'])
+                        // make sure hash is what we expect
+                        && $parameters['hash'] === $this->createSignatureHash('weaverryan', time() + 600, ['ryan@symfonycasts.com', 'pwhash']);
+                }),
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn('https://example.com/login/verify?user=weaverryan&hash=abchash&expires=1601235000');
+
+        $loginLink = $this->createLinker()->createLoginLink($user);
+        $this->assertSame('https://example.com/login/verify?user=weaverryan&hash=abchash&expires=1601235000', $loginLink->getUrl());
+    }
+
+    public function testConsumeLoginLink()
+    {
+        $expires = time() + 500;
+        $signature = $this->createSignatureHash('weaverryan', $expires, ['ryan@symfonycasts.com', 'pwhash']);
+        $request = Request::create(sprintf('/login/verify?user=weaverryan&hash=%s&expires=%d', $signature, $expires));
+
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+        $this->userProvider->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with('weaverryan')
+            ->willReturn($user);
+
+        $this->expiredLinkStorage->expects($this->once())
+            ->method('incrementUsages')
+            ->with($signature);
+
+        $linker = $this->createLinker(['max_uses' => 3]);
+        $actualUser = $linker->consumeLoginLink($request);
+        $this->assertSame($user, $actualUser);
+    }
+
+    public function testConsumeLoginLinkWithExpired()
+    {
+        $this->expectException(ExpiredLoginLinkException::class);
+        $expires = time() - 500;
+        $signature = $this->createSignatureHash('weaverryan', $expires, ['ryan@symfonycasts.com', 'pwhash']);
+        $request = Request::create(sprintf('/login/verify?user=weaverryan&hash=%s&expires=%d', $signature, $expires));
+
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+        $this->userProvider->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with('weaverryan')
+            ->willReturn($user);
+
+        $linker = $this->createLinker(['max_uses' => 3]);
+        $linker->consumeLoginLink($request);
+    }
+
+    public function testConsumeLoginLinkWithUserNotFound()
+    {
+        $this->expectException(InvalidLoginLinkException::class);
+        $request = Request::create('/login/verify?user=weaverryan&hash=thehash&expires=10000');
+
+        $this->userProvider->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with('weaverryan')
+            ->willThrowException(new UsernameNotFoundException());
+
+        $linker = $this->createLinker();
+        $linker->consumeLoginLink($request);
+    }
+
+    public function testConsumeLoginLinkWithDifferentSignature()
+    {
+        $this->expectException(InvalidLoginLinkException::class);
+        $request = Request::create(sprintf('/login/verify?user=weaverryan&hash=fake_hash&expires=%d', time() + 500));
+
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+        $this->userProvider->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with('weaverryan')
+            ->willReturn($user);
+
+        $linker = $this->createLinker();
+        $linker->consumeLoginLink($request);
+    }
+
+    public function testConsumeLoginLinkExceedsMaxUsage()
+    {
+        $this->expectException(ExpiredLoginLinkException::class);
+        $expires = time() + 500;
+        $signature = $this->createSignatureHash('weaverryan', $expires, ['ryan@symfonycasts.com', 'pwhash']);
+        $request = Request::create(sprintf('/login/verify?user=weaverryan&hash=%s&expires=%d', $signature, $expires));
+
+        $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
+        $this->userProvider->expects($this->once())
+            ->method('loadUserByUsername')
+            ->with('weaverryan')
+            ->willReturn($user);
+
+        $this->expiredLinkStorage->expects($this->once())
+            ->method('countUsages')
+            ->with($signature)
+            ->willReturn(3);
+
+        $linker = $this->createLinker(['max_uses' => 3]);
+        $linker->consumeLoginLink($request);
+    }
+
+    private function createSignatureHash(string $username, int $expires, array $extraFields): string
+    {
+        $fields = [base64_encode($username), $expires];
+        foreach ($extraFields as $extraField) {
+            $fields[] = base64_encode($extraField);
+        }
+
+        // matches hash logic in the class
+        return base64_encode(hash_hmac('sha256', implode(':', $fields), 's3cret'));
+    }
+
+    private function createLinker(array $options = []): LoginLinkHandler
+    {
+        $options = array_merge([
+            'lifetime' => 600,
+            'route_name' => 'app_check_login_link_route',
+        ], $options);
+
+        return new LoginLinkHandler($this->router, $this->userProvider, $this->propertyAccessor, ['emailProperty', 'passwordProperty'], 's3cret', $options, $this->expiredLinkStorage);
+    }
+}
+
+class TestLoginLinkHandlerUser implements UserInterface
+{
+    public $username;
+    public $emailProperty;
+    public $passwordProperty;
+
+    public function __construct($username, $emailProperty, $passwordProperty)
+    {
+        $this->username = $username;
+        $this->emailProperty = $emailProperty;
+        $this->passwordProperty = $passwordProperty;
+    }
+
+    public function getRoles()
+    {
+        return [];
+    }
+
+    public function getPassword()
+    {
+        return $this->passwordProperty;
+    }
+
+    public function getSalt()
+    {
+        return '';
+    }
+
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    public function eraseCredentials()
+    {
+    }
+}

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -25,6 +25,7 @@
         "symfony/property-access": "^4.4|^5.0"
     },
     "require-dev": {
+        "symfony/cache": "^4.4|^5.0",
         "symfony/rate-limiter": "^5.2",
         "symfony/routing": "^4.4|^5.0",
         "symfony/security-csrf": "^4.4|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | TODO

Hi!

This adds a Slack-style "magic link" login authenticator to the new login system: (A) enter your email into a form, (B) receive an email with a link in it (C) click that link and you are authenticated!

For most users, implementing this would require:

A) Create a [controller](https://github.com/weaverryan/symfony-magic-login-link-example/blob/master/src/Controller/MagicLinkLoginController.php) with the "enter your email" form and a route for the "check" functionality (similar to `form_login`)
B) Activate in `security.yaml`:

```yml
security:
    enable_authenticator_manager: true
    # ...
    firewalls:
        # ...
        main:
            # ...
            login_link:
                check_route: 'magic_link_verify'
                # this is an important and powerful option
                # An array of properties on your User that are used to sign the link.
                # If any of these change, all existing links will become invalid
                # tl;dr If you want the modification of ANY field to invalidate ALL existing magic links immediately,
                # then you can add it to this list. You could even add a "lastLoginLinkSentAt" to invalid
                # all existing login links when a new one is sent.
                signature_properties: [id, password, email]

                # optional - by default, links can be reused but have a 10 minute lifetime
                #max_uses: 3
                #used_link_cache: cache.app
```

Done! This will generate a URL that looks something like this:

> https://127.0.0.1:9033/login/verify?user=weaverryan@gmail.com&expires=1601342578&hash=YzE1ZDJlYjM3YTMyMjgwZDdkYzg2ZjFlMjZhN2E5ZWRmMzk3NjAxNjRjYThiMjMzNmIxYzAzYzQ4NmQ2Zjk4NA%3D%3D

We would implement a Maker command this config + login/controller. The implementation is done via a "signed URL" and an optional cache pool to "expire" links. The hash of the signed URL can contain any user fields you want, which give you a powerful mechanism to invalidate magic tokens on user data changes. See `signature_properties` above.

#### Security notes:

There is a LOT of variability about how secure these need to be: 

* A) Many/most implementation only allow links to be used ONE time. That is *possible* with this implementation, but is not the *default*. You CAN add a `max_uses` config which stores the expired links in a cache so they cannot be re-used. However, to make this work, you need to do more work by adding some "page" between the link the users clicks and *actually* using the login link. Why? Because unless you do this, email clients may follow the link to "preview" it and will "consume" the link.

* B) Many implementations will invalidate all other login links for a user when a new one is created. We do *not* do that, but that IS possible (and we could even generate the code for it) by adding a `lastLoginLinkSentAt` field to `User` and including this in `signature_properties`.

* C) We *do* invalidate all links if the user's email address is changed (assuming the `email` is included in `signature_properties`, which it should be). You can also invalidate on password change or whatever you want.

* D) Some implementations add a "state" so that you can only use the link on the same device that created it. That is, in many cases, quite annoying. We do not currently support that, but we could in the future (and the user could add it themselves).

Thanks!

#### TODOS:

* [x] A) more tests: functional (?) traits
* [ ] B) documentation
* [ ] C) MakerBundle PR
* [ ] D) Make sure we have what we need to allow that "in between" page
* [ ] E) Create a new cache pool instead of relying on cache.app?
