### PR TITLE
[DI] Fix Preloader exception when preloading a class with an unknown parent/interface

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/Preloader.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/Preloader.php
@@ -87,7 +87,7 @@ class Preloader
 
                 self::preloadType($m->getReturnType(), $preloaded);
             }
-        } catch (\ReflectionException $e) {
+        } catch (\Throwable $e) {
             // ignore missing classes
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PreloaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PreloaderTest.php
@@ -35,6 +35,20 @@ class PreloaderTest extends TestCase
     }
 
     /**
+     * @requires PHP 7.4
+     */
+    public function testPreloadSkipsNonExistingInterface()
+    {
+        $r = new \ReflectionMethod(Preloader::class, 'doPreload');
+        $r->setAccessible(true);
+
+        $preloaded = [];
+
+        $r->invokeArgs(null, ['Symfony\Component\DependencyInjection\Tests\Fixtures\Preload\DummyWithInterface', &$preloaded]);
+        self::assertFalse(class_exists('Symfony\Component\DependencyInjection\Tests\Fixtures\Preload\DummyWithInterface', false));
+    }
+
+    /**
      * @requires PHP 8
      */
     public function testPreloadUnion()

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Preload/DummyWithInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Preload/DummyWithInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Preload;
+
+final class DummyWithInterface implements \NonExistentDummyInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38693
| License       | MIT

Fixes Preloader exception when preloading a class with an unknown parent/interface.