### PR TITLE
[Security][RateLimiter] Added request rate limiter to prevent breadth-first attacks

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
@@ -118,7 +118,7 @@ return static function (ContainerConfigurator $container) {
             ->abstract()
             ->args([
                 service('request_stack'),
-                abstract_arg('rate limiter'),
+                abstract_arg('request rate limiter'),
             ])
 
         // Authenticators

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/login.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Resources/views/Login/login.html.twig
@@ -4,6 +4,7 @@
 
     {% if error %}
         <div>{{ error.messageKey }}</div>
+        <div>{{ error.messageKey|replace(error.messageData) }}</div>
     {% endif %}
 
     <form action="{{ path('form_login_check') }}" method="post">

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * added `HeaderUtils::parseQuery()`: it does the same as `parse_str()` but preserves dots in variable names
  * added `File::getContent()`
  * added ability to use comma separated ip addresses for `RequestMatcher::matchIps()`
+ * added `RateLimiter\RequestRateLimiterInterface` and `RateLimiter\AbstractRequestRateLimiter`
 
 5.1.0
 -----

--- a/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
+++ b/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RateLimiter;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\RateLimiter\Limit;
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\NoLimiter;
+
+/**
+ * An implementation of RequestRateLimiterInterface that
+ * fits most use-cases.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ *
+ * @experimental in Symfony 5.2
+ */
+abstract class AbstractRequestRateLimiter implements RequestRateLimiterInterface
+{
+    public function consume(Request $request): Limit
+    {
+        $limiters = $this->getLimiters($request);
+        if (0 === \count($limiters)) {
+            $limiters = [new NoLimiter()];
+        }
+
+        $minimalLimit = null;
+        foreach ($limiters as $limiter) {
+            $limit = $limiter->consume(1);
+
+            if (null === $minimalLimit || $limit->getRemainingTokens() < $minimalLimit->getRemainingTokens()) {
+                $minimalLimit = $limit;
+            }
+        }
+
+        return $minimalLimit;
+    }
+
+    public function reset(): void
+    {
+        foreach ($this->getLimiters($request) as $limiter) {
+            $limiter->reset();
+        }
+    }
+
+    /**
+     * @return LimiterInterface[] a set of limiters using keys extracted from the request
+     */
+    abstract protected function getLimiters(Request $request): array;
+}

--- a/src/Symfony/Component/HttpFoundation/RateLimiter/RequestRateLimiterInterface.php
+++ b/src/Symfony/Component/HttpFoundation/RateLimiter/RequestRateLimiterInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\RateLimiter;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\RateLimiter\Limit;
+
+/**
+ * A special type of limiter that deals with requests.
+ *
+ * This allows to limit on different types of information
+ * from the requests.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ *
+ * @experimental in Symfony 5.2
+ */
+interface RequestRateLimiterInterface
+{
+    public function consume(Request $request): Limit;
+
+    public function reset(): void;
+}

--- a/src/Symfony/Component/RateLimiter/NoLimiter.php
+++ b/src/Symfony/Component/RateLimiter/NoLimiter.php
@@ -25,7 +25,7 @@ final class NoLimiter implements LimiterInterface
 {
     public function consume(int $tokens = 1): Limit
     {
-        return new Limit(\INF, new \DateTimeImmutable(), true, 'no_limit');
+        return new Limit(\INF, new \DateTimeImmutable(), true);
     }
 
     public function reset(): void

--- a/src/Symfony/Component/Security/Core/Exception/TooManyLoginAttemptsAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/TooManyLoginAttemptsAuthenticationException.php
@@ -19,11 +19,46 @@ namespace Symfony\Component\Security\Core\Exception;
  */
 class TooManyLoginAttemptsAuthenticationException extends AuthenticationException
 {
+    private $threshold;
+
+    public function __construct(int $threshold = null)
+    {
+        $this->threshold = $threshold;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageData(): array
+    {
+        return [
+            '%minutes%' => $this->threshold,
+        ];
+    }
+
     /**
      * {@inheritdoc}
      */
     public function getMessageKey(): string
     {
-        return 'Too many failed login attempts, please try again later.';
+        return 'Too many failed login attempts, please try again '.($this->threshold ? 'in %minutes% minute'.($this->threshold > 1 ? 's' : '').'.' : 'later.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __serialize(): array
+    {
+        return [$this->threshold, parent::__serialize()];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __unserialize(array $data): void
+    {
+        [$this->threshold, $parentData] = $data;
+        $parentData = \is_array($parentData) ? $parentData : unserialize($parentData);
+        parent::__unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
+++ b/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\RateLimiter;
+
+use Symfony\Component\HttpFoundation\RateLimiter\AbstractRequestRateLimiter;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\RateLimiter\Limiter;
+use Symfony\Component\Security\Core\Security;
+
+/**
+ * A default login throttling limiter.
+ *
+ * This limiter prevents breadth-first attacks by enforcing
+ * a limit on username+IP and a (higher) limit on IP.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ *
+ * @experimental in Symfony 5.2
+ */
+final class DefaultLoginRateLimiter extends AbstractRequestRateLimiter
+{
+    private $globalLimiter;
+    private $localLimiter;
+
+    public function __construct(Limiter $globalLimiter, Limiter $localLimiter)
+    {
+        $this->globalLimiter = $globalLimiter;
+        $this->localLimiter = $localLimiter;
+    }
+
+    protected function getLimiters(Request $request): array
+    {
+        return [
+            $this->globalLimiter->create($request->getClientIp()),
+            $this->localLimiter->create($request->attributes->get(Security::LAST_USERNAME).$request->getClientIp()),
+        ];
+    }
+}

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "symfony/deprecation-contracts": "^2.1",
         "symfony/security-core": "^5.2",
-        "symfony/http-foundation": "^4.4.7|^5.0.7",
+        "symfony/http-foundation": "^5.2",
         "symfony/http-kernel": "^5.2",
         "symfony/polyfill-php80": "^1.15",
         "symfony/property-access": "^4.4|^5.0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This allows limiting on different elements of a request. The normal `CompoundLimiter` requires the same key for all its limiters.

This request limiter is useful to e.g. prevent breadth-first attacks, by allowing to enforce a limit on both IP and IP+username. It can also be useful for applications using some sort of API request limiting (or e.g. file upload limiting).

The default login throttling limiter will allow `max_attempts` (default: 5) attempts per minute for `username + IP` and `5 * max_attempts` for `IP`. Customizing this will require creating a new service that extends `AbstractRequestRateLimiter` and implementing `getLimiters(Request $request): LimiterInterface[]`.