### PR TITLE
[HttpClient] Allow bearer token with colon

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -110,7 +110,7 @@ trait HttpClientTrait
             throw new InvalidArgumentException(sprintf('Option "auth_basic" must be string or an array, "%s" given.', \gettype($options['auth_basic'])));
         }
 
-        if (isset($options['auth_bearer']) && (!\is_string($options['auth_bearer']) || !preg_match('{^[-._=~+/0-9a-zA-Z]++$}', $options['auth_bearer']))) {
+        if (isset($options['auth_bearer']) && (!\is_string($options['auth_bearer']) || !preg_match('{^[-._=:~+/0-9a-zA-Z]++$}', $options['auth_bearer']))) {
             throw new InvalidArgumentException(sprintf('Option "auth_bearer" must be a string containing only characters from the base 64 alphabet, '.(\is_string($options['auth_bearer']) ? 'invalid string given.' : '"%s" given.'), \gettype($options['auth_bearer'])));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The JetBrains Hub (YouTrack API) creates tokens with a `perm:` prefix. This doesn't work right now, because HttpClient doesn't allow a colon in the bearer token.

As far as I can see, there is no reason to disallow the use of the semicolon in the bearer token, so this PR fixes it.

Example of a token: `perm:c3RlcGhhbg==.NTUtMw==.NiZw16agafhsQAShTvclhb78hyJh2H`