### PR TITLE
[HttpClient] skip Vulcain-based tests if the binary cannot be executed

### DIFF
--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -169,6 +169,14 @@ class CurlHttpClientTest extends HttpClientTestCase
         sleep('\\' === \DIRECTORY_SEPARATOR ? 10 : 1);
 
         if (!$process->isRunning()) {
+            if ('\\' !== \DIRECTORY_SEPARATOR && 127 === $process->getExitCode()) {
+                $this->markTestSkipped('vulcain binary is missing');
+            }
+
+            if ('\\' !== \DIRECTORY_SEPARATOR && 126 === $process->getExitCode()) {
+                $this->markTestSkipped('vulcain binary is not executable');
+            }
+
             throw new ProcessFailedException($process);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 