### PR TITLE
[PhpUnitBridge] Fix Deprecation file when it comes from the TestsListener

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 
 use PHPUnit\Util\Test;
+use Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerFor;
 
 /**
  * @internal
@@ -83,6 +84,11 @@ class Deprecation
 
                 return;
             }
+
+            if (isset($line['class']) && 0 === strpos($line['class'], SymfonyTestsListenerFor::class)) {
+                return;
+            }
+
             $this->originClass = isset($line['object']) ? \get_class($line['object']) : $line['class'];
             $this->originMethod = $line['function'];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

https://github.com/symfony/symfony/pull/38031 caused an unwanted regression: if the frame `class` matches `SymfonyTestsListenerFor` it used to always return, now it continues so the `originClass` and `originMethod` properties are set. Therefore, the deprecation is considered as coming from the test listener. It ends up in the "legacy" group and muted because the test listeners contains the word "Legacy" in their namespaces.

Example test:
```php
<?php

namespace App\Tests;

use PHPUnit\Framework\TestCase;
use Symfony\Component\EventDispatcher\DependencyInjection\ExtractingEventDispatcher;

final class FooTest extends TestCase
{
    public function test(): void
    {
        // ExtractingEventDispatcher is @internal
        new class extends ExtractingEventDispatcher {};

        $this->assertTrue(true);
    }
}
```

On 4.4:
```
Other deprecation notices (1)

  1x: The "Symfony\Component\EventDispatcher\DependencyInjection\ExtractingEventDispatcher" class is considered internal. It may change without further notice. You should not use it from "Symfony\Component\EventDispatcher\DependencyInjection\ExtractingEventDispatcher@anonymous".
```

On 5.1:
```
Legacy deprecation notices (1)
```