### PR TITLE
[Config] Disable XML external entity loading for all versions of libxml

### DIFF
--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -199,9 +199,7 @@ class XmlUtilsTest extends TestCase
     // test for issue https://github.com/symfony/symfony/issues/9731
     public function testLoadWrongEmptyXMLWithErrorHandler()
     {
-        if (\LIBXML_VERSION < 20900) {
-            $originalDisableEntities = libxml_disable_entity_loader(false);
-        }
+        $originalDisableEntities = libxml_disable_entity_loader(false);
         $errorReporting = error_reporting(-1);
 
         set_error_handler(function ($errno, $errstr) {
@@ -221,13 +219,11 @@ class XmlUtilsTest extends TestCase
             error_reporting($errorReporting);
         }
 
-        if (\LIBXML_VERSION < 20900) {
-            $disableEntities = libxml_disable_entity_loader(true);
-            libxml_disable_entity_loader($disableEntities);
+        $disableEntities = libxml_disable_entity_loader(true);
+        libxml_disable_entity_loader($disableEntities);
 
-            libxml_disable_entity_loader($originalDisableEntities);
-            $this->assertFalse($disableEntities);
-        }
+        libxml_disable_entity_loader($originalDisableEntities);
+        $this->assertFalse($disableEntities);
 
         // should not throw an exception
         XmlUtils::loadFile(__DIR__.'/../Fixtures/Util/valid.xml', __DIR__.'/../Fixtures/Util/schema.xsd');

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -51,17 +51,13 @@ class XmlUtils
         }
 
         $internalErrors = libxml_use_internal_errors(true);
-        if (\LIBXML_VERSION < 20900) {
-            $disableEntities = libxml_disable_entity_loader(true);
-        }
+        $disableEntities = libxml_disable_entity_loader(true);
         libxml_clear_errors();
 
         $dom = new \DOMDocument();
         $dom->validateOnParse = true;
         if (!$dom->loadXML($content, \LIBXML_NONET | (\defined('LIBXML_COMPACT') ? \LIBXML_COMPACT : 0))) {
-            if (\LIBXML_VERSION < 20900) {
-                libxml_disable_entity_loader($disableEntities);
-            }
+            libxml_disable_entity_loader($disableEntities);
 
             throw new XmlParsingException(implode("\n", static::getXmlErrors($internalErrors)));
         }
@@ -69,9 +65,7 @@ class XmlUtils
         $dom->normalizeDocument();
 
         libxml_use_internal_errors($internalErrors);
-        if (\LIBXML_VERSION < 20900) {
-            libxml_disable_entity_loader($disableEntities);
-        }
+        libxml_disable_entity_loader($disableEntities);
 
         foreach ($dom->childNodes as $child) {
             if (\XML_DOCUMENT_TYPE_NODE === $child->nodeType) {

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -620,13 +620,9 @@ $imports
 EOF
         ;
 
-        if (\LIBXML_VERSION < 20900) {
-            $disableEntities = libxml_disable_entity_loader(false);
-            $valid = @$dom->schemaValidateSource($source);
-            libxml_disable_entity_loader($disableEntities);
-        } else {
-            $valid = @$dom->schemaValidateSource($source);
-        }
+        $disableEntities = libxml_disable_entity_loader(false);
+        $valid = @$dom->schemaValidateSource($source);
+        libxml_disable_entity_loader($disableEntities);
 
         foreach ($tmpfiles as $tmpfile) {
             @unlink($tmpfile);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/xxe_schema.xsd
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/xxe_schema.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<xsd:schema xmlns="http://symfony.com/schema"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://symfony.com/schema"
+            elementFormDefault="qualified">
+
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:import namespace="http://symfony.com/schema/dic/services" schemaLocation="file:///dev/null" />
+
+</xsd:schema>

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -182,9 +182,7 @@ class Crawler implements \Countable, \IteratorAggregate
     public function addHtmlContent($content, $charset = 'UTF-8')
     {
         $internalErrors = libxml_use_internal_errors(true);
-        if (\LIBXML_VERSION < 20900) {
-            $disableEntities = libxml_disable_entity_loader(true);
-        }
+        $disableEntities = libxml_disable_entity_loader(true);
 
         $dom = new \DOMDocument('1.0', $charset);
         $dom->validateOnParse = true;
@@ -205,9 +203,7 @@ class Crawler implements \Countable, \IteratorAggregate
         }
 
         libxml_use_internal_errors($internalErrors);
-        if (\LIBXML_VERSION < 20900) {
-            libxml_disable_entity_loader($disableEntities);
-        }
+        libxml_disable_entity_loader($disableEntities);
 
         $this->addDocument($dom);
 
@@ -250,9 +246,7 @@ class Crawler implements \Countable, \IteratorAggregate
         }
 
         $internalErrors = libxml_use_internal_errors(true);
-        if (\LIBXML_VERSION < 20900) {
-            $disableEntities = libxml_disable_entity_loader(true);
-        }
+        $disableEntities = libxml_disable_entity_loader(true);
 
         $dom = new \DOMDocument('1.0', $charset);
         $dom->validateOnParse = true;
@@ -262,9 +256,7 @@ class Crawler implements \Countable, \IteratorAggregate
         }
 
         libxml_use_internal_errors($internalErrors);
-        if (\LIBXML_VERSION < 20900) {
-            libxml_disable_entity_loader($disableEntities);
-        }
+        libxml_disable_entity_loader($disableEntities);
 
         $this->addDocument($dom);
 

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -83,18 +83,14 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
         }
 
         $internalErrors = libxml_use_internal_errors(true);
-        if (\LIBXML_VERSION < 20900) {
-            $disableEntities = libxml_disable_entity_loader(true);
-        }
+        $disableEntities = libxml_disable_entity_loader(true);
         libxml_clear_errors();
 
         $dom = new \DOMDocument();
         $dom->loadXML($data, $this->loadOptions);
 
         libxml_use_internal_errors($internalErrors);
-        if (\LIBXML_VERSION < 20900) {
-            libxml_disable_entity_loader($disableEntities);
-        }
+        libxml_disable_entity_loader($disableEntities);
 
         if ($error = libxml_get_last_error()) {
             libxml_clear_errors();

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -189,13 +189,9 @@ class XliffFileLoader implements LoaderInterface
     {
         $internalErrors = libxml_use_internal_errors(true);
 
-        if (\LIBXML_VERSION < 20900) {
-            $disableEntities = libxml_disable_entity_loader(false);
-            $isValid = @$dom->schemaValidateSource($schema);
-            libxml_disable_entity_loader($disableEntities);
-        } else {
-            $isValid = @$dom->schemaValidateSource($schema);
-        }
+        $disableEntities = libxml_disable_entity_loader(false);
+        $isValid = @$dom->schemaValidateSource($schema);
+        libxml_disable_entity_loader($disableEntities);
 
         if (!$isValid) {
             throw new InvalidResourceException(sprintf('Invalid resource provided: "%s"; Errors: ', $file).implode("\n", $this->getXmlErrors($internalErrors)));

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -49,17 +49,13 @@ class XliffFileLoaderTest extends TestCase
 
     public function testLoadWithExternalEntitiesDisabled()
     {
-        if (\LIBXML_VERSION < 20900) {
-            $disableEntities = libxml_disable_entity_loader(true);
-        }
+        $disableEntities = libxml_disable_entity_loader(true);
 
         $loader = new XliffFileLoader();
         $resource = __DIR__.'/../fixtures/resources.xlf';
         $catalogue = $loader->load($resource, 'en', 'domain1');
 
-        if (\LIBXML_VERSION < 20900) {
-            libxml_disable_entity_loader($disableEntities);
-        }
+        libxml_disable_entity_loader($disableEntities);
 
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals([new FileResource($resource)], $catalogue->getResources());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The libxml_disable_entity_loader() function was deprecated in PHP 8.0 and will trigger a deprecation notice going forward. However, **external entity loading is still enabled**.

The PR where the function was deprecated, https://github.com/php/php-src/pull/5867, claims that XXE loading is diabled by default since libxml 2.9.0.

However, this was not the case in at least the following systems:
- the php:7.4-fpm-alpine docker image
- the php:8.0-rc-cli-alpine
- the default php-7.4 package from the Ubuntu 20.04 package repositories

All of these installations report LIBXML_VERSION > 20900 and are still vulnerable to XXE attacks unless libxml_disable_entity_loader() is used.

Calling libxml_disable_entity_loader() before Kernel::hande() fails now with a XmlParsingException due to XmlFileLoader not temporarily enabling XXE loading. The external entity in question was src/Symfony/[...]/services-1.0.xsd which was being used to validate src/Symfony/[...]/config/web.xml.

Calling libxml_disable_entity_loader() is recommended by OWASP, and is a very good security practice to globally prevent XXE attacks:
https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#php

You can modify the xxe_schema.xsd file introduced in this commit to point to a https://webhook.site/ URL instead of file:///dev/null. This will demonstrate that these XXE calls will even try to make network requests.

I don't like where I placed the test I added. I chose XmlFileLoaderTest because that XmlFileLoader was causing Symfony to crash in my case. I think it's a good test to have, though, as it will prevent regressions on this. Perhasp you can suggest a better place.