### PR TITLE
Allow DBAL 3 on Symfony 3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.6",
         "doctrine/data-fixtures": "^1.1",
-        "doctrine/dbal": "~2.4",
+        "doctrine/dbal": "~2.4||^3.0.0",
         "doctrine/orm": "~2.4,>=2.4.5",
         "doctrine/doctrine-bundle": "~1.4",
         "monolog/monolog": "~1.11",

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.6",
         "doctrine/data-fixtures": "^1.1",
-        "doctrine/dbal": "~2.4|~3.0",
+        "doctrine/dbal": "~2.4|^3.0",
         "doctrine/orm": "~2.4,>=2.4.5",
         "doctrine/doctrine-bundle": "~1.4",
         "monolog/monolog": "~1.11",

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "doctrine/annotations": "~1.0",
         "doctrine/cache": "~1.6",
         "doctrine/data-fixtures": "^1.1",
-        "doctrine/dbal": "~2.4||^3.0.0",
+        "doctrine/dbal": "~2.4|~3.0",
         "doctrine/orm": "~2.4,>=2.4.5",
         "doctrine/doctrine-bundle": "~1.4",
         "monolog/monolog": "~1.11",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -35,7 +35,7 @@
         "symfony/validator": "^3.2.5|~4.0",
         "symfony/translation": "~2.8|~3.0|~4.0",
         "doctrine/data-fixtures": "^1.1",
-        "doctrine/dbal": "~2.4",
+        "doctrine/dbal": "~2.4|^3.0",
         "doctrine/orm": "^2.4.5"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

In order to make Symfony 3.4 work on PHP 8, dbal 3 should be allowed as indicated there https://github.com/symfony/symfony/issues/36872

Edit note :

As tests are green on PHP 8 without dbal 3, it's useless to allow it right now