### PR TITLE
[Console] Add Question::setDefault

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+* Added `Question::setDefault()`
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -63,6 +63,18 @@ class Question
     }
 
     /**
+     * Changes the default answer.
+     *
+     * @return mixed
+     */
+    public function setDefault($default = null)
+    {
+        return $this->default = $default;
+
+        return $this;
+    }
+
+    /**
      * Returns whether the user response accepts newline characters.
      */
     public function isMultiline(): bool

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -69,7 +69,7 @@ class Question
      */
     public function setDefault($default = null)
     {
-        return $this->default = $default;
+        $this->default = $default;
 
         return $this;
     }

--- a/src/Symfony/Component/Console/Tests/Question/QuestionTest.php
+++ b/src/Symfony/Component/Console/Tests/Question/QuestionTest.php
@@ -45,6 +45,7 @@ class QuestionTest extends TestCase
         $question = new Question('Test question', 'Default value');
         $question->setDefault('A New Default');
         self::assertSame('A New Default', $question->getDefault());
+        self::assertSame('Question', get_class($question));
     }
 
     public function testGetDefaultDefault()

--- a/src/Symfony/Component/Console/Tests/Question/QuestionTest.php
+++ b/src/Symfony/Component/Console/Tests/Question/QuestionTest.php
@@ -40,6 +40,13 @@ class QuestionTest extends TestCase
         self::assertSame('Default value', $question->getDefault());
     }
 
+    public function testSetDefault()
+    {
+        $question = new Question('Test question', 'Default value');
+        $question->setDefault('A New Default');
+        self::assertSame('A New Default', $question->getDefault());
+    }
+
     public function testGetDefaultDefault()
     {
         self::assertNull($this->question->getDefault());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | documented with getDefault
<!--
This adds a setDefault method to the Question class so that the default can be changed after object creation.  This is useful when eg. reading in config after the questions have been created, and changing the defaults based on the config.  

Could not find any documentation for getDefault, so I added the documentation for setDefault right next to it (ie. there is none).  

Could also not figure out a way to run tests without submitting a pull request.  

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->
