### PR TITLE
[ProxyManager] Fix bridge deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -292,6 +292,9 @@ install:
           rm vendor/composer/package-versions-deprecated -Rf
           if [[ $PHP = 7.* ]]; then
               ([[ $deps ]] && cd src/Symfony/Component/HttpFoundation; composer config platform.ext-mongodb 1.6.0; composer require --dev --no-update mongodb/mongodb ~1.5.0)
+              if [[ $PHP != 7.4 ]]; then
+                  ([[ $deps ]] && cd src/Symfony/Bridge/ProxyManager; composer require --dev --no-update composer/package-versions-deprecated ^1.0)
+              fi
           fi
           tfold 'composer update' $COMPOSER_UP
           if [[ $TRAVIS_PHP_VERSION = 5.* ]]; then


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`ocramius/proxy-manager` requires `ocramius/package-versions` which requires either composer:v1 or PHP 7.4

This PR adds replacement `composer/package-versions-deprecated` in travis script