### PR TITLE
[Framework] Add tag assets.package to register asset packages

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * added `assertCheckboxChecked()` and `assertCheckboxNotChecked()` in `WebTestCase`
  * added `assertFormValue()` and `assertNoFormValue()` in `WebTestCase`
  * Added "--as-tree=3" option to `translation:update` command to dump messages as a tree-like structure. The given value defines the level where to switch to inline YAML
+ * Added tag `assets.package` to register asset packages
 
 5.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -23,6 +23,7 @@ class UnusedTagsPass implements CompilerPassInterface
 {
     private $knownTags = [
         'annotations.cached_reader',
+        'assets.package',
         'auto_alias',
         'cache.pool',
         'cache.pool.clearer',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -445,6 +445,8 @@ class FrameworkExtension extends Extension
             $loader->load('mime_type.php');
         }
 
+        $container->registerForAutoconfiguration(PackageInterface::class)
+            ->addTag('assets.package');
         $container->registerForAutoconfiguration(Command::class)
             ->addTag('console.command');
         $container->registerForAutoconfiguration(ResourceCheckerInterface::class)

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1057,7 +1057,6 @@ class FrameworkExtension extends Extension
         $defaultPackage = $this->createPackageDefinition($config['base_path'], $config['base_urls'], $defaultVersion);
         $container->setDefinition('assets._default_package', $defaultPackage);
 
-        $namedPackages = [];
         foreach ($config['packages'] as $name => $package) {
             if (null !== $package['version_strategy']) {
                 $version = new Reference($package['version_strategy']);
@@ -1071,15 +1070,11 @@ class FrameworkExtension extends Extension
                 $version = $this->createVersion($container, $version, $format, $package['json_manifest_path'], $name);
             }
 
-            $container->setDefinition('assets._package_'.$name, $this->createPackageDefinition($package['base_path'], $package['base_urls'], $version));
+            $packageDefinition = $this->createPackageDefinition($package['base_path'], $package['base_urls'], $version)
+                ->addTag('assets.package', ['package' => $name]);
+            $container->setDefinition('assets._package_'.$name, $packageDefinition);
             $container->registerAliasForArgument('assets._package_'.$name, PackageInterface::class, $name.'.package');
-            $namedPackages[$name] = new Reference('assets._package_'.$name);
         }
-
-        $container->getDefinition('assets.packages')
-            ->replaceArgument(0, new Reference('assets._default_package'))
-            ->replaceArgument(1, $namedPackages)
-        ;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.php
@@ -30,8 +30,8 @@ return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('assets.packages', Packages::class)
             ->args([
-                service('assets.empty_package'),
-                [],
+                service('assets._default_package'),
+                tagged_iterator('assets.package', 'package'),
             ])
 
         ->alias(Packages::class, 'assets.packages')
@@ -40,6 +40,8 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('assets.empty_version_strategy'),
             ])
+
+        ->alias('assets._default_package', 'assets.empty_package')
 
         ->set('assets.context', RequestStackContext::class)
             ->args([

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.php
@@ -31,7 +31,7 @@ return static function (ContainerConfigurator $container) {
         ->set('assets.packages', Packages::class)
             ->args([
                 service('assets._default_package'),
-                tagged_iterator('assets.package', 'package'),
+                tagged_iterator('assets.package', 'package', 'getDefaultName'),
             ])
 
         ->alias(Packages::class, 'assets.packages')

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -578,8 +578,13 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertUrlPackage($container, $defaultPackage, ['http://cdn.example.com'], 'SomeVersionScheme', '%%s?version=%%s');
 
         // packages
-        $packages = $packages->getArgument(1);
-        $this->assertCount(7, $packages);
+        $packageTags = $container->findTaggedServiceIds('assets.package');
+        $this->assertCount(7, $packageTags);
+
+        $packages = [];
+        foreach ($packageTags as $serviceId => $tagAttributes) {
+            $packages[$tagAttributes[0]['package']] = $serviceId;
+        }
 
         $package = $container->getDefinition((string) $packages['images_path']);
         $this->assertPathPackage($container, $package, '/foo', 'SomeVersionScheme', '%%s?version=%%s');

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "doctrine/annotations": "~1.7",
         "doctrine/cache": "~1.0",
-        "symfony/asset": "^5.1",
+        "symfony/asset": "^5.2",
         "symfony/browser-kit": "^4.4|^5.0",
         "symfony/console": "^5.2",
         "symfony/css-selector": "^4.4|^5.0",
@@ -71,7 +71,7 @@
         "phpdocumentor/reflection-docblock": "<3.0",
         "phpdocumentor/type-resolver": "<0.2.1",
         "phpunit/phpunit": "<5.4.3",
-        "symfony/asset": "<5.1",
+        "symfony/asset": "<5.2",
         "symfony/browser-kit": "<4.4",
         "symfony/console": "<5.2",
         "symfony/dotenv": "<5.1",

--- a/src/Symfony/Component/Asset/CHANGELOG.md
+++ b/src/Symfony/Component/Asset/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * the `Packages` constructor accepts any iterable.
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/Asset/Packages.php
+++ b/src/Symfony/Component/Asset/Packages.php
@@ -28,7 +28,7 @@ class Packages
     /**
      * @param PackageInterface[] $packages Additional packages indexed by name
      */
-    public function __construct(PackageInterface $defaultPackage = null, array $packages = [])
+    public function __construct(PackageInterface $defaultPackage = null, iterable $packages = [])
     {
         $this->defaultPackage = $defaultPackage;
 

--- a/src/Symfony/Component/Asset/Tests/PackagesTest.php
+++ b/src/Symfony/Component/Asset/Tests/PackagesTest.php
@@ -48,7 +48,7 @@ class PackagesTest extends TestCase
     {
         $packages = new Packages(
             new Package(new StaticVersionStrategy('default')),
-            ['a' => new Package(new StaticVersionStrategy('a'))]
+            new \ArrayIterator(['a' => new Package(new StaticVersionStrategy('a'))])
         );
 
         $this->assertSame('/foo?default', $packages->getUrl('/foo'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#14313

To configure asset packages in an application, we have to declare it in the `framework` configuration ([doc for assets config](https://symfony.com/doc/current/reference/configuration/framework.html#assets)). In some case we cannot use this configuration:
- To use a custom class as package
- To register an asset package in a shared bundle (my use-case).

This PR adds the `assets.package` tag. This tag is use to collect and inject package services into the `assets.packages` service, that is the registry for all packages. Since every package needs a name, the `package` attribute of the tag is used (same naming convention that the `console.command` tag).


Main changes:
- the packages defined in the `framework.assets` configuration are injected into the `assets.packages` using the tag instead of being directly injected in service declaration.
- changed signature of `Symfony\Components\Assets\Packages` constructor to accept an iterator (backward compatible).
- a new alias `assets._default_package` is defined even if assets are not configured.


### Example in `symfony/demo` ([commit](https://github.com/symfony/demo/compare/e5e5a8fff048351ea8a8fe2b418f0256eabeee12...GromNaN:assets-package-tag)):

In `config/services.yaml`:
```yaml
    avatar.strategy:
        class: Symfony\Component\Asset\VersionStrategy\JsonManifestVersionStrategy
        arguments:
            - '%kernel.project_dir%/public/build/manifest.json'

    avatar.package:
        class:  Symfony\Component\Asset\Package
        arguments:
            - '@avatar.strategy'
            - '@assets.context'
        tags:
            - { name: assets.package, package: avatars }
```

Then we can use the package anywhere
```twig
<img src="{{ asset('build/images/fa-brands-400.svg', 'avatars') }}">
```