### PR TITLE
Put branch-version in the source for CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,6 @@ init:
     - SET PATH=c:\php;%PATH%
     - SET COMPOSER_NO_INTERACTION=1
     - SET SYMFONY_DEPRECATIONS_HELPER=strict
-    - SET "SYMFONY_REQUIRE=>=3.4"
     - SET ANSICON=121x90 (121x90)
     - SET SYMFONY_PHPUNIT_VERSION=4.8
     - SET SYMFONY_PHPUNIT_DISABLE_RESULT_CACHE=1
@@ -49,18 +48,23 @@ install:
     - echo curl.cainfo=c:\php\cacert.pem >> php.ini-max
     - copy /Y php.ini-min php.ini
     - echo extension=php_openssl.dll >> php.ini
+    - echo extension=php_curl.dll >> php.ini
+    - echo curl.cainfo=c:\php\cacert.pem >> php.ini
     - cd c:\projects\symfony
-    - IF NOT EXIST composer.phar (appveyor DownloadFile https://github.com/composer/composer/releases/download/1.9.0/composer.phar)
-    - php composer.phar self-update
+    - IF NOT EXIST composer.phar (appveyor DownloadFile https://github.com/composer/composer/releases/download/2.0.0/composer.phar)
+    - php composer.phar self-update --2
     - copy /Y .github\composer-config.json %APPDATA%\Composer\config.json
     - php composer.phar global require --no-progress --no-scripts --no-plugins symfony/flex
     - git config --global user.email ""
     - git config --global user.name "Symfony"
-    - php .github/build-packages.php "HEAD^" %APPVEYOR_REPO_BRANCH% src\Symfony\Bridge\PhpUnit
-    - SET COMPOSER_ROOT_VERSION=%APPVEYOR_REPO_BRANCH%.x-dev
-    - php composer.phar config platform.php 5.5.9
-    - php composer.phar update --no-progress --no-suggest --ansi
+    - FOR /F "tokens=* USEBACKQ" %%F IN (`bash -c "grep branch-version composer.json | grep -o '[0-9.]*'"`) DO (SET SYMFONY_VERSION=%%F)
+    - php .github/build-packages.php "HEAD^" %SYMFONY_VERSION% src\Symfony\Bridge\PhpUnit
+    - SET "SYMFONY_REQUIRE=>=%SYMFONY_VERSION%"
+    - SET COMPOSER_ROOT_VERSION=%SYMFONY_VERSION%.x-dev
+    - php composer.phar config --global platform.php 5.5.9
+    - php composer.phar update --no-progress --ansi
     - php phpunit install
+    - break > .phpunit/phpunit-4.8-0/vendor/composer/platform_check.php
 
 test_script:
     - SET X=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,8 +75,8 @@ before_install:
       cp .github/composer-config.json ~/.composer/config.json
       export PHPUNIT=$(readlink -f ./phpunit)
       export PHPUNIT_X="$PHPUNIT --exclude-group tty,benchmark,intl-data"
-      export COMPOSER_UP='composer update --no-progress --no-suggest --ansi'
-      export COMPONENTS=$(find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist -printf '%h\n' | sort)
+      export COMPOSER_UP='composer update --no-progress --ansi'
+      export COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -printf '%h\n' | sort)
       find ~/.phpenv -name xdebug.ini -delete
 
       if [[ $TRAVIS_PHP_VERSION = 5.* ]]; then
@@ -220,13 +220,15 @@ install:
       git config --global user.email ""
       git config --global user.name "Symfony"
 
+      export SYMFONY_VERSION=$(grep branch-version composer.json | grep -o '[0-9.]*')
+
       if [[ ! $deps ]]; then
-          php .github/build-packages.php HEAD^ $TRAVIS_BRANCH src/Symfony/Bridge/PhpUnit
+          php .github/build-packages.php HEAD^ $SYMFONY_VERSION src/Symfony/Bridge/PhpUnit
       else
           export SYMFONY_DEPRECATIONS_HELPER=weak &&
           cp composer.json composer.json.orig &&
           echo -e '{\n"require":{'"$(grep phpunit-bridge composer.json)"'"php":"*"},"minimum-stability":"dev"}' > composer.json &&
-          php .github/build-packages.php HEAD^ $TRAVIS_BRANCH $(find src/Symfony -mindepth 2 -type f -name composer.json -printf '%h\n' | sort) &&
+          php .github/build-packages.php HEAD^ $SYMFONY_VERSION $(find src/Symfony -mindepth 2 -type f -name composer.json -printf '%h\n' | sort) &&
           mv composer.json composer.json.phpunit &&
           mv composer.json.orig composer.json
       fi
@@ -242,9 +244,7 @@ install:
           export SYMFONY_VERSION=$(git ls-remote -q --heads | grep -o '/[1-9]\.[0-9].*' | tail -n 1 | sed s/.//) &&
           git fetch --depth=2 origin $SYMFONY_VERSION &&
           git checkout -m FETCH_HEAD &&
-          export COMPONENTS=$(find src/Symfony -mindepth 3 -type f -name phpunit.xml.dist -printf '%h\n' | sort)
-      else
-        export SYMFONY_VERSION=$TRAVIS_BRANCH
+          export COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -printf '%h\n' | sort)
       fi
 
     - |
@@ -289,6 +289,7 @@ install:
               return
           fi
           phpenv global ${PHP/hhvm*/hhvm}
+          rm vendor/composer/package-versions-deprecated -Rf
           if [[ $PHP = 7.* ]]; then
               ([[ $deps ]] && cd src/Symfony/Component/HttpFoundation; composer config platform.ext-mongodb 1.6.0; composer require --dev --no-update mongodb/mongodb ~1.5.0)
           fi
@@ -311,6 +312,7 @@ install:
               tfold src/Symfony/Component/Console.tty $PHPUNIT src/Symfony/Component/Console --group tty
               if [[ $PHP = ${MIN_PHP%.*} ]]; then
                   export PHP=$MIN_PHP
+                  echo '' > vendor/composer/platform_check.php
                   echo -e "1\\n0" | xargs -I{} bash -c "tfold src/Symfony/Component/Process.sigchild{} SYMFONY_DEPRECATIONS_HELPER=weak ENHANCE_SIGCHLD={} php-$MIN_PHP/sapi/cli/php .phpunit/phpunit-4.8-1/phpunit --colors=always src/Symfony/Component/Process/"
               fi
           fi

--- a/composer.json
+++ b/composer.json
@@ -133,5 +133,8 @@
     "autoload-dev": {
         "files": [ "src/Symfony/Component/VarDumper/Resources/functions/dump.php" ]
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "extra": {
+        "branch-version": "3.4"
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The CI must know the branch-version. We could put the version in each CI script, but that'd mean upgrading as many CI configs every 6 months. I'm trying to put the version in one file instead.