### PR TITLE
[Translation] Prohibit installation of translation-contracts ^2

### DIFF
--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.1.3",
         "symfony/polyfill-mbstring": "~1.0",
-        "symfony/translation-contracts": "^1.1.6|^2"
+        "symfony/translation-contracts": "^1.1.6"
     },
     "require-dev": {
         "symfony/config": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
`translation-contracts` 2.x changes the method signature of `LocaleAwareInterface::setLocale()`, making it incompatible with `TranslatorInterface::setLocale()`.

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38537 
| License       | MIT
| Doc PR        | -
