### PR TITLE
[WebProfiler] Fixed AJAX requests not being displayed in toolbar if started before toolbar was initialized

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -126,7 +126,7 @@ class WebDebugToolbarListener implements EventSubscriberInterface
                     'csp_script_nonce' => isset($nonces['csp_script_nonce']) ? $nonces['csp_script_nonce'] : null,
                 ]
             );
-            $content = substr($content, 0, $pos).$requestStack.substr($content, $pos);
+            $content = substr_replace($content, $requestStack, $pos, 0);
             $response->setContent($content);
         }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -117,6 +117,19 @@ class WebDebugToolbarListener implements EventSubscriberInterface
     protected function injectToolbar(Response $response, Request $request, array $nonces)
     {
         $content = $response->getContent();
+        $pos = strripos($content, '</head>');
+
+        if (false !== $pos) {
+            $requestStack = $this->twig->render(
+                '@WebProfiler/Profiler/request_stack_js.html.twig',
+                [
+                    'csp_script_nonce' => isset($nonces['csp_script_nonce']) ? $nonces['csp_script_nonce'] : null,
+                ]
+            );
+            $content = substr($content, 0, $pos).$requestStack.substr($content, $pos);
+            $response->setContent($content);
+        }
+
         $pos = strripos($content, '</body>');
 
         if (false !== $pos) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -323,6 +323,8 @@
                     processSingleFetch(req[0], req[1]);
                 });
 
