### PR TITLE
[String] allow passing null to string functions

### DIFF
--- a/src/Symfony/Component/String/Resources/functions.php
+++ b/src/Symfony/Component/String/Resources/functions.php
@@ -11,20 +11,22 @@
 
 namespace Symfony\Component\String;
 
-function u(string $string = ''): UnicodeString
+function u(?string $string = ''): UnicodeString
 {
-    return new UnicodeString($string);
+    return new UnicodeString($string ?? '');
 }
 
-function b(string $string = ''): ByteString
+function b(?string $string = ''): ByteString
 {
-    return new ByteString($string);
+    return new ByteString($string ?? '');
 }
 
 /**
  * @return UnicodeString|ByteString
  */
-function s(string $string): AbstractString
+function s(?string $string = ''): AbstractString
 {
+    $string = $string ?? '';
+
     return preg_match('//u', $string) ? new UnicodeString($string) : new ByteString($string);
 }

--- a/src/Symfony/Component/String/Tests/FunctionsTest.php
+++ b/src/Symfony/Component/String/Tests/FunctionsTest.php
@@ -13,25 +13,65 @@ namespace Symfony\Component\String\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\String\AbstractString;
+use function Symfony\Component\String\b;
 use Symfony\Component\String\ByteString;
 use function Symfony\Component\String\s;
+use function Symfony\Component\String\u;
 use Symfony\Component\String\UnicodeString;
 
 final class FunctionsTest extends TestCase
 {
     /**
-     * @dataProvider provideStrings
+     * @dataProvider provideSStrings
      */
-    public function testS(AbstractString $expected, string $input)
+    public function testS(AbstractString $expected, ?string $input)
     {
         $this->assertEquals($expected, s($input));
     }
 
-    public function provideStrings(): array
+    public function provideSStrings(): array
     {
         return [
+            [new UnicodeString(''), ''],
+            [new UnicodeString(''), null],
             [new UnicodeString('foo'), 'foo'],
             [new UnicodeString('अनुच्छेद'), 'अनुच्छेद'],
+            [new ByteString("b\x80ar"), "b\x80ar"],
+            [new ByteString("\xfe\xff"), "\xfe\xff"],
+        ];
+    }
+
+    /**
+     * @dataProvider provideUStrings
+     */
+    public function testU(UnicodeString $expected, ?string $input)
+    {
+        $this->assertEquals($expected, u($input));
+    }
+
+    public function provideUStrings(): array
+    {
+        return [
+            [new UnicodeString(''), ''],
+            [new UnicodeString(''), null],
+            [new UnicodeString('foo'), 'foo'],
+            [new UnicodeString('अनुच्छेद'), 'अनुच्छेद'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideBStrings
+     */
+    public function testB(ByteString $expected, ?string $input)
+    {
+        $this->assertEquals($expected, b($input));
+    }
+
+    public function provideBStrings(): array
+    {
+        return [
+            [new ByteString(''), ''],
+            [new ByteString(''), null],
             [new ByteString("b\x80ar"), "b\x80ar"],
             [new ByteString("\xfe\xff"), "\xfe\xff"],
         ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #38260 
| License       | MIT
| Doc PR        | n/a

I also added a default value for `s` to match the other functions.
