### PR TITLE
[Filesystem] Check if failed unlink was caused by permission denied

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -179,7 +179,7 @@ class Filesystem
                 if (!self::box('rmdir', $file) && file_exists($file)) {
                     throw new IOException(sprintf('Failed to remove directory "%s": ', $file).self::$lastError);
                 }
-            } elseif (!self::box('unlink', $file) && file_exists($file)) {
+            } elseif (!self::box('unlink', $file) && (false !== strpos(self::$lastError, 'Permission denied') || file_exists($file))) {
                 throw new IOException(sprintf('Failed to remove file "%s": ', $file).self::$lastError);
             }
         }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Filesystem\Tests;
 
+use Symfony\Component\Filesystem\Exception\IOException;
+
 /**
  * Test class for Filesystem.
  */
@@ -332,6 +334,28 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->remove($files);
 
         $this->assertFileDoesNotExist($basePath.'dir');
+    }
+
+    public function testRemoveThrowsExceptionOnPermissionDenied()
+    {
+        $this->markAsSkippedIfChmodIsMissing();
+
+        $basePath = $this->workspace.\DIRECTORY_SEPARATOR.'dir_permissions';
+        mkdir($basePath);
+        $file = $basePath.\DIRECTORY_SEPARATOR.'file';
+        touch($file);
+        chmod($basePath, 0400);
+
+        try {
+            $this->filesystem->remove($file);
+            $this->fail('Filesystem::remove() should throw an exception');
+        } catch (IOException $e) {
+            $this->assertStringContainsString('Failed to remove file "'.$file.'"', $e->getMessage());
+            $this->assertStringContainsString('Permission denied', $e->getMessage());
+        } finally {
+            // Make sure we can clean up this file
+            chmod($basePath, 0777);
+        }
     }
 
     public function testRemoveCleansInvalidLinks()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38650
| License       | MIT
| Doc PR        | 

Check why we failed to unlink the file. If the file was missing, then no exception should be thrown. However, if we failed to unlink it because of permissions, we should throw an exception. 
