### PR TITLE
Release v5.1.7

### DIFF
--- a/CHANGELOG-5.1.md
+++ b/CHANGELOG-5.1.md
@@ -7,6 +7,27 @@ in 5.1 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v5.1.0...v5.1.1
 
+* 5.1.7 (2020-10-04)
+
+ * bug #38396 Handle consecutive supports() calls in the RememberMeAuthenticator (wouterj)
+ * bug #36291 [Lock] Fix StoreFactory to accept same DSN syntax as AbstractAdapter (Jontsa)
+ * bug #38390 [Serializer][Minor] Fix circular reference exception message (bad limit displayed) (l-vo)
+ * bug #38388 [HttpClient] Always "buffer" empty responses (nicolas-grekas)
+ * bug #38384 [PhpUnitBridge] Fix Deprecation file when it comes from the TestsListener (fancyweb)
+ * bug #38380 [Form] propagate validation groups to subforms (johanderuijter, xabbuh)
+ * bug #38377  Ignore more deprecations for Mockery mocks (fancyweb)
+ * bug #38375 [HttpClient] fix using proxies with NativeHttpClient (nicolas-grekas)
+ * bug #38372 [Routing] fix using !important and defaults/reqs in inline route definitions (nicolas-grekas)
+ * bug #38373 [ErrorHandler][DebugClassLoader] Do not check Mockery mocks classes (fancyweb)
+ * bug #38368 [HttpClient] Fix using https with proxies (bohanyang)
+ * bug #38350 [TwigBundle] Only remove kernel exception listener if twig is used (dmolineus)
+ * bug #38360 [BrowserKit] Cookie expiration at current timestamp (iquito)
+ * bug #38357 [DI] fix dumping non-shared lazy services (nicolas-grekas)
+ * bug #38358 [Messenger] Fix redis connection error message (alexander-schranz)
+ * bug #38343 Revert "bug #38063 [FrameworkBundle] generate preload.php in src/ to make opcache.preload predictable" (nicolas-grekas)
+ * bug #38348 [FrameworkBundle] Add Mailjet definition (michaelKaefer)
+ * bug #38336 [PhpUnitBridge] Fixed class_alias() for PHPUnit\Framework\Error\Error (stevegrunwell)
+
 * 5.1.6 (2020-09-27)
 
  * bug #38291 [OptionsResolver] Fix deprecation message access (fancyweb)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -73,12 +73,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     private static $freshCache = [];
 
-    const VERSION = '5.1.7-DEV';
+    const VERSION = '5.1.7';
     const VERSION_ID = 50107;
     const MAJOR_VERSION = 5;
     const MINOR_VERSION = 1;
     const RELEASE_VERSION = 7;
-    const EXTRA_VERSION = 'DEV';
+    const EXTRA_VERSION = '';
 
     const END_OF_MAINTENANCE = '01/2021';
     const END_OF_LIFE = '01/2021';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v5.1.6...v5.1.7)

 * bug #38396 Handle consecutive supports() calls in the RememberMeAuthenticator (@wouterj)
 * bug #36291 [Lock] Fix StoreFactory to accept same DSN syntax as AbstractAdapter (@Jontsa)
 * bug #38390 [Serializer][Minor] Fix circular reference exception message (bad limit displayed) (@l-vo)
 * bug #38388 [HttpClient] Always "buffer" empty responses (@nicolas-grekas)
 * bug #38384 [PhpUnitBridge] Fix Deprecation file when it comes from the TestsListener (@fancyweb)
 * bug #38380 [Form] propagate validation groups to subforms (@johanderuijter, @xabbuh)
 * bug #38377  Ignore more deprecations for Mockery mocks (@fancyweb)
 * bug #38375 [HttpClient] fix using proxies with NativeHttpClient (@nicolas-grekas)
 * bug #38372 [Routing] fix using !important and defaults/reqs in inline route definitions (@nicolas-grekas)
 * bug #38373 [ErrorHandler][DebugClassLoader] Do not check Mockery mocks classes (@fancyweb)
 * bug #38368 [HttpClient] Fix using https with proxies (@bohanyang)
 * bug #38350 [TwigBundle] Only remove kernel exception listener if twig is used (@dmolineus)
 * bug #38360 [BrowserKit] Cookie expiration at current timestamp (@iquito)
 * bug #38357 [DI] fix dumping non-shared lazy services (@nicolas-grekas)
 * bug #38358 [Messenger] Fix redis connection error message (@alexander-schranz)
 * bug #38343 Revert "bug #38063 [FrameworkBundle] generate preload.php in src/ to make opcache.preload predictable" (@nicolas-grekas)
 * bug #38348 [FrameworkBundle] Add Mailjet definition (@michaelKaefer)
 * bug #38336 [PhpUnitBridge] Fixed class_alias() for PHPUnit\Framework\Error\Error (@stevegrunwell)
