### PR TITLE
[Security] Allow bubbling of interactive login event as AuthenticatorManager is dispatching it

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPass.php
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\LoginFailureEvent;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
 
 /**
  * Makes sure all event listeners on the global dispatcher are also listening
@@ -31,7 +32,7 @@ use Symfony\Component\Security\Http\Event\LogoutEvent;
  */
 class RegisterGlobalSecurityEventListenersPass implements CompilerPassInterface
 {
-    private static $eventBubblingEvents = [CheckPassportEvent::class, LoginFailureEvent::class, LoginSuccessEvent::class, LogoutEvent::class];
+    private static $eventBubblingEvents = [CheckPassportEvent::class, LoginFailureEvent::class, LoginSuccessEvent::class, LogoutEvent::class, SecurityEvents::INTERACTIVE_LOGIN];
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPassTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
 
 class RegisterGlobalSecurityEventListenersPassTest extends TestCase
 {
@@ -79,6 +80,7 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
             [LogoutEvent::class, [TestSubscriber::class, 'onLogout'], -200],
             [CheckPassportEvent::class, [TestSubscriber::class, 'onCheckPassport'], 120],
             [LoginSuccessEvent::class, [TestSubscriber::class, 'onLoginSuccess'], 0],
+            [SecurityEvents::INTERACTIVE_LOGIN, [TestSubscriber::class, 'onInteractiveLogin'], 0],
         ]);
     }
 
@@ -161,6 +163,7 @@ class TestSubscriber implements EventSubscriberInterface
             LogoutEvent::class => ['onLogout', -200],
             CheckPassportEvent::class => ['onCheckPassport', 120],
             LoginSuccessEvent::class => 'onLoginSuccess',
+            SecurityEvents::INTERACTIVE_LOGIN => 'onInteractiveLogin',
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The [`Symfony\Security\Authentication\AuthenticatorManager:L290`](https://github.com/symfony/symfony/blob/5.1/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php#L209) dispatches `Symfony\Component\Security\Http\SecurityEvents::INTERACTIVE_LOGIN` but it is not allowed for bubbling.