### PR TITLE
[Messenger] Improve error message readability

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -488,7 +488,7 @@ class ConnectionTest extends TestCase
     public function testObfuscatePasswordInDsn()
     {
         $this->expectException('AMQPException');
-        $this->expectExceptionMessage('Could not connect to the AMQP server. Please verify the provided DSN. ({"host":"localhost","port":5672,"vhost":"\/","login":"user","password":"********"})');
+        $this->expectExceptionMessage('Could not connect to the AMQP server. Please verify the provided DSN. ({"host":"localhost","port":5672,"vhost":"/","login":"user","password":"********"})');
         $factory = new TestAmqpFactory(
             $amqpConnection = $this->createMock(\AMQPConnection::class),
             $amqpChannel = $this->createMock(\AMQPChannel::class),

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -470,7 +470,7 @@ class Connection
                 $credentials['password'] = '********';
                 unset($credentials['delay']);
 
-                throw new \AMQPException(sprintf('Could not connect to the AMQP server. Please verify the provided DSN. (%s).', json_encode($credentials)), 0, $e);
+                throw new \AMQPException(sprintf('Could not connect to the AMQP server. Please verify the provided DSN. (%s).', json_encode($credentials, \JSON_UNESCAPED_SLASHES)), 0, $e);
             }
             $this->amqpChannel = $this->amqpFactory->createChannel($connection);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Since slashes are escaped, vhosts are not very readable:

![Capture d’écran 2020-09-14 à 14 37 53](https://user-images.githubusercontent.com/15314293/93088345-140cc880-f69a-11ea-9fc0-53e65ebd7573.png)

This minor PR unescape slashes in `json_encode`