### PR TITLE
[ProxyManager] use "composer/package-versions-deprecated" instead of "ocramius/package-versions"

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
+        "composer/package-versions-deprecated": "^1.8",
         "symfony/dependency-injection": "^4.0|^5.0",
         "ocramius/proxy-manager": "~2.1"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As highlighted by our CI, `ocramius/proxy-manager` cannot be installed on PHP 7.3 using composer 2 because of broken versioning policies:
![image](https://user-images.githubusercontent.com/243674/97278564-37e73080-183a-11eb-885c-7b3cc07c26af.png)

Fortunately, the package that causes all this mess (`ocramius/package-versions`) has been forked precisely to work around these broken policies.

Requiring this fork allows resolving the dependencies properly.