+                window.Sfjs_globalFetchStack.length = 0;
+
                 /* Rewrite the global fetch stack push method */
                 window.Sfjs_globalFetchStack.push = function (args) {
                     processSingleFetch(args[0], args[1]);
@@ -386,6 +388,8 @@
                 window.Sfjs_globalXHRStack.forEach(function (req) {
                     processSingleXHR(req[0], req[1], req[2]);
                 });
+
+                window.Sfjs_globalXHRStack.length = 0;
 
                 /* Rewrite the global xhr stack push method */
                 window.Sfjs_globalXHRStack.push = function (args) {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -269,21 +269,19 @@
         };
 
         {% if excluded_ajax_paths is defined %}
-            if (window.fetch && window.fetch.polyfill === undefined) {
-                var oldFetch = window.fetch;
-                window.fetch = function () {
-                    var promise = oldFetch.apply(this, arguments);
-                    var url = arguments[0];
-                    var params = arguments[1];
-                    var paramType = Object.prototype.toString.call(arguments[0]);
+            if (typeof window.Sfjs_globalFetchStack !== 'undefined') {
+                function processSingleFetch(promise, args) {
+                    var url = args[0];
+                    var params = args[1];
+                    var paramType = Object.prototype.toString.call(args[0]);
                     if (paramType === '[object Request]') {
-                        url = arguments[0].url;
+                        url = args[0].url;
                         params = {
-                            method: arguments[0].method,
-                            credentials: arguments[0].credentials,
-                            headers: arguments[0].headers,
-                            mode: arguments[0].mode,
-                            redirect: arguments[0].redirect
+                            method: args[0].method,
+                            credentials: args[0].credentials,
+                            headers: args[0].headers,
+                            mode: args[0].mode,
+                            redirect: args[0].redirect
                         };
                     } else {
                         url = String(url);
@@ -318,18 +316,22 @@
                         });
                         startAjaxRequest(idx);
                     }
+                }
 
-                    return promise;
+                /* Process the pending requests in global fetch stack */
+                window.Sfjs_globalFetchStack.forEach(function (req) {
+                    processSingleFetch(req[0], req[1]);
+                });
+
+                /* Rewrite the global fetch stack push method */
+                window.Sfjs_globalFetchStack.push = function (args) {
+                    processSingleFetch(args[0], args[1]);
                 };
             }
-            if (window.XMLHttpRequest && XMLHttpRequest.prototype.addEventListener) {
-                var proxied = XMLHttpRequest.prototype.open;
-
-                XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
-                    var self = this;
-
-                    /* prevent logging AJAX calls to static and inline files, like templates */
+            if (typeof window.Sfjs_globalXHRStack !== 'undefined') {
+                function processSingleXHR(xhr, method, url) {
                     var path = url;
+                    /* prevent logging AJAX calls to static and inline files, like templates */
                     if (url.substr(0, 1) === '/') {
                         if (0 === url.indexOf('{{ request.basePath|e('js') }}')) {
                             path = url.substr({{ request.basePath|length }});
@@ -350,21 +352,36 @@
 
                         var idx = requestStack.push(stackElement) - 1;
 
-                        this.addEventListener('readystatechange', function() {
-                            if (self.readyState == 4) {
-                                stackElement.duration = new Date() - stackElement.start;
-                                stackElement.error = self.status < 200 || self.status >= 400;
-                                stackElement.statusCode = self.status;
-                                extractHeaders(self, stackElement);
+                        function onRequestComplete(stackElement, xhr) {
+                            stackElement.duration = new Date() - stackElement.start;
+                            stackElement.error = xhr.status < 200 || xhr.status >= 400;
+                            stackElement.statusCode = xhr.status;
+                            extractHeaders(xhr, stackElement);
+                            finishAjaxRequest(idx);
+                        }
 
-                                finishAjaxRequest(idx);
-                            }
-                        }, false);
+                        if (xhr.readyState == 4) {
+                            onRequestComplete(stackElement, xhr);
+                        } else {
+                            xhr.addEventListener('readystatechange', function() {
+                                if (xhr.readyState == 4) {
+                                    onRequestComplete(stackElement, xhr);
+                                }
+                            }, false);
+                        }
 
                         startAjaxRequest(idx);
                     }
+                }
 
-                    proxied.apply(this, Array.prototype.slice.call(arguments));
+                /* Process the pending xhr requests in global stack */
+                window.Sfjs_globalXHRStack.forEach(function (req) {
+                    processSingleXHR(req[0], req[1], req[2]);
+                });
+
+                /* Rewrite the global xhr stack push method */
+                window.Sfjs_globalXHRStack.push = function (args) {
+                    processSingleXHR(args[0], args[1], args[2]);
                 };
             }
         {% endif %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -269,55 +269,55 @@
         };
 
         {% if excluded_ajax_paths is defined %}
-            if (typeof window.Sfjs_globalFetchStack !== 'undefined') {
-                function processSingleFetch(promise, args) {
-                    var url = args[0];
-                    var params = args[1];
-                    var paramType = Object.prototype.toString.call(args[0]);
-                    if (paramType === '[object Request]') {
-                        url = args[0].url;
-                        params = {
-                            method: args[0].method,
-                            credentials: args[0].credentials,
-                            headers: args[0].headers,
-                            mode: args[0].mode,
-                            redirect: args[0].redirect
-                        };
-                    } else {
-                        url = String(url);
-                    }
-                    if (!url.match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
-                        var method = 'GET';
-                        if (params && params.method !== undefined) {
-                            method = params.method;
-                        }
-
-                        var stackElement = {
-                            error: false,
-                            url: url,
-                            method: method,
-                            type: 'fetch',
-                            start: new Date()
-                        };
-
-                        var idx = requestStack.push(stackElement) - 1;
-                        promise.then(function (r) {
-                            stackElement.duration = new Date() - stackElement.start;
-                            stackElement.error = r.status < 200 || r.status >= 400;
-                            stackElement.statusCode = r.status;
-                            stackElement.profile = r.headers.get('x-debug-token');
-                            stackElement.profilerUrl = r.headers.get('x-debug-token-link');
-                            stackElement.toolbarReplaceFinished = false;
-                            stackElement.toolbarReplace = '1' === r.headers.get('Symfony-Debug-Toolbar-Replace');
-                            finishAjaxRequest(idx);
-                        }, function (e){
-                            stackElement.error = true;
-                            finishAjaxRequest(idx);
-                        });
-                        startAjaxRequest(idx);
-                    }
+            function processSingleFetch(promise, args) {
+                var url = args[0];
+                var params = args[1];
+                var paramType = Object.prototype.toString.call(args[0]);
+                if (paramType === '[object Request]') {
+                    url = args[0].url;
+                    params = {
+                        method: args[0].method,
+                        credentials: args[0].credentials,
+                        headers: args[0].headers,
+                        mode: args[0].mode,
+                        redirect: args[0].redirect
+                    };
+                } else {
+                    url = String(url);
                 }
+                if (!url.match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
+                    var method = 'GET';
+                    if (params && params.method !== undefined) {
+                        method = params.method;
+                    }
 
+                    var stackElement = {
+                        error: false,
+                        url: url,
+                        method: method,
+                        type: 'fetch',
+                        start: new Date()
+                    };
+
+                    var idx = requestStack.push(stackElement) - 1;
+                    promise.then(function (r) {
+                        stackElement.duration = new Date() - stackElement.start;
+                        stackElement.error = r.status < 200 || r.status >= 400;
+                        stackElement.statusCode = r.status;
+                        stackElement.profile = r.headers.get('x-debug-token');
+                        stackElement.profilerUrl = r.headers.get('x-debug-token-link');
+                        stackElement.toolbarReplaceFinished = false;
+                        stackElement.toolbarReplace = '1' === r.headers.get('Symfony-Debug-Toolbar-Replace');
+                        finishAjaxRequest(idx);
+                    }, function (e){
+                        stackElement.error = true;
+                        finishAjaxRequest(idx);
+                    });
+                    startAjaxRequest(idx);
+                }
+            }
+
+            if (typeof window.Sfjs_globalFetchStack !== 'undefined') {
                 /* Process the pending requests in global fetch stack */
                 window.Sfjs_globalFetchStack.forEach(function (req) {
                     processSingleFetch(req[0], req[1]);
@@ -327,53 +327,61 @@
                 window.Sfjs_globalFetchStack.push = function (args) {
                     processSingleFetch(args[0], args[1]);
                 };
+            } else if (window.fetch && window.fetch.polyfill === undefined) {
+                var oldFetch = window.fetch;
+                window.fetch = function () {
+                    var promise = oldFetch.apply(this, arguments);
+                    processSingleFetch(promise, arguments);
+                    return promise;
+                }
             }
-            if (typeof window.Sfjs_globalXHRStack !== 'undefined') {
-                function processSingleXHR(xhr, method, url) {
-                    var path = url;
-                    /* prevent logging AJAX calls to static and inline files, like templates */
-                    if (url.substr(0, 1) === '/') {
-                        if (0 === url.indexOf('{{ request.basePath|e('js') }}')) {
-                            path = url.substr({{ request.basePath|length }});
-                        }
-                    }
-                    else if (0 === url.indexOf('{{ (request.schemeAndHttpHost ~ request.basePath)|e('js') }}')) {
-                        path = url.substr({{ (request.schemeAndHttpHost ~ request.basePath)|length }});
-                    }
 
-                    if (!path.match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
-                        var stackElement = {
-                            error: false,
-                            url: url,
-                            method: method,
-                            type: 'xhr',
-                            start: new Date()
-                        };
-
-                        var idx = requestStack.push(stackElement) - 1;
-
-                        function onRequestComplete(stackElement, xhr) {
-                            stackElement.duration = new Date() - stackElement.start;
-                            stackElement.error = xhr.status < 200 || xhr.status >= 400;
-                            stackElement.statusCode = xhr.status;
-                            extractHeaders(xhr, stackElement);
-                            finishAjaxRequest(idx);
-                        }
-
-                        if (xhr.readyState == 4) {
-                            onRequestComplete(stackElement, xhr);
-                        } else {
-                            xhr.addEventListener('readystatechange', function() {
-                                if (xhr.readyState == 4) {
-                                    onRequestComplete(stackElement, xhr);
-                                }
-                            }, false);
-                        }
-
-                        startAjaxRequest(idx);
+            function processSingleXHR(xhr, method, url) {
+                var path = url;
+                /* prevent logging AJAX calls to static and inline files, like templates */
+                if (url.substr(0, 1) === '/') {
+                    if (0 === url.indexOf('{{ request.basePath|e('js') }}')) {
+                        path = url.substr({{ request.basePath|length }});
                     }
                 }
+                else if (0 === url.indexOf('{{ (request.schemeAndHttpHost ~ request.basePath)|e('js') }}')) {
+                    path = url.substr({{ (request.schemeAndHttpHost ~ request.basePath)|length }});
+                }
 
+                if (!path.match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
+                    var stackElement = {
+                        error: false,
+                        url: url,
+                        method: method,
+                        type: 'xhr',
+                        start: new Date()
+                    };
+
+                    var idx = requestStack.push(stackElement) - 1;
+
+                    function onRequestComplete(stackElement, xhr) {
+                        stackElement.duration = new Date() - stackElement.start;
+                        stackElement.error = xhr.status < 200 || xhr.status >= 400;
+                        stackElement.statusCode = xhr.status;
+                        extractHeaders(xhr, stackElement);
+                        finishAjaxRequest(idx);
+                    }
+
+                    if (xhr.readyState == 4) {
+                        onRequestComplete(stackElement, xhr);
+                    } else {
+                        xhr.addEventListener('readystatechange', function() {
+                            if (xhr.readyState == 4) {
+                                onRequestComplete(stackElement, xhr);
+                            }
+                        }, false);
+                    }
+
+                    startAjaxRequest(idx);
+                }
+            }
+
+            if (typeof window.Sfjs_globalXHRStack !== 'undefined') {
                 /* Process the pending xhr requests in global stack */
                 window.Sfjs_globalXHRStack.forEach(function (req) {
                     processSingleXHR(req[0], req[1], req[2]);
@@ -382,6 +390,12 @@
                 /* Rewrite the global xhr stack push method */
                 window.Sfjs_globalXHRStack.push = function (args) {
                     processSingleXHR(args[0], args[1], args[2]);
+                };
+            } else if (window.XMLHttpRequest && XMLHttpRequest.prototype.addEventListener) {
+                var proxied = XMLHttpRequest.prototype.open;
+                XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
+                    processSingleXHR(this, method, url);
+                    proxied.apply(this, Array.prototype.slice.call(arguments));
                 };
             }
         {% endif %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/request_stack_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/request_stack_js.html.twig
@@ -1,0 +1,24 @@
+<script{% if csp_script_nonce %} nonce="{{ csp_script_nonce }}"{% endif %}>/*<![CDATA[*/
+(function () {
+    if (window.fetch && window.fetch.polyfill === undefined) {
+        window.Sfjs_globalFetchStack = window.Sfjs_globalFetchStack||[];
+
+        var oldFetch = window.fetch;
+        window.fetch = function () {
+            var promise = oldFetch.apply(this, arguments);
+            window.Sfjs_globalFetchStack.push([promise, arguments]);
+            return promise;
+        }
+    }
+
+    if (window.XMLHttpRequest && XMLHttpRequest.prototype.addEventListener) {
+        window.Sfjs_globalXHRStack = window.Sfjs_globalXHRStack||[];
+
+        var proxied = XMLHttpRequest.prototype.open;
+        XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
+            window.Sfjs_globalXHRStack.push([this, method, url]);
+            proxied.apply(this, Array.prototype.slice.call(arguments));
+        };
+    }
+})();
+/*]]>*/</script>

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/EventListener/WebDebugToolbarListenerTest.php
@@ -40,7 +40,7 @@ class WebDebugToolbarListenerTest extends TestCase
     public function getInjectToolbarTests()
     {
         return [
-            ['<html><head></head><body></body></html>', "<html><head></head><body>\nWDT\n</body></html>"],
+            ['<html><head></head><body></body></html>', "<html><head>WDT</head><body>\nWDT\n</body></html>"],
             ['<html>
             <head></head>
             <body>
@@ -49,7 +49,7 @@ class WebDebugToolbarListenerTest extends TestCase
             </html>', "<html>
             <head></head>
             <body>
-            <textarea><html><head></head><body></body></html></textarea>
+            <textarea><html><head>WDT</head><body></body></html></textarea>
             \nWDT\n</body>
             </html>"],
         ];
@@ -94,7 +94,7 @@ class WebDebugToolbarListenerTest extends TestCase
         $listener = new WebDebugToolbarListener($this->getTwigMock());
         $listener->onKernelResponse($event);
 
-        $this->assertEquals("<html><head></head><body>\nWDT\n</body></html>", $response->getContent());
+        $this->assertEquals("<html><head>WDT</head><body>\nWDT\n</body></html>", $response->getContent());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix #38331 
| License       | MIT

A pretty lengthy fix, but I don't see a better solution.

The global variables work by initializing to an empty array -> the proxies fill the array -> the array is processed by the toolbar -> the `push()` method of the arrays is overridden -> the toolbar continues to process calls to `push()` using a custom handler.

Since proxying of calls to `window.fetch` and `XMLHttpRequest.prototype.open` has to be done before any scripts are executed, I added them just before `</head>`. This complicates the `ToolbarListener` a bit and I don't really know how to properly test it.

Since `fetch` and `XMLHttpRequest` are wildly different, I chose to create two global stacks and process them separately. They could be unified and the code could be minified a little but I chose not to for the sake of clarity.

Finally, since the ticket talks about Axios, you can try that 

```html
<!DOCTYPE html>
<html lang="">
<head>
    <meta charset="UTF-8">
    <title>Axios demo</title>
</head>
<body>
    <script src="https://unpkg.com/axios/dist/axios.min.js"></script>

    <pre id="axios">
        Pending...
    </pre>

    <script type="application/javascript">
    axios.get('https://api.github.com/zen').then((r) => {
        document.getElementById('axios').innerText = r.data;
    }).catch((err) => {
        document.getElementById('axios').innerText = err;
    });
    </script>
</body>
</html>
```

doesn't display the request unless this fix is applied.

Possible TODOs
 - [ ] Better test for `WebDebugToolbarListener`
 - [ ] Some sort of a Selenium test...?