### PR TITLE
[Console] Test degraded true colors

### DIFF
--- a/src/Symfony/Component/Console/Tests/ColorTest.php
+++ b/src/Symfony/Component/Console/Tests/ColorTest.php
@@ -40,4 +40,20 @@ class ColorTest extends TestCase
         $color = new Color('#ffffff', '#000000');
         $this->assertSame("\033[38;2;255;255;255;48;2;0;0;0m \033[39;49m", $color->apply(' '));
     }
+
+    public function testDegradedTrueColors()
+    {
+        $colorterm = getenv('COLORTERM');
+        putenv('COLORTERM=');
+
+        try {
+            $color = new Color('#f00', '#ff0');
+            $this->assertSame("\033[31;43m \033[39;49m", $color->apply(' '));
+
+            $color = new Color('#c0392b', '#f1c40f');
+            $this->assertSame("\033[31;43m \033[39;49m", $color->apply(' '));
+        } finally {
+            putenv('COLORTERM='.$colorterm);
+        }
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#14494 <!-- required for new features -->

Testing hidden feature of hex colors degraded to ANSI named colors for terminals without true color support.
