### PR TITLE
[PHPUnitBridge] Support PHPUnit 8 and PHPUnit 9 in constraint compatibility trait

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/ConstraintTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/ConstraintTrait.php
@@ -20,9 +20,19 @@ if (\PHP_VERSION_ID < 70000 || !$r->getMethod('matches')->hasReturnType()) {
     {
         use Legacy\ConstraintTraitForV6;
     }
-} else {
+} elseif ($r->getProperty('exporter')->isProtected()) {
     trait ConstraintTrait
     {
         use Legacy\ConstraintTraitForV7;
+    }
+} elseif (\PHP_VERSION < 70100 || !$r->getMethod('evaluate')->hasReturnType()) {
+    trait ConstraintTrait
+    {
+        use Legacy\ConstraintTraitForV8;
+    }
+} else {
+    trait ConstraintTrait
+    {
+        use Legacy\ConstraintTraitForV9;
     }
 }

--- a/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintLogicTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintLogicTrait.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Legacy;
+
+/**
+ * @internal
+ */
+trait ConstraintLogicTrait
+{
+    private function doEvaluate($other, $description, $returnResult)
+    {
+        $success = false;
+
+        if ($this->matches($other)) {
+            $success = true;
+        }
+
+        if ($returnResult) {
+            return $success;
+        }
+
+        if (!$success) {
+            $this->fail($other, $description);
+        }
+
+        return null;
+    }
+
+    private function doAdditionalFailureDescription($other): string
+    {
+        return '';
+    }
+
+    private function doCount(): int
+    {
+        return 1;
+    }
+
+    private function doFailureDescription($other): string
+    {
+        return $this->exporter()->export($other).' '.$this->toString();
+    }
+
+    private function doMatches($other): bool
+    {
+        return false;
+    }
+
+    private function doToString(): string
+    {
+        return '';
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintTraitForV6.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintTraitForV6.php
@@ -19,6 +19,14 @@ use SebastianBergmann\Exporter\Exporter;
 trait ConstraintTraitForV6
 {
     /**
+     * @return bool|null
+     */
+    public function evaluate($other, $description = '', $returnResult = false)
+    {
+        return $this->doEvaluate($other, $description, $returnResult);
+    }
+
+    /**
      * @return int
      */
     public function count()
@@ -84,6 +92,25 @@ trait ConstraintTraitForV6
     private function doCount()
     {
         return 1;
+    }
+
+    private function doEvaluate($other, $description, $returnResult)
+    {
+        $success = false;
+
+        if ($this->matches($other)) {
+            $success = true;
+        }
+
+        if ($returnResult) {
+            return $success;
+        }
+
+        if (!$success) {
+            $this->fail($other, $description);
+        }
+
+        return null;
     }
 
     private function doFailureDescription($other)

--- a/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintTraitForV8.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintTraitForV8.php
@@ -14,7 +14,7 @@ namespace Symfony\Bridge\PhpUnit\Legacy;
 /**
  * @internal
  */
-trait ConstraintTraitForV7
+trait ConstraintTraitForV8
 {
     use ConstraintLogicTrait;
 

--- a/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintTraitForV9.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/ConstraintTraitForV9.php
@@ -14,14 +14,11 @@ namespace Symfony\Bridge\PhpUnit\Legacy;
 /**
  * @internal
  */
-trait ConstraintTraitForV7
+trait ConstraintTraitForV9
 {
     use ConstraintLogicTrait;
 
-    /**
-     * @return bool|null
-     */
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {
         return $this->doEvaluate($other, $description, $returnResult);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | not really
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

This expands the compatibility layer for PHPUnit constraints by supporting PHPUnit 8 and PHPUnit 9. Support for the latter requires also adding the `evaluate` method to the trait, as this method gets a signature change in PHPUnit 9.