### PR TITLE
[HttpClient] relax auth bearer format requirements

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -110,8 +110,13 @@ trait HttpClientTrait
             throw new InvalidArgumentException(sprintf('Option "auth_basic" must be string or an array, "%s" given.', \gettype($options['auth_basic'])));
         }
 
-        if (isset($options['auth_bearer']) && (!\is_string($options['auth_bearer']) || !preg_match('{^[-._=:~+/0-9a-zA-Z]++$}', $options['auth_bearer']))) {
-            throw new InvalidArgumentException(sprintf('Option "auth_bearer" must be a string containing only characters from the base 64 alphabet, '.(\is_string($options['auth_bearer']) ? 'invalid string given.' : '"%s" given.'), \gettype($options['auth_bearer'])));
+        if (isset($options['auth_bearer'])) {
+            if (!\is_string($options['auth_bearer'])) {
+                throw new InvalidArgumentException(sprintf('Option "auth_bearer" must be a string, "%s" given.', \gettype($options['auth_bearer'])));
+            }
+            if (preg_match('{[^\x21-\x7E]}', $options['auth_bearer'])) {
+                throw new InvalidArgumentException('Invalid character found in option "auth_bearer": '.json_encode($options['auth_bearer']).'.');
+            }
         }
 
         if (isset($options['auth_basic'], $options['auth_bearer'])) {

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
@@ -179,14 +179,14 @@ class HttpClientTraitTest extends TestCase
     public function testInvalidAuthBearerOption()
     {
         $this->expectException('Symfony\Component\HttpClient\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('Option "auth_bearer" must be a string containing only characters from the base 64 alphabet, "object" given.');
+        $this->expectExceptionMessage('Option "auth_bearer" must be a string, "object" given.');
         self::prepareRequest('POST', 'http://example.com', ['auth_bearer' => new \stdClass()], HttpClientInterface::OPTIONS_DEFAULTS);
     }
 
     public function testInvalidAuthBearerValue()
     {
         $this->expectException('Symfony\Component\HttpClient\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('Option "auth_bearer" must be a string containing only characters from the base 64 alphabet, invalid string given.');
+        $this->expectExceptionMessage('Invalid character found in option "auth_bearer": "a\nb".');
         self::prepareRequest('POST', 'http://example.com', ['auth_bearer' => "a\nb"], HttpClientInterface::OPTIONS_DEFAULTS);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38609
| License       | MIT
| Doc PR        | 