### PR TITLE
[DomCrawler] Add `assertFormValue()` in `WebTestCase`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add `cache.adapter.redis_tag_aware` tag to use `RedisCacheAwareAdapter`
  * added `framework.http_client.retry_failing` configuration tree
  * added `assertCheckboxChecked()` and `assertCheckboxNotChecked()` in `WebTestCase`
+ * added `assertFormValue()` and `assertNoFormValue()` in `WebTestCase`
 
 5.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Test/DomCrawlerAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/DomCrawlerAssertionsTrait.php
@@ -101,6 +101,23 @@ trait DomCrawlerAssertionsTrait
         ), $message);
     }
 
+    public static function assertFormValue(string $formSelector, string $fieldName, string $value, string $message = ''): void
+    {
+        $node = self::getCrawler()->filter($formSelector);
+        self::assertNotEmpty($node, sprintf('Form "%s" not found.', $formSelector));
+        $values = $node->form()->getValues();
+        self::assertArrayHasKey($fieldName, $values, $message ?: sprintf('Field "%s" not found in form "%s".', $fieldName, $formSelector));
+        self::assertSame($value, $values[$fieldName]);
+    }
+
+    public static function assertNoFormValue(string $formSelector, string $fieldName, string $message = ''): void
+    {
+        $node = self::getCrawler()->filter($formSelector);
+        self::assertNotEmpty($node, sprintf('Form "%s" not found.', $formSelector));
+        $values = $node->form()->getValues();
+        self::assertArrayNotHasKey($fieldName, $values, $message ?: sprintf('Field "%s" has a value in form "%s".', $fieldName, $formSelector));
+    }
+
     private static function getCrawler(): Crawler
     {
         if (!$crawler = self::getClient()->getCrawler()) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -236,6 +236,22 @@ class WebTestCaseTest extends TestCase
         $this->getCrawlerTester(new Crawler('<html><body><form><input type="checkbox" name="rememberMe" checked>'))->assertCheckboxNotChecked('rememberMe');
     }
 
+    public function testAssertFormValue()
+    {
+        $this->getCrawlerTester(new Crawler('<html><body><form id="form"><input type="text" name="username" value="Fabien">', 'http://localhost'))->assertFormValue('#form', 'username', 'Fabien');
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Failed asserting that two strings are identical.');
+        $this->getCrawlerTester(new Crawler('<html><body><form id="form"><input type="text" name="username" value="Fabien">', 'http://localhost'))->assertFormValue('#form', 'username', 'Jane');
+    }
+
+    public function testAssertNoFormValue()
+    {
+        $this->getCrawlerTester(new Crawler('<html><body><form id="form"><input type="checkbox" name="rememberMe">', 'http://localhost'))->assertNoFormValue('#form', 'rememberMe');
+        $this->expectException(AssertionFailedError::class);
+        $this->expectExceptionMessage('Field "rememberMe" has a value in form "#form".');
+        $this->getCrawlerTester(new Crawler('<html><body><form id="form"><input type="checkbox" name="rememberMe" checked>', 'http://localhost'))->assertNoFormValue('#form', 'rememberMe');
+    }
+
     public function testAssertRequestAttributeValueSame()
     {
         $this->getRequestTester()->assertRequestAttributeValueSame('foo', 'bar');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Add new assertions for checking form values, to use in functional tests.

Example:

```php
    public function testForm()
    {
        $this->visit('/edit-form');

        self::assertNoFormValue('#form', 'activateMembership'); // checkboxes don't have values when unchecked
        self::assertFormValue('#form', 'trialPeriod', '15');

        $this->client->submitForm('Save', [
            'activateMembership' => 'on',
            'trialPeriod' => '7',
        ]);

        self::assertResponseIsSuccessful();
        self::assertFormValue('#form', 'activateMembership', 'on');
        self::assertFormValue('#form', 'trialPeriod', '7');
    }
```

I resorted to using the `->form()` API because:

- checking the value of checkboxes was not possible today via existing assertions (I opened #38287 for that)
- checking the value of selects was impossible using CSS selectors (as far as I know), but possible with the `->form()` helper