### PR TITLE
Use createMock() rather than createStub()

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -114,7 +114,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             ->method('hasField')
             ->willReturn(true)
         ;
-        $refl = $this->createStub(\ReflectionProperty::class);
+        $refl = $this->createMock(\ReflectionProperty::class);
         $refl
             ->method('getValue')
             ->willReturn(true)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | kinda, it's for a bug in the CI
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

The CI is not using a recent enough version of PHPUnit for that.

As asked by @jderusse in https://github.com/symfony/symfony/pull/38870#issuecomment-718121772