### PR TITLE
Handle consecutive supports() calls in the RememberMeAuthenticator

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
@@ -56,6 +56,13 @@ class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
             return false;
         }
 
+        // if the attribute is set, this is a lazy firewall. The previous
+        // support call already indicated support, so return null and avoid
+        // recreating the cookie
+        if ($request->attributes->has('_remember_me_token')) {
+            return null;
+        }
+
         $token = $this->rememberMeServices->autoLogin($request);
         if (null === $token) {
             return false;

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
@@ -60,6 +60,14 @@ class RememberMeAuthenticatorTest extends TestCase
         yield [$this->createMock(TokenInterface::class), null];
     }
 
+    public function testConsecutiveSupportsCalls()
+    {
+        $this->rememberMeServices->expects($this->once())->method('autoLogin')->with($this->request)->willReturn($this->createMock(TokenInterface::class));
+
+        $this->assertNull($this->authenticator->supports($this->request));
+        $this->assertNull($this->authenticator->supports($this->request));
+    }
+
     public function testAuthenticate()
     {
         $this->request->attributes->set('_remember_me_token', new RememberMeToken($user = new User('wouter', 'test'), 'main', 'secret'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38206 
| License       | MIT
| Doc PR        | -

If I read the issue correctly, the problem is not so much that `autoLogin()` is called in supports, but that it is called multiple times in the same request (in lazy firewalls). This is fixed by this issue.

@qurben or @fancyweb do you have an application with this error, and can you please test the patch in this PR? Please let me know if this actually fixed the issue. (if you can't, I'll create a small demo app to test this one)