### PR TITLE
[HttpClient] add RetryStrategyInterface

### DIFF
--- a/src/Symfony/Component/HttpClient/Retry/HttpStatusCodeDecider.php
+++ b/src/Symfony/Component/HttpClient/Retry/HttpStatusCodeDecider.php
@@ -28,7 +28,7 @@ final class HttpStatusCodeDecider implements RetryDeciderInterface
         $this->statusCodes = $statusCodes;
     }
 
-    public function shouldRetry(string $requestMethod, string $requestUrl, array $requestOptions, int $responseStatusCode, array $responseHeaders, ?string $responseContent): ?bool
+    public function shouldRetry(int $retryCount, string $requestMethod, string $requestUrl, array $requestOptions, int $responseStatusCode, array $responseHeaders, ?string $responseContent): ?bool
     {
         return \in_array($responseStatusCode, $this->statusCodes, true);
     }

--- a/src/Symfony/Component/HttpClient/Retry/RetryDeciderInterface.php
+++ b/src/Symfony/Component/HttpClient/Retry/RetryDeciderInterface.php
@@ -23,5 +23,5 @@ interface RetryDeciderInterface
      *
      * @return ?bool Returns null to signal that the body is required to take a decision
      */
-    public function shouldRetry(string $requestMethod, string $requestUrl, array $requestOptions, int $responseStatusCode, array $responseHeaders, ?string $responseContent): ?bool;
+    public function shouldRetry(int $retryCount, string $requestMethod, string $requestUrl, array $requestOptions, int $responseStatusCode, array $responseHeaders, ?string $responseContent): ?bool;
 }

--- a/src/Symfony/Component/HttpClient/Retry/RetryStrategyInterface.php
+++ b/src/Symfony/Component/HttpClient/Retry/RetryStrategyInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Retry;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface RetryStrategyInterface
+{
+    public function getToken(string $requestMethod, string $requestUrl, array $requestOptions): ?RetryToken;
+}

--- a/src/Symfony/Component/HttpClient/Retry/RetryToken.php
+++ b/src/Symfony/Component/HttpClient/Retry/RetryToken.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Retry;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class RetryToken
+{
+    private $shouldRetry;
+    private $getDelay;
+
+    public function __construct(\Closure $shouldRetry, \Closure $getDelay)
+    {
+        $this->shouldRetry = $shouldRetry;
+        $this->getDelay = $getDelay;
+    }
+
+    /**
+     * Returns whether the request should be retried.
+     *
+     * @param ?string $responseContent Null is passed when the body did not arrive yet
+     *
+     * @return ?bool Returns null to signal that the body is required to take a decision
+     */
+    public function shouldRetry(int $retryCount, int $responseStatusCode, array $responseHeaders, ?string $responseContent): ?bool
+    {
+        return ($this->shouldRetry)($retryCount, $responseStatusCode, $responseHeaders, $responseContent);
+    }
+
+    /**
+     * Returns the time to wait in milliseconds.
+     */
+    public function getDelay(int $retryCount, int $responseStatusCode, array $responseHeaders, ?string $responseContent, ?TransportExceptionInterface $exception): int
+    {
+        return ($this->getDelay)($retryCount, $responseStatusCode, $responseHeaders, $responseContent, $exception);
+    }
+}

--- a/src/Symfony/Component/HttpClient/Retry/StatelessStrategy.php
+++ b/src/Symfony/Component/HttpClient/Retry/StatelessStrategy.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Retry;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class StatelessStrategy implements RetryStrategyInterface
+{
+    private $decider;
+    private $backoff;
+
+    public function __construct(RetryDeciderInterface $decider = null, RetryBackOffInterface $backoff = null)
+    {
+        $this->decider = $decider ?? new HttpStatusCodeDecider();
+        $this->backoff = $backoff ?? new ExponentialBackOff();
+    }
+
+    public function getToken(string $requestMethod, string $requestUrl, array $requestOptions): ?RetryToken
+    {
+        $decider = function ($retryCount, $responseStatusCode, $responseHeaders, $responseContent) use ($requestMethod, $requestUrl, $requestOptions) {
+            return $this->decider->shouldRetry($retryCount, $requestMethod, $requestUrl, $requestOptions, $responseStatusCode, $responseHeaders, $responseContent);
+        };
+
+        $backoff = function ($retryCount, $responseStatusCode, $responseHeaders, $responseContent, $exception) use ($requestMethod, $requestUrl, $requestOptions) {
+            return $this->backoff->getDelay($retryCount, $requestMethod, $requestUrl, $requestOptions, $responseStatusCode, $responseHeaders, $responseContent, $exception);
+        };
+
+        return new RetryToken($decider, $backoff);
+    }
+}

