### PR TITLE
[PHPUnitBridge] Silence warnings from mkdir()

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
@@ -41,7 +41,7 @@ class DeprecationTest extends TestCase
         }
 
         self::$vendorDir = $vendorDir;
-        mkdir($vendorDir.'/myfakevendor/myfakepackage2');
+        @mkdir($vendorDir.'/myfakevendor/myfakepackage2');
         touch($vendorDir.'/myfakevendor/myfakepackage1/MyFakeFile1.php');
         touch($vendorDir.'/myfakevendor/myfakepackage1/MyFakeFile2.php');
         touch($vendorDir.'/myfakevendor/myfakepackage2/MyFakeFile.php');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When I run `./phpunit` the second time I get a warning thrown at me. I think we could silence this warning. If the directory cannot be created then we will get a similar warning from the `touch()` function. 

```
 ./phpunit --exclude-group tty,benchmark,intl-data
#!/usr/bin/env php
PHP Warning:  mkdir(): File exists in /path/to/symfony/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php on line 44
PHP Stack trace:
PHP   1. {main}() /path/to/symfony/phpunit:0
PHP   2. require() /path/to/symfony/phpunit:31
PHP   3. require() /path/to/symfony/vendor/symfony/phpunit-bridge/bin/simple-phpunit:13
PHP   4. include() /path/to/symfony/vendor/symfony/phpunit-bridge/bin/simple-phpunit.php:411
PHP   5. PHPUnit\TextUI\Command::main($exit = *uninitialized*) /path/to/symfony/.phpunit/phpunit-9.4-0/phpunit:22
PHP   6. Symfony\Bridge\PhpUnit\Legacy\CommandForV9->run($argv = *uninitialized*, $exit = *uninitialized*) /path/to/symfony/.phpunit/phpunit-9.4-0/src/TextUI/Command.php:101
PHP   7. Symfony\Bridge\PhpUnit\Legacy\CommandForV9->handleArguments($argv = *uninitialized*) /path/to/symfony/.phpunit/phpunit-9.4-0/src/TextUI/Command.php:116
PHP   8. PHPUnit\TextUI\XmlConfiguration\TestSuiteMapper->map($configuration = *uninitialized*, $filter = *uninitialized*) /U
```