### PR TITLE
[RateLimiter] rename Limit to RateLimit and add RateLimit::getLimit()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
+++ b/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
@@ -12,9 +12,9 @@
 namespace Symfony\Component\HttpFoundation\RateLimiter;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\RateLimiter\Limit;
 use Symfony\Component\RateLimiter\LimiterInterface;
 use Symfony\Component\RateLimiter\NoLimiter;
+use Symfony\Component\RateLimiter\RateLimit;
 
 /**
  * An implementation of RequestRateLimiterInterface that
@@ -26,23 +26,23 @@ use Symfony\Component\RateLimiter\NoLimiter;
  */
 abstract class AbstractRequestRateLimiter implements RequestRateLimiterInterface
 {
-    public function consume(Request $request): Limit
+    public function consume(Request $request): RateLimit
     {
         $limiters = $this->getLimiters($request);
         if (0 === \count($limiters)) {
             $limiters = [new NoLimiter()];
         }
 
-        $minimalLimit = null;
+        $minimalRateLimit = null;
         foreach ($limiters as $limiter) {
-            $limit = $limiter->consume(1);
+            $rateLimit = $limiter->consume(1);
 
-            if (null === $minimalLimit || $limit->getRemainingTokens() < $minimalLimit->getRemainingTokens()) {
-                $minimalLimit = $limit;
+            if (null === $minimalRateLimit || $rateLimit->getRemainingTokens() < $minimalRateLimit->getRemainingTokens()) {
+                $minimalRateLimit = $rateLimit;
             }
         }
 
-        return $minimalLimit;
+        return $minimalRateLimit;
     }
 
     public function reset(Request $request): void

--- a/src/Symfony/Component/HttpFoundation/RateLimiter/RequestRateLimiterInterface.php
+++ b/src/Symfony/Component/HttpFoundation/RateLimiter/RequestRateLimiterInterface.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\HttpFoundation\RateLimiter;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\RateLimiter\Limit;
+use Symfony\Component\RateLimiter\RateLimit;
 
 /**
  * A special type of limiter that deals with requests.
@@ -26,7 +26,7 @@ use Symfony\Component\RateLimiter\Limit;
  */
 interface RequestRateLimiterInterface
 {
-    public function consume(Request $request): Limit;
+    public function consume(Request $request): RateLimit;
 
     public function reset(Request $request): void;
 }

--- a/src/Symfony/Component/RateLimiter/CompoundLimiter.php
+++ b/src/Symfony/Component/RateLimiter/CompoundLimiter.php
@@ -38,18 +38,18 @@ final class CompoundLimiter implements LimiterInterface
         throw new ReserveNotSupportedException(__CLASS__);
     }
 
-    public function consume(int $tokens = 1): Limit
+    public function consume(int $tokens = 1): RateLimit
     {
-        $minimalLimit = null;
+        $minimalRateLimit = null;
         foreach ($this->limiters as $limiter) {
-            $limit = $limiter->consume($tokens);
+            $rateLimit = $limiter->consume($tokens);
 
-            if (null === $minimalLimit || $limit->getRemainingTokens() < $minimalLimit->getRemainingTokens()) {
-                $minimalLimit = $limit;
+            if (null === $minimalRateLimit || $rateLimit->getRemainingTokens() < $minimalRateLimit->getRemainingTokens()) {
+                $minimalRateLimit = $rateLimit;
             }
         }
 
-        return $minimalLimit;
+        return $minimalRateLimit;
     }
 
     public function reset(): void

--- a/src/Symfony/Component/RateLimiter/Exception/MaxWaitDurationExceededException.php
+++ b/src/Symfony/Component/RateLimiter/Exception/MaxWaitDurationExceededException.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\RateLimiter\Exception;
 
-use Symfony\Component\RateLimiter\Limit;
+use Symfony\Component\RateLimiter\RateLimit;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
@@ -20,17 +20,17 @@ use Symfony\Component\RateLimiter\Limit;
  */
 class MaxWaitDurationExceededException extends \RuntimeException
 {
-    private $limit;
+    private $rateLimit;
 
-    public function __construct(string $message, Limit $limit, int $code = 0, ?\Throwable $previous = null)
+    public function __construct(string $message, RateLimit $rateLimit, int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
 
-        $this->limit = $limit;
+        $this->rateLimit = $rateLimit;
     }
 
-    public function getLimit(): Limit
+    public function getRateLimit(): RateLimit
     {
-        return $this->limit;
+        return $this->rateLimit;
     }
 }

--- a/src/Symfony/Component/RateLimiter/Exception/RateLimitExceededException.php
+++ b/src/Symfony/Component/RateLimiter/Exception/RateLimitExceededException.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\RateLimiter\Exception;
 
-use Symfony\Component\RateLimiter\Limit;
+use Symfony\Component\RateLimiter\RateLimit;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -20,27 +20,32 @@ use Symfony\Component\RateLimiter\Limit;
  */
 class RateLimitExceededException extends \RuntimeException
 {
-    private $limit;
+    private $rateLimit;
 
-    public function __construct(Limit $limit, $code = 0, \Throwable $previous = null)
+    public function __construct(RateLimit $rateLimit, $code = 0, \Throwable $previous = null)
     {
         parent::__construct('Rate Limit Exceeded', $code, $previous);
 
-        $this->limit = $limit;
+        $this->rateLimit = $rateLimit;
     }
 
-    public function getLimit(): Limit
+    public function getRateLimit(): RateLimit
     {
-        return $this->limit;
+        return $this->rateLimit;
     }
 
     public function getRetryAfter(): \DateTimeImmutable
     {
-        return $this->limit->getRetryAfter();
+        return $this->rateLimit->getRetryAfter();
     }
 
     public function getRemainingTokens(): int
     {
-        return $this->limit->getRemainingTokens();
+        return $this->rateLimit->getRemainingTokens();
+    }
+
+    public function getLimit(): int
+    {
+        return $this->rateLimit->getLimit();
     }
 }

--- a/src/Symfony/Component/RateLimiter/LimiterInterface.php
+++ b/src/Symfony/Component/RateLimiter/LimiterInterface.php
@@ -43,7 +43,7 @@ interface LimiterInterface
      *
      * @param int $tokens the number of tokens required
      */
-    public function consume(int $tokens = 1): Limit;
+    public function consume(int $tokens = 1): RateLimit;
 
     /**
      * Resets the limit.

--- a/src/Symfony/Component/RateLimiter/NoLimiter.php
+++ b/src/Symfony/Component/RateLimiter/NoLimiter.php
@@ -25,12 +25,12 @@ final class NoLimiter implements LimiterInterface
 {
     public function reserve(int $tokens = 1, ?float $maxTime = null): Reservation
     {
-        return new Reservation(time(), new Limit(\INF, new \DateTimeImmutable(), true));
+        return new Reservation(time(), new RateLimit(\INF, new \DateTimeImmutable(), true, \INF));
     }
 
-    public function consume(int $tokens = 1): Limit
+    public function consume(int $tokens = 1): RateLimit
     {
-        return new Limit(\INF, new \DateTimeImmutable(), true);
+        return new RateLimit(\INF, new \DateTimeImmutable(), true, \INF);
     }
 
     public function reset(): void

--- a/src/Symfony/Component/RateLimiter/RateLimit.php
+++ b/src/Symfony/Component/RateLimiter/RateLimit.php
@@ -18,17 +18,19 @@ use Symfony\Component\RateLimiter\Exception\RateLimitExceededException;
  *
  * @experimental in 5.2
  */
-class Limit
+class RateLimit
 {
     private $availableTokens;
     private $retryAfter;
     private $accepted;
+    private $limit;
 
-    public function __construct(int $availableTokens, \DateTimeImmutable $retryAfter, bool $accepted)
+    public function __construct(int $availableTokens, \DateTimeImmutable $retryAfter, bool $accepted, int $limit)
     {
         $this->availableTokens = $availableTokens;
         $this->retryAfter = $retryAfter;
         $this->accepted = $accepted;
+        $this->limit = $limit;
     }
 
     public function isAccepted(): bool
@@ -56,6 +58,11 @@ class Limit
     public function getRemainingTokens(): int
     {
         return $this->availableTokens;
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
     }
 
     public function wait(): void

--- a/src/Symfony/Component/RateLimiter/Reservation.php
+++ b/src/Symfony/Component/RateLimiter/Reservation.php
@@ -19,15 +19,15 @@ namespace Symfony\Component\RateLimiter;
 final class Reservation
 {
     private $timeToAct;
-    private $limit;
+    private $rateLimit;
 
     /**
      * @param float $timeToAct Unix timestamp in seconds when this reservation should act
      */
-    public function __construct(float $timeToAct, Limit $limit)
+    public function __construct(float $timeToAct, RateLimit $rateLimit)
     {
         $this->timeToAct = $timeToAct;
-        $this->limit = $limit;
+        $this->rateLimit = $rateLimit;
     }
 
     public function getTimeToAct(): float
@@ -40,9 +40,9 @@ final class Reservation
         return max(0, (-microtime(true)) + $this->timeToAct);
     }
 
-    public function getLimit(): Limit
+    public function getRateLimit(): RateLimit
     {
-        return $this->limit;
+        return $this->rateLimit;
     }
 
     public function wait(): void

--- a/src/Symfony/Component/RateLimiter/SlidingWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/SlidingWindowLimiter.php
@@ -76,7 +76,7 @@ final class SlidingWindowLimiter implements LimiterInterface
     /**
      * {@inheritdoc}
      */
-    public function consume(int $tokens = 1): Limit
+    public function consume(int $tokens = 1): RateLimit
     {
         $this->lock->acquire(true);
 
@@ -91,13 +91,13 @@ final class SlidingWindowLimiter implements LimiterInterface
             $hitCount = $window->getHitCount();
             $availableTokens = $this->getAvailableTokens($hitCount);
             if ($availableTokens < $tokens) {
-                return new Limit($availableTokens, $window->getRetryAfter(), false);
+                return new RateLimit($availableTokens, $window->getRetryAfter(), false, $this->limit);
             }
 
             $window->add($tokens);
             $this->storage->save($window);
 
-            return new Limit($this->getAvailableTokens($window->getHitCount()), $window->getRetryAfter(), true);
+            return new RateLimit($this->getAvailableTokens($window->getHitCount()), $window->getRetryAfter(), true, $this->limit);
         } finally {
             $this->lock->release();
         }

--- a/src/Symfony/Component/RateLimiter/Tests/FixedWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/FixedWindowLimiterTest.php
@@ -41,10 +41,12 @@ class FixedWindowLimiterTest extends TestCase
             sleep(5);
         }
 
-        $limit = $limiter->consume();
-        $this->assertTrue($limit->isAccepted());
-        $limit = $limiter->consume();
-        $this->assertFalse($limit->isAccepted());
+        $rateLimit = $limiter->consume();
+        $this->assertSame(10, $rateLimit->getLimit());
+        $this->assertTrue($rateLimit->isAccepted());
+        $rateLimit = $limiter->consume();
+        $this->assertFalse($rateLimit->isAccepted());
+        $this->assertSame(10, $rateLimit->getLimit());
     }
 
     public function testConsumeOutsideInterval()
@@ -58,18 +60,18 @@ class FixedWindowLimiterTest extends TestCase
         $limiter->consume(9);
         // ...try bursting again at the start of the next window
         sleep(10);
-        $limit = $limiter->consume(10);
-        $this->assertEquals(0, $limit->getRemainingTokens());
-        $this->assertTrue($limit->isAccepted());
+        $rateLimit = $limiter->consume(10);
+        $this->assertEquals(0, $rateLimit->getRemainingTokens());
+        $this->assertTrue($rateLimit->isAccepted());
     }
 
     public function testWrongWindowFromCache()
     {
         $this->storage->save(new DummyWindow());
         $limiter = $this->createLimiter();
-        $limit = $limiter->consume();
-        $this->assertTrue($limit->isAccepted());
-        $this->assertEquals(9, $limit->getRemainingTokens());
+        $rateLimit = $limiter->consume();
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertEquals(9, $rateLimit->getRemainingTokens());
     }
 
     private function createLimiter(): FixedWindowLimiter

