### PR TITLE
[BrowserKit] Cookie expiration at current timestamp

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -296,6 +296,6 @@ class Cookie
      */
     public function isExpired()
     {
-        return null !== $this->expires && 0 != $this->expires && $this->expires < time();
+        return null !== $this->expires && 0 != $this->expires && $this->expires <= time();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

In `Symfony\Component\BrowserKit\Cookie` a cookie is expired if the `expires` timestamp is in the past. I would like to change it to also be expired if the `expires` timestamp equals the current exact timestamp. This would still be in line with [RFC 6265](https://tools.ietf.org/html/rfc6265#section-4.1.2.1), as it states `The Expires attribute indicates the maximum lifetime of the cookie, represented as the date and time at which the cookie expires`.

Reason for this change: Cookies usually both have `expires` and `Max-Age` set, and Symfony sets `Max-Age` to zero if a cookie is expired (in `Symfony\Component\HttpFoundation\Cookie`). When converting cookies between string and object representations, `Max-Age` is the preferred source of truth for the expiration, but `Max-Age` set to zero is converted to an `expires` timestamp at this exact second, currently making the cookie not expired in `Symfony\Component\BrowserKit\Cookie`, even though it should be.

I noticed this discrepancy in my tests when checking if a cookie no longer existed after deleting it, yet it was still there, because `Cookie` thought it would only expire after the `expires` timestamp had passed. I am also thinking of raising an issue for `Symfony\Component\HttpFoundation\Cookie`, as importing and exporting an expired cookie (via strings) changes the `expired` value. I thought this change was a simpler one for now, and should have no negative/unexpected impact.