### PR TITLE
[DoctrineBridge] Remove dependency on doctrine/reflection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,6 @@
         "doctrine/data-fixtures": "^1.1",
         "doctrine/dbal": "~2.4|^3.0",
         "doctrine/orm": "~2.4,>=2.4.5",
-        "doctrine/reflection": "~1.0",
         "doctrine/doctrine-bundle": "^1.5|^2.0",
         "guzzlehttp/promises": "^1.3.1",
         "masterminds/html5": "^2.6",

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -114,17 +114,8 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             ->method('hasField')
             ->willReturn(true)
         ;
-        $reflParser = $this->getMockBuilder('Doctrine\Common\Reflection\StaticReflectionParser')
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-        $refl = $this->getMockBuilder('Doctrine\Common\Reflection\StaticReflectionProperty')
-            ->setConstructorArgs([$reflParser, 'property-name'])
-            ->setMethods(['getValue'])
-            ->getMock()
-        ;
+        $refl = $this->createStub(\ReflectionProperty::class);
         $refl
-            ->expects($this->any())
             ->method('getValue')
             ->willReturn(true)
         ;

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -44,8 +44,7 @@
         "doctrine/collections": "~1.0",
         "doctrine/data-fixtures": "^1.1",
         "doctrine/dbal": "~2.4|^3.0",
-        "doctrine/orm": "^2.6.3",
-        "doctrine/reflection": "~1.0"
+        "doctrine/orm": "^2.6.3"
     },
     "conflict": {
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | kinda
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

That package is being phased out, and there are good chances that the
classes involved at runtime are completely different from the classes
involved in the test changed in that commit. That test was the only
piece of code I could find still referencing the
`Doctrine\Common\Reflection` namespace.