### PR TITLE
[FrameworkBundle] Fix xsd definition which prevent to add more than one workflow metadata

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -348,7 +348,7 @@
 
     <xsd:complexType name="metadata">
         <xsd:sequence>
-            <xsd:any minOccurs="0" processContents="lax"/>
+            <xsd:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
         </xsd:sequence>
     </xsd:complexType>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
@@ -10,6 +10,10 @@ $container->loadFromExtension('framework', [
                 FrameworkExtensionTest::class,
             ],
             'initial_marking' => ['draft'],
+            'metadata' => [
+                'title' => 'article workflow',
+                'description' => 'workflow for articles'
+            ],
             'places' => [
                 'draft',
                 'wait_for_journalist',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows.xml
@@ -35,6 +35,10 @@
                 <framework:from>approved_by_spellchecker</framework:from>
                 <framework:to>published</framework:to>
             </framework:transition>
+            <framework:metadata>
+                <framework:title>article workflow</framework:title>
+                <framework:description>workflow for articles</framework:description>
+            </framework:metadata>
         </framework:workflow>
 
         <framework:workflow name="pull_request">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/workflows.yml
@@ -5,6 +5,9 @@ framework:
             supports:
                 - Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest
             initial_marking: [draft]
+            metadata:
+                title: article workflow
+                description: workflow for articles
             places:
                 # simple format
                 - draft

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -55,6 +55,7 @@ use Symfony\Component\Validator\DependencyInjection\AddConstraintValidatorsPass;
 use Symfony\Component\Validator\Mapping\Loader\PropertyInfoLoader;
 use Symfony\Component\Validator\Util\LegacyTranslatorProxy;
 use Symfony\Component\Workflow;
+use Symfony\Component\Workflow\Metadata\InMemoryMetadataStore;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 abstract class FrameworkExtensionTest extends TestCase
@@ -242,6 +243,12 @@ abstract class FrameworkExtensionTest extends TestCase
         );
         $this->assertCount(4, $workflowDefinition->getArgument(1));
         $this->assertSame(['draft'], $workflowDefinition->getArgument(2));
+        $metadataStoreDefinition = $workflowDefinition->getArgument(3);
+        $this->assertSame(InMemoryMetadataStore::class, $metadataStoreDefinition->getClass());
+        $this->assertSame([
+            'title' => 'article workflow',
+            'description' => 'workflow for articles',
+        ], $metadataStoreDefinition->getArgument(0));
 
         $this->assertTrue($container->hasDefinition('state_machine.pull_request'), 'State machine is registered as a service');
         $this->assertSame('state_machine.abstract', $container->getDefinition('state_machine.pull_request')->getParent());
@@ -266,7 +273,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $metadataStoreDefinition = $stateMachineDefinition->getArgument(3);
         $this->assertInstanceOf(Definition::class, $metadataStoreDefinition);
-        $this->assertSame(Workflow\Metadata\InMemoryMetadataStore::class, $metadataStoreDefinition->getClass());
+        $this->assertSame(InMemoryMetadataStore::class, $metadataStoreDefinition->getClass());
 
         $workflowMetadata = $metadataStoreDefinition->getArgument(0);
         $this->assertSame(['title' => 'workflow title'], $workflowMetadata);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Fix xsd definition which prevent to add more than one workflow metadata (only in xml configuration format)