### PR TITLE
[RateLimiter] Make sure we actually can use sliding_window and no_limit

### DIFF
--- a/src/Symfony/Component/RateLimiter/RateLimiter.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiter.php
@@ -80,7 +80,7 @@ final class RateLimiter
             ->define('id')->required()
             ->define('strategy')
                 ->required()
-                ->allowedValues('token_bucket', 'fixed_window')
+                ->allowedValues('token_bucket', 'fixed_window', 'sliding_window', 'no_limit')
 
             ->define('limit')->allowedTypes('int')
             ->define('interval')->allowedTypes('string')->normalize($intervalNormalizer)

--- a/src/Symfony/Component/RateLimiter/Tests/RateLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/RateLimiterTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\RateLimiter\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+use Symfony\Component\RateLimiter\FixedWindowLimiter;
+use Symfony\Component\RateLimiter\NoLimiter;
+use Symfony\Component\RateLimiter\RateLimiter;
+use Symfony\Component\RateLimiter\SlidingWindowLimiter;
+use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
+use Symfony\Component\RateLimiter\TokenBucketLimiter;
+
+class RateLimiterTest extends TestCase
+{
+    /**
+     * @dataProvider validConfigProvider
+     */
+    public function testValidConfig(string $expectedClass, array $config)
+    {
+        $factory = new RateLimiter($config, new InMemoryStorage());
+        $rateLimiter = $factory->create('key');
+        $this->assertInstanceOf($expectedClass, $rateLimiter);
+    }
+
+    public function validConfigProvider()
+    {
+        yield [TokenBucketLimiter::class, [
+            'strategy' => 'token_bucket',
+            'id' => 'test',
+            'limit' => 5,
+            'rate' => [
+                'interval' => '5 seconds',
+            ],
+        ]];
+        yield [FixedWindowLimiter::class, [
+            'strategy' => 'fixed_window',
+            'id' => 'test',
+            'limit' => 5,
+            'interval' => '5 seconds',
+        ]];
+        yield [SlidingWindowLimiter::class, [
+            'strategy' => 'sliding_window',
+            'id' => 'test',
+            'limit' => 5,
+            'interval' => '5 seconds',
+        ]];
+        yield [NoLimiter::class, [
+            'strategy' => 'no_limit',
+            'id' => 'test',
+        ]];
+    }
+
+    /**
+     * @dataProvider invalidConfigProvider
+     */
+    public function testInvalidConfig(string $exceptionClass, array $config)
+    {
+        $this->expectException($exceptionClass);
+        $factory = new RateLimiter($config, new InMemoryStorage());
+        $factory->create('key');
+    }
+
+    public function invalidConfigProvider()
+    {
+        yield [MissingOptionsException::class, [
+            'strategy' => 'token_bucket',
+        ]];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

I found that we never tested the config on the actually RateLimiter class. This PR adds a tests and bugfix
