### PR TITLE
[Messenger] Add new Google Pub/Sub transport

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransportFactory;
 use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportFactory;
+use Symfony\Component\Messenger\Bridge\GooglePubSub\Transport\GooglePubSubTransportFactory;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
 use Symfony\Component\Messenger\EventListener\DispatchPcntlSignalListener;
 use Symfony\Component\Messenger\EventListener\SendFailedMessageForRetryListener;
@@ -127,6 +128,8 @@ return static function (ContainerConfigurator $container) {
             ->tag('kernel.reset', ['method' => 'reset'])
 
         ->set('messenger.transport.sqs.factory', AmazonSqsTransportFactory::class)
+
+        ->set('messenger.transport.gps.factory', GooglePubSubTransportFactory::class)
 
         ->set('messenger.transport.beanstalkd.factory', BeanstalkdTransportFactory::class)
 

--- a/src/Symfony/Component/Messenger/Bridge/GooglePubSub/.gitattributes
+++ b/src/Symfony/Component/Messenger/Bridge/GooglePubSub/.gitattributes
@@ -1,0 +1,3 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/Messenger/Bridge/GooglePubSub/.gitignore
+++ b/src/Symfony/Component/Messenger/Bridge/GooglePubSub/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Messenger/Bridge/GooglePubSub/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/GooglePubSub/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.3.0
+-----
+
+ * Introduced the Google Pub/Sub bridge.

--- a/src/Symfony/Component/Messenger/Bridge/GooglePubSub/LICENSE
+++ b/src/Symfony/Component/Messenger/Bridge/GooglePubSub/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Messenger/Bridge/GooglePubSub/README.md
+++ b/src/Symfony/Component/Messenger/Bridge/GooglePubSub/README.md
@@ -1,0 +1,12 @@
+Google Pub/Sub Messenger
+========================
+
+Provides Google Pub/Sub integration for Symfony Messenger.
+
+Resources
+---------
+
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Messenger/Bridge/GooglePubSub/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/GooglePubSub/Transport/Connection.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\GooglePubSub\Transport;
+
+use Google\Cloud\Core\Exception\GoogleException;
+use Google\Cloud\PubSub\PubSubClient;
+use Google\Cloud\PubSub\Subscription;
+use Google\Cloud\PubSub\Topic;
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+use Symfony\Component\Messenger\Exception\TransportException;
+
+/**
+ * @author Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ *
+ * @internal
+ */
+class Connection
+{
+    private const DEFAULT_OPTIONS = [
+        // PubSub client
+        'apiEndpoint'    => null,
+        'projectId'      => null,
+        'keyFile'        => null,
+        'keyFilePath'    => null,
+        'requestTimeout' => null,
+        'retries'        => 3,
+        'scopes'         => null,
+        'quotaProject'   => null,
+
+        // Internal
+        'auto_setup'     => true,
+        'topic'          => null,
+        'subscription'   => null,
+    ];
+
+    private $configuration;
+    private $client;
+
+    public function __construct(array $configuration, PubSubClient $client = null)
+    {
+        $this->configuration = array_replace_recursive(self::DEFAULT_OPTIONS, $configuration);
+        $this->client        = $client ?? new PubSubClient([]);
+    }
+
+    /**
+     * Creates a connection based on the DSN and options.
+     *
+     * Available options:
+     *
+     * * apiEndpoint: The hostname with optional port to use in place of the default service endpoint
+     * * projectId: The project ID from the Google Developer's Console
+     * * keyFile: The contents of the service account credentials.json file retrieved from the Google Developer's Console.
+     * * keyFilePath: The full path to your service account credentials .json file retrieved from the Google Developers Console.
+     * * requestTimeout: Seconds to wait before timing out the request. (Defaults: `0` with REST and `60` with gRPC)
+     * * retries: Number of retries for a failed request. (Default: `3`)
+     * * scopes: Scopes to be used for the request
+     * * quotaProject: Specifies a user project to bill for access charges associated with the request
+     * * topic: The name of the topic (when messages should be published)
+     * * subscription: The name of the subscription (when messages should be received)
+     * * auto_setup: Whether the queue should be created automatically during send / get (Default: true)
+     */
+    public static function fromDsn(string $dsn, array $options = []): self
+    {
+        if (false === $parsedUrl = parse_url($dsn)) {
+            throw new InvalidArgumentException(sprintf('The given Google Pub/Sub DSN "%s" is invalid.', $dsn));
+        }
+
+        $query = [];
+        if (isset($parsedUrl['query'])) {
+            parse_str($parsedUrl['query'], $query);
+        }
+
+        // Check for unsupported keys in options
+        $optionsExtraKeys = array_diff(array_keys($options), array_keys(self::DEFAULT_OPTIONS));
+        if (0 < \count($optionsExtraKeys)) {
+            throw new InvalidArgumentException(sprintf('Unknown option found: [%s]. Allowed options are [%s].', implode(', ', $optionsExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
+        }
+
+        // Check for unsupported keys in query
+        $queryExtraKeys = array_diff(array_keys($query), array_keys(self::DEFAULT_OPTIONS));
+        if (0 < \count($queryExtraKeys)) {
+            throw new InvalidArgumentException(sprintf('Unknown option found in DSN: [%s]. Allowed options are [%s].', implode(', ', $queryExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
+        }
+
+        $options       = $query + $options + self::DEFAULT_OPTIONS;
+        $configuration = [
+            'topic'        => $options['topic'],
+            'subscription' => $options['subscription'],
+            'auto_setup'   => (bool) $options['auto_setup'],
+        ];
+
+        $clientConfiguration = [
+            'projectId'      => ltrim($parsedUrl['path'] ?? '', '/') ?? self::DEFAULT_OPTIONS['projectId'],
+            'requestTimeout' => $options['requestTimeout'] ?? self::DEFAULT_OPTIONS['requestTimeout'],
+            'retries'        => $options['retries'] ?? self::DEFAULT_OPTIONS['retries'],
+            'quotaProject'   => $options['quotaProject'] ?? self::DEFAULT_OPTIONS['quotaProject'],
+        ];
+
+        // Set the service account key
+        if (is_array($options['keyFile'])) {
+            $clientConfiguration['keyFile'] = $options['keyFile'];
+        } else {
+            $clientConfiguration['keyFilePath'] = rawurldecode($parsedUrl['keyFilePath'] ?? '') ?: $options['keyFilePath'];
+        }
+
+        if (is_array($options['scopes'])) {
+            $clientConfiguration['scopes'] = $options['scopes'];
+        }
+
+        // Set the optional api endpoint (hostname+port)
+        if ('default' !== ($parsedUrl['host'] ?? 'default')) {
+            $clientConfiguration['apiEndpoint'] = sprintf('%s%s', $parsedUrl['host'], ($parsedUrl['port'] ?? null) ? ':' . $parsedUrl['port'] : '');
+        }
+
+        return new self($configuration, new PubSubClient($clientConfiguration));
+    }
+
+    public function setupTopic(): ?Topic
+    {
+        if (null === $this->configuration['topic']) {
+            return null;
+        }
+
+        $topic = $this->client->topic($this->configuration['topic']);
+        if ($topic->exists()) {
+            return $topic;
+        }
+
+        if (!$this->configuration['auto_setup']) {
+            return null;
+        }
+
+        try {
+            $topic->create();
+        } catch (GoogleException $e) {
+            throw new TransportException(sprintf('Failed to create the Google Pub/Sub topic "%s".', $this->configuration['topic']), 0, $e);
+        }
+
+        return $topic;
+    }
+
+    public function setupSubscription(): ?Subscription
+    {
+        if (null === $this->configuration['subscription']) {
+            return null;
+        }
+
+        $subscription = $this->client->subscription($this->configuration['subscription']);
+        if ($subscription->exists()) {
+            return $subscription;
+        }
+
+        if (!$this->configuration['auto_setup']) {
+            return null;
+        }
+
+        try {
+            $subscription->create();
+        } catch (GoogleException $e) {
+            throw new TransportException(sprintf('Failed to create the Google Pub/Sub subscription "%s".', $this->configuration['subscription']), 0, $e);
+        }
+
+        return $subscription;
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/GooglePubSub/Transport/GooglePubSubReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/GooglePubSub/Transport/GooglePubSubReceivedStamp.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\GooglePubSub\Transport;
+
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+
+/**
+ * @author Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ */
+class GooglePubSubReceivedStamp implements NonSendableStampInterface
+{
+    private $id;
+    private $ackId;
+
+    public function __construct(string $id, string $ackId)
+    {
+        $this->id = $id;
+        $this->ackId = $ackId;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getAckId(): string
+    {
+        return $this->ackId;
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/GooglePubSub/Transport/GooglePubSubReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/GooglePubSub/Transport/GooglePubSubReceiver.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\GooglePubSub\Transport;
+
+use Google\Cloud\PubSub\Message;
+use Google\Cloud\PubSub\Subscription;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\LogicException;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+
+/**
+ * @author Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ */
+class GooglePubSubReceiver implements ReceiverInterface
+{
+    private const MESSAGE_ATTRIBUTE_NAME = 'X-Symfony-Messenger';
+
+    private $subscription;
+    private $serializer;
+
+    /** @var array[] */
+    private $buffer = [];
+
+    public function __construct(Subscription $subscription, SerializerInterface $serializer = null)
+    {
+        $this->subscription = $subscription;
+        $this->serializer   = $serializer ?? new PhpSerializer();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get(): iterable
+    {
+        $gpsEnvelope = $this->getMessage();
+        if (null === $gpsEnvelope) {
+            return;
+        }
+
+        try {
+            $envelope = $this->serializer->decode([
+                'body' => $gpsEnvelope['body'],
+                'headers' => $gpsEnvelope['headers'],
+            ]);
+        } catch (MessageDecodingFailedException $exception) {
+            $this->subscription->delete($gpsEnvelope['id']);
+
+            throw $exception;
+        }
+
+        yield $envelope->with(new GooglePubSubReceivedStamp($gpsEnvelope['id'], $gpsEnvelope['ackId']));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ack(Envelope $envelope): void
+    {
+        $stamp = $this->findReceivedStamp($envelope);
+
+        $this->subscription->acknowledge(new Message([], ['ackId' => $stamp->getAckId()]));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reject(Envelope $envelope): void
+    {
+        $this->ack($envelope);
+    }
+
+    private function findReceivedStamp(Envelope $envelope): GooglePubSubReceivedStamp
+    {
+        /** @var GooglePubSubReceivedStamp|null $stamp */
+        $stamp = $envelope->last(GooglePubSubReceivedStamp::class);
+
+        if (null === $stamp) {
+            throw new LogicException('No GooglePubSubReceivedStamp found on the Envelope.');
+        }
+
+        return $stamp;
+    }
+
+    private function getMessage(): ?array
+    {
+        foreach ($this->getNextMessages() as $message) {
+            return $message;
+        }
+
+        return null;
+    }
+
+    private function getNextMessages(): \Generator
+    {
+        yield from $this->getPendingMessages();
+        yield from $this->getNewMessages();
+    }
+
+    private function getPendingMessages(): \Generator
+    {
+        while (!empty($this->buffer)) {
+            yield array_shift($this->buffer);
+        }
+    }
+
+    private function getNewMessages(): \Generator
+    {
+        $this->fetchMessages();
+
+        yield from $this->getPendingMessages();
+    }
+
+    private function fetchMessages(): void
+    {
+        foreach ($this->subscription->pull() as $message) {
+            $headers = [];
+
+            $attributes = $message->attributes();
+            if (isset($attributes[self::MESSAGE_ATTRIBUTE_NAME])) {
+                $headers = json_decode($attributes[self::MESSAGE_ATTRIBUTE_NAME], true);
+                unset($attributes[self::MESSAGE_ATTRIBUTE_NAME]);
+            }
+
+            $headers += $attributes;
+
+            $this->buffer[] = [
+                'id'      => $message->id(),
+                'ackId'   => $message->ackId(),
+                'body'    => $message->data(),
+                'headers' => $headers,
+            ];
+        }
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/GooglePubSub/Transport/GooglePubSubSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/GooglePubSub/Transport/GooglePubSubSender.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\GooglePubSub\Transport;
+
+use AsyncAws\Core\Exception\Http\HttpException;
+use Google\Cloud\Core\Exception\BadRequestException;
+use Google\Cloud\Core\Exception\GoogleException;
+use Google\Cloud\PubSub\Message;
+use Google\Cloud\PubSub\Topic;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+
+/**
+ * @author Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ */
+class GooglePubSubSender implements SenderInterface
+{
+    private $topic;
+    private $serializer;
+
+    public function __construct(Topic $topic, SerializerInterface $serializer)
+    {
+        $this->topic      = $topic;
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function send(Envelope $envelope): Envelope
+    {
+        $encodedMessage = $this->serializer->encode($envelope);
+
+        try {
+            $this->topic->publish(
+                new Message(
+                    [
+                        'data'       => $encodedMessage['body'],
+                        'attributes' => $encodedMessage['headers'] ?? []
+                    ]
+                )
+            );
+        } catch (GoogleException $e) {
+            throw new TransportException($e->getMessage(), 0, $e);
+        }
+
+        return $envelope;
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/GooglePubSub/Transport/GooglePubSubTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/GooglePubSub/Transport/GooglePubSubTransport.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\GooglePubSub\Transport;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\TransportException;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+/**
+ * @author Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ */
+class GooglePubSubTransport implements TransportInterface
+{
+    private $serializer;
+    private $connection;
+    private $receiver;
+    private $sender;
+
+    public function __construct(Connection $connection, SerializerInterface $serializer = null)
+    {
+        $this->connection = $connection;
+        $this->serializer = $serializer ?? new PhpSerializer();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get(): iterable
+    {
+        return ($this->receiver ?? $this->getReceiver())->get();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ack(Envelope $envelope): void
+    {
+        ($this->receiver ?? $this->getReceiver())->ack($envelope);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reject(Envelope $envelope): void
+    {
+        ($this->receiver ?? $this->getReceiver())->reject($envelope);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function send(Envelope $envelope): Envelope
+    {
+        return ($this->sender ?? $this->getSender())->send($envelope);
+    }
+
+    private function getReceiver(): GooglePubSubReceiver
+    {
+        if (null === $subscription = $this->connection->setupSubscription()) {
+            throw new TransportException('Receiving messages is not supported or auto-setup is disabled');
+        }
+
+        return $this->receiver = new GooglePubSubReceiver($subscription, $this->serializer);
+    }
+
+    private function getSender(): GooglePubSubSender
+    {
+        if (null === $topic = $this->connection->setupTopic()) {
+            throw new TransportException('Sending messages is not supported or auto-setup is disabled');
+        }
+
+        return $this->sender = new GooglePubSubSender($topic, $this->serializer);
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/GooglePubSub/Transport/GooglePubSubTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/GooglePubSub/Transport/GooglePubSubTransportFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\GooglePubSub\Transport;
+
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+
+/**
+ * @author Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ */
+class GooglePubSubTransportFactory implements TransportFactoryInterface
+{
+    public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
+    {
+        unset($options['transport_name']);
+
+        return new GooglePubSubTransport(Connection::fromDsn($dsn, $options), $serializer);
+    }
+
+    public function supports(string $dsn, array $options): bool
+    {
+        return 0 === strpos($dsn, 'gps://');
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/GooglePubSub/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/GooglePubSub/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "symfony/google-pubsub-messenger",
+    "type": "symfony-bridge",
+    "description": "Symfony Google Pub/Sub extension Messenger Bridge",
+    "keywords": [],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Fabien Potencier",
+            "email": "fabien@symfony.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=7.2.5",
+        "ext-json": "*",
+        "google/cloud-pubsub": "^1.0",
+        "symfony/messenger": "^4.3|^5.0",
+        "symfony/service-contracts": "^1.1|^2"
+    },
+    "require-dev": {
+        "symfony/http-client-contracts": "^1.0|^2.0",
+        "symfony/property-access": "^4.4|^5.0",
+        "symfony/serializer": "^4.4|^5.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Messenger\\Bridge\\GooglePubSub\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-version": "5.2"
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/GooglePubSub/phpunit.xml.dist
+++ b/src/Symfony/Component/Messenger/Bridge/GooglePubSub/phpunit.xml.dist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Google Pub/Sub Messenger Component Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | TODO

This PR adds a Google Pub/Sub transport bridge for the Messenger component.

Google Pub/Sub is different from other transports like Amazon SQS. Instead of queues, Pub/Sub has topics and subscriptions. One publishes a message to a topic and it’s delivered once per subscription. This comes with both higher flexibility and higher complexity.  
In practice, you can either set-up one transport in Symfony with one topic and one subscription or multiple transports with different topics and subscriptions. You can also define transports that only receive messages from one topic but cannot publish. See the snippet below for some examples. I found [this documentation about 1:n pub/sub systems](https://cloud.google.com/pubsub/docs/building-pubsub-messaging-system) helpful.

#### (Documentation) Set up

##### Authentication

To access the Pub/Sub service, you must first set up authentication by creating a service account. Follow [this documentation](https://cloud.google.com/pubsub/docs/reference/libraries#cloud-console). For the messenger, assign at least the roles "Pub/Sub viewer" and ("Pub/Sub publisher" and/or "Pub/Sub subscriber"). Place the JSON file in your Symfony project.

##### Symfony config
```yaml
# /config/packages/messenger.yml

framework:
  messenger:
    transports:
      async:
        dsn: 'gps://default/my-awesome-project?topic[name]=my-topic-1&subscription[name]=my-subscription-1'
        options:
          # Define the access key as content (must be an array from the json) OR absolute path. Can also be configured via DSN
          keyFile: '%env(json:file:GCP_KEY_FILE)%'
          keyFilePath: '%kernel.project_dir%/config/gcp/key-c434604cd07b.json'

      can_only_send: 'gps://default/my-awesome-project?topic[name]=my-topic-1'
      can_only_receive: 'gps://default/my-awesome-project?subscription[name]=my-subscription-1'
```

#### TODO:

* [ ] Tests (incl. integration test with emulator)

_____

Looking forward to some reviews. Eventually from people having experience with Google Pub/Sub.
Looking good? Then I'll happy to add the tests.