### PR TITLE
Can define ChatMessage transport to null

### DIFF
--- a/src/Symfony/Component/Notifier/Message/ChatMessage.php
+++ b/src/Symfony/Component/Notifier/Message/ChatMessage.php
@@ -77,7 +77,7 @@ final class ChatMessage implements MessageInterface
     /**
      * @return $this
      */
-    public function transport(string $transport): self
+    public function transport(?string $transport): self
     {
         $this->transport = $transport;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT

I'm using notiier & messenger together to send notification asynchronously.

In order to have json messages in my broker, here is the messenger config I use:
```yaml
        serializer:
            default_serializer: messenger.transport.symfony_serializer
            symfony_serializer:
                format: json
                context: { }
```

I send a new `ChatMessage`:

```php
use Symfony\Component\Notifier\ChatterInterface;
use Symfony\Component\Notifier\Message\ChatMessage;

$chatter->send(new ChatMessage('Using notifier & messenger together is amazing!');
```

Message is correctly sent to my broker, in json:

```json
{
  "subject": "Using notifier & messenger together is amazing!",
  "recipientId": null,
  "options": null,
  "transport": null,
  "notification": null
}
```

But when I want to consume it, as the `transport` method used by the serializer to create the `ChatMessage` doesn't accept `null` value, I get the following error:

```
  [Symfony\Component\Messenger\Exception\MessageDecodingFailedException]                                                                                                                                                  
  Could not decode message: Failed to denormalize attribute "transport" value for class "Symfony\Component\Notifier\Message\ChatMessage": Expected argument of type "string", "null" given at property path "transport".
```

This PR correct the problem, even if I'm not sure it's the best way to go...