### PR TITLE
[FrameworkBundle] Missing Changelog for deprecating services

### DIFF
--- a/UPGRADE-5.2.md
+++ b/UPGRADE-5.2.md
@@ -15,6 +15,7 @@ FrameworkBundle
    keep cache namespaces separated by environment of the app. The `%kernel.container_class%` (which includes the environment)
    used to be added by default to the seed, which is not the case anymore. This allows sharing caches between
    apps or different environments.
+ * Deprecated the `lock.RESOURCE_NAME` service and the `lock` and `LockInterface` aliases, use `lock.RESOURCE_NAME.factory`, `lock.factory` or `LockFactory` instead.
 
 Form
 ----

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -58,6 +58,7 @@ FrameworkBundle
  * Removed `session.attribute_bag` service and `session.flash_bag` service.
  * The `form.factory`, `form.type.file`, `translator`, `security.csrf.token_manager`, `serializer`,
    `cache_clearer`, `filesystem` and `validator` services are now private.
+ * Removed the `lock.RESOURCE_NAME` service and the `lock` and `LockInterface` aliases, use `lock.RESOURCE_NAME.factory`, `lock.factory` or `LockFactory` instead.
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * added `assertCheckboxChecked()` and `assertCheckboxNotChecked()` in `WebTestCase`
  * added `assertFormValue()` and `assertNoFormValue()` in `WebTestCase`
  * Added "--as-tree=3" option to `translation:update` command to dump messages as a tree-like structure. The given value defines the level where to switch to inline YAML
+ * Deprecated the `lock.RESOURCE_NAME` service and the `lock` and `LockInterface` aliases, use `lock.RESOURCE_NAME.factory`, `lock.factory` or `LockFactory` instead.
 
 5.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1702,7 +1702,7 @@ class FrameworkExtension extends Extension
             } else {
                 $container->registerAliasForArgument('lock.'.$resourceName.'.store', PersistingStoreInterface::class, $resourceName.'.lock.store');
                 $container->registerAliasForArgument('lock.'.$resourceName.'.factory', LockFactory::class, $resourceName.'.lock.factory');
-                $container->registerAliasForArgument('lock.'.$resourceName, LockInterface::class, $resourceName.'.lock');
+                $container->registerAliasForArgument('lock.'.$resourceName, LockInterface::class, $resourceName.'.lock')->setDeprecated('symfony/framework-bundle', '5.2', 'The "%alias_id%" alias is deprecated, use "'.LockFactory::class.' $'.$resourceName.'LockFactory" instead.');
             }
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | /
| License       | MIT
| Doc PR        | /

I forgot to add CHANGELOG/UPGRADE when deprecating alias `lock` in #38576. (thank you  @nicolas-grekas for reminding this)

This PR also adds a missing alias registered for argument.