### PR TITLE
[HttpClient] Never process more than 300 requests at the same time

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -365,6 +365,10 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
                 curl_setopt($ch, \CURLOPT_VERBOSE, false);
             }
         }
+
+        foreach ($this->multi->pendingHandles as [$ch]) {
+            curl_setopt($ch, CURLOPT_VERBOSE, false);
+        }
     }
 
     public function __destruct()

--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -30,6 +30,8 @@ final class CurlClientState extends ClientState
     public $pauseExpiries = [];
     public $execCounter = \PHP_INT_MIN;
 
+    public $pendingHandles = [];
+
     public function __construct()
     {
         $this->handle = curl_multi_init();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Almost one year ago, I wrote this patch to put curl handles on an internal queue when more than 300 requests are run concurrently.

I have a reproducing script from @Seldaek that mirrors packagist instances and that makes roughly a million requests while doing so.

This script is able to chunk the requests by batches, e.g completing 500 reqs, then 500 again, etc. until the end.

Batching is required because curl/the network hangs otherwise when concurrency goes high (>5k).

I wrote this patch hoping to remove the need for batching requests in smaller chunks. It works, but at some point it still hangs.

I'm therefore submitting this patch for the record as it would need more work to be made bulletproof under the said situation. Since batching just works well enough, this might not be needed after all.

/cc @fancyweb @jderusse FYI since you're interested in high throughput uses of HttpClient.

Note that neither AmpHttpClient is able to handle the load here. /cc @kelunik 