### PR TITLE
[DoctrineBridge][Validator] Allow validating every class against unique entity constraint

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+7.1
+---
+
+* Allow validating every class against `UniqueEntity` constraint
+
 7.0
 ---
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CreateDoubleNameEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/CreateDoubleNameEntity.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+class CreateDoubleNameEntity
+{
+    public $primaryName;
+    public $secondaryName;
+
+    public function __construct($primaryName, $secondaryName)
+    {
+        $this->primaryName = $primaryName;
+        $this->secondaryName = $secondaryName;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Dto.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Dto.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+class Dto
+{
+    public string $foo;
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HireAnEmployee.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/HireAnEmployee.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+class HireAnEmployee
+{
+    public $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/UpdateCompositeIntIdEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/UpdateCompositeIntIdEntity.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+class UpdateCompositeIntIdEntity
+{
+    public $id1;
+    public $id2;
+    public $name;
+
+    public function __construct($id1, $id2, $name)
+    {
+        $this->id1 = $id1;
+        $this->id2 = $id2;
+        $this->name = $name;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/UpdateCompositeObjectNoToStringIdEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/UpdateCompositeObjectNoToStringIdEntity.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+class UpdateCompositeObjectNoToStringIdEntity
+{
+    /**
+     * @var SingleIntIdNoToStringEntity
+     */
+    protected $object1;
+
+    /**
+     * @var SingleIntIdNoToStringEntity
+     */
+    protected $object2;
+
+    public $name;
+
+    public function __construct(SingleIntIdNoToStringEntity $object1, SingleIntIdNoToStringEntity $object2, $name)
+    {
+        $this->object1 = $object1;
+        $this->object2 = $object2;
+        $this->name = $name;
+    }
+
+    public function getObject1(): SingleIntIdNoToStringEntity
+    {
+        return $this->object1;
+    }
+
+    public function getObject2(): SingleIntIdNoToStringEntity
+    {
+        return $this->object2;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/UpdateEmployeeProfile.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/UpdateEmployeeProfile.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+class UpdateEmployeeProfile
+{
+    public $id;
+    public $name;
+
+    public function __construct($id, $name)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -25,9 +25,12 @@ use Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\AssociationEntity2;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeIntIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeObjectNoToStringIdEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\CreateDoubleNameEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoubleNameEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\DoubleNullableNameEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\Dto;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\Employee;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\HireAnEmployee;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\Person;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity;
@@ -35,6 +38,9 @@ use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdStringWrapperNameEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\Type\StringWrapper;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\Type\StringWrapperType;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\UpdateCompositeIntIdEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\UpdateCompositeObjectNoToStringIdEntity;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\UpdateEmployeeProfile;
 use Symfony\Bridge\Doctrine\Tests\TestRepositoryFactory;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator;
@@ -942,5 +948,244 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
                 }
             }],
         ];
+    }
+
+    public function testValidateDTOUniqueness()
+    {
+        $constraint = new UniqueEntity([
+            'message' => 'myMessage',
+            'fields' => ['name'],
+            'em' => self::EM_NAME,
+            'entityClass' => Person::class,
+        ]);
+
+        $entity = new Person(1, 'Foo');
+        $dto = new HireAnEmployee('Foo');
+
+        $this->validator->validate($entity, $constraint);
+
+        $this->assertNoViolation();
+
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        $this->validator->validate($entity, $constraint);
+
+        $this->assertNoViolation();
+
+        $this->validator->validate($dto, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->atPath('property.path.name')
+            ->setInvalidValue('Foo')
+            ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
+            ->setCause([$entity])
+            ->setParameters(['{{ value }}' => '"Foo"'])
+            ->assertRaised();
+    }
+
+    public function testValidateMappingOfFieldNames()
+    {
+        $constraint = new UniqueEntity([
+            'message' => 'myMessage',
+            'fields' => ['primaryName' => 'name', 'secondaryName' => 'name2'],
+            'em' => self::EM_NAME,
+            'entityClass' => DoubleNameEntity::class,
+        ]);
+
+        $entity = new DoubleNameEntity(1, 'Foo', 'Bar');
+        $dto = new CreateDoubleNameEntity('Foo', 'Bar');
+
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        $this->validator->validate($dto, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->atPath('property.path.name')
+            ->setParameter('{{ value }}', '"Foo"')
+            ->setInvalidValue('Foo')
+            ->setCause([$entity])
+            ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
+            ->assertRaised();
+    }
+
+    public function testInvalidateDTOFieldName()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The field "primaryName" is not a property of class "Symfony\Bridge\Doctrine\Tests\Fixtures\HireAnEmployee".');
+        $constraint = new UniqueEntity([
+            'message' => 'myMessage',
+            'fields' => ['primaryName' => 'name'],
+            'em' => self::EM_NAME,
+            'entityClass' => SingleStringIdEntity::class,
+        ]);
+
+        $dto = new HireAnEmployee('Foo');
+        $this->validator->validate($dto, $constraint);
+    }
+
+    public function testInvalidateEntityFieldName()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The field "name2" is not mapped by Doctrine, so it cannot be validated for uniqueness.');
+        $constraint = new UniqueEntity([
+            'message' => 'myMessage',
+            'fields' => ['name2'],
+            'em' => self::EM_NAME,
+            'entityClass' => SingleStringIdEntity::class,
+        ]);
+
+        $dto = new HireAnEmployee('Foo');
+        $this->validator->validate($dto, $constraint);
+    }
+
+    public function testValidateDTOUniquenessWhenUpdatingEntity()
+    {
+        $constraint = new UniqueEntity([
+            'message' => 'myMessage',
+            'fields' => ['name'],
+            'em' => self::EM_NAME,
+            'entityClass' => Person::class,
+            'identifierFieldNames' => ['id'],
+        ]);
+
+        $entity1 = new Person(1, 'Foo');
+        $entity2 = new Person(2, 'Bar');
+
+        $this->em->persist($entity1);
+        $this->em->persist($entity2);
+        $this->em->flush();
+
+        $dto = new UpdateEmployeeProfile(2, 'Foo');
+
+        $this->validator->validate($dto, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->atPath('property.path.name')
+            ->setInvalidValue('Foo')
+            ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
+            ->setCause([$entity1])
+            ->setParameters(['{{ value }}' => '"Foo"'])
+            ->assertRaised();
+    }
+
+    public function testValidateDTOUniquenessWhenUpdatingEntityWithTheSameValue()
+    {
+        $constraint = new UniqueEntity([
+            'message' => 'myMessage',
+            'fields' => ['name'],
+            'em' => self::EM_NAME,
+            'entityClass' => CompositeIntIdEntity::class,
+            'identifierFieldNames' => ['id1', 'id2'],
+        ]);
+
+        $entity = new CompositeIntIdEntity(1, 2, 'Foo');
+
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        $dto = new UpdateCompositeIntIdEntity(1, 2, 'Foo');
+
+        $this->validator->validate($dto, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testValidateIdentifierMappingOfFieldNames()
+    {
+        $constraint = new UniqueEntity([
+            'message' => 'myMessage',
+            'fields' => ['object1' => 'objectOne', 'object2' => 'objectTwo'],
+            'em' => self::EM_NAME,
+            'entityClass' => CompositeObjectNoToStringIdEntity::class,
+            'identifierFieldNames' => ['object1' => 'objectOne', 'object2' => 'objectTwo'],
+        ]);
+
+        $objectOne = new SingleIntIdNoToStringEntity(1, 'foo');
+        $objectTwo = new SingleIntIdNoToStringEntity(2, 'bar');
+
+        $this->em->persist($objectOne);
+        $this->em->persist($objectTwo);
+        $this->em->flush();
+
+        $entity = new CompositeObjectNoToStringIdEntity($objectOne, $objectTwo);
+
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        $dto = new UpdateCompositeObjectNoToStringIdEntity($objectOne, $objectTwo, 'Foo');
+
+        $this->validator->validate($dto, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidateMissingIdentifierFieldName()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('The "Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeObjectNoToStringIdEntity" entity identifier field names should be "objectOne, objectTwo", not "objectTwo".');
+        $constraint = new UniqueEntity([
+            'message' => 'myMessage',
+            'fields' => ['object1' => 'objectOne', 'object2' => 'objectTwo'],
+            'em' => self::EM_NAME,
+            'entityClass' => CompositeObjectNoToStringIdEntity::class,
+            'identifierFieldNames' => ['object2' => 'objectTwo'],
+        ]);
+
+        $objectOne = new SingleIntIdNoToStringEntity(1, 'foo');
+        $objectTwo = new SingleIntIdNoToStringEntity(2, 'bar');
+
+        $this->em->persist($objectOne);
+        $this->em->persist($objectTwo);
+        $this->em->flush();
+
+        $entity = new CompositeObjectNoToStringIdEntity($objectOne, $objectTwo);
+
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        $dto = new UpdateCompositeObjectNoToStringIdEntity($objectOne, $objectTwo, 'Foo');
+        $this->validator->validate($dto, $constraint);
+    }
+
+    public function testUninitializedValueThrowException()
+    {
+        $this->expectExceptionMessage('Typed property Symfony\Bridge\Doctrine\Tests\Fixtures\Dto::$foo must not be accessed before initialization');
+        $constraint = new UniqueEntity([
+            'message' => 'myMessage',
+            'fields' => ['foo' => 'name'],
+            'em' => self::EM_NAME,
+            'entityClass' => DoubleNameEntity::class,
+        ]);
+
+        $entity = new DoubleNameEntity(1, 'Foo', 'Bar');
+        $dto = new Dto();
+
+        $this->em->persist($entity);
+        $this->em->flush();
+
+        $this->validator->validate($dto, $constraint);
+    }
+
+    public function testEntityManagerNullObjectWhenDTO()
+    {
+        $this->expectException(ConstraintDefinitionException::class);
+        $this->expectExceptionMessage('Unable to find the object manager associated with an entity of class "Symfony\Bridge\Doctrine\Tests\Fixtures\Person"');
+        $constraint = new UniqueEntity([
+            'message' => 'myMessage',
+            'fields' => ['name'],
+            'entityClass' => Person::class,
+            // no "em" option set
+        ]);
+
+        $this->em = null;
+        $this->registry = $this->createRegistryMock($this->em);
+        $this->validator = $this->createValidator();
+        $this->validator->initialize($this->context);
+
+        $dto = new HireAnEmployee('Foo');
+
+        $this->validator->validate($dto, $constraint);
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -35,6 +35,7 @@ class UniqueEntity extends Constraint
     public array|string $fields = [];
     public ?string $errorPath = null;
     public bool|array|string $ignoreNull = true;
+    public array $identifierFieldNames = [];
 
     /**
      * @param array|string         $fields           The combination of fields that must contain unique values or a set of options
@@ -54,6 +55,7 @@ class UniqueEntity extends Constraint
         ?string $repositoryMethod = null,
         ?string $errorPath = null,
         bool|string|array|null $ignoreNull = null,
+        ?array $identifierFieldNames = null,
         ?array $groups = null,
         $payload = null,
         array $options = [],
@@ -73,6 +75,7 @@ class UniqueEntity extends Constraint
         $this->repositoryMethod = $repositoryMethod ?? $this->repositoryMethod;
         $this->errorPath = $errorPath ?? $this->errorPath;
         $this->ignoreNull = $ignoreNull ?? $this->ignoreNull;
+        $this->identifierFieldNames = $identifierFieldNames ?? $this->identifierFieldNames;
     }
 
     public function getRequiredOptions(): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.x <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- pleasedate src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #22592
| License       | MIT
| Doc PR        | symfony/symfony-docs#14458 <!-- required for new features -->

Yet another try to allow validating every class against unique entity constraint.
Based on the knowledge from issue https://github.com/symfony/symfony/issues/22592 and pull request https://github.com/symfony/symfony/pull/24974.

This constraint doesn’t provide any protection against race conditions, which is enough in most cases. You can always try-catch flush method. Let's not talk about this problem.

Current state:
- can be applied only to an entity,
- support entity inheritance,
- can validate unique combinations of multiple fields,
- meaningful errors related to entities,
- is valid during an update, when the only matched entity is the same as the entity being validated

New state:
- preserve the current state,
- all old tests pass (no changes in them),
- no breaking changes,
- can be applied to any class (like DTO),
- can map object fields to entity fields (optional),
- when the object update some entity, there is an option to provide the identifier field names to match that entity (optional)

Examples:
1. DTO adds a new entity.
```
namespace App\Message;

use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;

/**
 * @UniqueEntity(fields={"name"}, entityClass="App\Entity\User")
 */
class HireAnEmployee
{
    public $name;

    public function __construct($name)
    {
        $this->name = $name;
    }
}
```

2. DTO adds a new entity, but the name of the field in the entity is different.
```
namespace App\Message;

use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;

/**
 * @UniqueEntity(fields={"name": "username"}, entityClass="App\Entity\User")
 */
class HireAnEmployee
{
    public $name;

    public function __construct($name)
    {
        $this->name = $name;
    }
}
```

3. DTO updates an entity.
```
namespace App\Message;

use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;

/**
 * @UniqueEntity(fields={"name"}, entityClass="App\Entity\User", identifierFieldNames={"uid": "id"})
 */
class UpdateEmployeeProfile
{
    public $uid;
    public $name;

    public function __construct($uid, $name)
    {
        $this->uid = $uid;
        $this->name = $name;
    }
}
```
