### PR TITLE
Bump APCu to 5.1.19 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,23 +142,6 @@ before_install:
       }
       export -f tpecl
 
-      install_apcu_dev () {
-          local ref=$1
-          local INI=$2
-
-          wget https://github.com/krakjoe/apcu/archive/${ref}.zip
-          unzip ${ref}.zip
-          cd apcu-${ref}
-          phpize
-          ./configure
-          make
-          mv modules/apcu.so $(php -r "echo ini_get('extension_dir');")
-          echo 'extension = apcu.so' >> $INI
-          cd ..
-          rm -rf apcu-${ref} ${ref}.zip
-      }
-      export -f install_apcu_dev
-
     - |
       # Install sigchild-enabled PHP to test the Process component on the lowest PHP matrix line
       if [[ ! $deps && $TRAVIS_PHP_VERSION = ${MIN_PHP%.*} && ! -d php-$MIN_PHP/sapi ]]; then
@@ -200,11 +183,11 @@ before_install:
               [[ -e $ext_cache ]] || (tfold ext.symfony_debug "cd src/Symfony/Component/Debug/Resources/ext && phpize && ./configure && make && mv modules/symfony_debug.so $ext_cache && phpize --clean")
               echo extension = $ext_cache >> $INI
           elif [[ $PHP = 7.* ]]; then
-              tfold ext.apcu tpecl apcu-5.1.17 apcu.so $INI
+              tfold ext.apcu tpecl apcu-5.1.19 apcu.so $INI
               tfold ext.mongodb tpecl mongodb-1.6.0 mongodb.so $INI
           elif [[ $PHP = nightly ]]; then
               tfold ext.memcached tpecl memcached-3.1.5 memcached.so $INI
-              tfold ext.apcu install_apcu_dev 9c36db45100d4d27ec33072f4be90f1f5a0108b7 $INI
+              tfold ext.apcu tpecl apcu-5.1.19 apcu.so $INI
           fi
       done
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | #36872 
| License       | MIT
| Doc PR        | N/A

This PR reverts one of the hacks we had to apply to the Travis configuration in order to get the CI to work with PHP 8. Since we did not have a compatible stable APCu release we pulled a snapshot from GitHub. APCu 5.1.19 should be compatible now, so let's use it.

I've bumped to that release for our PHP 7 build as well because why not. 😃 