### PR TITLE
[Cache] Fixed broken test

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ChainAdapterTest.php
@@ -38,7 +38,7 @@ class ChainAdapterTest extends AdapterTestCase
 
     public static function tearDownAfterClass(): void
     {
-        FilesystemAdapterTest::rmdir(sys_get_temp_dir().'/symfony-cache');
+        (new Filesystem())->remove(sys_get_temp_dir().'/symfony-cache');
     }
 
     public function testEmptyAdaptersException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I added this line of code in https://github.com/symfony/symfony/pull/38635

However, some time between 4.4 and 5.x the `FilesystemAdapterTest::rmdir()` was removed. This PR make sure tests does not fail on 5.x. 

I target 4.4, I believe it will be simple to merge up to 5.1 and 5.x. Let me know if I should target 5.x instead. 
