### PR TITLE
[RateLimiter] Rename RateLimiter to RateLimiterFactory

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -132,7 +132,7 @@ use Symfony\Component\PropertyInfo\PropertyReadInfoExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyWriteInfoExtractorInterface;
 use Symfony\Component\RateLimiter\LimiterInterface;
-use Symfony\Component\RateLimiter\RateLimiter;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\CacheStorage;
 use Symfony\Component\Routing\Loader\AnnotationDirectoryLoader;
 use Symfony\Component\Routing\Loader\AnnotationFileLoader;
@@ -2280,7 +2280,7 @@ class FrameworkExtension extends Extension
         $limiterConfig['id'] = $name;
         $limiter->replaceArgument(0, $limiterConfig);
 
-        $container->registerAliasForArgument($limiterId, RateLimiter::class, $name.'.limiter');
+        $container->registerAliasForArgument($limiterId, RateLimiterFactory::class, $name.'.limiter');
     }
 
     private function resolveTrustedHeaders(array $headers): int

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/rate_limiter.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/rate_limiter.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Symfony\Component\RateLimiter\RateLimiter;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -19,7 +19,7 @@ return static function (ContainerConfigurator $container) {
             ->parent('cache.app')
             ->tag('cache.pool')
 
-        ->set('limiter', RateLimiter::class)
+        ->set('limiter', RateLimiterFactory::class)
             ->abstract()
             ->args([
                 abstract_arg('config'),

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface;
-use Symfony\Component\RateLimiter\RateLimiter;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Security\Http\EventListener\LoginThrottlingListener;
 use Symfony\Component\Security\Http\RateLimiter\DefaultLoginRateLimiter;
 
@@ -63,7 +63,7 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface, SecurityF
             throw new \LogicException('Login throttling requires symfony/security-http:^5.2.');
         }
 
-        if (!class_exists(RateLimiter::class)) {
+        if (!class_exists(RateLimiterFactory::class)) {
             throw new \LogicException('Login throttling requires symfony/rate-limiter to be installed and enabled.');
         }
 

--- a/src/Symfony/Component/RateLimiter/README.md
+++ b/src/Symfony/Component/RateLimiter/README.md
@@ -18,11 +18,11 @@ $ composer require symfony/rate-limiter
 
 ```php
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
-use Symfony\Component\RateLimiter\RateLimiter;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 
-$limiter = new RateLimiter([
+$limiter = new RateLimiterFactory([
     'id' => 'login',
-    'strategy' => 'token_bucket', // or 'fixed_window'
+    'strategy' => 'token_bucket',
     'limit' => 10,
     'rate' => ['interval' => '15 minutes'],
 ], new InMemoryStorage());

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -22,7 +22,7 @@ use Symfony\Component\RateLimiter\Storage\StorageInterface;
  *
  * @experimental in 5.2
  */
-final class RateLimiter
+final class RateLimiterFactory
 {
     private $config;
     private $storage;

--- a/src/Symfony/Component/RateLimiter/Tests/LimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/LimiterTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\RateLimiter\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\RateLimiter\FixedWindowLimiter;
-use Symfony\Component\RateLimiter\RateLimiter;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\StorageInterface;
 use Symfony\Component\RateLimiter\TokenBucketLimiter;
 
@@ -61,6 +61,6 @@ class LimiterTest extends TestCase
 
     private function createFactory(array $options)
     {
-        return new RateLimiter($options, $this->createMock(StorageInterface::class), $this->createMock(LockFactory::class));
+        return new RateLimiterFactory($options, $this->createMock(StorageInterface::class), $this->createMock(LockFactory::class));
     }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/RateLimiterFactoryTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/RateLimiterFactoryTest.php
@@ -15,19 +15,19 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Symfony\Component\RateLimiter\FixedWindowLimiter;
 use Symfony\Component\RateLimiter\NoLimiter;
-use Symfony\Component\RateLimiter\RateLimiter;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\SlidingWindowLimiter;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Symfony\Component\RateLimiter\TokenBucketLimiter;
 
-class RateLimiterTest extends TestCase
+class RateLimiterFactoryTest extends TestCase
 {
     /**
      * @dataProvider validConfigProvider
      */
     public function testValidConfig(string $expectedClass, array $config)
     {
-        $factory = new RateLimiter($config, new InMemoryStorage());
+        $factory = new RateLimiterFactory($config, new InMemoryStorage());
         $rateLimiter = $factory->create('key');
         $this->assertInstanceOf($expectedClass, $rateLimiter);
     }
@@ -66,7 +66,7 @@ class RateLimiterTest extends TestCase
     public function testInvalidConfig(string $exceptionClass, array $config)
     {
         $this->expectException($exceptionClass);
-        $factory = new RateLimiter($config, new InMemoryStorage());
+        $factory = new RateLimiterFactory($config, new InMemoryStorage());
         $factory->create('key');
     }
 

--- a/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
+++ b/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Security\Http\RateLimiter;
 
 use Symfony\Component\HttpFoundation\RateLimiter\AbstractRequestRateLimiter;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\RateLimiter\RateLimiter;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\Security\Core\Security;
 
 /**
@@ -28,20 +28,20 @@ use Symfony\Component\Security\Core\Security;
  */
 final class DefaultLoginRateLimiter extends AbstractRequestRateLimiter
 {
-    private $globalLimiter;
-    private $localLimiter;
+    private $globalFactory;
+    private $localFactory;
 
-    public function __construct(RateLimiter $globalLimiter, RateLimiter $localLimiter)
+    public function __construct(RateLimiterFactory $globalFactory, RateLimiterFactory $localFactory)
     {
-        $this->globalLimiter = $globalLimiter;
-        $this->localLimiter = $localLimiter;
+        $this->globalFactory = $globalFactory;
+        $this->localFactory = $localFactory;
     }
 
     protected function getLimiters(Request $request): array
     {
         return [
-            $this->globalLimiter->create($request->getClientIp()),
-            $this->localLimiter->create($request->attributes->get(Security::LAST_USERNAME).$request->getClientIp()),
+            $this->globalFactory->create($request->getClientIp()),
+            $this->localFactory->create($request->attributes->get(Security::LAST_USERNAME).$request->getClientIp()),
         ];
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Security\Http\Tests\EventListener;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\RateLimiter\RateLimiter;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\TooManyLoginAttemptsAuthenticationException;
@@ -35,13 +35,13 @@ class LoginThrottlingListenerTest extends TestCase
     {
         $this->requestStack = new RequestStack();
 
-        $localLimiter = new RateLimiter([
+        $localLimiter = new RateLimiterFactory([
             'id' => 'login',
             'strategy' => 'fixed_window',
             'limit' => 3,
             'interval' => '1 minute',
         ], new InMemoryStorage());
-        $globalLimiter = new RateLimiter([
+        $globalLimiter = new RateLimiterFactory([
             'id' => 'login',
             'strategy' => 'fixed_window',
             'limit' => 6,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | No, not released yet
| Tickets       | 
| License       | MIT
| Doc PR        | should be added

Sorry for making a few BC breaks. 

@wouterj [said](https://github.com/symfony/symfony/pull/38562#issue-503193238) that this class was suggested to be named `LimiterFactory` before. But that was rejected. 

Just my looking at the names of the classes we currently have: 
- Rate
- RateLimit
- RateLimiter

I find it hard to know what these are doing and the difference between them. Note that none of them are used as a rate limiter (ie implements `LimiterInterface`)

I would like to be clear that a `RateLimiterFactory` is used to create an object implementing `LimiterInterface`. 