### PR TITLE
[Cache] Allow cache tags to be objects implementing __toString()

### DIFF
--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -119,9 +119,10 @@ final class CacheItem implements ItemInterface
             $tags = [$tags];
         }
         foreach ($tags as $tag) {
-            if (!\is_string($tag)) {
-                throw new InvalidArgumentException(sprintf('Cache tag must be string, "%s" given.', \is_object($tag) ? \get_class($tag) : \gettype($tag)));
+            if (!\is_string($tag) && !(\is_object($tag) && method_exists($tag, '__toString'))) {
+                throw new InvalidArgumentException(sprintf('Cache tag must be string or object that implements __toString(), "%s" given.', \is_object($tag) ? \get_class($tag) : \gettype($tag)));
             }
+            $tag = (string) $tag;
             if (isset($this->newMetadata[self::METADATA_TAGS][$tag])) {
                 continue;
             }

--- a/src/Symfony/Component/Cache/Tests/CacheItemTest.php
+++ b/src/Symfony/Component/Cache/Tests/CacheItemTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Cache\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\CacheItem;
+use Symfony\Component\Cache\Tests\Fixtures\StringableTag;
 
 class CacheItemTest extends TestCase
 {
@@ -61,9 +62,11 @@ class CacheItemTest extends TestCase
 
         $this->assertSame($item, $item->tag('foo'));
         $this->assertSame($item, $item->tag(['bar', 'baz']));
+        $this->assertSame($item, $item->tag(new StringableTag('qux')));
+        $this->assertSame($item, $item->tag([new StringableTag('quux'), new StringableTag('quuux')]));
 
         (\Closure::bind(function () use ($item) {
-            $this->assertSame(['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz'], $item->newMetadata[CacheItem::METADATA_TAGS]);
+            $this->assertSame(['foo' => 'foo', 'bar' => 'bar', 'baz' => 'baz', 'qux' => 'qux', 'quux' => 'quux', 'quuux' => 'quuux'], $item->newMetadata[CacheItem::METADATA_TAGS]);
         }, $this, CacheItem::class))();
     }
 

--- a/src/Symfony/Component/Cache/Tests/Fixtures/StringableTag.php
+++ b/src/Symfony/Component/Cache/Tests/Fixtures/StringableTag.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Fixtures;
+
+class StringableTag
+{
+    /**
+     * @var string
+     */
+    private $tag;
+
+    public function __construct(string $tag)
+    {
+        $this->tag = $tag;
+    }
+
+    public function __toString(): string
+    {
+        return $this->tag;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | maybe
| New feature?  | maybe
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |


`\Symfony\Contracts\Cache\CacheInterface::get(string $key, …)` implicitly converts objects with `__toString` while `CacheItem::tag()` will throw an exception. That’s a bit of a sharp edge.