### PR TITLE
[OptionsResolver] Trigger a deprecated option message closure from other options

### DIFF
--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * added the `$closureTriggerOptions` argument to the `OptionsResolver::setDeprecated()` method.
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/OptionsResolver/Tests/Debug/OptionsResolverIntrospectorTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/Debug/OptionsResolverIntrospectorTest.php
@@ -257,13 +257,15 @@ class OptionsResolverIntrospectorTest extends TestCase
     {
         $resolver = new OptionsResolver();
         $resolver->setDefined('foo');
-        $resolver->setDeprecated('foo', 'vendor/package', '1.1', $closure = function (Options $options, $value) {});
+        $resolver->setDefined('bar');
+        $resolver->setDeprecated('foo', 'vendor/package', '1.1', $closure = function (Options $options, $value) {}, ['bar']);
 
         $debug = new OptionsResolverIntrospector($resolver);
         $this->assertSame([
             'package' => 'vendor/package',
             'version' => '1.1',
             'message' => $closure,
+            'closure_trigger_options' => ['bar'],
         ], $debug->getDeprecation('foo'));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Ref https://github.com/symfony/symfony/pull/37837

The idea is that some other options might need to trigger the execution of a deprecated option message \Closure. See the referenced PR for an example.

When a deprecated option logic involves other values, instead of having to deprecate all those options one by one to account for all the possible scenarios, we would only need to deprecate one and declare its "closure trigger options".