### PR TITLE
[ErrorHandler] Return false directly and remove unused variable

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorHandler.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorHandler.php
@@ -419,9 +419,8 @@ class ErrorHandler
         }
 
         if (!$type || (!$log && !$throw)) {
-            return !$silenced && $type && $log;
+            return false;
         }
-        $scope = $this->scopedErrors & $type;
 
         if (false !== strpos($message, "@anonymous\0")) {
             $logMessage = $this->parseAnonymousClass($message);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/37848
| License       | MIT
| Doc PR        | -

To return true, $type and $log both need to be true. But to enter the condition, one of them has to be false.

I also spotted an unused variable below so I removed it.