### PR TITLE
[Validator] Use comparison constraints as attributes

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -105,6 +105,8 @@ Validator
     */
    ```
 
+ * Deprecated the `NumberConstraintTrait` trait.
+
 Security
 --------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -184,6 +184,8 @@ Validator
     */
    ```
 
+ * Removed the `NumberConstraintTrait` trait.
+
 Yaml
 ----
 

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -33,6 +33,7 @@ CHANGELOG
  * added the `ULID` constraint and validator
  * added support for UUIDv6 in `Uuid` constraint
  * enabled the validator to load constraints from PHP attributes
+ * deprecated the `NumberConstraintTrait` trait
 
 5.1.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
@@ -30,28 +30,33 @@ abstract class AbstractComparison extends Constraint
 
     /**
      * {@inheritdoc}
+     *
+     * @param mixed $value the value to compare or a set of options
      */
-    public function __construct($options = null)
+    public function __construct($value = null, $propertyPath = null, string $message = null, array $groups = null, $payload = null, array $options = [])
     {
-        if (null === $options) {
-            $options = [];
+        if (\is_array($value)) {
+            $options = array_merge($value, $options);
+        } elseif (null !== $value) {
+            $options['value'] = $value;
         }
 
-        if (\is_array($options)) {
-            if (!isset($options['value']) && !isset($options['propertyPath'])) {
-                throw new ConstraintDefinitionException(sprintf('The "%s" constraint requires either the "value" or "propertyPath" option to be set.', static::class));
-            }
+        parent::__construct($options, $groups, $payload);
 
-            if (isset($options['value']) && isset($options['propertyPath'])) {
-                throw new ConstraintDefinitionException(sprintf('The "%s" constraint requires only one of the "value" or "propertyPath" options to be set, not both.', static::class));
-            }
+        $this->message = $message ?? $this->message;
+        $this->propertyPath = $propertyPath ?? $this->propertyPath;
 
-            if (isset($options['propertyPath']) && !class_exists(PropertyAccess::class)) {
-                throw new LogicException(sprintf('The "%s" constraint requires the Symfony PropertyAccess component to use the "propertyPath" option.', static::class));
-            }
+        if (null === $this->value && null === $this->propertyPath) {
+            throw new ConstraintDefinitionException(sprintf('The "%s" constraint requires either the "value" or "propertyPath" option to be set.', static::class));
         }
 
-        parent::__construct($options);
+        if (null !== $this->value && null !== $this->propertyPath) {
+            throw new ConstraintDefinitionException(sprintf('The "%s" constraint requires only one of the "value" or "propertyPath" options to be set, not both.', static::class));
+        }
+
+        if (null !== $this->propertyPath && !class_exists(PropertyAccess::class)) {
+            throw new LogicException(sprintf('The "%s" constraint requires the Symfony PropertyAccess component to use the "propertyPath" option.', static::class));
+        }
     }
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/DivisibleBy.php
+++ b/src/Symfony/Component/Validator/Constraints/DivisibleBy.php
@@ -17,6 +17,7 @@ namespace Symfony\Component\Validator\Constraints;
  *
  * @author Colin O'Dell <colinodell@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class DivisibleBy extends AbstractComparison
 {
     const NOT_DIVISIBLE_BY = '6d99d6c3-1464-4ccf-bdc7-14d083cf455c';

--- a/src/Symfony/Component/Validator/Constraints/EqualTo.php
+++ b/src/Symfony/Component/Validator/Constraints/EqualTo.php
@@ -18,6 +18,7 @@ namespace Symfony\Component\Validator\Constraints;
  * @author Daniel Holmes <daniel@danielholmes.org>
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class EqualTo extends AbstractComparison
 {
     const NOT_EQUAL_ERROR = '478618a7-95ba-473d-9101-cabd45e49115';

--- a/src/Symfony/Component/Validator/Constraints/GreaterThan.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThan.php
@@ -18,6 +18,7 @@ namespace Symfony\Component\Validator\Constraints;
  * @author Daniel Holmes <daniel@danielholmes.org>
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class GreaterThan extends AbstractComparison
 {
     const TOO_LOW_ERROR = '778b7ae0-84d3-481a-9dec-35fdb64b1d78';

--- a/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqual.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqual.php
@@ -18,6 +18,7 @@ namespace Symfony\Component\Validator\Constraints;
  * @author Daniel Holmes <daniel@danielholmes.org>
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class GreaterThanOrEqual extends AbstractComparison
 {
     const TOO_LOW_ERROR = 'ea4e51d1-3342-48bd-87f1-9e672cd90cad';

--- a/src/Symfony/Component/Validator/Constraints/IdenticalTo.php
+++ b/src/Symfony/Component/Validator/Constraints/IdenticalTo.php
@@ -18,6 +18,7 @@ namespace Symfony\Component\Validator\Constraints;
  * @author Daniel Holmes <daniel@danielholmes.org>
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class IdenticalTo extends AbstractComparison
 {
     const NOT_IDENTICAL_ERROR = '2a8cc50f-58a2-4536-875e-060a2ce69ed5';

--- a/src/Symfony/Component/Validator/Constraints/LessThan.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThan.php
@@ -18,6 +18,7 @@ namespace Symfony\Component\Validator\Constraints;
  * @author Daniel Holmes <daniel@danielholmes.org>
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class LessThan extends AbstractComparison
 {
     const TOO_HIGH_ERROR = '079d7420-2d13-460c-8756-de810eeb37d2';

--- a/src/Symfony/Component/Validator/Constraints/LessThanOrEqual.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThanOrEqual.php
@@ -18,6 +18,7 @@ namespace Symfony\Component\Validator\Constraints;
  * @author Daniel Holmes <daniel@danielholmes.org>
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class LessThanOrEqual extends AbstractComparison
 {
     const TOO_HIGH_ERROR = '30fbb013-d015-4232-8b3b-8f3be97a7e14';

--- a/src/Symfony/Component/Validator/Constraints/Negative.php
+++ b/src/Symfony/Component/Validator/Constraints/Negative.php
@@ -17,19 +17,10 @@ namespace Symfony\Component\Validator\Constraints;
  *
  * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Negative extends LessThan
 {
-    use NumberConstraintTrait;
+    use ZeroComparisonConstraintTrait;
 
     public $message = 'This value should be negative.';
-
-    public function __construct($options = null)
-    {
-        parent::__construct($this->configureNumberConstraintOptions($options));
-    }
-
-    public function validatedBy(): string
-    {
-        return LessThanValidator::class;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/NegativeOrZero.php
+++ b/src/Symfony/Component/Validator/Constraints/NegativeOrZero.php
@@ -17,19 +17,10 @@ namespace Symfony\Component\Validator\Constraints;
  *
  * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class NegativeOrZero extends LessThanOrEqual
 {
-    use NumberConstraintTrait;
+    use ZeroComparisonConstraintTrait;
 
     public $message = 'This value should be either negative or zero.';
-
-    public function __construct($options = null)
-    {
-        parent::__construct($this->configureNumberConstraintOptions($options));
-    }
-
-    public function validatedBy(): string
-    {
-        return LessThanOrEqualValidator::class;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/NotEqualTo.php
+++ b/src/Symfony/Component/Validator/Constraints/NotEqualTo.php
@@ -18,6 +18,7 @@ namespace Symfony\Component\Validator\Constraints;
  * @author Daniel Holmes <daniel@danielholmes.org>
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class NotEqualTo extends AbstractComparison
 {
     const IS_EQUAL_ERROR = 'aa2e33da-25c8-4d76-8c6c-812f02ea89dd';

--- a/src/Symfony/Component/Validator/Constraints/NotIdenticalTo.php
+++ b/src/Symfony/Component/Validator/Constraints/NotIdenticalTo.php
@@ -18,6 +18,7 @@ namespace Symfony\Component\Validator\Constraints;
  * @author Daniel Holmes <daniel@danielholmes.org>
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class NotIdenticalTo extends AbstractComparison
 {
     const IS_IDENTICAL_ERROR = '4aaac518-0dda-4129-a6d9-e216b9b454a0';

--- a/src/Symfony/Component/Validator/Constraints/Positive.php
+++ b/src/Symfony/Component/Validator/Constraints/Positive.php
@@ -17,19 +17,10 @@ namespace Symfony\Component\Validator\Constraints;
  *
  * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Positive extends GreaterThan
 {
-    use NumberConstraintTrait;
+    use ZeroComparisonConstraintTrait;
 
     public $message = 'This value should be positive.';
-
-    public function __construct($options = null)
-    {
-        parent::__construct($this->configureNumberConstraintOptions($options));
-    }
-
-    public function validatedBy(): string
-    {
-        return GreaterThanValidator::class;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/PositiveOrZero.php
+++ b/src/Symfony/Component/Validator/Constraints/PositiveOrZero.php
@@ -17,19 +17,10 @@ namespace Symfony\Component\Validator\Constraints;
  *
  * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class PositiveOrZero extends GreaterThanOrEqual
 {
-    use NumberConstraintTrait;
+    use ZeroComparisonConstraintTrait;
 
     public $message = 'This value should be either positive or zero.';
-
-    public function __construct($options = null)
-    {
-        parent::__construct($this->configureNumberConstraintOptions($options));
-    }
-
-    public function validatedBy(): string
-    {
-        return GreaterThanOrEqualValidator::class;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/ZeroComparisonConstraintTrait.php
+++ b/src/Symfony/Component/Validator/Constraints/ZeroComparisonConstraintTrait.php
@@ -13,21 +13,18 @@ namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
-trigger_deprecation('symfony/validator', '5.2', '%s is deprecated.', NumberConstraintTrait::class);
-
 /**
- * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ * @internal
  *
- * @deprecated since Symfony 5.2
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ * @author Alexander M. Turek <me@derrabus.de>
  */
-trait NumberConstraintTrait
+trait ZeroComparisonConstraintTrait
 {
-    private function configureNumberConstraintOptions($options): array
+    public function __construct(array $options = null, string $message = null, array $groups = null, $payload = null)
     {
         if (null === $options) {
             $options = [];
-        } elseif (!\is_array($options)) {
-            $options = [$this->getDefaultOption() => $options];
         }
 
         if (isset($options['propertyPath'])) {
@@ -38,8 +35,11 @@ trait NumberConstraintTrait
             throw new ConstraintDefinitionException(sprintf('The "value" option of the "%s" constraint cannot be set.', static::class));
         }
 
-        $options['value'] = 0;
+        parent::__construct(0, null, $message, $groups, $payload, $options);
+    }
 
-        return $options;
+    public function validatedBy(): string
+    {
+        return parent::class.'Validator';
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DivisibleByTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\DivisibleBy;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @requires PHP 8
+ */
+class DivisibleByTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(DivisibleByDummy::class);
+        $loader = new AnnotationLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        list($aConstraint) = $metadata->properties['a']->getConstraints();
+        self::assertSame(2, $aConstraint->value);
+        self::assertNull($aConstraint->propertyPath);
+
+        list($bConstraint) = $metadata->properties['b']->getConstraints();
+        self::assertSame(4711, $bConstraint->value);
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame(['Default', 'DivisibleByDummy'], $bConstraint->groups);
+
+        list($cConstraint) = $metadata->properties['c']->getConstraints();
+        self::assertNull($cConstraint->value);
+        self::assertSame('b', $cConstraint->propertyPath);
+        self::assertSame('myMessage', $cConstraint->message);
+        self::assertSame(['foo'], $cConstraint->groups);
+    }
+}
+
+class DivisibleByDummy
+{
+    #[DivisibleBy(2)]
+    private $a;
+
+    #[DivisibleBy(value: 4711, message: 'myMessage')]
+    private $b;
+
+    #[DivisibleBy(propertyPath: 'b', message: 'myMessage', groups: ['foo'])]
+    private $c;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\EqualTo;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @requires PHP 8
+ */
+class EqualToTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(EqualToDummy::class);
+        $loader = new AnnotationLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        list($aConstraint) = $metadata->properties['a']->getConstraints();
+        self::assertSame(2, $aConstraint->value);
+        self::assertNull($aConstraint->propertyPath);
+
+        list($bConstraint) = $metadata->properties['b']->getConstraints();
+        self::assertSame(4711, $bConstraint->value);
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame(['Default', 'EqualToDummy'], $bConstraint->groups);
+
+        list($cConstraint) = $metadata->properties['c']->getConstraints();
+        self::assertNull($cConstraint->value);
+        self::assertSame('b', $cConstraint->propertyPath);
+        self::assertSame('myMessage', $cConstraint->message);
+        self::assertSame(['foo'], $cConstraint->groups);
+    }
+}
+
+class EqualToDummy
+{
+    #[EqualTo(2)]
+    private $a;
+
+    #[EqualTo(value: 4711, message: 'myMessage')]
+    private $b;
+
+    #[EqualTo(propertyPath: 'b', message: 'myMessage', groups: ['foo'])]
+    private $c;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @requires PHP 8
+ */
+class GreaterThanOrEqualTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(GreaterThanOrEqualDummy::class);
+        $loader = new AnnotationLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        list($aConstraint) = $metadata->properties['a']->getConstraints();
+        self::assertSame(2, $aConstraint->value);
+        self::assertNull($aConstraint->propertyPath);
+
+        list($bConstraint) = $metadata->properties['b']->getConstraints();
+        self::assertSame(4711, $bConstraint->value);
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame(['Default', 'GreaterThanOrEqualDummy'], $bConstraint->groups);
+
+        list($cConstraint) = $metadata->properties['c']->getConstraints();
+        self::assertNull($cConstraint->value);
+        self::assertSame('b', $cConstraint->propertyPath);
+        self::assertSame('myMessage', $cConstraint->message);
+        self::assertSame(['foo'], $cConstraint->groups);
+    }
+}
+
+class GreaterThanOrEqualDummy
+{
+    #[GreaterThanOrEqual(2)]
+    private $a;
+
+    #[GreaterThanOrEqual(value: 4711, message: 'myMessage')]
+    private $b;
+
+    #[GreaterThanOrEqual(propertyPath: 'b', message: 'myMessage', groups: ['foo'])]
+    private $c;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @requires PHP 8
+ */
+class GreaterThanTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(GreaterThanDummy::class);
+        $loader = new AnnotationLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        list($aConstraint) = $metadata->properties['a']->getConstraints();
+        self::assertSame(2, $aConstraint->value);
+        self::assertNull($aConstraint->propertyPath);
+
+        list($bConstraint) = $metadata->properties['b']->getConstraints();
+        self::assertSame(4711, $bConstraint->value);
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame(['Default', 'GreaterThanDummy'], $bConstraint->groups);
+
+        list($cConstraint) = $metadata->properties['c']->getConstraints();
+        self::assertNull($cConstraint->value);
+        self::assertSame('b', $cConstraint->propertyPath);
+        self::assertSame('myMessage', $cConstraint->message);
+        self::assertSame(['foo'], $cConstraint->groups);
+    }
+}
+
+class GreaterThanDummy
+{
+    #[GreaterThan(2)]
+    private $a;
+
+    #[GreaterThan(value: 4711, message: 'myMessage')]
+    private $b;
+
+    #[GreaterThan(propertyPath: 'b', message: 'myMessage', groups: ['foo'])]
+    private $c;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\IdenticalTo;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @requires PHP 8
+ */
+class IdenticalToTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(IdenticalToDummy::class);
+        $loader = new AnnotationLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        list($aConstraint) = $metadata->properties['a']->getConstraints();
+        self::assertSame(2, $aConstraint->value);
+        self::assertNull($aConstraint->propertyPath);
+
+        list($bConstraint) = $metadata->properties['b']->getConstraints();
+        self::assertSame(4711, $bConstraint->value);
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame(['Default', 'IdenticalToDummy'], $bConstraint->groups);
+
+        list($cConstraint) = $metadata->properties['c']->getConstraints();
+        self::assertNull($cConstraint->value);
+        self::assertSame('b', $cConstraint->propertyPath);
+        self::assertSame('myMessage', $cConstraint->message);
+        self::assertSame(['foo'], $cConstraint->groups);
+    }
+}
+
+class IdenticalToDummy
+{
+    #[IdenticalTo(2)]
+    private $a;
+
+    #[IdenticalTo(value: 4711, message: 'myMessage')]
+    private $b;
+
+    #[IdenticalTo(propertyPath: 'b', message: 'myMessage', groups: ['foo'])]
+    private $c;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\LessThanOrEqual;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @requires PHP 8
+ */
+class LessThanOrEqualTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(LessThanOrEqualDummy::class);
+        $loader = new AnnotationLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        list($aConstraint) = $metadata->properties['a']->getConstraints();
+        self::assertSame(2, $aConstraint->value);
+        self::assertNull($aConstraint->propertyPath);
+
+        list($bConstraint) = $metadata->properties['b']->getConstraints();
+        self::assertSame(4711, $bConstraint->value);
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame(['Default', 'LessThanOrEqualDummy'], $bConstraint->groups);
+
+        list($cConstraint) = $metadata->properties['c']->getConstraints();
+        self::assertNull($cConstraint->value);
+        self::assertSame('b', $cConstraint->propertyPath);
+        self::assertSame('myMessage', $cConstraint->message);
+        self::assertSame(['foo'], $cConstraint->groups);
+    }
+}
+
+class LessThanOrEqualDummy
+{
+    #[LessThanOrEqual(2)]
+    private $a;
+
+    #[LessThanOrEqual(value: 4711, message: 'myMessage')]
+    private $b;
+
+    #[LessThanOrEqual(propertyPath: 'b', message: 'myMessage', groups: ['foo'])]
+    private $c;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\LessThan;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @requires PHP 8
+ */
+class LessThanTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(LessThanDummy::class);
+        $loader = new AnnotationLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        list($aConstraint) = $metadata->properties['a']->getConstraints();
+        self::assertSame(2, $aConstraint->value);
+        self::assertNull($aConstraint->propertyPath);
+
+        list($bConstraint) = $metadata->properties['b']->getConstraints();
+        self::assertSame(4711, $bConstraint->value);
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame(['Default', 'LessThanDummy'], $bConstraint->groups);
+
+        list($cConstraint) = $metadata->properties['c']->getConstraints();
+        self::assertNull($cConstraint->value);
+        self::assertSame('b', $cConstraint->propertyPath);
+        self::assertSame('myMessage', $cConstraint->message);
+        self::assertSame(['foo'], $cConstraint->groups);
+    }
+}
+
+class LessThanDummy
+{
+    #[LessThan(2)]
+    private $a;
+
+    #[LessThan(value: 4711, message: 'myMessage')]
+    private $b;
+
+    #[LessThan(propertyPath: 'b', message: 'myMessage', groups: ['foo'])]
+    private $c;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/NegativeOrZeroTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NegativeOrZeroTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\NegativeOrZero;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @requires PHP 8
+ */
+class NegativeOrZeroTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(NegativeOrZeroDummy::class);
+        $loader = new AnnotationLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        list($aConstraint) = $metadata->properties['a']->getConstraints();
+        self::assertSame(0, $aConstraint->value);
+        self::assertNull($aConstraint->propertyPath);
+        self::assertSame(['Default', 'NegativeOrZeroDummy'], $aConstraint->groups);
+
+        list($bConstraint) = $metadata->properties['b']->getConstraints();
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame(['foo'], $bConstraint->groups);
+    }
+}
+
+class NegativeOrZeroDummy
+{
+    #[NegativeOrZero]
+    private $a;
+
+    #[NegativeOrZero(message: 'myMessage', groups: ['foo'])]
+    private $b;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/NegativeTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NegativeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\Negative;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @requires PHP 8
+ */
+class NegativeTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(NegativeDummy::class);
+        $loader = new AnnotationLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        list($aConstraint) = $metadata->properties['a']->getConstraints();
+        self::assertSame(0, $aConstraint->value);
+        self::assertNull($aConstraint->propertyPath);
+        self::assertSame(['Default', 'NegativeDummy'], $aConstraint->groups);
+
+        list($bConstraint) = $metadata->properties['b']->getConstraints();
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame(['foo'], $bConstraint->groups);
+    }
+}
+
+class NegativeDummy
+{
+    #[Negative]
+    private $a;
+
+    #[Negative(message: 'myMessage', groups: ['foo'])]
+    private $b;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\NotEqualTo;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @requires PHP 8
+ */
+class NotEqualToTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(NotEqualToDummy::class);
+        $loader = new AnnotationLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        list($aConstraint) = $metadata->properties['a']->getConstraints();
+        self::assertSame(2, $aConstraint->value);
+        self::assertNull($aConstraint->propertyPath);
+
+        list($bConstraint) = $metadata->properties['b']->getConstraints();
+        self::assertSame(4711, $bConstraint->value);
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame(['Default', 'NotEqualToDummy'], $bConstraint->groups);
+
+        list($cConstraint) = $metadata->properties['c']->getConstraints();
+        self::assertNull($cConstraint->value);
+        self::assertSame('b', $cConstraint->propertyPath);
+        self::assertSame('myMessage', $cConstraint->message);
+        self::assertSame(['foo'], $cConstraint->groups);
+    }
+}
+
+class NotEqualToDummy
+{
+    #[NotEqualTo(2)]
+    private $a;
+
+    #[NotEqualTo(value: 4711, message: 'myMessage')]
+    private $b;
+
+    #[NotEqualTo(propertyPath: 'b', message: 'myMessage', groups: ['foo'])]
+    private $c;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\NotIdenticalTo;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @requires PHP 8
+ */
+class NotIdenticalToTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(NotIdenticalToDummy::class);
+        $loader = new AnnotationLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        list($aConstraint) = $metadata->properties['a']->getConstraints();
+        self::assertSame(2, $aConstraint->value);
+        self::assertNull($aConstraint->propertyPath);
+
+        list($bConstraint) = $metadata->properties['b']->getConstraints();
+        self::assertSame(4711, $bConstraint->value);
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame(['Default', 'NotIdenticalToDummy'], $bConstraint->groups);
+
+        list($cConstraint) = $metadata->properties['c']->getConstraints();
+        self::assertNull($cConstraint->value);
+        self::assertSame('b', $cConstraint->propertyPath);
+        self::assertSame('myMessage', $cConstraint->message);
+        self::assertSame(['foo'], $cConstraint->groups);
+    }
+}
+
+class NotIdenticalToDummy
+{
+    #[NotIdenticalTo(2)]
+    private $a;
+
+    #[NotIdenticalTo(value: 4711, message: 'myMessage')]
+    private $b;
+
+    #[NotIdenticalTo(propertyPath: 'b', message: 'myMessage', groups: ['foo'])]
+    private $c;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/PositiveOrZeroTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PositiveOrZeroTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\PositiveOrZero;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @requires PHP 8
+ */
+class PositiveOrZeroTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(PositiveOrZeroDummy::class);
+        $loader = new AnnotationLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        list($aConstraint) = $metadata->properties['a']->getConstraints();
+        self::assertSame(0, $aConstraint->value);
+        self::assertNull($aConstraint->propertyPath);
+        self::assertSame(['Default', 'PositiveOrZeroDummy'], $aConstraint->groups);
+
+        list($bConstraint) = $metadata->properties['b']->getConstraints();
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame(['foo'], $bConstraint->groups);
+    }
+}
+
+class PositiveOrZeroDummy
+{
+    #[PositiveOrZero]
+    private $a;
+
+    #[PositiveOrZero(message: 'myMessage', groups: ['foo'])]
+    private $b;
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/PositiveTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/PositiveTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\Positive;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
+
+/**
+ * @requires PHP 8
+ */
+class PositiveTest extends TestCase
+{
+    public function testAttributes()
+    {
+        $metadata = new ClassMetadata(PositiveDummy::class);
+        $loader = new AnnotationLoader();
+        self::assertTrue($loader->loadClassMetadata($metadata));
+
+        list($aConstraint) = $metadata->properties['a']->getConstraints();
+        self::assertSame(0, $aConstraint->value);
+        self::assertNull($aConstraint->propertyPath);
+        self::assertSame(['Default', 'PositiveDummy'], $aConstraint->groups);
+
+        list($bConstraint) = $metadata->properties['b']->getConstraints();
+        self::assertSame('myMessage', $bConstraint->message);
+        self::assertSame(['foo'], $bConstraint->groups);
+    }
+}
+
+class PositiveDummy
+{
+    #[Positive]
+    private $a;
+
+    #[Positive(message: 'myMessage', groups: ['foo'])]
+    private $b;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | #38096 
| License       | MIT
| Doc PR        | TODO, let's add it to symfony/symfony-docs#14305

This PR enables all child classes of `AbstractComparison` to be used as attributes.

Some of those constraints used a trait called `NumberConstraintTrait` for a shared implementation. After my changes, that trait did not fit well anymore, so I've added a new `ZeroComparisonConstraintTrait` as a replacement. Although I don't expect `NumberConstraintTrait` to provide much value outside of the Symfony codebase, I think we cannot safely change it because it was not labelled as `@internal`. This is basically why I went for the deprecation.