### PR TITLE
[HttpClient] added `extra.trace_content` option to `TraceableHttpClient` to prevent it from keeping the content in memory

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * added `EventSourceHttpClient` a Server-Sent events stream implementing the [EventSource specification](https://www.w3.org/TR/eventsource/#eventsource)
  * added option "extra.curl" to allow setting additional curl options in `CurlHttpClient`
  * added `RetryableHttpClient` to automatically retry failed HTTP requests.
+ * added `extra.trace_content` option to `TraceableHttpClient` to prevent it from keeping the content in memory
 
 5.1.0
 -----

--- a/src/Symfony/Component/HttpClient/Response/TraceableResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/TraceableResponse.php
@@ -52,6 +52,10 @@ class TraceableResponse implements ResponseInterface, StreamableInterface
 
     public function getContent(bool $throw = true): string
     {
+        if (false === $this->content) {
+            return $this->response->getContent($throw);
+        }
+
         $this->content = $this->response->getContent(false);
 
         if ($throw) {
@@ -63,6 +67,10 @@ class TraceableResponse implements ResponseInterface, StreamableInterface
 
     public function toArray(bool $throw = true): array
     {
+        if (false === $this->content) {
+            return $this->response->toArray($throw);
+        }
+
         $this->content = $this->response->toArray(false);
 
         if ($throw) {

--- a/src/Symfony/Component/HttpClient/TraceableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/TraceableHttpClient.php
@@ -49,6 +49,11 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface, 
         ];
         $onProgress = $options['on_progress'] ?? null;
 
+        if (false === ($options['extra']['trace_content'] ?? true)) {
+            unset($content);
+            $content = false;
+        }
+
         $options['on_progress'] = function (int $dlNow, int $dlSize, array $info) use (&$traceInfo, $onProgress) {
             $traceInfo = $info;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`TraceableHttpClient` leaks memory by definition. But sometimes, this leak is to important, especially when keeping the response content in memory.

This PR adds a new `trace_content` option under `extra` so that consumers can tell the client to not trace the content. This will be ignored when `TraceableHttpClient` is not in use.