### PR TITLE
[FrameworkBundle] correct default arg

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
@@ -53,7 +53,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('translation loaders locator'),
                 service('translator.formatter'),
                 param('kernel.default_locale'),
-                abstract_arg('translation loaders ids'),
+                [], // translation loaders ids
                 [
                     'cache_dir' => param('kernel.cache_dir').'/translations',
                     'debug' => param('kernel.debug'),


### PR DESCRIPTION
correct default arg from abstract_arg to empty array. fixes #38615

| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38615
| License       | MIT
| Doc PR        | n/a

