### PR TITLE
Add BinaryFileResponse::streamsEntireFile method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -356,4 +356,13 @@ class BinaryFileResponse extends Response
 
         return $this;
     }
+
+    /**
+     * Returns true if the entire file is streamed when calling sendContent().
+     * Usually this will return false when the client requests a specific range of the file with the Range header.
+     */
+    public function streamsEntireFile(): bool
+    {
+        return -1 === $this->maxlen && 0 === $this->offset;
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+4.4.14
+------
+
+ * [BC BREAK] added `streamsEntireFile()` to `BinaryFileResponse`.
+
 4.4.0
 -----
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/symfony/psr-http-message-bridge/issues/84
| License       | MIT
| Doc PR        | TODO

This method will return false when the client requests only a specific
range of a file.

See https://github.com/symfony/psr-http-message-bridge/issues/84

This method is needed for the `PsrHttpFactory` to know `BinaryFileResponse`s can pass a stream of the given file to the psr response or if the content needs to be loaded into memory (because only a `Range` of the file is streamed). As mentioned in the issue above, I'm not sure if this change is acceptable in a patch because it does have a theoretical BC break as `BinaryFileResponse` is not `final`.