### PR TITLE
[Security] Improve exception when rate-limiter is not installed and throttling enabled

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -17,6 +17,7 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\RateLimiter\Limiter;
 use Symfony\Component\Security\Http\EventListener\LoginThrottlingListener;
 
 /**
@@ -60,9 +61,13 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface, SecurityF
             throw new \LogicException('Login throttling requires symfony/security-http:^5.2.');
         }
 
+        if (!class_exists(Limiter::class)) {
+            throw new \LogicException('Login throttling requires symfony/rate-limiter to be installed and enabled.');
+        }
+
         if (!isset($config['limiter'])) {
             if (!class_exists(FrameworkExtension::class) || !method_exists(FrameworkExtension::class, 'registerRateLimiter')) {
-                throw new \LogicException('You must either configure a rate limiter for "security.firewalls.'.$firewallName.'.login_throttling" or install symfony/framework-bundle:^5.2');
+                throw new \LogicException('You must either configure a rate limiter for "security.firewalls.'.$firewallName.'.login_throttling" or install symfony/framework-bundle:^5.2.');
             }
 
             FrameworkExtension::registerRateLimiter($container, $config['limiter'] = '_login_'.$firewallName, [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes-ish
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a

When the rate-limiter component is not installed and if one enables login throttling, the error message is not easy to understand: `Service "limiter._login_local_main": Parent definition "limiter" does not exist.`.

This fixes the error message to be easier to understand.

/cc @wouterj 

