### PR TITLE
[Messenger][Doctrine] Avoid early db access for pgsql detection

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Bridge\Doctrine\Transport;
 
+use Doctrine\DBAL\Driver\AbstractPostgreSQLDriver;
 use Doctrine\Persistence\ConnectionRegistry;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\Messenger\Exception\TransportException;
@@ -47,7 +48,7 @@ class DoctrineTransportFactory implements TransportFactoryInterface
             throw new TransportException(sprintf('Could not find Doctrine connection from Messenger DSN "%s".', $dsn), 0, $e);
         }
 
-        if ($useNotify && ($wrappedConnection = $driverConnection->getWrappedConnection()) && method_exists($wrappedConnection, 'pgsqlGetNotify')) {
+        if ($useNotify && $driverConnection->getDriver() instanceof AbstractPostgreSQLDriver) {
             $connection = new PostgreSqlConnection($configuration, $driverConnection);
         } else {
             $connection = new Connection($configuration, $driverConnection);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37069
| License       | MIT
| Doc PR        | -

Keeps the connection lazy using an instanceof check on the DBAL driver instead.
