### PR TITLE
[Form] [Validator] When using group sequences on a form, sometimes constraints are ignored even though they should fail.

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorFunctionalTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorFunctionalTest.php
@@ -236,6 +236,34 @@ class FormValidatorFunctionalTest extends TestCase
         $this->assertInstanceOf(Length::class, $errors[0]->getCause()->getConstraint());
     }
 
+    public function testConstraintsInDifferentGroupsOnSingleFieldWithAdditionalFieldThatHasNoConstraintsAddedBeforeTheFieldWithConstraints()
+    {
+        $form = $this->formFactory->create(FormType::class, null, [
+            'validation_groups' => new GroupSequence(['group1', 'group2']),
+        ])
+            ->add('bar')
+            ->add('foo', TextType::class, [
+                'constraints' => [
+                    new NotBlank([
+                        'groups' => ['group1'],
+                    ]),
+                    new Length([
+                        'groups' => ['group2'],
+                        'max' => 3,
+                    ]),
+                ],
+            ]);
+        $form->submit([
+            'foo' => 'test@example.com',
+        ]);
+
+        $errors = $form->getErrors(true);
+
+        $this->assertFalse($form->isValid());
+        $this->assertCount(1, $errors);
+        $this->assertInstanceOf(Length::class, $errors[0]->getCause()->getConstraint());
+    }
+
     public function testCascadeValidationToChildFormsUsingPropertyPaths()
     {
         $form = $this->formFactory->create(FormType::class, null, [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes/no
| New feature?  | no
| Deprecations? | no
| License       | MIT

**Symfony version(s) affected**: >= 4.4.10

**Description**  
When using group sequences on a form, sometimes constraints are ignored even though they should fail. This appears to happen where there is a field with multiple constraints added with a group sequence and also an additional field that does not have any constraints whatsoever. It appears to matter whether the additional field is added before or after the field with the constraints that have a sequence.

My initial case was a much more complicated form, but this seems to be the root of the problem.

So far, i only have a failing test case. It is a copy of the test above with only one change: an additional field above the field that was already there.

- [ ] write actual fix

Because i had a failing test case, i decided to create a PR, but if you'd rather i make an issue, i can close this and do that instead.
