### PR TITLE
[Console] Remove "php" invokation from help messages.

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
     * Added `Application::getSignalRegistry()` and `Application::setSignalsToDispatchEvent()` methods
     * Added `SignalableCommandInterface` interface
  * Added `TableCellStyle` class to customize table cell
+ * Removed `php ` prefix invocation from help messages.
 
 5.1.0
 -----

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -44,11 +44,11 @@ class HelpCommand extends Command
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command displays help for a given command:
 
-  <info>php %command.full_name% list</info>
+  <info>%command.full_name% list</info>
 
 You can also output the help in other formats by using the <comment>--format</comment> option:
 
-  <info>php %command.full_name% --format=xml list</info>
+  <info>%command.full_name% --format=xml list</info>
 
 To display the list of available commands, please use the <info>list</info> command.
 EOF

--- a/src/Symfony/Component/Console/Command/ListCommand.php
+++ b/src/Symfony/Component/Console/Command/ListCommand.php
@@ -40,19 +40,19 @@ class ListCommand extends Command
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command lists all commands:
 
-  <info>php %command.full_name%</info>
+  <info>%command.full_name%</info>
 
 You can also display the commands for a specific namespace:
 
-  <info>php %command.full_name% test</info>
+  <info>%command.full_name% test</info>
 
 You can also output the information in other formats by using the <comment>--format</comment> option:
 
-  <info>php %command.full_name% --format=xml</info>
+  <info>%command.full_name% --format=xml</info>
 
 It's also possible to get raw list of commands (useful for embedding command runner):
 
