### PR TITLE
[HttpKernel] HttpKernelBrowser: don't set a default Accept header

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -13,6 +13,7 @@ CHANGELOG
  * Allowed adding attributes on controller arguments that will be passed to argument resolvers.
  * kernels implementing the `ExtensionInterface` will now be auto-registered to the container
  * added parameter `kernel.runtime_environment`, defined as `%env(default:kernel.environment:APP_RUNTIME_ENV)%`
+ * do not set a default `Accept` HTTP header when using `HttpKernelBrowser`
 
 5.1.0
 -----

--- a/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
@@ -130,7 +130,10 @@ EOF;
      */
     protected function filterRequest(DomRequest $request)
     {
-        $httpRequest = Request::create($request->getUri(), $request->getMethod(), $request->getParameters(), $request->getCookies(), $request->getFiles(), $request->getServer(), $request->getContent());
+        $httpRequest = Request::create($request->getUri(), $request->getMethod(), $request->getParameters(), $request->getCookies(), $request->getFiles(), $server = $request->getServer(), $request->getContent());
+        if (!isset($server['HTTP_ACCEPT'])) {
+            $httpRequest->headers->remove('Accept');
+        }
 
         foreach ($this->filterFiles($httpRequest->files->all()) as $key => $value) {
             $httpRequest->files->set($key, $value);

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
@@ -179,4 +179,15 @@ class HttpKernelBrowserTest extends TestCase
 
         unlink($source);
     }
+
+    public function testAcceptHeaderNotSet()
+    {
+        $client = new HttpKernelBrowser(new TestHttpKernel());
+
+        $client->request('GET', '/');
+        $this->assertFalse($client->getRequest()->headers->has('Accept'));
+
+        $client->request('GET', '/', [], [], ['HTTP_ACCEPT' => 'application/ld+json']);
+        $this->assertSame('application/ld+json', $client->getRequest()->headers->get('Accept'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #33393
| License       | MIT
| Doc PR        | n/a

Currently, the `Accept` HTTP header is set automatically, because there is a default value for this value in HttpFoundation's `Request::create()` method.
This PR remove the default value if it hasn't been set automatically.

This will fix API Platform's `ApiTestCase` and `Behatch/contexts` (the previous workarounds aren't applicable anymore because we added type checks in Symfony).