### PR TITLE
[Console] Add new placeholder for application invoke method.

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1162,7 +1162,7 @@ class Application implements ResetInterface
     /**
      * Gets the recommended invoke method.
      *
-     * @return string The method that should be used to invoke this Application.
+     * @return string the method that should be used to invoke this Application
      */
     public function getInvokeMethod()
     {

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -77,6 +77,7 @@ class Application implements ResetInterface
     private $dispatcher;
     private $terminal;
     private $defaultCommand;
+    private $invokeMethod;
     private $singleCommand = false;
     private $initialized;
     private $signalRegistry;
@@ -88,6 +89,7 @@ class Application implements ResetInterface
         $this->version = $version;
         $this->terminal = new Terminal();
         $this->defaultCommand = 'list';
+        $this->invokeMethod = 'php';
         $this->signalRegistry = new SignalRegistry();
         if (\defined('SIGINT')) {
             $this->signalsToDispatchEvent = [\SIGINT, \SIGTERM, \SIGUSR1, \SIGUSR2];
@@ -1143,6 +1145,28 @@ class Application implements ResetInterface
         }
 
         return $this;
+    }
+
+    /**
+     * Sets the recommended invoke method.
+     *
+     * @return self
+     */
+    public function setInvokeMethod(string $invokeMethod)
+    {
+        $this->invokeMethod = $invokeMethod;
+
+        return $this;
+    }
+
+    /**
+     * Gets the recommended invoke method.
+     *
+     * @return string The method that should be used to invoke this Application.
+     */
+    public function getInvokeMethod()
+    {
+        return $this->invokeMethod;
     }
 
     /**

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -12,6 +12,9 @@ CHANGELOG
     * Added `Application::getSignalRegistry()` and `Application::setSignalsToDispatchEvent()` methods
     * Added `SignalableCommandInterface` interface
  * Added `TableCellStyle` class to customize table cell
+ * Added `Application::$invokeMethod` property:
+    * Added set and get methods.
+    * Added new `%application.invoke_method%` placeholder for help texts.
 
 5.1.0
 -----

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -530,10 +530,12 @@ class Command
         $isSingleCommand = $this->application && $this->application->isSingleCommand();
 
         $placeholders = [
+            '%application.invoke_method%',
             '%command.name%',
             '%command.full_name%',
         ];
         $replacements = [
+            ltrim($this->application->getInvokeMethod().' '),
             $name,
             $isSingleCommand ? $_SERVER['PHP_SELF'] : $_SERVER['PHP_SELF'].' '.$name,
         ];

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -528,6 +528,7 @@ class Command
     {
         $name = $this->name;
         $isSingleCommand = $this->application && $this->application->isSingleCommand();
+        $invokeMethod = $this->application ? ltrim($this->application->getInvokeMethod().' ') : 'php ';
 
         $placeholders = [
             '%application.invoke_method%',
@@ -535,7 +536,7 @@ class Command
             '%command.full_name%',
         ];
         $replacements = [
-            ltrim($this->application->getInvokeMethod().' '),
+            $invokeMethod,
             $name,
             $isSingleCommand ? $_SERVER['PHP_SELF'] : $_SERVER['PHP_SELF'].' '.$name,
         ];

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -44,11 +44,11 @@ class HelpCommand extends Command
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command displays help for a given command:
 
-  <info>php %command.full_name% list</info>
+  <info>%application.invoke_method%%command.full_name% list</info>
 
 You can also output the help in other formats by using the <comment>--format</comment> option:
 
-  <info>php %command.full_name% --format=xml list</info>
+  <info>%application.invoke_method%%command.full_name% --format=xml list</info>
 
 To display the list of available commands, please use the <info>list</info> command.
 EOF

--- a/src/Symfony/Component/Console/Command/ListCommand.php
+++ b/src/Symfony/Component/Console/Command/ListCommand.php
@@ -40,19 +40,19 @@ class ListCommand extends Command
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command lists all commands:
 
-  <info>php %command.full_name%</info>
+  <info>%application.invoke_method%%command.full_name%</info>
 
 You can also display the commands for a specific namespace:
 
-  <info>php %command.full_name% test</info>
+  <info>%application.invoke_method%%command.full_name% test</info>
 
 You can also output the information in other formats by using the <comment>--format</comment> option:
 
-  <info>php %command.full_name% --format=xml</info>
+  <info>%application.invoke_method%%command.full_name% --format=xml</info>
 
 It's also possible to get raw list of commands (useful for embedding command runner):
 
-  <info>php %command.full_name% --raw</info>
+  <info>%application.invoke_method%%command.full_name% --raw</info>
 EOF
             )
         ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | -

I was a bit puzzled to find that the help for the `list` and `help` commands suggests that you call the console application by prefixing it with `php myconsoleapp`.
I am providing a script with a shebang like the first example from like is suggested in the following link:
https://symfony.com/doc/current/components/console.html
Eventually I want to distribute my console app as docker image so there is no need for php installed or the users even knowing is written in php.
The script name is easy to override by just setting a different value to `$_SERVER['PHP_SELF']` but this `php ` prefix is hardcoded into the help strings for the the two default commands available.

What I came up with is the concept of "invoke method" to refer to that `php ` prefix and I added methods in the Application class to be able to remove it completely when is not needed. The default is set to the value that symfony 5.1 currently uses so is backwards compatible.

Slightly related to https://github.com/symfony/symfony/pull/38347 as I am trying to improve the console help output.
I didn't see any reference to the other placeholders in symfony/symfony-docs but I am willing to create docs for the three available if there interest in this feature.

What do you think?
