### PR TITLE
[RateLimiter] Remove Window::sleep()

### DIFF
--- a/src/Symfony/Component/RateLimiter/Window.php
+++ b/src/Symfony/Component/RateLimiter/Window.php
@@ -85,12 +85,4 @@ final class Window implements LimiterStateInterface
 
         return $cyclesRequired * $this->intervalInSeconds;
     }
-
-    /**
-     * @internal
-     */
-    public function __sleep(): array
-    {
-        return ['id', 'hitCount', 'intervalInSeconds', 'timer', 'maxSize'];
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | 
| Tickets       | 
| License       | MIT
| Doc PR        | 

This function is not needed since #38562
