### PR TITLE
[RateLimiter] Added reserve() to LimiterInterface and rename Limiter to RateLimiter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -128,8 +128,8 @@ use Symfony\Component\PropertyInfo\PropertyListExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyReadInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
-use Symfony\Component\RateLimiter\Limiter;
 use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimiter;
 use Symfony\Component\RateLimiter\Storage\CacheStorage;
 use Symfony\Component\Routing\Loader\AnnotationDirectoryLoader;
 use Symfony\Component\Routing\Loader\AnnotationFileLoader;
@@ -2266,7 +2266,7 @@ class FrameworkExtension extends Extension
         $limiterConfig['id'] = $name;
         $limiter->replaceArgument(0, $limiterConfig);
 
-        $container->registerAliasForArgument($limiterId, Limiter::class, $name.'.limiter');
+        $container->registerAliasForArgument($limiterId, RateLimiter::class, $name.'.limiter');
     }
 
     private function resolveTrustedHeaders(array $headers): int

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/rate_limiter.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/rate_limiter.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Symfony\Component\RateLimiter\Limiter;
+use Symfony\Component\RateLimiter\RateLimiter;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -19,7 +19,7 @@ return static function (ContainerConfigurator $container) {
             ->parent('cache.app')
             ->tag('cache.pool')
 
-        ->set('limiter', Limiter::class)
+        ->set('limiter', RateLimiter::class)
             ->abstract()
             ->args([
                 abstract_arg('config'),

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface;
-use Symfony\Component\RateLimiter\Limiter;
+use Symfony\Component\RateLimiter\RateLimiter;
 use Symfony\Component\Security\Http\EventListener\LoginThrottlingListener;
 use Symfony\Component\Security\Http\RateLimiter\DefaultLoginRateLimiter;
 
@@ -63,7 +63,7 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface, SecurityF
             throw new \LogicException('Login throttling requires symfony/security-http:^5.2.');
         }
 
-        if (!class_exists(Limiter::class)) {
+        if (!class_exists(RateLimiter::class)) {
             throw new \LogicException('Login throttling requires symfony/rate-limiter to be installed and enabled.');
         }
 

--- a/src/Symfony/Component/RateLimiter/CompoundLimiter.php
+++ b/src/Symfony/Component/RateLimiter/CompoundLimiter.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\RateLimiter;
 
+use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
+
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
  *
@@ -29,6 +31,11 @@ final class CompoundLimiter implements LimiterInterface
             throw new \LogicException(sprintf('"%s::%s()" require at least one limiter.', self::class, __METHOD__));
         }
         $this->limiters = $limiters;
+    }
+
+    public function reserve(int $tokens = 1, ?float $maxTime = null): Reservation
+    {
+        throw new ReserveNotSupportedException(__CLASS__);
     }
 
     public function consume(int $tokens = 1): Limit

--- a/src/Symfony/Component/RateLimiter/Exception/MaxWaitDurationExceededException.php
+++ b/src/Symfony/Component/RateLimiter/Exception/MaxWaitDurationExceededException.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\RateLimiter\Exception;
 
+use Symfony\Component\RateLimiter\Limit;
+
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
  *
@@ -18,4 +20,17 @@ namespace Symfony\Component\RateLimiter\Exception;
  */
 class MaxWaitDurationExceededException extends \RuntimeException
 {
+    private $limit;
+
+    public function __construct(string $message, Limit $limit, int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->limit = $limit;
+    }
+
+    public function getLimit(): Limit
+    {
+        return $this->limit;
+    }
 }

--- a/src/Symfony/Component/RateLimiter/Exception/ReserveNotSupportedException.php
+++ b/src/Symfony/Component/RateLimiter/Exception/ReserveNotSupportedException.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\RateLimiter\Exception;
+
+/**
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ *
+ * @experimental in 5.2
+ */
+class ReserveNotSupportedException extends \BadMethodCallException
+{
+    public function __construct(string $limiterClass, int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct(sprintf('Reserving tokens is not supported by "%s".', $limiterClass), $code, $previous);
+    }
+}

--- a/src/Symfony/Component/RateLimiter/LimiterInterface.php
+++ b/src/Symfony/Component/RateLimiter/LimiterInterface.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\RateLimiter;
 
+use Symfony\Component\RateLimiter\Exception\MaxWaitDurationExceededException;
+use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
+
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
  *
@@ -18,6 +21,22 @@ namespace Symfony\Component\RateLimiter;
  */
 interface LimiterInterface
 {
+    /**
+     * Waits until the required number of tokens is available.
+     *
+     * The reserved tokens will be taken into account when calculating
+     * future token consumptions. Do not use this method if you intend
+     * to skip this process.
+     *
+     * @param int   $tokens  the number of tokens required
+     * @param float $maxTime maximum accepted waiting time in seconds
+     *
+     * @throws MaxWaitDurationExceededException if $maxTime is set and the process needs to wait longer than its value (in seconds)
+     * @throws ReserveNotSupportedException     if this limiter implementation doesn't support reserving tokens
+     * @throws \InvalidArgumentException        if $tokens is larger than the maximum burst size
+     */
+    public function reserve(int $tokens = 1, ?float $maxTime = null): Reservation;
+
     /**
      * Use this method if you intend to drop if the required number
      * of tokens is unavailable.

--- a/src/Symfony/Component/RateLimiter/NoLimiter.php
+++ b/src/Symfony/Component/RateLimiter/NoLimiter.php
@@ -23,6 +23,11 @@ namespace Symfony\Component\RateLimiter;
  */
 final class NoLimiter implements LimiterInterface
 {
+    public function reserve(int $tokens = 1, ?float $maxTime = null): Reservation
+    {
+        return new Reservation(time(), new Limit(\INF, new \DateTimeImmutable(), true));
+    }
+
     public function consume(int $tokens = 1): Limit
     {
         return new Limit(\INF, new \DateTimeImmutable(), true);

--- a/src/Symfony/Component/RateLimiter/README.md
+++ b/src/Symfony/Component/RateLimiter/README.md
@@ -18,9 +18,9 @@ $ composer require symfony/rate-limiter
 
 ```php
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
-use Symfony\Component\RateLimiter\Limiter;
+use Symfony\Component\RateLimiter\RateLimiter;
 
-$limiter = new Limiter([
+$limiter = new RateLimiter([
     'id' => 'login',
     'strategy' => 'token_bucket', // or 'fixed_window'
     'limit' => 10,

--- a/src/Symfony/Component/RateLimiter/RateLimiter.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiter.php
@@ -22,7 +22,7 @@ use Symfony\Component\RateLimiter\Storage\StorageInterface;
  *
  * @experimental in 5.2
  */
-final class Limiter
+final class RateLimiter
 {
     private $config;
     private $storage;

--- a/src/Symfony/Component/RateLimiter/Reservation.php
+++ b/src/Symfony/Component/RateLimiter/Reservation.php
@@ -19,13 +19,15 @@ namespace Symfony\Component\RateLimiter;
 final class Reservation
 {
     private $timeToAct;
+    private $limit;
 
     /**
      * @param float $timeToAct Unix timestamp in seconds when this reservation should act
      */
-    public function __construct(float $timeToAct)
+    public function __construct(float $timeToAct, Limit $limit)
     {
         $this->timeToAct = $timeToAct;
+        $this->limit = $limit;
     }
 
     public function getTimeToAct(): float
@@ -36,6 +38,11 @@ final class Reservation
     public function getWaitDuration(): float
     {
         return max(0, (-microtime(true)) + $this->timeToAct);
+    }
+
+    public function getLimit(): Limit
+    {
+        return $this->limit;
     }
 
     public function wait(): void

--- a/src/Symfony/Component/RateLimiter/SlidingWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/SlidingWindowLimiter.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\RateLimiter;
 
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\NoLock;
+use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
 use Symfony\Component\RateLimiter\Storage\StorageInterface;
 use Symfony\Component\RateLimiter\Util\TimeUtil;
 
@@ -65,6 +66,11 @@ final class SlidingWindowLimiter implements LimiterInterface
         $this->id = $id;
         $this->limit = $limit;
         $this->interval = TimeUtil::dateIntervalToSeconds($interval);
+    }
+
+    public function reserve(int $tokens = 1, ?float $maxTime = null): Reservation
+    {
+        throw new ReserveNotSupportedException(__CLASS__);
     }
 
     /**

--- a/src/Symfony/Component/RateLimiter/Tests/CompoundLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/CompoundLimiterTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\RateLimiter\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\RateLimiter\CompoundLimiter;
+use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
 use Symfony\Component\RateLimiter\FixedWindowLimiter;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
@@ -38,20 +39,24 @@ class CompoundLimiterTest extends TestCase
         $limiter3 = $this->createLimiter(12, new \DateInterval('PT30S'));
         $limiter = new CompoundLimiter([$limiter1, $limiter2, $limiter3]);
 
-        // Reach limiter 1 limit, verify that limiter2 available tokens reduced by 5 and fetch successfully limiter 1
-        $this->assertEquals(3, $limiter->consume(5)->getRemainingTokens(), 'Limiter 1 reached the limit');
+        $this->assertEquals(0, $limiter->consume(4)->getRemainingTokens(), 'Limiter 1 reached the limit');
         sleep(1); // reset limiter1's window
-        $this->assertTrue($limiter->consume(2)->isAccepted());
-
-        // Reach limiter 2 limit, verify that limiter2 available tokens reduced by 5 and and fetch successfully
-        $this->assertEquals(0, $limiter->consume()->getRemainingTokens(), 'Limiter 2 has no remaining tokens left');
-        sleep(9); // reset limiter2's window
         $this->assertTrue($limiter->consume(3)->isAccepted());
 
-        // Reach limiter 3 limit, verify that limiter2 available tokens reduced by 5 and fetch successfully
+        $this->assertEquals(0, $limiter->consume()->getRemainingTokens(), 'Limiter 2 has no remaining tokens left');
+        sleep(10); // reset limiter2's window
+        $this->assertTrue($limiter->consume(3)->isAccepted());
+
         $this->assertEquals(0, $limiter->consume()->getRemainingTokens(), 'Limiter 3 reached the limit');
         sleep(20); // reset limiter3's window
         $this->assertTrue($limiter->consume()->isAccepted());
+    }
+
+    public function testReserve()
+    {
+        $this->expectException(ReserveNotSupportedException::class);
+
+        (new CompoundLimiter([$this->createLimiter(4, new \DateInterval('PT1S'))]))->reserve();
     }
 
     private function createLimiter(int $limit, \DateInterval $interval): FixedWindowLimiter

--- a/src/Symfony/Component/RateLimiter/Tests/FixedWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/FixedWindowLimiterTest.php
@@ -60,7 +60,7 @@ class FixedWindowLimiterTest extends TestCase
         sleep(10);
         $limit = $limiter->consume(10);
         $this->assertEquals(0, $limit->getRemainingTokens());
-        $this->assertEquals(time() + 60, $limit->getRetryAfter()->getTimestamp());
+        $this->assertTrue($limit->isAccepted());
     }
 
     public function testWrongWindowFromCache()

--- a/src/Symfony/Component/RateLimiter/Tests/LimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/LimiterTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\RateLimiter\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\RateLimiter\FixedWindowLimiter;
-use Symfony\Component\RateLimiter\Limiter;
+use Symfony\Component\RateLimiter\RateLimiter;
 use Symfony\Component\RateLimiter\Storage\StorageInterface;
 use Symfony\Component\RateLimiter\TokenBucketLimiter;
 
@@ -61,6 +61,6 @@ class LimiterTest extends TestCase
 
     private function createFactory(array $options)
     {
-        return new Limiter($options, $this->createMock(StorageInterface::class), $this->createMock(LockFactory::class));
+        return new RateLimiter($options, $this->createMock(StorageInterface::class), $this->createMock(LockFactory::class));
     }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/SlidingWindowLimiterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\RateLimiter\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
 use Symfony\Component\RateLimiter\SlidingWindowLimiter;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
@@ -48,6 +49,13 @@ class SlidingWindowLimiterTest extends TestCase
         sleep(13);
         $limit = $limiter->consume(10);
         $this->assertTrue($limit->isAccepted());
+    }
+
+    public function testReserve()
+    {
+        $this->expectException(ReserveNotSupportedException::class);
+
+        $this->createLimiter()->reserve();
     }
 
     private function createLimiter(): SlidingWindowLimiter

--- a/src/Symfony/Component/RateLimiter/Tests/Storage/CacheStorageTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Storage/CacheStorageTest.php
@@ -31,15 +31,14 @@ class CacheStorageTest extends TestCase
     public function testSave()
     {
         $cacheItem = $this->createMock(CacheItemInterface::class);
-        $cacheItem->expects($this->once())->method('expiresAfter')->with(10);
+        $cacheItem->expects($this->exactly(2))->method('expiresAfter')->with(10);
 
         $this->pool->expects($this->any())->method('getItem')->with(sha1('test'))->willReturn($cacheItem);
         $this->pool->expects($this->exactly(2))->method('save')->with($cacheItem);
 
-        $window = new Window('test', 10);
+        $window = new Window('test', 10, 20);
         $this->storage->save($window);
 
-        // test that expiresAfter is only called when getExpirationAt() does not return null
         $window = unserialize(serialize($window));
         $this->storage->save($window);
     }
@@ -47,7 +46,7 @@ class CacheStorageTest extends TestCase
     public function testFetchExistingState()
     {
         $cacheItem = $this->createMock(CacheItemInterface::class);
-        $window = new Window('test', 10);
+        $window = new Window('test', 10, 20);
         $cacheItem->expects($this->any())->method('get')->willReturn($window);
         $cacheItem->expects($this->any())->method('isHit')->willReturn(true);
 

--- a/src/Symfony/Component/RateLimiter/TokenBucket.php
+++ b/src/Symfony/Component/RateLimiter/TokenBucket.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\RateLimiter;
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
  *
+ * @internal
  * @experimental in 5.2
  */
 final class TokenBucket implements LimiterStateInterface
@@ -32,6 +33,10 @@ final class TokenBucket implements LimiterStateInterface
      */
     public function __construct(string $id, int $initialTokens, Rate $rate, ?float $timer = null)
     {
+        if ($initialTokens < 1) {
+            throw new \InvalidArgumentException(sprintf('Cannot set the limit of "%s" to 0, as that would never accept any hit.', TokenBucketLimiter::class));
+        }
+
         $this->id = $id;
         $this->tokens = $this->burstSize = $initialTokens;
         $this->rate = $rate;

--- a/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
+++ b/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Security\Http\RateLimiter;
 
 use Symfony\Component\HttpFoundation\RateLimiter\AbstractRequestRateLimiter;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\RateLimiter\Limiter;
+use Symfony\Component\RateLimiter\RateLimiter;
 use Symfony\Component\Security\Core\Security;
 
 /**
@@ -31,7 +31,7 @@ final class DefaultLoginRateLimiter extends AbstractRequestRateLimiter
     private $globalLimiter;
     private $localLimiter;
 
-    public function __construct(Limiter $globalLimiter, Limiter $localLimiter)
+    public function __construct(RateLimiter $globalLimiter, RateLimiter $localLimiter)
     {
         $this->globalLimiter = $globalLimiter;
         $this->localLimiter = $localLimiter;

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Security\Http\Tests\EventListener;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\RateLimiter\Limiter;
+use Symfony\Component\RateLimiter\RateLimiter;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\TooManyLoginAttemptsAuthenticationException;
@@ -35,13 +35,13 @@ class LoginThrottlingListenerTest extends TestCase
     {
         $this->requestStack = new RequestStack();
 
-        $localLimiter = new Limiter([
+        $localLimiter = new RateLimiter([
             'id' => 'login',
             'strategy' => 'fixed_window',
             'limit' => 3,
             'interval' => '1 minute',
         ], new InMemoryStorage());
-        $globalLimiter = new Limiter([
+        $globalLimiter = new RateLimiter([
             'id' => 'login',
             'strategy' => 'fixed_window',
             'limit' => 6,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While Javier wrote documentation for this new component, we found a couple of confusing elements that might need some tweaks:

* The `Limiter` class (previously called `LimiterFactory`) has imho a bit strange name, as it's not a limiter and it doesn't implement `LimiterInterface`. It can only new limiters. I believe `LimiterFactory` - like `LockFactory` - would be the most clear, but as that was rejected before, here is another proposal using `RateLimiter`.
* `reserve()` was now only part of the token bucket implementation. That made it a bit less useful. I think I've found a way to also allow reserving future hits in the fixed window implementation, so I've moved it to the `LimiterInterface`.