### PR TITLE
[HttpClient] Fix nesteed stream in AsyncResponse

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -34,6 +34,7 @@ final class AsyncResponse implements ResponseInterface, StreamableInterface
     private $response;
     private $info = ['canceled' => false];
     private $passthru;
+    private $lastYielded = false;
 
     /**
      * @param ?callable(ChunkInterface, AsyncContext): ?\Iterator $passthru
@@ -255,7 +256,10 @@ final class AsyncResponse implements ResponseInterface, StreamableInterface
                 }
             }
 
-            if (null === $chunk->getError() && !$chunk->isLast() && $r->response === $response && null !== $r->client) {
+            if (null === $chunk->getError() && $chunk->isLast()) {
+                $r->lastYielded = true;
+            }
+            if (null === $chunk->getError() && !$r->lastYielded && $r->response === $response && null !== $r->client) {
                 throw new \LogicException('A chunk passthru must yield an "isLast()" chunk before ending a stream.');
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #38509
| License       | MIT
| Doc PR        | /

When streaming twice (streaming inside streaming) an AsycResponse the second stream will yield the LastChunk, but the first Stream won't have access to it and ends with an exception `A chunk passthru must yield an "isLast()" chunk`
This PR adds a state in AsyncRsponse to remember if the lastChunk has been yielded.

Reproducer:
```php
// a Simple Client that return an AsyncResponse
$client = new class(HttpClient::create()) implements HttpClientInterface {
    use AsyncDecoratorTrait;
    private $client;
    public function __construct(HttpClientInterface $client)
    {
        $this->client = $client;
    }

    public function request(string $method, string $url, array $options = []): ResponseInterface
    {
        return new AsyncResponse($this->client, $method, $url, $options, null);
    }
};

$response = $client->request('GET', 'https://httpbin.org/status/200');

foreach ($client->stream($response) as $chunk) { // will end in a FirstChunk <== bug 
    foreach ($client->stream($response) as $chunk) { // This will correctly handle the LastChunk

    }
}

```