### PR TITLE
Remove content-type check on toArray methods

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
+++ b/src/Symfony/Component/HttpClient/Response/ResponseTrait.php
@@ -143,12 +143,6 @@ trait ResponseTrait
             return $this->jsonData;
         }
 
-        $contentType = $this->headers['content-type'][0] ?? 'application/json';
-
-        if (!preg_match('/\bjson\b/i', $contentType)) {
-            throw new JsonException(sprintf('Response content-type is "%s" while a JSON-compatible one was expected for "%s".', $contentType, $this->getInfo('url')));
-        }
-
         try {
             $content = json_decode($content, true, 512, \JSON_BIGINT_AS_STRING | (\PHP_VERSION_ID >= 70300 ? \JSON_THROW_ON_ERROR : 0));
         } catch (\JsonException $e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

Sometime the server provides a generic content type `text/plain` and prevent people using the `toArray` method. (ie. AWS metadata endpoint).

This PR removes the check on the content-type.
People trying to json_decode something else will ends with a `JsonException` anyway.