### PR TITLE
[Translation] Allow Translatable objects to be used as strings

### DIFF
--- a/src/Symfony/Component/Translation/Tests/TranslatableTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatableTest.php
@@ -27,7 +27,7 @@ class TranslatableTest extends TestCase
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', [$translatable->getMessage() => $translation], $locale, $translatable->getDomain());
 
-        $this->assertEquals($expected, Translatable::trans($translator, $translatable, $locale));
+        $this->assertSame($expected, Translatable::trans($translator, $translatable, $locale));
     }
 
     /**
@@ -39,7 +39,12 @@ class TranslatableTest extends TestCase
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', $messages, 'fr', '');
 
-        $this->assertEquals($expected, Translatable::trans($translator, $translatable, 'fr'));
+        $this->assertSame($expected, Translatable::trans($translator, $translatable, 'fr'));
+    }
+
+    public function testToString()
+    {
+        $this->assertSame('Symfony is great!', (string) new Translatable('Symfony is great!'));
     }
 
     public function getTransTests()

--- a/src/Symfony/Component/Translation/Translatable.php
+++ b/src/Symfony/Component/Translation/Translatable.php
@@ -29,6 +29,11 @@ final class Translatable
         $this->domain = $domain;
     }
 
+    public function __toString(): string
+    {
+        return $this->message;
+    }
+
     public function getMessage(): string
     {
         return $this->message;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Allow Translatable objects to be used as strings.
