### PR TITLE
[HttpClient] Parameterize list of retryable methods

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -64,6 +64,7 @@ use Symfony\Component\Form\FormTypeExtensionInterface;
 use Symfony\Component\Form\FormTypeGuesserInterface;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Retry\GenericRetryStrategy;
 use Symfony\Component\HttpClient\RetryableHttpClient;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\HttpFoundation\Request;
@@ -2072,8 +2073,17 @@ class FrameworkExtension extends Extension
             $retryStrategy = new Reference($options['retry_strategy']);
         } else {
             $retryStrategy = new ChildDefinition('http_client.abstract_retry_strategy');
+            $codes = [];
+            foreach ($options['http_codes'] as $code => $codeOptions) {
+                if ($codeOptions['methods']) {
+                    $codes[$code] = $codeOptions['methods'];
+                } else {
+                    $codes[] = $code;
+                }
+            }
+
             $retryStrategy
-                ->replaceArgument(0, $options['http_codes'])
+                ->replaceArgument(0, $codes ?: GenericRetryStrategy::DEFAULT_RETRY_STATUS_CODES)
                 ->replaceArgument(1, $options['delay'])
                 ->replaceArgument(2, $options['multiplier'])
                 ->replaceArgument(3, $options['max_delay'])

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -578,7 +578,7 @@
 
     <xsd:complexType name="http_client_retry_failed">
         <xsd:sequence>
-            <xsd:element name="http-code" type="xsd:integer" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="http-code" type="http_client_retry_code" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
         <xsd:attribute name="enabled" type="xsd:boolean" />
         <xsd:attribute name="retry-strategy" type="xsd:string" />
@@ -588,6 +588,13 @@
         <xsd:attribute name="max-delay" type="xsd:float" />
         <xsd:attribute name="jitter" type="xsd:float" />
         <xsd:attribute name="response_header" type="xsd:boolean" />
+    </xsd:complexType>
+
+    <xsd:complexType name="http_client_retry_code">
+        <xsd:sequence>
+            <xsd:element name="method" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+        <xsd:attribute name="code" type="xsd:integer" />
     </xsd:complexType>
 
     <xsd:complexType name="http_query" mixed="true">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_retry.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_retry.php
@@ -5,7 +5,7 @@ $container->loadFromExtension('framework', [
         'default_options' => [
             'retry_failed' => [
                 'retry_strategy' => null,
-                'http_codes' => [429, 500],
+                'http_codes' => [429, 500 => ['GET', 'HEAD']],
                 'max_retries' => 2,
                 'delay' => 100,
                 'multiplier' => 2,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_retry.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_retry.xml
@@ -14,8 +14,11 @@
                         max-retries="2"
                         multiplier="2"
                         jitter="0.3">
-                    <framework:http-code>429</framework:http-code>
-                    <framework:http-code>500</framework:http-code>
+                    <framework:http-code code="429"/>
+                    <framework:http-code code="500">
+                        <framework:method>GET</framework:method>
+                        <framework:method>HEAD</framework:method>
+                    </framework:http-code>
                 </framework:retry-failed>
             </framework:default-options>
             <framework:scoped-client name="foo" base-uri="http://example.com">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_retry.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_retry.yml
@@ -3,7 +3,9 @@ framework:
         default_options:
             retry_failed:
                 retry_strategy: null
-                http_codes: [429, 500]
+                http_codes:
+                    429: true
+                    500: ['GET', 'HEAD']
                 max_retries: 2
                 delay: 100
                 multiplier: 2

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1500,7 +1500,7 @@ abstract class FrameworkExtensionTest extends TestCase
         }
         $container = $this->createContainerFromFile('http_client_retry');
 
-        $this->assertSame([429, 500], $container->getDefinition('http_client.retry_strategy')->getArgument(0));
+        $this->assertSame([429, 500 => ['GET', 'HEAD']], $container->getDefinition('http_client.retry_strategy')->getArgument(0));
         $this->assertSame(100, $container->getDefinition('http_client.retry_strategy')->getArgument(1));
         $this->assertSame(2, $container->getDefinition('http_client.retry_strategy')->getArgument(2));
         $this->assertSame(0, $container->getDefinition('http_client.retry_strategy')->getArgument(3));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | TODO

Retrying non-idempotent methods is not always acceptable for user. This PR adds an easy way to configure this behavior.

The `RetryDeciderInterface::shouldRetry()` now take the exception in parameter, in order to let decider not retrying the request when the methods should never by retried.

With #38420, this code would belongs to the RetryStrategy implementation, and would return an `NeverRetryDecider` when method is not allowed.