### PR TITLE
[lock] Prevent user serializing the key when store does not support it.

### DIFF
--- a/src/Symfony/Component/Lock/Exception/UnserializableKeyException.php
+++ b/src/Symfony/Component/Lock/Exception/UnserializableKeyException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Exception;
+
+/**
+ * UnserializableKeyException is thrown when the key contains state that can no
+ * be serialized and the user try to serialize it.
+ * ie. Connection with a database, flock, semaphore, ...
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class UnserializableKeyException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Lock/Store/FlockStore.php
+++ b/src/Symfony/Component/Lock/Store/FlockStore.php
@@ -125,6 +125,7 @@ class FlockStore implements BlockingStoreInterface, SharedLockStoreInterface
         }
 
         $key->setState(__CLASS__, [$read, $handle]);
+        $key->markUnserializable();
     }
 
     /**

--- a/src/Symfony/Component/Lock/Store/SemaphoreStore.php
+++ b/src/Symfony/Component/Lock/Store/SemaphoreStore.php
@@ -76,6 +76,7 @@ class SemaphoreStore implements BlockingStoreInterface
         }
 
         $key->setState(__CLASS__, $resource);
+        $key->markUnserializable();
     }
 
     /**

--- a/src/Symfony/Component/Lock/Store/ZookeeperStore.php
+++ b/src/Symfony/Component/Lock/Store/ZookeeperStore.php
@@ -65,6 +65,7 @@ class ZookeeperStore implements PersistingStoreInterface
         $token = $this->getUniqueToken($key);
 
         $this->createNewLock($resource, $token);
+        $key->markUnserializable();
 
         $this->checkNotExpired($key);
     }

--- a/src/Symfony/Component/Lock/Tests/KeyTest.php
+++ b/src/Symfony/Component/Lock/Tests/KeyTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Lock\Exception\UnserializableKeyException;
+use Symfony\Component\Lock\Key;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class KeyTest extends TestCase
+{
+    public function testSerialize()
+    {
+        $key = new Key(__METHOD__);
+        $key->reduceLifetime(1);
+        $key->setState('foo', 'bar');
+
+        $copy = unserialize(serialize($key));
+        $this->assertSame($key->getState('foo'), $copy->getState('foo'));
+        $this->assertEqualsWithDelta($key->getRemainingLifetime(), $copy->getRemainingLifetime(), 0.001);
+    }
+
+    public function testUnserialize()
+    {
+        $key = new Key(__METHOD__);
+        $key->markUnserializable();
+
+        $this->expectException(UnserializableKeyException::class);
+        serialize($key);
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
@@ -22,6 +22,7 @@ class FlockStoreTest extends AbstractStoreTest
 {
     use BlockingStoreTestTrait;
     use SharedLockStoreTestTrait;
+    use UnserializableTestTrait;
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\Lock\Store\SemaphoreStore;
 class SemaphoreStoreTest extends AbstractStoreTest
 {
     use BlockingStoreTestTrait;
+    use UnserializableTestTrait;
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Lock/Tests/Store/UnserializableTestTrait.php
+++ b/src/Symfony/Component/Lock/Tests/Store/UnserializableTestTrait.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock\Tests\Store;
+
+use Symfony\Component\Lock\Exception\UnserializableKeyException;
+use Symfony\Component\Lock\Key;
+use Symfony\Component\Lock\PersistingStoreInterface;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+trait UnserializableTestTrait
+{
+    /**
+     * @see AbstractStoreTest::getStore()
+     *
+     * @return PersistingStoreInterface
+     */
+    abstract protected function getStore();
+
+    public function testUnserializableKey()
+    {
+        $store = $this->getStore();
+
+        $key = new Key(uniqid(__METHOD__, true));
+
+        $store->save($key);
+        $this->assertTrue($store->exists($key));
+
+        $this->expectException(UnserializableKeyException::class);
+        serialize($key);
+    }
+}

--- a/src/Symfony/Component/Lock/Tests/Store/ZookeeperStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/ZookeeperStoreTest.php
@@ -23,6 +23,8 @@ use Symfony\Component\Lock\Store\ZookeeperStore;
  */
 class ZookeeperStoreTest extends AbstractStoreTest
 {
+    use UnserializableTestTrait;
+
     /**
      * @return ZookeeperStore
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

Some store relies on connection with the running process. ie. kernel relaease flock/semaphore, or zookeeper neeeds a connection to the database.

When the users tries to serialize the key to send it to another process, they are not aware that they lose the lock.

This PR throws an exception in that situation.