### PR TITLE
[Notifier] Fix errors parsing in FirebaseTransport

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
@@ -73,7 +73,7 @@ final class FirebaseTransport extends AbstractTransport
             'json' => array_filter($options),
         ]);
 
-        $contentType = $response->getHeaders(false)['Content-Type'] ?? '';
+        $contentType = $response->getHeaders(false)['content-type'][0] ?? '';
         $jsonContents = 0 === strpos($contentType, 'application/json') ? $response->toArray(false) : null;
 
         if (200 !== $response->getStatusCode()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

I noticed that, when parsing the response, this transport use `getHeader()` like a `string[]` instead of `string[][]`. 

I did not test it and I'm not sure about this fix: could you have a look @Jeroeny ?