### PR TITLE
[Mailer] Fix mailjet image embedding

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -158,6 +158,7 @@ class MailjetApiTransport extends AbstractApiTransport
                 'Base64Content' => $attachment->bodyToString(),
             ];
             if ('inline' === $headers->getHeaderBody('Content-Disposition')) {
+                $formattedAttachment['ContentID'] = $headers->getHeaderParameter('Content-Disposition', 'name');
                 $inlines[] = $formattedAttachment;
             } else {
                 $attachments[] = $formattedAttachment;


### PR DESCRIPTION
Filename is not enough to embed the image through cid, ContentID field
has to be set with the cid identifier used in the HTMLPart

| Q             | A
| ------------- | ---
| Branch?       | 5.1 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | none <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | not needed <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

Hello!

While switching from `Mandrill` to `Mailjet` I noticed that embedding images was not working properly, the `Content-ID` mime is not set properly without setting the `ContentID` key. With this change things will work as described in the [symfony documentation](https://symfony.com/doc/current/mailer.html#embedding-images)

[Mailjet reference](https://dev.mailjet.com/email/guides/send-api-v31/#send-with-attached-files)
