### PR TITLE
[HttpClient] Deactivate inner-response throwing on destruct in AsyncResponse

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -166,6 +166,9 @@ final class AsyncResponse implements ResponseInterface, StreamableInterface
         if (null !== $httpException) {
             throw $httpException;
         }
+
+        // Deactivate underlying response throwing on HTTP errors
+        $this->response->getStatusCode();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37663
| License       | MIT
| Doc PR        | -

See the previous issue and newly added tests for more information.

The issue can also be reproduced by code like this:
```php
<?php

declare(strict_types=1);

use Monolog\Handler\StreamHandler;
use Monolog\Logger;
use Symfony\Component\HttpClient\CurlHttpClient;
use Symfony\Component\HttpClient\Retry\ExponentialBackOff;
use Symfony\Component\HttpClient\Retry\HttpStatusCodeDecider;
use Symfony\Component\HttpClient\RetryableHttpClient;

require __DIR__ . '/vendor/autoload.php';

$client = new RetryableHttpClient(new CurlHttpClient(), new HttpStatusCodeDecider(), new ExponentialBackOff(), 2, new Logger('HttpClient', [new StreamHandler('php://stderr')]));
$resp = $client->request('GET', 'https://httpbin.org/status/429');
var_dump($resp->getContent(false)); // string(0) ""
```
```
PHP Fatal error:  Uncaught Symfony\Component\HttpClient\Exception\ClientException: HTTP/2 429  returned for "https://httpbin.org/status/429". in /home/debian/PromiseHttpClient/vendor/symfony/http-client/Response/CommonResponseTrait.php:176
Stack trace:
#0 /home/debian/PromiseHttpClient/vendor/symfony/http-client/Response/TransportResponseTrait.php(132): Symfony\Component\HttpClient\Response\CurlResponse->checkStatusCode()
#1 /home/debian/PromiseHttpClient/vendor/symfony/http-client/Response/CurlResponse.php(231): Symfony\Component\HttpClient\Response\CurlResponse->doDestruct()
#2 [internal function]: Symfony\Component\HttpClient\Response\CurlResponse->__destruct()
#3 {main}
  thrown in /home/debian/PromiseHttpClient/vendor/symfony/http-client/Response/CommonResponseTrait.php on line 176
```