### PR TITLE
[Lock] Reset lifetime on acquireRead()

### DIFF
--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -121,6 +121,7 @@ final class Lock implements SharedLockInterface, LoggerAwareInterface
      */
     public function acquireRead(bool $blocking = false): bool
     {
+        $this->key->resetLifetime();
         try {
             if (!$this->store instanceof SharedLockStoreInterface) {
                 $this->logger->debug('Store does not support ReadLocks, fallback to WriteLock.', ['resource' => $this->key]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | n/a

Same as #38553 but this is for `acquireRead()` instead of `acquire()`. 

`acquireRead()` is new in 5.2. 
