### PR TITLE
Make Translator::getLocale() behave the same as TranslatorTrait::getLocale()

### DIFF
--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -510,7 +510,6 @@ class TranslatorTest extends TestCase
     public function getValidLocalesTests()
     {
         return [
-            [''],
             ['fr'],
             ['francais'],
             ['FR'],

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -91,6 +91,10 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
      */
     public function __construct(string $locale, MessageFormatterInterface $formatter = null, string $cacheDir = null, bool $debug = false, array $cacheVary = [])
     {
+        if ('' === $locale) {
+            trigger_deprecation('symfony/translator', '5.2', sprintf('Passing "" as the $locale argument to %s::%s() is deprecated, it will throw an InvalidArgumentException in version 6.0.', static::class, __METHOD__));
+        }
+
         $this->setLocale($locale);
 
         if (null === $formatter) {
@@ -158,7 +162,7 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
      */
     public function getLocale()
     {
-        return $this->locale;
+        return $this->locale ?: \Locale::getDefault();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Relates to #38124  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

This is a follow-up PR on https://github.com/symfony/symfony/pull/38127 and a proposal for discussion.

While working on #38127 I realized that `Translator::getLocale()` and `TranslatorTrait::getLocale()` behave differently. For the `Translator` an empty locale is a valid locale and for the `TranslatorTrait` an empty locale will result in getting the default locale when calling `getLocale()`.

To make things more consistent, I thought it would be a good idea to deprecate the injection of en empty locale, so we can add a proper validation in `assertValidLocale(string $locale)` and throw an `InvalidArgumentException` in version 6.

/cc @ro0NL 