### PR TITLE
Change ExceptionListenerPass removeDefinition args

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExceptionListenerPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExceptionListenerPass.php
@@ -40,12 +40,12 @@ class ExceptionListenerPass implements CompilerPassInterface
         if ($container->hasParameter('templating.engines')) {
             $engines = $container->getParameter('templating.engines');
             if (\in_array('twig', $engines, true)) {
-                $container->removeDefinition('exception_listener');
+                $container->removeDefinition('twig.exception_listener');
 
                 return;
             }
         }
 
-        $container->removeDefinition('twig.exception_listener');
+        $container->removeDefinition('exception_listener');
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExceptionListenerPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExceptionListenerPass.php
@@ -39,10 +39,8 @@ class ExceptionListenerPass implements CompilerPassInterface
 
         if ($container->hasParameter('templating.engines')) {
             $engines = $container->getParameter('templating.engines');
-            if (\in_array('twig', $engines, true)) {
+            if (!\in_array('twig', $engines, true)) {
                 $container->removeDefinition('twig.exception_listener');
-
-                return;
             }
         }
 

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/ExceptionListenerPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/ExceptionListenerPassTest.php
@@ -46,7 +46,7 @@ class ExceptionListenerPassTest extends TestCase
         $this->assertTrue($builder->hasDefinition('exception_listener'));
         $this->assertFalse($builder->hasDefinition('twig.exception_listener'));
     }
-    
+
     public function testRemovesBothExceptionListenerIfTwigIsNotUsedAsTemplateEngine(): void
     {
         $builder = new ContainerBuilder();
@@ -65,7 +65,7 @@ class ExceptionListenerPassTest extends TestCase
     public function testRemovesTwigExceptionListenerIfTwigIsNotUsedAsTemplateEngine(): void
     {
         $this->markTestSkipped(sprintf('This test was implemented in accordance to version %. However, the implementation which this test cover was a behavior change.', '4.4.15'));
-        
+
         $builder = new ContainerBuilder();
         $builder->register('twig', Environment::class);
         $builder->register('exception_listener', ExceptionListener::class);

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/ExceptionListenerPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/ExceptionListenerPassTest.php
@@ -46,9 +46,26 @@ class ExceptionListenerPassTest extends TestCase
         $this->assertTrue($builder->hasDefinition('exception_listener'));
         $this->assertFalse($builder->hasDefinition('twig.exception_listener'));
     }
+    
+    public function testRemovesBothExceptionListenerIfTwigIsNotUsedAsTemplateEngine(): void
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('twig', Environment::class);
+        $builder->register('exception_listener', ExceptionListener::class);
+        $builder->register('twig.exception_listener', ExceptionListener::class);
+        $builder->setParameter('twig.exception_listener.controller', 'exception_controller::showAction');
+        $builder->setParameter('templating.engines', ['php']);
+
+        ($pass = new ExceptionListenerPass())->process($builder);
+
+        $this->assertFalse($builder->hasDefinition('exception_listener'));
+        $this->assertFalse($builder->hasDefinition('twig.exception_listener'));
+    }
 
     public function testRemovesTwigExceptionListenerIfTwigIsNotUsedAsTemplateEngine(): void
     {
+        $this->markTestSkipped(sprintf('This test was implemented in accordance to version %. However, the implementation which this test cover was a behavior change.', '4.4.15'));
+        
         $builder = new ContainerBuilder();
         $builder->register('twig', Environment::class);
         $builder->register('exception_listener', ExceptionListener::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #38482 
| License       | MIT
| Doc PR        |

Since the 4.4.15 upgrade, our FOSRest (2.6) configuration did not work anymore.

See the issue in #38482 for more explanation.