### PR TITLE
[Form] Implement Twig helpers to get field variables

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * added support for translating `Translatable` objects
  * added the `t()` function to easily create `Translatable` objects
  * Added support for extracting messages from the `t()` function
+ * Added `field_*` Twig functions to access string values from Form fields
 
 5.0.0
 -----

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionFieldHelpersTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionFieldHelpersTest.php
@@ -1,0 +1,237 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\Extension;
+
+use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubTranslator;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\Test\FormIntegrationTestCase;
+
+class FormExtensionFieldHelpersTest extends FormIntegrationTestCase
+{
+    /**
+     * @var FormExtension
+     */
+    private $rawExtension;
+
+    /**
+     * @var FormExtension
+     */
+    private $translatorExtension;
+
+    /**
+     * @var FormView
+     */
+    private $view;
+
+    protected function getTypes()
+    {
+        return [new TextType(), new ChoiceType()];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rawExtension = new FormExtension();
+        $this->translatorExtension = new FormExtension(new StubTranslator());
+
+        $form = $this->factory->createNamedBuilder('register', FormType::class, ['username' => 'tgalopin'])
+            ->add('username', TextType::class, [
+                'label' => 'base.username',
+                'label_translation_parameters' => ['%label_brand%' => 'Symfony'],
+                'help' => 'base.username_help',
+                'help_translation_parameters' => ['%help_brand%' => 'Symfony'],
+                'translation_domain' => 'forms',
+            ])
+            ->add('choice_flat', ChoiceType::class, [
+                'choices' => [
+                    'base.yes' => 'yes',
+                    'base.no' => 'no',
+                ],
+                'choice_translation_domain' => 'forms',
+            ])
+            ->add('choice_grouped', ChoiceType::class, [
+                'choices' => [
+                    'base.europe' => [
+                        'base.fr' => 'fr',
+                        'base.de' => 'de',
+                    ],
+                    'base.asia' => [
+                        'base.cn' => 'cn',
+                        'base.jp' => 'jp',
+                    ],
+                ],
+                'choice_translation_domain' => 'forms',
+            ])
+            ->getForm()
+        ;
+
+        $form->get('username')->addError(new FormError('username.max_length'));
+
+        $this->view = $form->createView();
+    }
+
+    public function testFieldName()
+    {
+        $this->assertFalse($this->view->children['username']->isRendered());
+        $this->assertSame('register[username]', $this->rawExtension->getFieldName($this->view->children['username']));
+        $this->assertTrue($this->view->children['username']->isRendered());
+    }
+
+    public function testFieldValue()
+    {
+        $this->assertSame('tgalopin', $this->rawExtension->getFieldValue($this->view->children['username']));
+    }
+
+    public function testFieldLabel()
+    {
+        $this->assertSame('base.username', $this->rawExtension->getFieldLabel($this->view->children['username']));
+    }
+
+    public function testFieldTranslatedLabel()
+    {
+        $this->assertSame('[trans]base.username[/trans]', $this->translatorExtension->getFieldLabel($this->view->children['username']));
+    }
+
+    public function testFieldHelp()
+    {
+        $this->assertSame('base.username_help', $this->rawExtension->getFieldHelp($this->view->children['username']));
+    }
+
+    public function testFieldTranslatedHelp()
+    {
+        $this->assertSame('[trans]base.username_help[/trans]', $this->translatorExtension->getFieldHelp($this->view->children['username']));
+    }
+
+    public function testFieldErrors()
+    {
+        $errors = $this->rawExtension->getFieldErrors($this->view->children['username']);
+        $this->assertSame(['username.max_length'], iterator_to_array($errors));
+    }
+
+    public function testFieldTranslatedErrors()
+    {
+        $errors = $this->translatorExtension->getFieldErrors($this->view->children['username']);
+        $this->assertSame(['username.max_length'], iterator_to_array($errors));
+    }
+
+    public function testFieldChoicesFlat()
+    {
+        $choices = $this->rawExtension->getFieldChoices($this->view->children['choice_flat']);
+
+        $choicesArray = [];
+        foreach ($choices as $label => $value) {
+            $choicesArray[] = ['label' => $label, 'value' => $value];
+        }
+
+        $this->assertCount(2, $choicesArray);
+
+        $this->assertSame('yes', $choicesArray[0]['value']);
+        $this->assertSame('base.yes', $choicesArray[0]['label']);
+
+        $this->assertSame('no', $choicesArray[1]['value']);
+        $this->assertSame('base.no', $choicesArray[1]['label']);
+    }
+
+    public function testFieldTranslatedChoicesFlat()
+    {
+        $choices = $this->translatorExtension->getFieldChoices($this->view->children['choice_flat']);
+
+        $choicesArray = [];
+        foreach ($choices as $label => $value) {
+            $choicesArray[] = ['label' => $label, 'value' => $value];
+        }
+
+        $this->assertCount(2, $choicesArray);
+
+        $this->assertSame('yes', $choicesArray[0]['value']);
+        $this->assertSame('[trans]base.yes[/trans]', $choicesArray[0]['label']);
+
+        $this->assertSame('no', $choicesArray[1]['value']);
+        $this->assertSame('[trans]base.no[/trans]', $choicesArray[1]['label']);
+    }
+
+    public function testFieldChoicesGrouped()
+    {
+        $choices = $this->rawExtension->getFieldChoices($this->view->children['choice_grouped']);
+
+        $choicesArray = [];
+        foreach ($choices as $groupLabel => $groupChoices) {
+            $groupChoicesArray = [];
+            foreach ($groupChoices as $label => $value) {
+                $groupChoicesArray[] = ['label' => $label, 'value' => $value];
+            }
+
+            $choicesArray[] = ['label' => $groupLabel, 'choices' => $groupChoicesArray];
+        }
+
+        $this->assertCount(2, $choicesArray);
+
+        $this->assertCount(2, $choicesArray[0]['choices']);
+        $this->assertSame('base.europe', $choicesArray[0]['label']);
+
+        $this->assertSame('fr', $choicesArray[0]['choices'][0]['value']);
+        $this->assertSame('base.fr', $choicesArray[0]['choices'][0]['label']);
+
+        $this->assertSame('de', $choicesArray[0]['choices'][1]['value']);
+        $this->assertSame('base.de', $choicesArray[0]['choices'][1]['label']);
+
+        $this->assertCount(2, $choicesArray[1]['choices']);
+        $this->assertSame('base.asia', $choicesArray[1]['label']);
+
+        $this->assertSame('cn', $choicesArray[1]['choices'][0]['value']);
+        $this->assertSame('base.cn', $choicesArray[1]['choices'][0]['label']);
+
+        $this->assertSame('jp', $choicesArray[1]['choices'][1]['value']);
+        $this->assertSame('base.jp', $choicesArray[1]['choices'][1]['label']);
+    }
+
+    public function testFieldTranslatedChoicesGrouped()
+    {
+        $choices = $this->translatorExtension->getFieldChoices($this->view->children['choice_grouped']);
+
+        $choicesArray = [];
+        foreach ($choices as $groupLabel => $groupChoices) {
+            $groupChoicesArray = [];
+            foreach ($groupChoices as $label => $value) {
+                $groupChoicesArray[] = ['label' => $label, 'value' => $value];
+            }
+
+            $choicesArray[] = ['label' => $groupLabel, 'choices' => $groupChoicesArray];
+        }
+
+        $this->assertCount(2, $choicesArray);
+
+        $this->assertCount(2, $choicesArray[0]['choices']);
+        $this->assertSame('[trans]base.europe[/trans]', $choicesArray[0]['label']);
+
+        $this->assertSame('fr', $choicesArray[0]['choices'][0]['value']);
+        $this->assertSame('[trans]base.fr[/trans]', $choicesArray[0]['choices'][0]['label']);
+
+        $this->assertSame('de', $choicesArray[0]['choices'][1]['value']);
+        $this->assertSame('[trans]base.de[/trans]', $choicesArray[0]['choices'][1]['label']);
+
+        $this->assertCount(2, $choicesArray[1]['choices']);
+        $this->assertSame('[trans]base.asia[/trans]', $choicesArray[1]['label']);
+
+        $this->assertSame('cn', $choicesArray[1]['choices'][0]['value']);
+        $this->assertSame('[trans]base.cn[/trans]', $choicesArray[1]['choices'][0]['label']);
+
+        $this->assertSame('jp', $choicesArray[1]['choices'][1]['value']);
+        $this->assertSame('[trans]base.jp[/trans]', $choicesArray[1]['choices'][1]['label']);
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/form.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/form.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\FormRenderer;
 return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('twig.extension.form', FormExtension::class)
+            ->args([service('translator')->nullOnInvalid()])
 
         ->set('twig.form.engine', TwigRendererEngine::class)
             ->args([param('twig.form.resources'), service('twig')])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/14308

Designing Symfony Forms has always been difficult, especially for developers not comfortable with Symfony or Twig. The reason behind this difficulty is that the current `form_*` helper functions, while providing a way to quickly render a form, are hiding the generated HTML behind a notation specific to Symfony.

HTML standards introduced many new attributes since the Form component was created, from new constraints to how should inputs be displayed, treated by screen readers, etc.

I propose to introduce a series of new Twig functions to help create more flexible forms without the hurdle of having to use `form_*` functions. I called these methods `field_*` because they aim at rendering only the tiny bits of strings necessary to map forms to the Symfony backend.

The functions introduced are:

* `field_name` returns the name of the given field
* `field_value` returns the current value of the given field
* `field_label` returns the label of the given field, translated if possible
* `field_help` returns the help of the given field, translated if possible
* `field_errors` returns an iterator of strings for each of the errors of the given field
* `field_choices` returns an iterator of choices (the structure depending on whether the field uses or doesn't use optgroup) with translated labels if possible as keys and values as values

A quick example of usage of these functions could be the following:

``` twig
<input
    name="{{ field_name(form.username) }}"
    value="{{ field_value(form.username) }}"
    placeholder="{{ field_label(form.username) }}"
    class="form-control"
/>

<select name="{{ field_name(form.country) }}" class="form-control">
    <option value="">{{ field_label(form.country) }}</option>

    {% for label, value in field_choices(form.country) %}
        <option value="{{ value }}">{{ label }}</option>
    {% endfor %}
</select>

<select name="{{ field_name(form.stockStatus) }}" class="form-control">
    <option value="">{{ field_label(form.stockStatus) }}</option>

    {% for groupLabel, groupChoices in field_choices(form.stockStatus) %}
        <optgroup label="{{ groupLabel }}">
            {% for label, value in groupChoices %}
                <option value="{{ value }}">{{ label }}</option>
            {% endfor %}
        </optgroup>
    {% endfor %}
</select>

{% for error in field_errors(form.country) %}
    <div class="text-danger mb-2">
        {{ error }}
    </div>
{% endfor %}
```

There are several advantages to using these functions instead of their `form_*` equivalents:

* they are much easier to use for developers not knowing Symfony: they rely on native HTML with bits of logic inside, instead of relying on specific tools needing to be configured to display proper HTML 
* they allow for better integration with CSS frameworks or Javascript libraries as adding a new HTML attribute is trivial (no need to look at the documentation)
* they are easier to use in contexts where one would like to customize the rendering of a input in details: having the label as placeholder, displaying a select empty field, ...

The `form_*` functions are still usable of course, but I'd argue this technique is actually easier to read and understand.