### PR TITLE
[HttpClient] Content doesn't get decoded when fetched from an exception

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -225,7 +225,6 @@ final class CurlResponse implements ResponseInterface
      */
     private function close(): void
     {
-        $this->inflate = null;
         unset($this->multi->openHandles[$this->id], $this->multi->handlesActivity[$this->id]);
         curl_setopt($this->handle, \CURLOPT_PRIVATE, '_0');
 

--- a/src/Symfony/Component/HttpClient/Response/NativeResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/NativeResponse.php
@@ -193,7 +193,7 @@ final class NativeResponse implements ResponseInterface
     private function close(): void
     {
         unset($this->multi->openHandles[$this->id], $this->multi->handlesActivity[$this->id]);
-        $this->handle = $this->buffer = $this->inflate = $this->onProgress = null;
+        $this->handle = $this->buffer = $this->onProgress = null;
     }
 
     /**

--- a/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
+++ b/src/Symfony/Contracts/HttpClient/Test/Fixtures/web/index.php
@@ -63,6 +63,12 @@ switch ($vars['REQUEST_URI']) {
         header('Content-Type: application/json', true, 404);
         break;
 
+    case '/404-gzipped':
+        header('Content-Type: text/plain', true, 404);
+        ob_start('ob_gzhandler');
+        echo 'some text';
+        exit;
+
     case '/301':
         if ('Basic Zm9vOmJhcg==' === $vars['HTTP_AUTHORIZATION']) {
             header('Location: http://127.0.0.1:8057/302', true, 301);

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -835,6 +835,18 @@ abstract class HttpClientTestCase extends TestCase
         }
     }
 
+    public function testGetEncodedContentAfterDestruct()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+
+        try {
+            $client->request('GET', 'http://localhost:8057/404-gzipped');
+            $this->fail(ClientExceptionInterface::class.' expected');
+        } catch (ClientExceptionInterface $e) {
+            $this->assertSame('some text', $e->getResponse()->getContent(false));
+        }
+    }
+
     public function testProxy()
     {
         $client = $this->getHttpClient(__FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

My previous PR #38493 created a new bug, the content doesn't get decoded when fetched from an exception because the inflate resource gets unset:

```php
<?php

use Symfony\Component\HttpClient\CurlHttpClient;
use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;

include __DIR__.'/symfony/vendor/autoload.php';

$client = new CurlHttpClient();

try {
    $client->request('GET', 'http://example.com/404');
} catch (ClientExceptionInterface $exception) {
    echo $exception->getResponse()->getContent(false);
}
```

I've removed the part where the resource gets unset since it still might be used at some point.

The test is implementation independent so I believe it should go in contracts, please correct me if I wrong. Also, I was unable to find a way to do the test without adding a new endpoint this time, any suggestions would be appreciated.