### PR TITLE
[RateLimiter] Moved classes implementing LimiterInterface to a new namespace

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Notifier\Notifier;
 use Symfony\Component\PropertyInfo\PropertyInfoExtractorInterface;
-use Symfony\Component\RateLimiter\TokenBucketLimiter;
+use Symfony\Component\RateLimiter\Policy\TokenBucketLimiter;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Translation\Translator;
 use Symfony\Component\Validator\Validation;
@@ -1843,7 +1843,7 @@ class Configuration implements ConfigurationInterface
                                         ->info('The service ID of a custom storage implementation, this precedes any configured "cache_pool"')
                                         ->defaultNull()
                                     ->end()
-                                    ->enumNode('strategy')
+                                    ->enumNode('policy')
                                         ->info('The rate limiting algorithm to use for this rate')
                                         ->isRequired()
                                         ->values(['fixed_window', 'token_bucket', 'sliding_window', 'no_limit'])
@@ -1853,10 +1853,10 @@ class Configuration implements ConfigurationInterface
                                         ->isRequired()
                                     ->end()
                                     ->scalarNode('interval')
-                                        ->info('Configures the fixed interval if "strategy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).')
+                                        ->info('Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).')
                                     ->end()
                                     ->arrayNode('rate')
-                                        ->info('Configures the fill rate if "strategy" is set to "token_bucket"')
+                                        ->info('Configures the fill rate if "policy" is set to "token_bucket"')
                                         ->children()
                                             ->scalarNode('interval')
                                                 ->info('Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).')

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -73,7 +73,7 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface, SecurityF
             }
 
             $limiterOptions = [
-                'strategy' => 'fixed_window',
+                'policy' => 'fixed_window',
                 'limit' => $config['max_attempts'],
                 'interval' => '1 minute',
             ];

