### PR TITLE
[HttpClient] never trace content of event-stream responses

### DIFF
--- a/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
+++ b/src/Symfony/Component/HttpClient/EventSourceHttpClient.php
@@ -60,6 +60,10 @@ final class EventSourceHttpClient implements HttpClientInterface
 
         if ($accept = self::normalizeHeaders($options['headers'] ?? [])['accept'] ?? []) {
             $state->buffer = \in_array($accept, [['Accept: text/event-stream'], ['accept: text/event-stream']], true) ? '' : null;
+
+            if (null !== $state->buffer) {
+                $options['extra']['trace_content'] = false;
+            }
         }
 
         return new AsyncResponse($this->client, $method, $url, $options, static function (ChunkInterface $chunk, AsyncContext $context) use ($state, $method, $url, $options) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Let's leverage #38587 in `EventSourceHttpClient`