### PR TITLE
[EventDispatcher] drop logger mock in favor of using the BufferingLogger

### DIFF
--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -22,6 +22,7 @@
         "symfony/dependency-injection": "~3.3|~4.0",
         "symfony/expression-language": "~2.8|~3.0|~4.0",
         "symfony/config": "~2.8|~3.0|~4.0",
+        "symfony/debug": "~3.4|~4.4",
         "symfony/stopwatch": "~2.8|~3.0|~4.0",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/pull/37808#discussion_r469463688
| License       | MIT
| Doc PR        | 