--- a/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
+++ b/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\HttpFoundation\RateLimiter;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\RateLimiter\LimiterInterface;
-use Symfony\Component\RateLimiter\NoLimiter;
+use Symfony\Component\RateLimiter\Policy\NoLimiter;
 use Symfony\Component\RateLimiter\RateLimit;
 
 /**

--- a/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
@@ -9,11 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\RateLimiter;
+namespace Symfony\Component\RateLimiter\Policy;
 
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\NoLock;
 use Symfony\Component\RateLimiter\Exception\MaxWaitDurationExceededException;
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimit;
+use Symfony\Component\RateLimiter\Reservation;
 use Symfony\Component\RateLimiter\Storage\StorageInterface;
 use Symfony\Component\RateLimiter\Util\TimeUtil;
 

--- a/src/Symfony/Component/RateLimiter/Policy/NoLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/NoLimiter.php
@@ -9,7 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\RateLimiter;
+namespace Symfony\Component\RateLimiter\Policy;
+
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimit;
+use Symfony\Component\RateLimiter\Reservation;
 
 /**
  * Implements a non limiting limiter.

--- a/src/Symfony/Component/RateLimiter/Policy/Rate.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Rate.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\RateLimiter;
+namespace Symfony\Component\RateLimiter\Policy;
 
 use Symfony\Component\RateLimiter\Util\TimeUtil;
 

--- a/src/Symfony/Component/RateLimiter/Policy/ResetLimiterTrait.php
+++ b/src/Symfony/Component/RateLimiter/Policy/ResetLimiterTrait.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\RateLimiter;
+namespace Symfony\Component\RateLimiter\Policy;
 
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\RateLimiter\Storage\StorageInterface;

--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
@@ -9,9 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\RateLimiter;
+namespace Symfony\Component\RateLimiter\Policy;
 
 use Symfony\Component\RateLimiter\Exception\InvalidIntervalException;
+use Symfony\Component\RateLimiter\LimiterStateInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>

--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
@@ -9,11 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\RateLimiter;
+namespace Symfony\Component\RateLimiter\Policy;
 
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\NoLock;
 use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimit;
+use Symfony\Component\RateLimiter\Reservation;
 use Symfony\Component\RateLimiter\Storage\StorageInterface;
 use Symfony\Component\RateLimiter\Util\TimeUtil;
 

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucket.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucket.php
@@ -9,7 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\RateLimiter;
+namespace Symfony\Component\RateLimiter\Policy;
+
+use Symfony\Component\RateLimiter\LimiterStateInterface;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
@@ -9,11 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\RateLimiter;
+namespace Symfony\Component\RateLimiter\Policy;
 
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\NoLock;
 use Symfony\Component\RateLimiter\Exception\MaxWaitDurationExceededException;
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimit;
+use Symfony\Component\RateLimiter\Reservation;
 use Symfony\Component\RateLimiter\Storage\StorageInterface;
 
 /**

--- a/src/Symfony/Component/RateLimiter/Policy/Window.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Window.php
@@ -9,7 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\RateLimiter;
+namespace Symfony\Component\RateLimiter\Policy;
+
+use Symfony\Component\RateLimiter\LimiterStateInterface;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>

--- a/src/Symfony/Component/RateLimiter/README.md
+++ b/src/Symfony/Component/RateLimiter/README.md
@@ -22,7 +22,7 @@ use Symfony\Component\RateLimiter\RateLimiterFactory;
 
 $limiter = new RateLimiterFactory([
     'id' => 'login',
-    'strategy' => 'token_bucket',
+    'policy' => 'token_bucket',
     'limit' => 10,
     'rate' => ['interval' => '15 minutes'],
 ], new InMemoryStorage());

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -15,6 +15,11 @@ use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\NoLock;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\RateLimiter\Policy\FixedWindowLimiter;
+use Symfony\Component\RateLimiter\Policy\NoLimiter;
+use Symfony\Component\RateLimiter\Policy\Rate;
+use Symfony\Component\RateLimiter\Policy\SlidingWindowLimiter;
+use Symfony\Component\RateLimiter\Policy\TokenBucketLimiter;
 use Symfony\Component\RateLimiter\Storage\StorageInterface;
 
 /**
@@ -44,7 +49,7 @@ final class RateLimiterFactory
         $id = $this->config['id'].$key;
         $lock = $this->lockFactory ? $this->lockFactory->createLock($id) : new NoLock();
 
-        switch ($this->config['strategy']) {
+        switch ($this->config['policy']) {
             case 'token_bucket':
                 return new TokenBucketLimiter($id, $this->config['limit'], $this->config['rate'], $this->storage, $lock);
 
@@ -58,7 +63,7 @@ final class RateLimiterFactory
                 return new NoLimiter();
 
             default:
-                throw new \LogicException(sprintf('Limiter strategy "%s" does not exists, it must be either "token_bucket", "sliding_window", "fixed_window" or "no_limit".', $this->config['strategy']));
+                throw new \LogicException(sprintf('Limiter policy "%s" does not exists, it must be either "token_bucket", "sliding_window", "fixed_window" or "no_limit".', $this->config['policy']));
         }
     }
 
@@ -78,7 +83,7 @@ final class RateLimiterFactory
 
         $options
             ->define('id')->required()
-            ->define('strategy')
+            ->define('policy')
                 ->required()
                 ->allowedValues('token_bucket', 'fixed_window', 'sliding_window', 'no_limit')
 

--- a/src/Symfony/Component/RateLimiter/Tests/CompoundLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/CompoundLimiterTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\RateLimiter\CompoundLimiter;
 use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
-use Symfony\Component\RateLimiter\FixedWindowLimiter;
+use Symfony\Component\RateLimiter\Policy\FixedWindowLimiter;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 /**

--- a/src/Symfony/Component/RateLimiter/Tests/LimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/LimiterTest.php
@@ -13,10 +13,10 @@ namespace Symfony\Component\RateLimiter\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Lock\LockFactory;
-use Symfony\Component\RateLimiter\FixedWindowLimiter;
+use Symfony\Component\RateLimiter\Policy\FixedWindowLimiter;
+use Symfony\Component\RateLimiter\Policy\TokenBucketLimiter;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\StorageInterface;
-use Symfony\Component\RateLimiter\TokenBucketLimiter;
 
 class LimiterTest extends TestCase
 {
@@ -24,7 +24,7 @@ class LimiterTest extends TestCase
     {
         $factory = $this->createFactory([
             'id' => 'test',
-            'strategy' => 'token_bucket',
+            'policy' => 'token_bucket',
             'limit' => 10,
             'rate' => ['interval' => '1 second'],
         ]);
@@ -37,7 +37,7 @@ class LimiterTest extends TestCase
     {
         $factory = $this->createFactory([
             'id' => 'test',
-            'strategy' => 'fixed_window',
+            'policy' => 'fixed_window',
             'limit' => 10,
             'interval' => '1 minute',
         ]);
@@ -53,7 +53,7 @@ class LimiterTest extends TestCase
 
         $this->createFactory([
             'id' => 'test',
-            'strategy' => 'fixed_window',
+            'policy' => 'fixed_window',
             'limit' => 10,
             'interval' => '1 minut',
         ]);

--- a/src/Symfony/Component/RateLimiter/Tests/RateLimiterFactoryTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/RateLimiterFactoryTest.php
@@ -13,12 +13,12 @@ namespace Symfony\Component\RateLimiter\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
-use Symfony\Component\RateLimiter\FixedWindowLimiter;
-use Symfony\Component\RateLimiter\NoLimiter;
+use Symfony\Component\RateLimiter\Policy\FixedWindowLimiter;
+use Symfony\Component\RateLimiter\Policy\NoLimiter;
+use Symfony\Component\RateLimiter\Policy\SlidingWindowLimiter;
+use Symfony\Component\RateLimiter\Policy\TokenBucketLimiter;
 use Symfony\Component\RateLimiter\RateLimiterFactory;
-use Symfony\Component\RateLimiter\SlidingWindowLimiter;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
-use Symfony\Component\RateLimiter\TokenBucketLimiter;
 
 class RateLimiterFactoryTest extends TestCase
 {
@@ -35,7 +35,7 @@ class RateLimiterFactoryTest extends TestCase
     public function validConfigProvider()
     {
         yield [TokenBucketLimiter::class, [
-            'strategy' => 'token_bucket',
+            'policy' => 'token_bucket',
             'id' => 'test',
             'limit' => 5,
             'rate' => [
@@ -43,19 +43,19 @@ class RateLimiterFactoryTest extends TestCase
             ],
         ]];
         yield [FixedWindowLimiter::class, [
-            'strategy' => 'fixed_window',
+            'policy' => 'fixed_window',
             'id' => 'test',
             'limit' => 5,
             'interval' => '5 seconds',
         ]];
         yield [SlidingWindowLimiter::class, [
-            'strategy' => 'sliding_window',
+            'policy' => 'sliding_window',
             'id' => 'test',
             'limit' => 5,
             'interval' => '5 seconds',
         ]];
         yield [NoLimiter::class, [
-            'strategy' => 'no_limit',
+            'policy' => 'no_limit',
             'id' => 'test',
         ]];
     }
@@ -73,7 +73,7 @@ class RateLimiterFactoryTest extends TestCase
     public function invalidConfigProvider()
     {
         yield [MissingOptionsException::class, [
-            'strategy' => 'token_bucket',
+            'policy' => 'token_bucket',
         ]];
     }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/Storage/CacheStorageTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Storage/CacheStorageTest.php
@@ -14,8 +14,8 @@ namespace Symfony\Component\RateLimiter\Tests\Storage;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\RateLimiter\Policy\Window;
 use Symfony\Component\RateLimiter\Storage\CacheStorage;
-use Symfony\Component\RateLimiter\Window;
 
 class CacheStorageTest extends TestCase
 {

--- a/src/Symfony/Component/RateLimiter/Tests/Strategy/FixedWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Strategy/FixedWindowLimiterTest.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\RateLimiter\Tests;
+namespace Symfony\Component\RateLimiter\Tests\Policy;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClockMock;
-use Symfony\Component\RateLimiter\FixedWindowLimiter;
+use Symfony\Component\RateLimiter\Policy\FixedWindowLimiter;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Symfony\Component\RateLimiter\Tests\Resources\DummyWindow;
 

--- a/src/Symfony/Component/RateLimiter/Tests/Strategy/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Strategy/SlidingWindowLimiterTest.php
@@ -9,12 +9,12 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\RateLimiter\Tests;
+namespace Symfony\Component\RateLimiter\Tests\Policy;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
-use Symfony\Component\RateLimiter\SlidingWindowLimiter;
+use Symfony\Component\RateLimiter\Policy\SlidingWindowLimiter;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 /**

--- a/src/Symfony/Component/RateLimiter/Tests/Strategy/SlidingWindowTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Strategy/SlidingWindowTest.php
@@ -9,11 +9,11 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\RateLimiter\Tests;
+namespace Symfony\Component\RateLimiter\Tests\Policy;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\RateLimiter\Exception\InvalidIntervalException;
-use Symfony\Component\RateLimiter\SlidingWindow;
+use Symfony\Component\RateLimiter\Policy\SlidingWindow;
 
 class SlidingWindowTest extends TestCase
 {

--- a/src/Symfony/Component/RateLimiter/Tests/Strategy/TokenBucketLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Strategy/TokenBucketLimiterTest.php
@@ -9,16 +9,16 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\RateLimiter\Tests;
+namespace Symfony\Component\RateLimiter\Tests\Policy;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\RateLimiter\Exception\MaxWaitDurationExceededException;
-use Symfony\Component\RateLimiter\Rate;
+use Symfony\Component\RateLimiter\Policy\Rate;
+use Symfony\Component\RateLimiter\Policy\TokenBucket;
+use Symfony\Component\RateLimiter\Policy\TokenBucketLimiter;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Symfony\Component\RateLimiter\Tests\Resources\DummyWindow;
-use Symfony\Component\RateLimiter\TokenBucket;
-use Symfony\Component\RateLimiter\TokenBucketLimiter;
 
 /**
  * @group time-sensitive

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
@@ -37,13 +37,13 @@ class LoginThrottlingListenerTest extends TestCase
 
         $localLimiter = new RateLimiterFactory([
             'id' => 'login',
-            'strategy' => 'fixed_window',
+            'policy' => 'fixed_window',
             'limit' => 3,
             'interval' => '1 minute',
         ], new InMemoryStorage());
         $globalLimiter = new RateLimiterFactory([
             'id' => 'login',
-            'strategy' => 'fixed_window',
+            'policy' => 'fixed_window',
             'limit' => 6,
             'interval' => '1 minute',
         ], new InMemoryStorage());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no?
| Tickets       | 
| License       | MIT
| Doc PR        | 

Before we release the RateLimit component. 
I think it would be a good idea to put the 7 classes that belongs to a specific strategy in their own "Policy" namespace. It is very likely that it will be more strategies in the future and the `Symfony\Component\RateLimiter` namespace is crowed as it is. 

I decided not to put the `CompoundLimiter` in this namespace as it is not a strategy. 