### PR TITLE
[Security][Login Link] Allow null and DateTime objects to be used as signatureProperties

### DIFF
--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -106,7 +106,11 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
         $signatureFields = [base64_encode($user->getUsername()), $expires];
 
         foreach ($this->signatureProperties as $property) {
-            $value = $this->propertyAccessor->getValue($user, $property);
+            $value = $this->propertyAccessor->getValue($user, $property) ?? '';
+            if ($value instanceof \DateTimeInterface) {
+                $value = $value->format('c');
+            }
+
             if (!is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
                 throw new \InvalidArgumentException(sprintf('The property path "%s" on the user object "%s" must return a value that can be cast to a string, but "%s" was returned.', $property, \get_class($user), get_debug_type($value)));
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Returning `DateTime` objects seems like a common use-case to automatically expire all login links when one is used or to only allow the login link to be used once.

**Before**

```php
class User
{
    private ?\DateTime $lastAuthenticatedAt = null;
    // ...

    public function getLastAuthenticatedAtString(): string
    {
        return null === $this->lastAuthenticatedAt ? '' : $this->lastAuthenticatedAt->format('c');
    }
}
```
```yaml
security:
  firewalls:
    main:
      login_link:
        # ...
        signature_properties: ['lastAuthenticatedAtString']
````

**After**

```php
class User
{
    private ?\DateTime $lastAuthenticatedAt = null;
    // ...

    public function getLastAuthenticatedAt(): ?\DateTime
    {
        return $this->lastAuthenticatedAt;
    }
}
```
```yaml
security:
  firewalls:
    main:
      login_link:
        # ...
        signature_properties: ['lastAuthenticatedAt']
````

---

The disadvantage of this patch is that there needs to be some boundary as to which objects we want to support casting to a scalar, but I'm convinced that `DateTime` objects will commonly be used as signature properties.

cc @weaverryan 