### PR TITLE
[DomCrawler] Add checkbox assertions for functional tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Added `TemplateAwareDataCollectorInterface` and `AbstractDataCollector` to simplify custom data collector creation and leverage autoconfiguration
  * Add `cache.adapter.redis_tag_aware` tag to use `RedisCacheAwareAdapter`
  * added `framework.http_client.retry_failing` configuration tree
+ * added `assertCheckboxChecked()` and `assertCheckboxNotChecked()` in `WebTestCase`
 
 5.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Test/DomCrawlerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/DomCrawlerAssertionsTrait.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\Constraint\LogicalAnd;
 use PHPUnit\Framework\Constraint\LogicalNot;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Test\Constraint as DomCrawlerConstraint;
+use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorAttributeValueSame;
+use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorExists;
 
 /**
  * Ideas borrowed from Laravel Dusk's assertions.
@@ -80,6 +82,22 @@ trait DomCrawlerAssertionsTrait
         self::assertThat(self::getCrawler(), LogicalAnd::fromConstraints(
             new DomCrawlerConstraint\CrawlerSelectorExists("input[name=\"$fieldName\"]"),
             new LogicalNot(new DomCrawlerConstraint\CrawlerSelectorAttributeValueSame("input[name=\"$fieldName\"]", 'value', $expectedValue))
+        ), $message);
+    }
+
+    public static function assertCheckboxChecked(string $fieldName, string $message = ''): void
+    {
+        self::assertThat(self::getCrawler(), LogicalAnd::fromConstraints(
+            new CrawlerSelectorExists("input[name=\"$fieldName\"]"),
+            new CrawlerSelectorAttributeValueSame("input[name=\"$fieldName\"]", 'checked', 'checked')
+        ), $message);
+    }
+
+    public static function assertCheckboxNotChecked(string $fieldName, string $message = ''): void
+    {
+        self::assertThat(self::getCrawler(), LogicalAnd::fromConstraints(
+            new CrawlerSelectorExists("input[name=\"$fieldName\"]"),
+            new LogicalNot(new CrawlerSelectorAttributeValueSame("input[name=\"$fieldName\"]", 'checked', 'checked'))
         ), $message);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -220,6 +220,22 @@ class WebTestCaseTest extends TestCase
         $this->getCrawlerTester(new Crawler('<html><body><form><input type="text" name="password" value="pa$$">'))->assertInputValueNotSame('password', 'pa$$');
     }
 
+    public function testAssertCheckboxChecked()
+    {
+        $this->getCrawlerTester(new Crawler('<html><body><form><input type="checkbox" name="rememberMe" checked>'))->assertCheckboxChecked('rememberMe');
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('matches selector "input[name="rememberMe"]" and has a node matching selector "input[name="rememberMe"]" with attribute "checked" of value "checked".');
+        $this->getCrawlerTester(new Crawler('<html><body><form><input type="checkbox" name="rememberMe">'))->assertCheckboxChecked('rememberMe');
+    }
+
+    public function testAssertCheckboxNotChecked()
+    {
+        $this->getCrawlerTester(new Crawler('<html><body><form><input type="checkbox" name="rememberMe">'))->assertCheckboxNotChecked('rememberMe');
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('matches selector "input[name="rememberMe"]" and does not have a node matching selector "input[name="rememberMe"]" with attribute "checked" of value "checked".');
+        $this->getCrawlerTester(new Crawler('<html><body><form><input type="checkbox" name="rememberMe" checked>'))->assertCheckboxNotChecked('rememberMe');
+    }
+
     public function testAssertRequestAttributeValueSame()
     {
         $this->getRequestTester()->assertRequestAttributeValueSame('foo', 'bar');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Add new assertions for checkboxes, to use in functional tests.

Example:

```php
    public function testAssertCheckboxChecked()
    {
        $this->visit('/edit-form');

        $this->client->submitForm('Save', [
            'activateMembership' => 'on',
        ]);

        self::assertResponseIsSuccessful();
        // Check that the field is checked after the form was submitted
        self::assertCheckboxChecked('activateMembership');
    }
```

This wasn't possible to achieve with the existing `self::assertInputValueSame()` assertion.