### PR TITLE
[Cache] Add tests on CacheDataCollector

### DIFF
--- a/src/Symfony/Component/Cache/Tests/DataCollector/CacheDataCollectorTest.php
+++ b/src/Symfony/Component/Cache/Tests/DataCollector/CacheDataCollectorTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Cache\Tests\Marshaller;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\TraceableAdapter;
+use Symfony\Component\Cache\DataCollector\CacheDataCollector;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CacheDataCollectorTest extends TestCase
+{
+    private const INSTANCE_NAME = 'test';
+
+    public function testEmptyDataCollector()
+    {
+        $statistics = $this->getCacheDataCollectorStatisticsFromEvents([]);
+
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['calls'], 0, 'calls');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['reads'], 0, 'reads');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['hits'], 0, 'hits');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['misses'], 0, 'misses');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['writes'], 0, 'writes');
+    }
+
+    public function testOneEventDataCollector()
+    {
+        $traceableAdapterEvent = new \stdClass();
+        $traceableAdapterEvent->name = 'getItem';
+        $traceableAdapterEvent->start = 0;
+        $traceableAdapterEvent->end = 0;
+        $traceableAdapterEvent->hits = 0;
+
+        $statistics = $this->getCacheDataCollectorStatisticsFromEvents([$traceableAdapterEvent]);
+
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['calls'], 1, 'calls');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['reads'], 1, 'reads');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['hits'], 0, 'hits');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['misses'], 1, 'misses');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['writes'], 0, 'writes');
+    }
+
+    public function testHitedEventDataCollector()
+    {
+        $traceableAdapterEvent = new \stdClass();
+        $traceableAdapterEvent->name = 'hasItem';
+        $traceableAdapterEvent->start = 0;
+        $traceableAdapterEvent->end = 0;
+        $traceableAdapterEvent->hits = 1;
+        $traceableAdapterEvent->misses = 0;
+        $traceableAdapterEvent->result = ['foo' => false];
+
+        $statistics = $this->getCacheDataCollectorStatisticsFromEvents([$traceableAdapterEvent]);
+
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['calls'], 1, 'calls');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['reads'], 1, 'reads');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['hits'], 1, 'hits');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['misses'], 0, 'misses');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['writes'], 0, 'writes');
+    }
+
+    public function testSavedEventDataCollector()
+    {
+        $traceableAdapterEvent = new \stdClass();
+        $traceableAdapterEvent->name = 'save';
+        $traceableAdapterEvent->start = 0;
+        $traceableAdapterEvent->end = 0;
+
+        $statistics = $this->getCacheDataCollectorStatisticsFromEvents([$traceableAdapterEvent]);
+
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['calls'], 1, 'calls');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['reads'], 0, 'reads');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['hits'], 0, 'hits');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['misses'], 0, 'misses');
+        $this->assertEquals($statistics[self::INSTANCE_NAME]['writes'], 1, 'writes');
+    }
+
+    private function getCacheDataCollectorStatisticsFromEvents(array $traceableAdapterEvents)
+    {
+        $traceableAdapterMock = $this->createMock(TraceableAdapter::class);
+        $traceableAdapterMock->method('getCalls')->willReturn($traceableAdapterEvents);
+
+        $cacheDataCollector = new CacheDataCollector();
+        $cacheDataCollector->addInstance(self::INSTANCE_NAME, $traceableAdapterMock);
+        $cacheDataCollector->collect(new Request(), new Response());
+
+        return $cacheDataCollector->getStatistics();
+    }
+}

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -37,6 +37,7 @@
         "symfony/config": "^4.2|^5.0",
         "symfony/dependency-injection": "^3.4|^4.1|^5.0",
         "symfony/filesystem": "^4.4|^5.0",
+        "symfony/http-kernel": "^4.4|^5.0",
         "symfony/var-dumper": "^4.4|^5.0"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

The `calculateStatistics()` method of `Symfony\Component\Cache\DataCollector\CacheDataCollector` contain a lot of logic and manipulate multi-dimensional array that could be refactor with VO. 

But before doing this, I would add test on this part.