### PR TITLE
[FrameworkBundle] Fixing TranslationUpdateCommand failure when using "--no-backup"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 5.1.0
 -----
-
+ * Removed `--no-backup` option from `translation:update` command (broken since `5.0.0`)
  * Added link to source for controllers registered as named services
  * Added link to source on controller on `router:match`/`debug:router` (when `framework.ide` is configured)
  * Added the `framework.router.default_uri` configuration option to configure the default `RequestContext`

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -79,7 +79,6 @@ class TranslationUpdateCommand extends Command
                 new InputOption('output-format', null, InputOption::VALUE_OPTIONAL, 'Override the default output format', 'xlf'),
                 new InputOption('dump-messages', null, InputOption::VALUE_NONE, 'Should the messages be dumped in the console'),
                 new InputOption('force', null, InputOption::VALUE_NONE, 'Should the update be done'),
-                new InputOption('no-backup', null, InputOption::VALUE_NONE, 'Should backup be disabled'),
                 new InputOption('clean', null, InputOption::VALUE_NONE, 'Should clean not found messages'),
                 new InputOption('domain', null, InputOption::VALUE_OPTIONAL, 'Specify the domain to update'),
                 new InputOption('xliff-version', null, InputOption::VALUE_OPTIONAL, 'Override the default xliff version', '1.2'),
@@ -281,10 +280,6 @@ EOF
             }
 
             $resultMessage = sprintf('%d message%s successfully extracted', $extractedMessagesCount, $extractedMessagesCount > 1 ? 's were' : ' was');
-        }
-
-        if (true === $input->getOption('no-backup')) {
-            $this->writer->disableBackup();
         }
 
         // save the files


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

[5.0.0](https://github.com/symfony/symfony/blob/5.0/src/Symfony/Component/Translation/CHANGELOG.md#500) removed `TranslationWriter::disableBackup()` but `TranslationUpdateCommand` still has `--no-backup` flag. Using that flag throws an error so I think that removing it without deprecation may be the right choice.

Thrown error:
```
In TranslationUpdateCommand.php line 287:
                                                                            
  Attempted to call an undefined method named "disableBackup" of class "Symfony\Component\Translation\Writer\TranslationWriter".
```

Further references to the topic:
 - https://github.com/symfony/symfony/pull/18290#issuecomment-204065567
 - https://github.com/symfony/symfony/pull/25860