### PR TITLE
Fix type annotation in ExpressionLanguage\Token

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Token.php
+++ b/src/Symfony/Component/ExpressionLanguage/Token.php
@@ -54,7 +54,7 @@ class Token
     /**
      * Tests the current token for a type and/or a value.
      *
-     * @param array|int   $type  The type to test
+     * @param string      $type  The type to test
      * @param string|null $value The token value
      *
      * @return bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The expected argument `$type` should be a string - the strict comparison would always fail with the current annotated types (`array|int`). 

See the constructor + constants for reference:
https://github.com/symfony/symfony/blob/7db7dcc431cfafff38123e835ca6754980f5dab6/src/Symfony/Component/ExpressionLanguage/Token.php#L33

https://github.com/symfony/symfony/blob/7db7dcc431cfafff38123e835ca6754980f5dab6/src/Symfony/Component/ExpressionLanguage/Token.php#L25-L30