### PR TITLE
[ErrorHandler] Serialize FlattenException

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
@@ -275,9 +275,10 @@ class FlattenException
     /**
      * @return $this
      */
-    public function setTrace($trace, $file, $line): self
+    public function setTrace($trace, $file = null, $line = null): self
     {
         $this->trace = [];
+        if ($file)
         $this->trace[] = [
             'namespace' => '',
             'short_class' => '',
@@ -357,6 +358,18 @@ class FlattenException
 
     public function getTraceAsString(): string
     {
+        if ($this->traceAsString === null) {
+            $this->traceAsString = '';
+            if ($this->trace !== null) {
+                foreach ($this->trace as $i => $trace) {
+                    if ($i === 0) {
+                        continue;
+                    }
+                    $this->traceAsString .= sprintf('#%d %s(%s): %s%s%s()', $i-1, $trace['file'], $trace['line'], $trace['class'], $trace['type'], $trace['function']).PHP_EOL;
+                }
+            }
+        }
+
         return $this->traceAsString;
     }
 

--- a/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
@@ -278,17 +278,19 @@ class FlattenException
     public function setTrace($trace, $file = null, $line = null): self
     {
         $this->trace = [];
-        if ($file)
-        $this->trace[] = [
-            'namespace' => '',
-            'short_class' => '',
-            'class' => '',
-            'type' => '',
-            'function' => '',
-            'file' => $file,
-            'line' => $line,
-            'args' => [],
-        ];
+        if (null !== $file) {
+            $this->trace[] = [
+                'namespace' => '',
+                'short_class' => '',
+                'class' => '',
+                'type' => '',
+                'function' => '',
+                'file' => $file,
+                'line' => $line,
+                'args' => [],
+            ];
+        }
+
         foreach ($trace as $entry) {
             $class = '';
             $namespace = '';
@@ -358,14 +360,14 @@ class FlattenException
 
     public function getTraceAsString(): string
     {
-        if ($this->traceAsString === null) {
+        if (null === $this->traceAsString) {
             $this->traceAsString = '';
-            if ($this->trace !== null) {
+            if (null !== $this->trace) {
                 foreach ($this->trace as $i => $trace) {
-                    if ($i === 0) {
+                    if (0 === $i) {
                         continue;
                     }
-                    $this->traceAsString .= sprintf('#%d %s(%s): %s%s%s()', $i-1, $trace['file'], $trace['line'], $trace['class'], $trace['type'], $trace['function']).PHP_EOL;
+                    $this->traceAsString .= sprintf('#%d %s(%s): %s%s%s()', $i - 1, $trace['file'], $trace['line'], $trace['class'], $trace['type'], $trace['function']).\PHP_EOL;
                 }
             }
         }

--- a/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Exception/FlattenExceptionTest.php
@@ -422,7 +422,7 @@ class FlattenExceptionTest extends TestCase
 
         // Verify that they look kind of similar.
         $this->assertEquals(substr($trace, 0, 100), substr($restoredTrace, 0, 100));
-        $this->assertEquals(count(explode(PHP_EOL, $trace)), count(explode(PHP_EOL, $restoredTrace)));
+        $this->assertEquals(\count(explode(\PHP_EOL, $trace)), \count(explode(\PHP_EOL, $restoredTrace)));
     }
 
     private function createException($foo): \Exception

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -610,7 +610,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             'enable_magic_methods_extraction' => $this->magicMethodsFlags,
             'enable_constructor_extraction' => false,
             'enable_adder_remover_extraction' => $useAdderAndRemover,
-            'value' => $value
+            'value' => $value,
         ]);
 
         if (isset($item)) {

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -610,6 +610,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             'enable_magic_methods_extraction' => $this->magicMethodsFlags,
             'enable_constructor_extraction' => false,
             'enable_adder_remover_extraction' => $useAdderAndRemover,
+            'value' => $value
         ]);
 
         if (isset($item)) {

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -390,7 +390,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             $method = $reflClass->getMethod($methodName);
             /** @var \ReflectionParameter $parameter */
             $parameter = $method->getParameters()[0];
-            if (array_key_exists('value', $context) && $context['value'] === null && !$parameter->allowsNull()) {
+            if (\array_key_exists('value', $context) && null === $context['value'] && !$parameter->allowsNull()) {
                 $errors[] = sprintf('The method "%s" in class "%s" was found but does not allow null.', $methodName, $class);
                 continue;
             }

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -388,6 +388,12 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             }
 
             $method = $reflClass->getMethod($methodName);
+            /** @var \ReflectionParameter $parameter */
+            $parameter = $method->getParameters()[0];
+            if (array_key_exists('value', $context) && $context['value'] === null && !$parameter->allowsNull()) {
+                $errors[] = sprintf('The method "%s" in class "%s" was found but does not allow null.', $methodName, $class);
+                continue;
+            }
 
             if (!\in_array($mutatorPrefix, $this->arrayMutatorPrefixes, true)) {
                 return new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, $methodName, $this->getWriteVisiblityForMethod($method), $method->isStatic());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Related to #38792
| License       | MIT
| Doc PR        | Not needed

The `FlatternException` is used with messenger. When it is serialized with the Serializer component we fail to restore all its properties. 

When `FlatternException::$traceAsString` is null and we call `FlatternException::getTraceAsString()` we get an exception thrown in our face. That is what #38792 is about. 

This PR does two things (sorry about that). 

1. It modifies `FlatternException::setTrace()` so the serializer can populate the trace property when unserializing. I also try to rebuild the traceAsString from the `$trace`

2. It modifies the PropertyAccess and PropertyInfo component to be aware of nullable setters. Ie, It finds `FlatternException::setPrevious()`, but that function does not allow nullable parameters, but it still try to set the value `null` and we get another exception thrown in our face. 



