### PR TITLE
[DependencyInjection] Allow array attributes for service tags

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
@@ -48,11 +48,7 @@ class DefaultsConfigurator extends AbstractServiceConfigurator
             throw new InvalidArgumentException('The tag name in "_defaults" must be a non-empty string.');
         }
 
-        foreach ($attributes as $attribute => $value) {
-            if (null !== $value && !is_scalar($value)) {
-                throw new InvalidArgumentException(sprintf('Tag "%s", attribute "%s" in "_defaults" must be of a scalar-type.', $name, $attribute));
-            }
-        }
+        $this->recursiveValidateAttributes($name, $attributes);
 
         $this->definition->addTag($name, $attributes);
 
@@ -65,5 +61,16 @@ class DefaultsConfigurator extends AbstractServiceConfigurator
     final public function instanceof(string $fqcn): InstanceofConfigurator
     {
         return $this->parent->instanceof($fqcn);
+    }
+
+    private function recursiveValidateAttributes(string $name, array $attributes, string $prefix = ''): void
+    {
+        foreach ($attributes as $attribute => $value) {
+            if (\is_array($value)) {
+                $this->recursiveValidateAttributes($name, $attributes, $attribute.'.');
+            } elseif (!is_scalar($value) && null !== $value) {
+                throw new InvalidArgumentException(sprintf('Tag "%s", attribute "%s" in "_defaults" must be of a scalar-type or an array of scalar-type.', $name, $prefix.$attribute));
+            }
+        }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
@@ -48,7 +48,7 @@ class DefaultsConfigurator extends AbstractServiceConfigurator
             throw new InvalidArgumentException('The tag name in "_defaults" must be a non-empty string.');
         }
 
-        $this->recursiveValidateAttributes($name, $attributes);
+        $this->validateAttributes($name, $attributes);
 
         $this->definition->addTag($name, $attributes);
 
@@ -63,13 +63,13 @@ class DefaultsConfigurator extends AbstractServiceConfigurator
         return $this->parent->instanceof($fqcn);
     }
 
