### PR TITLE
[Messenger] Allow to customize message type resolving

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -93,6 +93,7 @@ use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Transport\Serialization\Serializer as MessagerSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -1791,9 +1792,15 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('messenger.transport.beanstalkd.factory');
             $container->removeAlias(SerializerInterface::class);
         } else {
+            $context = $config['serializer']['symfony_serializer']['context'];
+            if (isset($context['type_resolver']) && $context['type_resolver']) {
+                $context[MessagerSerializer::TYPE_RESOLVER] = new Reference($context['type_resolver']);
+                unset($context['type_resolver']);
+            }
+
             $container->getDefinition('messenger.transport.symfony_serializer')
                 ->replaceArgument(1, $config['serializer']['symfony_serializer']['format'])
-                ->replaceArgument(2, $config['serializer']['symfony_serializer']['context']);
+                ->replaceArgument(2, $context);
             $container->setAlias('messenger.default_serializer', $config['serializer']['default_serializer']);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transport.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/messenger_transport.php
@@ -7,7 +7,10 @@ $container->loadFromExtension('framework', [
             'default_serializer' => 'messenger.transport.symfony_serializer',
             'symfony_serializer' => [
                 'format' => 'csv',
-                'context' => ['enable_max_depth' => true],
+                'context' => [
+                    'enable_max_depth' => true,
+                    'type_resolver' => 'App\Serializer\TypeResolver',
+                ],
             ],
         ],
         'transports' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transport.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/messenger_transport.xml
@@ -12,6 +12,7 @@
                 <framework:symfony-serializer format="csv">
                     <framework:context>
                         <framework:enable_max_depth>true</framework:enable_max_depth>
+                        <framework:type_resolver>App\Serializer\TypeResolver</framework:type_resolver>
                     </framework:context>
                 </framework:symfony-serializer>
             </framework:serializer>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transport.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/messenger_transport.yml
@@ -7,5 +7,6 @@ framework:
                 format: csv
                 context:
                     enable_max_depth: true
+                    type_resolver: 'App\Serializer\TypeResolver'
         transports:
             default: 'amqp://localhost/%2f/messages'

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -727,7 +727,10 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $serializerTransportDefinition = $container->getDefinition('messenger.transport.symfony_serializer');
         $this->assertSame('csv', $serializerTransportDefinition->getArgument(1));
-        $this->assertSame(['enable_max_depth' => true], $serializerTransportDefinition->getArgument(2));
+        $this->assertEquals([
+            'enable_max_depth' => true,
+            'messenger_type_resolver' => new Reference('App\Serializer\TypeResolver'),
+        ], $serializerTransportDefinition->getArgument(2));
     }
 
     public function testMessengerWithMultipleBuses()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -61,10 +61,10 @@ use Symfony\Component\Translation\DependencyInjection\TranslatorPass;
 use Symfony\Component\Validator\DependencyInjection\AddConstraintValidatorsPass;
 use Symfony\Component\Validator\Mapping\Loader\PropertyInfoLoader;
 use Symfony\Component\Workflow;
+use Symfony\Component\Workflow\Metadata\InMemoryMetadataStore;
 use Symfony\Component\Workflow\WorkflowEvents;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
-use Symfony\Component\Workflow\Metadata\InMemoryMetadataStore;
 
 abstract class FrameworkExtensionTest extends TestCase
 {

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
 * Removed the exception when dispatching a message with a `DispatchAfterCurrentBusStamp` and not in a context of another dispatch call
 * Added `WorkerMessageRetriedEvent`
 * Added `WorkerMessageReceivedEvent::setEnvelope()` and made event mutable
+* Added `TypeResolverInterface` and `DecodedAwareTypeResolverInterface` to allow to consume messages from a non-Symfony application.
 
 5.1.0
 -----

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -171,12 +171,12 @@ class SerializerTest extends TestCase
     {
         yield 'no_body' => [
             ['headers' => ['type' => 'bar']],
-            'Encoded envelope should have at least a "body" and some "headers".',
+            'Encoded envelope should have at least a "body".',
         ];
 
         yield 'no_headers' => [
             ['body' => '{}'],
-            'Encoded envelope should have at least a "body" and some "headers".',
+            'Encoded envelope does not have a "type" header.',
         ];
 
         yield 'no_headers_type' => [

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -314,18 +314,9 @@ class SerializerTest extends TestCase
      */
     public function testDecodingWithTypeResolver(array $serializerContext, array $encodedEnvelope, object $expectedInstance, bool $useFullSerializer)
     {
-        $interfaces = SerializerComponentInterface::class;
-
-        if ($useFullSerializer) {
-            $interfaces = [
-                $interfaces,
-                SerializerComponent\Encoder\DecoderInterface::class,
-                SerializerComponent\Normalizer\DenormalizerInterface::class,
-            ];
-        }
-
+        $serializerToMock = $useFullSerializer ? SymfonySerializerRealInterface::class : SerializerComponentInterface::class;
         $serializer = new Serializer(
-            $symfonySerializer = $this->createMock($interfaces),
+            $symfonySerializer = $this->createMock($serializerToMock),
             'json',
             $serializerContext
         );
@@ -413,4 +404,8 @@ class DummySymfonySerializerInvalidConstructor
     public function __construct(string $missingArgument)
     {
     }
+}
+
+interface SymfonySerializerRealInterface extends SerializerComponentInterface, SerializerComponent\Normalizer\NormalizerInterface, SerializerComponent\Normalizer\DenormalizerInterface, SerializerComponent\Encoder\EncoderInterface, SerializerComponent\Encoder\DecoderInterface
+{
 }

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/TypeResolver/HeaderTypeResolverTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/TypeResolver/HeaderTypeResolverTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport\Serialization\TypeResolver;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Transport\Serialization\TypeResolver\HeaderTypeResolver;
+
+final class HeaderTypeResolverTest extends TestCase
+{
+    public function testResolverWithTypeHeader()
+    {
+        $sut = new HeaderTypeResolver('class_type');
+
+        $class = $sut->resolve(['headers' => ['class_type' => 'App\MyClass']]);
+        $this->assertSame('App\MyClass', $class);
+    }
+
+    public function provideResolverWithoutTypeHeaderShouldThrowException(): array
+    {
+        return [
+            [['headers' => []]],
+            [[]],
+        ];
+    }
+
+    /**
+     * @dataProvider provideResolverWithoutTypeHeaderShouldThrowException
+     */
+    public function testResolverWithoutTypeHeaderShouldThrowException(array $encodedEnvelope)
+    {
+        $this->expectException(MessageDecodingFailedException::class);
+        $this->expectExceptionMessage('Encoded envelope does not have a "class_type" header.');
+
+        $sut = new HeaderTypeResolver('class_type');
+        $sut->resolve($encodedEnvelope);
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -100,18 +100,18 @@ class Serializer implements SerializerInterface
             return $this->serializer->deserialize($encodedEnvelope['body'], $type, $this->format, $context);
         }
 
-        if ($resolver instanceof DecodedAwareTypeResolverInterface) {
-            if (!$this->serializer instanceof DecoderInterface || !$this->serializer instanceof DenormalizerInterface) {
-                throw new MessageDecodingFailedException(sprintf('A serializer implementing "%s" and "%s" is needed to use "%s".', DecoderInterface::class, DenormalizerInterface::class, \get_class($resolver)));
-            }
-
-            $decodedBody = $this->serializer->decode($encodedEnvelope['body'], $this->format, $context);
-            $type = $resolver->resolve($encodedEnvelope, $decodedBody);
-
-            return $this->serializer->denormalize($decodedBody, $type, $this->format, $context);
+        if (!$resolver instanceof DecodedAwareTypeResolverInterface) {
+            throw new MessageDecodingFailedException(sprintf('"%s" must be an instance of "%s" or "%s", "%s" given.', self::TYPE_RESOLVER, TypeResolverInterface::class, DecodedAwareTypeResolverInterface::class, \is_object($resolver) ? \get_class($resolver) : \gettype($resolver)));
         }
 
-        throw new MessageDecodingFailedException(sprintf(sprintf('"%s" must be an instance of "%s" or "%s", "%s" given.', self::TYPE_RESOLVER, TypeResolverInterface::class, DecodedAwareTypeResolverInterface::class, \is_object($resolver) ? \get_class($resolver) : \gettype($resolver))));
+        if (!$this->serializer instanceof DecoderInterface || !$this->serializer instanceof DenormalizerInterface) {
+            throw new MessageDecodingFailedException(sprintf('A serializer implementing "%s" and "%s" is needed to use "%s".', DecoderInterface::class, DenormalizerInterface::class, \get_class($resolver)));
+        }
+
+        $decodedBody = $this->serializer->decode($encodedEnvelope['body'], $this->format, $context);
+        $type = $resolver->resolve($encodedEnvelope, $decodedBody);
+
+        return $this->serializer->denormalize($decodedBody, $type, $this->format, $context);
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -69,12 +69,8 @@ class Serializer implements SerializerInterface
      */
     public function decode(array $encodedEnvelope): Envelope
     {
-        $headersRequired = !isset($this->context[self::TYPE_RESOLVER]) || $this->context[self::TYPE_RESOLVER] instanceof HeaderTypeResolver;
-        if (empty($encodedEnvelope['body']) || ($headersRequired && empty($encodedEnvelope['headers']))) {
-            $message = $headersRequired ?
-                'Encoded envelope should have at least a "body" and some "headers".' :
-                'Encoded envelope should have at least a "body".';
-            throw new MessageDecodingFailedException($message);
+        if (empty($encodedEnvelope['body'])) {
+            throw new MessageDecodingFailedException('Encoded envelope should have at least a "body".');
         }
 
         $stamps = $this->decodeStamps($encodedEnvelope);

--- a/src/Symfony/Component/Messenger/Transport/Serialization/TypeResolver/DecodedAwareTypeResolverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/TypeResolver/DecodedAwareTypeResolverInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Serialization\TypeResolver;
+
+/**
+ * Resolve denormalization class based on message headers and decoded data.
+ *
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ */
+interface DecodedAwareTypeResolverInterface
+{
+    public function resolve(array $encodedEnvelope, array $body): string;
+}

--- a/src/Symfony/Component/Messenger/Transport/Serialization/TypeResolver/DecodedAwareTypeResolverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/TypeResolver/DecodedAwareTypeResolverInterface.php
@@ -18,5 +18,10 @@ namespace Symfony\Component\Messenger\Transport\Serialization\TypeResolver;
  */
 interface DecodedAwareTypeResolverInterface
 {
+    /**
+     * @return string the FQDN class to use as deserialization format
+     *
+     * @param array $body decoded message body
+     */
     public function resolve(array $encodedEnvelope, array $body): string;
 }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/TypeResolver/HeaderTypeResolver.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/TypeResolver/HeaderTypeResolver.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Serialization\TypeResolver;
+
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+
+/**
+ * Resolve denormalization class based on a message header value.
+ *
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ */
+final class HeaderTypeResolver implements TypeResolverInterface
+{
+    /**
+     * @var string
+     */
+    private $field;
+
+    public function __construct(string $field = 'type')
+    {
+        $this->field = $field;
+    }
+
+    public function resolve(array $encodedEnvelope): string
+    {
+        $headers = $encodedEnvelope['headers'] ?? [];
+        if (!isset($headers[$this->field]) || !$headers[$this->field]) {
+            throw new MessageDecodingFailedException(sprintf('Encoded envelope does not have a "%s" header.', $this->field));
+        }
+
+        return $headers[$this->field];
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/Serialization/TypeResolver/HeaderTypeResolver.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/TypeResolver/HeaderTypeResolver.php
@@ -20,23 +20,20 @@ use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
  */
 final class HeaderTypeResolver implements TypeResolverInterface
 {
-    /**
-     * @var string
-     */
-    private $field;
+    private $headerName;
 
-    public function __construct(string $field = 'type')
+    public function __construct(string $headerName = 'type')
     {
-        $this->field = $field;
+        $this->headerName = $headerName;
     }
 
     public function resolve(array $encodedEnvelope): string
     {
         $headers = $encodedEnvelope['headers'] ?? [];
-        if (!isset($headers[$this->field]) || !$headers[$this->field]) {
-            throw new MessageDecodingFailedException(sprintf('Encoded envelope does not have a "%s" header.', $this->field));
+        if (!isset($headers[$this->headerName]) || !$headers[$this->headerName]) {
+            throw new MessageDecodingFailedException(sprintf('Encoded envelope does not have a "%s" header.', $this->headerName));
         }
 
-        return $headers[$this->field];
+        return $headers[$this->headerName];
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Serialization/TypeResolver/TypeResolverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/TypeResolver/TypeResolverInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Transport\Serialization\TypeResolver;
+
+/**
+ * Resolve denormalization class based on message headers.
+ *
+ * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
+ */
+interface TypeResolverInterface
+{
+    public function resolve(array $encodedEnvelope): string;
+}

--- a/src/Symfony/Component/Messenger/Transport/Serialization/TypeResolver/TypeResolverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/TypeResolver/TypeResolverInterface.php
@@ -19,8 +19,6 @@ namespace Symfony\Component\Messenger\Transport\Serialization\TypeResolver;
 interface TypeResolverInterface
 {
     /**
-     * @throws \Symfony\Component\Messenger\Exception\MessageDecodingFailedException
-     *
      * @return string the FQDN class to use as deserialization format
      */
     public function resolve(array $encodedEnvelope): string;

--- a/src/Symfony/Component/Messenger/Transport/Serialization/TypeResolver/TypeResolverInterface.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/TypeResolver/TypeResolverInterface.php
@@ -18,5 +18,10 @@ namespace Symfony\Component\Messenger\Transport\Serialization\TypeResolver;
  */
 interface TypeResolverInterface
 {
+    /**
+     * @throws \Symfony\Component\Messenger\Exception\MessageDecodingFailedException
+     *
+     * @return string the FQDN class to use as deserialization format
+     */
     public function resolve(array $encodedEnvelope): string;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

For now messages types (classes names used by the handlers) are resolved in the following ways:
- Class name is included in the body with PHP native serialization
- Class name is in a `type` header with Symfony serializer.

A problem arises when the message comes from another application (potentially not a PHP/Symfony application):
- PHP native serialization can only be used with PHP apps
- Using Symfony serializer, the app that sends the message must use a header name imposed by the consumer and must know the consumer internal structure (the target class name). Unless I miss something, it seems not ideal.

This PR suggests to override this behavior introducing type resolvers.
- Implementing `TypeResolverInterface` allows to resolve a class depending on many headers of the message (that are not necessarily a classname, so the sender doesn't have to know which application will consume the message)
- To go further, `DecodedAwareTypeResolverInterface` allows to resolve a class even without headers, based on the message decoded body.

## Exemple with non-class header value

Given a message with a header `type` (any other header name can be used) with value `mytype` is received:
```yaml
# config/packages/messenger.yaml
framework:
    #...
    messenger:
        serializer:
            default_serializer: messenger.transport.symfony_serializer
            symfony_serializer:
                format: json
                context:
                    type_resolver: 'App\Serializer\TypeResolver'
```
```php
namespace App\Serializer;

use Symfony\Component\Messenger\Transport\Serialization\TypeResolver\TypeResolverInterface;

class TypeResolver implements TypeResolverInterface
{
    //... 
   
    public function resolve(array $encodedEnvelope): string
    {
        $type = $encodedEnvelope['headers']['type'] ?? '';
        $deserializationType = /* Some stuff to transform 'mytype' to a class name to use in deserialization process (or throw a MessageDecodingFailedException) */;

        return $deserializationType;
    }    
}
```

## Exemple without headers usage

```json
{
  "user_id": 4711,
  "newsletter_id": "new-updates",
  "status": "subscribed"
}
```
Given the message body above is received:
```yaml
# config/packages/messenger.yaml
framework:
    #...
    messenger:
        serializer:
            default_serializer: messenger.transport.symfony_serializer
            symfony_serializer:
                format: json
                context:
                    type_resolver: 'App\Serializer\TypeResolver'
```
```php
namespace App\Serializer;

use  App\Message\NewsletterMessage;
use Symfony\Component\Messenger\Transport\Serialization\TypeResolver\DecodedAwareTypeResolverInterface;

class TypeResolver implements DecodedAwareTypeResolverInterface
{
    //... 
   
    public function resolve(array $encodedEnvelope, array $body): string
    {
        if (isset($body['newsletter_id']) {
            return NewsletterMessage::class;
        }
         
        // Some stuff to process other cases or throw a MessageDecodingFailedException
        // Headers from $encodedEnvelope can also be used like in the first example
    }    
}
```
