### PR TITLE
[Console] reopen inputStream after a ctrl+D/ctrl+Z

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -521,6 +521,7 @@ class QuestionHelper extends Helper
         while (false !== ($char = fgetc($inputStream))) {
             $ret .= $char;
         }
+        $this->inputStream = fopen('php://stdin', 'r');
 
         return $ret;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | I did not open a ticket
| License       | MIT
| Doc PR        | N/A

I encountered a problem with the new multiline question.

it appears when you ask a question AFTER a multiline question

It seems STDIN needs to be reopen (<- does it make sense ?).

I have no idea if this is the best way to fix it, but it does fix it ^^