### PR TITLE
[Contracts] add branch-aliases for dev-main

### DIFF
--- a/src/Symfony/Contracts/Cache/composer.json
+++ b/src/Symfony/Contracts/Cache/composer.json
@@ -33,6 +33,9 @@
         }
     },
     "extra": {
-        "branch-version": "1.1"
+        "branch-version": "1.1",
+        "branch-alias": {
+            "dev-main": "1.1-dev"
+        }
     }
 }

--- a/src/Symfony/Contracts/EventDispatcher/composer.json
+++ b/src/Symfony/Contracts/EventDispatcher/composer.json
@@ -33,6 +33,9 @@
         }
     },
     "extra": {
-        "branch-version": "1.1"
+        "branch-version": "1.1",
+        "branch-alias": {
+            "dev-main": "1.1-dev"
+        }
     }
 }

--- a/src/Symfony/Contracts/HttpClient/composer.json
+++ b/src/Symfony/Contracts/HttpClient/composer.json
@@ -32,6 +32,9 @@
         }
     },
     "extra": {
-        "branch-version": "1.1"
+        "branch-version": "1.1",
+        "branch-alias": {
+            "dev-main": "1.1-dev"
+        }
     }
 }

--- a/src/Symfony/Contracts/Service/composer.json
+++ b/src/Symfony/Contracts/Service/composer.json
@@ -33,6 +33,9 @@
         }
     },
     "extra": {
-        "branch-version": "1.1"
+        "branch-version": "1.1",
+        "branch-alias": {
+            "dev-main": "1.1-dev"
+        }
     }
 }

--- a/src/Symfony/Contracts/Translation/composer.json
+++ b/src/Symfony/Contracts/Translation/composer.json
@@ -32,6 +32,9 @@
         }
     },
     "extra": {
-        "branch-version": "1.1"
+        "branch-version": "1.1",
+        "branch-alias": {
+            "dev-main": "1.1-dev"
+        }
     }
 }

--- a/src/Symfony/Contracts/composer.json
+++ b/src/Symfony/Contracts/composer.json
@@ -46,6 +46,9 @@
     },
     "minimum-stability": "dev",
     "extra": {
-        "branch-version": "1.1"
+        "branch-version": "1.1",
+        "branch-alias": {
+            "dev-main": "1.1-dev"
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

symfony/contracts is still using a "main" branch so we need to alias it for composer to know which version this maps to.