### PR TITLE
[ErrorHandler] fix html W3C compliance

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -137,7 +137,7 @@ final class CodeExtension extends AbstractExtension
             }
 
             for ($i = max($line - $srcContext, 1), $max = min($line + $srcContext, \count($content)); $i <= $max; ++$i) {
-                $lines[] = '<li'.($i == $line ? ' class="selected"' : '').'><a class="anchor" name="line'.$i.'"></a><code>'.self::fixCodeMarkup($content[$i - 1]).'</code></li>';
+                $lines[] = '<li'.($i == $line ? ' class="selected"' : '').'><a class="anchor" id="line'.$i.'"></a><code>'.self::fixCodeMarkup($content[$i - 1]).'</code></li>';
             }
 
             return '<ol start="'.max($line - $srcContext, 1).'">'.implode("\n", $lines).'</ol>';

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
@@ -283,7 +283,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
             }
 
             for ($i = max($line - $srcContext, 1), $max = min($line + $srcContext, \count($content)); $i <= $max; ++$i) {
-                $lines[] = '<li'.($i == $line ? ' class="selected"' : '').'><a class="anchor" name="line'.$i.'"></a><code>'.$this->fixCodeMarkup($content[$i - 1]).'</code></li>';
+                $lines[] = '<li'.($i == $line ? ' class="selected"' : '').'><code>'.$this->fixCodeMarkup($content[$i - 1]).'</code></li>';
             }
 
             return '<ol start="'.max($line - $srcContext, 1).'">'.implode("\n", $lines).'</ol>';
@@ -302,9 +302,9 @@ class HtmlErrorRenderer implements ErrorRendererInterface
         }
 
         // missing </span> tag at the end of line
-        $opening = strpos($line, '<span');
-        $closing = strpos($line, '</span>');
-        if (false !== $opening && (false === $closing || $closing > $opening)) {
+        $opening = strrpos($line, '<span');
+        $closing = strrpos($line, '</span>');
+        if (false !== $opening && (false === $closing || $closing < $opening)) {
             $line .= '</span>';
         }
 

--- a/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/css/exception.css
@@ -124,7 +124,7 @@ tr.status-error td, tr.status-warning td { border-bottom: 1px solid var(--base-2
 .status-warning .colored { color: #A46A1F; }
 .status-error .colored  { color: var(--color-error); }
 
-.sf-toggle { cursor: pointer; }
+.sf-toggle { cursor: pointer; position: relative; }
 .sf-toggle-content { -moz-transition: display .25s ease; -webkit-transition: display .25s ease; transition: display .25s ease; }
 .sf-toggle-content.sf-toggle-hidden { display: none; }
 .sf-toggle-content.sf-toggle-visible { display: block; }

--- a/src/Symfony/Component/ErrorHandler/Resources/views/logs.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/logs.html.php
@@ -23,7 +23,7 @@
             $status = \E_DEPRECATED === $severity || \E_USER_DEPRECATED === $severity ? 'warning' : 'normal';
         } ?>
         <tr class="status-<?= $status; ?>" data-filter-level="<?= strtolower($this->escape($log['priorityName'])); ?>"<?php if ($channelIsDefined) { ?> data-filter-channel="<?= $this->escape($log['channel']); ?>"<?php } ?>>
-            <td class="text-small" nowrap>
+            <td class="text-small nowrap">
                 <span class="colored text-bold"><?= $this->escape($log['priorityName']); ?></span>
                 <span class="text-muted newline"><?= date('H:i:s', $log['timestamp']); ?></span>
             </td>

--- a/src/Symfony/Component/ErrorHandler/Resources/views/traces.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/traces.html.php
@@ -1,21 +1,30 @@
 <div class="trace trace-as-html" id="trace-box-<?= $index; ?>">
     <div class="trace-details">
         <div class="trace-head">
-            <span class="sf-toggle" data-toggle-selector="#trace-html-<?= $index; ?>" data-toggle-initial="<?= $expand ? 'display' : ''; ?>">
-                <h3 class="trace-class">
-                    <span class="icon icon-close"><?= $this->include('assets/images/icon-minus-square-o.svg'); ?></span>
-                    <span class="icon icon-open"><?= $this->include('assets/images/icon-plus-square-o.svg'); ?></span>
+            <div class="sf-toggle" data-toggle-selector="#trace-html-<?= $index; ?>" data-toggle-initial="<?= $expand ? 'display' : ''; ?>">
+                <span class="icon icon-close"><?= $this->include('assets/images/icon-minus-square-o.svg'); ?></span>
+                <span class="icon icon-open"><?= $this->include('assets/images/icon-plus-square-o.svg'); ?></span>
+                <?php
+                $separator = strrpos($exception['class'], '\\');
+                $separator = false === $separator ? 0 : $separator + 1;
 
-                    <span class="trace-namespace">
-                        <?= implode('\\', array_slice(explode('\\', $exception['class']), 0, -1)); ?><?= count(explode('\\', $exception['class'])) > 1 ? '\\' : ''; ?>
-                    </span>
-                    <?= ($parts = explode('\\', $exception['class'])) ? end($parts) : ''; ?>
-                </h3>
-
+                $namespace = substr($exception['class'], 0, $separator);
+                $class = substr($exception['class'], $separator);
+                ?>
+                <?php if ('' === $class) { ?>
+                    </br>
+                <?php } else { ?>
+                    <h3 class="trace-class">
+                        <?php if ('' !== $namespace) { ?>
+                            <span class="trace-namespace"><?= $namespace; ?></span>
+                        <?php } ?>
+                        <?= $class; ?>
+                    </h3>
+                <?php } ?>
                 <?php if ($exception['message'] && $index > 1) { ?>
                     <p class="break-long-words trace-message"><?= $this->escape($exception['message']); ?></p>
                 <?php } ?>
-            </span>
+            </div>
         </div>
 
         <div id="trace-html-<?= $index; ?>" class="sf-toggle-content">

--- a/src/Symfony/Component/ErrorHandler/Resources/views/traces_text.html.php
+++ b/src/Symfony/Component/ErrorHandler/Resources/views/traces_text.html.php
@@ -2,14 +2,14 @@
     <thead class="trace-head">
         <tr>
             <th class="sf-toggle" data-toggle-selector="#trace-text-<?= $index; ?>" data-toggle-initial="<?= 1 === $index ? 'display' : ''; ?>">
-                <h3 class="trace-class">
+                <div class="trace-class">
                     <?php if ($numExceptions > 1) { ?>
                         <span class="text-muted">[<?= $numExceptions - $index + 1; ?>/<?= $numExceptions; ?>]</span>
                     <?php } ?>
                     <?= ($parts = explode('\\', $exception['class'])) ? end($parts) : ''; ?>
                     <span class="icon icon-close"><?= $this->include('assets/images/icon-minus-square-o.svg'); ?></span>
                     <span class="icon icon-open"><?= $this->include('assets/images/icon-plus-square-o.svg'); ?></span>
-                </h3>
+                </div>
             </th>
         </tr>
     </thead>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes but not really
| New feature?  | no
| Deprecations? | no
| Tickets       | Fixes #38471
| License       | MIT

Fixes:
- `<h3>` inside `<span></span>`
- `name` attribute on `<a>` is deprecated
- stray `</span>`
- `nowrap` attribute is deprecated
- `<h3>` inside `<th>` (heading content in a table header)