### PR TITLE
[Mailer] Add `MessageSentEvent`

### DIFF
--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * added `NativeTransportFactory` to configure a transport based on php.ini settings
  * added `local_domain`, `restart_threshold`, `restart_threshold_sleep` and `ping_threshold` options for `smtp`
  * added `command` option for `sendmail`
+ * added `MessageSentEvent`
 
 4.4.0
 -----

--- a/src/Symfony/Component/Mailer/Event/MessageSentEvent.php
+++ b/src/Symfony/Component/Mailer/Event/MessageSentEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Event;
+
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\SentMessage;
+use Symfony\Component\Mime\RawMessage;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Allows access to SentMessage after the mail has been sent.
+ */
+final class MessageSentEvent extends Event
+{
+    private $message;
+    private $transport;
+
+    public function __construct(SentMessage $message, string $transport)
+    {
+        $this->message = $message;
+        $this->transport = $transport;
+    }
+
+    public function getMessage(): SentMessage
+    {
+        return $this->message;
+    }
+
+    public function setMessage(SentMessage $message): void
+    {
+        $this->message = $message;
+    }
+
+    public function getTransport(): string
+    {
+        return $this->transport;
+    }
+}

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -17,6 +17,7 @@ use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Event\MessageEvent;
+use Symfony\Component\Mailer\Event\MessageSentEvent;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\RawMessage;
@@ -67,6 +68,9 @@ abstract class AbstractTransport implements TransportInterface
         $message = new SentMessage($message, $envelope);
         $this->doSend($message);
 
+        if (null !== $this->dispatcher) {
+            $this->dispatcher->dispatch(new MessageSentEvent($message, (string) $this));
+        }
         $this->checkThrottling();
 
         return $message;


### PR DESCRIPTION
… the transport

| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This would be an alternative way to access the `SentMessage` after the message has been sent through a transport. More general than #38517, but the DX might be worse because it takes you of of the current program flow.

But also nicer because it always works the same way, with messenger and without. 