### PR TITLE
[HttpFoundation] Add Request::toArray() for JSON content

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * added `HeaderUtils::parseQuery()`: it does the same as `parse_str()` but preserves dots in variable names
  * added `File::getContent()`
  * added ability to use comma separated ip addresses for `RequestMatcher::matchIps()`
+ * added `Request::toArray()` to parse a JSON request body to an array
  * added `RateLimiter\RequestRateLimiterInterface` and `RateLimiter\AbstractRequestRateLimiter`
 
 5.1.0

--- a/src/Symfony/Component/HttpFoundation/Exception/JsonException.php
+++ b/src/Symfony/Component/HttpFoundation/Exception/JsonException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Exception;
+
+/**
+ * Thrown by Request::toArray() when the content cannot be JSON-decoded.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+final class JsonException extends \UnexpectedValueException implements RequestExceptionInterface
+{
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Exception\JsonException;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -1248,6 +1249,30 @@ class RequestTest extends TestCase
             ['delete'],
             ['patch'],
         ];
+    }
+
+    public function testToArrayEmpty()
+    {
+        $req = new Request();
+        $this->expectException(JsonException::class);
+        $this->expectExceptionMessage('Response body is empty.');
+        $req->toArray();
+    }
+
+    public function testToArrayNonJson()
+    {
+        $req = new Request([], [], [], [], [], [], 'foobar');
+        $this->expectException(JsonException::class);
+        $this->expectExceptionMessageMatches('|Could not decode request body.+|');
+        $req->toArray();
+    }
+
+    public function testToArray()
+    {
+        $req = new Request([], [], [], [], [], [], json_encode([]));
+        $this->assertEquals([], $req->toArray());
+        $req = new Request([], [], [], [], [], [], json_encode(['foo' => 'bar']));
+        $this->assertEquals(['foo' => 'bar'], $req->toArray());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | ni
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The past few months I've been working more and more with javascript and APIs. I've written controllers that parse json from the request body. I've found myself copying code between projects so I looked at the possibility to add this code to the `Request` class itself. 

### Usage

```http
POST /add-user
Content-Type: application/json

{"name": "Tobias", "email": "tobias.nyholm@gmail.com"}
```

```php
use Symfony\Component\HttpFoundation\Exception\JsonException;
use Symfony\Component\HttpFoundation\Request;
use Symfony\Component\HttpFoundation\JsonResponse;

class MyController
    // ...
    public function addUser(Request $request): JsonResponse
    {
        try {
            $data = $request->toArray();
        } catch (JsonException $e) {
            return new JsonResponse(['message'=>'Request does not contain valid json'], 415);
        }
        
        $command = new AddUser($data['email'] ?? '', $data['name'] ?? '');
        
        try {
            $this->commandBus->dispatch($command);
        } catch (ValidationFailedException $e) {
            return new JsonResponse(['message' => 'Unexpected JSON body'], 400);
        }
        
        return new JsonResponse(['message' => 'User successfully added']);
    }
}
```
----------


I've searched but I have not found that this has been proposed before.. With is strange.. ¯\\_(ツ)_/¯ 