### PR TITLE
[Messenger] Make all the dependencies of AmazonSqsTransport injectable

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * Added new `debug` option to log HTTP requests and responses.
+ * Allowed for receiver & sender injection into AmazonSqsTransport
 
 5.2.0
 -----

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportTest.php
@@ -11,17 +11,55 @@
 
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Transport;
 
+use AsyncAws\Core\Exception\Http\HttpException;
+use AsyncAws\Core\Exception\Http\ServerException;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsReceiver;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransport;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\Connection;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class AmazonSqsTransportTest extends TestCase
 {
+    /**
+     * @var MockObject|Connection
+     */
+    private $connection;
+
+    /**
+     * @var MockObject|ReceiverInterface
+     */
+    private $receiver;
+
+    /**
+     * @var MockObject|SenderInterface|MessageCountAwareInterface
+     */
+    private $sender;
+
+    /**
+     * @var AmazonSqsTransport
+     */
+    private $transport;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+        // Mocking the concrete receiver class because mocking multiple interfaces is deprecated
+        $this->receiver = $this->createMock(AmazonSqsReceiver::class);
+        $this->sender = $this->createMock(SenderInterface::class);
+
+        $this->transport = new AmazonSqsTransport($this->connection, null, $this->receiver, $this->sender);
+    }
+
     public function testItIsATransport()
     {
         $transport = $this->getTransport();
@@ -58,11 +96,87 @@ class AmazonSqsTransportTest extends TestCase
         $this->assertInstanceOf(MessageCountAwareInterface::class, $transport);
     }
 
+    public function testItCanGetMessagesViaTheReceiver(): void
+    {
+        $envelopes = [new Envelope(new \stdClass()), new Envelope(new \stdClass())];
+        $this->receiver->expects($this->once())->method('get')->willReturn($envelopes);
+        $this->assertSame($envelopes, $this->transport->get());
+    }
+
+    public function testItCanAcknowledgeAMessageViaTheReceiver(): void
+    {
+        $envelope = new Envelope(new \stdClass());
+        $this->receiver->expects($this->once())->method('ack')->with($envelope);
+        $this->transport->ack($envelope);
+    }
+
+    public function testItCanRejectAMessageViaTheReceiver(): void
+    {
+        $envelope = new Envelope(new \stdClass());
+        $this->receiver->expects($this->once())->method('reject')->with($envelope);
+        $this->transport->reject($envelope);
+    }
+
+    public function testItCanGetMessageCountViaTheReceiver(): void
+    {
+        $messageCount = 15;
+        $this->receiver->expects($this->once())->method('getMessageCount')->willReturn($messageCount);
+        $this->assertSame($messageCount, $this->transport->getMessageCount());
+    }
+
+    public function testItCanSendAMessageViaTheSender(): void
+    {
+        $envelope = new Envelope(new \stdClass());
+        $this->sender->expects($this->once())->method('send')->with($envelope)->willReturn($envelope);
+        $this->assertSame($envelope, $this->transport->send($envelope));
+    }
+
+    public function testItCanSetUpTheConnection(): void
+    {
+        $this->connection->expects($this->once())->method('setup');
+        $this->transport->setup();
+    }
+
+    public function testItConvertsHttpExceptionDuringSetupIntoTransportException(): void
+    {
+        $this->connection
+            ->expects($this->once())
+            ->method('setup')
+            ->willThrowException($this->createHttpException());
+
+        $this->expectException(TransportException::class);
+
+        $this->transport->setup();
+    }
+
+    public function testItCanResetTheConnection(): void
+    {
+        $this->connection->expects($this->once())->method('reset');
+        $this->transport->reset();
+    }
+
+    public function testItConvertsHttpExceptionDuringResetIntoTransportException(): void
+    {
+        $this->connection
+            ->expects($this->once())
+            ->method('reset')
+            ->willThrowException($this->createHttpException());
+
+        $this->expectException(TransportException::class);
+
+        $this->transport->reset();
+    }
+
     private function getTransport(SerializerInterface $serializer = null, Connection $connection = null)
     {
         $serializer = $serializer ?: $this->getMockBuilder(SerializerInterface::class)->getMock();
         $connection = $connection ?: $this->getMockBuilder(Connection::class)->disableOriginalConstructor()->getMock();
 
         return new AmazonSqsTransport($connection, $serializer);
+    }
+
+    private function createHttpException(): HttpException
+    {
+        return new ServerException($this->createMock(ResponseInterface::class));
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsTransport.php
@@ -15,6 +15,8 @@ use AsyncAws\Core\Exception\Http\HttpException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\SetupableTransportInterface;
@@ -31,10 +33,12 @@ class AmazonSqsTransport implements TransportInterface, SetupableTransportInterf
     private $receiver;
     private $sender;
 
-    public function __construct(Connection $connection, SerializerInterface $serializer = null)
+    public function __construct(Connection $connection, SerializerInterface $serializer = null, ReceiverInterface $receiver = null, SenderInterface $sender = null)
     {
         $this->connection = $connection;
         $this->serializer = $serializer ?? new PhpSerializer();
+        $this->receiver = $receiver;
+        $this->sender = $sender;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x for features
| Bug fix?      | no
| New feature?  | yes - updated changelog
| Deprecations? | no
| Tickets       | Fix #38640
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This is a pure refactoring PR that enables more flexibility with service injection without actually changing any behaviour or breaking backwards compatibility. It satisfies only 1 of 2 acceptance criteria of #38640 but since they're independent, I'm not marking the PR as WIP.

## Receiver & sender injection into AmazonSqsTransport
It is now possible to inject your own receiver and sender into `Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransport`.

### Recommended way - AmazonSqsTransport::create
For clean dependency injection, I recommed using the `create` static method, which obliges you to pass all dependencies:
```php
$transport = AmazonSqsTransport::create($connection, $receiver, $sender);
```

For example, this code from `Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory`:
```php
return new AmazonSqsTransport(Connection::fromDsn($dsn, $options), $serializer);
```
could be replaced with this:
```php
$connection = Connection::fromDsn($dsn, $options);

return AmazonSqsTransport::create(
    $connection,
    new AmazonSqsReceiver($connection, $serializer),
    new AmazonSqsSender($connection, $serializer)
);
```
I didn't replace that code in the factory because I didn't find it essential but I will certainly do it in my custom factory in my project, passing my own receiver implementation.

### Using the main constructor
You can still use the main constructor but it's most suited for backwards compatibility, i.e. when you don't want to inject a receiver or a sender. With the full list of arguments it gets a bit messy due to their optionality.

#### Minimal call
```php
new AmazonSqsTransport($connection);
```
As before this PR, a receiver and a sender will be created using the default serializer, i.e. `Symfony\Component\Messenger\Transport\Serialization\PhpSerializer`.

#### With a custom serializer
```php
new AmazonSqsTransport($connection, $serializer);
```
As before this PR, a receiver and a sender will be created using the passed serializer.

#### With a custom receiver and sender
```php
new AmazonSqsTransport($connection, null, $receiver, $sender);
```
The injected services will be used. The second parameter (serializer) is unnecessary because it was only ever used while creating a receiver and a sender inside the transport. Because of this, I recommend using the new static `create` method.