### PR TITLE
Fixed translations for Norwegian

### DIFF
--- a/src/Symfony/Component/Form/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.nb.xlf
@@ -14,6 +14,126 @@
                 <source>The CSRF token is invalid.</source>
                 <target>CSRF nøkkelen er ugyldig.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>Denne verdien er ikke en gyldig HTML5-farge.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Vennligst oppgi gyldig fødselsdato.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>Det valgte valget er ugyldig.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>Samlingen er ugyldig.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Velg en gyldig farge.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Vennligst velg et gyldig land.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Vennligst velg en gyldig valuta.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Vennligst velg et gyldig datointervall.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Vennligst angi en gyldig dato og tid.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Vennligst oppgi en gyldig dato.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Vennligst velg en gyldig fil.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Det skjulte feltet er ugyldig.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Vennligst skriv inn et heltall.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Vennligst velg et gyldig språk.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Vennligst velg et gyldig sted.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Vennligst angi et gyldig pengebeløp.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Vennligst skriv inn et nummer.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>Passordet er ugyldig.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Vennligst angi en prosentverdi.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>Verdiene stemmer ikke overens.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Vennligst angi et gyldig tidspunkt.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Vennligst velg en gyldig tidssone.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Vennligst skriv inn en gyldig URL.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Vennligst angi et gyldig søketerm.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Vennligst oppgi et gyldig telefonnummer.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>Avkrysningsboksen har en ugyldig verdi.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Vennligst skriv inn en gyldig e-post adresse.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Vennligst velg et gyldig alternativ.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Vennligst velg et gyldig område.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Vennligst skriv inn en gyldig uke.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.nb.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.nb.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Brukerkonto er sperret.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>For mange mislykkede påloggingsforsøk. Prøv igjen senere.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Ugyldig eller utløpt påloggingskobling.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nb.xlf
@@ -366,6 +366,26 @@
                 <source>This value should be between {{ min }} and {{ max }}.</source>
                 <target>Verdien må være mellom {{ min }} og {{ max }}.</target>
             </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>Denne verdien er ikke et gyldig vertsnavn.</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>Antall elementer i denne samlingen bør være et multiplum av {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target>Denne verdien skal tilfredsstille minst en av følgende begrensninger:</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target>Hvert element i denne samlingen skal tilfredsstille sitt eget sett med begrensninger.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>Denne verdien er ikke et gyldig International Securities Identification Number (ISIN).</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

This will fix Travis build on 4.4


Norwegian has two dialects. "old" or "written" (Bokmål) and "new" (Nynorsk). The "new" one is the one everybody* speaks. The locales for these languages are: 
- Norwegian: no
- "old": nb
- "new": nn

It does not make sense, sure. However, Symfony have tests that make sure that `no` and `nb` are the same. This PR just copies the `no` translations to `nb`. 


----------

\* By "everybody" I mean the younger half of the population, especially in Olso. I am generalising partly because Im ignorant and partly because I wish more people spoke Nynork because that is the dialect I understand. 