### PR TITLE
[SecurityGuard] Implement PostAuthenticationGuardToken::getFirewallName()

### DIFF
--- a/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
+++ b/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
@@ -69,6 +69,11 @@ class PostAuthenticationGuardToken extends AbstractToken implements GuardTokenIn
         return $this->providerKey;
     }
 
+    public function getFirewallName(): string
+    {
+        return $this->getProviderKey();
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38421
| License       | MIT
| Doc PR        | N/A