### PR TITLE
[RateLimiter] Be more type safe when fetching from cache

### DIFF
--- a/src/Symfony/Component/RateLimiter/Storage/CacheStorage.php
+++ b/src/Symfony/Component/RateLimiter/Storage/CacheStorage.php
@@ -42,11 +42,12 @@ class CacheStorage implements StorageInterface
     public function fetch(string $limiterStateId): ?LimiterStateInterface
     {
         $cacheItem = $this->pool->getItem(sha1($limiterStateId));
-        if (!$cacheItem->isHit()) {
-            return null;
+        $value = $cacheItem->get();
+        if ($value instanceof LimiterStateInterface) {
+            return $value;
         }
 
-        return $cacheItem->get();
+        return null;
     }
 
     public function delete(string $limiterStateId): void

--- a/src/Symfony/Component/RateLimiter/Tests/Storage/CacheStorageTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Storage/CacheStorageTest.php
@@ -55,6 +55,18 @@ class CacheStorageTest extends TestCase
         $this->assertEquals($window, $this->storage->fetch('test'));
     }
 
+    public function testFetchExistingJunk()
+    {
+        $cacheItem = $this->createMock(CacheItemInterface::class);
+
+        $cacheItem->expects($this->any())->method('get')->willReturn('junk');
+        $cacheItem->expects($this->any())->method('isHit')->willReturn(true);
+
+        $this->pool->expects($this->any())->method('getItem')->with(sha1('test'))->willReturn($cacheItem);
+
+        $this->assertNull($this->storage->fetch('test'));
+    }
+
     public function testFetchNonExistingState()
     {
         $cacheItem = $this->createMock(CacheItemInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This is a super minor thing. A `$cacheItem` can be a hit, but it does not contain a `LimiterStateInterface`. 

Also, PSR-6 specifies that if the `$cacheItem` is not a hit, it must return null.
