### PR TITLE
[RateLimiter] Call all compound limiters on failure and added IO blocking

### DIFF
--- a/src/Symfony/Component/RateLimiter/CompoundLimiter.php
+++ b/src/Symfony/Component/RateLimiter/CompoundLimiter.php
@@ -37,10 +37,6 @@ final class CompoundLimiter implements LimiterInterface
         foreach ($this->limiters as $limiter) {
             $limit = $limiter->consume($tokens);
 
-            if (0 === $limit->getRemainingTokens()) {
-                return $limit;
-            }
-
             if (null === $minimalLimit || $limit->getRemainingTokens() < $minimalLimit->getRemainingTokens()) {
                 $minimalLimit = $limit;
             }

--- a/src/Symfony/Component/RateLimiter/Limit.php
+++ b/src/Symfony/Component/RateLimiter/Limit.php
@@ -43,4 +43,9 @@ class Limit
     {
         return $this->availableTokens;
     }
+
+    public function wait(): void
+    {
+        sleep(($this->retryAfter->getTimestamp() - time()) * 1e6);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Two small improvements that I missed in #38257:

* Added `wait()` method, to be able to do logic like this:
   ```php
   while (!($limit = $limiter->consume())->isAccepted()) {
       $limit->wait();
   }
   ```
* Fixed the `CompoundLimiter` to always call all limiters (even when one already blocks). This was the original behavior of the compound limiter and imho the best behavior (at least, it's always consistent and doesn't rely on the order of limiters - which is unsorted).