### PR TITLE
[DoctrineBridge] Convert values to Rfc4122 before inserting them into the database

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Types/UlidTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/UlidTypeTest.php
@@ -48,7 +48,7 @@ final class UlidTypeTest extends TestCase
     {
         $ulid = Ulid::fromString(self::DUMMY_ULID);
 
-        $expected = $ulid->__toString();
+        $expected = $ulid->toRfc4122();
         $actual = $this->type->convertToDatabaseValue($ulid, $this->platform);
 
         $this->assertEquals($expected, $actual);
@@ -60,7 +60,7 @@ final class UlidTypeTest extends TestCase
 
         $ulid
             ->expects($this->once())
-            ->method('__toString')
+            ->method('toRfc4122')
             ->willReturn('foo');
 
         $actual = $this->type->convertToDatabaseValue($ulid, $this->platform);
@@ -71,8 +71,11 @@ final class UlidTypeTest extends TestCase
     public function testUlidStringConvertsToDatabaseValue(): void
     {
         $actual = $this->type->convertToDatabaseValue(self::DUMMY_ULID, $this->platform);
+        $ulid = Ulid::fromString(self::DUMMY_ULID);
 
-        $this->assertEquals(self::DUMMY_ULID, $actual);
+        $expected = $ulid->toRfc4122();
+
+        $this->assertEquals($expected, $actual);
     }
 
     public function testInvalidUlidConversionForDatabaseValue(): void

--- a/src/Symfony/Bridge/Doctrine/Tests/Types/UuidTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/UuidTypeTest.php
@@ -60,7 +60,7 @@ final class UuidTypeTest extends TestCase
 
         $uuid
             ->expects($this->once())
-            ->method('__toString')
+            ->method('toRfc4122')
             ->willReturn('foo');
 
         $actual = $this->type->convertToDatabaseValue($uuid, $this->platform);

--- a/src/Symfony/Bridge/Doctrine/Types/AbstractUidType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/AbstractUidType.php
@@ -56,7 +56,7 @@ abstract class AbstractUidType extends GuidType
         }
 
         if ($value instanceof AbstractUid) {
-            return (string) $value;
+            return $value->toRfc4122();
         }
 
         if (!\is_string($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
@@ -64,7 +64,13 @@ abstract class AbstractUidType extends GuidType
         }
 
         if ($this->getUidClass()::isValid((string) $value)) {
-            return (string) $value;
+            try {
+                $uuid = $this->getUidClass()::fromString($value);
+
+                return $uuid->toRfc4122();
+            } catch (\InvalidArgumentException $e) {
+                throw ConversionException::conversionFailed($value, $this->getName());
+            }
         }
 
         throw ConversionException::conversionFailed($value, $this->getName());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #38599 
| License       | MIT

This PR formats the ULID into RFC4211 before inserting it into the database to avoid insertion failure on Postgres due to not recognized formating.
