### PR TITLE
Add forward-compatible constants for Command return codes

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -29,6 +29,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Command
 {
+    public const SUCCESS = 0;
+    public const FAILURE = 1;
+
     /**
      * @var string|null The default command name
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | maybe
| Deprecations? | no
| Tickets       | Adds forward compatibility for new constants from #35478
| License       | MIT

In Symfony 5.0 it is mandatory to return an integer from Command::execute-methods.

In 5.1 two constants have been added to prevent having to write magic numbers or redefine constants for the two most used return codes.
This change includes those two constants in 4.4, to allow an easier transition to 5.1 compatible Commands.

I.e., now the constants can be used right away, rather than first changing all Commands to use magic numbers or custom constants and replacing those with these Symfony-constants after the upgrade to 5.1.