### PR TITLE
[FrameworkBundle] loadRoutes shoud receive RoutingPhpFileLoader

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -152,7 +152,7 @@ trait MicroKernelTrait
     {
         $file = (new \ReflectionObject($this))->getFileName();
         /* @var RoutingPhpFileLoader $kernelLoader */
-        $kernelLoader = $loader->getResolver()->resolve($file);
+        $kernelLoader = $loader->getResolver()->resolve($file, 'php');
         $kernelLoader->setCurrentDir(\dirname($file));
         $collection = new RouteCollection();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| License       | MIT
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch master.
-->

In case when `sensio_framework_extra.router.annotations` options is set to `true` or not defined will throw this error

> In RoutingConfigurator.php line 28:
>                                                                                                                                                                                                                              
>  Argument 2 passed to Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator::__construct() must be an instance of Symfony\Component\Routing\Loader\PhpFileLoader, instance of Symfony\Component\Routing\Loader\AnnotationFileLoader given, called in /opt/app/vendor/symfony/framework-bundle/Kernel/MicroKernelTrait.php on line 176                                             
