### PR TITLE
[HttpClient] fix lowest allowed version of the HTTP client contracts

### DIFF
--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.2.5",
         "psr/log": "^1.0",
-        "symfony/http-client-contracts": "^2.1.1",
+        "symfony/http-client-contracts": "^2.2",
         "symfony/polyfill-php73": "^1.11",
         "symfony/polyfill-php80": "^1.15",
         "symfony/service-contracts": "^1.0|^2"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

fixes `deps=low` builds for the HttpClient component by making sure that the installed version of the HTTP client contracts package contains the changes from #37831