### PR TITLE
[Messenger] Fix redis connection error message

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -54,7 +54,7 @@ class Connection
         $this->connection->setOption(\Redis::OPT_SERIALIZER, $redisOptions['serializer'] ?? \Redis::SERIALIZER_PHP);
 
         if (isset($connectionCredentials['auth']) && !$this->connection->auth($connectionCredentials['auth'])) {
-            throw new InvalidArgumentException(sprintf('Redis connection failed: %s', $redis->getLastError()));
+            throw new InvalidArgumentException(sprintf('Redis connection failed: %s', $this->connection->getLastError()));
         }
 
         $this->stream = $configuration['stream'] ?? self::DEFAULT_OPTIONS['stream'];


### PR DESCRIPTION
Use correct instance of redis to getLastError

| Q             | A
| ------------- | ---
| Branch?       | 4.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The `$redis` is only set in the tests, the correct redis instance is available under `$this->connection`.

Reproduce: give a false `AUTH` to the redis:

Before:

> [Error]
>  Call to a member function getLastError() on null

Now:

>  [Symfony\Component\Messenger\Exception\InvalidArgumentException]
>  Redis connection failed: ERR Client sent AUTH, but no password is set
