### PR TITLE
[RateLimiter] Fix delete method of the cache storage

### DIFF
--- a/src/Symfony/Component/RateLimiter/Storage/CacheStorage.php
+++ b/src/Symfony/Component/RateLimiter/Storage/CacheStorage.php
@@ -52,6 +52,6 @@ class CacheStorage implements StorageInterface
 
     public function delete(string $limiterStateId): void
     {
-        $this->pool->deleteItem($limiterStateId);
+        $this->pool->deleteItem(sha1($limiterStateId));
     }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/Storage/CacheStorageTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Storage/CacheStorageTest.php
@@ -76,4 +76,11 @@ class CacheStorageTest extends TestCase
 
         $this->assertNull($this->storage->fetch('test'));
     }
+
+    public function testDelete()
+    {
+        $this->pool->expects($this->once())->method('deleteItem')->with(sha1('test'))->willReturn(true);
+
+        $this->assertNull($this->storage->delete('test'));
+    }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/Storage/CacheStorageTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Storage/CacheStorageTest.php
@@ -81,6 +81,6 @@ class CacheStorageTest extends TestCase
     {
         $this->pool->expects($this->once())->method('deleteItem')->with(sha1('test'))->willReturn(true);
 
-        $this->assertNull($this->storage->delete('test'));
+        $this->storage->delete('test');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT

This PR fixes a small issue with RateLimiter's cache storage and the delete method: all getItems are called with a sha1 of the id, but not the one for delete, which makes it miss the deletion.