### PR TITLE
Add missing use statement

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -74,6 +74,7 @@ use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\StoreFactory;
+use Symfony\Component\Lock\StoreInterface;
 use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesTransportFactory;
 use Symfony\Component\Mailer\Bridge\Google\Transport\GmailTransportFactory;
 use Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillTransportFactory;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

The `StoreInterface` has been renamed into `PersistingStoreInterface` in 4.4, but people are allowed to use an old version of the Lock component with a recent version of the FrameworkBundle.

The StoreInterface is used here: 
https://github.com/symfony/symfony/blob/3e587d7013fa33ce9abec2afb534ee1baea9ef41/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1582