### PR TITLE
[Messenger] Add authorization checker middleware

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1766,6 +1766,12 @@ class FrameworkExtension extends Extension
                 if (!$validationConfig['enabled'] && \in_array($middlewareItem['id'], ['validation', 'messenger.middleware.validation'], true)) {
                     throw new LogicException('The Validation middleware is only available when the Validator component is installed and enabled. Try running "composer require symfony/validator".');
                 }
+
+                if (\in_array($middlewareItem['id'], ['authorization_checker', 'messenger.middleware.authorization_checker'], true)) {
+                    if (!class_exists(Security::class)) {
+                        throw new LogicException('The Authorization checker middleware is only available when the Security component is installed. Try running "composer require symfony/security-core".');
+                    }
+                }
             }
 
             if ($container->getParameter('kernel.debug') && class_exists(Stopwatch::class)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -21,6 +21,7 @@ use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTranspor
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnSigtermSignalListener;
 use Symfony\Component\Messenger\Middleware\AddBusNameStampMiddleware;
+use Symfony\Component\Messenger\Middleware\AuthorizationCheckerMiddleware;
 use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
 use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
@@ -87,6 +88,11 @@ return static function (ContainerConfigurator $container) {
         ->set('messenger.middleware.validation', ValidationMiddleware::class)
             ->args([
                 service('validator'),
+            ])
+
+        ->set('messenger.middleware.authorization_checker', AuthorizationCheckerMiddleware::class)
+            ->args([
+                service('security.authorization_checker'),
             ])
 
         ->set('messenger.middleware.reject_redelivered_message_middleware', RejectRedeliveredMessageMiddleware::class)

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
 * Removed the exception when dispatching a message with a `DispatchAfterCurrentBusStamp` and not in a context of another dispatch call
 * Added `WorkerMessageRetriedEvent`
 * Added `WorkerMessageReceivedEvent::setEnvelope()` and made event mutable
+* Added `AuthorizationCheckerMiddleware` to check the message authorization with a `AuthorizationAttributeStamp`.
 
 5.1.0
 -----

--- a/src/Symfony/Component/Messenger/Exception/UnauthorizedException.php
+++ b/src/Symfony/Component/Messenger/Exception/UnauthorizedException.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+/**
+ * @author Maxime Perrimond <max.perrimond@gmail.com>
+ */
+class UnauthorizedException extends RuntimeException
+{
+    private $attribute;
+    private $subject;
+
+    public function __construct(string $attribute, $subject)
+    {
+        parent::__construct(sprintf('Message of type "%s" with attribute "%s" is unauthorized.', \get_class($subject), $attribute));
+
+        $this->attribute = $attribute;
+        $this->subject = $subject;
+    }
+
+    public function getAttribute(): string
+    {
+        return $this->attribute;
+    }
+
+    public function getSubject()
+    {
+        return $this->subject;
+    }
+}

--- a/src/Symfony/Component/Messenger/Middleware/AuthorizationCheckerMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/AuthorizationCheckerMiddleware.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\UnauthorizedException;
+use Symfony\Component\Messenger\Stamp\AuthorizationAttributeStamp;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+/**
+ * @author Maxime Perrimond <max.perrimond@gmail.com>
+ */
+class AuthorizationCheckerMiddleware implements MiddlewareInterface
+{
+    private $authorizationChecker;
+
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker)
+    {
+        $this->authorizationChecker = $authorizationChecker;
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        $message = $envelope->getMessage();
+        $attribute = null;
+        /** @var AuthorizationAttributeStamp|null $stamp */
+        if ($stamp = $envelope->last(AuthorizationAttributeStamp::class)) {
+            $attribute = $stamp->getAttribute();
+        }
+
+        if ($attribute && !$this->authorizationChecker->isGranted($attribute, $message)) {
+            throw new UnauthorizedException($attribute, $message);
+        }
+
+        return $stack->next()->handle($envelope, $stack);
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/AuthorizationAttributeStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/AuthorizationAttributeStamp.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * Apply this stamp to check the message authorization in the bus.
+ *
+ * @see \Symfony\Component\Messenger\Middleware\AuthorizationCheckerMiddleware
+ *
+ * @author Maxime Perrimond <max.perrimond@gmail.com>
+ */
+final class AuthorizationAttributeStamp implements StampInterface
+{
+    private $attribute;
+
+    public function __construct(string $attribute)
+    {
+        $this->attribute = $attribute;
+    }
+
+    public function getAttribute(): string
+    {
+        return $this->attribute;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/AuthorizationCheckerMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/AuthorizationCheckerMiddlewareTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\AuthorizationCheckerMiddleware;
+use Symfony\Component\Messenger\Stamp\AuthorizationAttributeStamp;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+/**
+ * @author Maxime Perrimond <max.perrimond@gmail.com>
+ */
+class AuthorizationCheckerMiddlewareTest extends MiddlewareTestCase
+{
+    public function testAuthorizationCheckWithNoStampAndNextMiddleware()
+    {
+        $message = new DummyMessage('Hey');
+        $envelope = new Envelope($message);
+
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker
+            ->expects($this->never())
+            ->method('isGranted')
+        ;
+
+        (new AuthorizationCheckerMiddleware($authorizationChecker))->handle($envelope, $this->getStackMock());
+    }
+
+    public function testAuthorizationCheckWithStampAndNextMiddleware()
+    {
+        $message = new DummyMessage('Hey');
+        $envelope = (new Envelope($message))->with(new AuthorizationAttributeStamp($attribute = 'foo'));
+
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker
+            ->expects($this->once())
+            ->method('isGranted')
+            ->with($attribute, $message)
+            ->willReturn(true)
+        ;
+
+        (new AuthorizationCheckerMiddleware($authorizationChecker))->handle($envelope, $this->getStackMock());
+    }
+
+    public function testUnauthorizedException()
+    {
+        $this->expectException('Symfony\Component\Messenger\Exception\UnauthorizedException');
+        $this->expectExceptionMessage('Message of type "Symfony\Component\Messenger\Tests\Fixtures\DummyMessage" with attribute "foo" is unauthorized.');
+
+        $message = new DummyMessage('Hey');
+        $envelope = (new Envelope($message))->with(new AuthorizationAttributeStamp($attribute = 'foo'));
+
+        $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authorizationChecker
+            ->expects($this->once())
+            ->method('isGranted')
+            ->with($attribute, $message)
+            ->willReturn(false)
+        ;
+
+        (new AuthorizationCheckerMiddleware($authorizationChecker))->handle($envelope, $this->getStackMock(false));
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Stamp/AuthorizationAttributeStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/AuthorizationAttributeStampTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Stamp;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Stamp\AuthorizationAttributeStamp;
+
+/**
+ * @author Maxime Perrimond <max.perrimond@gmail.com>
+ */
+class AuthorizationAttributeStampTest extends TestCase
+{
+    public function testStamp()
+    {
+        $stamp = new AuthorizationAttributeStamp($attribute = 'foo');
+        $this->assertSame($attribute, $stamp->getAttribute());
+    }
+
+    public function testSerializable()
+    {
+        $this->assertEquals($stamp = new AuthorizationAttributeStamp('foo'), unserialize(serialize($stamp)));
+    }
+}

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -32,6 +32,7 @@
         "symfony/http-kernel": "^4.4|^5.0",
         "symfony/process": "^4.4|^5.0",
         "symfony/property-access": "^4.4|^5.0",
+        "symfony/security-core": "^4.4|^5.0",
         "symfony/serializer": "^4.4|^5.0",
         "symfony/service-contracts": "^1.1|^2",
         "symfony/stopwatch": "^4.4|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | TODO

This add a new middleware to be able to check with an attribute, the authorization of a message and throw an `UnauthorizedException` if it failed.
This middleware in the current proposal, only checks if there is an `AuthorizationAttributeStamp` in the envelope.

It's quite similar to https://github.com/symfony/symfony/pull/30303 with a stamp. But there is still the issue of async with the token so this makes the middleware only usable in a synchronous transport.
So not sure if it's relevant to have this middleware available without a support of async transports. Maybe it requires a way to pass the token in an envelope to "authenticate/contextualize with a user" a message during the process.

As mentioned in the previous proposal, it might be useful for CQRS architecture. It can be questionable to have this in the bus but I see middlewares like this one or the validation one as gate keepers to have consistent actions and avoid UI layer to have to much responsibility.

**TODO**
- [ ] Doc