-  <info>php %command.full_name% --raw</info>
+  <info>%command.full_name% --raw</info>
 EOF
             )
         ;

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -153,7 +153,7 @@ class CommandTest extends TestCase
     public function testGetProcessedHelp()
     {
         $command = new \TestCommand();
-        $command->setHelp('The %command.name% command does... Example: php %command.full_name%.');
+        $command->setHelp('The %command.name% command does... Example: %command.full_name%.');
         $this->assertStringContainsString('The namespace:name command does...', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.name% correctly');
         $this->assertStringNotContainsString('%command.full_name%', $command->getProcessedHelp(), '->getProcessedHelp() replaces %command.full_name%');
 
@@ -162,7 +162,7 @@ class CommandTest extends TestCase
         $this->assertStringContainsString('description', $command->getProcessedHelp(), '->getProcessedHelp() falls back to the description');
 
         $command = new \TestCommand();
-        $command->setHelp('The %command.name% command does... Example: php %command.full_name%.');
+        $command->setHelp('The %command.name% command does... Example: %command.full_name%.');
         $application = new Application();
         $application->add($command);
         $application->setDefaultCommand('namespace:name', true);

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
@@ -7,7 +7,7 @@
                 "help [--format FORMAT] [--raw] [--] [<command_name>]"
             ],
             "description": "Displays help for a command",
-            "help": "The <info>help<\/info> command displays help for a given command:\n\n  <info>php app\/console help list<\/info>\n\nYou can also output the help in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.",
+            "help": "The <info>help<\/info> command displays help for a given command:\n\n  <info>app\/console help list<\/info>\n\nYou can also output the help in other formats by using the <comment>--format<\/comment> option:\n\n  <info>app\/console help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.",
             "definition": {
                 "arguments": {
                     "command_name": {
@@ -110,7 +110,7 @@
                 "list [--raw] [--format FORMAT] [--] [<namespace>]"
             ],
             "description": "Lists commands",
-            "help": "The <info>list<\/info> command lists all commands:\n\n  <info>php app\/console list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>php app\/console list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>php app\/console list --raw<\/info>",
+            "help": "The <info>list<\/info> command lists all commands:\n\n  <info>app\/console list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>app\/console list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>app\/console list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>app\/console list --raw<\/info>",
             "definition": {
                 "arguments": {
                     "namespace": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
@@ -15,11 +15,11 @@ Displays help for a command
 
 The help command displays help for a given command:
 
-  php app/console help list
+  app/console help list
 
 You can also output the help in other formats by using the --format option:
 
-  php app/console help --format=xml list
+  app/console help --format=xml list
 
 To display the list of available commands, please use the list command.
 
@@ -127,19 +127,19 @@ Lists commands
 
 The list command lists all commands:
 
-  php app/console list
+  app/console list
 
 You can also display the commands for a specific namespace:
 
-  php app/console list test
+  app/console list test
 
 You can also output the information in other formats by using the --format option:
 
-  php app/console list --format=xml
+  app/console list --format=xml
 
 It's also possible to get raw list of commands (useful for embedding command runner):
 
-  php app/console list --raw
+  app/console list --raw
 
 ### Arguments
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
@@ -8,11 +8,11 @@
       <description>Displays help for a command</description>
       <help>The &lt;info&gt;help&lt;/info&gt; command displays help for a given command:
  
-   &lt;info&gt;php app/console help list&lt;/info&gt;
+   &lt;info&gt;app/console help list&lt;/info&gt;
  
  You can also output the help in other formats by using the &lt;comment&gt;--format&lt;/comment&gt; option:
  
-   &lt;info&gt;php app/console help --format=xml list&lt;/info&gt;
+   &lt;info&gt;app/console help --format=xml list&lt;/info&gt;
  
  To display the list of available commands, please use the &lt;info&gt;list&lt;/info&gt; command.</help>
       <arguments>
@@ -63,19 +63,19 @@
       <description>Lists commands</description>
       <help>The &lt;info&gt;list&lt;/info&gt; command lists all commands:
  
-   &lt;info&gt;php app/console list&lt;/info&gt;
+   &lt;info&gt;app/console list&lt;/info&gt;
  
  You can also display the commands for a specific namespace:
  
-   &lt;info&gt;php app/console list test&lt;/info&gt;
+   &lt;info&gt;app/console list test&lt;/info&gt;
  
  You can also output the information in other formats by using the &lt;comment&gt;--format&lt;/comment&gt; option:
  
-   &lt;info&gt;php app/console list --format=xml&lt;/info&gt;
+   &lt;info&gt;app/console list --format=xml&lt;/info&gt;
  
  It's also possible to get raw list of commands (useful for embedding command runner):
  
-   &lt;info&gt;php app/console list --raw&lt;/info&gt;</help>
+   &lt;info&gt;app/console list --raw&lt;/info&gt;</help>
       <arguments>
         <argument name="namespace" is_required="0" is_array="0">
           <description>The namespace name</description>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -11,7 +11,7 @@
                 "help [--format FORMAT] [--raw] [--] [<command_name>]"
             ],
             "description": "Displays help for a command",
-            "help": "The <info>help<\/info> command displays help for a given command:\n\n  <info>php app\/console help list<\/info>\n\nYou can also output the help in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.",
+            "help": "The <info>help<\/info> command displays help for a given command:\n\n  <info>app\/console help list<\/info>\n\nYou can also output the help in other formats by using the <comment>--format<\/comment> option:\n\n  <info>app\/console help --format=xml list<\/info>\n\nTo display the list of available commands, please use the <info>list<\/info> command.",
             "definition": {
                 "arguments": {
                     "command_name": {
@@ -114,7 +114,7 @@
                 "list [--raw] [--format FORMAT] [--] [<namespace>]"
             ],
             "description": "Lists commands",
-            "help": "The <info>list<\/info> command lists all commands:\n\n  <info>php app\/console list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>php app\/console list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>php app\/console list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>php app\/console list --raw<\/info>",
+            "help": "The <info>list<\/info> command lists all commands:\n\n  <info>app\/console list<\/info>\n\nYou can also display the commands for a specific namespace:\n\n  <info>app\/console list test<\/info>\n\nYou can also output the information in other formats by using the <comment>--format<\/comment> option:\n\n  <info>app\/console list --format=xml<\/info>\n\nIt's also possible to get raw list of commands (useful for embedding command runner):\n\n  <info>app\/console list --raw<\/info>",
             "definition": {
                 "arguments": {
                     "namespace": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
@@ -28,11 +28,11 @@ Displays help for a command
 
 The help command displays help for a given command:
 
-  php app/console help list
+  app/console help list
 
 You can also output the help in other formats by using the --format option:
 
-  php app/console help --format=xml list
+  app/console help --format=xml list
 
 To display the list of available commands, please use the list command.
 
@@ -140,19 +140,19 @@ Lists commands
 
 The list command lists all commands:
 
-  php app/console list
+  app/console list
 
 You can also display the commands for a specific namespace:
 
-  php app/console list test
+  app/console list test
 
 You can also output the information in other formats by using the --format option:
 
-  php app/console list --format=xml
+  app/console list --format=xml
 
 It's also possible to get raw list of commands (useful for embedding command runner):
 
-  php app/console list --raw
+  app/console list --raw
 
 ### Arguments
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -8,11 +8,11 @@
       <description>Displays help for a command</description>
       <help>The &lt;info&gt;help&lt;/info&gt; command displays help for a given command:
  
-   &lt;info&gt;php app/console help list&lt;/info&gt;
+   &lt;info&gt;app/console help list&lt;/info&gt;
  
  You can also output the help in other formats by using the &lt;comment&gt;--format&lt;/comment&gt; option:
  
-   &lt;info&gt;php app/console help --format=xml list&lt;/info&gt;
+   &lt;info&gt;app/console help --format=xml list&lt;/info&gt;
  
  To display the list of available commands, please use the &lt;info&gt;list&lt;/info&gt; command.</help>
       <arguments>
@@ -63,19 +63,19 @@
       <description>Lists commands</description>
       <help>The &lt;info&gt;list&lt;/info&gt; command lists all commands:
  
-   &lt;info&gt;php app/console list&lt;/info&gt;
+   &lt;info&gt;app/console list&lt;/info&gt;
  
  You can also display the commands for a specific namespace:
  
-   &lt;info&gt;php app/console list test&lt;/info&gt;
+   &lt;info&gt;app/console list test&lt;/info&gt;
  
  You can also output the information in other formats by using the &lt;comment&gt;--format&lt;/comment&gt; option:
  
-   &lt;info&gt;php app/console list --format=xml&lt;/info&gt;
+   &lt;info&gt;app/console list --format=xml&lt;/info&gt;
  
  It's also possible to get raw list of commands (useful for embedding command runner):
  
-   &lt;info&gt;php app/console list --raw&lt;/info&gt;</help>
+   &lt;info&gt;app/console list --raw&lt;/info&gt;</help>
       <arguments>
         <argument name="namespace" is_required="0" is_array="0">
           <description>The namespace name</description>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
@@ -19,11 +19,11 @@ Displays help for a command
 
 The help command displays help for a given command:
 
-  php app/console help list
+  app/console help list
 
 You can also output the help in other formats by using the --format option:
 
-  php app/console help --format=xml list
+  app/console help --format=xml list
 
 To display the list of available commands, please use the list command.
 
@@ -131,19 +131,19 @@ Lists commands
 
 The list command lists all commands:
 
-  php app/console list
+  app/console list
 
 You can also display the commands for a specific namespace:
 
-  php app/console list test
+  app/console list test
 
 You can also output the information in other formats by using the --format option:
 
-  php app/console list --format=xml
+  app/console list --format=xml
 
 It's also possible to get raw list of commands (useful for embedding command runner):
 
-  php app/console list --raw
+  app/console list --raw
 
 ### Arguments
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
@@ -21,16 +21,16 @@ Options:
 Help:
   The list command lists all commands:
   
-    php app/console list
+    app/console list
   
   You can also display the commands for a specific namespace:
   
-    php app/console list test
+    app/console list test
   
   You can also output the information in other formats by using the --format option:
   
-    php app/console list --format=xml
+    app/console list --format=xml
   
   It's also possible to get raw list of commands (useful for embedding command runner):
   
-    php app/console list --raw
+    app/console list --raw

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
@@ -21,16 +21,16 @@ Options:
 Help:
   The list command lists all commands:
   
-    php app/console list
+    app/console list
   
   You can also display the commands for a specific namespace:
   
-    php app/console list test
+    app/console list test
   
   You can also output the information in other formats by using the --format option:
   
-    php app/console list --format=xml
+    app/console list --format=xml
   
   It's also possible to get raw list of commands (useful for embedding command runner):
   
-    php app/console list --raw
+    app/console list --raw

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run5.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run5.txt
@@ -21,10 +21,10 @@ Options:
 Help:
   The help command displays help for a given command:
   
-    php app/console help list
+    app/console help list
   
   You can also output the help in other formats by using the --format option:
   
-    php app/console help --format=xml list
+    app/console help --format=xml list
   
   To display the list of available commands, please use the list command.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Discusstion started here:
https://github.com/symfony/symfony/pull/38349

I was a bit puzzled to find that the help for the list and help commands suggests that you call the console application by prefixing it with `php myconsoleapp`.

As suggested in the PR above I am removing the `php ` prefix from the help.

I am providing a script with a shebang like the first example suggested in the following link:
https://symfony.com/doc/current/components/console.html
Eventually I want to distribute my console app as docker image so there is no need for php installed or the users even knowing is written in php.
The script name is easy to override by just setting a different value to `$_SERVER['PHP_SELF']` but this php prefix is hardcoded into the help strings for the the two default commands available.

Slightly related to #38347 as I am trying to improve the console help output.
