### PR TITLE
[Mailer] Return `SentMessage` from `Mailer::send` if available

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * added `NativeTransportFactory` to configure a transport based on php.ini settings
  * added `local_domain`, `restart_threshold`, `restart_threshold_sleep` and `ping_threshold` options for `smtp`
  * added `command` option for `sendmail`
+ * return `SentMessage` after `Mailer::send` if not using messenger and available from transport
 
 4.4.0
 -----

--- a/src/Symfony/Component/Mailer/Mailer.php
+++ b/src/Symfony/Component/Mailer/Mailer.php
@@ -36,12 +36,10 @@ final class Mailer implements MailerInterface
         $this->dispatcher = class_exists(Event::class) ? LegacyEventDispatcherProxy::decorate($dispatcher) : $dispatcher;
     }
 
-    public function send(RawMessage $message, Envelope $envelope = null): void
+    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
     {
         if (null === $this->bus) {
-            $this->transport->send($message, $envelope);
-
-            return;
+            return $this->transport->send($message, $envelope);
         }
 
         if (null !== $this->dispatcher) {

--- a/src/Symfony/Component/Mailer/MailerInterface.php
+++ b/src/Symfony/Component/Mailer/MailerInterface.php
@@ -26,5 +26,5 @@ interface MailerInterface
     /**
      * @throws TransportExceptionInterface
      */
-    public function send(RawMessage $message, Envelope $envelope = null): void;
+    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage;
 }

--- a/src/Symfony/Component/Mailer/Tests/MailerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/MailerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Mailer\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Exception\LogicException;
 use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Mime\RawMessage;
@@ -21,11 +22,23 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class MailerTest extends TestCase
 {
-    public function testSendingRawMessages()
+    public function testSendingRawMessagesWithMessenger()
     {
         $this->expectException(LogicException::class);
 
         $transport = new Mailer($this->createMock(TransportInterface::class), $this->createMock(MessageBusInterface::class), $this->createMock(EventDispatcherInterface::class));
         $transport->send(new RawMessage('Some raw email message'));
+    }
+
+    public function testSendingRawMessagesWithoutMessenger()
+    {
+        $transportMock = $this->createMock(TransportInterface::class);
+        $transportMock
+            ->expects(self::once())
+            ->method('send')
+            ->willReturn($this->createMock(SentMessage::class));
+        $transport = new Mailer($transportMock, null, $this->createMock(EventDispatcherInterface::class));
+        $result = $transport->send(new RawMessage('Some raw email message without messenger'));
+        self::assertInstanceOf(SentMessage::class, $result);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
|Tickets|#35670
| License       | MIT
| Doc PR        | Coming Soon :-)

Since #36424, you can get the `SentMessage` if sending was handled by the messenger. But there's no easy and developer friendly way to do it without messenger. 

This has been discussed a few times already (threads in #35670, #33681, #35670), but none of these discussions have resulted in a solution with good DX.

The `SentMessage` helps you get the Messge-ID, which some transports (such as Amazon SES) set by themselves. That might be useful as proof-of-delivery or when building something like a ticketing system (for matching replies using `In-Reply-To` and `References` headers).

I think returning `SentMessage` here is dev-friendly and pragmatic: If we have it, we return it. If we don't have it, we return `null`. 