### PR TITLE
[DoctrineBridge] Fix data extraction in relation using IndexBy and different column name

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -110,10 +110,15 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
                 $associationMapping = $metadata->getAssociationMapping($property);
 
                 if (isset($associationMapping['indexBy'])) {
-                    $indexColumn = $associationMapping['indexBy'];
+                    $indexField = $associationMapping['indexBy'];
                     /** @var ClassMetadataInfo $subMetadata */
                     $subMetadata = $this->classMetadataFactory->getMetadataFor($associationMapping['targetEntity']);
-                    $typeOfField = $subMetadata->getTypeOfField($subMetadata->getFieldForColumn($indexColumn));
+
+                    $typeOfField = $subMetadata->getTypeOfField($indexField);
+
+                    if (!$typeOfField) {
+                        $typeOfField = $subMetadata->getTypeOfField($subMetadata->getFieldForColumn($indexField));
+                    }
 
                     if (!$collectionKeyType = $this->getPhpType($typeOfField)) {
                         return null;

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -76,6 +76,7 @@ class DoctrineExtractorTest extends TestCase
             'indexedFoo',
             'indexedByDt',
             'indexedByCustomType',
+            'indexedBaz'
         ]);
 
         $this->assertEquals(
@@ -179,6 +180,14 @@ class DoctrineExtractorTest extends TestCase
                 new Type(Type::BUILTIN_TYPE_OBJECT, false, DoctrineRelation::class)
             )]],
             ['indexedByCustomType', null],
+            ['indexedBaz', [new Type(
+                Type::BUILTIN_TYPE_OBJECT,
+                false,
+                'Doctrine\Common\Collections\Collection',
+                true,
+                new Type(Type::BUILTIN_TYPE_STRING),
+                new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineRelation')
+            )]]
         ];
 
         if (class_exists(Types::class)) {

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -76,7 +76,7 @@ class DoctrineExtractorTest extends TestCase
             'indexedFoo',
             'indexedByDt',
             'indexedByCustomType',
-            'indexedBaz'
+            'indexedBaz',
         ]);
 
         $this->assertEquals(
@@ -187,7 +187,7 @@ class DoctrineExtractorTest extends TestCase
                 true,
                 new Type(Type::BUILTIN_TYPE_STRING),
                 new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Symfony\Bridge\Doctrine\Tests\PropertyInfo\Fixtures\DoctrineRelation')
-            )]]
+            )]],
         ];
 
         if (class_exists(Types::class)) {

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
@@ -122,4 +122,9 @@ class DoctrineDummy
      * @OneToMany(targetEntity="DoctrineRelation", mappedBy="customType", indexBy="customType")
      */
     private $indexedByCustomType;
+
+    /**
+     * @OneToMany(targetEntity="DoctrineRelation", mappedBy="bazField", indexBy="bazField")
+     */
+    protected $indexedBaz;
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineRelation.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineRelation.php
@@ -49,4 +49,10 @@ class DoctrineRelation
      * @Column(type="foo")
      */
     private $customType;
+
+    /**
+     * @Column(type="guid", name="different_than_field")
+     * @ManyToOne(targetEntity="DoctrineDummy", inversedBy="indexedBaz")
+     */
+    protected $bazField;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38861
| License       | MIT
| Doc PR        |  -

The issue is that the process of property data extraction fails when we have a situation when a relation has an "indexedBy" property set to a field with a column that isn't the same or doesn't follow the naming strategy, for example:

field:  foo
colum: bar_baz

I changed it so first we treat it as a field and then we fall back to treating it as a column name as it is now
