### PR TITLE
Use short array deconstruction syntax

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -15,6 +15,7 @@ return PhpCsFixer\Config::create()
         'protected_to_private' => false,
         'native_constant_invocation' => true,
         'combine_nested_dirname' => true,
+        'list_syntax' => ['syntax' => 'short'],
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -195,7 +195,7 @@ class DoctrineDataCollector extends DataCollector
                 }
             }
 
-            list($query['params'][$j], $explainable, $runnable) = $this->sanitizeParam($param, $e);
+            [$query['params'][$j], $explainable, $runnable] = $this->sanitizeParam($param, $e);
             if (!$explainable) {
                 $query['explainable'] = false;
             }
@@ -231,7 +231,7 @@ class DoctrineDataCollector extends DataCollector
             $a = [];
             $explainable = $runnable = true;
             foreach ($var as $k => $v) {
-                list($value, $e, $r) = $this->sanitizeParam($v, null);
+                [$value, $e, $r] = $this->sanitizeParam($v, null);
                 $explainable = $explainable && $e;
                 $runnable = $runnable && $r;
                 $a[$k] = $value;

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
@@ -65,7 +65,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
         $taggedSubscribers = $this->findAndSortTags($subscriberTag, $container);
 
         foreach ($taggedSubscribers as $taggedSubscriber) {
-            list($id, $tag) = $taggedSubscriber;
+            [$id, $tag] = $taggedSubscriber;
             $connections = isset($tag['connection']) ? [$tag['connection']] : array_keys($this->connections);
             foreach ($connections as $con) {
                 if (!isset($this->connections[$con])) {
@@ -84,7 +84,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
         $listenerRefs = [];
 
         foreach ($taggedListeners as $taggedListener) {
-            list($id, $tag) = $taggedListener;
+            [$id, $tag] = $taggedListener;
             if (!isset($tag['event'])) {
                 throw new InvalidArgumentException(sprintf('Doctrine event listener "%s" must specify the "event" attribute.', $id));
             }

--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -49,7 +49,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
             return new TypeGuess('Symfony\Component\Form\Extension\Core\Type\TextType', [], Guess::LOW_CONFIDENCE);
         }
 
-        list($metadata, $name) = $ret;
+        [$metadata, $name] = $ret;
 
         if ($metadata->hasAssociation($property)) {
             $multiple = $metadata->isCollectionValuedAssociation($property);

--- a/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/LoggerTest.php
@@ -75,7 +75,7 @@ class LoggerTest extends TestCase
 
         $logger->info('test');
         $this->assertCount(1, $logger->getLogs());
-        list($record) = $logger->getLogs();
+        [$record] = $logger->getLogs();
 
         $this->assertEquals('test', $record['message']);
         $this->assertEquals(Logger::INFO, $record['priority']);

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -22,7 +22,7 @@ class WebProcessorTest extends TestCase
 {
     public function testUsesRequestServerData()
     {
-        list($event, $server) = $this->createRequestEvent();
+        [$event, $server] = $this->createRequestEvent();
 
         $processor = new WebProcessor();
         $processor->onKernelRequest($event);
@@ -39,7 +39,7 @@ class WebProcessorTest extends TestCase
     public function testUseRequestClientIp()
     {
         Request::setTrustedProxies(['192.168.0.1'], Request::HEADER_X_FORWARDED_ALL);
-        list($event, $server) = $this->createRequestEvent(['X_FORWARDED_FOR' => '192.168.0.2']);
+        [$event, $server] = $this->createRequestEvent(['X_FORWARDED_FOR' => '192.168.0.2']);
 
         $processor = new WebProcessor();
         $processor->onKernelRequest($event);
@@ -61,7 +61,7 @@ class WebProcessorTest extends TestCase
             $this->markTestSkipped('WebProcessor of the installed Monolog version does not support $extraFields parameter');
         }
 
-        list($event, $server) = $this->createRequestEvent();
+        [$event, $server] = $this->createRequestEvent();
 
         $processor = new WebProcessor(['url', 'referrer']);
         $processor->onKernelRequest($event);

--- a/src/Symfony/Bridge/Twig/Command/DebugCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/DebugCommand.php
@@ -161,7 +161,7 @@ EOF
                     $shortnames[] = str_replace('\\', '/', $file->getRelativePathname());
                 }
 
-                list($namespace, $shortname) = $this->parseTemplateName($name);
+                [$namespace, $shortname] = $this->parseTemplateName($name);
                 $alternatives = $this->findAlternatives($shortname, $shortnames);
                 if (FilesystemLoader::MAIN_NAMESPACE !== $namespace) {
                     $alternatives = array_map(function ($shortname) use ($namespace) {
@@ -482,7 +482,7 @@ EOF
 
     private function findTemplateFiles(string $name): array
     {
-        list($namespace, $shortname) = $this->parseTemplateName($name);
+        [$namespace, $shortname] = $this->parseTemplateName($name);
 
         $files = [];
         foreach ($this->getFilesystemLoaders() as $loader) {

--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -72,7 +72,7 @@ class CodeExtension extends AbstractExtension
     public function abbrMethod($method)
     {
         if (false !== strpos($method, '::')) {
-            list($class, $method) = explode('::', $method, 2);
+            [$class, $method] = explode('::', $method, 2);
             $result = sprintf('%s::%s()', $this->abbrClass($class), $method);
         } elseif ('Closure' === $method) {
             $result = sprintf('<abbr title="%s">%1$s</abbr>', $method);

--- a/src/Symfony/Bridge/Twig/Node/TransNode.php
+++ b/src/Symfony/Bridge/Twig/Node/TransNode.php
@@ -60,7 +60,7 @@ class TransNode extends Node
             $defaults = $this->getNode('vars');
             $vars = null;
         }
-        list($msg, $defaults) = $this->compileString($this->getNode('body'), $defaults, (bool) $vars);
+        [$msg, $defaults] = $this->compileString($this->getNode('body'), $defaults, (bool) $vars);
 
         $compiler
             ->write('echo $this->env->getExtension(\'Symfony\Bridge\Twig\Extension\TranslationExtension\')->trans(')

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
@@ -58,7 +58,7 @@ class ControllerNameParser
         }
 
         $originalController = $controller;
-        list($bundleName, $controller, $action) = $parts;
+        [$bundleName, $controller, $action] = $parts;
         $controller = str_replace('/', '\\', $controller);
 
         try {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -589,7 +589,7 @@ class FrameworkExtension extends Extension
         $container->setParameter('profiler_listener.only_master_requests', $config['only_master_requests']);
 
         // Choose storage class based on the DSN
-        list($class) = explode(':', $config['dsn'], 2);
+        [$class] = explode(':', $config['dsn'], 2);
         if ('file' !== $class) {
             throw new \LogicException(sprintf('Driver "%s" is not supported for the profiler.', $class));
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -64,7 +64,7 @@ class CodeHelper extends Helper
     public function abbrMethod($method)
     {
         if (false !== strpos($method, '::')) {
-            list($class, $method) = explode('::', $method, 2);
+            [$class, $method] = explode('::', $method, 2);
             $result = sprintf('%s::%s()', $this->abbrClass($class), $method);
         } elseif ('Closure' === $method) {
             $result = sprintf('<abbr title="%s">%1$s</abbr>', $method);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SessionController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/SessionController.php
@@ -71,7 +71,7 @@ class SessionController implements ContainerAwareInterface
         $session = $request->getSession();
 
         if ($session->getFlashBag()->has('notice')) {
-            list($output) = $session->getFlashBag()->get('notice');
+            [$output] = $session->getFlashBag()->get('notice');
         } else {
             $output = 'No flash was set.';
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -144,7 +144,7 @@ class Translator extends BaseTranslator implements WarmableInterface
             $this->addResourceFiles();
         }
         foreach ($this->resources as $key => $params) {
-            list($format, $resource, $locale, $domain) = $params;
+            [$format, $resource, $locale, $domain] = $params;
             parent::addResource($format, $resource, $locale, $domain);
         }
         $this->resources = [];

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -239,7 +239,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
             $configId = 'security.firewall.map.config.'.$name;
 
-            list($matcher, $listeners, $exceptionListener, $logoutListener) = $this->createFirewall($container, $name, $firewall, $authenticationProviders, $providerIds, $configId);
+            [$matcher, $listeners, $exceptionListener, $logoutListener] = $this->createFirewall($container, $name, $firewall, $authenticationProviders, $providerIds, $configId);
 
             $contextId = 'security.firewall.map.context.'.$name;
             $context = new ChildDefinition($firewall['stateless'] || empty($firewall['anonymous']['lazy']) ? 'security.firewall.context' : 'security.firewall.lazy_context');
@@ -397,7 +397,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $configuredEntryPoint = isset($firewall['entry_point']) ? $firewall['entry_point'] : null;
 
         // Authentication listeners
-        list($authListeners, $defaultEntryPoint) = $this->createAuthenticationListeners($container, $id, $firewall, $authenticationProviders, $defaultProvider, $providerIds, $configuredEntryPoint, $contextListenerId);
+        [$authListeners, $defaultEntryPoint] = $this->createAuthenticationListeners($container, $id, $firewall, $authenticationProviders, $defaultProvider, $providerIds, $configuredEntryPoint, $contextListenerId);
 
         $config->replaceArgument(7, $configuredEntryPoint ?: $defaultEntryPoint);
 
@@ -479,7 +479,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                         throw new InvalidConfigurationException(sprintf('Not configuring explicitly the provider for the "%s" listener on "%s" firewall is ambiguous as there is more than one registered provider.', $key, $id));
                     }
 
-                    list($provider, $listenerId, $defaultEntryPoint) = $factory->create($container, $id, $firewall[$key], $userProvider, $defaultEntryPoint);
+                    [$provider, $listenerId, $defaultEntryPoint] = $factory->create($container, $id, $firewall[$key], $userProvider, $defaultEntryPoint);
 
                     $listeners[] = new Reference($listenerId);
                     $authenticationProviders[] = $provider;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -236,7 +236,7 @@ abstract class CompleteConfigurationTest extends TestCase
         }
 
         $matcherIds = [];
-        foreach ($rules as list($matcherId, $attributes, $channel)) {
+        foreach ($rules as [$matcherId, $attributes, $channel]) {
             $requestMatcher = $container->getDefinition($matcherId);
 
             $this->assertArrayNotHasKey($matcherId, $matcherIds);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
@@ -19,7 +19,7 @@ class AbstractFactoryTest extends TestCase
 {
     public function testCreate()
     {
-        list($container, $authProviderId, $listenerId, $entryPointId) = $this->callFactory('foo', [
+        [$container, $authProviderId, $listenerId, $entryPointId] = $this->callFactory('foo', [
             'use_forward' => true,
             'failure_path' => '/foo',
             'success_handler' => 'custom_success_handler',
@@ -61,7 +61,7 @@ class AbstractFactoryTest extends TestCase
             $options['failure_handler'] = $serviceId;
         }
 
-        list($container) = $this->callFactory('foo', $options, 'user_provider', 'entry_point');
+        [$container] = $this->callFactory('foo', $options, 'user_provider', 'entry_point');
 
         $definition = $container->getDefinition('abstract_listener.foo');
         $arguments = $definition->getArguments();
@@ -99,7 +99,7 @@ class AbstractFactoryTest extends TestCase
             $options['success_handler'] = $serviceId;
         }
 
-        list($container) = $this->callFactory('foo', $options, 'user_provider', 'entry_point');
+        [$container] = $this->callFactory('foo', $options, 'user_provider', 'entry_point');
 
         $definition = $container->getDefinition('abstract_listener.foo');
         $arguments = $definition->getArguments();
@@ -150,7 +150,7 @@ class AbstractFactoryTest extends TestCase
         $container->register('custom_success_handler');
         $container->register('custom_failure_handler');
 
-        list($authProviderId, $listenerId, $entryPointId) = $factory->create($container, $id, $config, $userProviderId, $defaultEntryPointId);
+        [$authProviderId, $listenerId, $entryPointId] = $factory->create($container, $id, $config, $userProviderId, $defaultEntryPointId);
 
         return [$container, $authProviderId, $listenerId, $entryPointId];
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/GuardAuthenticationFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/GuardAuthenticationFactoryTest.php
@@ -103,7 +103,7 @@ class GuardAuthenticationFactoryTest extends TestCase
             'authenticators' => ['authenticator123'],
             'entry_point' => null,
         ];
-        list($container, $entryPointId) = $this->executeCreate($config, null);
+        [$container, $entryPointId] = $this->executeCreate($config, null);
         $this->assertEquals('authenticator123', $entryPointId);
 
         $providerDefinition = $container->getDefinition('security.authentication.provider.guard.my_firewall');
@@ -126,7 +126,7 @@ class GuardAuthenticationFactoryTest extends TestCase
             'authenticators' => ['authenticator123'],
             'entry_point' => null,
         ];
-        list(, $entryPointId) = $this->executeCreate($config, 'some_default_entry_point');
+        [, $entryPointId] = $this->executeCreate($config, 'some_default_entry_point');
         $this->assertEquals('some_default_entry_point', $entryPointId);
     }
 
@@ -159,7 +159,7 @@ class GuardAuthenticationFactoryTest extends TestCase
             'authenticators' => ['authenticator123', 'authenticatorABC'],
             'entry_point' => 'authenticatorABC',
         ];
-        list(, $entryPointId) = $this->executeCreate($config, null);
+        [, $entryPointId] = $this->executeCreate($config, null);
         $this->assertEquals('authenticatorABC', $entryPointId);
     }
 
@@ -172,7 +172,7 @@ class GuardAuthenticationFactoryTest extends TestCase
         $userProviderId = 'my_user_provider';
 
         $factory = new GuardAuthenticationFactory();
-        list(, , $entryPointId) = $factory->create($container, $id, $config, $userProviderId, $defaultEntryPointId);
+        [, , $entryPointId] = $factory->create($container, $id, $config, $userProviderId, $defaultEntryPointId);
 
         return [$container, $entryPointId];
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Profiler/TemplateManager.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Profiler/TemplateManager.php
@@ -76,7 +76,7 @@ class TemplateManager
                 continue;
             }
 
-            list($name, $template) = $arguments;
+            [$name, $template] = $arguments;
 
             if (!$this->profiler->has($name) || !$profile->hasCollector($name)) {
                 continue;

--- a/src/Symfony/Bundle/WebServerBundle/Command/ServerStatusCommand.php
+++ b/src/Symfony/Bundle/WebServerBundle/Command/ServerStatusCommand.php
@@ -80,7 +80,7 @@ EOF
         $server = new WebServer($this->pidFileDirectory);
         if ($filter = $input->getOption('filter')) {
             if ($server->isRunning($input->getOption('pidfile'))) {
-                list($host, $port) = explode(':', $address = $server->getAddress($input->getOption('pidfile')));
+                [$host, $port] = explode(':', $address = $server->getAddress($input->getOption('pidfile')));
                 if ('address' === $filter) {
                     $output->write($address);
                 } elseif ('host' === $filter) {

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -136,7 +136,7 @@ class Cookie
             throw new \InvalidArgumentException(sprintf('The cookie string "%s" is not valid.', $parts[0]));
         }
 
-        list($name, $value) = explode('=', array_shift($parts), 2);
+        [$name, $value] = explode('=', array_shift($parts), 2);
 
         $values = [
             'name' => trim($name),

--- a/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PhpArrayAdapterTest.php
@@ -155,7 +155,7 @@ class PhpArrayAdapterWrapper extends PhpArrayAdapter
             $this->keys[$key] = $id = \count($this->values);
             $this->data[$key] = $this->values[$id] = $item->get();
             $this->warmUp($this->data);
-            list($this->keys, $this->values) = eval(substr(file_get_contents($this->file), 6));
+            [$this->keys, $this->values] = eval(substr(file_get_contents($this->file), 6));
         }, $this, PhpArrayAdapter::class))();
 
         return true;

--- a/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheWrapper.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PhpArrayCacheWrapper.php
@@ -22,7 +22,7 @@ class PhpArrayCacheWrapper extends PhpArrayCache
         (\Closure::bind(function () use ($key, $value) {
             $this->data[$key] = $value;
             $this->warmUp($this->data);
-            list($this->keys, $this->values) = eval(substr(file_get_contents($this->file), 6));
+            [$this->keys, $this->values] = eval(substr(file_get_contents($this->file), 6));
         }, $this, PhpArrayCache::class))();
 
         return true;
@@ -38,7 +38,7 @@ class PhpArrayCacheWrapper extends PhpArrayCache
                 $this->data[$key] = $value;
             }
             $this->warmUp($this->data);
-            list($this->keys, $this->values) = eval(substr(file_get_contents($this->file), 6));
+            [$this->keys, $this->values] = eval(substr(file_get_contents($this->file), 6));
         }, $this, PhpArrayCache::class))();
 
         return true;

--- a/src/Symfony/Component/Cache/Traits/MemcachedTrait.php
+++ b/src/Symfony/Component/Cache/Traits/MemcachedTrait.php
@@ -111,7 +111,7 @@ trait MemcachedTrait
                 }
                 $params = preg_replace_callback('#^memcached:(//)?(?:([^@]*+)@)?#', function ($m) use (&$username, &$password) {
                     if (!empty($m[2])) {
-                        list($username, $password) = explode(':', $m[2], 2) + [1 => null];
+                        [$username, $password] = explode(':', $m[2], 2) + [1 => null];
                     }
 
                     return 'file:'.($m[1] ?? '');

--- a/src/Symfony/Component/Cache/Traits/PhpArrayTrait.php
+++ b/src/Symfony/Component/Cache/Traits/PhpArrayTrait.php
@@ -163,7 +163,7 @@ EOF;
         if (2 !== \count($values) || !isset($values[0], $values[1])) {
             $this->keys = $this->values = [];
         } else {
-            list($this->keys, $this->values) = $values;
+            [$this->keys, $this->values] = $values;
         }
     }
 }

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -469,7 +469,7 @@ trait RedisTrait
             foreach ($connections as $h => $c) {
                 $connections[$h] = $c[0]->exec();
             }
-            foreach ($results as $k => list($h, $c)) {
+            foreach ($results as $k => [$h, $c]) {
                 $results[$k] = $connections[$h][$c];
             }
         } else {

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -342,7 +342,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
      */
     protected function remapXml($value)
     {
-        foreach ($this->xmlRemappings as list($singular, $plural)) {
+        foreach ($this->xmlRemappings as [$singular, $plural]) {
             if (!isset($value[$singular])) {
                 continue;
             }

--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -53,7 +53,7 @@ class XmlReferenceDumper
             });
 
             if (\count($remapping)) {
-                list($singular) = current($remapping);
+                [$singular] = current($remapping);
                 $rootName = $singular;
             }
         }

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -430,13 +430,13 @@ class Table
 
         $crossings = $this->style->getCrossingChars();
         if (self::SEPARATOR_MID === $type) {
-            list($horizontal, $leftChar, $midChar, $rightChar) = [$borders[2], $crossings[8], $crossings[0], $crossings[4]];
+            [$horizontal, $leftChar, $midChar, $rightChar] = [$borders[2], $crossings[8], $crossings[0], $crossings[4]];
         } elseif (self::SEPARATOR_TOP === $type) {
-            list($horizontal, $leftChar, $midChar, $rightChar) = [$borders[0], $crossings[1], $crossings[2], $crossings[3]];
+            [$horizontal, $leftChar, $midChar, $rightChar] = [$borders[0], $crossings[1], $crossings[2], $crossings[3]];
         } elseif (self::SEPARATOR_TOP_BOTTOM === $type) {
-            list($horizontal, $leftChar, $midChar, $rightChar) = [$borders[0], $crossings[9], $crossings[10], $crossings[11]];
+            [$horizontal, $leftChar, $midChar, $rightChar] = [$borders[0], $crossings[9], $crossings[10], $crossings[11]];
         } else {
-            list($horizontal, $leftChar, $midChar, $rightChar) = [$borders[0], $crossings[7], $crossings[6], $crossings[5]];
+            [$horizontal, $leftChar, $midChar, $rightChar] = [$borders[0], $crossings[7], $crossings[6], $crossings[5]];
         }
 
         $markup = $leftChar;

--- a/src/Symfony/Component/CssSelector/Parser/Parser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Parser.php
@@ -113,7 +113,7 @@ class Parser implements ParserInterface
 
     private function parserSelectorNode(TokenStream $stream): Node\SelectorNode
     {
-        list($result, $pseudoElement) = $this->parseSimpleSelector($stream);
+        [$result, $pseudoElement] = $this->parseSimpleSelector($stream);
 
         while (true) {
             $stream->skipWhitespace();
@@ -134,7 +134,7 @@ class Parser implements ParserInterface
                 $combinator = ' ';
             }
 
-            list($nextSelector, $pseudoElement) = $this->parseSimpleSelector($stream);
+            [$nextSelector, $pseudoElement] = $this->parseSimpleSelector($stream);
             $result = new Node\CombinedSelectorNode($result, $combinator, $nextSelector);
         }
 
@@ -209,7 +209,7 @@ class Parser implements ParserInterface
                         throw SyntaxErrorException::nestedNot();
                     }
 
-                    list($argument, $argumentPseudoElement) = $this->parseSimpleSelector($stream, true);
+                    [$argument, $argumentPseudoElement] = $this->parseSimpleSelector($stream, true);
                     $next = $stream->getNext();
 
                     if (null !== $argumentPseudoElement) {

--- a/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
@@ -51,7 +51,7 @@ class FunctionExtension extends AbstractExtension
     public function translateNthChild(XPathExpr $xpath, FunctionNode $function, bool $last = false, bool $addNameTest = true): XPathExpr
     {
         try {
-            list($a, $b) = Parser::parseSeries($function->getArguments());
+            [$a, $b] = Parser::parseSeries($function->getArguments());
         } catch (SyntaxErrorException $e) {
             throw new ExpressionErrorException(sprintf('Invalid series: "%s".', implode('", "', $function->getArguments())), 0, $e);
         }

--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -300,7 +300,7 @@ class DebugClassLoader
                     $hasCall = $refl->hasMethod('__call');
                     $hasStaticCall = $refl->hasMethod('__callStatic');
                     foreach (self::$method[$use] as $method) {
-                        list($interface, $name, $static, $description) = $method;
+                        [$interface, $name, $static, $description] = $method;
                         if ($static ? $hasStaticCall : $hasCall) {
                             continue;
                         }
@@ -335,12 +335,12 @@ class DebugClassLoader
             }
 
             if ($parent && isset(self::$finalMethods[$parent][$method->name])) {
-                list($declaringClass, $message) = self::$finalMethods[$parent][$method->name];
+                [$declaringClass, $message] = self::$finalMethods[$parent][$method->name];
                 $deprecations[] = sprintf('The "%s::%s()" method is considered final%s. It may change without further notice as of its next major version. You should not extend it from "%s".', $declaringClass, $method->name, $message, $class);
             }
 
             if (isset(self::$internalMethods[$class][$method->name])) {
-                list($declaringClass, $message) = self::$internalMethods[$class][$method->name];
+                [$declaringClass, $message] = self::$internalMethods[$class][$method->name];
                 if (strncmp($ns, $declaringClass, $len)) {
                     $deprecations[] = sprintf('The "%s::%s()" method is considered internal%s. It may change without further notice. You should not extend it from "%s".', $declaringClass, $method->name, $message, $class);
                 }
@@ -388,7 +388,7 @@ class DebugClassLoader
                     $definedParameters[$parameter->name] = true;
                 }
             }
-            foreach ($matches as list(, $parameterType, $parameterName)) {
+            foreach ($matches as [, $parameterType, $parameterName]) {
                 if (!isset($definedParameters[$parameterName])) {
                     $parameterType = trim($parameterType);
                     self::$annotatedParameters[$class][$method->name][$parameterName] = sprintf('The "%%s::%s()" method will require a new "%s$%s" argument in the next major version of its %s "%s", not defining it is deprecated.', $method->name, $parameterType ? $parameterType.' ' : '', $parameterName, interface_exists($class) ? 'interface' : 'parent class', $method->class);

--- a/src/Symfony/Component/DependencyInjection/Argument/BoundArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/BoundArgument.php
@@ -54,9 +54,9 @@ final class BoundArgument implements ArgumentInterface
     public function setValues(array $values)
     {
         if (5 === \count($values)) {
-            list($this->value, $this->identifier, $this->used, $this->type, $this->file) = $values;
+            [$this->value, $this->identifier, $this->used, $this->type, $this->file] = $values;
         } else {
-            list($this->value, $this->identifier, $this->used) = $values;
+            [$this->value, $this->identifier, $this->used] = $values;
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -130,7 +130,7 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
         }
 
         if ($factory) {
-            list($class, $method) = $factory;
+            [$class, $method] = $factory;
             if ($class instanceof Reference) {
                 $class = $this->container->findDefinition((string) $class)->getClass();
             } elseif ($class instanceof Definition) {

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -126,7 +126,7 @@ class AutowirePass extends AbstractRecursivePass
         $this->methodCalls = $this->autowireCalls($reflectionClass, $isRoot);
 
         if ($constructor) {
-            list(, $arguments) = array_shift($this->methodCalls);
+            [, $arguments] = array_shift($this->methodCalls);
 
             if ($arguments !== $value->getArguments()) {
                 $value->setArguments($arguments);
@@ -152,7 +152,7 @@ class AutowirePass extends AbstractRecursivePass
 
         foreach ($this->methodCalls as $i => $call) {
             $this->decoratedMethodIndex = $i;
-            list($method, $arguments) = $call;
+            [$method, $arguments] = $call;
 
             if ($method instanceof \ReflectionFunctionAbstract) {
                 $reflectionMethod = $method;

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredMethodsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowireRequiredMethodsPass.php
@@ -37,7 +37,7 @@ class AutowireRequiredMethodsPass extends AbstractRecursivePass
         $alreadyCalledMethods = [];
         $withers = [];
 
-        foreach ($value->getMethodCalls() as list($method)) {
+        foreach ($value->getMethodCalls() as [$method]) {
             $alreadyCalledMethods[strtolower($method)] = true;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -39,9 +39,9 @@ class DecoratorServicePass implements CompilerPassInterface
         }
         $decoratingDefinitions = [];
 
-        foreach ($definitions as list($id, $definition)) {
+        foreach ($definitions as [$id, $definition]) {
             $decoratedService = $definition->getDecoratedService();
-            list($inner, $renamedId) = $decoratedService;
+            [$inner, $renamedId] = $decoratedService;
             $invalidBehavior = $decoratedService[3] ?? ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
 
             $definition->setDecoratedService(null);

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -41,11 +41,11 @@ class ResolveBindingsPass extends AbstractRecursivePass
         try {
             parent::process($container);
 
-            foreach ($this->unusedBindings as list($key, $serviceId, $bindingType, $file)) {
+            foreach ($this->unusedBindings as [$key, $serviceId, $bindingType, $file]) {
                 $argumentType = $argumentName = $message = null;
 
                 if (false !== strpos($key, ' ')) {
-                    list($argumentType, $argumentName) = explode(' ', $key, 2);
+                    [$argumentType, $argumentName] = explode(' ', $key, 2);
                 } elseif ('$' === $key[0]) {
                     $argumentName = $key;
                 } else {
@@ -117,7 +117,7 @@ class ResolveBindingsPass extends AbstractRecursivePass
         $bindingNames = [];
 
         foreach ($bindings as $key => $binding) {
-            list($bindingValue, $bindingId, $used, $bindingType, $file) = $binding->getValues();
+            [$bindingValue, $bindingId, $used, $bindingType, $file] = $binding->getValues();
             if ($used) {
                 $this->usedBindings[$bindingId] = true;
                 unset($this->unusedBindings[$bindingId]);
@@ -156,7 +156,7 @@ class ResolveBindingsPass extends AbstractRecursivePass
         }
 
         foreach ($calls as $i => $call) {
-            list($method, $arguments) = $call;
+            [$method, $arguments] = $call;
 
             if ($method instanceof \ReflectionFunctionAbstract) {
                 $reflectionMethod = $method;
@@ -210,7 +210,7 @@ class ResolveBindingsPass extends AbstractRecursivePass
         }
 
         if ($constructor) {
-            list(, $arguments) = array_pop($calls);
+            [, $arguments] = array_pop($calls);
 
             if ($arguments !== $value->getArguments()) {
                 $value->setArguments($arguments);
@@ -229,7 +229,7 @@ class ResolveBindingsPass extends AbstractRecursivePass
      */
     private function getBindingValue(BoundArgument $binding)
     {
-        list($bindingValue, $bindingId) = $binding->getValues();
+        [$bindingValue, $bindingId] = $binding->getValues();
 
         $this->usedBindings[$bindingId] = true;
         unset($this->unusedBindings[$bindingId]);

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNamedArgumentsPass.php
@@ -36,7 +36,7 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
         $calls[] = ['__construct', $value->getArguments()];
 
         foreach ($calls as $i => $call) {
-            list($method, $arguments) = $call;
+            [$method, $arguments] = $call;
             $parameters = null;
             $resolvedArguments = [];
 
@@ -98,7 +98,7 @@ class ResolveNamedArgumentsPass extends AbstractRecursivePass
             }
         }
 
-        list(, $arguments) = array_pop($calls);
+        [, $arguments] = array_pop($calls);
 
         if ($arguments !== $value->getArguments()) {
             $value->setArguments($arguments);

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1511,7 +1511,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     {
         if ($this->hasDefinition($id)) {
             foreach ($this->getDefinition($id)->getBindings() as $key => $binding) {
-                list(, $bindingId) = $binding->getValues();
+                [, $bindingId] = $binding->getValues();
                 $this->removedBindingIds[(int) $bindingId] = true;
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -568,7 +568,7 @@ EOF;
                 }
             }
 
-            foreach ($this->serviceCalls as $id => list($callCount, $behavior)) {
+            foreach ($this->serviceCalls as $id => [$callCount, $behavior]) {
                 if ('service_container' !== $id && $id !== $cId
                     && ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE !== $behavior
                     && $this->container->has($id)
@@ -878,7 +878,7 @@ EOF;
             $targetId = (string) $this->container->getAlias($targetId);
         }
 
-        list($callCount, $behavior) = $this->serviceCalls[$targetId];
+        [$callCount, $behavior] = $this->serviceCalls[$targetId];
 
         if ($id === $targetId) {
             return $this->addInlineService($id, $definition, $definition);
@@ -934,7 +934,7 @@ EOTXT
         $code = '';
 
         if ($isSimpleInstance = $isRootInstance = null === $inlineDef) {
-            foreach ($this->serviceCalls as $targetId => list($callCount, $behavior, $byConstructor)) {
+            foreach ($this->serviceCalls as $targetId => [$callCount, $behavior, $byConstructor]) {
                 if ($byConstructor && isset($this->circularReferences[$id][$targetId]) && !$this->circularReferences[$id][$targetId]) {
                     $code .= $this->addInlineReference($id, $definition, $targetId, $forConstructor);
                 }
@@ -1004,7 +1004,7 @@ EOTXT
         }
 
         foreach ($definitions as $id => $definition) {
-            if (!(list($file, $code) = $services[$id]) || null !== $file) {
+            if (!([$file, $code] = $services[$id]) || null !== $file) {
                 continue;
             }
             if ($definition->isPublic()) {
@@ -1022,7 +1022,7 @@ EOTXT
         $definitions = $this->container->getDefinitions();
         ksort($definitions);
         foreach ($definitions as $id => $definition) {
-            if ((list($file, $code) = $services[$id]) && null !== $file && ($definition->isPublic() || !$this->isTrivialInstance($definition) || isset($this->locatedIds[$id]))) {
+            if (([$file, $code] = $services[$id]) && null !== $file && ($definition->isPublic() || !$this->isTrivialInstance($definition) || isset($this->locatedIds[$id]))) {
                 if (!$definition->isShared()) {
                     $i = strpos($code, "\n\ninclude_once ");
                     if (false !== $i && false !== $i = strpos($code, "\n\n", 2 + $i)) {
@@ -1732,7 +1732,7 @@ EOF;
                     return sprintf('new \%s($this->getService, [%s%s], [%s%s])', ServiceLocator::class, $serviceMap, $serviceMap ? "\n        " : '', $serviceTypes, $serviceTypes ? "\n        " : '');
                 }
             } finally {
-                list($this->definitionVariables, $this->referenceVariables) = $scope;
+                [$this->definitionVariables, $this->referenceVariables] = $scope;
             }
         } elseif ($value instanceof Definition) {
             if ($value->hasErrors() && $e = $value->getErrors()) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -117,7 +117,7 @@ class XmlDumper extends Dumper
             $service->setAttribute('lazy', 'true');
         }
         if (null !== $decoratedService = $definition->getDecoratedService()) {
-            list($decorated, $renamedId, $priority) = $decoratedService;
+            [$decorated, $renamedId, $priority] = $decoratedService;
             $service->setAttribute('decorates', $decorated);
 
             $decorationOnInvalid = $decoratedService[3] ?? ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -132,7 +132,7 @@ class YamlDumper extends Dumper
         }
 
         if (null !== $decoratedService = $definition->getDecoratedService()) {
-            list($decorated, $renamedId, $priority) = $decoratedService;
+            [$decorated, $renamedId, $priority] = $decoratedService;
             $code .= sprintf("        decorates: %s\n", $decorated);
             if (null !== $renamedId) {
                 $code .= sprintf("        decoration_inner_name: %s\n", $renamedId);

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -443,7 +443,7 @@ class XmlFileLoader extends FileLoader
 
         // resolve definitions
         uksort($definitions, 'strnatcmp');
-        foreach (array_reverse($definitions) as $id => list($domElement, $file)) {
+        foreach (array_reverse($definitions) as $id => [$domElement, $file]) {
             if (null !== $definition = $this->parseDefinition($domElement, $file, [])) {
                 $this->setDefinition($id, $definition);
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveParameterPlaceHoldersPassTest.php
@@ -67,7 +67,7 @@ class ResolveParameterPlaceHoldersPassTest extends TestCase
 
     public function testBindingsShouldBeResolved()
     {
-        list($boundValue) = $this->container->getDefinition('foo')->getBindings()['$baz']->getValues();
+        [$boundValue] = $this->container->getDefinition('foo')->getBindings()['$baz']->getValues();
 
         $this->assertSame($this->container->getParameterBag()->resolveValue('%env(BAZ)%'), $boundValue);
     }

--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -494,7 +494,7 @@ class DebugClassLoader
                     $hasCall = $refl->hasMethod('__call');
                     $hasStaticCall = $refl->hasMethod('__callStatic');
                     foreach (self::$method[$use] as $method) {
-                        list($interface, $name, $static, $description) = $method;
+                        [$interface, $name, $static, $description] = $method;
                         if ($static ? $hasStaticCall : $hasCall) {
                             continue;
                         }
@@ -556,12 +556,12 @@ class DebugClassLoader
             }
 
             if ($parent && isset(self::$finalMethods[$parent][$method->name])) {
-                list($declaringClass, $message) = self::$finalMethods[$parent][$method->name];
+                [$declaringClass, $message] = self::$finalMethods[$parent][$method->name];
                 $deprecations[] = sprintf('The "%s::%s()" method is considered final%s. It may change without further notice as of its next major version. You should not extend it from "%s".', $declaringClass, $method->name, $message, $className);
             }
 
             if (isset(self::$internalMethods[$class][$method->name])) {
-                list($declaringClass, $message) = self::$internalMethods[$class][$method->name];
+                [$declaringClass, $message] = self::$internalMethods[$class][$method->name];
                 if (strncmp($ns, $declaringClass, $len)) {
                     $deprecations[] = sprintf('The "%s::%s()" method is considered internal%s. It may change without further notice. You should not extend it from "%s".', $declaringClass, $method->name, $message, $className);
                 }
@@ -601,7 +601,7 @@ class DebugClassLoader
             }
 
             if (null !== ($returnType = self::$returnTypes[$class][$method->name] ?? self::MAGIC_METHODS[$method->name] ?? null) && !$method->hasReturnType() && !($doc && preg_match('/\n\s+\* @return +(\S+)/', $doc))) {
-                list($normalizedType, $returnType, $declaringClass, $declaringFile) = \is_string($returnType) ? [$returnType, $returnType, '', ''] : $returnType;
+                [$normalizedType, $returnType, $declaringClass, $declaringFile] = \is_string($returnType) ? [$returnType, $returnType, '', ''] : $returnType;
 
                 if ('void' === $normalizedType) {
                     $canAddReturnType = false;
@@ -669,7 +669,7 @@ class DebugClassLoader
                     $definedParameters[$parameter->name] = true;
                 }
             }
-            foreach ($matches as list(, $parameterType, $parameterName)) {
+            foreach ($matches as [, $parameterType, $parameterName]) {
                 if (!isset($definedParameters[$parameterName])) {
                     $parameterType = trim($parameterType);
                     self::$annotatedParameters[$class][$method->name][$parameterName] = sprintf('The "%%s::%s()" method will require a new "%s$%s" argument in the next major version of its %s "%s", not defining it is deprecated.', $method->name, $parameterType ? $parameterType.' ' : '', $parameterName, interface_exists($className) ? 'interface' : 'parent class', $className);
@@ -940,10 +940,10 @@ class DebugClassLoader
                 continue;
             }
 
-            list($namespace, $useOffset, $useMap) = $useStatements[$file] ?? $useStatements[$file] = self::getUseStatements($file);
+            [$namespace, $useOffset, $useMap] = $useStatements[$file] ?? $useStatements[$file] = self::getUseStatements($file);
 
             if ('\\' !== $type[0]) {
-                list($declaringNamespace, , $declaringUseMap) = $useStatements[$declaringFile] ?? $useStatements[$declaringFile] = self::getUseStatements($declaringFile);
+                [$declaringNamespace, , $declaringUseMap] = $useStatements[$declaringFile] ?? $useStatements[$declaringFile] = self::getUseStatements($declaringFile);
 
                 $p = strpos($type, '\\', 1);
                 $alias = $p ? substr($type, 0, $p) : $type;

--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -196,7 +196,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
         $hash = 1 <= \func_num_args() && null !== ($request = func_get_arg(0)) ? spl_object_hash($request) : null;
         $called = [];
         foreach ($this->callStack as $listener) {
-            list($eventName, $requestHash) = $this->callStack->getInfo();
+            [$eventName, $requestHash] = $this->callStack->getInfo();
             if (null === $hash || $hash === $requestHash) {
                 $called[] = $listener->getInfo($eventName);
             }
@@ -228,7 +228,7 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
 
         if (null !== $this->callStack) {
             foreach ($this->callStack as $calledListener) {
-                list(, $requestHash) = $this->callStack->getInfo();
+                [, $requestHash] = $this->callStack->getInfo();
 
                 if (null === $hash || $hash === $requestHash) {
                     $calledListeners[] = $calledListener->getWrappedListener();

--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -62,7 +62,7 @@ class Lexer
                     throw new SyntaxError(sprintf('Unexpected "%s".', $expression[$cursor]), $cursor, $expression);
                 }
 
-                list($expect, $cur) = array_pop($brackets);
+                [$expect, $cur] = array_pop($brackets);
                 if ($expression[$cursor] != strtr($expect, '([{', ')]}')) {
                     throw new SyntaxError(sprintf('Unclosed "%s".', $expect), $cur, $expression);
                 }
@@ -94,7 +94,7 @@ class Lexer
         $tokens[] = new Token(Token::EOF_TYPE, null, $cursor + 1);
 
         if (!empty($brackets)) {
-            list($expect, $cur) = array_pop($brackets);
+            [$expect, $cur] = array_pop($brackets);
             throw new SyntaxError(sprintf('Unclosed "%s".', $expect), $cur, $expression);
         }
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -474,8 +474,8 @@ class Filesystem
             return $result;
         };
 
-        list($endPath, $endDriveLetter) = $splitDriveLetter($endPath);
-        list($startPath, $startDriveLetter) = $splitDriveLetter($startPath);
+        [$endPath, $endDriveLetter] = $splitDriveLetter($endPath);
+        [$startPath, $startDriveLetter] = $splitDriveLetter($startPath);
 
         $startPathArr = $splitPath($startPath);
         $endPathArr = $splitPath($endPath);
@@ -617,7 +617,7 @@ class Filesystem
      */
     public function tempnam($dir, $prefix)
     {
-        list($scheme, $hierarchy) = $this->getSchemeAndHierarchy($dir);
+        [$scheme, $hierarchy] = $this->getSchemeAndHierarchy($dir);
 
         // If no scheme or scheme is "file" or "gs" (Google Cloud) create temp file in local filesystem
         if (null === $scheme || 'file' === $scheme || 'gs' === $scheme) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
@@ -153,7 +153,7 @@ class FileType extends AbstractType
         $messageParameters = [];
 
         if (\UPLOAD_ERR_INI_SIZE === $errorCode) {
-            list($limitAsString, $suffix) = $this->factorizeSizes(0, self::getMaxFilesize());
+            [$limitAsString, $suffix] = $this->factorizeSizes(0, self::getMaxFilesize());
             $messageTemplate = 'The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.';
             $messageParameters = [
                 '{{ limit }}' => $limitAsString,

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -228,7 +228,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
      */
     private function resolveChild(string $name): FormBuilderInterface
     {
-        list($type, $options) = $this->unresolvedChildren[$name];
+        [$type, $options] = $this->unresolvedChildren[$name];
 
         unset($this->unresolvedChildren[$name]);
 

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -220,7 +220,7 @@ class BinaryFileResponse extends Response
                 // @link https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/#x-accel-redirect
                 $parts = HeaderUtils::split($request->headers->get('X-Accel-Mapping', ''), ',=');
                 foreach ($parts as $part) {
-                    list($pathPrefix, $location) = $part;
+                    [$pathPrefix, $location] = $part;
                     if (substr($path, 0, \strlen($pathPrefix)) === $pathPrefix) {
                         $path = $location.substr($path, \strlen($pathPrefix));
                         // Only set X-Accel-Redirect header if a valid URI can be produced
@@ -240,7 +240,7 @@ class BinaryFileResponse extends Response
                 $range = $request->headers->get('Range');
 
                 if (0 === strpos($range, 'bytes=')) {
-                    list($start, $end) = explode('-', substr($range, 6), 2) + [0];
+                    [$start, $end] = explode('-', substr($range, 6), 2) + [0];
 
                     $end = ('' === $end) ? $fileSize - 1 : (int) $end;
 

--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -73,7 +73,7 @@ class IpUtils
         }
 
         if (false !== strpos($ip, '/')) {
-            list($address, $netmask) = explode('/', $ip, 2);
+            [$address, $netmask] = explode('/', $ip, 2);
 
             if ('0' === $netmask) {
                 return self::$checkedIps[$cacheKey] = filter_var($address, \FILTER_VALIDATE_IP, \FILTER_FLAG_IPV4);
@@ -121,7 +121,7 @@ class IpUtils
         }
 
         if (false !== strpos($ip, '/')) {
-            list($address, $netmask) = explode('/', $ip, 2);
+            [$address, $netmask] = explode('/', $ip, 2);
 
             if ('0' === $netmask) {
                 return (bool) unpack('n*', @inet_pton($address));

--- a/src/Symfony/Component/HttpFoundation/ServerBag.php
+++ b/src/Symfony/Component/HttpFoundation/ServerBag.php
@@ -66,7 +66,7 @@ class ServerBag extends ParameterBag
                     // Decode AUTHORIZATION header into PHP_AUTH_USER and PHP_AUTH_PW when authorization header is basic
                     $exploded = explode(':', base64_decode(substr($authorizationHeader, 6)), 2);
                     if (2 == \count($exploded)) {
-                        list($headers['PHP_AUTH_USER'], $headers['PHP_AUTH_PW']) = $exploded;
+                        [$headers['PHP_AUTH_USER'], $headers['PHP_AUTH_PW']] = $exploded;
                     }
                 } elseif (empty($this->parameters['PHP_AUTH_DIGEST']) && (0 === stripos($authorizationHeader, 'digest '))) {
                     // In some circumstances PHP_AUTH_DIGEST needs to be set

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -116,7 +116,7 @@ class ControllerResolver implements ControllerResolverInterface
             return $controller;
         }
 
-        list($class, $method) = explode('::', $controller, 2);
+        [$class, $method] = explode('::', $controller, 2);
 
         try {
             $controller = [$this->instantiateController($class), $method];
@@ -176,7 +176,7 @@ class ControllerResolver implements ControllerResolverInterface
             return 'Invalid array callable, expected [controller, method].';
         }
 
-        list($controller, $method) = $callable;
+        [$controller, $method] = $callable;
 
         if (\is_string($controller) && !class_exists($controller)) {
             return sprintf('Class "%s" does not exist.', $controller);

--- a/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DumpDataCollector.php
@@ -75,7 +75,7 @@ class DumpDataCollector extends DataCollector implements DataDumperInterface
             $this->stopwatch->start('dump');
         }
 
-        list('name' => $name, 'file' => $file, 'line' => $line, 'file_excerpt' => $fileExcerpt) = $this->sourceContextProvider->getContext();
+        ['name' => $name, 'file' => $file, 'line' => $line, 'file_excerpt' => $fileExcerpt] = $this->sourceContextProvider->getContext();
 
         if ($this->dumper instanceof Connection) {
             if (!$this->dumper->write($data)) {

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -99,7 +99,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                 if (!isset($methods[$action = strtolower($attributes['action'])])) {
                     throw new InvalidArgumentException(sprintf('Invalid "action" attribute on tag "%s" for service "%s": no public "%s()" method found on class "%s".', $this->controllerTag, $id, $attributes['action'], $class));
                 }
-                list($r, $parameters) = $methods[$action];
+                [$r, $parameters] = $methods[$action];
                 $found = false;
 
                 foreach ($parameters as $p) {
@@ -117,7 +117,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                 }
             }
 
-            foreach ($methods as list($r, $parameters)) {
+            foreach ($methods as [$r, $parameters]) {
                 /** @var \ReflectionMethod $r */
 
                 // create a per-method map of argument-names to service/type-references
@@ -139,7 +139,7 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
                     } elseif (isset($bindings[$bindingName = $type.' $'.$p->name]) || isset($bindings[$bindingName = '$'.$p->name]) || isset($bindings[$bindingName = $type])) {
                         $binding = $bindings[$bindingName];
 
-                        list($bindingValue, $bindingId, , $bindingType, $bindingFile) = $binding->getValues();
+                        [$bindingValue, $bindingId, , $bindingType, $bindingFile] = $binding->getValues();
                         $binding->setValues([$bindingValue, $bindingId, true, $bindingType, $bindingFile]);
 
                         if (!$bindingValue instanceof Reference) {

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
@@ -42,9 +42,9 @@ class RemoveEmptyControllerArgumentLocatorsPass implements CompilerPassInterface
             } else {
                 // any methods listed for call-at-instantiation cannot be actions
                 $reason = false;
-                list($id, $action) = explode('::', $controller);
+                [$id, $action] = explode('::', $controller);
                 $controllerDef = $container->getDefinition($id);
-                foreach ($controllerDef->getMethodCalls() as list($method)) {
+                foreach ($controllerDef->getMethodCalls() as [$method]) {
                     if (0 === strcasecmp($action, $method)) {
                         $reason = sprintf('Removing method "%s" of service "%s" from controller candidates: the method is called at instantiation, thus cannot be an action.', $action, $id);
                         break;

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -262,7 +262,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $bundleName = substr($name, 1);
         $path = '';
         if (false !== strpos($bundleName, '/')) {
-            list($bundleName, $path) = explode('/', $bundleName, 2);
+            [$bundleName, $path] = explode('/', $bundleName, 2);
         }
 
         $isResource = 0 === strpos($path, 'Resources') && null !== $dir;
@@ -893,7 +893,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     public function unserialize($data)
     {
         @trigger_error(sprintf('The "%s" method is deprecated since Symfony 4.3.', __METHOD__), \E_USER_DEPRECATED);
-        list($environment, $debug) = unserialize($data, ['allowed_classes' => false]);
+        [$environment, $debug] = unserialize($data, ['allowed_classes' => false]);
 
         $this->__construct($environment, $debug);
     }

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -61,7 +61,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
         $result = [];
         while (\count($result) < $limit && $line = $this->readLineFromFile($file)) {
             $values = str_getcsv($line);
-            list($csvToken, $csvIp, $csvMethod, $csvUrl, $csvTime, $csvParent, $csvStatusCode) = $values;
+            [$csvToken, $csvIp, $csvMethod, $csvUrl, $csvTime, $csvParent, $csvStatusCode] = $values;
             $csvTime = (int) $csvTime;
 
             if ($ip && false === strpos($csvIp, $ip) || $url && false === strpos($csvUrl, $url) || $method && false === strpos($csvMethod, $method) || $statusCode && false === strpos($csvStatusCode, $statusCode)) {

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ControllerArgumentValueResolverPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ControllerArgumentValueResolverPassTest.php
@@ -39,7 +39,7 @@ class ControllerArgumentValueResolverPassTest extends TestCase
         $container = new ContainerBuilder();
         $container->setDefinition('argument_resolver', $definition);
 
-        foreach ($services as $id => list($tag)) {
+        foreach ($services as $id => [$tag]) {
             $container->register($id)->addTag('controller.argument_value_resolver', $tag);
         }
 
@@ -72,7 +72,7 @@ class ControllerArgumentValueResolverPassTest extends TestCase
         $container->register('debug.stopwatch', Stopwatch::class);
         $container->setDefinition('argument_resolver', $definition);
 
-        foreach ($services as $id => list($tag)) {
+        foreach ($services as $id => [$tag]) {
             $container->register($id)->addTag('controller.argument_value_resolver', $tag);
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
@@ -92,7 +92,7 @@ class StoreTest extends TestCase
     {
         $cacheKey = $this->storeSimpleEntry();
         $entries = $this->getStoreMetadata($cacheKey);
-        list(, $res) = $entries[0];
+        [, $res] = $entries[0];
 
         $this->assertEquals('en9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08', $res['x-content-digest'][0]);
     }
@@ -103,7 +103,7 @@ class StoreTest extends TestCase
 
         $cacheKey = $this->store->write($this->request, $response);
         $entries = $this->getStoreMetadata($cacheKey);
-        list(, $res) = $entries[0];
+        [, $res] = $entries[0];
 
         $this->assertEquals('en9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08', $res['x-content-digest'][0]);
         $this->assertEquals('en9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08', $response->headers->get('X-Content-Digest'));

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/TestHttpKernel.php
@@ -43,13 +43,13 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface, 
     {
         $trustedConfig = [Request::getTrustedProxies(), Request::getTrustedHeaderSet()];
 
-        list($trustedProxies, $trustedHeaderSet, $backendRequest) = $this->backendRequest;
+        [$trustedProxies, $trustedHeaderSet, $backendRequest] = $this->backendRequest;
         Request::setTrustedProxies($trustedProxies, $trustedHeaderSet);
 
         try {
             $callback($backendRequest);
         } finally {
-            list($trustedProxies, $trustedHeaderSet) = $trustedConfig;
+            [$trustedProxies, $trustedHeaderSet] = $trustedConfig;
             Request::setTrustedProxies($trustedProxies, $trustedHeaderSet);
         }
     }

--- a/src/Symfony/Component/Lock/Store/MemcachedStore.php
+++ b/src/Symfony/Component/Lock/Store/MemcachedStore.php
@@ -94,7 +94,7 @@ class MemcachedStore implements StoreInterface
 
         $token = $this->getUniqueToken($key);
 
-        list($value, $cas) = $this->getValueAndCas($key);
+        [$value, $cas] = $this->getValueAndCas($key);
 
         $key->reduceLifetime($ttl);
         // Could happens when we ask a putOff after a timeout but in luck nobody steal the lock
@@ -126,7 +126,7 @@ class MemcachedStore implements StoreInterface
     {
         $token = $this->getUniqueToken($key);
 
-        list($value, $cas) = $this->getValueAndCas($key);
+        [$value, $cas] = $this->getValueAndCas($key);
 
         if ($value !== $token) {
             // we are not the owner of the lock. Nothing to do.

--- a/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/SemaphoreStoreTest.php
@@ -60,7 +60,7 @@ class SemaphoreStoreTest extends AbstractStoreTest
         if ('------ Semaphore Status --------' !== $lines[0]) {
             throw new \Exception('Failed to extract list of opened semaphores. Expected a Semaphore status, got '.implode(\PHP_EOL, $lines));
         }
-        list($key, $value) = explode(' = ', $lines[1]);
+        [$key, $value] = explode(' = ', $lines[1]);
         if ('used arrays' !== $key) {
             throw new \Exception('Failed to extract list of opened semaphores. Expected a "used arrays" key, got '.implode(\PHP_EOL, $lines));
         }

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -83,7 +83,7 @@ class Transport
 
     public function fromString(string $dsn): TransportInterface
     {
-        list($transport, $offset) = $this->parseDsn($dsn);
+        [$transport, $offset] = $this->parseDsn($dsn);
         if ($offset !== \strlen($dsn)) {
             throw new InvalidArgumentException(sprintf('The DSN has some garbage at the end: "%s".', substr($dsn, $offset)));
         }
@@ -111,7 +111,7 @@ class Transport
                     ++$offset;
                     $args = [];
                     while (true) {
-                        list($arg, $offset) = $this->parseDsn($dsn, $offset);
+                        [$arg, $offset] = $this->parseDsn($dsn, $offset);
                         $args[] = $arg;
                         if (\strlen($dsn) === $offset) {
                             break;

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -290,7 +290,7 @@ class SmtpTransport extends AbstractTransport
             throw new TransportException(sprintf('Expected response code "%s" but got an empty response.', implode('/', $codes)));
         }
 
-        list($code) = sscanf($response, '%3d');
+        [$code] = sscanf($response, '%3d');
         $valid = \in_array($code, $codes);
 
         if (!$valid) {

--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -266,7 +266,7 @@ class Email extends Message
      */
     public function getPriority(): int
     {
-        list($priority) = sscanf($this->getHeaders()->getHeaderBody('X-Priority'), '%[1-5]');
+        [$priority] = sscanf($this->getHeaders()->getHeaderBody('X-Priority'), '%[1-5]');
 
         return $priority ?? 3;
     }

--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -35,7 +35,7 @@ class DataPart extends TextPart
         if (null === $contentType) {
             $contentType = 'application/octet-stream';
         }
-        list($this->mediaType, $subtype) = explode('/', $contentType);
+        [$this->mediaType, $subtype] = explode('/', $contentType);
 
         parent::__construct($body, null, $subtype, $encoding);
 

--- a/src/Symfony/Component/Process/Tests/ErrorProcessInitiator.php
+++ b/src/Symfony/Component/Process/Tests/ErrorProcessInitiator.php
@@ -16,7 +16,7 @@ use Symfony\Component\Process\Process;
 
 require \dirname(__DIR__).'/vendor/autoload.php';
 
-list('e' => $php) = getopt('e:') + ['e' => 'php'];
+['e' => $php] = getopt('e:') + ['e' => 'php'];
 
 try {
     $process = new Process("exec $php -r \"echo 'ready'; trigger_error('error', E_USER_ERROR);\"");

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -202,7 +202,7 @@ class PropertyAccessor implements PropertyAccessorInterface
         }
 
         if (preg_match('/^\S+::\S+\(\): Argument #\d+ \(\$\S+\) must be of type (\S+), (\S+) given/', $message, $matches)) {
-            list(, $expectedType, $actualType) = $matches;
+            [, $expectedType, $actualType] = $matches;
 
             throw new InvalidArgumentException(sprintf('Expected argument of type "%s", "%s" given at property path "%s".', $expectedType, 'NULL' === $actualType ? 'null' : $actualType, $propertyPath), 0, $previous);
         }
@@ -392,7 +392,7 @@ class PropertyAccessor implements PropertyAccessorInterface
                 try {
                     $result[self::VALUE] = $object->{$access[self::ACCESS_NAME]}();
                 } catch (\TypeError $e) {
-                    list($trace) = $e->getTrace();
+                    [$trace] = $e->getTrace();
 
                     // handle uninitialized properties in PHP >= 7
                     if (__FILE__ === $trace['file']

--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -77,7 +77,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     public function getShortDescription($class, $property, array $context = []): ?string
     {
         /** @var $docBlock DocBlock */
-        list($docBlock) = $this->getDocBlock($class, $property);
+        [$docBlock] = $this->getDocBlock($class, $property);
         if (!$docBlock) {
             return null;
         }
@@ -107,7 +107,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     public function getLongDescription($class, $property, array $context = []): ?string
     {
         /** @var $docBlock DocBlock */
-        list($docBlock) = $this->getDocBlock($class, $property);
+        [$docBlock] = $this->getDocBlock($class, $property);
         if (!$docBlock) {
             return null;
         }
@@ -123,7 +123,7 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
     public function getTypes($class, $property, array $context = []): ?array
     {
         /** @var $docBlock DocBlock */
-        list($docBlock, $source, $prefix) = $this->getDocBlock($class, $property);
+        [$docBlock, $source, $prefix] = $this->getDocBlock($class, $property);
         if (!$docBlock) {
             return null;
         }
@@ -176,11 +176,11 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
                 $data = [$docBlock, self::PROPERTY, null];
                 break;
 
-            case list($docBlock) = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::ACCESSOR):
+            case [$docBlock] = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::ACCESSOR):
                 $data = [$docBlock, self::ACCESSOR, null];
                 break;
 
-            case list($docBlock, $prefix) = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::MUTATOR):
+            case [$docBlock, $prefix] = $this->getDocBlockFromMethod($class, $ucFirstProperty, self::MUTATOR):
                 $data = [$docBlock, self::MUTATOR, $prefix];
                 break;
 

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -182,7 +182,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             return true;
         }
 
-        list($reflectionMethod) = $this->getAccessorMethod($class, $property);
+        [$reflectionMethod] = $this->getAccessorMethod($class, $property);
 
         return null !== $reflectionMethod;
     }
@@ -196,7 +196,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             return true;
         }
 
-        list($reflectionMethod) = $this->getMutatorMethod($class, $property);
+        [$reflectionMethod] = $this->getMutatorMethod($class, $property);
 
         return null !== $reflectionMethod;
     }
@@ -234,7 +234,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      */
     private function extractFromMutator(string $class, string $property): ?array
     {
-        list($reflectionMethod, $prefix) = $this->getMutatorMethod($class, $property);
+        [$reflectionMethod, $prefix] = $this->getMutatorMethod($class, $property);
         if (null === $reflectionMethod) {
             return null;
         }
@@ -261,7 +261,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
      */
     private function extractFromAccessor(string $class, string $property): ?array
     {
-        list($reflectionMethod, $prefix) = $this->getAccessorMethod($class, $property);
+        [$reflectionMethod, $prefix] = $this->getAccessorMethod($class, $property);
         if (null === $reflectionMethod) {
             return null;
         }

--- a/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
+++ b/src/Symfony/Component/PropertyInfo/Util/PhpDocTypeHelper.php
@@ -90,7 +90,7 @@ final class PhpDocTypeHelper
         $docType = $docType ?? (string) $type;
 
         if ($type instanceof Collection) {
-            list($phpType, $class) = $this->getPhpTypeAndClass((string) $type->getFqsen());
+            [$phpType, $class] = $this->getPhpTypeAndClass((string) $type->getFqsen());
 
             $key = $this->getTypes($type->getKeyType());
             $value = $this->getTypes($type->getValueType());
@@ -121,7 +121,7 @@ final class PhpDocTypeHelper
         }
 
         $docType = $this->normalizeType($docType);
-        list($phpType, $class) = $this->getPhpTypeAndClass($docType);
+        [$phpType, $class] = $this->getPhpTypeAndClass($docType);
 
         if ('array' === $docType) {
             return new Type(Type::BUILTIN_TYPE_ARRAY, $nullable, null, true, null, null);

--- a/src/Symfony/Component/Routing/Generator/CompiledUrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/CompiledUrlGenerator.php
@@ -50,7 +50,7 @@ class CompiledUrlGenerator extends UrlGenerator
             throw new RouteNotFoundException(sprintf('Unable to generate a URL for the named route "%s" as such route does not exist.', $name));
         }
 
-        list($variables, $defaults, $requirements, $tokens, $hostTokens, $requiredSchemes) = $this->compiledRoutes[$name];
+        [$variables, $defaults, $requirements, $tokens, $hostTokens, $requiredSchemes] = $this->compiledRoutes[$name];
 
         if (isset($defaults['_canonical_route']) && isset($defaults['_locale'])) {
             if (!\in_array('_locale', $variables, true)) {

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -113,7 +113,7 @@ class XmlFileLoader extends FileLoader
         $schemes = preg_split('/[\s,\|]++/', $node->getAttribute('schemes'), -1, \PREG_SPLIT_NO_EMPTY);
         $methods = preg_split('/[\s,\|]++/', $node->getAttribute('methods'), -1, \PREG_SPLIT_NO_EMPTY);
 
-        list($defaults, $requirements, $options, $condition, $paths) = $this->parseConfigs($node, $path);
+        [$defaults, $requirements, $options, $condition, $paths] = $this->parseConfigs($node, $path);
 
         if (!$paths && '' === $node->getAttribute('path')) {
             throw new \InvalidArgumentException(sprintf('The <route> element in file "%s" must have a "path" attribute or <path> child nodes.', $path));
@@ -159,7 +159,7 @@ class XmlFileLoader extends FileLoader
         $methods = $node->hasAttribute('methods') ? preg_split('/[\s,\|]++/', $node->getAttribute('methods'), -1, \PREG_SPLIT_NO_EMPTY) : null;
         $trailingSlashOnRoot = $node->hasAttribute('trailing-slash-on-root') ? XmlUtils::phpize($node->getAttribute('trailing-slash-on-root')) : true;
 
-        list($defaults, $requirements, $options, $condition, /* $paths */, $prefixes) = $this->parseConfigs($node, $path);
+        [$defaults, $requirements, $options, $condition, /* $paths */, $prefixes] = $this->parseConfigs($node, $path);
 
         if ('' !== $prefix && $prefixes) {
             throw new \InvalidArgumentException(sprintf('The <route> element in file "%s" must not have both a "prefix" attribute and <prefix> child nodes.', $path));

--- a/src/Symfony/Component/Routing/Matcher/CompiledUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/CompiledUrlMatcher.php
@@ -26,6 +26,6 @@ class CompiledUrlMatcher extends UrlMatcher
     public function __construct(array $compiledRoutes, RequestContext $context)
     {
         $this->context = $context;
-        list($this->matchHost, $this->staticRoutes, $this->regexpList, $this->dynamicRoutes, $this->checkCondition) = $compiledRoutes;
+        [$this->matchHost, $this->staticRoutes, $this->regexpList, $this->dynamicRoutes, $this->checkCondition] = $compiledRoutes;
     }
 }

--- a/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherDumper.php
@@ -83,7 +83,7 @@ EOF;
             $routes = $this->getRoutes();
         }
 
-        list($staticRoutes, $dynamicRoutes) = $this->groupStaticRoutes($routes);
+        [$staticRoutes, $dynamicRoutes] = $this->groupStaticRoutes($routes);
 
         $conditions = [null];
         $compiledRoutes[] = $this->compileStaticRoutes($staticRoutes, $conditions);
@@ -131,7 +131,7 @@ EOF;
 
     private function generateCompiledRoutes(): string
     {
-        list($matchHost, $staticRoutes, $regexpCode, $dynamicRoutes, $checkConditionCode) = $this->getCompiledRoutes(true);
+        [$matchHost, $staticRoutes, $regexpCode, $dynamicRoutes, $checkConditionCode] = $this->getCompiledRoutes(true);
 
         $code = self::export($matchHost).', // $matchHost'."\n";
 
@@ -186,7 +186,7 @@ EOF;
                 if ($hasTrailingSlash) {
                     $url = substr($url, 0, -1);
                 }
-                foreach ($dynamicRegex as list($hostRx, $rx, $prefix)) {
+                foreach ($dynamicRegex as [$hostRx, $rx, $prefix]) {
                     if (('' === $prefix || 0 === strpos($url, $prefix)) && (preg_match($rx, $url) || preg_match($rx, $url.'/')) && (!$host || !$hostRx || preg_match($hostRx, $host))) {
                         $dynamicRegex[] = [$hostRegex, $regex, $staticPrefix];
                         $dynamicRoutes->add($name, $route);
@@ -221,7 +221,7 @@ EOF;
 
         foreach ($staticRoutes as $url => $routes) {
             $compiledRoutes[$url] = [];
-            foreach ($routes as $name => list($route, $hasTrailingSlash)) {
+            foreach ($routes as $name => [$route, $hasTrailingSlash]) {
                 $compiledRoutes[$url][] = $this->compileRoute($route, $name, (!$route->compile()->getHostVariables() ? $route->getHost() : $route->compile()->getHostRegex()) ?: null, $hasTrailingSlash, false, $conditions);
             }
         }
@@ -287,7 +287,7 @@ EOF;
             $routes->add($name, $route);
         }
 
-        foreach ($perModifiers as list($modifiers, $routes)) {
+        foreach ($perModifiers as [$modifiers, $routes]) {
             $prev = false;
             $perHost = [];
             foreach ($routes->all() as $name => $route) {
@@ -306,7 +306,7 @@ EOF;
             $state->mark += \strlen($rx);
             $state->regex = $rx;
 
-            foreach ($perHost as list($hostRegex, $routes)) {
+            foreach ($perHost as [$hostRegex, $routes]) {
                 if ($matchHost) {
                     if ($hostRegex) {
                         preg_match('#^.\^(.*)\$.[a-zA-Z]*$#', $hostRegex, $rx);
@@ -391,7 +391,7 @@ EOF;
                 continue;
             }
 
-            list($name, $regex, $vars, $route, $hasTrailingSlash, $hasTrailingVar) = $route;
+            [$name, $regex, $vars, $route, $hasTrailingSlash, $hasTrailingVar] = $route;
             $compiledRoute = $route->compile();
             $vars = array_merge($state->hostVars, $vars);
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherTrait.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/CompiledUrlMatcherTrait.php
@@ -87,7 +87,7 @@ trait CompiledUrlMatcherTrait
         }
         $supportsRedirections = 'GET' === $canonicalMethod && $this instanceof RedirectableUrlMatcherInterface;
 
-        foreach ($this->staticRoutes[$trimmedPathinfo] ?? [] as list($ret, $requiredHost, $requiredMethods, $requiredSchemes, $hasTrailingSlash, , $condition)) {
+        foreach ($this->staticRoutes[$trimmedPathinfo] ?? [] as [$ret, $requiredHost, $requiredMethods, $requiredSchemes, $hasTrailingSlash, , $condition]) {
             if ($condition && !($this->checkCondition)($condition, $context, 0 < $condition ? $request ?? $request = $this->request ?: $this->createRequest($pathinfo) : null)) {
                 continue;
             }
@@ -127,7 +127,7 @@ trait CompiledUrlMatcherTrait
 
         foreach ($this->regexpList as $offset => $regex) {
             while (preg_match($regex, $matchedPathinfo, $matches)) {
-                foreach ($this->dynamicRoutes[$m = (int) $matches['MARK']] as list($ret, $vars, $requiredMethods, $requiredSchemes, $hasTrailingSlash, $hasTrailingVar, $condition)) {
+                foreach ($this->dynamicRoutes[$m = (int) $matches['MARK']] as [$ret, $vars, $requiredMethods, $requiredSchemes, $hasTrailingSlash, $hasTrailingVar, $condition]) {
                     if (null !== $condition) {
                         if (0 === $condition) { // marks the last route in the regexp
                             continue 3;

--- a/src/Symfony/Component/Routing/Matcher/Dumper/StaticPrefixCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/StaticPrefixCollection.php
@@ -65,12 +65,12 @@ class StaticPrefixCollection
      */
     public function addRoute(string $prefix, $route)
     {
-        list($prefix, $staticPrefix) = $this->getCommonPrefix($prefix, $prefix);
+        [$prefix, $staticPrefix] = $this->getCommonPrefix($prefix, $prefix);
 
         for ($i = \count($this->items) - 1; 0 <= $i; --$i) {
             $item = $this->items[$i];
 
-            list($commonPrefix, $commonStaticPrefix) = $this->getCommonPrefix($prefix, $this->prefixes[$i]);
+            [$commonPrefix, $commonStaticPrefix] = $this->getCommonPrefix($prefix, $this->prefixes[$i]);
 
             if ($this->prefix === $commonPrefix) {
                 // the new route and a previous one have no common prefix, let's see if they are exclusive to each others
@@ -104,8 +104,8 @@ class StaticPrefixCollection
             } else {
                 // the new route and a previous one have a common prefix, let's merge them
                 $child = new self($commonPrefix);
-                list($child->prefixes[0], $child->staticPrefixes[0]) = $child->getCommonPrefix($this->prefixes[$i], $this->prefixes[$i]);
-                list($child->prefixes[1], $child->staticPrefixes[1]) = $child->getCommonPrefix($prefix, $prefix);
+                [$child->prefixes[0], $child->staticPrefixes[0]] = $child->getCommonPrefix($this->prefixes[$i], $this->prefixes[$i]);
+                [$child->prefixes[1], $child->staticPrefixes[1]] = $child->getCommonPrefix($prefix, $prefix);
                 $child->items = [$this->items[$i], $route];
 
                 $this->staticPrefixes[$i] = $commonStaticPrefix;

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/StaticPrefixCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/StaticPrefixCollectionTest.php
@@ -16,7 +16,7 @@ class StaticPrefixCollectionTest extends TestCase
         $collection = new StaticPrefixCollection('/');
 
         foreach ($routes as $route) {
-            list($path, $name) = $route;
+            [$path, $name] = $route;
             $staticPrefix = (new Route($path))->compile()->getStaticPrefix();
             $collection->addRoute($staticPrefix, [$name]);
         }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/TraceableAccessDecisionManagerTest.php
@@ -40,7 +40,7 @@ class TraceableAccessDecisionManagerTest extends TestCase
             ->with($token, $attributes, $object)
             ->willReturnCallback(function ($token, $attributes, $object) use ($voterVotes, $adm, $result) {
                 foreach ($voterVotes as $voterVote) {
-                    list($voter, $vote) = $voterVote;
+                    [$voter, $vote] = $voterVote;
                     $adm->addVoterVote($voter, $attributes, $vote);
                 }
 

--- a/src/Symfony/Component/Security/Csrf/Tests/CsrfTokenManagerTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/CsrfTokenManagerTest.php
@@ -175,28 +175,28 @@ class CsrfTokenManagerTest extends TestCase
     {
         $data = [];
 
-        list($generator, $storage) = $this->getGeneratorAndStorage();
+        [$generator, $storage] = $this->getGeneratorAndStorage();
         $data[] = ['', new CsrfTokenManager($generator, $storage, ''), $storage, $generator];
 
-        list($generator, $storage) = $this->getGeneratorAndStorage();
+        [$generator, $storage] = $this->getGeneratorAndStorage();
         $data[] = ['https-', new CsrfTokenManager($generator, $storage), $storage, $generator];
 
-        list($generator, $storage) = $this->getGeneratorAndStorage();
+        [$generator, $storage] = $this->getGeneratorAndStorage();
         $data[] = ['aNamespace-', new CsrfTokenManager($generator, $storage, 'aNamespace-'), $storage, $generator];
 
         $requestStack = new RequestStack();
         $requestStack->push(new Request([], [], [], [], [], ['HTTPS' => 'on']));
-        list($generator, $storage) = $this->getGeneratorAndStorage();
+        [$generator, $storage] = $this->getGeneratorAndStorage();
         $data[] = ['https-', new CsrfTokenManager($generator, $storage, $requestStack), $storage, $generator];
 
-        list($generator, $storage) = $this->getGeneratorAndStorage();
+        [$generator, $storage] = $this->getGeneratorAndStorage();
         $data[] = ['generated-', new CsrfTokenManager($generator, $storage, function () {
             return 'generated-';
         }), $storage, $generator];
 
         $requestStack = new RequestStack();
         $requestStack->push(new Request());
-        list($generator, $storage) = $this->getGeneratorAndStorage();
+        [$generator, $storage] = $this->getGeneratorAndStorage();
         $data[] = ['', new CsrfTokenManager($generator, $storage, $requestStack), $storage, $generator];
 
         return $data;

--- a/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
@@ -45,7 +45,7 @@ class ChannelListener extends AbstractListener implements ListenerInterface
      */
     public function supports(Request $request): ?bool
     {
-        list(, $channel) = $this->map->getPatterns($request);
+        [, $channel] = $this->map->getPatterns($request);
 
         if ('https' === $channel && !$request->isSecure()) {
             if (null !== $this->logger) {

--- a/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
@@ -92,7 +92,7 @@ class LogoutUrlGenerator
      */
     private function generateLogoutUrl(?string $key, int $referenceType): string
     {
-        list($logoutPath, $csrfTokenId, $csrfParameter, $csrfTokenManager) = $this->getListener($key);
+        [$logoutPath, $csrfTokenId, $csrfParameter, $csrfTokenManager] = $this->getListener($key);
 
         if (null === $logoutPath) {
             throw new \LogicException('Unable to generate the logout URL without a path.');
@@ -154,7 +154,7 @@ class LogoutUrlGenerator
         }
 
         // Fetch from injected current firewall information, if possible
-        list($key, $context) = $this->currentFirewall;
+        [$key, $context] = $this->currentFirewall;
 
         if (isset($this->listeners[$key])) {
             return $this->listeners[$key];

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
@@ -49,7 +49,7 @@ class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
         if (null !== ($cookie = $request->cookies->get($this->options['name']))
             && 2 === \count($parts = $this->decodeCookie($cookie))
         ) {
-            list($series) = $parts;
+            [$series] = $parts;
             $this->tokenProvider->deleteTokenBySeries($series);
         }
     }
@@ -63,7 +63,7 @@ class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
             throw new AuthenticationException('The cookie is invalid.');
         }
 
-        list($series, $tokenValue) = $cookieParts;
+        [$series, $tokenValue] = $cookieParts;
         $persistentToken = $this->tokenProvider->loadTokenBySeries($series);
 
         if (!hash_equals($persistentToken->getTokenValue(), $tokenValue)) {

--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -35,7 +35,7 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
             throw new AuthenticationException('The cookie is invalid.');
         }
 
-        list($class, $username, $expires, $hash) = $cookieParts;
+        [$class, $username, $expires, $hash] = $cookieParts;
         if (false === $username = base64_decode($username, true)) {
             throw new AuthenticationException('$username contains a character from outside the base64 alphabet.');
         }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
@@ -21,9 +21,9 @@ class LogoutListenerTest extends TestCase
 {
     public function testHandleUnmatchedPath()
     {
-        list($listener, , $httpUtils, $options) = $this->getListener();
+        [$listener, , $httpUtils, $options] = $this->getListener();
 
-        list($event, $request) = $this->getGetResponseEvent();
+        [$event, $request] = $this->getGetResponseEvent();
 
         $event->expects($this->never())
             ->method('setResponse');
@@ -41,9 +41,9 @@ class LogoutListenerTest extends TestCase
         $successHandler = $this->getSuccessHandler();
         $tokenManager = $this->getTokenManager();
 
-        list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener($successHandler, $tokenManager);
+        [$listener, $tokenStorage, $httpUtils, $options] = $this->getListener($successHandler, $tokenManager);
 
-        list($event, $request) = $this->getGetResponseEvent();
+        [$event, $request] = $this->getGetResponseEvent();
 
         $request->query->set('_csrf_token', 'token');
 
@@ -87,9 +87,9 @@ class LogoutListenerTest extends TestCase
     {
         $successHandler = $this->getSuccessHandler();
 
-        list($listener, $tokenStorage, $httpUtils, $options) = $this->getListener($successHandler);
+        [$listener, $tokenStorage, $httpUtils, $options] = $this->getListener($successHandler);
 
-        list($event, $request) = $this->getGetResponseEvent();
+        [$event, $request] = $this->getGetResponseEvent();
 
         $httpUtils->expects($this->once())
             ->method('checkRequestPath')
@@ -128,9 +128,9 @@ class LogoutListenerTest extends TestCase
         $this->expectException('RuntimeException');
         $successHandler = $this->getSuccessHandler();
 
-        list($listener, , $httpUtils, $options) = $this->getListener($successHandler);
+        [$listener, , $httpUtils, $options] = $this->getListener($successHandler);
 
-        list($event, $request) = $this->getGetResponseEvent();
+        [$event, $request] = $this->getGetResponseEvent();
 
         $httpUtils->expects($this->once())
             ->method('checkRequestPath')
@@ -150,9 +150,9 @@ class LogoutListenerTest extends TestCase
         $this->expectException('Symfony\Component\Security\Core\Exception\LogoutException');
         $tokenManager = $this->getTokenManager();
 
-        list($listener, , $httpUtils, $options) = $this->getListener(null, $tokenManager);
+        [$listener, , $httpUtils, $options] = $this->getListener(null, $tokenManager);
 
-        list($event, $request) = $this->getGetResponseEvent();
+        [$event, $request] = $this->getGetResponseEvent();
 
         $request->query->set('_csrf_token', 'token');
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/RememberMeListenerTest.php
@@ -25,7 +25,7 @@ class RememberMeListenerTest extends TestCase
 {
     public function testOnCoreSecurityDoesNotTryToPopulateNonEmptyTokenStorage()
     {
-        list($listener, $tokenStorage) = $this->getListener();
+        [$listener, $tokenStorage] = $this->getListener();
 
         $tokenStorage
             ->expects($this->any())
@@ -43,7 +43,7 @@ class RememberMeListenerTest extends TestCase
 
     public function testOnCoreSecurityDoesNothingWhenNoCookieIsSet()
     {
-        list($listener, $tokenStorage, $service) = $this->getListener();
+        [$listener, $tokenStorage, $service] = $this->getListener();
 
         $tokenStorage
             ->expects($this->any())
@@ -64,7 +64,7 @@ class RememberMeListenerTest extends TestCase
 
     public function testOnCoreSecurityIgnoresAuthenticationExceptionThrownByAuthenticationManagerImplementation()
     {
-        list($listener, $tokenStorage, $service, $manager) = $this->getListener();
+        [$listener, $tokenStorage, $service, $manager] = $this->getListener();
         $request = new Request();
         $exception = new AuthenticationException('Authentication failed.');
 
@@ -101,7 +101,7 @@ class RememberMeListenerTest extends TestCase
     {
         $this->expectException('Symfony\Component\Security\Core\Exception\AuthenticationException');
         $this->expectExceptionMessage('Authentication failed.');
-        list($listener, $tokenStorage, $service, $manager) = $this->getListener(false, false);
+        [$listener, $tokenStorage, $service, $manager] = $this->getListener(false, false);
 
         $tokenStorage
             ->expects($this->any())
@@ -134,7 +134,7 @@ class RememberMeListenerTest extends TestCase
 
     public function testOnCoreSecurityAuthenticationExceptionDuringAutoLoginTriggersLoginFail()
     {
-        list($listener, $tokenStorage, $service, $manager) = $this->getListener();
+        [$listener, $tokenStorage, $service, $manager] = $this->getListener();
 
         $tokenStorage
             ->expects($this->any())
@@ -166,7 +166,7 @@ class RememberMeListenerTest extends TestCase
 
     public function testOnCoreSecurity()
     {
-        list($listener, $tokenStorage, $service, $manager) = $this->getListener();
+        [$listener, $tokenStorage, $service, $manager] = $this->getListener();
 
         $tokenStorage
             ->expects($this->any())
@@ -200,7 +200,7 @@ class RememberMeListenerTest extends TestCase
 
     public function testSessionStrategy()
     {
-        list($listener, $tokenStorage, $service, $manager, , , $sessionStrategy) = $this->getListener(false, true, true);
+        [$listener, $tokenStorage, $service, $manager, , , $sessionStrategy] = $this->getListener(false, true, true);
 
         $tokenStorage
             ->expects($this->any())
@@ -250,7 +250,7 @@ class RememberMeListenerTest extends TestCase
 
     public function testSessionIsMigratedByDefault()
     {
-        list($listener, $tokenStorage, $service, $manager) = $this->getListener(false, true, false);
+        [$listener, $tokenStorage, $service, $manager] = $this->getListener(false, true, false);
 
         $tokenStorage
             ->expects($this->any())
@@ -298,7 +298,7 @@ class RememberMeListenerTest extends TestCase
 
     public function testOnCoreSecurityInteractiveLoginEventIsDispatchedIfDispatcherIsPresent()
     {
-        list($listener, $tokenStorage, $service, $manager, , $dispatcher) = $this->getListener(true);
+        [$listener, $tokenStorage, $service, $manager, , $dispatcher] = $this->getListener(true);
 
         $tokenStorage
             ->expects($this->any())

--- a/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
@@ -53,7 +53,7 @@ class FirewallMapTest extends TestCase
 
         $map->add($tooLateMatcher, [function () {}]);
 
-        list($listeners, $exception) = $map->getListeners($request);
+        [$listeners, $exception] = $map->getListeners($request);
 
         $this->assertEquals([$theListener], $listeners);
         $this->assertEquals($theException, $exception);
@@ -88,7 +88,7 @@ class FirewallMapTest extends TestCase
 
         $map->add($tooLateMatcher, [function () {}]);
 
-        list($listeners, $exception) = $map->getListeners($request);
+        [$listeners, $exception] = $map->getListeners($request);
 
         $this->assertEquals([$theListener], $listeners);
         $this->assertEquals($theException, $exception);
@@ -110,7 +110,7 @@ class FirewallMapTest extends TestCase
 
         $map->add($notMatchingMatcher, [function () {}]);
 
-        list($listeners, $exception) = $map->getListeners($request);
+        [$listeners, $exception] = $map->getListeners($request);
 
         $this->assertEquals([], $listeners);
         $this->assertNull($exception);

--- a/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/CsvEncoder.php
@@ -96,7 +96,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
             }
         }
 
-        list($delimiter, $enclosure, $escapeChar, $keySeparator, $headers, $escapeFormulas, $outputBom) = $this->getCsvOptions($context);
+        [$delimiter, $enclosure, $escapeChar, $keySeparator, $headers, $escapeFormulas, $outputBom] = $this->getCsvOptions($context);
 
         foreach ($data as &$value) {
             $flattened = [];
@@ -157,7 +157,7 @@ class CsvEncoder implements EncoderInterface, DecoderInterface
         $headerCount = [];
         $result = [];
 
-        list($delimiter, $enclosure, $escapeChar, $keySeparator) = $this->getCsvOptions($context);
+        [$delimiter, $enclosure, $escapeChar, $keySeparator] = $this->getCsvOptions($context);
 
         while (false !== ($cols = fgetcsv($handle, 0, $delimiter, $enclosure, $escapeChar))) {
             $nbCols = \count($cols);

--- a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
@@ -48,7 +48,7 @@ class TranslatorPathsPass extends AbstractRecursivePass
         foreach ($this->findControllerArguments($container) as $controller => $argument) {
             $id = substr($controller, 0, strpos($controller, ':') ?: \strlen($controller));
             if ($container->hasDefinition($id)) {
-                list($locatorRef) = $argument->getValues();
+                [$locatorRef] = $argument->getValues();
                 $this->controllers[(string) $locatorRef][$container->getDefinition($id)->getClass()] = true;
             }
         }

--- a/src/Symfony/Component/Translation/Loader/MoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/MoFileLoader.php
@@ -90,7 +90,7 @@ class MoFileLoader extends FileLoader
             $singularId = fread($stream, $length);
 
             if (false !== strpos($singularId, "\000")) {
-                list($singularId, $pluralId) = explode("\000", $singularId);
+                [$singularId, $pluralId] = explode("\000", $singularId);
             }
 
             fseek($stream, $offsetTranslated + $i * 8);

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -63,7 +63,7 @@ class FileValidator extends ConstraintValidator
                         $binaryFormat = null === $constraint->binaryFormat ? true : $constraint->binaryFormat;
                     }
 
-                    list(, $limitAsString, $suffix) = $this->factorizeSizes(0, $limitInBytes, $binaryFormat);
+                    [, $limitAsString, $suffix] = $this->factorizeSizes(0, $limitInBytes, $binaryFormat);
                     $this->context->buildViolation($constraint->uploadIniSizeErrorMessage)
                         ->setParameter('{{ limit }}', $limitAsString)
                         ->setParameter('{{ suffix }}', $suffix)
@@ -157,7 +157,7 @@ class FileValidator extends ConstraintValidator
             $limitInBytes = $constraint->maxSize;
 
             if ($sizeInBytes > $limitInBytes) {
-                list($sizeAsString, $limitAsString, $suffix) = $this->factorizeSizes($sizeInBytes, $limitInBytes, $constraint->binaryFormat);
+                [$sizeAsString, $limitAsString, $suffix] = $this->factorizeSizes($sizeInBytes, $limitInBytes, $constraint->binaryFormat);
                 $this->context->buildViolation($constraint->maxSizeMessage)
                     ->setParameter('{{ file }}', $this->formatValue($path))
                     ->setParameter('{{ size }}', $sizeAsString)

--- a/src/Symfony/Component/Validator/Constraints/NotCompromisedPasswordValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotCompromisedPasswordValidator.php
@@ -91,7 +91,7 @@ class NotCompromisedPasswordValidator extends ConstraintValidator
         }
 
         foreach (explode("\r\n", $result) as $line) {
-            list($hashSuffix, $count) = explode(':', $line);
+            [$hashSuffix, $count] = explode(':', $line);
 
             if ($hashPrefix.$hashSuffix === $hash && $constraint->threshold <= (int) $count) {
                 $this->context->buildViolation($constraint->message)

--- a/src/Symfony/Component/Validator/DependencyInjection/AddValidatorInitializersPass.php
+++ b/src/Symfony/Component/Validator/DependencyInjection/AddValidatorInitializersPass.php
@@ -51,7 +51,7 @@ class AddValidatorInitializersPass implements CompilerPassInterface
         $builder = $container->getDefinition($this->builderService);
         $calls = [];
 
-        foreach ($builder->getMethodCalls() as list($method, $arguments)) {
+        foreach ($builder->getMethodCalls() as [$method, $arguments]) {
             if ('setTranslator' === $method) {
                 if (!$arguments[0] instanceof Reference) {
                     $translator = $arguments[0];

--- a/src/Symfony/Component/Validator/Mapping/Loader/AbstractLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AbstractLoader.php
@@ -72,7 +72,7 @@ abstract class AbstractLoader implements LoaderInterface
         if (false !== strpos($name, '\\') && class_exists($name)) {
             $className = (string) $name;
         } elseif (false !== strpos($name, ':')) {
-            list($prefix, $className) = explode(':', $name, 2);
+            [$prefix, $className] = explode(':', $name, 2);
 
             if (!isset($this->namespaces[$prefix])) {
                 throw new MappingException(sprintf('Undefined namespace prefix "%s".', $prefix));

--- a/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Test/ConstraintValidatorTestCase.php
@@ -413,7 +413,7 @@ class AssertingContextualValidator implements ContextualValidatorInterface
     {
         Assert::assertFalse($this->expectNoValidate, 'No validation calls have been expected.');
 
-        list($expectedValue, $expectedGroup, $expectedConstraints) = $this->expectedValidate[++$this->validateCalls];
+        [$expectedValue, $expectedGroup, $expectedConstraints] = $this->expectedValidate[++$this->validateCalls];
 
         Assert::assertSame($expectedValue, $value);
         $expectedConstraints($constraints);

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -202,7 +202,7 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
 
     public function testInvalidComparisonToPropertyPathAddsPathAsParameter()
     {
-        list($dirtyValue, $dirtyValueAsString, $comparedValue, $comparedValueString, $comparedValueType) = current($this->provideAllInvalidComparisons());
+        [$dirtyValue, $dirtyValueAsString, $comparedValue, $comparedValueString, $comparedValueType] = current($this->provideAllInvalidComparisons());
 
         $constraint = $this->createConstraint(['propertyPath' => 'value']);
         $constraint->message = 'Constraint Message';

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -456,7 +456,7 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
             $reflection = new \ReflectionClass(\get_class(new FileValidator()));
             $method = $reflection->getMethod('factorizeSizes');
             $method->setAccessible(true);
-            list(, $limit, $suffix) = $method->invokeArgs(new FileValidator(), [0, UploadedFile::getMaxFilesize(), false]);
+            [, $limit, $suffix] = $method->invokeArgs(new FileValidator(), [0, UploadedFile::getMaxFilesize(), false]);
 
             // it correctly parses the maxSize option and not only uses simple string comparison
             // 1000M should be bigger than the ini value

--- a/src/Symfony/Component/VarDumper/Caster/ArgsStub.php
+++ b/src/Symfony/Component/VarDumper/Caster/ArgsStub.php
@@ -24,7 +24,7 @@ class ArgsStub extends EnumStub
 
     public function __construct(array $args, string $function, ?string $class)
     {
-        list($variadic, $params) = self::getParameters($function, $class);
+        [$variadic, $params] = self::getParameters($function, $class);
 
         $values = [];
         foreach ($args as $k => $v) {

--- a/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
+++ b/src/Symfony/Component/VarDumper/Cloner/AbstractCloner.php
@@ -296,7 +296,7 @@ abstract class AbstractCloner implements ClonerInterface
             $stub->class = get_debug_type($obj);
         }
         if (isset($this->classInfo[$class])) {
-            list($i, $parents, $hasDebugInfo, $fileInfo) = $this->classInfo[$class];
+            [$i, $parents, $hasDebugInfo, $fileInfo] = $this->classInfo[$class];
         } else {
             $i = 2;
             $parents = [$class];

--- a/src/Symfony/Component/VarDumper/Server/DumpServer.php
+++ b/src/Symfony/Component/VarDumper/Server/DumpServer.php
@@ -71,7 +71,7 @@ class DumpServer
                 continue;
             }
 
-            list($data, $context) = $payload;
+            [$data, $context] = $payload;
 
             $callback($data, $context, $clientId);
         }

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -338,7 +338,7 @@ final class FinalArrayIterator extends \ArrayIterator
         if ('' === $data) {
             throw new \InvalidArgumentException('Serialized data is empty.');
         }
-        list(, $data) = unserialize($data);
+        [, $data] = unserialize($data);
         parent::unserialize($data);
     }
 }
@@ -392,7 +392,7 @@ class FooSerializable implements \Serializable
 
     public function unserialize($str)
     {
-        list($this->foo) = unserialize($str);
+        [$this->foo] = unserialize($str);
     }
 }
 
@@ -405,7 +405,7 @@ class Php74Serializable implements \Serializable
 
     public function __unserialize(array $data)
     {
-        list($this->foo) = $data;
+        [$this->foo] = $data;
     }
 
     public function __sleep(): array

--- a/src/Symfony/Component/VarExporter/VarExporter.php
+++ b/src/Symfony/Component/VarExporter/VarExporter.php
@@ -71,7 +71,7 @@ final class VarExporter
         $values = [];
         $states = [];
         foreach ($objectsPool as $i => $v) {
-            list(, $classes[], $values[], $wakeup) = $objectsPool[$v];
+            [, $classes[], $values[], $wakeup] = $objectsPool[$v];
             if (0 < $wakeup) {
                 $states[$wakeup] = $i;
             } elseif (0 > $wakeup) {

--- a/src/Symfony/Component/Workflow/Registry.php
+++ b/src/Symfony/Component/Workflow/Registry.php
@@ -49,7 +49,7 @@ class Registry
     {
         $matched = [];
 
-        foreach ($this->workflows as list($workflow, $supportStrategy)) {
+        foreach ($this->workflows as [$workflow, $supportStrategy]) {
             if ($this->supports($workflow, $supportStrategy, $subject, $workflowName)) {
                 $matched[] = $workflow;
             }
@@ -78,7 +78,7 @@ class Registry
     public function all($subject): array
     {
         $matched = [];
-        foreach ($this->workflows as list($workflow, $supportStrategy)) {
+        foreach ($this->workflows as [$workflow, $supportStrategy]) {
             if ($supportStrategy->supports($workflow, $subject)) {
                 $matched[] = $workflow;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Now that the support for the 3.4 branch is coming to an end, I think we should consider banning a relic from old php 5 times from our codebase: The old array deconstructor `list()`. Right now, both deconstructors `list()` and `[]` are being used, with `list()` being the more common one.

The changes in this PR were done with PHP CS Fixer and I can easily redo them later if we decide that the time of this PR hasn't come yet. 😃 