### PR TITLE
[Console] Improve description for the help flag.

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1020,8 +1020,7 @@ class Application implements ResetInterface
     {
         return new InputDefinition([
             new InputArgument('command', InputArgument::REQUIRED, 'The command to execute'),
-
-            new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display this help message'),
+            new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display help for the given command. When no command is given display help for the <info>' . $this->defaultCommand . '</info> command'),
             new InputOption('--quiet', '-q', InputOption::VALUE_NONE, 'Do not output any message'),
             new InputOption('--verbose', '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
             new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Display this application version'),

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1020,7 +1020,7 @@ class Application implements ResetInterface
     {
         return new InputDefinition([
             new InputArgument('command', InputArgument::REQUIRED, 'The command to execute'),
-            new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display help for the given command. When no command is given display help for the <info>' . $this->defaultCommand . '</info> command'),
+            new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display help for the given command. When no command is given display help for the <info>'.$this->defaultCommand.'</info> command'),
             new InputOption('--quiet', '-q', InputOption::VALUE_NONE, 'Do not output any message'),
             new InputOption('--verbose', '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
             new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Display this application version'),

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -77,7 +77,7 @@ Usage:
   command [options] [arguments]
 
 Options:
-  -h, --help            Display this help message
+  -h, --help            Display help for the given command. When no command is given display help for the list command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
       --ansi            Force ANSI output

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
@@ -43,7 +43,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Display this help message",
+                        "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
                     "quiet": {
@@ -146,7 +146,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Display this help message",
+                        "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
                     "quiet": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
@@ -55,7 +55,7 @@ To output raw command help
 
 #### `--help|-h`
 
-Display this help message
+Display help for the given command. When no command is given display help for the list command
 
 * Accept value: no
 * Is value required: no
@@ -173,7 +173,7 @@ The output format (txt, xml, json, or md)
 
 #### `--help|-h`
 
-Display this help message
+Display help for the given command. When no command is given display help for the list command
 
 * Accept value: no
 * Is value required: no

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.txt
@@ -4,7 +4,7 @@ Console Tool
   command [options] [arguments]
 
 <comment>Options:</comment>
-  <info>-h, --help</info>            Display this help message
+  <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
   <info>-q, --quiet</info>           Do not output any message
   <info>-V, --version</info>         Display this application version
   <info>    --ansi</info>            Force ANSI output

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
@@ -34,7 +34,7 @@
           <description>To output raw command help</description>
         </option>
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Display this help message</description>
+          <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
         <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
@@ -93,7 +93,7 @@
           </defaults>
         </option>
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Display this help message</description>
+          <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
         <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -47,7 +47,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Display this help message",
+                        "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
                     "quiet": {
@@ -150,7 +150,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Display this help message",
+                        "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
                     "quiet": {
@@ -229,7 +229,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Display this help message",
+                        "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
                     "quiet": {
@@ -325,7 +325,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Display this help message",
+                        "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
                     "quiet": {
@@ -402,7 +402,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Display this help message",
+                        "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
                     "quiet": {
@@ -481,7 +481,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Display this help message",
+                        "description": "Display help for the given command. When no command is given display help for the <info>list</info> command",
                         "default": false
                     },
                     "quiet": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
@@ -68,7 +68,7 @@ To output raw command help
 
 #### `--help|-h`
 
-Display this help message
+Display help for the given command. When no command is given display help for the list command
 
 * Accept value: no
 * Is value required: no
@@ -186,7 +186,7 @@ The output format (txt, xml, json, or md)
 
 #### `--help|-h`
 
-Display this help message
+Display help for the given command. When no command is given display help for the list command
 
 * Accept value: no
 * Is value required: no
@@ -264,7 +264,7 @@ command 1 help
 
 #### `--help|-h`
 
-Display this help message
+Display help for the given command. When no command is given display help for the list command
 
 * Accept value: no
 * Is value required: no
@@ -357,7 +357,7 @@ command 2 help
 
 #### `--help|-h`
 
-Display this help message
+Display help for the given command. When no command is given display help for the list command
 
 * Accept value: no
 * Is value required: no
@@ -432,7 +432,7 @@ Do not ask any interactive question
 
 #### `--help|-h`
 
-Display this help message
+Display help for the given command. When no command is given display help for the list command
 
 * Accept value: no
 * Is value required: no

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.txt
@@ -4,7 +4,7 @@ My Symfony application <info>v1.0</info>
   command [options] [arguments]
 
 <comment>Options:</comment>
-  <info>-h, --help</info>            Display this help message
+  <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
   <info>-q, --quiet</info>           Do not output any message
   <info>-V, --version</info>         Display this application version
   <info>    --ansi</info>            Force ANSI output

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -34,7 +34,7 @@
           <description>To output raw command help</description>
         </option>
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Display this help message</description>
+          <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
         <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
@@ -93,7 +93,7 @@
           </defaults>
         </option>
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Display this help message</description>
+          <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
         <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
@@ -126,7 +126,7 @@
       <arguments/>
       <options>
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Display this help message</description>
+          <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
         <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
@@ -167,7 +167,7 @@
           <description></description>
         </option>
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Display this help message</description>
+          <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
         <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
@@ -198,7 +198,7 @@
       <arguments/>
       <options>
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Display this help message</description>
+          <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
         <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>
@@ -231,7 +231,7 @@
       <arguments/>
       <options>
         <option name="--help" shortcut="-h" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Display this help message</description>
+          <description>Display help for the given command. When no command is given display help for the &lt;info&gt;list&lt;/info&gt; command</description>
         </option>
         <option name="--quiet" shortcut="-q" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not output any message</description>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_filtered_namespace.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_filtered_namespace.txt
@@ -4,7 +4,7 @@ My Symfony application <info>v1.0</info>
   command [options] [arguments]
 
 <comment>Options:</comment>
-  <info>-h, --help</info>            Display this help message
+  <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
   <info>-q, --quiet</info>           Do not output any message
   <info>-V, --version</info>         Display this application version
   <info>    --ansi</info>            Force ANSI output

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
@@ -59,7 +59,7 @@ To output raw command help
 
 #### `--help|-h`
 
-Display this help message
+Display help for the given command. When no command is given display help for the list command
 
 * Accept value: no
 * Is value required: no
@@ -177,7 +177,7 @@ The output format (txt, xml, json, or md)
 
 #### `--help|-h`
 
-Display this help message
+Display help for the given command. When no command is given display help for the list command
 
 * Accept value: no
 * Is value required: no
@@ -270,7 +270,7 @@ command åèä help
 
 #### `--help|-h`
 
-Display this help message
+Display help for the given command. When no command is given display help for the list command
 
 * Accept value: no
 * Is value required: no

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.txt
@@ -4,7 +4,7 @@ MbString åpplicätion
   command [options] [arguments]
 
 <comment>Options:</comment>
-  <info>-h, --help</info>            Display this help message
+  <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
   <info>-q, --quiet</info>           Do not output any message
   <info>-V, --version</info>         Display this application version
   <info>    --ansi</info>            Force ANSI output

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run1.txt
@@ -4,7 +4,7 @@ Usage:
   command [options] [arguments]
 
 Options:
-  -h, --help            Display this help message
+  -h, --help            Display help for the given command. When no command is given display help for the list command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
       --ansi            Force ANSI output

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
@@ -10,7 +10,7 @@ Arguments:
 Options:
       --raw             To output raw command list
       --format=FORMAT   The output format (txt, xml, json, or md) [default: "txt"]
-  -h, --help            Display this help message
+  -h, --help            Display help for the given command. When no command is given display help for the list command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
       --ansi            Force ANSI output

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
@@ -10,7 +10,7 @@ Arguments:
 Options:
       --raw             To output raw command list
       --format=FORMAT   The output format (txt, xml, json, or md) [default: "txt"]
-  -h, --help            Display this help message
+  -h, --help            Display help for the given command. When no command is given display help for the list command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
       --ansi            Force ANSI output

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run5.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run5.txt
@@ -10,7 +10,7 @@ Arguments:
 Options:
       --format=FORMAT   The output format (txt, xml, json, or md) [default: "txt"]
       --raw             To output raw command help
-  -h, --help            Display this help message
+  -h, --help            Display help for the given command. When no command is given display help for the list command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
       --ansi            Force ANSI output

--- a/src/Symfony/Component/Console/Tests/phpt/single_application/help_name.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/single_application/help_name.phpt
@@ -28,7 +28,7 @@ Usage:
   %s
 
 Options:
-  -h, --help            Display this help message
+  -h, --help            Display help for the given command. When no command is given display help for the %s command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
       --ansi            Force ANSI output


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Tickets       | no
| License       | MIT

I am currently trying to improve a CLI tool called `robo` (https://robo.li) that relies heavily on the console component.
First thing I did was running it without any argument like `./robo` to find the description for the help flag `-h` or `--help`
"Display this help message"
This is typical for any CLI tool out there except that when I run `./robo --help` I get the help for the `list` command (same output as `robo help list`).

One of the options I considered was to fix this behavior by showing the same output when no command is given disregarding the help flag (just for the case of no command given) but I actually like how symfony console handles the help flag. 
I think it needs a clarification for the description given so I changed it to:

> Display help for the given command. When no command is given display help for the list command

Which is more descriptive about what actually happens in the code when that flag is given. Specially the "this" word can be a little confusing.