### PR TITLE
[HttpKernel] Auto-register kernel as an extension

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * content of request parameter `_password` is now also hidden
    in the request profiler raw content section
  * Allowed adding attributes on controller arguments that will be passed to argument resolvers.
+ * kernels implementing the `ExtensionInterface` will now be auto-registered to the container
 
 5.1.0
 -----

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -23,6 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\Dumper\Preloader;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\DependencyInjection\Loader\DirectoryLoader;
 use Symfony\Component\DependencyInjection\Loader\GlobFileLoader;
@@ -688,6 +689,9 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $container = new ContainerBuilder();
         $container->getParameterBag()->add($this->getKernelParameters());
 
+        if ($this instanceof ExtensionInterface) {
+            $container->registerExtension($this);
+        }
         if ($this instanceof CompilerPassInterface) {
             $container->addCompilerPass($this, PassConfig::TYPE_BEFORE_OPTIMIZATION, -10000);
         }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -473,6 +474,34 @@ EOF;
         $this->assertNotInstanceOf($containerClass, $kernel->getContainer());
         $this->assertFileExists($containerFile);
         $this->assertFileExists(\dirname($containerFile).'.legacy');
+    }
+
+    public function testKernelExtension()
+    {
+        $kernel = new class() extends CustomProjectDirKernel implements ExtensionInterface {
+            public function load(array $configs, ContainerBuilder $container)
+            {
+                $container->setParameter('test.extension-registered', true);
+            }
+
+            public function getNamespace()
+            {
+                return '';
+            }
+
+            public function getXsdValidationBasePath()
+            {
+                return false;
+            }
+
+            public function getAlias()
+            {
+                return 'test-extension';
+            }
+        };
+        $kernel->boot();
+
+        $this->assertTrue($kernel->getContainer()->getParameter('test.extension-registered'));
     }
 
     public function testKernelPass()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Symfony already supports having the kernel as an extension. This is evident by the fact that the [`config:dump-reference` and `debug:config`](https://github.com/symfony/symfony/pull/36186) commands check whether the kernel implements the `ExtensionInterface`. Nonetheless, it's still required to register the kernel manually as an extension.

With this PR the kernel will be automatically registered as an extension if it implements the `ExtensionInterface`. This is the same logic as when the kernel implements the `CompilerPassInterface`.