### PR TITLE
[Notifier] Add unit tests for NullMessage, NullTransport and NullTransportFactory

### DIFF
--- a/src/Symfony/Component/Notifier/Tests/Message/DummyMessageWithTransport.php
+++ b/src/Symfony/Component/Notifier/Tests/Message/DummyMessageWithTransport.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Message;
+
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+/**
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class DummyMessageWithTransport implements MessageInterface
+{
+    public function getRecipientId(): ?string
+    {
+        return 'recipient_id';
+    }
+
+    public function getSubject(): string
+    {
+        return 'subject';
+    }
+
+    public function getOptions(): ?MessageOptionsInterface
+    {
+        return null;
+    }
+
+    public function getTransport(): ?string
+    {
+        return 'transport';
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Message/DummyMessageWithoutTransport.php
+++ b/src/Symfony/Component/Notifier/Tests/Message/DummyMessageWithoutTransport.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Message;
+
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+/**
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class DummyMessageWithoutTransport implements MessageInterface
+{
+    public function getRecipientId(): ?string
+    {
+        return 'recipient_id';
+    }
+
+    public function getSubject(): string
+    {
+        return 'subject';
+    }
+
+    public function getOptions(): ?MessageOptionsInterface
+    {
+        return null;
+    }
+
+    public function getTransport(): ?string
+    {
+        return null;
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Message/EmailMessageTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Message/EmailMessageTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Notifier\Tests\Message;
 
 use PHPUnit\Framework\TestCase;

--- a/src/Symfony/Component/Notifier/Tests/Message/NullMessageTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Message/NullMessageTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Message;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\NullMessage;
+
+/**
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class NullMessageTest extends TestCase
+{
+    /**
+     * @dataProvider messageDataProvider
+     */
+    public function testCanBeConstructed(MessageInterface $message)
+    {
+        $nullMessage = new NullMessage($message);
+
+        $this->assertSame($message->getSubject(), $nullMessage->getSubject());
+        $this->assertSame($message->getRecipientId(), $nullMessage->getRecipientId());
+        $this->assertSame($message->getOptions(), $nullMessage->getOptions());
+
+        (null === $message->getTransport())
+            ? $this->assertSame('null', $nullMessage->getTransport())
+            : $this->assertSame($message->getTransport(), $nullMessage->getTransport());
+    }
+
+    public function messageDataProvider(): \Generator
+    {
+        yield [new DummyMessageWithoutTransport()];
+        yield [new DummyMessageWithTransport()];
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Message/SmsMessageTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Message/SmsMessageTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Notifier\Tests\Message;
 
 use PHPUnit\Framework\TestCase;

--- a/src/Symfony/Component/Notifier/Tests/Transport/DummyMessage.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/DummyMessage.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Transport;
+
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+/**
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class DummyMessage implements MessageInterface
+{
+    public function getRecipientId(): ?string
+    {
+        return 'recipient_id';
+    }
+
+    public function getSubject(): string
+    {
+        return 'subject';
+    }
+
+    public function getOptions(): ?MessageOptionsInterface
+    {
+        return null;
+    }
+
+    public function getTransport(): ?string
+    {
+        return null;
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Transport/NullTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/NullTransportFactoryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Transport\NullTransport;
+use Symfony\Component\Notifier\Transport\NullTransportFactory;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class NullTransportFactoryTest extends TestCase
+{
+    /**
+     * @var NullTransportFactory
+     */
+    private $nullTransportFactory;
+
+    protected function setUp(): void
+    {
+        $this->nullTransportFactory = new NullTransportFactory(
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(HttpClientInterface::class)
+        );
+    }
+
+    public function testCreateThrowsUnsupportedSchemeException()
+    {
+        $this->expectException(UnsupportedSchemeException::class);
+
+        $this->nullTransportFactory->create(new Dsn('foo', ''));
+    }
+
+    public function testCreate()
+    {
+        $this->assertInstanceOf(
+            NullTransport::class,
+            $this->nullTransportFactory->create(new Dsn('null', ''))
+        );
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Transport/NullTransportTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/NullTransportTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Transport;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Transport\NullTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @author Jan Schädlich <jan.schaedlich@sensiolabs.de>
+ */
+class NullTransportTest extends TestCase
+{
+    public function testToString()
+    {
+        $this->assertEquals('null', (string) (new NullTransport()));
+    }
+
+    public function testSend()
+    {
+        $nullTransport = new NullTransport(
+            $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class)
+        );
+
+        $eventDispatcherMock->expects($this->once())->method('dispatch');
+        $nullTransport->send(new DummyMessage());
+    }
+}

--- a/src/Symfony/Component/Notifier/composer.json
+++ b/src/Symfony/Component/Notifier/composer.json
@@ -20,6 +20,10 @@
         "symfony/polyfill-php80": "^1.15",
         "psr/log": "~1.0"
     },
+    "require-dev": {
+        "symfony/event-dispatcher-contracts": "^2",
+        "symfony/http-client-contracts": "^2"
+    },
     "conflict": {
         "symfony/http-kernel": "<4.4",
         "symfony/firebase-notifier": "<5.2",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->
