### PR TITLE
[Security] Added check_post_only to the login link authenticator

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginLinkFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginLinkFactory.php
@@ -36,7 +36,11 @@ class LoginLinkFactory extends AbstractFactory implements AuthenticatorFactoryIn
         $builder
             ->scalarNode('check_route')
                 ->isRequired()
-                ->info('Route that will validate the login link - e.g. app_login_link_verify.')
+                ->info('Route that will validate the login link - e.g. "app_login_link_verify".')
+            ->end()
+            ->scalarNode('check_post_only')
+                ->defaultFalse()
+                ->info('If true, only HTTP POST requests to "check_route" will be handled by the authenticator.')
             ->end()
             ->arrayNode('signature_properties')
                 ->isRequired()
@@ -128,6 +132,7 @@ class LoginLinkFactory extends AbstractFactory implements AuthenticatorFactoryIn
             ->replaceArgument(3, new Reference($this->createAuthenticationFailureHandler($container, $firewallName, $config)))
             ->replaceArgument(4, [
                 'check_route' => $config['check_route'],
+                'check_post_only' => $config['check_post_only'],
             ]);
 
         return $authenticatorId;

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Added translator to `\Symfony\Component\Security\Http\Authenticator\JsonLoginAuthenticator` and `\Symfony\Component\Security\Http\Firewall\UsernamePasswordJsonAuthenticationListener` to translate authentication failure messages
  * Added a CurrentUser attribute to force the UserValueResolver to resolve an argument to the current user.
  * Added `LoginThrottlingListener`.
+ * Added `LoginLinkAuthenticator`.
 
 5.1.0
 -----

--- a/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
@@ -43,18 +43,18 @@ final class LoginLinkAuthenticator extends AbstractAuthenticator implements Inte
         $this->httpUtils = $httpUtils;
         $this->successHandler = $successHandler;
         $this->failureHandler = $failureHandler;
-        $this->options = $options;
+        $this->options = $options + ['check_post_only' => false];
     }
 
     public function supports(Request $request): ?bool
     {
-        return $this->httpUtils->checkRequestPath($request, $this->options['check_route']);
+        return ($this->options['check_post_only'] ? $request->isMethod('POST') : true)
+            && $this->httpUtils->checkRequestPath($request, $this->options['check_route']);
     }
 
     public function authenticate(Request $request): PassportInterface
     {
         $username = $request->get('user');
-
         if (!$username) {
             throw new InvalidLoginLinkAuthenticationException('Missing user from link.');
         }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/LoginLinkAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/LoginLinkAuthenticatorTest.php
@@ -39,6 +39,24 @@ class LoginLinkAuthenticatorTest extends TestCase
         $this->failureHandler = $this->createMock(AuthenticationFailureHandlerInterface::class);
     }
 
+    /**
+     * @dataProvider provideSupportData
+     */
+    public function testSupport(array $options, $request, bool $supported)
+    {
+        $this->setUpAuthenticator($options);
+
+        $this->assertEquals($supported, $this->authenticator->supports($request));
+    }
+
+    public function provideSupportData()
+    {
+        yield [['check_route' => '/validate_link'], Request::create('/validate_link?hash=abc123'), true];
+        yield [['check_route' => '/validate_link'], Request::create('/login?hash=abc123'), false];
+        yield [['check_route' => '/validate_link', 'check_post_only' => true], Request::create('/validate_link?hash=abc123'), false];
+        yield [['check_route' => '/validate_link', 'check_post_only' => true], Request::create('/validate_link?hash=abc123', 'POST'), true];
+    }
+
     public function testSuccessfulAuthenticate()
     {
         $this->setUpAuthenticator();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This is useful when adding a page that requires a user action in order to validate the check link. That is required when using a single-use login link, to workaround browser and email client previews (which trigger a request).

See also the short docs discussion about this: https://github.com/symfony/symfony-docs/pull/14389#discussion_r502906341

For reference, I choose this option name as it relates to the `post_only` option in the `FormLoginAuthenticator`, which is about exactly the same thing. I didn't think `post_only` was a 100% clear name, but I'm happy to change this option to that for complete consistency.

cc @weaverryan