### PR TITLE
[Messenger] Fixed typos in Amqp Connection

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -123,8 +123,8 @@ class Connection
      *   * host: Hostname of the AMQP service
      *   * port: Port of the AMQP service
      *   * vhost: Virtual Host to use with the AMQP service
-     *   * user: Username to use to connect the the AMQP service
-     *   * password: Password to use the connect to the AMQP service
+     *   * user: Username to use to connect the AMQP service
+     *   * password: Password to use to connect to the AMQP service
      *   * read_timeout: Timeout in for income activity. Note: 0 or greater seconds. May be fractional.
      *   * write_timeout: Timeout in for outcome activity. Note: 0 or greater seconds. May be fractional.
      *   * connect_timeout: Connection timeout. Note: 0 or greater seconds. May be fractional.
@@ -155,8 +155,8 @@ class Connection
      *       which means heartbeats checked only during blocking calls.
      *
      *   TLS support (see https://www.rabbitmq.com/ssl.html for details):
-     *     * cacert: Path to the CA cert file in PEM format..
-     *     * cert: Path to the client certificate in PEM foramt.
+     *     * cacert: Path to the CA cert file in PEM format.
+     *     * cert: Path to the client certificate in PEM format.
      *     * key: Path to the client key in PEM format.
      *     * verify: Enable or disable peer verification. If peer verification is enabled then the common name in the
      *       server certificate must match the server name. Peer verification is enabled by default.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | n/a

Sorry for a small PR. When working with https://github.com/symfony/symfony-docs/pull/14404, I found a typo, then another one.. When I found 4 of them I decided to make a PR. 