### PR TITLE
[Yaml] fix parsing comments not prefixed by a space

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -127,7 +127,7 @@ class Inline
             }
 
             // some comments are allowed at the end
-            if (preg_replace('/\s+#.*$/A', '', substr($value, $i))) {
+            if (preg_replace('/\s*#.*$/A', '', substr($value, $i))) {
                 throw new ParseException(sprintf('Unexpected characters near "%s".', substr($value, $i)), self::$parsedLineNumber + 1, $value, self::$parsedFilename);
             }
 

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -860,4 +860,14 @@ class InlineTest extends TestCase
     {
         self::assertSame('-0123456789', Inline::parse('-0123456789'));
     }
+
+    public function testParseCommentNotPrefixedBySpaces()
+    {
+        self::assertSame('foo', Inline::parse('"foo"#comment'));
+    }
+
+    public function testParseUnquotedStringContainingHashTagNotPrefixedBySpace()
+    {
+        self::assertSame('foo#nocomment', Inline::parse('foo#nocomment'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38223
| License       | MIT
| Doc PR        | 