### PR TITLE
[Intl] fix test by letting mock throw the actual expected exception

### DIFF
--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
@@ -144,7 +144,10 @@ class BundleEntryReaderTest extends TestCase
                 [self::RES_DIR, 'en_GB'],
                 [self::RES_DIR, 'en']
             )
-            ->willReturnOnConsecutiveCalls(self::$data, self::$fallbackData);
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new ResourceBundleNotFoundException()),
+                self::$fallbackData
+            );
 
         $this->assertSame('Lah', $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Entries', 'Bam']));
     }
@@ -283,7 +286,7 @@ class BundleEntryReaderTest extends TestCase
                 [self::RES_DIR, 'en_GB'],
                 [self::RES_DIR, 'en']
             )
-            ->willReturnOnConsecutiveCalls(['Foo' => 'Baz'], ['Foo' => 'Baz']);
+            ->willReturnOnConsecutiveCalls(['Foo' => 'Baz'], ['Foo' => 'Bar']);
 
         $this->reader->readEntry(self::RES_DIR, 'en_GB', ['Foo', 'Bar'], true);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37808
| License       | MIT
| Doc PR        | 

This fixes a mistake I made when rewriting the tests in #37808.