### PR TITLE
[PhpUnitBridge] Add missing exporter function for PHPUnit 7

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintTraitForV7.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintTraitForV7.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bridge\PhpUnit\Legacy;
 
+use SebastianBergmann\Exporter\Exporter;
+
 /**
  * @internal
  */
@@ -29,6 +31,15 @@ trait ConstraintTraitForV7
     protected function additionalFailureDescription($other): string
     {
         return $this->doAdditionalFailureDescription($other);
+    }
+
+    protected function exporter(): Exporter
+    {
+        if (null !== $this->exporter) {
+            $this->exporter = new Exporter();
+        }
+
+        return $this->exporter;
     }
 
     protected function failureDescription($other): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

This adds a missing `exporter` function to the compatibility trait for PHPUnit constraints. This method is still required for PhpUnit 7.