### PR TITLE
WebProfiler 5.2 is incompatible with HttpKernel 5.1

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "symfony/config": "^4.4|^5.0",
         "symfony/framework-bundle": "^5.1",
-        "symfony/http-kernel": "^4.4|^5.0",
+        "symfony/http-kernel": "^5.2",
         "symfony/routing": "^4.4|^5.0",
         "symfony/twig-bundle": "^4.4|^5.0",
         "twig/twig": "^2.10|^3.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

I have upgraded WebProfilerBundle to master in my project. Afterwards, the profiler crashes with the following error.

<img width="1049" alt="Bildschirmfoto 2020-09-17 um 21 45 23" src="https://user-images.githubusercontent.com/1506493/93520652-1a67a280-f92f-11ea-8f05-c72cbd996f19.png">

Looks like the changes of #36364 require HttpKernel to be bumped to 5.2 as well, so this PR suggests to do just that.