### PR TITLE
[DoctrineBridge]  indexBy could reference to association columns

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -110,10 +110,24 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
                 $associationMapping = $metadata->getAssociationMapping($property);
 
                 if (isset($associationMapping['indexBy'])) {
-                    $indexColumn = $associationMapping['indexBy'];
                     /** @var ClassMetadataInfo $subMetadata */
                     $subMetadata = $this->classMetadataFactory->getMetadataFor($associationMapping['targetEntity']);
-                    $typeOfField = $subMetadata->getTypeOfField($subMetadata->getFieldForColumn($indexColumn));
+
+                    // Check if indexBy value is a property
+                    $fieldName = $associationMapping['indexBy'];
+                    if (null === ($typeOfField = $subMetadata->getTypeOfField($fieldName))) {
+                        $fieldName = $subMetadata->getFieldForColumn($associationMapping['indexBy']);
+                        //Not a property, maybe a column name?
+                        if (null === ($typeOfField = $subMetadata->getTypeOfField($fieldName))) {
+                            //Maybe the column name is the association join column?
+                            $associationMapping = $subMetadata->getAssociationMapping($fieldName);
+
+                            /** @var ClassMetadataInfo $subMetadata */
+                            $indexProperty = $subMetadata->getSingleAssociationReferencedJoinColumnName($fieldName);
+                            $subMetadata = $this->classMetadataFactory->getMetadataFor($associationMapping['targetEntity']);
+                            $typeOfField = $subMetadata->getTypeOfField($indexProperty);
+                        }
+                    }
 
                     if (!$collectionKeyType = $this->getPhpType($typeOfField)) {
                         return null;

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -78,6 +78,7 @@ class DoctrineExtractorTest extends TestCase
             'indexedBaz',
             'indexedByDt',
             'indexedByCustomType',
+            'indexedBuz',
         ]);
 
         $this->assertEquals(
@@ -197,6 +198,14 @@ class DoctrineExtractorTest extends TestCase
                 new Type(Type::BUILTIN_TYPE_OBJECT, false, DoctrineRelation::class)
             )]],
             ['indexedByCustomType', null],
+            ['indexedBuz', [new Type(
+                Type::BUILTIN_TYPE_OBJECT,
+                false,
+                Collection::class,
+                true,
+                new Type(Type::BUILTIN_TYPE_STRING),
+                new Type(Type::BUILTIN_TYPE_OBJECT, false, DoctrineRelation::class)
+            )]],
         ];
 
         if (class_exists(Types::class)) {

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -72,8 +72,10 @@ class DoctrineExtractorTest extends TestCase
         $expected = array_merge($expected, [
             'foo',
             'bar',
+            'indexedRguid',
             'indexedBar',
             'indexedFoo',
+            'indexedBaz',
             'indexedByDt',
             'indexedByCustomType',
         ]);
@@ -151,6 +153,14 @@ class DoctrineExtractorTest extends TestCase
                 new Type(Type::BUILTIN_TYPE_INT),
                 new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineRelation')
             )]],
+            ['indexedRguid', [new Type(
+                Type::BUILTIN_TYPE_OBJECT,
+                false,
+                'Doctrine\Common\Collections\Collection',
+                true,
+                new Type(Type::BUILTIN_TYPE_STRING),
+                new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineRelation')
+            )]],
             ['indexedBar', [new Type(
                 Type::BUILTIN_TYPE_OBJECT,
                 false,
@@ -166,6 +176,14 @@ class DoctrineExtractorTest extends TestCase
                 true,
                 new Type(Type::BUILTIN_TYPE_STRING),
                 new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineRelation')
+            )]],
+            ['indexedBaz', [new Type(
+                Type::BUILTIN_TYPE_OBJECT,
+                false,
+                Collection::class,
+                true,
+                new Type(Type::BUILTIN_TYPE_INT),
+                new Type(Type::BUILTIN_TYPE_OBJECT, false, DoctrineRelation::class)
             )]],
             ['simpleArray', [new Type(Type::BUILTIN_TYPE_ARRAY, false, null, true, new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_STRING))]],
             ['customFoo', null],

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
@@ -132,4 +132,9 @@ class DoctrineDummy
      * @OneToMany(targetEntity="DoctrineRelation", mappedBy="customType", indexBy="customType")
      */
     private $indexedByCustomType;
+
+    /**
+     * @OneToMany(targetEntity="DoctrineRelation", mappedBy="buzField", indexBy="buzField")
+     */
+    protected $indexedBuz;
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
@@ -42,6 +42,11 @@ class DoctrineDummy
     public $bar;
 
     /**
+     * @ManyToMany(targetEntity="DoctrineRelation", indexBy="rguid")
+     */
+    protected $indexedRguid;
+
+    /**
      * @ManyToMany(targetEntity="DoctrineRelation", indexBy="rguid_column")
      */
     protected $indexedBar;
@@ -50,6 +55,11 @@ class DoctrineDummy
      * @OneToMany(targetEntity="DoctrineRelation", mappedBy="foo", indexBy="foo")
      */
     protected $indexedFoo;
+
+    /**
+     * @OneToMany(targetEntity="DoctrineRelation", mappedBy="baz", indexBy="baz_id")
+     */
+    protected $indexedBaz;
 
     /**
      * @Column(type="guid")

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineRelation.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineRelation.php
@@ -54,4 +54,10 @@ class DoctrineRelation
      * @Column(type="foo")
      */
     private $customType;
+
+    /**
+     * @Column(type="guid", name="different_than_field")
+     * @ManyToOne(targetEntity="DoctrineDummy", inversedBy="indexedBuz")
+     */
+    protected $buzField;
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineRelation.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineRelation.php
@@ -41,6 +41,11 @@ class DoctrineRelation
     protected $foo;
 
     /**
+     * @ManyToOne(targetEntity="DoctrineDummy")
+     */
+    protected $baz;
+
+    /**
      * @Column(type="datetime")
      */
     private $dt;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #37982 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | -
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

This is my approach to solve #37982. It partials reverts @xabbuh PR #38604 

This is my first Symfony contribution, so please, tell me if I need to do something more or something is wrong.

Also, this bug affects 4.x and 5.x versions. I think merging in this branches is done automatically. If not, please tell me.

Thanks you
