### PR TITLE
[DependencyInjection] added AutoDecorationServicePass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutoDecorationServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutoDecorationServicePass.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\DecorationPriorityAwareInterface;
+use Symfony\Component\DependencyInjection\DecoratorInterface;
+
+/**
+ * Adds decorated service to definition of services implementing DecoratorInterface.
+ *
+ * @author Grégory SURACI <gregory.suraci@free.fr>
+ */
+class AutoDecorationServicePass implements CompilerPassInterface
+{
+    private $throwOnException;
+
+    public function __construct(bool $throwOnException = true)
+    {
+        $this->throwOnException = $throwOnException;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->getDefinitions() as $definition) {
+            $className = $definition->getClass();
+
+            if (null === $className) {
+                continue;
+            }
+
+            try {
+                $classInterfaces = class_implements($className);
+
+                if (!\in_array(DecoratorInterface::class, $classInterfaces)) {
+                    continue;
+                }
+
+                if (\in_array(DecorationPriorityAwareInterface::class, $classInterfaces)) {
+                    $definition->setDecoratedService(
+                        $className::getDecoratedServiceId(),
+                        null,
+                        $className::getDecorationPriority()
+                    );
+
+                    continue;
+                }
+
+                $definition->setDecoratedService($className::getDecoratedServiceId());
+            } catch (\Throwable $e) {
+                if ($this->throwOnException) {
+                    throw $e;
+                }
+
+                continue;
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -61,6 +61,7 @@ class PassConfig
             new AutowireRequiredPropertiesPass(),
             new ResolveBindingsPass(),
             new ServiceLocatorTagPass(),
+            new AutoDecorationServicePass(false),
             new DecoratorServicePass(),
             new CheckDefinitionValidityPass(),
             new AutowirePass(false),

--- a/src/Symfony/Component/DependencyInjection/DecorationPriorityAwareInterface.php
+++ b/src/Symfony/Component/DependencyInjection/DecorationPriorityAwareInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+/**
+ * DecorationPriorityAwareInterface sets the decoration_priority value for a class implementing DecoratorInterface.
+ *
+ * @author Grégory SURACI <gregory.suraci@free.fr>
+ */
+interface DecorationPriorityAwareInterface
+{
+    /**
+     * @return int the decoration priority
+     */
+    public static function getDecorationPriority(): int;
+}

--- a/src/Symfony/Component/DependencyInjection/DecoratorInterface.php
+++ b/src/Symfony/Component/DependencyInjection/DecoratorInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+/**
+ * DecoratorInterface defines a decorator class without configuration.
+ *
+ * @author Grégory SURACI <gregory.suraci@free.fr>
+ */
+interface DecoratorInterface
+{
+    /**
+     * @return string the serviceId/FQCN that will be decorated by this interface's implementation
+     */
+    public static function getDecoratedServiceId(): string;
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutoDecorationServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutoDecorationServicePassTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Compiler\AutoDecorationServicePass;
+use Symfony\Component\DependencyInjection\Compiler\DecoratorServicePass;
+use Symfony\Component\DependencyInjection\Compiler\ResolveClassPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Dummy;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\DummyDecorator1;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\DummyDecorator2;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\DummyDecorator3;
+
+class AutoDecorationServicePassTest extends TestCase
+{
+    public function testProcessUsingFQCN()
+    {
+        $container = new ContainerBuilder();
+        $dummyDefinition = $container
+            ->register(Dummy::class)
+            ->setPublic(true)
+        ;
+        $decoratorDefinition = $container
+            ->register('dummy.extended', DummyDecorator1::class)
+            ->setPublic(true)
+        ;
+
+        $this->process($container);
+
+        $this->assertSame($dummyDefinition, $container->getDefinition('dummy.extended.inner'));
+        $this->assertFalse($container->getDefinition('dummy.extended.inner')->isPublic());
+
+        $this->assertNull($decoratorDefinition->getDecoratedService());
+    }
+
+    public function testProcessUsingStringServiceId()
+    {
+        $container = new ContainerBuilder();
+        $dummyDefinition = $container
+            ->register('dummy', Dummy::class)
+            ->setPublic(true)
+        ;
+        $decoratorDefinition = $container
+            ->register('dummy.extended', DummyDecorator2::class)
+            ->setPublic(true)
+        ;
+
+        $this->process($container);
+
+        $this->assertSame($dummyDefinition, $container->getDefinition('dummy.extended.inner'));
+        $this->assertFalse($container->getDefinition('dummy.extended.inner')->isPublic());
+
+        $this->assertNull($decoratorDefinition->getDecoratedService());
+    }
+
+    public function testProcessWithDecorationPriority()
+    {
+        $container = new ContainerBuilder();
+        $dummyDefinition = $container
+            ->register(Dummy::class)
+            ->setPublic(true)
+        ;
+        $decoratorWithHighPriorityDefinition = $container
+            ->register('dummy.extended', DummyDecorator3::class)
+            ->setPublic(true)
+        ;
+        $decoratorDefinition = $container
+            ->register('dummy.extended.extended', DummyDecorator1::class)
+            ->setPublic(true)
+        ;
+
+        $this->process($container);
+
+        $this->assertSame($dummyDefinition, $container->getDefinition('dummy.extended.inner'));
+        $this->assertFalse($container->getDefinition('dummy.extended.inner')->isPublic());
+
+        $this->assertEquals('dummy.extended', $container->getAlias('dummy.extended.extended.inner'));
+        $this->assertFalse($container->getAlias('dummy.extended.extended.inner')->isPublic());
+
+        $this->assertNull($decoratorWithHighPriorityDefinition->getDecoratedService());
+        $this->assertNull($decoratorDefinition->getDecoratedService());
+    }
+
+    protected function process(ContainerBuilder $container)
+    {
+        (new ResolveClassPass())->process($container);
+        (new AutoDecorationServicePass())->process($container);
+        (new DecoratorServicePass())->process($container);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Dummy.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class Dummy implements DummyInterface
+{
+    public function sayHello(): string
+    {
+        return 'Hello Dummy';
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/DummyDecorator1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/DummyDecorator1.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\DecoratorInterface;
+
+class DummyDecorator1 implements DecoratorInterface, DummyInterface
+{
+    /**
+     * @var DummyInterface
+     */
+    protected $decorated;
+
+    public function __construct(DummyInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    public static function getDecoratedServiceId(): string
+    {
+        return Dummy::class;
+    }
+
+    public function sayHello(): string
+    {
+        return sprintf('%s & Decorator1', $this->decorated->sayHello());
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/DummyDecorator2.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/DummyDecorator2.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\DecoratorInterface;
+
+class DummyDecorator2 implements DecoratorInterface, DummyInterface
+{
+    /**
+     * @var DummyInterface
+     */
+    protected $decorated;
+
+    public function __construct(DummyInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    public static function getDecoratedServiceId(): string
+    {
+        return 'dummy';
+    }
+
+    public function sayHello(): string
+    {
+        return sprintf('%s & Decorator2', $this->decorated->sayHello());
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/DummyDecorator3.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/DummyDecorator3.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\DecorationPriorityAwareInterface;
+
+class DummyDecorator3 extends DummyDecorator1 implements DecorationPriorityAwareInterface, DummyInterface
+{
+    public static function getDecorationPriority(): int
+    {
+        return 42;
+    }
+
+    public function sayHello(): string
+    {
+        return sprintf('%s & Decorator3', $this->decorated->sayHello());
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/DummyInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/DummyInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+interface DummyInterface
+{
+    public function sayHello(): string;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | TBD if feature is accepted

Hi everyone,

Here is a feature proposal for symfony/dependency-injection : implement a configuration-less decoration feature (auto decoration ?). 

Every service definition whose class implements `DecoratorInterface` will be automatically marked as a decorator for the service returned by `DecoratorInterface::getDecoratedServiceId()`

In addition to `DecoratorInterface`, a second interface `DecorationPriorityAwareInterface` is provided to provide the decoration priority.

To explain the "why" part, I encountered a few times already the use-case where it is required to maximize the use of decoration, leading to multiple decorators cascading, and therefore, to multiple lines in `services.yaml`. This will allow developers to use "abstract decorators" or traits to share the decoration behaviour upon multiple classes.

The advantage is that it would no longer be required to write decorator definition in configuration files for the majority of decoration use cases.
The limitations of this approach are the same as the one using autowiring, plus, It would add code coupling between service classes and the DI component, which is why this should be considered as an optional feature.

**Here is an example** 

_Before_

```yaml
services:
    App\CacheableSomeService:
        decorates: App\SomeService
```

```php
class CacheableSomeService implements SomeInterface
{
  private $decorated;

  public function __construct(SomeInterface $decorated) {
    $this->decorated = $decorated;
  }

  public function doSomething()
  {
     // .... something to do with $this->decorated
  }
}
```

_After_

```php
class CacheableSomeService implements SomeInterface, DecoratorInterface
{
  // ...

  public static function getDecoratedServiceId(): string
  {
    return SomeService::class;
  }
}
```

or


```php
class CacheableSomeService implements SomeInterface, DecoratorInterface, DecorationPriorityAwareInterface
{
  // ...

  public static function getDecoratedServiceId(): string
  {
    return SomeService::class;
  }

  public static function getDecorationPriority(): int
  {
    return 42;
  }
}
```

Looking forward for your remarks/reviews, especially as it is my first time here, I might have done something wrong :dog: 
