### PR TITLE
Stop using set-env in GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,8 +58,8 @@ jobs:
                 run: |
                     ([ -d ~/.composer ] || mkdir ~/.composer) && cp .github/composer-config.json ~/.composer/config.json
                     SYMFONY_VERSION=$(cat composer.json | grep '^ *\"branch-version\". *\"[1-9]' | grep -o '[0-9.]*')
-                    echo "::set-env name=SYMFONY_VERSION::$SYMFONY_VERSION"
-                    echo "::set-env name=COMPOSER_ROOT_VERSION::$SYMFONY_VERSION.x-dev"
+                    echo "SYMFONY_VERSION=$SYMFONY_VERSION" >> $GITHUB_ENV
+                    echo "COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev" >> $GITHUB_ENV
 
             -   name: Determine composer cache directory
                 id: composer-cache


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

In our integration tests, we currently get deprecation warnings because we use `set-env`.

<img width="1560" alt="Bildschirmfoto 2020-10-18 um 13 05 23" src="https://user-images.githubusercontent.com/1506493/96366863-a5b09f80-114a-11eb-9f85-ae785307eafc.png">

This PR follows GitHub's documentation on [how to set environment variables](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable) for subsequent steps of the same job.