--- a/src/Symfony/Component/HttpClient/Tests/Retry/HttpStatusCodeDeciderTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Retry/HttpStatusCodeDeciderTest.php
@@ -20,13 +20,13 @@ class HttpStatusCodeDeciderTest extends TestCase
     {
         $decider = new HttpStatusCodeDecider([500]);
 
-        self::assertTrue($decider->shouldRetry('GET', 'http://example.com/', [], 500, [], null));
+        self::assertTrue($decider->shouldRetry(1, 'GET', 'http://example.com/', [], 500, [], null));
     }
 
     public function testIsNotRetryableOk()
     {
         $decider = new HttpStatusCodeDecider([500]);
 
-        self::assertFalse($decider->shouldRetry('GET', 'http://example.com/', [], 200, [], null));
+        self::assertFalse($decider->shouldRetry(1, 'GET', 'http://example.com/', [], 200, [], null));
     }
 }

--- a/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/RetryableHttpClientTest.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpClient\Retry\ExponentialBackOff;
 use Symfony\Component\HttpClient\Retry\HttpStatusCodeDecider;
 use Symfony\Component\HttpClient\Retry\RetryDeciderInterface;
+use Symfony\Component\HttpClient\Retry\StatelessStrategy;
 use Symfony\Component\HttpClient\RetryableHttpClient;
 
 class RetryableHttpClientTest extends TestCase
@@ -20,8 +21,10 @@ class RetryableHttpClientTest extends TestCase
                 new MockResponse('', ['http_code' => 500]),
                 new MockResponse('', ['http_code' => 200]),
             ]),
-            new HttpStatusCodeDecider([500]),
-            new ExponentialBackOff(0),
+            new StatelessStrategy(
+                new HttpStatusCodeDecider([500]),
+                new ExponentialBackOff(0)
+            ),
             1
         );
 
@@ -38,8 +41,10 @@ class RetryableHttpClientTest extends TestCase
                 new MockResponse('', ['http_code' => 500]),
                 new MockResponse('', ['http_code' => 200]),
             ]),
-            new HttpStatusCodeDecider([500]),
-            new ExponentialBackOff(0),
+            new StatelessStrategy(
+                new HttpStatusCodeDecider([500]),
+                new ExponentialBackOff(0)
+            ),
             1
         );
 
@@ -56,13 +61,15 @@ class RetryableHttpClientTest extends TestCase
                 new MockResponse('', ['http_code' => 500]),
                 new MockResponse('', ['http_code' => 200]),
             ]),
-            new class() implements RetryDeciderInterface {
-                public function shouldRetry(string $requestMethod, string $requestUrl, array $requestOptions, int $responseCode, array $responseHeaders, ?string $responseContent): ?bool
-                {
-                    return null === $responseContent ? null : 200 !== $responseCode;
-                }
-            },
-            new ExponentialBackOff(0),
+            new StatelessStrategy(
+                new class() implements RetryDeciderInterface {
+                    public function shouldRetry(int $retryCount, string $requestMethod, string $requestUrl, array $requestOptions, int $responseCode, array $responseHeaders, ?string $responseContent): ?bool
+                    {
+                        return null === $responseContent ? null : 200 !== $responseCode;
+                    }
+                },
+                new ExponentialBackOff(0)
+            ),
             1
         );
 
@@ -78,13 +85,15 @@ class RetryableHttpClientTest extends TestCase
                 new MockResponse('', ['http_code' => 500]),
                 new MockResponse('', ['http_code' => 200]),
             ]),
-            new class() implements RetryDeciderInterface {
-                public function shouldRetry(string $requestMethod, string $requestUrl, array $requestOptions, int $responseCode, array $responseHeaders, ?string $responseContent, \Throwable $throwable = null): ?bool
-                {
-                    return null;
-                }
-            },
-            new ExponentialBackOff(0),
+            new StatelessStrategy(
+                new class() implements RetryDeciderInterface {
+                    public function shouldRetry(int $retryCount, string $requestMethod, string $requestUrl, array $requestOptions, int $responseCode, array $responseHeaders, ?string $responseContent, \Throwable $throwable = null): ?bool
+                    {
+                        return null;
+                    }
+                },
+                new ExponentialBackOff(0)
+            ),
             1
         );
 
@@ -100,8 +109,10 @@ class RetryableHttpClientTest extends TestCase
             new MockHttpClient([
                 new MockResponse('', ['http_code' => 500]),
             ]),
-            new HttpStatusCodeDecider([500]),
-            new ExponentialBackOff(0),
+            new StatelessStrategy(
+                new HttpStatusCodeDecider([500]),
+                new ExponentialBackOff(0)
+            ),
             0
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Inspired by #38415, this gives more flexibility to the `Retry\*` logic.

Notably:
- `$retryCount` is added to `RetryDeciderInterface::shouldRetry()`
- a `RetryToken` value object is introduced, to provide greater extensibility (adding new methods in the retry logic will be easier via a class vs an interface) and to enable strategies to track a single request across retries (allowing to keep the strategy service stateless when request tracking is desired).

```php
interface RetryStrategyInterface
{
    public function getToken(string $requestMethod, string $requestUrl, array $requestOptions): ?RetryToken;
}
```

For thoughts, /cc @jderusse 