### PR TITLE
[HttpClient] Add a Stopwatch on TraceableHttpClient

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.js
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.js
@@ -413,6 +413,7 @@ class Theme {
             'doctrine': '#ff6633',
             'messenger_middleware': '#bdb81e',
             'controller.argument_value_resolver': '#8c5de6',
+            'http_client': '#ffa333',
         };
 
         this.customCategoryColors = [

--- a/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php
+++ b/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpClient\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpClient\TraceableHttpClient;
 
@@ -36,7 +37,7 @@ final class HttpClientPass implements CompilerPassInterface
 
         foreach ($container->findTaggedServiceIds($this->clientTag) as $id => $tags) {
             $container->register('.debug.'.$id, TraceableHttpClient::class)
-                ->setArguments([new Reference('.debug.'.$id.'.inner')])
+                ->setArguments([new Reference('.debug.'.$id.'.inner'), new Reference('debug.stopwatch', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)])
                 ->setDecoratedService($id);
             $container->getDefinition('data_collector.http_client')
                 ->addMethodCall('registerClient', [$id, new Reference('.debug.'.$id)]);

--- a/src/Symfony/Component/HttpClient/Response/TraceableResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/TraceableResponse.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\HttpClient\Response;
 
+use Symfony\Component\HttpClient\Chunk\ErrorChunk;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\Exception\RedirectionException;
 use Symfony\Component\HttpClient\Exception\ServerException;
 use Symfony\Component\HttpClient\TraceableHttpClient;
+use Symfony\Component\Stopwatch\StopwatchEvent;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
@@ -32,57 +34,98 @@ class TraceableResponse implements ResponseInterface, StreamableInterface
     private $client;
     private $response;
     private $content;
+    private $event;
 
-    public function __construct(HttpClientInterface $client, ResponseInterface $response, &$content)
+    public function __construct(HttpClientInterface $client, ResponseInterface $response, &$content, StopwatchEvent $event = null)
     {
         $this->client = $client;
         $this->response = $response;
         $this->content = &$content;
+        $this->event = $event;
+    }
+
+    public function __destruct()
+    {
+        try {
+            $this->response->__destruct();
+        } finally {
+            if ($this->event && $this->event->isStarted()) {
+                $this->event->stop();
+            }
+        }
     }
 
     public function getStatusCode(): int
     {
-        return $this->response->getStatusCode();
+        try {
+            return $this->response->getStatusCode();
+        } finally {
+            if ($this->event && $this->event->isStarted()) {
+                $this->event->lap();
+            }
+        }
     }
 
     public function getHeaders(bool $throw = true): array
     {
-        return $this->response->getHeaders($throw);
+        try {
+            return $this->response->getHeaders($throw);
+        } finally {
+            if ($this->event && $this->event->isStarted()) {
+                $this->event->lap();
+            }
+        }
     }
 
     public function getContent(bool $throw = true): string
     {
-        if (false === $this->content) {
-            return $this->response->getContent($throw);
+        try {
+            if (false === $this->content) {
+                return $this->response->getContent($throw);
+            }
+
+            $this->content = $this->response->getContent(false);
+
+            if ($throw) {
+                $this->checkStatusCode($this->response->getStatusCode());
+            }
+
+            return $this->content;
+        } finally {
+            if ($this->event && $this->event->isStarted()) {
+                $this->event->stop();
+            }
         }
-
-        $this->content = $this->response->getContent(false);
-
-        if ($throw) {
-            $this->checkStatusCode($this->response->getStatusCode());
-        }
-
-        return $this->content;
     }
 
     public function toArray(bool $throw = true): array
     {
-        if (false === $this->content) {
-            return $this->response->toArray($throw);
+        try {
+            if (false === $this->content) {
+                return $this->response->toArray($throw);
+            }
+
+            $this->content = $this->response->toArray(false);
+
+            if ($throw) {
+                $this->checkStatusCode($this->response->getStatusCode());
+            }
+
+            return $this->content;
+        } finally {
+            if ($this->event && $this->event->isStarted()) {
+                $this->event->stop();
+            }
         }
-
-        $this->content = $this->response->toArray(false);
-
-        if ($throw) {
-            $this->checkStatusCode($this->response->getStatusCode());
-        }
-
-        return $this->content;
     }
 
     public function cancel(): void
     {
         $this->response->cancel();
+
+        if ($this->event && $this->event->isStarted()) {
+            $this->event->stop();
+        }
     }
 
     public function getInfo(string $type = null)
@@ -129,9 +172,28 @@ class TraceableResponse implements ResponseInterface, StreamableInterface
 
             $traceableMap[$r->response] = $r;
             $wrappedResponses[] = $r->response;
+            if ($r->event && !$r->event->isStarted()) {
+                $r->event->start();
+            }
         }
 
         foreach ($client->stream($wrappedResponses, $timeout) as $r => $chunk) {
+            if ($traceableMap[$r]->event && $traceableMap[$r]->event->isStarted()) {
+                try {
+                    if ($chunk->isTimeout() || !$chunk->isLast()) {
+                        $traceableMap[$r]->event->lap();
+                    } else {
+                        $traceableMap[$r]->event->stop();
+                    }
+                } catch (TransportExceptionInterface $e) {
+                    $traceableMap[$r]->event->stop();
+                    if ($chunk instanceof ErrorChunk) {
+                        $chunk->didThrow(false);
+                    } else {
+                        $chunk = new ErrorChunk($chunk->getOffset(), $e);
+                    }
+                }
+            }
             yield $traceableMap[$r] => $chunk;
         }
     }

--- a/src/Symfony/Component/HttpClient/TraceableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/TraceableHttpClient.php
@@ -15,6 +15,7 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Component\HttpClient\Response\TraceableResponse;
+use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
@@ -27,10 +28,12 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface, 
 {
     private $client;
     private $tracedRequests = [];
+    private $stopwatch;
 
-    public function __construct(HttpClientInterface $client)
+    public function __construct(HttpClientInterface $client, Stopwatch $stopwatch = null)
     {
         $this->client = $client;
+        $this->stopwatch = $stopwatch;
     }
 
     /**
@@ -62,7 +65,7 @@ final class TraceableHttpClient implements HttpClientInterface, ResetInterface, 
             }
         };
 
-        return new TraceableResponse($this->client, $this->client->request($method, $url, $options), $content);
+        return new TraceableResponse($this->client, $this->client->request($method, $url, $options), $content, null === $this->stopwatch ? null : $this->stopwatch->start("$method $url", 'http_client'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I used this code to generate the screenshot below.
```php
$response = $client->request('GET', 'https://httpstat.us/200');
$response->getContent();

$responses[] = $client->request('GET', 'https://httpstat.us/200?sleep=300');
$responses[] = $client->request('GET', 'https://httpstat.us/200?sleep=100');
foreach ($client->stream($responses) as $chunk) {
}
```
![Screenshot from 2020-10-23 02-04-43](https://user-images.githubusercontent.com/578547/96942031-41883580-14d4-11eb-848e-fd21d2f4fec9.png)


