### PR TITLE
[HttpClient] Fix decorating progress info in AsyncResponse

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2097,7 +2097,7 @@ class FrameworkExtension extends Extension
 
         $container
             ->register($name.'.retryable', RetryableHttpClient::class)
-            ->setDecoratedService($name, null, -10) // lower priority than TraceableHttpClient
+            ->setDecoratedService($name, null, 10) // higher priority than TraceableHttpClient
             ->setArguments([new Reference($name.'.retryable.inner'), $retryStrategy, $options['max_retries'], new Reference('logger')])
             ->addTag('monolog.logger', ['channel' => 'http_client']);
     }

--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -98,6 +98,7 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
         $errorCount = 0;
         $baseInfo = [
             'response_headers' => 1,
+            'retry_count' => 1,
             'redirect_count' => 1,
             'redirect_url' => 1,
             'user_data' => 1,
@@ -150,6 +151,11 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
                 $content = ['response_json' => $content];
             } else {
                 $content = [];
+            }
+
+            if (isset($info['retry_count'])) {
+                $content['retries'] = $info['previous_info'];
+                unset($info['previous_info']);
             }
 
             $debugInfo = array_diff_key($info, $baseInfo);

--- a/src/Symfony/Component/HttpClient/Response/AsyncContext.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncContext.php
@@ -151,6 +151,12 @@ final class AsyncContext
     public function replaceRequest(string $method, string $url, array $options = []): ResponseInterface
     {
         $this->info['previous_info'][] = $this->response->getInfo();
+        if (null !== $onProgress = $options['on_progress'] ?? null) {
+            $thisInfo = &$this->info;
+            $options['on_progress'] = static function (int $dlNow, int $dlSize, array $info) use (&$thisInfo, $onProgress) {
+                $onProgress($dlNow, $dlSize, $thisInfo + $info);
+            };
+        }
 
         return $this->response = $this->client->request($method, $url, ['buffer' => false] + $options);
     }

--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -43,6 +43,13 @@ final class AsyncResponse implements ResponseInterface, StreamableInterface
     {
         $this->client = $client;
         $this->shouldBuffer = $options['buffer'] ?? true;
+
+        if (null !== $onProgress = $options['on_progress'] ?? null) {
+            $thisInfo = &$this->info;
+            $options['on_progress'] = static function (int $dlNow, int $dlSize, array $info) use (&$thisInfo, $onProgress) {
+                $onProgress($dlNow, $dlSize, $thisInfo + $info);
+            };
+        }
         $this->response = $client->request($method, $url, ['buffer' => false] + $options);
         $this->passthru = $passthru;
         $this->initializer = static function (self $response) {

--- a/src/Symfony/Component/HttpClient/RetryableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/RetryableHttpClient.php
@@ -66,7 +66,6 @@ class RetryableHttpClient implements HttpClientInterface
                 }
             } catch (TransportExceptionInterface $exception) {
                 // catch TransportExceptionInterface to send it to the strategy
-                $context->setInfo('retry_count', $retryCount);
             }
             if (null !== $exception) {
                 // always retry request that fail to resolve DNS
@@ -91,8 +90,6 @@ class RetryableHttpClient implements HttpClientInterface
                     }
                 }
             } elseif ($chunk->isFirst()) {
-                $context->setInfo('retry_count', $retryCount);
-
                 if (false === $shouldRetry = $this->strategy->shouldRetry($context, null, null)) {
                     $context->passthru();
                     yield $chunk;
@@ -138,6 +135,7 @@ class RetryableHttpClient implements HttpClientInterface
                 'delay' => $delay,
             ]);
 
+            $context->setInfo('retry_count', $retryCount);
             $context->replaceRequest($method, $url, $options);
             $context->pause($delay / 1000);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38631
| License       | MIT
| Doc PR        | /

This PR reverts #38413, and send AsyncContext to onProgress callback.