### PR TITLE
[BrowserKit] Allowing body content from GET with a content-type

### DIFF
--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Added `jsonRequest` method to `AbstractBrowser`
+ * Allowed sending a body with GET requests when a content-type is defined
 
 5.2.0
 -----

--- a/src/Symfony/Component/BrowserKit/HttpBrowser.php
+++ b/src/Symfony/Component/BrowserKit/HttpBrowser.php
@@ -61,7 +61,7 @@ class HttpBrowser extends AbstractBrowser
      */
     private function getBodyAndExtraHeaders(Request $request, array $headers): array
     {
-        if (\in_array($request->getMethod(), ['GET', 'HEAD'])) {
+        if (\in_array($request->getMethod(), ['GET', 'HEAD']) && !isset($headers['content-type'])) {
             return ['', []];
         }
 

--- a/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
@@ -63,6 +63,14 @@ class HttpBrowserTest extends AbstractBrowserTest
             ['POST', 'http://example.com/', [], [], ['CONTENT_TYPE' => 'application/json'], '["content"]'],
             ['POST', 'http://example.com/', ['headers' => $defaultHeaders + ['content-type' => 'application/json'], 'body' => '["content"]', 'max_redirects' => 0]],
         ];
+        yield 'GET JSON' => [
+            ['GET', 'http://example.com/jsonrpc', [], [], ['CONTENT_TYPE' => 'application/json'], '["content"]'],
+            ['GET', 'http://example.com/jsonrpc', ['headers' => $defaultHeaders + ['content-type' => 'application/json'], 'body' => '["content"]', 'max_redirects' => 0]],
+        ];
+        yield 'HEAD JSON' => [
+            ['HEAD', 'http://example.com/jsonrpc', [], [], ['CONTENT_TYPE' => 'application/json'], '["content"]'],
+            ['HEAD', 'http://example.com/jsonrpc', ['headers' => $defaultHeaders + ['content-type' => 'application/json'], 'body' => '["content"]', 'max_redirects' => 0]],
+        ];
     }
 
     public function testMultiPartRequestWithSingleFile()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #37609 
| License       | MIT
| Doc PR        | N/A

This allows a GET request to sent a payload if it specifies a content-type in the HTTP header as per our conversation in the ticket.