-    private function recursiveValidateAttributes(string $name, array $attributes, string $prefix = ''): void
+    private function validateAttributes(string $tagName, array $attributes, string $prefix = ''): void
     {
         foreach ($attributes as $attribute => $value) {
             if (\is_array($value)) {
-                $this->recursiveValidateAttributes($name, $attributes, $attribute.'.');
+                $this->validateAttributes($tagName, $attributes, $attribute.'.');
             } elseif (!is_scalar($value) && null !== $value) {
-                throw new InvalidArgumentException(sprintf('Tag "%s", attribute "%s" in "_defaults" must be of a scalar-type or an array of scalar-type.', $name, $prefix.$attribute));
+                throw new InvalidArgumentException(sprintf('Tag "%s", attribute "%s" in "_defaults" must be of a scalar-type or an array of scalar-type.', $tagName, $prefix.$attribute));
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
@@ -26,20 +26,20 @@ trait TagTrait
             throw new InvalidArgumentException(sprintf('The tag name for service "%s" must be a non-empty string.', $this->id));
         }
 
-        $this->recursiveValidateAttributes($name, $attributes);
+        $this->validateAttributes($name, $attributes);
 
         $this->definition->addTag($name, $attributes);
 
         return $this;
     }
 
-    private function recursiveValidateAttributes(string $name, array $attributes, string $prefix = ''): void
+    private function validateAttributes(string $tagName, array $attributes, string $prefix = ''): void
     {
         foreach ($attributes as $attribute => $value) {
             if (\is_array($value)) {
-                $this->recursiveValidateAttributes($name, $attributes, $attribute.'.');
+                $this->validateAttributes($tagName, $attributes, $attribute.'.');
             } elseif (!is_scalar($value) && null !== $value) {
-                throw new InvalidArgumentException(sprintf('A tag attribute must be of a scalar-type or an array of scalar-types for service "%s", tag "%s", attribute "%s".', $this->id, $name, $prefix.$attribute));
+                throw new InvalidArgumentException(sprintf('A tag attribute must be of a scalar-type or an array of scalar-types for service "%s", tag "%s", attribute "%s".', $this->id, $tagName, $prefix.$attribute));
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
@@ -26,14 +26,21 @@ trait TagTrait
             throw new InvalidArgumentException(sprintf('The tag name for service "%s" must be a non-empty string.', $this->id));
         }
 
-        foreach ($attributes as $attribute => $value) {
-            if (!is_scalar($value) && null !== $value) {
-                throw new InvalidArgumentException(sprintf('A tag attribute must be of a scalar-type for service "%s", tag "%s", attribute "%s".', $this->id, $name, $attribute));
-            }
-        }
+        $this->recursiveValidateAttributes($name, $attributes);
 
         $this->definition->addTag($name, $attributes);
 
         return $this;
+    }
+
+    private function recursiveValidateAttributes(string $name, array $attributes, string $prefix = ''): void
+    {
+        foreach ($attributes as $attribute => $value) {
+            if (\is_array($value)) {
+                $this->recursiveValidateAttributes($name, $attributes, $attribute.'.');
+            } elseif (!is_scalar($value) && null !== $value) {
+                throw new InvalidArgumentException(sprintf('A tag attribute must be of a scalar-type or an array of scalar-types for service "%s", tag "%s", attribute "%s".', $this->id, $name, $prefix.$attribute));
+            }
+        }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -335,14 +335,14 @@ class XmlFileLoader extends FileLoader
         $tags = $this->getChildren($service, 'tag');
 
         foreach ($tags as $tag) {
-            $tagName = $tag->nodeValue;
-            if ('' === $tagName && '' === $tagName = $tag->getAttribute('name')) {
+            $tagName = $tag->hasChildNodes() || '' === $tag->nodeValue ? $tag->getAttribute('name') : $tag->nodeValue;
+            if ('' === $tagName) {
                 throw new InvalidArgumentException(sprintf('The tag name for service "%s" in "%s" must be a non-empty string.', (string) $service->getAttribute('id'), $file));
             }
 
             $parameters = $this->getTagAttributes($tag, sprintf('The attribute name of tag "%s" for service "%s" in %s must be a non-empty string.', $tagName, (string) $service->getAttribute('id'), $file));
             foreach ($tag->attributes as $name => $node) {
-                if ('name' === $name && '' === $tagName) {
+                if ('name' === $name) {
                     continue;
                 }
 
@@ -597,7 +597,7 @@ class XmlFileLoader extends FileLoader
             }
 
             if ($this->getChildren($childNode, 'attribute')) {
-                $parameters[$childNode->getAttribute('name')] = $this->getTagAttributes($childNode, $missingName);
+                $parameters[$name] = $this->getTagAttributes($childNode, $missingName);
             } else {
                 if (false !== strpos($name, '-') && false === strpos($name, '_') && !\array_key_exists($normalizedName = str_replace('-', '_', $name), $parameters)) {
                     $parameters[$normalizedName] = XmlUtils::phpize($childNode->nodeValue);

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -335,8 +335,12 @@ class XmlFileLoader extends FileLoader
         $tags = $this->getChildren($service, 'tag');
 
         foreach ($tags as $tag) {
-            $parameters = [];
             $tagName = $tag->nodeValue;
+            if ('' === $tagName && '' === $tagName = $tag->getAttribute('name')) {
+                throw new InvalidArgumentException(sprintf('The tag name for service "%s" in "%s" must be a non-empty string.', (string) $service->getAttribute('id'), $file));
+            }
+
+            $parameters = $this->getRecursiveTagAttributes($tag, sprintf('The attribute name of tag "%s" for service "%s" in %s must be a non-empty string.', $tagName, (string) $service->getAttribute('id'), $file));
             foreach ($tag->attributes as $name => $node) {
                 if ('name' === $name && '' === $tagName) {
                     continue;
@@ -347,10 +351,6 @@ class XmlFileLoader extends FileLoader
                 }
                 // keep not normalized key
                 $parameters[$name] = XmlUtils::phpize($node->nodeValue);
-            }
-
-            if ('' === $tagName && '' === $tagName = $tag->getAttribute('name')) {
-                throw new InvalidArgumentException(sprintf('The tag name for service "%s" in "%s" must be a non-empty string.', (string) $service->getAttribute('id'), $file));
             }
 
             $definition->addTag($tagName, $parameters);
@@ -583,6 +583,31 @@ class XmlFileLoader extends FileLoader
         }
 
         return $children;
+    }
+
+    private function getRecursiveTagAttributes(\DOMNode $node, string $missingName): array
+    {
+        $parameters = [];
+        $children = $this->getChildren($node, 'attribute');
+
+        foreach ($children as $childNode) {
+            $name = $childNode->getAttribute('name');
+            if ('' === $name) {
+                throw new InvalidArgumentException($missingName);
+            }
+
+            if ($this->getChildren($childNode, 'attribute')) {
+                $parameters[$childNode->getAttribute('name')] = $this->getRecursiveTagAttributes($childNode, $missingName);
+            } else {
+                if (false !== strpos($name, '-') && false === strpos($name, '_') && !\array_key_exists($normalizedName = str_replace('-', '_', $name), $parameters)) {
+                    $parameters[$normalizedName] = XmlUtils::phpize($childNode->nodeValue);
+                }
+                // keep not normalized key
+                $parameters[$name] = XmlUtils::phpize($childNode->nodeValue);
+            }
+        }
+
+        return $parameters;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -340,7 +340,7 @@ class XmlFileLoader extends FileLoader
                 throw new InvalidArgumentException(sprintf('The tag name for service "%s" in "%s" must be a non-empty string.', (string) $service->getAttribute('id'), $file));
             }
 
-            $parameters = $this->getRecursiveTagAttributes($tag, sprintf('The attribute name of tag "%s" for service "%s" in %s must be a non-empty string.', $tagName, (string) $service->getAttribute('id'), $file));
+            $parameters = $this->getTagAttributes($tag, sprintf('The attribute name of tag "%s" for service "%s" in %s must be a non-empty string.', $tagName, (string) $service->getAttribute('id'), $file));
             foreach ($tag->attributes as $name => $node) {
                 if ('name' === $name && '' === $tagName) {
                     continue;
@@ -585,7 +585,7 @@ class XmlFileLoader extends FileLoader
         return $children;
     }
 
-    private function getRecursiveTagAttributes(\DOMNode $node, string $missingName): array
+    private function getTagAttributes(\DOMNode $node, string $missingName): array
     {
         $parameters = [];
         $children = $this->getChildren($node, 'attribute');
@@ -597,7 +597,7 @@ class XmlFileLoader extends FileLoader
             }
 
             if ($this->getChildren($childNode, 'attribute')) {
-                $parameters[$childNode->getAttribute('name')] = $this->getRecursiveTagAttributes($childNode, $missingName);
+                $parameters[$childNode->getAttribute('name')] = $this->getTagAttributes($childNode, $missingName);
             } else {
                 if (false !== strpos($name, '-') && false === strpos($name, '_') && !\array_key_exists($normalizedName = str_replace('-', '_', $name), $parameters)) {
                     $parameters[$normalizedName] = XmlUtils::phpize($childNode->nodeValue);

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -302,7 +302,7 @@ class YamlFileLoader extends FileLoader
                     throw new InvalidArgumentException(sprintf('The tag name in "_defaults" must be a non-empty string in "%s".', $file));
                 }
 
-                $this->recursiveValidateAttributes(sprintf('Tag "%s", attribute "%s" in "_defaults" must be of a scalar-type in "%s". Check your YAML syntax.', $name, '%s', $file), $tag);
+                $this->validateAttributes(sprintf('Tag "%s", attribute "%s" in "_defaults" must be of a scalar-type in "%s". Check your YAML syntax.', $name, '%s', $file), $tag);
             }
         }
 
@@ -610,7 +610,7 @@ class YamlFileLoader extends FileLoader
                 throw new InvalidArgumentException(sprintf('The tag name for service "%s" in "%s" must be a non-empty string.', $id, $file));
             }
 
-            $this->recursiveValidateAttributes(sprintf('A "tags" attribute must be of a scalar-type for service "%s", tag "%s", attribute "%s" in "%s". Check your YAML syntax.', $id, $name, '%s', $file), $tag);
+            $this->validateAttributes(sprintf('A "tags" attribute must be of a scalar-type for service "%s", tag "%s", attribute "%s" in "%s". Check your YAML syntax.', $id, $name, '%s', $file), $tag);
 
             $definition->addTag($name, $tag);
         }
@@ -953,11 +953,11 @@ class YamlFileLoader extends FileLoader
         }
     }
 
-    private function recursiveValidateAttributes(string $message, array $attributes, string $prefix = ''): void
+    private function validateAttributes(string $message, array $attributes, string $prefix = ''): void
     {
         foreach ($attributes as $attribute => $value) {
             if (\is_array($value)) {
-                $this->recursiveValidateAttributes($message, $attributes, $attribute.'.');
+                $this->validateAttributes($message, $attributes, $attribute.'.');
             } elseif (!is_scalar($value) && null !== $value) {
                 throw new InvalidArgumentException(sprintf($message, $prefix.$attribute));
             }

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -957,7 +957,7 @@ class YamlFileLoader extends FileLoader
     {
         foreach ($attributes as $attribute => $value) {
             if (\is_array($value)) {
-                $this->validateAttributes($message, $attributes, $attribute.'.');
+                $this->validateAttributes($message, $value, $attribute.'.');
             } elseif (!is_scalar($value) && null !== $value) {
                 throw new InvalidArgumentException(sprintf($message, $prefix.$attribute));
             }

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -208,15 +208,11 @@
     <xsd:attribute name="public" type="boolean" />
   </xsd:complexType>
 
-  <xsd:complexType name="tag">
+  <xsd:complexType name="tag" mixed="true">
     <xsd:choice minOccurs="0">
-      <xsd:element name="attribute" type="tag_attribute" maxOccurs="unbounded" />
+      <xsd:element name="attribute" type="tag_attribute" maxOccurs="unbounded"/>
     </xsd:choice>
-    <xsd:simpleContent>
-      <xsd:extension base="xsd:string">
-        <xsd:anyAttribute namespace="##any" processContents="lax" />
-      </xsd:extension>
-    </xsd:simpleContent>
+    <xsd:anyAttribute namespace="##any" processContents="lax" />
   </xsd:complexType>
 
   <xsd:complexType name="deprecated">
@@ -229,7 +225,7 @@
     </xsd:simpleContent>
   </xsd:complexType>
 
-  <xsd:complexType name="tag_attribute">
+  <xsd:complexType name="tag_attribute" mixed="true">
     <xsd:choice minOccurs="0">
       <xsd:element name="attribute" type="tag_attribute" maxOccurs="unbounded" />
     </xsd:choice>

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -209,6 +209,9 @@
   </xsd:complexType>
 
   <xsd:complexType name="tag">
+    <xsd:choice minOccurs="0">
+      <xsd:element name="attribute" type="tag_attribute" maxOccurs="unbounded" />
+    </xsd:choice>
     <xsd:simpleContent>
       <xsd:extension base="xsd:string">
         <xsd:anyAttribute namespace="##any" processContents="lax" />
@@ -224,6 +227,13 @@
         <xsd:attribute name="version" type="xsd:string" />
       </xsd:extension>
     </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:complexType name="tag_attribute">
+    <xsd:choice minOccurs="0">
+      <xsd:element name="attribute" type="tag_attribute" maxOccurs="unbounded" />
+    </xsd:choice>
+    <xsd:attribute name="name" type="xsd:string" use="required" />
   </xsd:complexType>
 
   <xsd:complexType name="parameters">

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_array_tags.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services_with_array_tags.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="foo" class="Foo">
+      <tag name="foo_tag">
+        <attribute name="foo">bar</attribute>
+        <attribute name="bar">
+          <attribute name="foo">bar</attribute>
+          <attribute name="bar">foo</attribute>
+        </attribute>
+      </tag>
+    </service>
+  </services>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/tag_array_arguments.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/tag_array_arguments.yml
@@ -2,5 +2,5 @@ services:
     foo_service:
         class:    FooClass
         tags:
-          # tag-attribute is not a scalar
+          # tag-attribute is an array
           - { name: foo, bar: { foo: foo, bar: bar } }

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -430,6 +430,15 @@ class XmlFileLoaderTest extends TestCase
         $this->assertEquals(new ServiceClosureArgument(new Reference('bar', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)), $container->getDefinition('foo')->getArgument(0));
     }
 
+    public function testParseServiceTagsWithArrayAttributes()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services_with_array_tags.xml');
+
+        $this->assertEquals(['foo_tag' => [['foo' => 'bar', 'bar' => ['foo' => 'bar', 'bar' => 'foo']]]], $container->getDefinition('foo')->getTags());
+    }
+
     public function testParseTagsWithoutNameThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -433,16 +433,14 @@ class YamlFileLoaderTest extends TestCase
         $this->assertCount(1, $container->getDefinition('foo_service')->getTag('foo'));
     }
 
-    public function testTagWithAttributeArrayThrowsException()
+    public function testTagWithAttributeArray()
     {
-        $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
-        try {
-            $loader->load('badtag3.yml');
-            $this->fail('->load() should throw an exception when a tag-attribute is not a scalar');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf(InvalidArgumentException::class, $e, '->load() throws an InvalidArgumentException if a tag-attribute is not a scalar');
-            $this->assertStringStartsWith('A "tags" attribute must be of a scalar-type for service "foo_service", tag "foo", attribute "bar"', $e->getMessage(), '->load() throws an InvalidArgumentException if a tag-attribute is not a scalar');
-        }
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('tag_array_arguments.yml');
+
+        $definition = $container->getDefinition('foo_service');
+        $this->assertEquals(['foo' => [['bar' => ['foo' => 'foo', 'bar' => 'bar']]]], $definition->getTags());
     }
 
     public function testLoadYamlOnlyWithKeys()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Tickets       | Fix #38339 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This adds array attribute support for container service tags as described in #38339. I'm not sure I catched all places this would apply. The most notable change is the additions to the XML schema for services, because that's the current limitation for not using array. 

I created this as draft PR because I'm very well aware the docs and tests need to be update. But please let me know if this sounds like a valid feature to add and if the approach seems reasonable or if I missed something 🙃 

---

With this PR, you can now define service tags like this:

**PHP:**
```php
$container->services()
        ->set('foo', BarClass::class)
            ->public()
            ->tag(
                'foo_tag', 
                [
                    'some_option' => 'cat', 
                    'array_option' => [
                        'key1' => 'lorem', 
                        'key2' => 'ipsum'
                    ]
                ]
            )
;
```

**XML:**
```xml
<?xml version="1.0" ?>
<container xmlns="http://symfony.com/schema/dic/services"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
  <services>
    <service id="foo" class="BarClass" public="true">
        <tag name="foo_tag" some-option="cat">
            <attribute name="array_option">
                <attribute name="key1">lorem</attribute>
                <attribute name="key2">ipsum</attribute>
            </attribute>
        </tag>
    </service>
  </services>
</container>
```

**YAML:**
```yaml
services:
    foo:
        class: BarClass
        tags:
            - { name: 'foo_tag', 'some-option': 'cat', array_option: [key1: lorem, key2: ipsum] }
```


---

As described in https://github.com/symfony/symfony/issues/38339, our service definition might look like this now:

```yaml
services:
    Vendor\Bundle\Controller\FooController:
        public: true
        tags:
            - { name: 'contao.page', path: 'foo/{id}', requirements: [ id: '\d+' ] }
```
