### PR TITLE
[String][AsciiSlugger] Fix typo

### DIFF
--- a/src/Symfony/Component/String/Slugger/AsciiSlugger.php
+++ b/src/Symfony/Component/String/Slugger/AsciiSlugger.php
@@ -72,7 +72,7 @@ class AsciiSlugger implements SluggerInterface, LocaleAwareInterface
     public function __construct(string $defaultLocale = null, $symbolsMap = null)
     {
         if (null !== $symbolsMap && !\is_array($symbolsMap) && !$symbolsMap instanceof \Closure) {
-            throw new \TypeError(sprintf('Argument 2 passed to "%s()" must be array, Closure or null, "%s" given.', __METHOD__, \gettype($symbolMap)));
+            throw new \TypeError(sprintf('Argument 2 passed to "%s()" must be array, Closure or null, "%s" given.', __METHOD__, \gettype($symbolsMap)));
         }
 
         $this->defaultLocale = $defaultLocale;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master<!-- see below -->
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |  -
| License       | MIT
| Doc PR        | -

I guess there was a little mistake on PR https://github.com/symfony/symfony/pull/38198 : In exception message it should be `$symbolsMap` instead of `$symbolMap`

;)
