### PR TITLE
[HttpClient] Fix missing abstract arg

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/http_client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/http_client.php
@@ -58,6 +58,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('delay ms'),
                 abstract_arg('multiplier'),
                 abstract_arg('max delay ms'),
+                abstract_arg('jitter'),
             ])
         ->set('http_client.retry.abstract_httpstatuscode_decider', HttpStatusCodeDecider::class)
             ->abstract()

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -587,6 +587,7 @@
         <xsd:attribute name="delay" type="xsd:integer" />
         <xsd:attribute name="multiplier" type="xsd:float" />
         <xsd:attribute name="max-delay" type="xsd:float" />
+        <xsd:attribute name="jitter" type="xsd:float" />
         <xsd:attribute name="response_header" type="xsd:boolean" />
     </xsd:complexType>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_retry.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_retry.php
@@ -11,6 +11,7 @@ $container->loadFromExtension('framework', [
                 'delay' => 100,
                 'multiplier' => 2,
                 'max_delay' => 0,
+                'jitter' => 0.3,
             ]
         ],
         'scoped_clients' => [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_retry.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_retry.xml
@@ -12,7 +12,8 @@
                         delay="100"
                         max-delay="0"
                         max-retries="2"
-                        multiplier="2">
+                        multiplier="2"
+                        jitter="0.3">
                     <framework:http-code>429</framework:http-code>
                     <framework:http-code>500</framework:http-code>
                 </framework:retry-failed>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_retry.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_retry.yml
@@ -9,6 +9,7 @@ framework:
                 delay: 100
                 multiplier: 2
                 max_delay: 0
+                jitter: 0.3
         scoped_clients:
             foo:
                 base_uri: http://example.com

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1504,6 +1504,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame(100, $container->getDefinition('http_client.retry.exponential_backoff')->getArgument(0));
         $this->assertSame(2, $container->getDefinition('http_client.retry.exponential_backoff')->getArgument(1));
         $this->assertSame(0, $container->getDefinition('http_client.retry.exponential_backoff')->getArgument(2));
+        $this->assertSame(0.3, $container->getDefinition('http_client.retry.exponential_backoff')->getArgument(3));
         $this->assertSame(2, $container->getDefinition('http_client.retry')->getArgument(3));
 
         $this->assertSame(RetryableHttpClient::class, $container->getDefinition('foo.retry')->getClass());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

Fix missing abstract argument and add tests