### PR TITLE
Deprecate public static read-only properties

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
@@ -65,8 +65,8 @@ class FlattenException
             $statusCode = 500;
         }
 
-        if (class_exists(Response::class) && isset(Response::$statusTexts[$statusCode])) {
-            $statusText = Response::$statusTexts[$statusCode];
+        if (class_exists(Response::class) && isset(Response::STATUS_TEXTS[$statusCode])) {
+            $statusText = Response::STATUS_TEXTS[$statusCode];
         } else {
             $statusText = 'Whoops, looks like something went wrong.';
         }

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -144,7 +144,7 @@ class Response
      *
      * @var array
      */
-    public static $statusTexts = [
+    public const STATUS_TEXTS = [
         100 => 'Continue',
         101 => 'Switching Protocols',
         102 => 'Processing',            // RFC2518
@@ -208,6 +208,11 @@ class Response
         510 => 'Not Extended',                                                // RFC2774
         511 => 'Network Authentication Required',                             // RFC6585
     ];
+
+    /**
+     * @deprecated since Symfony 5.2, use STATUS_TEXTS instead
+     */
+    public static $statusTexts = self::STATUS_TEXTS;
 
     /**
      * @throws \InvalidArgumentException When the HTTP status code is not valid
@@ -470,7 +475,7 @@ class Response
         }
 
         if (null === $text) {
-            $this->statusText = isset(self::$statusTexts[$code]) ? self::$statusTexts[$code] : 'unknown status';
+            $this->statusText = isset(self::STATUS_TEXTS[$code]) ? self::STATUS_TEXTS[$code] : 'unknown status';
 
             return $this;
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -1062,7 +1062,7 @@ class ResponseTest extends ResponseTestCase
      */
     public function testReasonPhraseDefaultsAgainstIana($code, $reasonPhrase)
     {
-        $this->assertEquals($reasonPhrase, Response::$statusTexts[$code]);
+        $this->assertEquals($reasonPhrase, Response::STATUS_TEXTS[$code]);
     }
 
     public function testSetContentSafe()

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -91,7 +91,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
             'format' => $request->getRequestFormat(),
             'content' => $content,
             'content_type' => $response->headers->get('Content-Type', 'text/html'),
-            'status_text' => isset(Response::$statusTexts[$statusCode]) ? Response::$statusTexts[$statusCode] : '',
+            'status_text' => isset(Response::STATUS_TEXTS[$statusCode]) ? Response::STATUS_TEXTS[$statusCode] : '',
             'status_code' => $statusCode,
             'request_query' => $request->query->all(),
             'request_request' => $request->request->all(),
@@ -153,7 +153,7 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                     'method' => $request->getMethod(),
                     'controller' => $this->parseController($request->attributes->get('_controller')),
                     'status_code' => $statusCode,
-                    'status_text' => Response::$statusTexts[(int) $statusCode],
+                    'status_text' => Response::STATUS_TEXTS[(int) $statusCode],
                 ]),
                 0, '/', null, $request->isSecure(), true, false, 'lax'
             ));

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -85,7 +85,7 @@ class Process implements \IteratorAggregate
      *
      * User-defined errors must use exit codes in the 64-113 range.
      */
