### PR TITLE
[Semaphore] Reset Key lifetime time before we acquire it

### DIFF
--- a/src/Symfony/Component/Semaphore/Key.php
+++ b/src/Symfony/Component/Semaphore/Key.php
@@ -80,6 +80,11 @@ final class Key
         return $this->state[$stateKey];
     }
 
+    public function resetLifetime(): void
+    {
+        $this->expiringTime = null;
+    }
+
     public function reduceLifetime(float $ttlInSeconds)
     {
         $newTime = microtime(true) + $ttlInSeconds;

--- a/src/Symfony/Component/Semaphore/Semaphore.php
+++ b/src/Symfony/Component/Semaphore/Semaphore.php
@@ -66,6 +66,7 @@ final class Semaphore implements SemaphoreInterface, LoggerAwareInterface
     public function acquire(): bool
     {
         try {
+            $this->key->resetLifetime();
             $this->store->save($this->key, $this->ttlInSecond);
             $this->key->reduceLifetime($this->ttlInSecond);
             $this->dirty = true;
@@ -97,6 +98,7 @@ final class Semaphore implements SemaphoreInterface, LoggerAwareInterface
         }
 
         try {
+            $this->key->resetLifetime();
             $this->store->putOffExpiration($this->key, $ttlInSecond);
             $this->key->reduceLifetime($ttlInSecond);
 

--- a/src/Symfony/Component/Semaphore/Tests/SemaphoreTest.php
+++ b/src/Symfony/Component/Semaphore/Tests/SemaphoreTest.php
@@ -252,4 +252,24 @@ class SemaphoreTest extends TestCase
         $semaphore = new Semaphore($key, $store);
         $this->assertTrue($semaphore->isExpired());
     }
+
+    /**
+     * @group time-sensitive
+     */
+    public function testExpirationResetAfter()
+    {
+        $store = $this->getMockBuilder(PersistingStoreInterface::class)->getMock();
+
+        $key = new Key('key', 1);
+        $semaphore = new Semaphore($key, $store, 1);
+
+        $semaphore->acquire();
+        $this->assertFalse($semaphore->isExpired());
+        $semaphore->release();
+
+        sleep(2);
+
+        $semaphore->acquire();
+        $this->assertFalse($semaphore->isExpired());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | /
| License       | MIT
| Doc PR        | /

This is the same issue fixed by #38553 but for Semaphore component.