### PR TITLE
[HttpClient] change piority of RetryableHttpClient

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2094,7 +2094,7 @@ class FrameworkExtension extends Extension
 
         $container
             ->register($name.'.retry', RetryableHttpClient::class)
-            ->setDecoratedService($name)
+            ->setDecoratedService($name, null, -10) // lower priority than TraceableHttpClient
             ->setArguments([new Reference($name.'.retry.inner'), $deciderReference, $backoffReference, $retryOptions['max_retries'], new Reference('logger')])
             ->addTag('monolog.logger', ['channel' => 'http_client']);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

This make the RetryableHttpClient decorated the TraceableHttpClient.
User will be able to check content of each sub-request
