### PR TITLE
[Validator] fix lowest allowed version for the PHPUnit bridge

### DIFF
--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -34,7 +34,7 @@
         "symfony/expression-language": "^5.1",
         "symfony/cache": "^4.4|^5.0",
         "symfony/mime": "^4.4|^5.0",
-        "symfony/phpunit-bridge": "^5.1",
+        "symfony/phpunit-bridge": "^5.1.1",
         "symfony/property-access": "^4.4|^5.0",
         "symfony/property-info": "^4.4|^5.0",
         "symfony/translation": "^4.4|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Fixes the `deps=low` build for the Validator component by only allowing versions of the PHPUnit bridge that contain #37153.