### PR TITLE
[HttpFoundation] Expired cookies string representation consistency & tests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -62,8 +62,9 @@ class Cookie
         $value = isset($part[1]) ? ($decode ? urldecode($part[1]) : $part[1]) : null;
 
         $data = HeaderUtils::combine($parts) + $data;
+        $data['expires'] = self::expiresTimestamp($data['expires']);
 
-        if (isset($data['max-age'])) {
+        if (isset($data['max-age']) && ($data['max-age'] > 0 || $data['expires'] > time())) {
             $data['expires'] = time() + (int) $data['max-age'];
         }
 
@@ -102,7 +103,7 @@ class Cookie
         $this->name = $name;
         $this->value = $value;
         $this->domain = $domain;
-        $this->expire = $this->withExpires($expire)->expire;
+        $this->expire = self::expiresTimestamp($expire);
         $this->path = empty($path) ? '/' : $path;
         $this->secure = $secure;
         $this->httpOnly = $httpOnly;
@@ -145,6 +146,21 @@ class Cookie
      */
     public function withExpires($expire = 0): self
     {
+        $cookie = clone $this;
+        $cookie->expire = self::expiresTimestamp($expire);
+
+        return $cookie;
+    }
+
+    /**
+     * Converts expires formats to a unix timestamp.
+     *
+     * @param int|string|\DateTimeInterface $expire
+     *
+     * @return int
+     */
+    private static function expiresTimestamp($expire = 0)
+    {
         // convert expiration time to a Unix timestamp
         if ($expire instanceof \DateTimeInterface) {
             $expire = $expire->format('U');
@@ -156,10 +172,7 @@ class Cookie
             }
         }
 
-        $cookie = clone $this;
-        $cookie->expire = 0 < $expire ? (int) $expire : 0;
-
-        return $cookie;
+        return 0 < $expire ? (int) $expire : 0;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

These changes add consistent behavior when converting expired cookies back and forth from string representation into `Symfony\Component\HttpFoundation\Cookie` instances in `Cookie::fromString`:

- When `Max-Age` is zero and `expires` is in the past, the `expires` date is kept as is (previous behavior: `expires` is overwritten with current timestamp because it is reset to current timestamp + `Max-Age`)
- When `Max-Age` is zero and `expires` is in the future, expires is reset to current timestamp, as `Max-Age` is the preferred "source of truth" (same as previous behavior)
- Add tests for how the Cookie class handles `Max-Age` in a cookie string and how `expires` and `Max-Age` interact
- Extract helper function `expiresTimestamp` so converting to a unix timestamp can be reused in `Cookie::fromString`

This is more a new feature than a bug fix in my mind, therefore I would include it in 5.1+.