### PR TITLE
[TwigBridge] Fix preload hint and remove "unlinked class class@anonymous" warning

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -23,6 +23,7 @@ use Twig\TwigFilter;
 
 // Help opcache.preload discover always-needed symbols
 class_exists(TranslatorInterface::class);
+class_exists(TranslatorTrait::class);
 
 /**
  * Provides integration of the Translation component with Twig.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38197 
| License       | MIT
| Doc PR        | n/a

This should fix the preload warning mentioned in https://github.com/symfony/symfony/issues/38197 by applying the fix as suggested by @nicolas-grekas:

```
PHP Warning:  Can't preload unlinked class class@anonymous: Unknown trait Symfony\\Contracts\\Translation\\TranslatorTrait in /var/www/html/vendor/symfony/twig-bridge/Extension/TranslationExtension.php on line 50
```

