### PR TITLE
[TwigBundle] Only remove kernel exception listener if twig is used

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExceptionListenerPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExceptionListenerPass.php
@@ -33,15 +33,19 @@ class ExceptionListenerPass implements CompilerPassInterface
         // register the exception listener only if it's currently used, else use the provided by FrameworkBundle
         if (null === $container->getParameter('twig.exception_listener.controller') && $container->hasDefinition('exception_listener')) {
             $container->removeDefinition('twig.exception_listener');
-        } else {
-            $container->removeDefinition('exception_listener');
 
-            if ($container->hasParameter('templating.engines')) {
-                $engines = $container->getParameter('templating.engines');
-                if (!\in_array('twig', $engines, true)) {
-                    $container->removeDefinition('twig.exception_listener');
-                }
+            return;
+        }
+
+        if ($container->hasParameter('templating.engines')) {
+            $engines = $container->getParameter('templating.engines');
+            if (\in_array('twig', $engines, true)) {
+                $container->removeDefinition('exception_listener');
+
+                return;
             }
         }
+
+        $container->removeDefinition('twig.exception_listener');
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/ExceptionListenerPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/ExceptionListenerPassTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Bundle\TwigBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\TwigBundle\DependencyInjection\Compiler\ExceptionListenerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Security\Http\Firewall\ExceptionListener;
+use Twig\Environment;
+
+class ExceptionListenerPassTest extends TestCase
+{
+    public function testExitsWhenTwigIsNotAvailable(): void
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('exception_listener', ExceptionListener::class);
+        $builder->register('twig.exception_listener', ExceptionListener::class);
+
+        ($pass = new ExceptionListenerPass())->process($builder);
+
+        $this->assertTrue($builder->hasDefinition('exception_listener'));
+        $this->assertTrue($builder->hasDefinition('twig.exception_listener'));
+    }
+
+    public function testRemovesTwigExceptionListenerWhenNoExceptionListenerControllerExists(): void
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('twig', Environment::class);
+        $builder->register('exception_listener', ExceptionListener::class);
+        $builder->register('twig.exception_listener', ExceptionListener::class);
+        $builder->setParameter('twig.exception_listener.controller', null);
+
+        ($pass = new ExceptionListenerPass())->process($builder);
+
+        $this->assertTrue($builder->hasDefinition('exception_listener'));
+        $this->assertFalse($builder->hasDefinition('twig.exception_listener'));
+    }
+
+    public function testRemovesTwigExceptionListenerIfTwigIsNotUsedAsTemplateEngine(): void
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('twig', Environment::class);
+        $builder->register('exception_listener', ExceptionListener::class);
+        $builder->register('twig.exception_listener', ExceptionListener::class);
+        $builder->setParameter('twig.exception_listener.controller', 'exception_controller::showAction');
+        $builder->setParameter('templating.engines', ['php']);
+
+        ($pass = new ExceptionListenerPass())->process($builder);
+
+        $this->assertTrue($builder->hasDefinition('exception_listener'));
+        $this->assertFalse($builder->hasDefinition('twig.exception_listener'));
+    }
+
+    public function testRemovesKernelExceptionListenerIfTwigIsUsedAsTemplateEngine(): void
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('twig', Environment::class);
+        $builder->register('exception_listener', ExceptionListener::class);
+        $builder->register('twig.exception_listener', ExceptionListener::class);
+        $builder->setParameter('twig.exception_listener.controller', 'exception_controller::showAction');
+        $builder->setParameter('templating.engines', ['twig']);
+
+        ($pass = new ExceptionListenerPass())->process($builder);
+
+        $this->assertFalse($builder->hasDefinition('exception_listener'));
+        $this->assertTrue($builder->hasDefinition('twig.exception_listener'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/contao/contao/issues/1527
| License       | MIT
| Doc PR        | 

In a setup using the template engine but not twig as the template engine no exceptions are logged. This is caused by the twig-bundle which removes the `exception_listener` service. For my understanding this should only happen if twig is used as template engine. This PR fixes the logic that only for the case where twig is enabled as template engine the http kernel exception listener is removed. Otherwise the twig exception listener got removed now.

Disclaimer: I'm not too deep into the details, so maybe I oversee something why it's implemented the way it is.