### PR TITLE
[Ldap] Bypass the use of `ldap_control_paged_result` on PHP >= 7.3

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -30,6 +30,9 @@ class Query extends AbstractQuery
     /** @var resource[] */
     private $results;
 
+    /** @var array */
+    private $serverctrls = [];
+
     public function __construct(Connection $connection, string $dn, string $query, array $options = [])
     {
         parent::__construct($connection, $dn, $query, $options);
@@ -97,22 +100,13 @@ class Query extends AbstractQuery
             $cookie = '';
             do {
                 if ($pageControl) {
-                    ldap_control_paged_result($con, $pageSize, true, $cookie);
+                    $this->controlPagedResult($con, $pageSize, $cookie);
                 }
                 $sizeLimit = $itemsLeft;
                 if ($pageSize > 0 && $sizeLimit >= $pageSize) {
                     $sizeLimit = 0;
                 }
-                $search = @$func(
-                    $con,
-                    $this->dn,
-                    $this->query,
-                    $this->options['filter'],
-                    $this->options['attrsOnly'],
-                    $sizeLimit,
-                    $this->options['timeout'],
-                    $this->options['deref']
-                );
+                $search = $this->callSearchFunction($con, $func, $sizeLimit);
 
                 if (false === $search) {
                     $ldapError = '';
@@ -133,7 +127,7 @@ class Query extends AbstractQuery
                     break;
                 }
                 if ($pageControl) {
-                    ldap_control_paged_result_response($con, $search, $cookie);
+                    $cookie = $this->controlPagedResultResponse($con, $search, $cookie);
                 }
             } while (null !== $cookie && '' !== $cookie);
 
@@ -180,7 +174,8 @@ class Query extends AbstractQuery
     private function resetPagination()
     {
         $con = $this->connection->getResource();
-        ldap_control_paged_result($con, 0);
+        $this->controlPagedResultResponse($con, 0, '');
+        $this->serverctrls = [];
 
         // This is a workaround for a bit of a bug in the above invocation
         // of ldap_control_paged_result. Instead of indicating to extldap that
@@ -202,5 +197,63 @@ class Query extends AbstractQuery
             }
             ldap_set_option($con, \LDAP_OPT_SERVER_CONTROLS, $ctl);
         }
+    }
+
+    /**
+     * Sets LDAP pagination controls.
+     *
+     * @param resource $con
+     */
+    private function controlPagedResult($con, int $pageSize, string $cookie): bool
+    {
+        if (\PHP_VERSION_ID < 70300) {
+            return ldap_control_paged_result($con, $pageSize, true, $cookie);
+        }
+        $this->serverctrls = [
+            [
+                'oid' => \LDAP_CONTROL_PAGEDRESULTS,
+                'isCritical' => true,
+                'value' => [
+                    'size' => $pageSize,
+                    'cookie' => $cookie,
+                ],
+            ],
+        ];
+
+        return true;
+    }
+
+    /**
+     * Retrieve LDAP pagination cookie.
+     *
+     * @param resource $con
+     * @param resource $result
+     */
+    private function controlPagedResultResponse($con, $result, string $cookie = ''): string
+    {
+        if (\PHP_VERSION_ID < 70300) {
+            ldap_control_paged_result_response($con, $result, $cookie);
+
+            return $cookie;
+        }
+        ldap_parse_result($con, $result, $errcode, $matcheddn, $errmsg, $referrals, $controls);
+
+        return $controls[\LDAP_CONTROL_PAGEDRESULTS]['value']['cookie'] ?? '';
+    }
+
+    /**
+     * Calls actual LDAP search function with the prepared options and parameters.
+     *
+     * @param resource $con
+     *
+     * @return resource
+     */
+    private function callSearchFunction($con, string $func, int $sizeLimit)
+    {
+        if (\PHP_VERSION_ID < 70300) {
+            return @$func($con, $this->dn, $this->query, $this->options['filter'], $this->options['attrsOnly'], $sizeLimit, $this->options['timeout'], $this->options['deref']);
+        }
+
+        return @$func($con, $this->dn, $this->query, $this->options['filter'], $this->options['attrsOnly'], $sizeLimit, $this->options['timeout'], $this->options['deref'], $this->serverctrls);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38352 
| License       | MIT
| Doc PR        | 

As stated on #38352 [ldap_control_paged_result](https://www.php.net/manual/en/function.ldap-control-paged-result.php) and [ldap_control_paged_result_response](https://www.php.net/manual/en/function.ldap-control-paged-result-response.php) have been deprecated since PHP 7.4 and will be removed on PHP 8.0.

With this fix, Query uses serverctrls to handle LDAP results pagination.

Since `serverctrls` where introduced in PHP 7.3 and they are the only way to circumvent the usage of `ldap_control_paged_result`, I've added a new Query class implementation which uses `serverctrls` to control pagination.

To do so I've also had to update the LDAP Adapter in order to use the new class if PHP version 7.3 or greater are found