### PR TITLE
[HttpFoundation][RateLimiter] fix RequestRateLimiterInterface::reset()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
+++ b/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
@@ -45,7 +45,7 @@ abstract class AbstractRequestRateLimiter implements RequestRateLimiterInterface
         return $minimalLimit;
     }
 
-    public function reset(): void
+    public function reset(Request $request): void
     {
         foreach ($this->getLimiters($request) as $limiter) {
             $limiter->reset();

--- a/src/Symfony/Component/HttpFoundation/RateLimiter/RequestRateLimiterInterface.php
+++ b/src/Symfony/Component/HttpFoundation/RateLimiter/RequestRateLimiterInterface.php
@@ -28,5 +28,5 @@ interface RequestRateLimiterInterface
 {
     public function consume(Request $request): Limit;
 
-    public function reset(): void;
+    public function reset(Request $request): void;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The reset method requires the `$request`.