### PR TITLE
Add createNamedFromBuilder and createNamedFrom to AbstractController

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2696,3 +2696,4 @@ Symfony is the result of the work of many people who made the code better
  - Vladislav Vlastovskiy (vlastv)
  - RENAUDIN Xavier (xorrox)
  - Yannick Vanhaeren (yvh)
+ - Kilian Riou (redheness)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2696,4 +2696,3 @@ Symfony is the result of the work of many people who made the code better
  - Vladislav Vlastovskiy (vlastv)
  - RENAUDIN Xavier (xorrox)
  - Yannick Vanhaeren (yvh)
- - Kilian Riou (redheness)

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * added `framework.http_client.retry_failing` configuration tree
  * added `assertCheckboxChecked()` and `assertCheckboxNotChecked()` in `WebTestCase`
  * added `assertFormValue()` and `assertNoFormValue()` in `WebTestCase`
+ * Added `createNamedFormBuilder` method to `AbstractController`
 
 5.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -13,7 +13,7 @@ CHANGELOG
  * added `framework.http_client.retry_failing` configuration tree
  * added `assertCheckboxChecked()` and `assertCheckboxNotChecked()` in `WebTestCase`
  * added `assertFormValue()` and `assertNoFormValue()` in `WebTestCase`
- * Added `createNamedFormBuilder` method to `AbstractController`
+ * Added `createNamedFormBuilder` and `createNamedForm` methods to `AbstractController`
 
 5.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -326,6 +326,14 @@ abstract class AbstractController implements ServiceSubscriberInterface
     {
         return $this->container->get('form.factory')->create($type, $data, $options);
     }
+    
+    /**
+    * Creates and returns a Form instance from the type of the form.
+    */
+    protected function createNamedForm(string $name, string $type, $data = null, array $options = []): FormInterface
+    {
+        return $this->container->get('form.factory')->createNamed($name, $type, $data, $options);
+    }
 
     /**
      * Creates and returns a form builder instance.

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -334,7 +334,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
     {
         return $this->container->get('form.factory')->createBuilder(FormType::class, $data, $options);
     }
-    
+
     /**
      * Creates and returns a named form builder instance.
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -334,6 +334,14 @@ abstract class AbstractController implements ServiceSubscriberInterface
     {
         return $this->container->get('form.factory')->createBuilder(FormType::class, $data, $options);
     }
+    
+    /**
+     * Creates and returns a named form builder instance.
+     */
+    protected function createNamedFormBuilder(string $name, $data = null, array $options = []): FormBuilderInterface
+    {
+        return $this->container->get('form.factory')->createNamedBuilder($name, FormType::class, $data, $options);
+    }
 
     /**
      * Shortcut to return the Doctrine Registry service.

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -326,10 +326,10 @@ abstract class AbstractController implements ServiceSubscriberInterface
     {
         return $this->container->get('form.factory')->create($type, $data, $options);
     }
-    
+
     /**
-    * Creates and returns a Form instance from the type of the form.
-    */
+     * Creates and returns a Form instance from the type of the form.
+     */
     protected function createNamedForm(string $name, string $type, $data = null, array $options = []): FormInterface
     {
         return $this->container->get('form.factory')->createNamed($name, $type, $data, $options);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -529,7 +529,7 @@ class AbstractControllerTest extends TestCase
 
         $this->assertEquals($formBuilder, $controller->createFormBuilder('foo'));
     }
-    
+
     public function testCreateNamedFormBuilder()
     {
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilderInterface')->getMock();
@@ -542,7 +542,7 @@ class AbstractControllerTest extends TestCase
 
         $controller = $this->createController();
         $controller->setContainer($container);
-        
+
         $this->assertEquals($formBuilder, $controller->createNamedFormBuilder('foo', 'bar'));
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -517,16 +517,16 @@ class AbstractControllerTest extends TestCase
     public function testCreateNamedForm()
     {
         $form = new Form($this->getMockBuilder(FormConfigInterface::class)->getMock());
-        
+
         $formFactory = $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();
         $formFactory->expects($this->once())->method('createNamed')->willReturn($form);
-        
+
         $container = new Container();
         $container->set('form.factory', $formFactory);
-        
+
         $controller = $this->createController();
         $controller->setContainer($container);
-        
+
         $this->assertEquals($form, $controller->createNamedForm('foo', 'bar'));
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -514,6 +514,22 @@ class AbstractControllerTest extends TestCase
         $this->assertEquals($form, $controller->createForm('foo'));
     }
 
+    public function testCreateNamedForm()
+    {
+        $form = new Form($this->getMockBuilder(FormConfigInterface::class)->getMock());
+        
+        $formFactory = $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();
+        $formFactory->expects($this->once())->method('createNamed')->willReturn($form);
+        
+        $container = new Container();
+        $container->set('form.factory', $formFactory);
+        
+        $controller = $this->createController();
+        $controller->setContainer($container);
+        
+        $this->assertEquals($form, $controller->createNamedForm('foo', 'bar'));
+    }
+
     public function testCreateFormBuilder()
     {
         $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilderInterface')->getMock();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -529,6 +529,22 @@ class AbstractControllerTest extends TestCase
 
         $this->assertEquals($formBuilder, $controller->createFormBuilder('foo'));
     }
+    
+    public function testCreateNamedFormBuilder()
+    {
+        $formBuilder = $this->getMockBuilder('Symfony\Component\Form\FormBuilderInterface')->getMock();
+
+        $formFactory = $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();
+        $formFactory->expects($this->once())->method('createNamedBuilder')->willReturn($formBuilder);
+
+        $container = new Container();
+        $container->set('form.factory', $formFactory);
+
+        $controller = $this->createController();
+        $controller->setContainer($container);
+        
+        $this->assertEquals($formBuilder, $controller->createNamedFormBuilder('foo', 'bar'));
+    }
 
     public function testGetDoctrine()
     {


### PR DESCRIPTION
This new method allow the user to use the `createNamedBuilder()` and `createNamedForm()` methods from the controller.
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs/form/form_customization.rst#ChangingtheFormName

[Controller] Add createNamedFromBuilder() method
[Controller] Add createNamedFrom() method