### PR TITLE
[Form] Change 'cache_key' to AbstractRendererEngine::CACHE_KEY_VAR in BaseType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\Core\Type;
 
+use Symfony\Component\Form\AbstractRendererEngine;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -100,7 +101,7 @@ abstract class BaseType extends AbstractType
             // collection form have different types (dynamically), they should
             // be rendered differently.
             // https://github.com/symfony/symfony/issues/5038
-            'cache_key' => $uniqueBlockPrefix.'_'.$form->getConfig()->getType()->getBlockPrefix(),
+            AbstractRendererEngine::CACHE_KEY_VAR => $uniqueBlockPrefix.'_'.$form->getConfig()->getType()->getBlockPrefix(),
         ]);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The purpose of this change is to find all usages of AbstractRendererEngine::CACHE_KEY_VAR. Currently, if you search for AbstractRendererEngine::CACHE_KEY_VAR you will see only access to it, i.e. (`$view->vars[AbstractRendererEngine::CACHE_KEY_VAR]`), but you can't find it in write level. With this pull request you can see where is was used for write.
