### PR TITLE
[Serializer] make XmlEncoder stateless thus reentrant

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopeNormalizer.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author Karoly Gossler <connor@connor.hu>
+ */
+class EnvelopeNormalizer implements NormalizerInterface
+{
+    private $serializer;
+
+    public function normalize($envelope, $format = null, array $context = [])
+    {
+        $xmlContent = $this->serializer->serialize($envelope->message, 'xml');
+
+        $encodedContent = base64_encode($xmlContent);
+
+        return [
+            'message' => $encodedContent,
+        ];
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof EnvelopeObject;
+    }
+
+    public function setSerializer($serializer)
+    {
+        $this->serializer = $serializer;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopeObject.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopeObject.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Karoly Gossler <connor@connor.hu>
+ */
+class EnvelopeObject
+{
+    public $message;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopedMessage.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopedMessage.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Karoly Gossler <connor@connor.hu>
+ */
+class EnvelopedMessage
+{
+    public $text;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopedMessageNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/EnvelopedMessageNormalizer.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author Karoly Gossler <connor@connor.hu>
+ */
+class EnvelopedMessageNormalizer implements NormalizerInterface
+{
+    public function normalize($message, $format = null, array $context = [])
+    {
+        return [
+            'text' => $message->text,
+        ];
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof EnvelopedMessage;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37354 
| License       | MIT

Changing dom property of XmlEncoder to stackable. It fixes a DOMException "Wrong document error". When you calling XmlEncoder->encode() in parallel createDomDocument replaces the DomDocument object.
Test code:
https://github.com/connorhu/symfony-serializer/blob/master/test.php
