### PR TITLE
[Translation] fall back to the en locale when the intl extension is not installed

### DIFF
--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -171,7 +171,7 @@ class Translator implements LegacyTranslatorInterface, TranslatorInterface, Tran
      */
     public function getLocale()
     {
-        return $this->locale ?? \Locale::getDefault();
+        return $this->locale ?? (class_exists(\Locale::class) ? \Locale::getDefault() : 'en');
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38279
| License       | MIT
| Doc PR        | 