### PR TITLE
[Bug] Fix RateLimiter framework configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2269,7 +2269,7 @@ class FrameworkExtension extends Extension
         }
 
         $limiter->replaceArgument(1, new Reference($storageId));
-        unset($limiterConfig['storage']);
+        unset($limiterConfig['storage_service']);
         unset($limiterConfig['cache_pool']);
 
         $limiterConfig['id'] = $name;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x for features <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | -

Small mistake in the rate limiter configuration, instead of unsetting the `storage_service` option the never existing `storage` option was unset, resulting into an application error when trying to use a Limiter in your application.

The exception was:
```
Uncaught PHP Exception: The option "storage_service" does not exist. Defined options are: "id", "interval", "limit", "rate", "strategy"."
```

This was introduced in #38204, so a highlight for @wouterj to check this :)
