### PR TITLE
[Lock] Reset Key lifetime time before we acquire it

### DIFF
--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -67,6 +67,7 @@ final class Lock implements LockInterface, LoggerAwareInterface
      */
     public function acquire($blocking = false): bool
     {
+        $this->key->resetLifetime();
         try {
             if ($blocking) {
                 if (!$this->store instanceof StoreInterface && !$this->store instanceof BlockingStoreInterface) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1 (maybe lower, I'll check)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38541
| License       | MIT
| Doc PR        | n/a

Im out on somewhat deep water now. I am pretty sure we should reset the Key lifetime every time we acquire it. Without it it will me tricky to re-use a lock. (As pointed out by #38541)

@jderusse can you confirm. 