### PR TITLE
Always require SQL comment hint

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Types/AbstractBinaryUidType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/AbstractBinaryUidType.php
@@ -79,4 +79,12 @@ abstract class AbstractBinaryUidType extends GuidType
             throw ConversionException::conversionFailed($value, $this->getName());
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }

--- a/src/Symfony/Bridge/Doctrine/Types/AbstractUidType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/AbstractUidType.php
@@ -69,4 +69,12 @@ abstract class AbstractUidType extends GuidType
 
         throw ConversionException::conversionFailed($value, $this->getName());
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The `GuidType` does not always return true, because it is mapped to the native uuid type if available. But `AbstractBinaryUidType` and `AbstractUidType`  are not mapped like that, so they always requires the comment hint to avoid issues when diffing the schema (the DB introspection would detect a `GuidType` and so a change would be needed).
