### PR TITLE
Remove translation keys that does not exists in English

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.fi.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.fi.xlf
@@ -30,10 +30,6 @@
                 <source>Invalid CSRF token.</source>
                 <target>Virheellinen CSRF tunnus.</target>
             </trans-unit>
-            <trans-unit id="8">
-                <source>Digest nonce has expired.</source>
-                <target>Digest nonce on vanhentunut.</target>
-            </trans-unit>
             <trans-unit id="9">
                 <source>No authentication provider found to support the authentication token.</source>
                 <target>Autentikointi tunnukselle ei löydetty tuettua autentikointi tarjoajaa.</target>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.sq.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.sq.xlf
@@ -30,10 +30,6 @@
                 <source>Invalid CSRF token.</source>
                 <target>Identifikues i pavlefshëm CSRF.</target>
             </trans-unit>
-            <trans-unit id="8">
-                <source>Digest nonce has expired.</source>
-                <target>Numeri një perdorimësh i verifikimit Digest ka skaduar.</target>
-            </trans-unit>
             <trans-unit id="9">
                 <source>No authentication provider found to support the authentication token.</source>
                 <target>Asnjë ofrues i vërtetimit nuk u gjet që të mbështesë simbolin e vërtetimit.</target>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.zh_TW.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.zh_TW.xlf
@@ -30,10 +30,6 @@
                 <source>Invalid CSRF token.</source>
                 <target>無效的 CSRF token 。</target>
             </trans-unit>
-            <trans-unit id="8">
-                <source>Digest nonce has expired.</source>
-                <target>摘要隨機串（digest nonce）已過期。</target>
-            </trans-unit>
             <trans-unit id="9">
                 <source>No authentication provider found to support the authentication token.</source>
                 <target>沒有找到支持此 token 的身份驗證服務提供方。</target>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

These keys has been removed from the [English file](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Security/Core/Resources/translations/security.en.xlf#L29-L36)