### PR TITLE
[HttpClient] Retry on timeout

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1667,6 +1667,7 @@ class Configuration implements ConfigurationInterface
                         ->defaultValue([423, 425, 429, 500, 502, 503, 504, 507, 510])
                     ->end()
                     ->integerNode('max_retries')->defaultValue(3)->min(0)->end()
+                    ->floatNode('retry_timeout')->defaultNull()->min(0)->info('The idle timeout in seconds before retrying the request, defaults to the "default_socket_timeout" ini parameter.')->end()
                     ->integerNode('delay')->defaultValue(1000)->min(0)->info('Time in ms to delay (or the initial value when multiplier is used)')->end()
                     ->floatNode('multiplier')->defaultValue(2)->min(1)->info('If greater than 1, delay will grow exponentially for each retry: (delay * (multiple ^ retries))')->end()
                     ->integerNode('max_delay')->defaultValue(0)->min(0)->info('Max time in ms that a retry should ever be delayed (0 = infinite)')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2096,7 +2096,7 @@ class FrameworkExtension extends Extension
         $container
             ->register($name.'.retry', RetryableHttpClient::class)
             ->setDecoratedService($name, null, -10) // lower priority than TraceableHttpClient
-            ->setArguments([new Reference($name.'.retry.inner'), $deciderReference, $backoffReference, $retryOptions['max_retries'], new Reference('logger')])
+            ->setArguments([new Reference($name.'.retry.inner'), $deciderReference, $backoffReference, $retryOptions['max_retries'], $retryOptions['retry_timeout'], new Reference('logger')])
             ->addTag('monolog.logger', ['channel' => 'http_client']);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -584,6 +584,7 @@
         <xsd:attribute name="backoff-service" type="xsd:string" />
         <xsd:attribute name="decider-service" type="xsd:string" />
         <xsd:attribute name="max-retries" type="xsd:integer" />
+        <xsd:attribute name="retry-timeout" type="xsd:float" />
         <xsd:attribute name="delay" type="xsd:integer" />
         <xsd:attribute name="multiplier" type="xsd:float" />
         <xsd:attribute name="max-delay" type="xsd:float" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_retry.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_retry.php
@@ -8,6 +8,7 @@ $container->loadFromExtension('framework', [
                 'decider_service' => null,
                 'http_codes' => [429, 500],
                 'max_retries' => 2,
+                'retry_timeout' => 10,
                 'delay' => 100,
                 'multiplier' => 2,
                 'max_delay' => 0,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_retry.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_retry.xml
@@ -12,6 +12,7 @@
                         delay="100"
                         max-delay="0"
                         max-retries="2"
+                        retry-timeout="10"
                         multiplier="2"
                         jitter="0.3">
                     <framework:http-code>429</framework:http-code>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_retry.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_retry.yml
@@ -6,6 +6,7 @@ framework:
                 decider_service: null
                 http_codes: [429, 500]
                 max_retries: 2
+                retry_timeout: 10
                 delay: 100
                 multiplier: 2
                 max_delay: 0

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1506,6 +1506,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame(0, $container->getDefinition('http_client.retry.exponential_backoff')->getArgument(2));
         $this->assertSame(0.3, $container->getDefinition('http_client.retry.exponential_backoff')->getArgument(3));
         $this->assertSame(2, $container->getDefinition('http_client.retry')->getArgument(3));
+        $this->assertSame(10, $container->getDefinition('http_client.retry')->getArgument(4));
 
         $this->assertSame(RetryableHttpClient::class, $container->getDefinition('foo.retry')->getClass());
         $this->assertSame(4, $container->getDefinition('foo.retry.exponential_backoff')->getArgument(1));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | TODO

This PR adds a new options to the RetryableHttpClient to retry IDLE sub-requests.