### PR TITLE
[RateLimiter] Allow configuration value "no_limit"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1846,7 +1846,7 @@ class Configuration implements ConfigurationInterface
                                     ->enumNode('strategy')
                                         ->info('The rate limiting algorithm to use for this rate')
                                         ->isRequired()
-                                        ->values(['fixed_window', 'token_bucket', 'sliding_window'])
+                                        ->values(['fixed_window', 'token_bucket', 'sliding_window', 'no_limit'])
                                     ->end()
                                     ->integerNode('limit')
                                         ->info('The maximum allowed hits in a fixed interval or burst')

--- a/src/Symfony/Component/RateLimiter/RateLimiter.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiter.php
@@ -54,8 +54,11 @@ final class RateLimiter
             case 'sliding_window':
                 return new SlidingWindowLimiter($id, $this->config['limit'], $this->config['interval'], $this->storage, $lock);
 
+            case 'no_limit':
+                return new NoLimiter();
+
             default:
-                throw new \LogicException(sprintf('Limiter strategy "%s" does not exists, it must be either "token_bucket", "sliding_window" or "fixed_window".', $this->config['strategy']));
+                throw new \LogicException(sprintf('Limiter strategy "%s" does not exists, it must be either "token_bucket", "sliding_window", "fixed_window" or "no_limit".', $this->config['strategy']));
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | maybe?
| New feature?  | not sure
| Deprecations? | 
| Tickets       | 
| License       | MIT
| Doc PR        | 

I dont see any reason why we should allow people to configure "no_limit". I assume this was just forgotten. 
