### PR TITLE
[BrowserKit] Add jsonRequest function to the browser-kit client

### DIFF
--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -162,6 +162,24 @@ abstract class AbstractBrowser
     }
 
     /**
+     * Converts the request parameters into a JSON string and uses it as request content.
+     */
+    public function jsonRequest(string $method, string $uri, array $parameters = [], array $server = [], bool $changeHistory = true): Crawler
+    {
+        $content = json_encode($parameters);
+
+        $this->setServerParameter('CONTENT_TYPE', 'application/json');
+        $this->setServerParameter('HTTP_ACCEPT', 'application/json');
+
+        try {
+            return $this->request($method, $uri, [], [], $server, $content, $changeHistory);
+        } finally {
+            unset($this->server['CONTENT_TYPE']);
+            unset($this->server['HTTP_ACCEPT']);
+        }
+    }
+
+    /**
      * Returns the History instance.
      *
      * @return History A History instance

--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+ * Added `jsonRequest` method to `AbstractBrowser`
+
 4.3.0
 -----
 

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -60,6 +60,17 @@ class AbstractBrowserTest extends TestCase
         $this->assertFalse($client->getServerParameter('HTTP_X_REQUESTED_WITH', false));
     }
 
+    public function testJsonRequest()
+    {
+        $client = $this->getBrowser();
+        $client->jsonRequest('GET', 'http://example.com/', ['param' => 1], [], true);
+        $this->assertSame('application/json', $client->getRequest()->getServer()['CONTENT_TYPE']);
+        $this->assertSame('application/json', $client->getRequest()->getServer()['HTTP_ACCEPT']);
+        $this->assertFalse($client->getServerParameter('CONTENT_TYPE', false));
+        $this->assertFalse($client->getServerParameter('HTTP_ACCEPT', false));
+        $this->assertSame('{"param":1}', $client->getRequest()->getContent());
+    }
+
     public function testGetRequestWithIpAsHttpHost()
     {
         $client = $this->getBrowser();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix - 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

If you use the FOSRestBundle for your Api's you have maybe many tests using just:

```php
$client->request('POST', '/api/contacts', ['param' => 1]);
```

To test your JSON api as in the real browser request FOSRestBundle converts the json body into the `$request->request` object. I think something similar is done by ApiPlatform. If you have tests like above they will now fail as the integer is converted to string see also #38591. 

This PR add a new `jsonRequest` which will look like the following and will so fix the above problem:

```php
$client->jsonRequest('POST', '/api/contacts', ['param' => 1]);
```