### PR TITLE
[CI] Fixed build on AppVeyor

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -142,7 +142,7 @@ class LintCommandTest extends TestCase
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {
-                unlink($file);
+                @unlink($file);
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
@@ -121,9 +121,9 @@ EOF;
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {
-                unlink($file);
+                @unlink($file);
             }
         }
-        rmdir(sys_get_temp_dir().'/xliff-lint-test');
+        @rmdir(sys_get_temp_dir().'/xliff-lint-test');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
@@ -168,9 +168,9 @@ EOF;
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {
-                unlink($file);
+                @unlink($file);
             }
         }
-        rmdir(sys_get_temp_dir().'/yml-lint-test');
+        @rmdir(sys_get_temp_dir().'/yml-lint-test');
     }
 }

--- a/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
@@ -30,7 +30,7 @@ class ConfigCacheTest extends TestCase
 
         foreach ($files as $file) {
             if (file_exists($file)) {
-                unlink($file);
+                @unlink($file);
             }
         }
     }

--- a/src/Symfony/Component/Config/Tests/Resource/FileExistenceResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileExistenceResourceTest.php
@@ -30,7 +30,7 @@ class FileExistenceResourceTest extends TestCase
     protected function tearDown(): void
     {
         if (file_exists($this->file)) {
-            unlink($this->file);
+            @unlink($this->file);
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
@@ -30,11 +30,9 @@ class FileResourceTest extends TestCase
 
     protected function tearDown(): void
     {
-        if (!file_exists($this->file)) {
-            return;
+        if (file_exists($this->file)) {
+            @unlink($this->file);
         }
-
-        unlink($this->file);
     }
 
     public function testGetResource()

--- a/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
@@ -31,7 +31,7 @@ class ResourceCheckerConfigCacheTest extends TestCase
 
         foreach ($files as $file) {
             if (file_exists($file)) {
-                unlink($file);
+                @unlink($file);
             }
         }
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
@@ -168,9 +168,9 @@ class FileBagTest extends TestCase
     protected function tearDown(): void
     {
         foreach (glob(sys_get_temp_dir().'/form_test/*') as $file) {
-            unlink($file);
+            @unlink($file);
         }
 
-        rmdir(sys_get_temp_dir().'/form_test');
+        @rmdir(sys_get_temp_dir().'/form_test');
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
@@ -43,7 +43,7 @@ class MockFileSessionStorageTest extends TestCase
     {
         array_map('unlink', glob($this->sessionDir.'/*'));
         if (is_dir($this->sessionDir)) {
-            rmdir($this->sessionDir);
+            @rmdir($this->sessionDir);
         }
         $this->sessionDir = null;
         $this->storage = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -47,7 +47,7 @@ class NativeSessionStorageTest extends TestCase
         session_write_close();
         array_map('unlink', glob($this->savePath.'/*'));
         if (is_dir($this->savePath)) {
-            rmdir($this->savePath);
+            @rmdir($this->savePath);
         }
 
         $this->savePath = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
@@ -43,7 +43,7 @@ class PhpBridgeSessionStorageTest extends TestCase
         session_write_close();
         array_map('unlink', glob($this->savePath.'/*'));
         if (is_dir($this->savePath)) {
-            rmdir($this->savePath);
+            @rmdir($this->savePath);
         }
 
         $this->savePath = null;

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php
@@ -50,7 +50,7 @@ class DoctrineIntegrationTest extends TestCase
     {
         $this->driverConnection->close();
         if (file_exists($this->sqliteFile)) {
-            unlink($this->sqliteFile);
+            @unlink($this->sqliteFile);
         }
     }
 

--- a/src/Symfony/Component/Routing/Tests/RouterTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouterTest.php
@@ -36,7 +36,7 @@ class RouterTest extends TestCase
     {
         if (is_dir($this->cacheDir)) {
             array_map('unlink', glob($this->cacheDir.\DIRECTORY_SEPARATOR.'*'));
-            rmdir($this->cacheDir);
+            @rmdir($this->cacheDir);
         }
 
         $this->loader = null;

--- a/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
@@ -179,10 +179,10 @@ XLIFF;
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {
-                unlink($file);
+                @unlink($file);
             }
         }
-        rmdir(sys_get_temp_dir().'/translation-xliff-lint-test');
+        @rmdir(sys_get_temp_dir().'/translation-xliff-lint-test');
     }
 
     public function provideStrictFilenames()

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -45,7 +45,7 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         }
 
         if (file_exists($this->path)) {
-            unlink($this->path);
+            @unlink($this->path);
         }
 
         $this->path = null;

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -129,11 +129,11 @@ YAML;
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {
-                unlink($file);
+                @unlink($file);
             }
         }
 
-        rmdir(sys_get_temp_dir().'/framework-yml-lint-test');
+        @rmdir(sys_get_temp_dir().'/framework-yml-lint-test');
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | 
| New feature?  | 
| Deprecations? | 
| Tickets       | 
| License       | MIT
| Doc PR        |

CI fails on AppVeyor with: 

> There was 1 error:
>1) Symfony\Bridge\PhpUnit\Tests\DeprecationErrorHandler\ConfigurationTest::testBaselineFileWriteError
unlink(C:\Users\appveyor\AppData\Local\Temp\1\sf-38AF.tmp): Permission denied
>C:\projects\symfony\src\Symfony\Bridge\PhpUnit\Tests\DeprecationErrorHandler\ConfigurationTest.php:404
ERRORS!

We dont need to fail the tests if we cannot remove a file on `tearDown()`

