### PR TITLE
[Messenger] Add DelayStamp::delayFor() and DelayStamp::delayUntil()

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
 * The `RedeliveryStamp` will no longer be populated with error data. This information is now stored in the `ErrorDetailsStamp` instead.
 * Added `FlattenExceptionNormalizer` to give more information about the exception on Messenger background processes. The `FlattenExceptionNormalizer` has a higher priority than `ProblemNormalizer` and it is only used when the Messenger serialization context is set.
-* Added factory methods to `DelayStamp`.
+* Added factory methods `DelayStamp::delayFor(\DateInterval)` and `DelayStamp::delayUntil(\DateTimeInterface)`.
 * Removed the exception when dispatching a message with a `DispatchAfterCurrentBusStamp` and not in a context of another dispatch call
 * Added `WorkerMessageRetriedEvent`
 * Added `WorkerMessageReceivedEvent::setEnvelope()` and made event mutable

--- a/src/Symfony/Component/Messenger/Stamp/DelayStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/DelayStamp.php
@@ -31,18 +31,16 @@ final class DelayStamp implements StampInterface
         return $this->delay;
     }
 
-    public static function delayForSeconds(int $seconds): self
+    public static function delayFor(\DateInterval $interval): self
     {
-        return new self($seconds * 1000);
+        $now = new \DateTimeImmutable();
+        $end = $now->add($interval);
+
+        return new self(($end->getTimestamp() - $now->getTimestamp()) * 1000);
     }
 
-    public static function delayForMinutes(int $minutes): self
+    public static function delayUntil(\DateTimeInterface $dateTime): self
     {
-        return self::delayForSeconds($minutes * 60);
-    }
-
-    public static function delayForHours(int $hours): self
-    {
-        return self::delayForMinutes($hours * 60);
+        return new self(($dateTime->getTimestamp() - time()) * 1000);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Stamp/DelayStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/DelayStampTest.php
@@ -19,21 +19,25 @@ use Symfony\Component\Messenger\Stamp\DelayStamp;
  */
 class DelayStampTest extends TestCase
 {
-    public function testSeconds()
+    public function testDelayFor()
     {
-        $stamp = DelayStamp::delayForSeconds(30);
+        $stamp = DelayStamp::delayFor(\DateInterval::createFromDateString('30 seconds'));
         $this->assertSame(30000, $stamp->getDelay());
-    }
-
-    public function testMinutes()
-    {
-        $stamp = DelayStamp::delayForMinutes(30);
+        $stamp = DelayStamp::delayFor(\DateInterval::createFromDateString('30 minutes'));
         $this->assertSame(1800000, $stamp->getDelay());
+        $stamp = DelayStamp::delayFor(\DateInterval::createFromDateString('30 hours'));
+        $this->assertSame(108000000, $stamp->getDelay());
+
+        $stamp = DelayStamp::delayFor(\DateInterval::createFromDateString('-5 seconds'));
+        $this->assertSame(-5000, $stamp->getDelay());
     }
 
-    public function testHours()
+    public function testDelayUntil()
     {
-        $stamp = DelayStamp::delayForHours(30);
-        $this->assertSame(108000000, $stamp->getDelay());
+        $stamp = DelayStamp::delayUntil(new \DateTimeImmutable('+30 seconds'));
+        $this->assertSame(30000, $stamp->getDelay());
+
+        $stamp = DelayStamp::delayUntil(new \DateTimeImmutable('-5 seconds'));
+        $this->assertSame(-5000, $stamp->getDelay());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #38141
| License       | MIT
| Doc PR        | 

This PR will revert the work by @Toflar in https://github.com/symfony/symfony/pull/38141. He added some helper methods and I want to add a generic factory method that adds a DateInterval. 

This PR will also close #38480 and fix #38459. It is also related to a comment in https://github.com/symfony/symfony/pull/36512#issuecomment-675462871 that was liked by a few people. 

Maybe adding both `DelayStamp::delayFor(\DateInterval)` and `DelayStamp::delayUntil(\DateTimeInterface)` is overkill. But this covers all the bases and I hope that it will be the last change to this small class. 
