### PR TITLE
Fix redis connection error message

### DIFF
--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -61,11 +61,11 @@ class Connection
         }
 
         if (null !== $auth && !$this->connection->auth($auth)) {
-            throw new InvalidArgumentException('Redis connection failed: '.$redis->getLastError());
+            throw new InvalidArgumentException('Redis connection failed: '.$this->connection->getLastError());
         }
 
         if (($dbIndex = $configuration['dbindex'] ?? self::DEFAULT_OPTIONS['dbindex']) && !$this->connection->select($dbIndex)) {
-            throw new InvalidArgumentException('Redis connection failed: '.$redis->getLastError());
+            throw new InvalidArgumentException('Redis connection failed: '.$this->connection->getLastError());
         }
 
         foreach (['stream', 'group', 'consumer'] as $key) {


### PR DESCRIPTION
Use correct instance of redis to getLastError

| Q             | A
| ------------- | ---
| Branch?       | 4.4 (for 4.3 see #38358)
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Same as #38358 but handles also the dbindex error correctly.

The `$redis` is only set in the tests, the correct redis instance is available under `$this->connection`.

Reproduce: give a false `AUTH` to the redis:

Before:

> [Error]
>  Call to a member function getLastError() on null

Now:

>  [Symfony\Component\Messenger\Exception\InvalidArgumentException]
>  Redis connection failed: ERR Client sent AUTH, but no password is set


In 5.x this class was moved hope git will  handle it correctly.