### PR TITLE
Accessibility improvements for Symfony profiler toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -112,7 +112,7 @@
     display: inline-block;
 }
 .sf-toolbar-block .sf-toolbar-value {
-    color: #F5F5F5;
+    color: #fff;
     font-size: 13px;
     line-height: 36px;
     padding: 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | #38205 
| License       | MIT

Fixes accessibility issues reported by pa11y, e.g.:
```
 • This element has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 4.13:1. Recommendation:  change text
   colour to #fff.

   (#sfToolbarMainContent-5a7255 > div:nth-child(8) > a > div > span)

   <span class="sf-toolbar-value">47</span>
```
