### PR TITLE
[Config] Added failing test with merge

### DIFF
--- a/src/Symfony/Component/Config/Tests/Definition/MergeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/MergeTest.php
@@ -189,4 +189,31 @@ class MergeTest extends TestCase
 
         $this->assertEquals(['append_elements' => ['a', 'b', 'c', 'd']], $tree->merge($a, $b));
     }
+
+    public function testMergingOfVariablePrototype()
+    {
+        $tb = new TreeBuilder('root', 'array');
+
+        $tree = $tb
+            ->getRootNode()
+                ->children()
+                    ->arrayNode('config')
+                        ->prototype('variable')->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->buildTree()
+        ;
+
+        $a = [
+            'config' => ['a' => null],
+        ];
+
+        $b = [
+            'config' => ['a' => 'bar'],
+        ];
+
+        $merge = $tree->merge($a, $b);
+        $this->assertEquals(['config' => ['a' => 'bar']], $merge);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I open this PR as an issue. @dcsg noticed this behaviour. 

If I have config like: 

```php
class Configuration implements ConfigurationInterface
{
    public function getConfigTreeBuilder()
    {
        $treeBuilder = new TreeBuilder('acme');

        $rootNode = $treeBuilder->getRootNode();

        $rootNode
            ->children()
                ->arrayNode('config')->prototype('variable')->end()->end()
            ->end();
      }
}
```


```yaml
# config/packages/acme.yaml
acme:
    config:
        foobar: ~

```

```yaml
# config/packages/dev/acme.yaml
acme:
    config:
        foobar: 'hello word'

```

The processed config looks like: 


```php
$config = [
    'config' => [
        'foobar' => null,
        0 => 'hello word',
    ],
];
```

I would expect it to be 

```php
$config = [
    'config' => [
        'foobar' => 'hello word',
    ],
];
```

Is this a bug or the intended behaviour? 

Ping @OskarStark. I see that you have recently added logic related to this. 