### PR TITLE
[PropertyInfo] Support for the mixed type

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -243,7 +243,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
         foreach ($reflectionType instanceof \ReflectionUnionType ? $reflectionType->getTypes() : [$reflectionType] as $type) {
             $phpTypeOrClass = $reflectionType instanceof \ReflectionNamedType ? $reflectionType->getName() : (string) $type;
-            if ('null' === $phpTypeOrClass) {
+            if ('null' === $phpTypeOrClass || 'mixed' === $phpTypeOrClass) {
                 continue;
             }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -221,6 +221,8 @@ class ReflectionExtractorTest extends TestCase
             ['timeout', [new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_FLOAT)]],
             ['optional', [new Type(Type::BUILTIN_TYPE_INT, true), new Type(Type::BUILTIN_TYPE_FLOAT, true)]],
             ['string', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Stringable'), new Type(Type::BUILTIN_TYPE_STRING)]],
+            ['payload', null],
+            ['data', null],
         ];
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80Dummy.php
@@ -23,4 +23,12 @@ class Php80Dummy
     public function setString(string|\Stringable $string)
     {
     }
+
+    public function setPayload(mixed $payload)
+    {
+    }
+
+    public function getData(): mixed
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

In php 8, `mixed` is [a valid type declaration](https://wiki.php.net/rfc/mixed_type_v2).

Running the following script on php 8…

```
use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;

class MyClass
{
    public function getA(): mixed {}
}

$reflection = new ReflectionExtractor();
$reflection->getTypes(MyClass::class, 'a');
```

… causes a fatal error:

```
PHP Fatal error:  Uncaught InvalidArgumentException: "mixed" is not a valid PHP type. in /path/to/symfony/src/Symfony/Component/PropertyInfo/Type.php:70
```

This PR should fix the issue.