### PR TITLE
[Console] Don't register signal handlers if pcntl is disabled

### DIFF
--- a/src/Symfony/Component/Console/SignalRegistry/SignalRegistry.php
+++ b/src/Symfony/Component/Console/SignalRegistry/SignalRegistry.php
@@ -37,6 +37,19 @@ final class SignalRegistry
         pcntl_signal($signal, [$this, 'handle']);
     }
 
+    public static function isSupported(): bool
+    {
+        if (!\function_exists('pcntl_signal')) {
+            return false;
+        }
+
+        if (\in_array('pcntl_signal', explode(',', ini_get('disable_functions')))) {
+            return false;
+        }
+
+        return true;
+    }
+
     /**
      * @internal
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38496 
| License       | MIT
| Doc PR        | todo

This PR skips the default signal registration when pcntl is not installed or disabled via the `disable_functions` INI directive (which is common for prod infrastructures).
When registering a `SignalableCommand`, a clear exception is thrown. 

Best reviewed [without whitespaces](https://github.com/symfony/symfony/pull/38589/files?w=1)