### PR TITLE
[Mime] Fix serialization of RawMessage

### DIFF
--- a/src/Symfony/Component/Mime/RawMessage.php
+++ b/src/Symfony/Component/Mime/RawMessage.php
@@ -78,7 +78,7 @@ class RawMessage implements \Serializable
 
     public function __serialize(): array
     {
-        return [$this->message];
+        return [$this->toString()];
     }
 
     public function __unserialize(array $data): void

--- a/src/Symfony/Component/Mime/Tests/RawMessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/RawMessageTest.php
@@ -32,4 +32,26 @@ class RawMessageTest extends TestCase
         $this->assertEquals('some string', $message->toString());
         $this->assertEquals('some string', implode('', iterator_to_array($message->toIterable())));
     }
+
+    public function testSerialization()
+    {
+        $message = new RawMessage('string');
+        $serialized = serialize($message);
+        $this->assertEquals('C:33:"Symfony\Component\Mime\RawMessage":23:{a:1:{i:0;s:6:"string";}}', $serialized);
+        $this->assertEquals('string', unserialize($serialized)->toString());
+        // calling methods more than once work
+        $serialized = serialize($message);
+        $this->assertEquals('C:33:"Symfony\Component\Mime\RawMessage":23:{a:1:{i:0;s:6:"string";}}', $serialized);
+        $this->assertEquals('string', unserialize($serialized)->toString());
+
+        $message = new RawMessage(new \ArrayObject(['some', ' ', 'string']));
+        $message = new RawMessage($message->toIterable());
+        $serialized = serialize($message);
+        $this->assertEquals('C:33:"Symfony\Component\Mime\RawMessage":29:{a:1:{i:0;s:11:"some string";}}', $serialized);
+        $this->assertEquals('some string', unserialize($serialized)->toString());
+        // calling methods more than once work
+        $serialized = serialize($message);
+        $this->assertEquals('C:33:"Symfony\Component\Mime\RawMessage":29:{a:1:{i:0;s:11:"some string";}}', $serialized);
+        $this->assertEquals('some string', unserialize($serialized)->toString());
+    }
 }

--- a/src/Symfony/Component/Mime/Tests/RawMessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/RawMessageTest.php
@@ -36,22 +36,14 @@ class RawMessageTest extends TestCase
     public function testSerialization()
     {
         $message = new RawMessage('string');
-        $serialized = serialize($message);
-        $this->assertEquals('C:33:"Symfony\Component\Mime\RawMessage":23:{a:1:{i:0;s:6:"string";}}', $serialized);
-        $this->assertEquals('string', unserialize($serialized)->toString());
+        $this->assertEquals('string', unserialize(serialize($message))->toString());
         // calling methods more than once work
-        $serialized = serialize($message);
-        $this->assertEquals('C:33:"Symfony\Component\Mime\RawMessage":23:{a:1:{i:0;s:6:"string";}}', $serialized);
-        $this->assertEquals('string', unserialize($serialized)->toString());
+        $this->assertEquals('string', unserialize(serialize($message))->toString());
 
         $message = new RawMessage(new \ArrayObject(['some', ' ', 'string']));
         $message = new RawMessage($message->toIterable());
-        $serialized = serialize($message);
-        $this->assertEquals('C:33:"Symfony\Component\Mime\RawMessage":29:{a:1:{i:0;s:11:"some string";}}', $serialized);
-        $this->assertEquals('some string', unserialize($serialized)->toString());
+        $this->assertEquals('some string', unserialize(serialize($message))->toString());
         // calling methods more than once work
-        $serialized = serialize($message);
-        $this->assertEquals('C:33:"Symfony\Component\Mime\RawMessage":29:{a:1:{i:0;s:11:"some string";}}', $serialized);
-        $this->assertEquals('some string', unserialize($serialized)->toString());
+        $this->assertEquals('some string', unserialize(serialize($message))->toString());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #38430, Related #33394 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

The serialization of RawMessage is currently broken if using a generator for message like done by `Symfony\Component\Mailer\SentMessage` see https://github.com/symfony/symfony/blob/5f1c3a797247a6d54992384df00bb22741fc1c34/src/Symfony/Component/Mailer/SentMessage.php#L45
This patch converts the message to a string so further serialization can be done.

This patch probably also solves #33394.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->
