### PR TITLE
[FrameworkBundle] disallow FrameworkBundle 4.4+

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -35,6 +35,7 @@
     "conflict": {
         "symfony/dependency-injection": "<3.4",
         "symfony/event-dispatcher": "<3.3.1",
+        "symfony/framework-bundle": ">4.3.99",
         "symfony/var-dumper": "<3.3"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Since #34619 (merged in 4.4.1) the request stack can no longer be passed as an argument to the `HtmlErrorRenderer` constructor. However, FrameworkBundle 4.4 refuses to be used with WebProfilerBundle 3.4 since #34369 (merged in 4.4.0-RC1).