### PR TITLE
Changed MIME type mapping to return "jpg" instead of "jpeg"

### DIFF
--- a/src/Symfony/Component/Mime/MimeTypes.php
+++ b/src/Symfony/Component/Mime/MimeTypes.php
@@ -1320,7 +1320,7 @@ final class MimeTypes implements MimeTypesInterface
         'image/ief' => ['ief'],
         'image/jls' => ['jls'],
         'image/jp2' => ['jp2', 'jpg2'],
-        'image/jpeg' => ['jpeg', 'jpg', 'jpe'],
+        'image/jpeg' => ['jpg', 'jpeg', 'jpe'],
         'image/jpeg2000' => ['jp2', 'jpg2'],
         'image/jpeg2000-image' => ['jp2', 'jpg2'],
         'image/jph' => ['jph'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38268
| License       | MIT
| Doc PR        | 

Fixed order of jpeg mime types for guessExtension() to return "jpg" over "jpeg" as discussed in #38268 