--- a/src/Symfony/Component/RateLimiter/Tests/RateLimitTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/RateLimitTest.php
@@ -13,25 +13,25 @@ namespace Symfony\Component\RateLimiter\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\RateLimiter\Exception\RateLimitExceededException;
-use Symfony\Component\RateLimiter\Limit;
+use Symfony\Component\RateLimiter\RateLimit;
 
-class LimitTest extends TestCase
+class RateLimitTest extends TestCase
 {
     public function testEnsureAcceptedDoesNotThrowExceptionIfAccepted()
     {
-        $limit = new Limit(10, new \DateTimeImmutable(), true);
+        $rateLimit = new RateLimit(10, new \DateTimeImmutable(), true, 10);
 
-        $this->assertSame($limit, $limit->ensureAccepted());
+        $this->assertSame($rateLimit, $rateLimit->ensureAccepted());
     }
 
     public function testEnsureAcceptedThrowsRateLimitExceptionIfNotAccepted()
     {
-        $limit = new Limit(10, $retryAfter = new \DateTimeImmutable(), false);
+        $rateLimit = new RateLimit(10, $retryAfter = new \DateTimeImmutable(), false, 10);
 
         try {
-            $limit->ensureAccepted();
+            $rateLimit->ensureAccepted();
         } catch (RateLimitExceededException $exception) {
-            $this->assertSame($limit, $exception->getLimit());
+            $this->assertSame($rateLimit, $exception->getRateLimit());
             $this->assertSame(10, $exception->getRemainingTokens());
             $this->assertSame($retryAfter, $exception->getRetryAfter());
 

--- a/src/Symfony/Component/RateLimiter/Tests/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/SlidingWindowLimiterTest.php
@@ -38,17 +38,19 @@ class SlidingWindowLimiterTest extends TestCase
         $limiter->consume(8);
         sleep(15);
 
-        $limit = $limiter->consume();
-        $this->assertTrue($limit->isAccepted());
+        $rateLimit = $limiter->consume();
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertSame(10, $rateLimit->getLimit());
 
         // We are 25% into the new window
-        $limit = $limiter->consume(5);
-        $this->assertFalse($limit->isAccepted());
-        $this->assertEquals(3, $limit->getRemainingTokens());
+        $rateLimit = $limiter->consume(5);
+        $this->assertFalse($rateLimit->isAccepted());
+        $this->assertEquals(3, $rateLimit->getRemainingTokens());
 
         sleep(13);
-        $limit = $limiter->consume(10);
-        $this->assertTrue($limit->isAccepted());
+        $rateLimit = $limiter->consume(10);
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertSame(10, $rateLimit->getLimit());
     }
 
     public function testReserve()

--- a/src/Symfony/Component/RateLimiter/Tests/TokenBucketLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/TokenBucketLimiterTest.php
@@ -74,26 +74,28 @@ class TokenBucketLimiterTest extends TestCase
         $limiter = $this->createLimiter(10, $rate);
 
         // enough free tokens
-        $limit = $limiter->consume(5);
-        $this->assertTrue($limit->isAccepted());
-        $this->assertEquals(5, $limit->getRemainingTokens());
-        $this->assertEqualsWithDelta(time(), $limit->getRetryAfter()->getTimestamp(), 1);
+        $rateLimit = $limiter->consume(5);
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertEquals(5, $rateLimit->getRemainingTokens());
+        $this->assertEqualsWithDelta(time(), $rateLimit->getRetryAfter()->getTimestamp(), 1);
+        $this->assertSame(10, $rateLimit->getLimit());
         // there are only 5 available free tokens left now
-        $limit = $limiter->consume(10);
-        $this->assertEquals(5, $limit->getRemainingTokens());
+        $rateLimit = $limiter->consume(10);
+        $this->assertEquals(5, $rateLimit->getRemainingTokens());
 
-        $limit = $limiter->consume(5);
-        $this->assertEquals(0, $limit->getRemainingTokens());
-        $this->assertEqualsWithDelta(time(), $limit->getRetryAfter()->getTimestamp(), 1);
+        $rateLimit = $limiter->consume(5);
+        $this->assertEquals(0, $rateLimit->getRemainingTokens());
+        $this->assertEqualsWithDelta(time(), $rateLimit->getRetryAfter()->getTimestamp(), 1);
+        $this->assertSame(10, $rateLimit->getLimit());
     }
 
     public function testWrongWindowFromCache()
     {
         $this->storage->save(new DummyWindow());
         $limiter = $this->createLimiter();
-        $limit = $limiter->consume();
-        $this->assertTrue($limit->isAccepted());
-        $this->assertEquals(9, $limit->getRemainingTokens());
+        $rateLimit = $limiter->consume();
+        $this->assertTrue($rateLimit->isAccepted());
+        $this->assertEquals(9, $rateLimit->getRemainingTokens());
     }
 
     private function createLimiter($initialTokens = 10, Rate $rate = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38489 
| License       | MIT
| Doc PR        | todo

After discussing #38489 with @wouterj, he agreed we should add `Limit::getLimit()` but this method name was unfortunate. We decided to rename the `Limit` object to `RateLimit` which, IMO, is a better name for the object and is inline with how this concept is described in the [RateLimit Header Fields for HTTP RFC](https://tools.ietf.org/id/draft-polli-ratelimit-headers-00.html).
