### PR TITLE
[SecurityBundle] Make user lazy loading working without user provider

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -249,10 +249,13 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         }
         $arguments[1] = $userProviderIteratorsArgument = new IteratorArgument($userProviders);
         $contextListenerDefinition->setArguments($arguments);
+        $nbUserProviders = \count($userProviders);
 
-        if (\count($userProviders) > 1) {
+        if ($nbUserProviders > 1) {
             $container->setDefinition('security.user_providers', new Definition(ChainUserProvider::class, [$userProviderIteratorsArgument]))
                 ->setPublic(false);
+        } elseif (0 === $nbUserProviders) {
+            $container->removeDefinition('security.listener.user_provider');
         } else {
             $container->setAlias('security.user_providers', new Alias(current($providerIds)))->setPublic(false);
         }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticatorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticatorTest.php
@@ -44,6 +44,20 @@ class AuthenticatorTest extends AbstractWebTestCase
         }
     }
 
+    /**
+     * @dataProvider provideEmails
+     */
+    public function testWithoutUserProvider($email)
+    {
+        $client = $this->createClient(['test_case' => 'Authenticator', 'root_config' => 'no_user_provider.yml']);
+
+        $client->request('GET', '/profile', [], [], [
+            'HTTP_X-USER-EMAIL' => $email,
+        ]);
+
+        $this->assertJsonStringEqualsJsonString('{"email":"'.$email.'"}', $client->getResponse()->getContent());
+    }
+
     public function provideEmails()
     {
         yield ['jane@example.org', true];

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/config.yml
@@ -15,19 +15,3 @@ services:
             - ['setContainer', ['@Psr\Container\ContainerInterface']]
         tags: [container.service_subscriber]
     Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator: ~
-
-security:
-    enable_authenticator_manager: true
-
-    encoders:
-        Symfony\Component\Security\Core\User\User: plaintext
-
-    providers:
-        in_memory:
-            memory:
-                users:
-                    'jane@example.org': { password: test, roles: [ROLE_USER] }
-        in_memory2:
-            memory:
-                users:
-                    'john@example.org': { password: test, roles: [ROLE_USER] }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/firewall_user_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/firewall_user_provider.yml
@@ -1,5 +1,6 @@
 imports:
 - { resource: ./config.yml }
+- { resource: ./security.yml }
 
 security:
     firewalls:
@@ -7,4 +8,3 @@ security:
             pattern: /
             provider: in_memory
             custom_authenticator: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator
-

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/no_user_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/no_user_provider.yml
@@ -1,8 +1,13 @@
 imports:
 - { resource: ./config.yml }
-- { resource: ./security.yml }
+
+services:
+    Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator:
+        - true
 
 security:
+    enable_authenticator_manager: true
+
     firewalls:
         api:
             pattern: /

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/security.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/security.yml
@@ -1,0 +1,15 @@
+security:
+    enable_authenticator_manager: true
+
+    encoders:
+        Symfony\Component\Security\Core\User\User: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    'jane@example.org': { password: test, roles: [ROLE_USER] }
+        in_memory2:
+            memory:
+                users:
+                    'john@example.org': { password: test, roles: [ROLE_USER] }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #38429  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Make user lazy loading in security working again without user provider.
