### PR TITLE
[ErrorHandler] Escape JSON encoded log context

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Resources/views/logs.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/logs.html.php
@@ -35,7 +35,7 @@
             <td>
                 <?= $this->formatLogMessage($log['message'], $log['context']); ?>
                 <?php if ($log['context']) { ?>
-                <pre class="text-muted prewrap m-t-5"><?= json_encode($log['context'], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES); ?></pre>
+                <pre class="text-muted prewrap m-t-5"><?= $this->escape(json_encode($log['context'], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES)); ?></pre>
                 <?php } ?>
             </td>
         </tr>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | eno <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Fixes https://github.com/symfony/symfony/issues/35569#issuecomment-581317792
Fixes https://github.com/symfony/symfony/issues/35569#issuecomment-696767559

The initial issue remains though (the webprofiler showing the logs tab in the exception panel), i'll try to give it another look sometime, but this is a quick win nevertheless.

cc @yceruto 