### PR TITLE
Remove array return type from Request::toArray()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1574,8 +1574,10 @@ class Request
      * Gets the request body decoded as array, typically from a JSON payload.
      *
      * @throws JsonException When the body cannot be decoded to an array
+     *
+     * @return array
      */
-    public function toArray(): array
+    public function toArray()
     {
         if ('' === $content = $this->getContent()) {
             throw new JsonException('Response body is empty.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38400
| License       | MIT
| Doc PR        | -

Laravel already extends Symfony's `Request` class and defines it's own `toArray` method. https://github.com/symfony/symfony/pull/38224 added a new `toArray` method to this class with a different signature to the one that is in Laravel, causing fatal errors (https://github.com/laravel/framework/issues/34660). I think the best course of action here is to remove the return type for now, and only add it in Symfony 6. This will allow Symfony 6.0 and Laravel 11 to synchronize adding the return type.

Older versions of Laravel can't just change their signature to add an array return type to them, because that would be a breaking change for Laravel users extending Laravel's request class. I'm thinking, in particular, API packages and the like, or just straight up application code.