### PR TITLE
Add wouterj as codeowner for Security related packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,11 @@
 /src/Symfony/Bridge/Doctrine/PropertyInfo/ @dunglas
 # Serializer
 /src/Symfony/Component/Serializer/ @dunglas
+# Security
+/src/Symfony/Bridge/Doctrine/Security/ @wouterj
+/src/Symfony/Bundle/SecurityBundle/ @wouterj
+/src/Symfony/Component/Security/ @wouterj
+/src/Symfony/Component/Ldap/Security/ @wouterj
 # TwigBundle
 /src/Symfony/Bundle/TwigBundle/ErrorRenderer/TwigHtmlErrorRenderer.php @yceruto
 # WebLink


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This is what I've manually been doing since the 5.1 release. Now that I'm part of the Symfony mergers team, I would be happy to let GitHub ping important PRs for me automatically :)

_as 3.4 is closing the end of its maintenance lifetime, I think it'll save some merge conflicts to only add this in 4.4+_