### PR TITLE
Cursor get window dimensions

### DIFF
--- a/src/Symfony/Component/Console/Cursor.php
+++ b/src/Symfony/Component/Console/Cursor.php
@@ -136,9 +136,9 @@ final class Cursor
 
         return $this;
     }
-    
+
     /**
-     * Return the total rows of the screen
+     * Return the total rows of the screen.
      */
     public function getRowCount(): int
     {
@@ -146,7 +146,7 @@ final class Cursor
     }
 
     /**
-     * Return the total columns of the screen
+     * Return the total columns of the screen.
      */
     public function getColumnCount(): int
     {

--- a/src/Symfony/Component/Console/Cursor.php
+++ b/src/Symfony/Component/Console/Cursor.php
@@ -136,6 +136,22 @@ final class Cursor
 
         return $this;
     }
+    
+    /**
+     * Return the total rows of the screen
+     */
+    public function getRowCount(): int
+    {
+        return (int) shell_exec('tput lines');
+    }
+
+    /**
+     * Return the total columns of the screen
+     */
+    public function getColumnCount(): int
+    {
+        return (int) shell_exec('tput cols');
+    }
 
     /**
      * Returns the current cursor position as x,y coordinates.


### PR DESCRIPTION
Add methods to get current window dimensions

| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | (will do if code is ok)

Not sure if we can test this actually.
And possibly needs a check if 'tput' works. An do something (RuntimeException?) if we are on eg: Windows