### PR TITLE
Display php info for extra versions in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -174,6 +174,8 @@ before_install:
       for PHP in $TRAVIS_PHP_VERSION $php_extra; do
           export PHP=$PHP
           phpenv global $PHP
+          composer self-update
+          composer self-update --2
           INI=~/.phpenv/versions/$PHP/etc/conf.d/travis.ini
           if [[ $PHP = 5.* ]]; then
               tfold ext.apcu tpecl apcu-4.0.11 apcu.so $INI
@@ -278,7 +280,16 @@ install:
 
     - |
       # phpinfo
-      php -i
+      phpinfo() {
+          phpenv global $1
+          php -r 'foreach (get_loaded_extensions() as $extension) echo $extension . " " . phpversion($extension) . PHP_EOL;'
+          php -i
+      }
+      export -f phpinfo
+
+      for PHP in $TRAVIS_PHP_VERSION $php_extra; do
+          tfold $PHP phpinfo $PHP
+      done
 
     - |
       run_tests () {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Display the PHP info of all tested versions when the test-suite use several versions of PHP

Helps to troubleshoot  https://github.com/symfony/symfony/pull/38818#issuecomment-716575154