### PR TITLE
[Framework] Add tag assets.package to register asset packages

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Added the `event_dispatcher.dispatcher` tag
  * Added `assertResponseFormatSame()` in `BrowserKitAssertionsTrait`
  * Add support for configuring UUID factory services
+ * Add tag `assets.package` to register asset packages
 
 5.2.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/UnusedTagsPass.php
@@ -23,6 +23,7 @@ class UnusedTagsPass implements CompilerPassInterface
 {
     private $knownTags = [
         'annotations.cached_reader',
+        'assets.package',
         'auto_alias',
         'cache.pool',
         'cache.pool.clearer',

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -471,6 +471,8 @@ class FrameworkExtension extends Extension
             $loader->load('mime_type.php');
         }
 
+        $container->registerForAutoconfiguration(PackageInterface::class)
+            ->addTag('assets.package');
         $container->registerForAutoconfiguration(Command::class)
             ->addTag('console.command');
         $container->registerForAutoconfiguration(ResourceCheckerInterface::class)
@@ -1095,7 +1097,6 @@ class FrameworkExtension extends Extension
         $defaultPackage = $this->createPackageDefinition($config['base_path'], $config['base_urls'], $defaultVersion);
         $container->setDefinition('assets._default_package', $defaultPackage);
 
-        $namedPackages = [];
         foreach ($config['packages'] as $name => $package) {
             if (null !== $package['version_strategy']) {
                 $version = new Reference($package['version_strategy']);
@@ -1109,15 +1110,11 @@ class FrameworkExtension extends Extension
                 $version = $this->createVersion($container, $version, $format, $package['json_manifest_path'], $name);
             }
 
-            $container->setDefinition('assets._package_'.$name, $this->createPackageDefinition($package['base_path'], $package['base_urls'], $version));
+            $packageDefinition = $this->createPackageDefinition($package['base_path'], $package['base_urls'], $version)
+                ->addTag('assets.package', ['package' => $name]);
+            $container->setDefinition('assets._package_'.$name, $packageDefinition);
             $container->registerAliasForArgument('assets._package_'.$name, PackageInterface::class, $name.'.package');
-            $namedPackages[$name] = new Reference('assets._package_'.$name);
         }
-
-        $container->getDefinition('assets.packages')
-            ->replaceArgument(0, new Reference('assets._default_package'))
-            ->replaceArgument(1, $namedPackages)
-        ;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.php
@@ -30,8 +30,8 @@ return static function (ContainerConfigurator $container) {
     $container->services()
         ->set('assets.packages', Packages::class)
             ->args([
-                service('assets.empty_package'),
-                [],
+                service('assets._default_package'),
+                tagged_iterator('assets.package', 'package'),
             ])
 
         ->alias(Packages::class, 'assets.packages')
@@ -40,6 +40,8 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('assets.empty_version_strategy'),
             ])
+
+        ->alias('assets._default_package', 'assets.empty_package')
 
         ->set('assets.context', RequestStackContext::class)
             ->args([

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -603,8 +603,13 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertUrlPackage($container, $defaultPackage, ['http://cdn.example.com'], 'SomeVersionScheme', '%%s?version=%%s');
 
         // packages
-        $packages = $packages->getArgument(1);
-        $this->assertCount(9, $packages);
+        $packageTags = $container->findTaggedServiceIds('assets.package');
+        $this->assertCount(9, $packageTags);
+
+        $packages = [];
+        foreach ($packageTags as $serviceId => $tagAttributes) {
+            $packages[$tagAttributes[0]['package']] = $serviceId;
+        }
 
         $package = $container->getDefinition((string) $packages['images_path']);
         $this->assertPathPackage($container, $package, '/foo', 'SomeVersionScheme', '%%s?version=%%s');

--- a/src/Symfony/Component/Asset/Packages.php
+++ b/src/Symfony/Component/Asset/Packages.php
@@ -28,7 +28,7 @@ class Packages
     /**
      * @param PackageInterface[] $packages Additional packages indexed by name
      */
-    public function __construct(PackageInterface $defaultPackage = null, array $packages = [])
+    public function __construct(PackageInterface $defaultPackage = null, iterable $packages = [])
     {
         $this->defaultPackage = $defaultPackage;
 

--- a/src/Symfony/Component/Asset/Tests/PackagesTest.php
+++ b/src/Symfony/Component/Asset/Tests/PackagesTest.php
@@ -51,7 +51,7 @@ class PackagesTest extends TestCase
     {
         $packages = new Packages(
             new Package(new StaticVersionStrategy('default')),
-            ['a' => new Package(new StaticVersionStrategy('a'))]
+            new \ArrayIterator(['a' => new Package(new StaticVersionStrategy('a'))])
         );
 
         $this->assertSame('/foo?default', $packages->getUrl('/foo'));


### PR DESCRIPTION
Replaces #38366 

| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#14962

To configure asset packages in an application, we have to declare it in the `framework` configuration ([doc for assets config](https://symfony.com/doc/current/reference/configuration/framework.html#assets)). In some case we cannot use this configuration:
- To use a custom class as package
- To register an asset package in a shared bundle (my use-case).

This PR adds the `assets.package` tag. This tag is use to collect and inject package services into the `assets.packages` service, that is the registry for all packages. Since every package needs a name, the `package` attribute of the tag is used (same naming convention that the `console.command` tag).


Main changes:
- the packages defined in the `framework.assets` configuration are injected into the `assets.packages` using the tag instead of being directly injected in service declaration.
- changed signature of `Symfony\Components\Assets\Packages` constructor to accept an iterator (backward compatible).
- a new alias `assets._default_package` is defined even if assets are not configured.


### Example in `symfony/demo` ([commit](https://github.com/symfony/demo/compare/e5e5a8fff048351ea8a8fe2b418f0256eabeee12...GromNaN:assets-package-tag)):

In `config/services.yaml`:
```yaml
    avatar.strategy:
        class: Symfony\Component\Asset\VersionStrategy\JsonManifestVersionStrategy
        arguments:
            - '%kernel.project_dir%/public/build/manifest.json'

    avatar.package:
        class:  Symfony\Component\Asset\Package
        arguments:
            - '@avatar.strategy'
            - '@assets.context'
        tags:
            - { name: assets.package, package: avatars }
```

Then we can use the package anywhere
```twig
<img src="{{ asset('anna.jpg', 'avatars') }}">
```

### Alternative using autoconfiguration with a custom class:

With a custom class implementing the `PackageInterface`, the package name can be provided by a the static method `getDefaultPackageName`. Autowiring and autoconfiguration will import the package.

```php
namespace App\Asset;

use Symfony\Component\Asset\PackageInterface;

class AvatarPackage implements PackageInterface
{
    public static function getDefaultPackageName(): string
    {
        return 'avatars';
    }

    // ... Implements the interface
}
```
