### PR TITLE
[HttpKernel] Do not override max_redirects option in HttpClientKernel

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpClientKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpClientKernel.php
@@ -35,7 +35,7 @@ final class HttpClientKernel implements HttpKernelInterface
 
     public function __construct(HttpClientInterface $client = null)
     {
-        if (!class_exists(HttpClient::class)) {
+        if (null === $client && !class_exists(HttpClient::class)) {
             throw new \LogicException(sprintf('You cannot use "%s" as the HttpClient component is not installed. Try running "composer require symfony/http-client".', __CLASS__));
         }
 
@@ -53,7 +53,6 @@ final class HttpClientKernel implements HttpKernelInterface
         $response = $this->client->request($request->getMethod(), $request->getUri(), [
             'headers' => $headers,
             'body' => $body,
-            'max_redirects' => 0,
         ] + $request->attributes->get('http_client_options', []));
 
         $response = new Response($response->getContent(!$catch), $response->getStatusCode(), $response->getHeaders(!$catch));

--- a/src/Symfony/Component/HttpKernel/Tests/HttpClientKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpClientKernelTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpClientKernel;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class HttpClientKernelTest extends TestCase
+{
+    public function testHandlePassesMaxRedirectsHttpClientOption()
+    {
+        $request = new Request();
+        $request->attributes->set('http_client_options', ['max_redirects' => 50]);
+
+        $response = $this->getMockBuilder(ResponseInterface::class)->getMock();
+        $response->expects($this->once())->method('getStatusCode')->willReturn(200);
+
+        $client = $this->getMockBuilder(HttpClientInterface::class)->getMock();
+        $client
+            ->expects($this->once())
+            ->method('request')
+            ->willReturnCallback(function (string $method, string $uri, array $options) use ($request, $response) {
+                $this->assertSame($request->getMethod(), $method);
+                $this->assertSame($request->getUri(), $uri);
+                $this->assertArrayHasKey('max_redirects', $options);
+                $this->assertSame(50, $options['max_redirects']);
+
+                return $response;
+            });
+
+        $kernel = new HttpClientKernel($client);
+        $kernel->handle($request);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -19,6 +19,7 @@
         "php": ">=7.1.3",
         "symfony/error-handler": "^4.4",
         "symfony/event-dispatcher": "^4.4",
+        "symfony/http-client-contracts": "^1.1|^2",
         "symfony/http-foundation": "^4.4|^5.0",
         "symfony/polyfill-ctype": "^1.8",
         "symfony/polyfill-php73": "^1.9",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38207
| License       | MIT
| Doc PR        | -

As [proposed](https://github.com/symfony/symfony/issues/38207#issuecomment-693382336) by @nicolas-grekas this pull request removes the `max_redirects` setting in the `\Symfony\Component\HttpKernel\HttpClientKernel::handle` method.

It solves the issue that requests made by the `\Symfony\Component\HttpClient\CachingHttpClient` wouldn't follow redirects as described in the linked issue.
