### PR TITLE
[HttpFoundation] Update `all` method to handle default value

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -37,7 +37,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @return array An array of parameters
      */
-    public function all(/*string $key = null*/)
+    public function all(/*string $key = null, array $default = []*/)
     {
         $key = \func_num_args() > 0 ? func_get_arg(0) : null;
 
@@ -45,7 +45,12 @@ class ParameterBag implements \IteratorAggregate, \Countable
             return $this->parameters;
         }
 
-        if (!\is_array($value = $this->parameters[$key] ?? [])) {
+        $default = \func_num_args() > 1 ? func_get_arg(1) : [];
+        if (!\is_array($default)) {
+            throw new \TypeError(sprintf('Unexpected value for default value: expecting "array", got "%s".', get_debug_type($default)));
+        }
+
+        if (!\is_array($value = $this->parameters[$key] ?? $default)) {
             throw new BadRequestException(sprintf('Unexpected value for parameter "%s": expecting "array", got "%s".', $key, get_debug_type($value)));
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -43,6 +43,21 @@ class ParameterBagTest extends TestCase
         $bag->all('foo');
     }
 
+    public function testAllWithDefaultKey()
+    {
+        $bag = new ParameterBag(['foo' => ['bar', 'baz'], 'null' => null]);
+
+        $this->assertEquals(['bar', 'baz'], $bag->all('foo', ['qux']), '->all() gets the value of a parameter');
+        $this->assertEquals(['qux'], $bag->all('unknown', ['qux']), '->all() returns an given default array if a parameter is not defined');
+    }
+
+    public function testAllThrowsForNonArrayDefaults()
+    {
+        $this->expectException(\TypeError::class);
+        $bag = new ParameterBag(['foo' => 'bar', 'null' => null]);
+        $bag->all('foo', 12345);
+    }
+
     public function testKeys()
     {
         $bag = new ParameterBag(['foo' => 'bar']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | none

~~I added a quick `getArray` method for better DX after #34363 changes.
I know we can use `all($key)` (and #37229 did almost same addition) with the same purpose but here this method will be here for its default value mostly which is not handled by `all($key)` method. 
I think it's better DX to do `getArray($key, $default)` rather than `all($key) ?? $default`~~

I updated `all()` method to handle a `$default` variable as second parameter as following: `all(string $key = null, array $default = [])`.