### PR TITLE
Serialize message into json before logging

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -100,6 +100,7 @@
             <tag name="monolog.logger" channel="messenger" />
             <argument /> <!-- senders service locator -->
             <argument type="service" id="messenger.retry_strategy_locator" />
+            <argument type="service" id="serializer" on-invalid="ignore" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 

--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
@@ -23,6 +23,7 @@ use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Stamp\StampInterface;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * @author Tobias Schultze <http://tobion.de>
@@ -33,8 +34,9 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
     private $retryStrategyLocator;
     private $logger;
     private $historySize;
+    private $seriliazer;
 
-    public function __construct(ContainerInterface $sendersLocator, ContainerInterface $retryStrategyLocator, LoggerInterface $logger = null, int $historySize = 10)
+    public function __construct(ContainerInterface $sendersLocator, ContainerInterface $retryStrategyLocator, SerializerInterface $seriliazer, LoggerInterface $logger = null, int $historySize = 10)
     {
         $this->sendersLocator = $sendersLocator;
         $this->retryStrategyLocator = $retryStrategyLocator;
@@ -50,7 +52,7 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
 
         $message = $envelope->getMessage();
         $context = [
-            'message' => $message,
+            'message' => $this->seriliazer->serialize($message, 'json'),
             'class' => \get_class($message),
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.4 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? |no 
| License       | MIT

Currently, if a message fails, the logger saves an empty array instead of recording the content of the message, so the logger will
which looks like this.

```[2020-10-11T14:53:49.515536+02:00] messenger.CRITICAL: Error thrown while handling message App\Message\Evaluation. Removing from transport after 3 retries. Error: "Item not found!" {"message":{"App\\Message\\Invitation":[]}```

After having the following fix the result will be as follows:

```[2020-10-11T14:53:49.515536+02:00] messenger.CRITICAL: Error thrown while handling message App\Message\Evaluation. Removing from transport after 3 retries. Error: "Item not found!" {"message":{"App\\Message\\Invitation":{userId : 30}}```
The advantage is the fact that those who use <a hred="https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bridge/Monolog/Handler/SwiftMailerHandler.php">MonologSwiftMailerHandler</a> will receive the content of the failed message at the level of their email.