### PR TITLE
[WebProfilerBundle] Hide debug toolbar in print view

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -565,6 +565,6 @@ div.sf-toolbar .sf-toolbar-block a:hover {
 /***** Media query print: Do not print the Toolbar. *****/
 @media print {
     .sf-toolbar {
-        display: none;
+        display: none !important;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The debug toolbar is intended to be hidden when printed. This was accomplished in 2.8 with [this PR](https://github.com/symfony/symfony/pull/23460). Since then, additional JavaScript code was added which results in `display: block` being applied directly to the toolbar element. This overrides the print style, which causes the toolbar to show up in the print view. I fixed this by adding `!important` to the print CSS display rule.

A few notes:

1. I hesitated to solve this with `!important` but couldn't come up with another way to make this work with the existing JavaScript code. Also, `profiler.css.twig` already has some `!important` styles, so I figured this was acceptable.
2. I wasn't sure how to write a test for this, but I am open to ideas.