### PR TITLE
Add required mbstring ext in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,6 +144,9 @@ before_install:
           if [[ $PHP != nightly ]]; then
               echo extension = memcached.so >> $INI
           fi
+          if [[ $PHP = 7.1 ]]; then
+              echo extension = mbstring.so >> $INI
+          fi
       done
 
     - |


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Similar to Fix #38803 
| License       | MIT
| Doc PR        | -

This enable the extension mbstring.

Not needed for branch 3.4 which don't use PHP 7.1