### PR TITLE
Fix tests typo

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnRestartSignalListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnRestartSignalListenerTest.php
@@ -30,7 +30,7 @@ class StopWorkerOnRestartSignalListenerTest extends TestCase
     {
         $cachePool = $this->createMock(CacheItemPoolInterface::class);
         $cacheItem = $this->createMock(CacheItemInterface::class);
-        $cacheItem->expects($this->once())->method('isHIt')->willReturn(true);
+        $cacheItem->expects($this->once())->method('isHit')->willReturn(true);
         $cacheItem->expects($this->once())->method('get')->willReturn(null === $lastRestartTimeOffset ? null : time() + $lastRestartTimeOffset);
         $cachePool->expects($this->once())->method('getItem')->willReturn($cacheItem);
 
@@ -54,7 +54,7 @@ class StopWorkerOnRestartSignalListenerTest extends TestCase
     {
         $cachePool = $this->createMock(CacheItemPoolInterface::class);
         $cacheItem = $this->createMock(CacheItemInterface::class);
-        $cacheItem->expects($this->once())->method('isHIt')->willReturn(false);
+        $cacheItem->expects($this->once())->method('isHit')->willReturn(false);
         $cacheItem->expects($this->never())->method('get');
         $cachePool->expects($this->once())->method('getItem')->willReturn($cacheItem);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


While working on PSR 16 cache tests, I found this small glitch in the mocked `isHit` method