### PR TITLE
[PhpUnitBridge] Fixed class_alias() for PHPUnit\Framework\Error\Error

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/BootstrapTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/BootstrapTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class BootstrapTest extends TestCase
+{
+    /**
+     * @requires PHPUnit < 6.0
+     */
+    public function testAliasingOfErrorClasses()
+    {
+        $this->assertInstanceOf(
+            \PHPUnit_Framework_Error::class,
+            new \PHPUnit\Framework\Error\Error('message', 0, __FILE__, __LINE__)
+        );
+        $this->assertInstanceOf(
+            \PHPUnit_Framework_Error_Deprecated::class,
+            new \PHPUnit\Framework\Error\Deprecated('message', 0, __FILE__, __LINE__)
+        );
+        $this->assertInstanceOf(
+            \PHPUnit_Framework_Error_Notice::class,
+            new \PHPUnit\Framework\Error\Notice('message', 0, __FILE__, __LINE__)
+        );
+        $this->assertInstanceOf(
+            \PHPUnit_Framework_Error_Warning::class,
+            new \PHPUnit\Framework\Error\Warning('message', 0, __FILE__, __LINE__)
+        );
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/bootstrap.php
+++ b/src/Symfony/Bridge/PhpUnit/bootstrap.php
@@ -56,7 +56,6 @@ if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Ve
         'PHPUnit_Framework_Constraint_TraversableContains',
         'PHPUnit_Framework_Constraint_TraversableContainsOnly',
 
-        'PHPUnit_Framework_Error',
         'PHPUnit_Framework_Error_Deprecated',
         'PHPUnit_Framework_Error_Notice',
         'PHPUnit_Framework_Error_Warning',
@@ -100,6 +99,7 @@ if (class_exists('PHPUnit_Runner_Version') && version_compare(\PHPUnit_Runner_Ve
     class_alias('PHPUnit_Framework_Constraint_Not', 'PHPUnit\Framework\Constraint\LogicalNot');
     class_alias('PHPUnit_Framework_Constraint_Or', 'PHPUnit\Framework\Constraint\LogicalOr');
     class_alias('PHPUnit_Framework_Constraint_Xor', 'PHPUnit\Framework\Constraint\LogicalXor');
+    class_alias('PHPUnit_Framework_Error', 'PHPUnit\Framework\Error\Error');
 }
 
 // Detect if we need to serialize deprecations to a file.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

PHPUnit 6.x removed the PHPUnit_Framework_* classes in favor of PHP namespaces, but one error class did not map the same as the others: `PHPUnit_Framework_Error`.

Instead of mapping to `PHPUnit\Framework\Error` in the same way that `PHPUnit_Framework_Error_Warning` mapped to `PHPUnit\Framework\Error\Warning`, this base class was replaced with `PHPUnit\Framework\Error\Error`, so we cannot map it using simple string replacement like its descendants.