-    public static $exitCodes = [
+    public const EXIT_CODES = [
         0 => 'OK',
         1 => 'General error',
         2 => 'Misuse of shell builtins',
@@ -127,6 +127,11 @@ class Process implements \IteratorAggregate
         // 158 - not defined
         159 => 'Bad syscall',
     ];
+
+    /**
+     * @deprecated since Symfony 5.2, use EXIT_CODES instead
+     */
+    public static $exitCodes = self::EXIT_CODES;
 
     /**
      * @param array          $command The command to run and its arguments listed as separate entries

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -66,9 +66,9 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         $this->docBlockFactory = $docBlockFactory ?: DocBlockFactory::createInstance();
         $this->contextFactory = new ContextFactory();
         $this->phpDocTypeHelper = new PhpDocTypeHelper();
-        $this->mutatorPrefixes = null !== $mutatorPrefixes ? $mutatorPrefixes : ReflectionExtractor::$defaultMutatorPrefixes;
-        $this->accessorPrefixes = null !== $accessorPrefixes ? $accessorPrefixes : ReflectionExtractor::$defaultAccessorPrefixes;
-        $this->arrayMutatorPrefixes = null !== $arrayMutatorPrefixes ? $arrayMutatorPrefixes : ReflectionExtractor::$defaultArrayMutatorPrefixes;
+        $this->mutatorPrefixes = null !== $mutatorPrefixes ? $mutatorPrefixes : ReflectionExtractor::DEFAULT_MUTATOR_PREFIXES;
+        $this->accessorPrefixes = null !== $accessorPrefixes ? $accessorPrefixes : ReflectionExtractor::DEFAULT_ACCESSOR_PREFIXES;
+        $this->arrayMutatorPrefixes = null !== $arrayMutatorPrefixes ? $arrayMutatorPrefixes : ReflectionExtractor::DEFAULT_ARRAY_MUTATOR_PREFIXES;
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -35,17 +35,17 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
     /**
      * @internal
      */
-    public static $defaultMutatorPrefixes = ['add', 'remove', 'set'];
+    public const DEFAULT_MUTATOR_PREFIXES = ['add', 'remove', 'set'];
 
     /**
      * @internal
      */
-    public static $defaultAccessorPrefixes = ['get', 'is', 'has', 'can'];
+    public const DEFAULT_ACCESSOR_PREFIXES = ['get', 'is', 'has', 'can'];
 
     /**
      * @internal
      */
-    public static $defaultArrayMutatorPrefixes = ['add', 'remove'];
+    public const DEFAULT_ARRAY_MUTATOR_PREFIXES = ['add', 'remove'];
 
     public const ALLOW_PRIVATE = 1;
     public const ALLOW_PROTECTED = 2;
@@ -75,9 +75,9 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      */
     public function __construct(array $mutatorPrefixes = null, array $accessorPrefixes = null, array $arrayMutatorPrefixes = null, bool $enableConstructorExtraction = true, int $accessFlags = self::ALLOW_PUBLIC, InflectorInterface $inflector = null)
     {
-        $this->mutatorPrefixes = null !== $mutatorPrefixes ? $mutatorPrefixes : self::$defaultMutatorPrefixes;
-        $this->accessorPrefixes = null !== $accessorPrefixes ? $accessorPrefixes : self::$defaultAccessorPrefixes;
-        $this->arrayMutatorPrefixes = null !== $arrayMutatorPrefixes ? $arrayMutatorPrefixes : self::$defaultArrayMutatorPrefixes;
+        $this->mutatorPrefixes = null !== $mutatorPrefixes ? $mutatorPrefixes : self::DEFAULT_MUTATOR_PREFIXES;
+        $this->accessorPrefixes = null !== $accessorPrefixes ? $accessorPrefixes : self::DEFAULT_ACCESSOR_PREFIXES;
+        $this->arrayMutatorPrefixes = null !== $arrayMutatorPrefixes ? $arrayMutatorPrefixes : self::DEFAULT_ARRAY_MUTATOR_PREFIXES;
         $this->enableConstructorExtraction = $enableConstructorExtraction;
         $this->methodReflectionFlags = $this->getMethodsFlags($accessFlags);
         $this->propertyReflectionFlags = $this->getPropertyFlags($accessFlags);

--- a/src/Symfony/Component/PropertyInfo/Type.php
+++ b/src/Symfony/Component/PropertyInfo/Type.php
@@ -36,7 +36,7 @@ class Type
      *
      * @var string[]
      */
-    public static $builtinTypes = [
+    public const BUILTIN_TYPES = [
         self::BUILTIN_TYPE_INT,
         self::BUILTIN_TYPE_FLOAT,
         self::BUILTIN_TYPE_STRING,
@@ -48,6 +48,11 @@ class Type
         self::BUILTIN_TYPE_NULL,
         self::BUILTIN_TYPE_ITERABLE,
     ];
+
+    /**
+     * @deprecated since Symfony 5.2, use BUILTIN_TYPES instead
+     */
+    public static $builtinTypes = self::BUILTIN_TYPES;
 
     private $builtinType;
     private $nullable;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -322,7 +322,7 @@ class PropertyNormalizerTest extends TestCase
         $obj = $this->normalizer->denormalize(['outOfScope' => true], PropertyDummy::class);
 
         $this->assertEquals(new PropertyDummy(), $obj);
-        $this->assertEquals('out_of_scope', PropertyDummy::$outOfScope);
+        $this->assertEquals('out_of_scope', PropertyDummy::OUT_OF_SCOPE);
     }
 
     public function testUnableToNormalizeObjectAttribute()
@@ -403,7 +403,7 @@ class PropertyNormalizerTest extends TestCase
 
 class PropertyDummy
 {
-    public static $outOfScope = 'out_of_scope';
+    public const OUT_OF_SCOPE = 'out_of_scope';
     public $foo;
     private $bar;
     protected $camelCase;

--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -39,7 +39,7 @@ class Email extends Constraint
      *
      * @internal
      */
-    public static $validationModes = [
+    public const VALIDATION_MODES = [
         self::VALIDATION_MODE_HTML5,
         self::VALIDATION_MODE_STRICT,
         self::VALIDATION_MODE_LOOSE,
@@ -51,7 +51,7 @@ class Email extends Constraint
 
     public function __construct($options = null)
     {
-        if (\is_array($options) && \array_key_exists('mode', $options) && !\in_array($options['mode'], self::$validationModes, true)) {
+        if (\is_array($options) && \array_key_exists('mode', $options) && !\in_array($options['mode'], self::VALIDATION_MODES, true)) {
             throw new InvalidArgumentException('The "mode" parameter value is not valid.');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -35,7 +35,7 @@ class EmailValidator extends ConstraintValidator
 
     public function __construct(string $defaultMode = Email::VALIDATION_MODE_LOOSE)
     {
-        if (!\in_array($defaultMode, Email::$validationModes, true)) {
+        if (!\in_array($defaultMode, Email::VALIDATION_MODES, true)) {
             throw new \InvalidArgumentException('The "defaultMode" parameter value is not valid.');
         }
 
@@ -72,7 +72,7 @@ class EmailValidator extends ConstraintValidator
             $constraint->mode = $this->defaultMode;
         }
 
-        if (!\in_array($constraint->mode, Email::$validationModes, true)) {
+        if (!\in_array($constraint->mode, Email::VALIDATION_MODES, true)) {
             throw new \InvalidArgumentException(sprintf('The "%s::$mode" parameter value is not valid.', get_debug_type($constraint)));
         }
 

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -21,7 +21,7 @@ use Symfony\Component\VarDumper\Exception\ThrowingCasterException;
  */
 abstract class AbstractCloner implements ClonerInterface
 {
-    public static $defaultCasters = [
+    public const DEFAULT_CASTERS = [
         '__PHP_Incomplete_Class' => ['Symfony\Component\VarDumper\Caster\Caster', 'castPhpIncompleteClass'],
 
         'Symfony\Component\VarDumper\Caster\CutStub' => ['Symfony\Component\VarDumper\Caster\StubCaster', 'castStub'],
@@ -176,6 +176,11 @@ abstract class AbstractCloner implements ClonerInterface
         'RdKafka\TopicConf' => ['Symfony\Component\VarDumper\Caster\RdKafkaCaster', 'castTopicConf'],
     ];
 
+    /**
+     * @deprecated since Symfony 5.2, use DEFAULT_CASTERS instead
+     */
+    public static $defaultCasters = self::DEFAULT_CASTERS;
+
     protected $maxItems = 2500;
     protected $maxString = -1;
     protected $minDepth = 1;
@@ -193,7 +198,7 @@ abstract class AbstractCloner implements ClonerInterface
     public function __construct(array $casters = null)
     {
         if (null === $casters) {
-            $casters = static::$defaultCasters;
+            $casters = static::DEFAULT_CASTERS;
         }
         $this->addCasters($casters);
     }


### PR DESCRIPTION
This goes a step further than #38213 and replaces public static arrays by public constants via a deprecation.
An arguable change because it is not possible to trigger deprecation messages. I opened this for discussion.
As the code to deprecate the static property is minimal it is also possible to leave it in for 2 major versions or any desired time...

I planned to just replace one for the moment but as there were less than feared I did all of them.

There are also a few protected static properties which potentially could be changed and one private static accessed via `static::`instead of `self::`
