### PR TITLE
[OptionsResolver] Assert that the error type is valid in deprecations test

### DIFF
--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -518,7 +518,9 @@ class OptionsResolverTest extends TestCase
     {
         $count = 0;
         error_clear_last();
-        set_error_handler(function () use (&$count) {
+        set_error_handler(function (int $type) use (&$count) {
+            $this->assertSame(\E_USER_DEPRECATED, $type);
+
             ++$count;
 
             return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

A change in the code could cause a warning for example and still produce the expected number of errors and the expected last error. Checking the type of the error is a little bit better. The best would be to check all the expected deprecations one by one, maybe later? 😄