### PR TITLE
[Messenger][Redis] Adding support for lazy connect

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Added a `delete_after_reject` option to the DSN to allow control over message
    deletion, similar to `delete_after_ack`.
+ * Added option `lazy` to delay connecting to Redis server until we first use it.
 
 5.1.0
 -----

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -387,4 +387,16 @@ class ConnectionTest extends TestCase
 
         $this->assertSame('xack error', $e->getMessage());
     }
+
+    public function testLazy()
+    {
+        $redis = new \Redis();
+        $connection = Connection::fromDsn('redis://localhost/messenger-lazy?lazy=1', [], $redis);
+
+        $connection->add('1', []);
+        $this->assertNotEmpty($message = $connection->get());
+        $this->assertSame('1', $message['body']);
+        $connection->reject($message['id']);
+        $redis->del('messenger-lazy');
+    }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisProxy.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisProxy.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\Redis\Transport;
+
+/**
+ * Allow to delay connection to Redis.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class RedisProxy
+{
+    private $redis;
+    private $initializer;
+    private $ready = false;
+
+    public function __construct(\Redis $redis, \Closure $initializer)
+    {
+        $this->redis = $redis;
+        $this->initializer = $initializer;
+    }
+
+    public function __call(string $method, array $args)
+    {
+        $this->ready ?: $this->ready = $this->initializer->__invoke($this->redis);
+
+        return $this->redis->{$method}(...$args);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #38558
| License       | MIT
| Doc PR        | Should be added

With inspiration from the CacheComponent. This PR makes it possible to make the connection to Redis only when you first use it. 