### PR TITLE
[Serializer] Exclude non-initialized properties accessed with getters

### DIFF
--- a/.github/build-packages.php
+++ b/.github/build-packages.php
@@ -1,7 +1,7 @@
 <?php
 
 if (3 > $_SERVER['argc']) {
-    echo "Usage: branch dir1 dir2 ... dirN\n";
+    echo "Usage: branch version dir1 dir2 ... dirN\n";
     exit(1);
 }
 chdir(dirname(__DIR__));
@@ -14,6 +14,7 @@ if ($json !== $package = preg_replace('/\n    "repositories": \[\n.*?\n    \],/s
 $dirs = $_SERVER['argv'];
 array_shift($dirs);
 $mergeBase = trim(shell_exec(sprintf('git merge-base "%s" HEAD', array_shift($dirs))));
+$version = array_shift($dirs);
 
 $packages = array();
 $flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
@@ -50,11 +51,7 @@ foreach ($dirs as $k => $dir) {
         passthru("cd $dir && git init && git add . && git commit -q -m - && git archive -o package.tar HEAD && rm .git/ -Rf");
     }
 
-    if (!isset($package->extra->{'branch-version'})) {
-        echo "Missing \"branch-version\" in composer.json's \"extra\".\n";
-        exit(1);
-    }
-    $package->version = $package->extra->{'branch-version'}.'.x-dev';
+    $package->version = (isset($package->extra->{'branch-version'}) ? $package->extra->{'branch-version'} : $version).'.x-dev';
     $package->dist['type'] = 'tar';
     $package->dist['url'] = 'file://'.str_replace(DIRECTORY_SEPARATOR, '/', dirname(__DIR__))."/$dir/package.tar";
 

--- a/.github/composer-config.json
+++ b/.github/composer-config.json
@@ -1,5 +1,6 @@
 {
     "config": {
+        "platform-check": false,
         "preferred-install": {
             "symfony/form": "source",
             "symfony/http-kernel": "source",

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,7 @@ before_install:
           [ -d /usr/lib/openldap ] && ln -s /usr/lib/openldap /tmp/slapd-modules || ln -s /usr/lib/ldap /tmp/slapd-modules
       fi
       slapd -f src/Symfony/Component/Ldap/Tests/Fixtures/conf/slapd.conf -h ldap://localhost:3389 &
-      [ -d ~/.composer ] || mkdir ~/.composer
-      cp .github/composer-config.json ~/.composer/config.json
+      cp .github/composer-config.json "$(composer config home)/config.json"
       export PHPUNIT=$(readlink -f ./phpunit)
       export PHPUNIT_X="$PHPUNIT --exclude-group tty,benchmark,intl-data"
       export COMPOSER_UP='composer update --no-progress --no-suggest --ansi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -266,7 +266,9 @@ install:
       else
           export SYMFONY_REQUIRE=">=$SYMFONY_VERSION"
       fi
-      composer global require --no-progress --no-scripts --no-plugins symfony/flex
+      if [[ ! $TRAVIS_PHP_VERSION = 5.* ]]; then
+          composer global require --no-progress --no-scripts --no-plugins symfony/flex
+      fi
 
     - |
       # Legacy tests are skipped when deps=high and when the current branch version has not the same major version number as the next one

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,18 +22,18 @@ Symfony is the result of the work of many people who made the code better
  - Jakub Zalas (jakubzalas)
  - Johannes S (johannes)
  - Kris Wallsmith (kriswallsmith)
+ - Alexander M. Turek (derrabus)
  - Wouter de Jong (wouterj)
  - Yonel Ceruto (yonelceruto)
- - Alexander M. Turek (derrabus)
- - Hugo Hamon (hhamon)
  - Thomas Calvet (fancyweb)
+ - Hugo Hamon (hhamon)
  - Abdellatif Ait boudad (aitboudad)
  - Samuel ROZE (sroze)
  - Romain Neutron (romain)
  - Pascal Borreli (pborreli)
+ - Jérémy DERUSSÉ (jderusse)
  - Joseph Bielawski (stloyd)
  - Karma Dordrak (drak)
- - Jérémy DERUSSÉ (jderusse)
  - Jules Pietri (heah)
  - Lukas Kahwe Smith (lsmith)
  - Martin Hasoň (hason)
@@ -42,12 +42,13 @@ Symfony is the result of the work of many people who made the code better
  - Jean-François Simon (jfsimon)
  - Benjamin Eberlei (beberlei)
  - Igor Wiedler (igorw)
- - Eriksen Costa (eriksencosta)
  - Tobias Nyholm (tobias)
+ - Eriksen Costa (eriksencosta)
  - Guilhem Niot (energetick)
  - Sarah Khalil (saro0h)
  - Jonathan Wage (jwage)
  - Lynn van der Berg (kjarli)
+ - Jan Schädlich (jschaedl)
  - Matthias Pigulla (mpdude)
  - Diego Saint Esteben (dosten)
  - Pierre du Plessis (pierredup)
@@ -55,28 +56,27 @@ Symfony is the result of the work of many people who made the code better
  - William Durand (couac)
  - Valentin Udaltsov (vudaltsov)
  - ornicar
- - Jan Schädlich (jschaedl)
  - Dany Maillard (maidmaid)
  - Francis Besset (francisbesset)
  - stealth35 ‏ (stealth35)
  - Alexander Mols (asm89)
+ - Kevin Bond (kbond)
  - Konstantin Myakshin (koc)
  - Grégoire Paris (greg0ire)
  - Bulat Shakirzyanov (avalanche123)
- - Kevin Bond (kbond)
  - Saša Stamenković (umpirsky)
  - Peter Rehm (rpet)
  - Gabriel Ostrolucký (gadelat)
+ - Titouan Galopin (tgalopin)
  - David Maicher (dmaicher)
  - Gábor Egyed (1ed)
  - Henrik Bjørnskov (henrikbjorn)
  - Miha Vrhovnik
- - Titouan Galopin (tgalopin)
  - Diego Saint Esteben (dii3g0)
  - Konstantin Kudryashov (everzet)
+ - Mathieu Piot (mpiot)
  - Vladimir Reznichenko (kalessil)
  - Bilal Amarni (bamarni)
- - Mathieu Piot (mpiot)
  - Florin Patan (florinpatan)
  - Jáchym Toušek (enumag)
  - Andrej Hudec (pulzarraider)
@@ -86,13 +86,13 @@ Symfony is the result of the work of many people who made the code better
  - Charles Sarrazin (csarrazi)
  - Christian Raue
  - Douglas Greenshields (shieldo)
- - Arnout Boks (aboks)
- - Jérôme Tamarelle (gromnan)
  - Laurent VOULLEMIER (lvo)
+ - Arnout Boks (aboks)
+ - Graham Campbell (graham)
+ - Jérôme Tamarelle (gromnan)
  - Deni
  - Henrik Westphal (snc)
  - Dariusz Górecki (canni)
- - Graham Campbell (graham)
  - David Buchmann (dbu)
  - Dariusz Ruminski
  - Fran Moreno (franmomu)
@@ -100,11 +100,11 @@ Symfony is the result of the work of many people who made the code better
  - Brandon Turner
  - Luis Cordova (cordoval)
  - Daniel Holmes (dholmes)
+ - Alex Pott
  - Toni Uebernickel (havvg)
  - Bart van den Burg (burgov)
  - Jordan Alliot (jalliot)
  - John Wards (johnwards)
- - Alex Pott
  - Antoine Hérault (herzult)
  - Paráda József (paradajozsef)
  - Arnaud Le Blanc (arnaud-lb)
@@ -119,18 +119,19 @@ Symfony is the result of the work of many people who made the code better
  - marc.weistroff
  - Tomáš Votruba (tomas_votruba)
  - Peter Kokot (maastermedia)
+ - Lars Strojny (lstrojny)
  - lenar
  - Alexander Schwenn (xelaris)
  - Włodzimierz Gajda (gajdaw)
+ - Alexander Schranz (alexander-schranz)
+ - Oskar Stark (oskarstark)
  - Adrien Brault (adrienbrault)
- - Lars Strojny (lstrojny)
  - Massimiliano Arione (garak)
  - Jacob Dreesen (jdreesen)
  - Florian Voutzinos (florianv)
  - Teoh Han Hui (teohhanhui)
  - Przemysław Bogusz (przemyslaw-bogusz)
  - Colin Frei
- - Oskar Stark (oskarstark)
  - Javier Spagnoletti (phansys)
  - Joshua Thijssen
  - Daniel Wehner (dawehner)
@@ -138,7 +139,6 @@ Symfony is the result of the work of many people who made the code better
  - excelwebzone
  - Gordon Franke (gimler)
  - Joel Wurtz (brouznouf)
- - Alexander Schranz (alexander-schranz)
  - Fabien Pennequin (fabienpennequin)
  - Julien Falque (julienfalque)
  - Théo FIDRY (theofidry)
@@ -175,6 +175,7 @@ Symfony is the result of the work of many people who made the code better
  - Rafael Dohms (rdohms)
  - jwdeitch
  - Ahmed TAILOULOUTE (ahmedtai)
+ - Andreas Braun
  - Mikael Pajunen
  - Arman Hosseini (arman)
  - Niels Keurentjes (curry684)
@@ -209,6 +210,7 @@ Symfony is the result of the work of many people who made the code better
  - Marek Štípek (maryo)
  - Filippo Tessarotto (slamdunk)
  - Daniel Espendiller
+ - Maxime Helias (maxhelias)
  - Possum
  - Dorian Villet (gnutix)
  - Michaël Perrin (michael.perrin)
@@ -228,9 +230,9 @@ Symfony is the result of the work of many people who made the code better
  - Ruben Gonzalez (rubenrua)
  - Benjamin Dulau (dbenjamin)
  - Jan Rosier (rosier)
- - Andreas Braun
  - Mathieu Lemoine (lemoinem)
  - Rémon van de Kamp (rpkamp)
+ - HypeMC
  - Christian Schmidt
  - Andreas Hucks (meandmymonkey)
  - Tom Van Looy (tvlooy)
@@ -246,7 +248,6 @@ Symfony is the result of the work of many people who made the code better
  - Nikolay Labinskiy (e-moe)
  - Martin Schuhfuß (usefulthink)
  - apetitpa
- - Maxime Helias (maxhelias)
  - Matthieu Bontemps (mbontemps)
  - apetitpa
  - Pierre Minnieur (pminnieur)
@@ -255,6 +256,7 @@ Symfony is the result of the work of many people who made the code better
  - Dominique Bongiraud
  - Hidde Wieringa (hiddewie)
  - Jeremy Livingston (jeremylivingston)
+ - Olivier Dolbeau (odolbeau)
  - Michael Lee (zerustech)
  - Dmitrii Poddubnyi (karser)
  - Matthieu Auger (matthieuauger)
@@ -288,7 +290,6 @@ Symfony is the result of the work of many people who made the code better
  - Marco Pivetta (ocramius)
  - Antonio Pauletich (x-coder264)
  - Jeroen Spee (jeroens)
- - Olivier Dolbeau (odolbeau)
  - Rob Frawley 2nd (robfrawley)
  - julien pauli (jpauli)
  - Lorenz Schori
@@ -304,6 +305,7 @@ Symfony is the result of the work of many people who made the code better
  - Elnur Abdurrakhimov (elnur)
  - Manuel Reinhard (sprain)
  - Danny Berger (dpb587)
+ - zairig imad (zairigimad)
  - Antonio J. García Lagar (ajgarlag)
  - Adam Prager (padam87)
  - Benoît Burnichon (bburnichon)
@@ -338,11 +340,13 @@ Symfony is the result of the work of many people who made the code better
  - Jhonny Lidfors (jhonne)
  - Diego Agulló (aeoris)
  - jdhoek
+ - Michael Käfer (michael_kaefer)
  - Bob den Otter (bopp)
  - Thomas Schulz (king2500)
  - Frank de Jonge (frenkynet)
  - Nikita Konstantinov
  - Wodor Wodorski
+ - Timo Bakx (timobakx)
  - Joe Bennett (kralos)
  - Thomas Lallement (raziel057)
  - soyuka
@@ -370,8 +374,8 @@ Symfony is the result of the work of many people who made the code better
  - Simon Mönch (sm)
  - Christian Schmidt
  - Patrick Landolt (scube)
- - HypeMC
  - MatTheCat
+ - Bohan Yang (brentybh)
  - Vilius Grigaliūnas
  - David Badura (davidbadura)
  - Chad Sikorra (chadsikorra)
@@ -379,6 +383,7 @@ Symfony is the result of the work of many people who made the code better
  - Chris Smith (cs278)
  - Thomas Bisignani (toma)
  - Florian Klein (docteurklein)
+ - Timothée Barray (tyx)
  - Benjamin Leveque (benji07)
  - Manuel Kiessling (manuelkiessling)
  - Alexey Kopytko (sanmai)
@@ -412,7 +417,6 @@ Symfony is the result of the work of many people who made the code better
  - Romain Pierre (romain-pierre)
  - Julien Galenski (ruian)
  - Thomas Landauer (thomas-landauer)
- - Michael Käfer (michael_kaefer)
  - Bongiraud Dominique
  - janschoenherr
  - Emanuele Gaspari (inmarelibero)
@@ -423,6 +427,8 @@ Symfony is the result of the work of many people who made the code better
  - Sebastien Morel (plopix)
  - Ricard Clau (ricardclau)
  - Mark Challoner (markchalloner)
+ - ivan
+ - Karoly Gossler (connorhu)
  - Ahmed Raafat
  - Philippe Segatori
  - Gennady Telegin (gtelegin)
@@ -432,6 +438,7 @@ Symfony is the result of the work of many people who made the code better
  - Matthew Lewinski (lewinski)
  - Magnus Nordlander (magnusnordlander)
  - Thomas Royer (cydonia7)
+ - Nicolas Philippe (nikophil)
  - Nicolas LEFEVRE (nicoweb)
  - alquerci
  - Oleg Andreyev
@@ -441,12 +448,13 @@ Symfony is the result of the work of many people who made the code better
  - Vitaliy Zakharov (zakharovvi)
  - Tobias Sjösten (tobiassjosten)
  - Gyula Sallai (salla)
+ - Romaric Drigon (romaricdrigon)
  - Inal DJAFAR (inalgnu)
  - Christian Gärtner (dagardner)
  - Dmytro Borysovskyi (dmytr0)
  - Tomasz Kowalczyk (thunderer)
+ - Sylvain Fabre (sylfabre)
  - Artur Eshenbrener
- - Timo Bakx (timobakx)
  - Harm van Tilborg (hvt)
  - Thomas Perez (scullwm)
  - Felix Labrecque
@@ -498,7 +506,6 @@ Symfony is the result of the work of many people who made the code better
  - Endre Fejes
  - Tobias Naumann (tna)
  - Daniel Beyer
- - Timothée Barray (tyx)
  - Shein Alexey
  - Romain Gautier (mykiwi)
  - Joe Lencioni
@@ -540,9 +547,12 @@ Symfony is the result of the work of many people who made the code better
  - Jeanmonod David (jeanmonod)
  - Christopher Davis (chrisguitarguy)
  - Webnet team (webnet)
+ - Ben Ramsey (ramsey)
+ - Nate Wiebe (natewiebe13)
  - Marcin Szepczynski (czepol)
  - Mohammad Emran Hasan (phpfour)
  - Farhad Safarov
+ - Dmitriy Mamontov (mamontovdmitriy)
  - Jan Schumann
  - Niklas Fiekas
  - Markus Bachmann (baachi)
@@ -554,6 +564,7 @@ Symfony is the result of the work of many people who made the code better
  - Mihai Stancu
  - Ivan Nikolaev (destillat)
  - Gildas Quéméner (gquemener)
+ - Baptiste Leduc (korbeil)
  - Laurent Masforné (heisenberg)
  - Claude Khedhiri (ck-developer)
  - Desjardins Jérôme (jewome62)
@@ -563,22 +574,25 @@ Symfony is the result of the work of many people who made the code better
  - Toni Rudolf (toooni)
  - Asmir Mustafic (goetas)
  - DerManoMann
- - Nicolas Philippe (nikophil)
  - vagrant
  - Aurimas Niekis (gcds)
  - EdgarPE
+ - Bob van de Vijver (bobvandevijver)
  - Florian Pfitzer (marmelatze)
  - Asier Illarramendi (doup)
- - Sylvain Fabre (sylfabre)
  - Martijn Cuppens
  - Vlad Gregurco (vgregurco)
  - Boris Vujicic (boris.vujicic)
  - Artem Lopata
  - Judicaël RUFFIEUX (axanagor)
  - Chris Sedlmayr (catchamonkey)
+ - Indra Gunawan (indragunawan)
  - Kamil Kokot (pamil)
  - Seb Koelen
  - Christoph Mewes (xrstf)
+ - Andrew M-Y (andr)
+ - Krasimir Bosilkov (kbosilkov)
+ - Marcin Michalski (marcinmichalski)
  - Vitaliy Tverdokhlib (vitaliytv)
  - Ariel Ferrandini (aferrandini)
  - Dirk Pahl (dirkaholic)
@@ -590,10 +604,11 @@ Symfony is the result of the work of many people who made the code better
  - Tobias Weichart
  - Tarmo Leppänen (tarlepp)
  - Marcin Sikoń (marphi)
- - Bohan Yang (brentybh)
+ - M. Vondano
  - Dominik Zogg (dominik.zogg)
  - Marek Pietrzak
  - Luc Vieillescazes (iamluc)
+ - Lukáš Holeczy (holicz)
  - franek (franek)
  - Raulnet
  - Marco Petersen (ocrampete16)
@@ -659,6 +674,7 @@ Symfony is the result of the work of many people who made the code better
  - Leevi Graham (leevigraham)
  - Anthony Ferrara
  - Ioan Negulescu
+ - Greg ORIOL
  - Jakub Škvára (jskvara)
  - Andrew Udvare (audvare)
  - alexpods
@@ -668,7 +684,6 @@ Symfony is the result of the work of many people who made the code better
  - Erik Trapman (eriktrapman)
  - De Cock Xavier (xdecock)
  - Almog Baku (almogbaku)
- - Karoly Gossler (connorhu)
  - Scott Arciszewski
  - Xavier HAUSHERR
  - Norbert Orzechowicz (norzechowicz)
@@ -735,22 +750,18 @@ Symfony is the result of the work of many people who made the code better
  - Julien Montel (julienmgel)
  - Mátyás Somfai (smatyas)
  - Bastien DURAND (deamon)
- - Ben Ramsey (ramsey)
  - Simon DELICATA
  - Artem Henvald (artemgenvald)
  - Dmitry Simushev
  - alcaeus
  - Thomas Talbot (ioni)
- - Nate Wiebe (natewiebe13)
  - Fred Cox
  - vitaliytv
- - ivan
  - Philippe Segatori
  - Dalibor Karlović (dkarlovi)
  - Andrey Sevastianov
  - Sebastian Blum
  - Alexis Lefebvre
- - Dmitriy Mamontov (mamontovdmitriy)
  - aubx
  - Julien Turby
  - Marvin Butkereit
@@ -761,7 +772,6 @@ Symfony is the result of the work of many people who made the code better
  - Max Rath (drak3)
  - marie
  - Stéphane Escandell (sescandell)
- - Baptiste Leduc (korbeil)
  - Konstantin S. M. Möllers (ksmmoellers)
  - James Johnston
  - Noémi Salaün (noemi-salaun)
@@ -779,7 +789,6 @@ Symfony is the result of the work of many people who made the code better
  - Christophe Villeger (seragan)
  - Matthias Krauser (mkrauser)
  - Julien Fredon
- - Bob van de Vijver (bobvandevijver)
  - Xavier Leune (xleune)
  - Stefan Gehrig (sgehrig)
  - Hany el-Kerdany
@@ -795,7 +804,6 @@ Symfony is the result of the work of many people who made the code better
  - Geoffrey Brier (geoffrey-brier)
  - Alexandre Parent
  - Vladimir Tsykun
- - Romaric Drigon (romaricdrigon)
  - Dustin Dobervich (dustin10)
  - dantleech
  - Philipp Kolesnikov
@@ -804,7 +812,9 @@ Symfony is the result of the work of many people who made the code better
  - Carlos Pereira De Amorim (epitre)
  - zenmate
  - Michal Trojanowski
+ - Lescot Edouard (idetox)
  - David Fuhr
+ - Rodrigo Aguilera
  - Mathias STRASSER (roukmoute)
  - Max Grigorian (maxakawizard)
  - Rostyslav Kinash
@@ -822,13 +832,13 @@ Symfony is the result of the work of many people who made the code better
  - Xavier Briand (xavierbriand)
  - Ke WANG (yktd26)
  - Ivo Bathke (ivoba)
+ - David Molineus
  - Strate
  - Anton A. Sumin
  - Israel J. Carberry
  - Miquel Rodríguez Telep (mrtorrent)
  - Sergey Kolodyazhnyy (skolodyazhnyy)
  - umpirski
- - M. Vondano
  - Quentin de Longraye (quentinus95)
  - Chris Heng (gigablah)
  - Shaun Simmons (simshaun)
@@ -909,6 +919,7 @@ Symfony is the result of the work of many people who made the code better
  - Davide Borsatto (davide.borsatto)
  - Julien DIDIER (juliendidier)
  - Dominik Ritter (dritter)
+ - Andreas Leathley (iquito)
  - Sebastian Grodzicki (sgrodzicki)
  - Mohamed Gamal
  - Jeroen van den Enden (stoefke)
@@ -922,6 +933,7 @@ Symfony is the result of the work of many people who made the code better
  - Carson Full
  - Sergey Yastrebov
  - Trent Steel (trsteel88)
+ - Steve Grunwell
  - Yuen-Chi Lian
  - Tarjei Huse (tarjei)
  - Besnik Br
@@ -949,10 +961,10 @@ Symfony is the result of the work of many people who made the code better
  - Casper Valdemar Poulsen
  - Josiah (josiah)
  - Guillaume Verstraete (versgui)
- - Greg ORIOL
  - Joschi Kuphal
  - John Bohn (jbohn)
  - Marc Morera (mmoreram)
+ - Jason Tan
  - BENOIT POLASZEK (bpolaszek)
  - Julien Pauli
  - Mathieu Rochette (mathroc)
@@ -1026,7 +1038,6 @@ Symfony is the result of the work of many people who made the code better
  - Sergey Zolotov (enleur)
  - Maksim Kotlyar (makasim)
  - Neil Ferreira
- - Indra Gunawan (indragunawan)
  - Julie Hourcade (juliehde)
  - Dmitry Parnas (parnas)
  - Paul LE CORRE
@@ -1034,6 +1045,7 @@ Symfony is the result of the work of many people who made the code better
  - Daniel Gorgan
  - Tony Malzhacker
  - Mathieu MARCHOIS
+ - Tavo Nieves J
  - Cyril Quintin (cyqui)
  - Gerard van Helden (drm)
  - flack (flack)
@@ -1098,6 +1110,7 @@ Symfony is the result of the work of many people who made the code better
  - Johnson Page (jwpage)
  - Ruben Gonzalez (rubenruateltek)
  - Michael Roterman (wtfzdotnet)
+ - Dieter
  - Arno Geurts
  - Adán Lobato (adanlobato)
  - Ian Jenkins (jenkoian)
@@ -1133,6 +1146,7 @@ Symfony is the result of the work of many people who made the code better
  - Erik Saunier (snickers)
  - Thiago Cordeiro (thiagocordeiro)
  - Rootie
+ - Bernd Stellwag
  - Alireza Mirsepassi (alirezamirsepassi)
  - Daniel Alejandro Castro Arellano (lexcast)
  - sensio
@@ -1157,6 +1171,7 @@ Symfony is the result of the work of many people who made the code better
  - Christian Jul Jensen
  - Alexandre GESLIN (alexandregeslin)
  - The Whole Life to Learn
+ - Pierre Tondereau
  - Alex Vo (votanlean)
  - Mikkel Paulson
  - ergiegonzaga
@@ -1204,6 +1219,7 @@ Symfony is the result of the work of many people who made the code better
  - Luciano Mammino (loige)
  - fabios
  - Sander Coolen (scoolen)
+ - Laurent Clouet
  - Nicolas Le Goff (nlegoff)
  - Ben Oman
  - Chris de Kok
@@ -1213,21 +1229,22 @@ Symfony is the result of the work of many people who made the code better
  - Guillaume (guill)
  - Igor Timoshenko (igor.timoshenko)
  - Manuele Menozzi
- - zairig imad (zairigimad)
  - Anton Babenko (antonbabenko)
  - Irmantas Šiupšinskas (irmantas)
  - Benoit Mallo
- - Lescot Edouard (idetox)
  - Danilo Silva
  - Giuseppe Campanelli
+ - Valentin
  - pizzaminded
  - Arnaud PETITPAS (apetitpa)
  - Ken Stanley
  - Zachary Tong (polyfractal)
  - linh
+ - Guilherme Augusto Henschel
  - Mario Blažek (marioblazek)
  - Ashura
  - Hryhorii Hrebiniuk
+ - Eric Krona
  - johnstevenson
  - hamza
  - dantleech
@@ -1238,6 +1255,7 @@ Symfony is the result of the work of many people who made the code better
  - Stanislav Kocanda
  - DerManoMann
  - Damien  Fayet (rainst0rm)
+ - Ippei SUmida (ippey_s)
  - MatTheCat
  - Guillaume Royer
  - Artem (digi)
@@ -1247,6 +1265,7 @@ Symfony is the result of the work of many people who made the code better
  - Pierrick VIGNAND (pierrick)
  - Vadim Tyukov (vatson)
  - Arman
+ - Adamo Crespi (aerendir)
  - David Wolter (davewww)
  - Sortex
  - chispita
@@ -1322,12 +1341,15 @@ Symfony is the result of the work of many people who made the code better
  - Nikita Konstantinov
  - Martijn Evers
  - Philipp Fritsche
+ - tarlepp
+ - Luca Saba (lucasaba)
  - Benjamin Paap (benjaminpaap)
  - Claus Due (namelesscoder)
  - Christian
  - Alexandru Patranescu
  - Denis Golubovskiy (bukashk0zzz)
  - Sergii Smertin (nfx)
+ - Quentin Moreau (sheitak)
  - Mikkel Paulson
  - Michał Strzelecki
  - hugofonseca (fonsecas72)
@@ -1420,13 +1442,13 @@ Symfony is the result of the work of many people who made the code better
  - Arun Philip
  - Rémi Leclerc
  - Jan Vernarsky
+ - Jonas Hünig
  - Amine Yakoubi
  - Eduardo García Sanz (coma)
  - Sergio (deverad)
  - Makdessi Alex
  - James Gilliland
  - fduch (fduch)
- - David Molineus
  - Stuart Fyfe
  - David de Boer (ddeboer)
  - Eno Mullaraj (emullaraj)
@@ -1532,6 +1554,7 @@ Symfony is the result of the work of many people who made the code better
  - pthompson
  - Malaney J. Hill
  - Alexandre Pavy
+ - Adiel Cristo (arcristo)
  - Christian Flach (cmfcmf)
  - Cédric Girard (enk_)
  - Lars Ambrosius Wallenborn (larsborn)
@@ -1547,6 +1570,7 @@ Symfony is the result of the work of many people who made the code better
  - Javier Espinosa
  - Anton Kroshilin
  - Dawid Sajdak
+ - Norman Soetbeer
  - Ludek Stepan
  - Aaron Stephens (astephens)
  - Craig Menning (cmenning)
@@ -1557,7 +1581,6 @@ Symfony is the result of the work of many people who made the code better
  - Marc J. Schmidt (marcjs)
  - František Maša
  - Sebastian Schwarz
- - Jason Tan
  - Marco Jantke
  - Saem Ghani
  - Clément LEFEBVRE
@@ -1622,6 +1645,7 @@ Symfony is the result of the work of many people who made the code better
  - JL
  - Ilya Biryukov
  - Kim Laï Trinh
+ - Johan de Ruijter
  - Jason Desrosiers
  - m.chwedziak
  - Andreas Frömer
@@ -1694,6 +1718,7 @@ Symfony is the result of the work of many people who made the code better
  - Mara Blaga
  - Rick Prent
  - skalpa
+ - Kai
  - Martin Eckhardt
  - Bartłomiej Zając
  - Pieter Jordaan
@@ -1702,6 +1727,7 @@ Symfony is the result of the work of many people who made the code better
  - Michael Dowling (mtdowling)
  - Karlos Presumido (oneko)
  - Tony Vermeiren (tony)
+ - Jos Elstgeest
  - Thomas Counsell
  - BilgeXA
  - r1pp3rj4ck
@@ -1746,6 +1772,7 @@ Symfony is the result of the work of many people who made the code better
  - Pablo Ogando Ferreira
  - Thomas Ploch
  - Simon Neidhold
+ - Ben Hakim
  - Valentin VALCIU
  - Jeremiah VALERIE
  - Julien Menth
@@ -1773,6 +1800,7 @@ Symfony is the result of the work of many people who made the code better
  - Flavian (2much)
  - Gautier Deuette
  - mike
+ - Gilbertsoft
  - tadas
  - Kirk Madera
  - Keith Maika
@@ -1792,6 +1820,7 @@ Symfony is the result of the work of many people who made the code better
  - Zdeněk Drahoš
  - Dan Harper
  - moldcraft
+ - Marcin Kruk
  - Antoine Bellion (abellion)
  - Ramon Kleiss (akathos)
  - Antonio Peric-Mazar (antonioperic)
@@ -1853,6 +1882,7 @@ Symfony is the result of the work of many people who made the code better
  - Wing
  - Thomas Bibb
  - kick-the-bucket
+ - Joni Halme
  - Matt Farmer
  - catch
  - siganushka
@@ -2216,6 +2246,7 @@ Symfony is the result of the work of many people who made the code better
  - Gyula Szucs
  - Tomas Liubinas
  - Alex
+ - Thomas P
  - Jan Hort
  - Klaas Naaijkens
  - Daniel González Cerviño
@@ -2275,6 +2306,7 @@ Symfony is the result of the work of many people who made the code better
  - Vladimir Chernyshev (volch)
  - Wim Godden (wimg)
  - Yorkie Chadwick (yorkie76)
+ - Maxime Aknin (3m1x4m)
  - GuillaumeVerdon
  - Philipp Keck
  - Angel Fernando Quiroz Campos
@@ -2383,7 +2415,6 @@ Symfony is the result of the work of many people who made the code better
  - Jack Wright
  - MrNicodemuz
  - Anonymous User
- - Dieter
  - Paweł Tomulik
  - Eric J. Duran
  - Alexandru Bucur
@@ -2546,6 +2577,7 @@ Symfony is the result of the work of many people who made the code better
  - Damián Nohales (eagleoneraptor)
  - Jordane VASPARD (elementaire)
  - Elliot Anderson (elliot)
+ - Erwan Nader (ernadoo)
  - Fabien D. (fabd)
  - Carsten Eilers (fnc)
  - Sorin Gitlan (forapathy)
@@ -2619,6 +2651,7 @@ Symfony is the result of the work of many people who made the code better
  - Volker (skydiablo)
  - Success Go (successgo)
  - Julien Sanchez (sumbobyboys)
+ - Stephan Vierkant (svierkant)
  - Guillermo Gisinger (t3chn0r)
  - Markus Tacker (tacker)
  - Tom Newby (tomnewbyau)
@@ -2645,6 +2678,7 @@ Symfony is the result of the work of many people who made the code better
  - simpson
  - Antoine Leblanc
  - drublic
+ - Andre Johnson
  - MaPePeR
  - Andreas Streichardt
  - Alexandre Segura

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
@@ -42,7 +42,7 @@ class DoctrineDummy
     public $bar;
 
     /**
-     * @ManyToMany(targetEntity="DoctrineRelation", indexBy="rguid")
+     * @ManyToMany(targetEntity="DoctrineRelation", indexBy="rguid_column")
      */
     protected $indexedBar;
 

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineRelation.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineRelation.php
@@ -30,7 +30,7 @@ class DoctrineRelation
     public $id;
 
     /**
-     * @Column(type="guid")
+     * @Column(type="guid", name="rguid_column")
      */
     protected $rguid;
 

--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -142,7 +142,7 @@ class LintCommandTest extends TestCase
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {
-                unlink($file);
+                @unlink($file);
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
@@ -168,9 +168,9 @@ EOF;
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {
-                unlink($file);
+                @unlink($file);
             }
         }
-        rmdir(sys_get_temp_dir().'/yml-lint-test');
+        @rmdir(sys_get_temp_dir().'/yml-lint-test');
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -541,6 +541,6 @@ div.sf-toolbar .sf-toolbar-block a:hover {
 /***** Media query print: Do not print the Toolbar. *****/
 @media print {
     .sf-toolbar {
-        display: none;
+        display: none !important;
     }
 }

--- a/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ConfigCacheTest.php
@@ -30,7 +30,7 @@ class ConfigCacheTest extends TestCase
 
         foreach ($files as $file) {
             if (file_exists($file)) {
-                unlink($file);
+                @unlink($file);
             }
         }
     }

--- a/src/Symfony/Component/Config/Tests/Resource/FileExistenceResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileExistenceResourceTest.php
@@ -30,7 +30,7 @@ class FileExistenceResourceTest extends TestCase
     protected function tearDown(): void
     {
         if (file_exists($this->file)) {
-            unlink($this->file);
+            @unlink($this->file);
         }
     }
 

--- a/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
@@ -30,11 +30,9 @@ class FileResourceTest extends TestCase
 
     protected function tearDown(): void
     {
-        if (!file_exists($this->file)) {
-            return;
+        if (file_exists($this->file)) {
+            @unlink($this->file);
         }
-
-        unlink($this->file);
     }
 
     public function testGetResource()

--- a/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
+++ b/src/Symfony/Component/Config/Tests/ResourceCheckerConfigCacheTest.php
@@ -31,7 +31,7 @@ class ResourceCheckerConfigCacheTest extends TestCase
 
         foreach ($files as $file) {
             if (file_exists($file)) {
-                unlink($file);
+                @unlink($file);
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -481,6 +481,9 @@ EOF;
             return;
         }
         $file = $r->getFileName();
+        if (') : eval()\'d code' === substr($file, -17)) {
+            $file = substr($file, 0, strrpos($file, '(', -17));
+        }
         if (!$file || $this->doExport($file) === $exportedFile = $this->export($file)) {
             return;
         }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -180,7 +180,7 @@ class Filesystem
                 if (!self::box('rmdir', $file) && file_exists($file)) {
                     throw new IOException(sprintf('Failed to remove directory "%s": ', $file).self::$lastError);
                 }
-            } elseif (!self::box('unlink', $file) && file_exists($file)) {
+            } elseif (!self::box('unlink', $file) && (false !== strpos(self::$lastError, 'Permission denied') || file_exists($file))) {
                 throw new IOException(sprintf('Failed to remove file "%s": ', $file).self::$lastError);
             }
         }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Filesystem\Tests;
 
+use Symfony\Component\Filesystem\Exception\IOException;
+
 /**
  * Test class for Filesystem.
  */
@@ -332,6 +334,28 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->remove($files);
 
         $this->assertFileDoesNotExist($basePath.'dir');
+    }
+
+    public function testRemoveThrowsExceptionOnPermissionDenied()
+    {
+        $this->markAsSkippedIfChmodIsMissing();
+
+        $basePath = $this->workspace.\DIRECTORY_SEPARATOR.'dir_permissions';
+        mkdir($basePath);
+        $file = $basePath.\DIRECTORY_SEPARATOR.'file';
+        touch($file);
+        chmod($basePath, 0400);
+
+        try {
+            $this->filesystem->remove($file);
+            $this->fail('Filesystem::remove() should throw an exception');
+        } catch (IOException $e) {
+            $this->assertStringContainsString('Failed to remove file "'.$file.'"', $e->getMessage());
+            $this->assertStringContainsString('Permission denied', $e->getMessage());
+        } finally {
+            // Make sure we can clean up this file
+            chmod($basePath, 0777);
+        }
     }
 
     public function testRemoveCleansInvalidLinks()

--- a/src/Symfony/Component/Form/Resources/translations/validators.ar.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ar.xlf
@@ -14,6 +14,126 @@
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>قيمة رمز الموقع غير صحيحة. من فضلك اعد ارسال النموذج.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>هذه القيمة ليست لون HTML5 صالحًا.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>الرجاء ادخال تاريخ ميلاد صالح.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>الاختيار المحدد غير صالح.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>المجموعة غير صالحة.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>الرجاء اختيار لون صالح.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>الرجاء اختيار بلد صالح.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>الرجاء اختيار عملة صالحة.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>الرجاء اختيار فاصل زمني صالح.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>الرجاء إدخال تاريخ ووقت صالحين.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>الرجاء إدخال تاريخ صالح.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>الرجاء اختيار ملف صالح.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>الحقل المخفي غير صالح.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>الرجاء إدخال عدد صحيح.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>الرجاء اختيار لغة صالحة.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>الرجاء اختيار لغة صالحة.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>الرجاء إدخال مبلغ مالي صالح.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>الرجاء إدخال رقم.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>كلمة المرور غير صحيحة.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>الرجاء إدخال قيمة النسبة المئوية.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>القيم لا تتطابق.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>الرجاء إدخال وقت صالح.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>الرجاء تحديد منطقة زمنية صالحة.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>أدخل عنوان الرابط صحيح من فضلك.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>الرجاء إدخال مصطلح البحث ساري المفعول.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>يرجى تقديم رقم هاتف صالح.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>خانة الاختيار لها قيمة غير صالحة.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>رجاء قم بإدخال بريد الكتروني صحيح</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>الرجاء تحديد خيار صالح.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>يرجى تحديد نطاق صالح.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>الرجاء إدخال أسبوع صالح.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.bg.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.bg.xlf
@@ -14,6 +14,126 @@
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>Невалиден CSRF токен. Моля, опитайте да изпратите формата отново.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>Стойността не е валиден HTML5 цвят.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Моля въведете валидна дата на раждане.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>Избраните стойности не са валидни.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>Колекцията не е валидна.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Моля изберете валиден цвят.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Моля изберете валидна държава.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Моля изберете валидна валута.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Моля изберете валиден интервал от дати.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Моля въведете валидни дата и час.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Моля въведете валидна дата.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Моля изберете валиден файл.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Скритото поле е невалидно.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Моля попълнете цяло число.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Моля изберете валиден език.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Моля изберете валиден език.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Моля въведете валидна парична сума.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Моля въведете число.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>Паролата е невалидна.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Моля въведете процентна стойност.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>Стойностите не съвпадат.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Моля въведете валидно време.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Моля изберете валидна часова зона.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Моля въведете валиден URL.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Моля въведете валидно търсене.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Моля осигурете валиден телефонен номер.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>Отметката има невалидна стойност.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Моля въведете валидна ел. поща.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Моля изберете валидна опция.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Моля изберете валиден обхват.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Моля въведете валидна седмица.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.cs.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.cs.xlf
@@ -18,6 +18,122 @@
                 <source>This value is not a valid HTML5 color.</source>
                 <target>Tato hodnota není platná HTML5 barva.</target>
             </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Prosím zadejte platný datum narození.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>Vybraná možnost není platná.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>Kolekce není platná.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Prosím vyberte platnou barvu.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Prosím vyberte platnou zemi.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Prosím vyberte platnou měnu.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Prosím vyberte platné rozpětí dat.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Prosím zadejte platný datum a čas.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Prosím zadejte platný datum.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Prosím vyberte platný soubor.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Skryté pole není platné.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Prosím zadejte číslo.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Prosím zadejte platný jazyk.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Prosím zadejte platný jazyk.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Prosím zadejte platnou částku.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Prosím zadejte číslo.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>Heslo není platné.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Prosím zadejte procentuální hodnotu.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>Hodnoty se neshodují.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Prosím zadejte platný čas.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Prosím vyberte platné časové pásmo.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Prosím zadejte platnou URL.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Prosím zadejte platný výraz k vyhledání.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Prosím zadejte platné telefonní číslo.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>Zaškrtávací políčko má neplatnou hodnotu.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Prosím zadejte platnou emailovou adresu.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Prosím vyberte platnou možnost.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Prosím vyberte platný rozsah.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Prosím zadejte platný týden.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.de.xlf
@@ -18,6 +18,122 @@
                 <source>This value is not a valid HTML5 color.</source>
                 <target>Dieser Wert ist keine gültige HTML5 Farbe.</target>
             </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Bitte geben Sie ein gültiges Geburtsdatum ein.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>Die Auswahl ist ungültig.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>Diese Gruppe von Feldern ist ungültig.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Bitte geben Sie eine gültige Farbe ein.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Bitte wählen Sie ein gültiges Land aus.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Bitte wählen Sie eine gültige Währung aus.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Bitte wählen Sie ein gültiges Datumsintervall.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Bitte geben Sie ein gültiges Datum samt Uhrzeit ein.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Bitte geben Sie ein gültiges Datum ein.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Bitte wählen Sie eine gültige Datei.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Das versteckte Feld ist ungültig.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Bitte geben Sie eine ganze Zahl ein.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Bitte wählen Sie eine gültige Sprache.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Bitte wählen Sie eine gültige Locale-Einstellung aus.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Bitte geben Sie einen gültigen Geldbetrag ein.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Bitte geben Sie eine gültige Zahl ein.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>Das Kennwort ist ungültig.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Bitte geben Sie einen gültigen Prozentwert ein.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>Die Werte stimmen nicht überein.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Bitte geben Sie eine gültige Uhrzeit ein.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Bitte wählen Sie eine gültige Zeitzone.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Bitte geben Sie eine gültige URL ein.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Bitte geben Sie einen gültigen Suchbegriff ein.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Bitte geben Sie eine gültige Telefonnummer ein.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>Das Kontrollkästchen hat einen ungültigen Wert.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Bitte geben Sie eine gültige E-Mail-Adresse ein.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Bitte wählen Sie eine gültige Option.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Bitte wählen Sie einen gültigen Bereich.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Bitte geben Sie eine gültige Woche ein.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.en.xlf
@@ -114,6 +114,26 @@
                 <source>Please provide a valid phone number.</source>
                 <target>Please provide a valid phone number.</target>
             </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>The checkbox has an invalid value.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Please enter a valid email address.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Please select a valid option.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Please select a valid range.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Please enter a valid week.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.es.xlf
@@ -14,6 +14,126 @@
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>El token CSRF no es válido. Por favor, pruebe a enviar nuevamente el formulario.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>Este valor no es un color HTML5 válido.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Por favor, ingrese una fecha de cumpleaños válida.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>La opción seleccionada no es válida.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>La colección no es válida.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Por favor, seleccione un color válido.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Por favor, seleccione un país válido.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Por favor, seleccione una moneda válida.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Por favor, elija un intervalo de fechas válido.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Por favor, ingrese una fecha y hora válidas.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Por favor, ingrese una fecha valida.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Por favor, seleccione un archivo válido.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>El campo oculto no es válido.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Por favor, ingrese un número entero.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Por favor, seleccione un idioma válido.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Por favor, seleccione una configuración regional válida.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Por favor, ingrese una cantidad de dinero válida.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Por favor, ingrese un número.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>La contraseña no es válida.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Por favor, ingrese un valor porcentual.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>Los valores no coinciden.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Por favor, ingrese una hora válida.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Por favor, seleccione una zona horaria válida.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Por favor, ingrese una URL válida.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Por favor, ingrese un término de búsqueda válido.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Por favor, proporcione un número de teléfono válido.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>La casilla de verificación tiene un valor inválido.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Por favor, ingrese una dirección de correo electrónico válida.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Por favor, seleccione una opción válida.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Por favor, seleccione un rango válido.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Por favor, ingrese una semana válida.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.fa.xlf
@@ -4,15 +4,135 @@
         <body>
             <trans-unit id="28">
                 <source>This form should not contain extra fields.</source>
-                <target>این فرم نباید شامل فیلد اضافه ای باشد.</target>
+                <target>این فرم نباید شامل فیلدهای اضافی باشد.</target>
             </trans-unit>
             <trans-unit id="29">
                 <source>The uploaded file was too large. Please try to upload a smaller file.</source>
-                <target>فایل بارگذاری شده بسیار بزرگ می باشد. لطفا فایل کوچکتری را بارگذاری نمایید.</target>
+                <target>فایل بارگذاری‌شده بسیار بزرگ است. لطفاً فایل کوچک‌تری را بارگذاری نمایید.</target>
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
-                <target>توکن CSRF نامعتبر می باشد. لطفا فرم را مجددا ارسال نمایید.</target>
+                <target>توکن CSRF نامعتبر است. لطفاً فرم را مجدداً ارسال نمایید.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>این مقدار یک رنگ معتبر HTML5  نیست.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>لطفاً یک تاریخ تولد معتبر وارد نمایید.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>گزینه‌ی انتخاب‌شده نامعتبر است</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>این مجموعه نامعتبر است.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>لطفاً یک رنگ معتبر انتخاب کنید.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>لطفاً یک کشور معتبر انتخاب کنید.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>لطفاً یک واحد پولی معتبر انتخاب کنید.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>لطفاً یک بازه‌ی زمانی معتبر انتخاب کنید.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>لطفاً یک تاریخ و زمان معتبر وارد کنید.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>لطفاً یک تاریخ معتبر وارد کنید.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>لطفاً یک فایل معتبر انتخاب کنید.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>فیلد مخفی نامعتبر است.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>لطفاً یک عدد صحیح وارد کنید.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>لطفاً یک زبان معتبر انتخاب کنید.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>لطفاً یک جغرافیای (locale) معتبر انتخاب کنید.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>لطفاً یک مقدار پول معتبر وارد کنید.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>لطفاً یک عدد وارد کنید.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>رمزعبور نامعتبر است.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>لطفاً یک درصد معتبر وارد کنید.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>مقادیر تطابق ندارند.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>لطفاً یک زمان معتبر وارد کنید.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>لطفاً یک منطقه‌زمانی معتبر وارد کنید.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>لطفاً یک URL معتبر وارد کنید.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>لطفاً یک عبارت جستجوی معتبر وارد کنید.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>لطفاً یک شماره تلفن معتبر وارد کنید.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>کادر انتخاب (checkbox)  دارای مقداری نامعتبر است.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>لطفاً یک آدرس رایانامه‌ی معتبر وارد کنید.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>لطفاً یک گزینه‌ی معتبر انتخاب کنید.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>لطفاً یک محدوده‌ی معتبر انتخاب کنید.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>لطفاً یک هفته‌ی معتبر وارد کنید.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Form/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.fr.xlf
@@ -18,6 +18,122 @@
                 <source>This value is not a valid HTML5 color.</source>
                 <target>Cette valeur n'est pas une couleur HTML5 valide.</target>
             </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Veuillez entrer une date de naissance valide.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>Le choix sélectionné est invalide.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>La collection est invalide.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Veuillez sélectionner une couleur valide.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Veuillez sélectionner un pays valide.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Veuillez sélectionner une devise valide.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Veuillez choisir un intervalle de dates valide.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Veuillez saisir une date et une heure valides.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Veuillez entrer une date valide.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Veuillez sélectionner un fichier valide.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Le champ masqué n'est pas valide.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Veuillez saisir un entier.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Veuillez sélectionner une langue valide.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Veuillez sélectionner une langue valide.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Veuillez saisir un montant valide.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Veuillez saisir un nombre.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>Le mot de passe est invalide.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Veuillez saisir un pourcentage valide.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>Les valeurs ne correspondent pas.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Veuillez saisir une heure valide.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Veuillez sélectionner un fuseau horaire valide.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Veuillez saisir une URL valide.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Veuillez saisir un terme de recherche valide.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Veuillez fournir un numéro de téléphone valide.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>La case à cocher a une valeur non valide.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Veuillez saisir une adresse email valide.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Veuillez sélectionner une option valide.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Veuillez sélectionner une plage valide.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Veuillez entrer une semaine valide.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.id.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.id.xlf
@@ -14,6 +14,126 @@
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRF-Token tidak sah. Silahkan coba kirim ulang formulir.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>Nilai ini bukan merupakan HTML5 color yang sah.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Silahkan masukkan tanggal lahir yang sah.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>Pilihan yang dipilih tidak sah.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>Koleksi tidak sah.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Silahkan pilih warna yang sah.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Silahkan pilih negara yang sah.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Silahkan pilih mata uang yang sah.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Silahkan pilih interval tanggal yang sah.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Silahkan masukkan tanggal dan waktu yang sah.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Silahkan masukkan tanggal yang sah.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Silahkan pilih berkas yang sah.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Ruas yang tersembunyi tidak sah.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Silahkan masukkan angka.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Silahlan pilih bahasa yang sah.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Silahkan pilih local yang sah.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Silahkan masukkan nilai uang yang sah.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Silahkan masukkan sebuah angka</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>Kata sandi tidak sah.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Silahkan masukkan sebuah nilai persentase.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>Nilainya tidak cocok.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Silahkan masukkan waktu yang sah.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Silahkan pilih zona waktu yang sah.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Silahkan masukkan URL yang sah.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Silahkan masukkan kata pencarian yang sah.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Silahkan sediakan nomor telepon yang sah.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>Nilai dari checkbox tidak sah.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Silahkan masukkan alamat surel yang sah.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Silahkan pilih opsi yang sah.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Silahkan pilih rentang yang sah.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Silahkan masukkan minggu yang sah.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.it.xlf
@@ -8,11 +8,131 @@
             </trans-unit>
             <trans-unit id="29">
                 <source>The uploaded file was too large. Please try to upload a smaller file.</source>
-                <target>Il file caricato è troppo grande. Per favore caricare un file più piccolo.</target>
+                <target>Il file caricato è troppo grande. Per favore, carica un file più piccolo.</target>
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
-                <target>Il token CSRF non è valido. Provare a reinviare il form.</target>
+                <target>Il token CSRF non è valido. Prova a reinviare il form.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>Il valore non è un colore HTML5 valido.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Per favore, inserisci una data di compleanno valida.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>La scelta selezionata non è valida.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>La collezione non è valida.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Per favore, seleziona un colore valido.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Per favore, seleziona un paese valido.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Per favore, seleziona una valuta valida.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Per favore, scegli a valid date interval.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Per favore, inserisci a valid date and time.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Per favore, inserisci a valid date.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Per favore, seleziona un file valido.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Il campo nascosto non è valido.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Per favore, inserisci un numero intero.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Per favore, seleziona una lingua valida.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Per favore, seleziona una lingua valida.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Per favore, inserisci un importo valido.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Per favore, inserisci un numero.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>La password non è valida.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Per favore, inserisci un valore percentuale.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>I valori non corrispondono.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Per favore, inserisci un orario valido.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Per favore, seleziona un fuso orario valido.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Per favore, inserisci un URL valido.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Per favore, inserisci un termine di ricerca valido.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Per favore, indica un numero di telefono valido.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>La casella di selezione non ha un valore valido.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Per favore, indica un indirizzo email valido.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Per favore, seleziona un'opzione valida.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Per favore, seleziona un intervallo valido.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Per favore, inserisci una settimana valida.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ja.xlf
@@ -14,6 +14,126 @@
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRFトークンが無効です、再送信してください。</target>
             </trans-unit>
+            <trans-unit id="99">
+                 <source>This value is not a valid HTML5 color.</source>
+                 <target>有効なHTML5の色ではありません。</target>
+             </trans-unit>
+             <trans-unit id="100">
+                 <source>Please enter a valid birthdate.</source>
+                 <target>有効な生年月日を入力してください。</target>
+             </trans-unit>
+             <trans-unit id="101">
+                 <source>The selected choice is invalid.</source>
+                 <target>選択した値は無効です。</target>
+             </trans-unit>
+             <trans-unit id="102">
+                 <source>The collection is invalid.</source>
+                 <target>コレクションは無効です。</target>
+             </trans-unit>
+             <trans-unit id="103">
+                 <source>Please select a valid color.</source>
+                 <target>有効な色を選択してください。</target>
+             </trans-unit>
+             <trans-unit id="104">
+                 <source>Please select a valid country.</source>
+                 <target>有効な国を選択してください。</target>
+             </trans-unit>
+             <trans-unit id="105">
+                 <source>Please select a valid currency.</source>
+                 <target>有効な通貨を選択してください。</target>
+             </trans-unit>
+             <trans-unit id="106">
+                 <source>Please choose a valid date interval.</source>
+                 <target>有効な日付間隔を選択してください。</target>
+             </trans-unit>
+             <trans-unit id="107">
+                 <source>Please enter a valid date and time.</source>
+                 <target>有効な日時を入力してください。</target>
+             </trans-unit>
+             <trans-unit id="108">
+                 <source>Please enter a valid date.</source>
+                 <target>有効な日付を入力してください。</target>
+             </trans-unit>
+             <trans-unit id="109">
+                 <source>Please select a valid file.</source>
+                 <target>有効なファイルを選択してください。</target>
+             </trans-unit>
+             <trans-unit id="110">
+                 <source>The hidden field is invalid.</source>
+                 <target>隠しフィールドが無効です。</target>
+             </trans-unit>
+             <trans-unit id="111">
+                 <source>Please enter an integer.</source>
+                 <target>整数で入力してください。</target>
+             </trans-unit>
+             <trans-unit id="112">
+                 <source>Please select a valid language.</source>
+                 <target>有効な言語を選択してください。</target>
+             </trans-unit>
+             <trans-unit id="113">
+                 <source>Please select a valid locale.</source>
+                 <target>有効なロケールを選択してください。</target>
+             </trans-unit>
+             <trans-unit id="114">
+                 <source>Please enter a valid money amount.</source>
+                 <target>有効な金額を入力してください。</target>
+             </trans-unit>
+             <trans-unit id="115">
+                 <source>Please enter a number.</source>
+                 <target>数値で入力してください。</target>
+             </trans-unit>
+             <trans-unit id="116">
+                 <source>The password is invalid.</source>
+                 <target>パスワードが無効です。</target>
+             </trans-unit>
+             <trans-unit id="117">
+                 <source>Please enter a percentage value.</source>
+                 <target>パーセント値で入力してください。</target>
+             </trans-unit>
+             <trans-unit id="118">
+                 <source>The values do not match.</source>
+                 <target>値が一致しません。</target>
+             </trans-unit>
+             <trans-unit id="119">
+                 <source>Please enter a valid time.</source>
+                 <target>有効な時間を入力してください。</target>
+             </trans-unit>
+             <trans-unit id="120">
+                 <source>Please select a valid timezone.</source>
+                 <target>有効なタイムゾーンを選択してください。</target>
+             </trans-unit>
+             <trans-unit id="121">
+                 <source>Please enter a valid URL.</source>
+                 <target>有効なURLを入力してください。</target>
+             </trans-unit>
+             <trans-unit id="122">
+                 <source>Please enter a valid search term.</source>
+                 <target>有効な検索語を入力してください。</target>
+             </trans-unit>
+             <trans-unit id="123">
+                 <source>Please provide a valid phone number.</source>
+                 <target>有効な電話番号を入力してください。</target>
+             </trans-unit>
+             <trans-unit id="124">
+                 <source>The checkbox has an invalid value.</source>
+                 <target>チェックボックスの値が無効です。</target>
+             </trans-unit>
+             <trans-unit id="125">
+                 <source>Please enter a valid email address.</source>
+                 <target>有効なメールアドレスを入力してください。</target>
+             </trans-unit>
+             <trans-unit id="126">
+                 <source>Please select a valid option.</source>
+                 <target>有効な値を選択してください。</target>
+             </trans-unit>
+             <trans-unit id="127">
+                 <source>Please select a valid range.</source>
+                 <target>有効な範囲を選択してください。</target>
+             </trans-unit>
+             <trans-unit id="128">
+                 <source>Please enter a valid week.</source>
+                 <target>有効な週を入力してください。</target>
+             </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.lv.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.lv.xlf
@@ -14,6 +14,126 @@
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>Dotais CSRF talons nav derīgs. Lūdzu mēģiniet vēlreiz iesniegt veidlapu.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>Šī vertība nav derīga HTML5 krāsa.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Lūdzu, ievadiet derīgu dzimšanas datumu.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>Iezīmētā izvēle nav derīga.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>Kolekcija nav derīga.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Lūdzu, izvēlieties derīgu krāsu.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Lūdzu, izvēlieties derīgu valsti.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Lūdzu, izvēlieties derīgu valūtu.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Lūdzu, izvēlieties derīgu datumu intervālu.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Lūdzu, ievadiet derīgu datumu un laiku.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Lūdzu, ievadiet derīgu datumu.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Lūdzu, izvēlieties derīgu failu.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Slēptā lauka vērtība ir nederīga.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Lūdzu, ievadiet veselu skaitli.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Lūdzu, izvēlieties derīgu valodu.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Lūdzu, izvēlieties derīgu lokalizāciju.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Lūdzu, ievadiet derīgu naudas lielumu.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Lūdzu, ievadiet skaitli.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>Parole ir nederīga.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Lūdzu, ievadiet procentuālo lielumu.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>Vērtības nesakrīt.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Lūdzu, ievadiet derīgu laiku.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Lūdzu, izvēlieties derīgu laika zonu.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Lūdzu, ievadiet derīgu URL.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Lūdzu, ievadiet derīgu meklēšanas nosacījumu.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Lūdzu, ievadiet derīgu tālruņa numuru.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>Izvēles rūtiņai ir nederīga vērtība.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Lūdzu, ievadiet derīgu e-pasta adresi.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Lūdzu, izvēlieties derīgu opciju.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Lūdzu, izvēlieties derīgu diapazonu.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Lūdzu, ievadiet derīgu nedeļu.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.nl.xlf
@@ -14,6 +14,126 @@
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>De CSRF-token is ongeldig. Probeer het formulier opnieuw te versturen.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>Dit is geen geldige HTML5 kleur.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Vul een geldige geboortedatum in.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>Deze keuze is ongeldig.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>Deze collectie is ongeldig.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Kies een geldige kleur.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Kies een geldige landnaam.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Kies een geldige valuta.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Kies een geldig tijdinterval.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Vul een geldige datum en tijd in.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Vul een geldige datum in.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Kies een geldig bestand.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Het verborgen veld is incorrect.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Vul een geldig getal in.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Kies een geldige taal.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Kies een geldige locale.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Vul een geldig bedrag in.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Vul een geldig getal in.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>Het wachtwoord is incorrect.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Vul een geldig percentage in.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>De waardes komen niet overeen.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Vul een geldige tijd in.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Vul een geldige tijdzone in.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Vul een geldige URL in.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Vul een geldige zoekterm in.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Vul een geldig telefoonnummer in.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>De checkbox heeft een incorrecte waarde.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Vul een geldig e-mailadres in.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Kies een geldige optie.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Kies een geldig bereik.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Vul een geldige week in.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.pl.xlf
@@ -14,6 +14,126 @@
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>Token CSRF jest nieprawidłowy. Proszę spróbować wysłać formularz ponownie.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>Ta wartość nie jest prawidłowym kolorem HTML5.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Proszę wprowadzić prawidłową datę urodzenia.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>Wybrana wartość jest nieprawidłowa.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>Zbiór jest nieprawidłowy.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Proszę wybrać prawidłowy kolor.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Proszę wybrać prawidłowy kraj.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Proszę wybrać prawidłową walutę.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Proszę wybrać prawidłowy przedział czasowy.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Proszę wprowadzić prawidłową datę i czas.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Proszę wprowadzić prawidłową datę.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Proszę wybrać prawidłowy plik.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Ukryte pole jest nieprawidłowe.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Proszę wprowadzić liczbę całkowitą.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Proszę wybrać prawidłowy język.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Proszę wybrać prawidłową lokalizację.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Proszę wybrać prawidłową ilość pieniędzy.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Proszę wprowadzić liczbę.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>Hasło jest nieprawidłowe.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Proszę wprowadzić wartość procentową.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>Wartości się nie zgadzają.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Proszę wprowadzić prawidłowy czas.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Proszę wybrać prawidłową strefę czasową.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Proszę wprowadzić prawidłowy adres URL.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Proszę wprowadzić prawidłowy termin wyszukiwania.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Proszę wprowadzić prawidłowy numer telefonu.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>Pole wyboru posiada nieprawidłową wartość.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Proszę wprowadzić prawidłowy adres email.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Proszę wybrać prawidłową opcję.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Proszę wybrać prawidłowy zakres.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Proszę wybrać prawidłowy tydzień.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.pt_BR.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.pt_BR.xlf
@@ -114,6 +114,26 @@
                 <source>Please provide a valid phone number.</source>
                 <target>Por favor, informe um telefone válido.</target>
             </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>A caixa de seleção possui um valor inválido.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Por favor, informe um endereço de e-mail válido.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Por favor, selecione uma opção válida.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Por favor, selecione um intervalo válido.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Por favor, informe uma semana válida.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.ru.xlf
@@ -14,6 +14,126 @@
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRF значение недопустимо. Пожалуйста, попробуйте повторить отправку формы.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>Значение не является допустимым HTML5 цветом.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Пожалуйста, введите действительную дату рождения.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>Выбранный вариант недопустим.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>Коллекция недопустима.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Пожалуйста, выберите допустимый цвет.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Пожалуйста, выберите действительную страну.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Пожалуйста, выберите действительную валюту.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Пожалуйста, выберите действительный период.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Пожалуйста, введите действительные дату и время.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Пожалуйста, введите действительную дату.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Пожалуйста, выберите допустимый файл.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Значение скрытого поля недопустимо.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Пожалуйста, введите целое число.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Пожалуйста, выберите допустимый язык.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Пожалуйста, выберите допустимую локаль.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Пожалуйста, введите допустимое количество денег.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Пожалуйста, введите номер.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>Пароль недействителен.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Пожалуйста, введите процентное значение.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>Значения не совпадают.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Пожалуйста, введите действительное время.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Пожалуйста, выберите действительный часовой пояс.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Пожалуйста, введите действительный URL.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Пожалуйста, введите действительный поисковый запрос.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Пожалуйста, введите действительный номер телефона.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>Флажок имеет недопустимое значение.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Пожалуйста, введите допустимый email адрес.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Пожалуйста, выберите допустимый вариант.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Пожалуйста, выберите допустимый диапазон.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Пожалуйста, введите действительную неделю.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sq.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sq.xlf
@@ -1,0 +1,139 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="28">
+                <source>This form should not contain extra fields.</source>
+                <target>Kjo formë nuk duhet të përmbajë fusha shtesë.</target>
+            </trans-unit>
+            <trans-unit id="29">
+                <source>The uploaded file was too large. Please try to upload a smaller file.</source>
+                <target>Skedari i ngarkuar ishte shumë i madh. Ju lutemi provoni të ngarkoni një skedar më të vogël.</target>
+            </trans-unit>
+            <trans-unit id="30">
+                <source>The CSRF token is invalid. Please try to resubmit the form.</source>
+                <target>Vlera CSRF është e pavlefshme. Ju lutemi provoni të ridërgoni formën.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>Kjo vlerë nuk është një ngjyrë e vlefshme HTML5.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Ju lutemi shkruani një datëlindje të vlefshme.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>Opsioni i zgjedhur është i pavlefshëm.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>Koleksioni është i pavlefshëm.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Ju lutemi zgjidhni një ngjyrë të vlefshme.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Ju lutemi zgjidhni një shtet të vlefshëm.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Ju lutemi zgjidhni një monedhë të vlefshme.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Ju lutemi zgjidhni një interval të vlefshëm të datës.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Ju lutemi shkruani një datë dhe orë të vlefshme.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Ju lutemi shkruani një datë të vlefshme.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Ju lutemi zgjidhni një skedar të vlefshëm.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Fusha e fshehur është e pavlefshme.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Ju lutemi shkruani një numër të plotë.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Please select a valid language.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Ju lutemi zgjidhni një lokale të vlefshme.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Ju lutemi shkruani një shumë të vlefshme parash.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Ju lutemi shkruani një numër.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>Fjalëkalimi është i pavlefshëm.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Ju lutemi shkruani një vlerë përqindjeje.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>Vlerat nuk përputhen.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Ju lutemi shkruani një kohë të vlefshme.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Ju lutemi zgjidhni një zonë kohore të vlefshme.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Ju lutemi shkruani një URL të vlefshme.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Ju lutemi shkruani një term të vlefshëm kërkimi.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Ju lutemi jepni një numër telefoni të vlefshëm.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>Kutia e zgjedhjes ka një vlerë të pavlefshme.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Ju lutemi shkruani një adresë të vlefshme emaili.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Ju lutemi zgjidhni një opsion të vlefshëm.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Ju lutemi zgjidhni një diapazon të vlefshëm.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Ju lutemi shkruani një javë të vlefshme.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sv.xlf
@@ -14,6 +14,126 @@
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRF-elementet är inte giltigt. Försök att skicka formuläret igen.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>Värdet är inte en giltig HTML5-färg.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Ange ett giltigt födelsedatum.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>Det valda alternativet är ogiltigt.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>Den här samlingen är ogiltig.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Välj en giltig färg.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Välj ett land.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Välj en valuta.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Välj ett giltigt datumintervall.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Ange datum och tid.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Ange ett datum.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Välj en fil.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Det dolda fältet är ogiltigt.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Ange ett heltal.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Välj språk.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Välj plats.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Ange en giltig summa pengar.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Ange en siffra.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>Lösenordet är ogiltigt.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Ange ett procentuellt värde.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>De angivna värdena stämmer inte överens.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Ange en giltig tid.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Välj tidszon.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Ange en giltig URL.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Ange ett giltigt sökbegrepp.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Ange ett giltigt telefonnummer.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>Kryssrutan har ett ogiltigt värde.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Ange en giltig e-postadress.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Välj ett alternativ.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Välj ett intervall.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Ange en vecka.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.sv.xlf
@@ -48,11 +48,11 @@
             </trans-unit>
             <trans-unit id="107">
                 <source>Please enter a valid date and time.</source>
-                <target>Ange datum och tid.</target>
+                <target>Ange ett giltigt datum och tid.</target>
             </trans-unit>
             <trans-unit id="108">
                 <source>Please enter a valid date.</source>
-                <target>Ange ett datum.</target>
+                <target>Ange ett giltigt datum.</target>
             </trans-unit>
             <trans-unit id="109">
                 <source>Please select a valid file.</source>
@@ -100,7 +100,7 @@
             </trans-unit>
             <trans-unit id="120">
                 <source>Please select a valid timezone.</source>
-                <target>Välj tidszon.</target>
+                <target>Välj en tidszon.</target>
             </trans-unit>
             <trans-unit id="121">
                 <source>Please enter a valid URL.</source>
@@ -132,7 +132,7 @@
             </trans-unit>
             <trans-unit id="128">
                 <source>Please enter a valid week.</source>
-                <target>Ange en vecka.</target>
+                <target>Ange en giltig vecka.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Form/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.tr.xlf
@@ -14,6 +14,126 @@
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRF fişi geçersiz. Formu tekrar göndermeyi deneyin.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>Bu değer, geçerli bir HTML5 rengi değil.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Lütfen geçerli bir doğum tarihi girin.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>Seçilen seçim geçersiz.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>Koleksiyon geçersiz.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Lütfen geçerli bir renk seçin.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Lütfen geçerli bir ülke seçin.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Lütfen geçerli bir para birimi seçin.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Lütfen geçerli bir tarih aralığı seçin.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Lütfen geçerli bir tarih ve saat girin.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Lütfen geçerli bir tarih giriniz.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Lütfen geçerli bir dosya seçin.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Gizli alan geçersiz.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Lütfen bir tam sayı girin.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Lütfen geçerli bir dil seçin.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Lütfen geçerli bir yerel ayar seçin.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Lütfen geçerli bir para tutarı girin.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Lütfen bir numara giriniz.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>Şifre geçersiz.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Lütfen bir yüzde değeri girin.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>Değerler eşleşmiyor.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Lütfen geçerli bir zaman girin.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Lütfen geçerli bir saat dilimi seçin.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Lütfen geçerli bir giriniz URL.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Lütfen geçerli bir arama terimi girin.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>lütfen geçerli bir telefon numarası sağlayın.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>Onay kutusunda geçersiz bir değer var.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Lütfen geçerli bir e-posta adresi girin.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Lütfen geçerli bir seçenek seçin.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Lütfen geçerli bir aralık seçin.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Lütfen geçerli bir hafta girin.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.uk.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.uk.xlf
@@ -14,6 +14,126 @@
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRF значення недопустиме. Будь-ласка, спробуйте відправити форму знову.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>Це значення не є допустимим кольором HTML5.</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>Будь ласка, введіть дійсну дату народження.</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>Обраний варіант недійсний.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>Колекція недійсна.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>Будь ласка, оберіть дійсний колір.</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>Будь ласка, оберіть дійсну країну.</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>Будь ласка, оберіть дійсну валюту.</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>Будь ласка, оберіть дійсний інтервал дати.</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>Будь ласка, введіть дійсну дату та час.</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>Будь ласка, введіть дійсну дату.</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>Будь ласка, оберіть дійсний файл.</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>Приховане поле недійсне.</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>Будь ласка, введіть ціле число.</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>Будь ласка, оберіть дійсну мову.</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>Будь ласка, оберіть дійсну локаль.</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>Будь ласка, введіть дійсну суму грошей.</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>Будь ласка, введіть число.</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>Пароль недійсний.</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>Будь ласка, введіть процентне значення.</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>Значення не збігаються.</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>Будь ласка, введіть дійсний час.</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>Будь ласка, оберіть дійсний часовий пояс.</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>Будь ласка, введіть дійсну URL-адресу.</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>Будь ласка, введіть дійсний пошуковий термін.</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>Будь ласка, введіть дійсний номер телефону.</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>Прапорець має недійсне значення.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Будь ласка, введіть дійсну адресу електронної пошти.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Будь ласка, оберіть дійсний варіант.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Будь ласка, оберіть дійсний діапазон.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Будь ласка, введіть дійсний тиждень.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.uk.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.uk.xlf
@@ -8,11 +8,11 @@
             </trans-unit>
             <trans-unit id="29">
                 <source>The uploaded file was too large. Please try to upload a smaller file.</source>
-                <target>Завантажений файл занадто великий. Будь-ласка, спробуйте завантажити файл меншого розміру.</target>
+                <target>Завантажений файл занадто великий. Будь ласка, спробуйте завантажити файл меншого розміру.</target>
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
-                <target>CSRF значення недопустиме. Будь-ласка, спробуйте відправити форму знову.</target>
+                <target>CSRF значення недопустиме. Будь ласка, спробуйте відправити форму знову.</target>
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid HTML5 color.</source>

--- a/src/Symfony/Component/Form/Resources/translations/validators.vi.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.vi.xlf
@@ -114,6 +114,26 @@
                 <source>Please provide a valid phone number.</source>
                 <target>Vui lòng cung cấp số điện thoại hợp lệ.</target>
             </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>Hộp kiểm có một giá trị không hợp lệ.</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>Vui lòng nhập địa chỉ email hợp lệ.</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>Vui lòng chọn một phương án hợp lệ.</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>Vui lòng nhập một phạm vi hợp lệ.</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>Vui lòng nhập một tuần hợp lệ.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.zh_CN.xlf
@@ -14,6 +14,126 @@
                 <source>The CSRF token is invalid. Please try to resubmit the form.</source>
                 <target>CSRF 验证符无效， 请重新提交.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>该数值不是个有效的 HTML5 颜色。</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>请输入有效的生日日期。</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>所选的选项无效。</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>集合无效。</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>请选择有效的颜色。</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>请选择有效的国家。</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>请选择有效的货币。</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>请选择有效的日期间隔。</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>请输入有效的日期与时间。</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>请输入有效的日期。</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>请选择有效的文件。</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>隐藏字段无效。</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>请输入整数。</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>请选择有效的语言。</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>请选择有效的语言环境。</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>请输入正确的金额。</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>请输入数字。</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>密码无效。</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>请输入百分比值。</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>数值不匹配。</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>请输入有效的时间。</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>请选择有效的时区。</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>请输入有效的网址。</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>请输入有效的搜索词。</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>请提供有效的手机号码。</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>无效的选框值。</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>请输入有效的电子邮件地址。</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>请选择有效的选项。</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>请选择有效的范围。</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>请输入有效的星期。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Form/Resources/translations/validators.zh_TW.xlf
+++ b/src/Symfony/Component/Form/Resources/translations/validators.zh_TW.xlf
@@ -1,0 +1,139 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="28">
+                <source>This form should not contain extra fields.</source>
+                <target>該表單中不可有額外字段。</target>
+            </trans-unit>
+            <trans-unit id="29">
+                <source>The uploaded file was too large. Please try to upload a smaller file.</source>
+                <target>上傳文件太大， 請重新嘗試上傳一個較小的文件。</target>
+            </trans-unit>
+            <trans-unit id="30">
+                <source>The CSRF token is invalid. Please try to resubmit the form.</source>
+                <target>CSRF 驗證符無效， 請重新提交。</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid HTML5 color.</source>
+                <target>該數值不是個有效的 HTML5 顏色。</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>Please enter a valid birthdate.</source>
+                <target>請輸入有效的生日日期。</target>
+            </trans-unit>
+            <trans-unit id="101">
+                <source>The selected choice is invalid.</source>
+                <target>所選的選項無效。</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>The collection is invalid.</source>
+                <target>集合無效。</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>Please select a valid color.</source>
+                <target>請選擇有效的顏色。</target>
+            </trans-unit>
+            <trans-unit id="104">
+                <source>Please select a valid country.</source>
+                <target>請選擇有效的國家。</target>
+            </trans-unit>
+            <trans-unit id="105">
+                <source>Please select a valid currency.</source>
+                <target>請選擇有效的貨幣。</target>
+            </trans-unit>
+            <trans-unit id="106">
+                <source>Please choose a valid date interval.</source>
+                <target>請選擇有效的日期間隔。</target>
+            </trans-unit>
+            <trans-unit id="107">
+                <source>Please enter a valid date and time.</source>
+                <target>請輸入有效的日期與時間。</target>
+            </trans-unit>
+            <trans-unit id="108">
+                <source>Please enter a valid date.</source>
+                <target>請輸入有效的日期。</target>
+            </trans-unit>
+            <trans-unit id="109">
+                <source>Please select a valid file.</source>
+                <target>請選擇有效的文件。</target>
+            </trans-unit>
+            <trans-unit id="110">
+                <source>The hidden field is invalid.</source>
+                <target>隱藏字段無效。</target>
+            </trans-unit>
+            <trans-unit id="111">
+                <source>Please enter an integer.</source>
+                <target>請輸入整數。</target>
+            </trans-unit>
+            <trans-unit id="112">
+                <source>Please select a valid language.</source>
+                <target>請選擇有效的語言。</target>
+            </trans-unit>
+            <trans-unit id="113">
+                <source>Please select a valid locale.</source>
+                <target>請選擇有效的語言環境。</target>
+            </trans-unit>
+            <trans-unit id="114">
+                <source>Please enter a valid money amount.</source>
+                <target>請輸入正確的金額。</target>
+            </trans-unit>
+            <trans-unit id="115">
+                <source>Please enter a number.</source>
+                <target>請輸入數字。</target>
+            </trans-unit>
+            <trans-unit id="116">
+                <source>The password is invalid.</source>
+                <target>密碼無效。</target>
+            </trans-unit>
+            <trans-unit id="117">
+                <source>Please enter a percentage value.</source>
+                <target>請輸入百分比值。</target>
+            </trans-unit>
+            <trans-unit id="118">
+                <source>The values do not match.</source>
+                <target>數值不匹配。</target>
+            </trans-unit>
+            <trans-unit id="119">
+                <source>Please enter a valid time.</source>
+                <target>請輸入有效的時間。</target>
+            </trans-unit>
+            <trans-unit id="120">
+                <source>Please select a valid timezone.</source>
+                <target>請選擇有效的時區。</target>
+            </trans-unit>
+            <trans-unit id="121">
+                <source>Please enter a valid URL.</source>
+                <target>請輸入有效的網址。</target>
+            </trans-unit>
+            <trans-unit id="122">
+                <source>Please enter a valid search term.</source>
+                <target>請輸入有效的搜索詞。</target>
+            </trans-unit>
+            <trans-unit id="123">
+                <source>Please provide a valid phone number.</source>
+                <target>請提供有效的手機號碼。</target>
+            </trans-unit>
+            <trans-unit id="124">
+                <source>The checkbox has an invalid value.</source>
+                <target>無效的選框值。</target>
+            </trans-unit>
+            <trans-unit id="125">
+                <source>Please enter a valid email address.</source>
+                <target>請輸入有效的電子郵件地址。</target>
+            </trans-unit>
+            <trans-unit id="126">
+                <source>Please select a valid option.</source>
+                <target>請選擇有效的選項。</target>
+            </trans-unit>
+            <trans-unit id="127">
+                <source>Please select a valid range.</source>
+                <target>請選擇有效的範圍。</target>
+            </trans-unit>
+            <trans-unit id="128">
+                <source>Please enter a valid week.</source>
+                <target>請輸入有效的星期。</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -234,33 +234,36 @@ class BinaryFileResponse extends Response
                 $this->headers->set($type, $path);
                 $this->maxlen = 0;
             }
-        } elseif ($request->headers->has('Range')) {
+        } elseif ($request->headers->has('Range') && $request->isMethod('GET')) {
             // Process the range headers.
             if (!$request->headers->has('If-Range') || $this->hasValidIfRangeHeader($request->headers->get('If-Range'))) {
                 $range = $request->headers->get('Range');
 
-                list($start, $end) = explode('-', substr($range, 6), 2) + [0];
+                if (0 === strpos($range, 'bytes=')) {
+                    list($start, $end) = explode('-', substr($range, 6), 2) + [0];
 
-                $end = ('' === $end) ? $fileSize - 1 : (int) $end;
+                    $end = ('' === $end) ? $fileSize - 1 : (int) $end;
 
-                if ('' === $start) {
-                    $start = $fileSize - $end;
-                    $end = $fileSize - 1;
-                } else {
-                    $start = (int) $start;
-                }
+                    if ('' === $start) {
+                        $start = $fileSize - $end;
+                        $end = $fileSize - 1;
+                    } else {
+                        $start = (int) $start;
+                    }
 
-                if ($start <= $end) {
-                    if ($start < 0 || $end > $fileSize - 1) {
-                        $this->setStatusCode(416);
-                        $this->headers->set('Content-Range', sprintf('bytes */%s', $fileSize));
-                    } elseif (0 !== $start || $end !== $fileSize - 1) {
-                        $this->maxlen = $end < $fileSize ? $end - $start + 1 : -1;
-                        $this->offset = $start;
+                    if ($start <= $end) {
+                        $end = min($end, $fileSize - 1);
+                        if ($start < 0 || $start > $end) {
+                            $this->setStatusCode(416);
+                            $this->headers->set('Content-Range', sprintf('bytes */%s', $fileSize));
+                        } elseif ($end - $start < $fileSize - 1) {
+                            $this->maxlen = $end < $fileSize ? $end - $start + 1 : -1;
+                            $this->offset = $start;
 
-                        $this->setStatusCode(206);
-                        $this->headers->set('Content-Range', sprintf('bytes %s-%s/%s', $start, $end, $fileSize));
-                        $this->headers->set('Content-Length', $end - $start + 1);
+                            $this->setStatusCode(206);
+                            $this->headers->set('Content-Range', sprintf('bytes %s-%s/%s', $start, $end, $fileSize));
+                            $this->headers->set('Content-Length', $end - $start + 1);
+                        }
                     }
                 }
             }

--- a/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
@@ -168,9 +168,9 @@ class FileBagTest extends TestCase
     protected function tearDown(): void
     {
         foreach (glob(sys_get_temp_dir().'/form_test/*') as $file) {
-            unlink($file);
+            @unlink($file);
         }
 
-        rmdir(sys_get_temp_dir().'/form_test');
+        @rmdir(sys_get_temp_dir().'/form_test');
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
@@ -43,7 +43,7 @@ class MockFileSessionStorageTest extends TestCase
     {
         array_map('unlink', glob($this->sessionDir.'/*'));
         if (is_dir($this->sessionDir)) {
-            rmdir($this->sessionDir);
+            @rmdir($this->sessionDir);
         }
         $this->sessionDir = null;
         $this->storage = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -47,7 +47,7 @@ class NativeSessionStorageTest extends TestCase
         session_write_close();
         array_map('unlink', glob($this->savePath.'/*'));
         if (is_dir($this->savePath)) {
-            rmdir($this->savePath);
+            @rmdir($this->savePath);
         }
 
         $this->savePath = null;

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/PhpBridgeSessionStorageTest.php
@@ -43,7 +43,7 @@ class PhpBridgeSessionStorageTest extends TestCase
         session_write_close();
         array_map('unlink', glob($this->savePath.'/*'));
         if (is_dir($this->savePath)) {
-            rmdir($this->savePath);
+            @rmdir($this->savePath);
         }
 
         $this->savePath = null;

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/ResponseCacheStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/ResponseCacheStrategyTest.php
@@ -216,7 +216,7 @@ class ResponseCacheStrategyTest extends TestCase
         $cacheStrategy->add($embeddedResponse);
         $cacheStrategy->update($masterResponse);
 
-        $this->assertSame('60', $masterResponse->headers->getCacheControlDirective('s-maxage'));
+        $this->assertEqualsWithDelta(60, (int) $masterResponse->headers->getCacheControlDirective('s-maxage'), 1);
     }
 
     public function testResponseIsExpirableButNotValidateableWhenMasterResponseCombinesExpirationAndValidation()

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.ar.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.ar.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>الحساب مغلق.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>عدد كبير جدا من محاولات الدخول الفاشلة، يرجى المحاولة مرة أخرى في وقت لاحق.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>رابط تسجيل الدخول غير صالح أو منتهي الصلاحية.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.bg.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.bg.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Акаунта е заключен.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Твърде много грешни опити за вход, моля опитайте по-късно.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Невалиден или изтекъл линк за вход.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.cs.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.cs.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Účet je zablokovaný.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Příliš mnoho nepovedených pokusů přihlášení. Zkuste to prosím později.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Neplatný nebo expirovaný odkaz na přihlášení.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.de.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.de.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Der Account ist gesperrt.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Zu viele fehlgeschlagene Anmeldeversuche, bitte versuchen Sie es später noch einmal.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Ungültiger oder abgelaufener Anmelde-Link.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.en.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.en.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Account is locked.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Too many failed login attempts, please try again later.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Invalid or expired login link.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.es.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.es.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>La cuenta está bloqueada.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Demasiados intentos fallidos de inicio de sesión, inténtelo de nuevo más tarde.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Enlace de inicio de sesión inválido o expirado.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.fa.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.fa.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>حساب کاربری قفل گردیده است.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>تلاش‌های ناموفق زیادی برای ورود صورت گرفته است، لطفاً بعداً دوباره تلاش کنید.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>لینک ورود نامعتبر یا تاریخ‌گذشته است.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.fi.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.fi.xlf
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>An authentication exception occurred.</source>
+                <target>Autentikointi poikkeus tapahtui.</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>Authentication credentials could not be found.</source>
+                <target>Autentikoinnin tunnistetietoja ei löydetty.</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>Authentication request could not be processed due to a system problem.</source>
+                <target>Autentikointipyyntöä ei voitu käsitellä järjestelmäongelman vuoksi.</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>Invalid credentials.</source>
+                <target>Virheelliset tunnistetiedot.</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>Cookie has already been used by someone else.</source>
+                <target>Eväste on jo jonkin muun käytössä.</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>Not privileged to request the resource.</source>
+                <target>Ei oikeutta resurssiin.</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>Invalid CSRF token.</source>
+                <target>Virheellinen CSRF tunnus.</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>Digest nonce has expired.</source>
+                <target>Digest nonce on vanhentunut.</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>No authentication provider found to support the authentication token.</source>
+                <target>Autentikointi tunnukselle ei löydetty tuettua autentikointi tarjoajaa.</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>No session available, it either timed out or cookies are not enabled.</source>
+                <target>Sessio ei ole saatavilla, se on joko vanhentunut tai evästeet eivät ole käytössä.</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>No token could be found.</source>
+                <target>Tunnusta ei löytynyt.</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>Username could not be found.</source>
+                <target>Käyttäjätunnusta ei löydetty.</target>
+            </trans-unit>
+            <trans-unit id="13">
+                <source>Account has expired.</source>
+                <target>Tili on vanhentunut.</target>
+            </trans-unit>
+            <trans-unit id="14">
+                <source>Credentials have expired.</source>
+                <target>Tunnistetiedot ovat vanhentuneet.</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>Account is disabled.</source>
+                <target>Tili on poistettu käytöstä.</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>Account is locked.</source>
+                <target>Tili on lukittu.</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Liian monta epäonnistunutta kirjautumisyritystä, yritä myöhemmin uudelleen.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Virheellinen tai vanhentunut kirjautumislinkki.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.fr.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.fr.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Le compte est bloqué.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Plusieurs tentatives de connexion ont échoué, veuillez réessayer plus tard.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Lien de connexion invalide ou expiré.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.id.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.id.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Akun terkunci.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Terlalu banyak percobaan login yang salah, Silahkan coba lagi nanti.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Link login salah atau sudah kadaluwarsa.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.it.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.it.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>L'account è bloccato.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Troppi tentaivi di login falliti. Riprova tra un po'.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Link di login scaduto o non valido.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.ja.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.ja.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>アカウントはロックされています。</target>
             </trans-unit>
+            <trans-unit id="17">
+                 <source>Too many failed login attempts, please try again later.</source>
+                 <target>ログイン試行回数を超えました。しばらくして再度お試しください。</target>
+             </trans-unit>
+             <trans-unit id="18">
+                 <source>Invalid or expired login link.</source>
+                 <target>ログインリンクが有効期限切れ、もしくは無効です。</target>
+             </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.lv.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.lv.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Konts ir slēgts.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Pārāk daudz atteiktu ieejas mēģinājumu, lūdzu, mēģiniet vēlreiz vēlāk.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Ieejas saite ir nederīga vai arī tai ir beidzies derīguma termiņš.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.nl.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.nl.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Account is geblokkeerd.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Te veel onjuiste inlogpogingen, probeer het later nogmaals.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Ongeldige of verlopen inloglink.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.pl.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.pl.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Konto jest zablokowane.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Zbyt dużo nieudanych prób logowania, proszę spróbować ponownie później.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Nieprawidłowy lub wygasły link logowania.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.pt_BR.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.pt_BR.xlf
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="3">
                 <source>Authentication request could not be processed due to a system problem.</source>
-                <target>A autenticação não pôde ser concluída devido a um problema no sistema.</target>
+                <target>A solicitação de autenticação não pôde ser processada devido a um problema no sistema.</target>
             </trans-unit>
             <trans-unit id="4">
                 <source>Invalid credentials.</source>
@@ -20,11 +20,11 @@
             </trans-unit>
             <trans-unit id="5">
                 <source>Cookie has already been used by someone else.</source>
-                <target>Este cookie já está em uso.</target>
+                <target>Este cookie já foi usado por outra pessoa.</target>
             </trans-unit>
             <trans-unit id="6">
                 <source>Not privileged to request the resource.</source>
-                <target>Não possui privilégios o bastante para requisitar este recurso.</target>
+                <target>Sem privilégio para solicitar o recurso.</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>Invalid CSRF token.</source>
@@ -36,7 +36,7 @@
             </trans-unit>
             <trans-unit id="10">
                 <source>No session available, it either timed out or cookies are not enabled.</source>
-                <target>Nenhuma sessão disponível, ela expirou ou os cookies estão desativados.</target>
+                <target>Nenhuma sessão disponível, ela expirou ou os cookies não estão habilitados.</target>
             </trans-unit>
             <trans-unit id="11">
                 <source>No token could be found.</source>
@@ -61,6 +61,14 @@
             <trans-unit id="16">
                 <source>Account is locked.</source>
                 <target>A conta está travada.</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Muitas tentativas de login malsucedidas, tente novamente mais tarde.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Link de login inválido ou expirado.</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.ru.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.ru.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Учетная запись заблокирована.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Слишком много неудачных попыток входа, пожалуйста, попробуйте позже.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Ссылка для входа недействительна или просрочена.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.sk.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.sk.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Účet je zablokovaný.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Príliš mnoho neúspešných pokusov o prihlásenie. Skúste to prosím znovu neskôr.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Neplatný alebo expirovaný odkaz na prihlásenie.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.sq.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.sq.xlf
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>An authentication exception occurred.</source>
+                <target>Ndodhi një problem në autentikim.</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>Authentication credentials could not be found.</source>
+                <target>Kredencialet e autentikimit nuk mund të gjendeshin.</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>Authentication request could not be processed due to a system problem.</source>
+                <target>Kërkesa për autentikim nuk mund të përpunohej për shkak të një problemi në sistem.</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>Invalid credentials.</source>
+                <target>Kredenciale të pavlefshme.</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>Cookie has already been used by someone else.</source>
+                <target>Cookie është përdorur tashmë nga dikush tjetër.</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>Not privileged to request the resource.</source>
+                <target>Nuk është i privilegjuar të kërkojë burimin.</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>Invalid CSRF token.</source>
+                <target>Identifikues i pavlefshëm CSRF.</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>Digest nonce has expired.</source>
+                <target>Numeri një perdorimësh i verifikimit Digest ka skaduar.</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>No authentication provider found to support the authentication token.</source>
+                <target>Asnjë ofrues i vërtetimit nuk u gjet që të mbështesë simbolin e vërtetimit.</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>No session available, it either timed out or cookies are not enabled.</source>
+                <target>Nuk ka asnjë sesion të vlefshëm, i ka skaduar koha ose cookies nuk janë aktivizuar.</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>No token could be found.</source>
+                <target>Asnjë simbol identifikimi nuk mund të gjendej.</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>Username could not be found.</source>
+                <target>Emri i përdoruesit nuk mund të gjendej.</target>
+            </trans-unit>
+            <trans-unit id="13">
+                <source>Account has expired.</source>
+                <target>Llogaria ka skaduar.</target>
+            </trans-unit>
+            <trans-unit id="14">
+                <source>Credentials have expired.</source>
+                <target>Kredencialet kanë skaduar.</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>Account is disabled.</source>
+                <target>Llogaria është çaktivizuar.</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>Account is locked.</source>
+                <target>Llogaria është e kyçur.</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Shumë përpjekje të dështuara autentikimi, provo përsëri më vonë.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Link hyrje i pavlefshëm ose i skaduar.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.sv.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.sv.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Kontot är låst.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>För många misslyckade inloggningsförsök, försök igen senare.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Ogiltig eller utgången inloggningslänk.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.tr.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.tr.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Hesap kilitlenmiş.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Çok fazla başarısız giriş denemesi, lütfen daha sonra tekrar deneyin.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Geçersiz veya süresi dolmuş oturum açma bağlantısı.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.uk.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.uk.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Обліковий запис заблоковано.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Забагато невдалих спроб входу. Будь ласка, спробуйте пізніше.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Посилання для входу недійсне, або термін його дії закінчився.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.vi.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.vi.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>Tài khoản bị khóa.</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>Đăng nhập sai quá nhiều lần, vui lòng thử lại lần nữa.</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>Liên kết đăng nhập không hợp lệ hoặc quá hạn.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.zh_CN.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.zh_CN.xlf
@@ -62,6 +62,14 @@
                 <source>Account is locked.</source>
                 <target>帐号已被锁定。</target>
             </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>登入失败的次数过多，请稍后再试。</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>失效或过期的登入链接。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Core/Resources/translations/security.zh_TW.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.zh_TW.xlf
@@ -1,0 +1,79 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>An authentication exception occurred.</source>
+                <target>身份驗證發生異常。</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>Authentication credentials could not be found.</source>
+                <target>沒有找到身份驗證的憑證。</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>Authentication request could not be processed due to a system problem.</source>
+                <target>由於系統故障，身份驗證的請求無法被處理。</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>Invalid credentials.</source>
+                <target>無效的憑證。</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>Cookie has already been used by someone else.</source>
+                <target>Cookie 已經被其他人使用。</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>Not privileged to request the resource.</source>
+                <target>沒有權限請求此資源。</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>Invalid CSRF token.</source>
+                <target>無效的 CSRF token 。</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>Digest nonce has expired.</source>
+                <target>摘要隨機串（digest nonce）已過期。</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>No authentication provider found to support the authentication token.</source>
+                <target>沒有找到支持此 token 的身份驗證服務提供方。</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>No session available, it either timed out or cookies are not enabled.</source>
+                <target>Session 不可用。回話超時或沒有啓用 cookies 。</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>No token could be found.</source>
+                <target>找不到 token 。</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>Username could not be found.</source>
+                <target>找不到用戶名。</target>
+            </trans-unit>
+            <trans-unit id="13">
+                <source>Account has expired.</source>
+                <target>賬號已逾期。</target>
+            </trans-unit>
+            <trans-unit id="14">
+                <source>Credentials have expired.</source>
+                <target>憑證已逾期。</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>Account is disabled.</source>
+                <target>賬號已被禁用。</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>Account is locked.</source>
+                <target>賬號已被鎖定。</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>Too many failed login attempts, please try again later.</source>
+                <target>登入失敗的次數過多，請稍後再試。</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>Invalid or expired login link.</source>
+                <target>失效或過期的登入鏈接。</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -346,7 +346,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
         $typeCastAttributes = (bool) ($context[self::TYPE_CAST_ATTRIBUTES] ?? $this->defaultContext[self::TYPE_CAST_ATTRIBUTES]);
 
         foreach ($node->attributes as $attr) {
-            if (!is_numeric($attr->nodeValue) || !$typeCastAttributes || (isset($attr->nodeValue[1]) && '0' === $attr->nodeValue[0])) {
+            if (!is_numeric($attr->nodeValue) || !$typeCastAttributes || (isset($attr->nodeValue[1]) && '0' === $attr->nodeValue[0] && '.' !== $attr->nodeValue[1])) {
                 $data['@'.$attr->nodeName] = $attr->nodeValue;
 
                 continue;

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -106,9 +106,18 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         $checkPropertyInitialization = \PHP_VERSION_ID >= 70400;
 
         // properties
-        foreach ($reflClass->getProperties(\ReflectionProperty::IS_PUBLIC) as $reflProperty) {
-            if ($checkPropertyInitialization && !$reflProperty->isInitialized($object)) {
-                continue;
+        foreach ($reflClass->getProperties() as $reflProperty) {
+            if ($checkPropertyInitialization) {
+                if (!$reflProperty->isPublic()) {
+                    $reflProperty->setAccessible(true);
+                }
+                if (!$reflProperty->isInitialized($object)) {
+                    unset($attributes[$reflProperty->name]);
+                    continue;
+                }
+                if (!$reflProperty->isPublic()) {
+                    continue;
+                }
             }
 
             if ($reflProperty->isStatic() || !$this->isAllowedAttribute($object, $reflProperty->name, $format, $context)) {

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -291,10 +291,10 @@ XML;
     {
         $source = <<<XML
 <?xml version="1.0"?>
-<document index="-12.11">Name</document>
+<document index="12.11">Name</document>
 XML;
 
-        $this->assertSame(['@index' => -12.11, '#' => 'Name'], $this->encoder->decode($source, 'xml'));
+        $this->assertSame(['@index' => 12.11, '#' => 'Name'], $this->encoder->decode($source, 'xml'));
     }
 
     public function testDecodeNegativeFloatAttribute()
@@ -305,6 +305,16 @@ XML;
 XML;
 
         $this->assertSame(['@index' => -12.11, '#' => 'Name'], $this->encoder->decode($source, 'xml'));
+    }
+
+    public function testDecodeFloatAttributeWithZeroWholeNumber()
+    {
+        $source = <<<XML
+<?xml version="1.0"?>
+<document index="0.123">Name</document>
+XML;
+
+        $this->assertSame(['@index' => 0.123, '#' => 'Name'], $this->encoder->decode($source, 'xml'));
     }
 
     public function testNoTypeCastAttribute()

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Php74DummyPrivate.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Php74DummyPrivate.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Alexander Borisov <boshurik@gmail.com>
+ */
+final class Php74DummyPrivate
+{
+    private string $uninitializedProperty;
+
+    private string $initializedProperty = 'defaultValue';
+
+    public function getUninitializedProperty(): string
+    {
+        return $this->uninitializedProperty;
+    }
+
+    public function getInitializedProperty(): string
+    {
+        return $this->initializedProperty;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\GroupDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\MaxDepthDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\OtherSerializedNameDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74Dummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Php74DummyPrivate;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\AttributesTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CallbacksObject;
@@ -121,6 +122,18 @@ class ObjectNormalizerTest extends TestCase
     public function testNormalizeObjectWithUninitializedProperties()
     {
         $obj = new Php74Dummy();
+        $this->assertEquals(
+            ['initializedProperty' => 'defaultValue'],
+            $this->normalizer->normalize($obj, 'any')
+        );
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testNormalizeObjectWithUninitializedPrivateProperties()
+    {
+        $obj = new Php74DummyPrivate();
         $this->assertEquals(
             ['initializedProperty' => 'defaultValue'],
             $this->normalizer->normalize($obj, 'any')

--- a/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
@@ -334,6 +334,58 @@
                 <source>This value should be valid JSON.</source>
                 <target>Стойността трябва да е валиден JSON.</target>
             </trans-unit>
+            <trans-unit id="87">
+                <source>This collection should contain only unique elements.</source>
+                <target>Колекцията трябва да съдържа само уникални елементи.</target>
+            </trans-unit>
+            <trans-unit id="88">
+                <source>This value should be positive.</source>
+                <target>Стойността трябва да бъде положително число.</target>
+            </trans-unit>
+            <trans-unit id="89">
+                <source>This value should be either positive or zero.</source>
+                <target>Стойността трябва бъде положително число или нула.</target>
+            </trans-unit>
+            <trans-unit id="90">
+                <source>This value should be negative.</source>
+                <target>Стойността трябва да бъде отрицателно число.</target>
+            </trans-unit>
+            <trans-unit id="91">
+                <source>This value should be either negative or zero.</source>
+                <target>Стойността трябва да бъде отрицателно число или нула.</target>
+            </trans-unit>
+            <trans-unit id="92">
+                <source>This value is not a valid timezone.</source>
+                <target>Стойността не е валидна часова зона.</target>
+            </trans-unit>
+            <trans-unit id="93">
+                <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
+                <target>Тази парола е компрометирана, не трябва да бъде използвана. Моля използвайте друга парола.</target>
+            </trans-unit>
+            <trans-unit id="94">
+                <source>This value should be between {{ min }} and {{ max }}.</source>
+                <target>Стойността трябва да бъде между {{ min }} и {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>Стойността не е валиден hostname.</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>Броят на елементите в тази колекция трябва да бъде кратен на {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target>Стойността трябва да отговаря на поне едно от следните ограничения:</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target>Всеки елемент от тази колекция трябва да отговаря на собствения си набор от ограничения.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>Стойността не е валиден Международен идентификационен номер на ценни книжа (ISIN).</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.cs.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.cs.xlf
@@ -382,6 +382,10 @@
                 <source>Each element of this collection should satisfy its own set of constraints.</source>
                 <target>Každý prvek v této kolekci musí splňovat svá vlastní omezení.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>Tato hodnota není platné mezinárodní identifikační číslo cenného papíru (ISIN).</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.es.xlf
@@ -382,6 +382,10 @@
                 <source>Each element of this collection should satisfy its own set of constraints.</source>
                 <target>Cada elemento de esta colección debería satisfacer su propio conjunto de restricciones.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>Este valor no es un número de identificación internacional de valores (ISIN) válido.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.fa.xlf
@@ -330,6 +330,62 @@
                 <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
                 <target>این(BIC) با IBAN ارتباطی ندارد.</target>
             </trans-unit>
+            <trans-unit id="86">
+                <source>This value should be valid JSON.</source>
+                <target>این مقدار باید یک JSON معتبر باشد.</target>
+            </trans-unit>
+            <trans-unit id="87">
+                <source>This collection should contain only unique elements.</source>
+                <target>این مجموعه باید تنها شامل عناصر یکتا باشد.</target>
+            </trans-unit>
+            <trans-unit id="88">
+                <source>This value should be positive.</source>
+                <target>این مقدار باید مثبت باشد.</target>
+            </trans-unit>
+            <trans-unit id="89">
+                <source>This value should be either positive or zero.</source>
+                <target>این مقدار باید مثبت یا صفر باشد.</target>
+            </trans-unit>
+            <trans-unit id="90">
+                <source>This value should be negative.</source>
+                <target>این مقدار باید منفی باشد.</target>
+            </trans-unit>
+            <trans-unit id="91">
+                <source>This value should be either negative or zero.</source>
+                <target>این مقدار باید منفی یا صفر باشد.</target>
+            </trans-unit>
+            <trans-unit id="92">
+                <source>This value is not a valid timezone.</source>
+                <target>این مقدار یک منطقه‌زمانی (timezone) معتبر نیست.</target>
+            </trans-unit>
+            <trans-unit id="93">
+                <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
+                <target>این رمزعبور در یک رخنه‌ی اطلاعاتی نشت کرده است. لطفاً از یک رمزعبور دیگر استفاده کنید.</target>
+            </trans-unit>
+            <trans-unit id="94">
+                <source>This value should be between {{ min }} and {{ max }}.</source>
+                <target>این مقدار باید بین {{ min }} و {{ max }} باشد</target>
+            </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>این مقدار یک hostname معتبر نیست.</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>تعداد عناصر این مجموعه باید ضریبی از {{ compared_value }} باشد.</target>
+            </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target>این مقدار باید حداقل یکی از محدودیت‌های زیر را ارضا کند:</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target>هر یک از عناصر این مجموعه باید دسته محدودیت‌های خودش را ارضا کند.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>این مقدار یک شماره شناسایی بین‌المللی اوراق بهادار (ISIN) معتبر نیست.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.id.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.id.xlf
@@ -330,6 +330,62 @@
                 <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
                 <target>Business Identifier Code (BIC) ini tidak terkait dengan IBAN {{ iban }}.</target>
             </trans-unit>
+            <trans-unit id="86">
+                <source>This value should be valid JSON.</source>
+                <target>Nilai ini harus berisi JSON yang sah.</target>
+            </trans-unit>
+            <trans-unit id="87">
+                <source>This collection should contain only unique elements.</source>
+                <target>Kumpulan ini harus mengandung elemen yang unik.</target>
+            </trans-unit>
+            <trans-unit id="88">
+                <source>This value should be positive.</source>
+                <target>Nilai ini harus positif.</target>
+            </trans-unit>
+            <trans-unit id="89">
+                <source>This value should be either positive or zero.</source>
+                <target>Nilai ini harus positif atau nol.</target>
+            </trans-unit>
+            <trans-unit id="90">
+                <source>This value should be negative.</source>
+                <target>Nilai ini harus negatif.</target>
+            </trans-unit>
+            <trans-unit id="91">
+                <source>This value should be either negative or zero.</source>
+                <target>Nilai ini harus negatif atau nol.</target>
+            </trans-unit>
+            <trans-unit id="92">
+                <source>This value is not a valid timezone.</source>
+                <target>Nilai ini harus merupakan zona waktu yang sah.</target>
+            </trans-unit>
+            <trans-unit id="93">
+                <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
+                <target>Kata sandi ini telah bocor di data breach, harus tidak digunakan kembali. Silahkan gunakan kata sandi yang lain.</target>
+            </trans-unit>
+            <trans-unit id="94">
+                <source>This value should be between {{ min }} and {{ max }}.</source>
+                <target>Nilai ini harus berada diantara {{ min }} dan {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>Nilai ini bukan merupakan hostname yang sah.</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>Angka dari setiap elemen di dalam kumpulan ini harus kelipatan dari {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target>Nilai ini harus memenuhi setidaknya satu dari batasan berikut:</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target>Setiap elemen koleksi ini harus memenuhi batasannya sendiri.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>Nilai ini bukan merupakan International Securities Identification Number (ISIN) yang sah.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
@@ -374,6 +374,18 @@
                 <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
                 <target>要素の数は{{ compared_value }}の倍数でなければなりません。</target>
             </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target>以下の制約のうち少なくとも1つを満たす必要があります:</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target>コレクションの各要素は、それぞれの制約を満たす必要があります。</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>この値は有効な国際証券識別番号（ISIN）ではありません。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
@@ -334,6 +334,58 @@
                 <source>This value should be valid JSON.</source>
                 <target>Šai vērtībai jābūt derīgam JSON.</target>
             </trans-unit>
+            <trans-unit id="87">
+                <source>This collection should contain only unique elements.</source>
+                <target>Šai kolekcijai jāsatur tikai derīgi elementi.</target>
+            </trans-unit>
+            <trans-unit id="88">
+                <source>This value should be positive.</source>
+                <target>Šai vērtībāi jābūt pozitīvai.</target>
+            </trans-unit>
+            <trans-unit id="89">
+                <source>This value should be either positive or zero.</source>
+                <target>Šai vērtībāi jābūt pozitīvai vai vienādai ar nulli.</target>
+            </trans-unit>
+            <trans-unit id="90">
+                <source>This value should be negative.</source>
+                <target>Šai vērtībāi jābūt negatīvai.</target>
+            </trans-unit>
+            <trans-unit id="91">
+                <source>This value should be either negative or zero.</source>
+                <target>Šai vērtībāi jābūt negatīvai vai vienādai ar nulli.</target>
+            </trans-unit>
+            <trans-unit id="92">
+                <source>This value is not a valid timezone.</source>
+                <target>Šī vērtība nav derīga laika zona.</target>
+            </trans-unit>
+            <trans-unit id="93">
+                <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
+                <target>Šī parole tika publicēta datu noplūdē, viņu nedrīkst izmantot. Lūdzu, izvēlieties citu paroli.</target>
+            </trans-unit>
+            <trans-unit id="94">
+                <source>This value should be between {{ min }} and {{ max }}.</source>
+                <target>Šai vērtībai jābūt starp {{ min }} un {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>Šī vērtība nav derīgs tīmekļa servera nosaukums.</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>Elementu skaitam šajā kolekcijā jābūt {{ compared_value }} reizinājumam.</target>
+            </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target>Šai vērtībai jāiekļaujas vismaz vienā no sekojošiem ierobežojumiem:</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target>Šīs kolekcijas katram elementam jāiekļaujas savā ierobežojumu kopā.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>Šī vērtība nav derīgs starptautiskais vērtspapīru identifikācijas numurs (ISIN).</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
@@ -366,6 +366,26 @@
                 <source>This value should be between {{ min }} and {{ max }}.</source>
                 <target>Deze waarde moet zich tussen {{ min }} en {{ max }} bevinden.</target>
             </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>Deze waarde is geen geldige hostnaam.</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>Het aantal elementen van deze collectie moet een veelvoud zijn van {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target>Deze waarde moet voldoen aan tenminste een van de volgende voorwaarden:</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target>Elk element van deze collectie moet voldoen aan zijn eigen set voorwaarden.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>Deze waarde is geen geldig International Securities Identification Number (ISIN).</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ro.xlf
@@ -334,6 +334,58 @@
                 <source>This value should be valid JSON.</source>
                 <target>Această valoare trebuie să fie un JSON valid.</target>
             </trans-unit>
+            <trans-unit id="87">
+                <source>This collection should contain only unique elements.</source>
+                <target>Acest set ar trebui să conțină numai elemente unice.</target>
+            </trans-unit>
+            <trans-unit id="88">
+                <source>This value should be positive.</source>
+                <target>Această valoare ar trebui să fie pozitivă.</target>
+            </trans-unit>
+            <trans-unit id="89">
+                <source>This value should be either positive or zero.</source>
+                <target>Această valoare trebuie să fie pozitivă sau zero.</target>
+            </trans-unit>
+            <trans-unit id="90">
+                <source>This value should be negative.</source>
+                <target>Această valoare ar trebui să fie negativă.</target>
+            </trans-unit>
+            <trans-unit id="91">
+                <source>This value should be either negative or zero.</source>
+                <target>Această valoare trebuie să fie negativă sau zero.</target>
+            </trans-unit>
+            <trans-unit id="92">
+                <source>This value is not a valid timezone.</source>
+                <target>Această valoare nu este un fus orar valid.</target>
+            </trans-unit>
+            <trans-unit id="93">
+                <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
+                <target>Această parolă a fost compromisă și nu poate fi utilizată. Vă rugăm să utilizați o altă parolă.</target>
+            </trans-unit>
+            <trans-unit id="94">
+                <source>This value should be between {{ min }} and {{ max }}.</source>
+                <target>Această valoare trebuie să fie între {{ min }} și {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>Această valoare nu este un numele gazdei valid.</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>Numărul de elemente din această colecție ar trebui să fie un multiplu al {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target>Această valoare trebuie să îndeplinească cel puțin una dintre următoarele reguli:</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target>Fiecare element din acest set ar trebui să îndeplinească propriul set de reguli.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>Această valoare nu este un număr internațional de identificare (ISIN) valabil.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
@@ -382,6 +382,10 @@
                 <source>Each element of this collection should satisfy its own set of constraints.</source>
                 <target>Каждый элемент этой коллекции должен удовлетворять своему собственному набору ограничений.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>Значение не является корректным международным идентификационным номером ценных бумаг (ISIN).</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sk.xlf
@@ -366,6 +366,26 @@
                 <source>This value should be between {{ min }} and {{ max }}.</source>
                 <target>Táto hodnota by mala byť medzi {{ min }} a {{ max }}.</target>
             </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>Táto hodnota nie je platný hostname.</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>Počet prvkov v tejto kolekcii musí byť násobok {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target>Táto hodnota musí spĺňať aspoň jedno z nasledujúcich obmedzení:</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target>Každý prvok v tejto kolekcii musí spĺňať svoje vlastné obmedzenia.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>Táto hodnota nie je platné medzinárodné označenie cenného papiera (ISIN).</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sq.xlf
@@ -330,6 +330,62 @@
                 <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
                 <target>Ky Kod Identifikues i Biznesit (BIC) nuk është i lidhur me IBAN {{ iban }}.</target>
             </trans-unit>
+            <trans-unit id="86">
+                <source>This value should be valid JSON.</source>
+                <target>Kjo vlerë duhet të jetë JSON i vlefshëm.</target>
+            </trans-unit>
+            <trans-unit id="87">
+                <source>This collection should contain only unique elements.</source>
+                <target>Ky koleksion duhet të përmbajë vetëm elementë unikë.</target>
+            </trans-unit>
+            <trans-unit id="88">
+                <source>This value should be positive.</source>
+                <target>Kjo vlerë duhet të jetë pozitive.</target>
+            </trans-unit>
+            <trans-unit id="89">
+                <source>This value should be either positive or zero.</source>
+                <target>Kjo vlerë duhet të jetë pozitive ose zero.</target>
+            </trans-unit>
+            <trans-unit id="90">
+                <source>This value should be negative.</source>
+                <target>Kjo vlerë duhet të jetë negative.</target>
+            </trans-unit>
+            <trans-unit id="91">
+                <source>This value should be either negative or zero.</source>
+                <target>Kjo vlerë duhet të jetë negative ose zero.</target>
+            </trans-unit>
+            <trans-unit id="92">
+                <source>This value is not a valid timezone.</source>
+                <target>Kjo vlerë nuk është një zonë e vlefshme kohore.</target>
+            </trans-unit>
+            <trans-unit id="93">
+                <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
+                <target>Ky fjalëkalim është zbuluar në një shkelje të të dhënave, nuk duhet të përdoret. Ju lutemi përdorni një fjalëkalim tjetër.</target>
+            </trans-unit>
+            <trans-unit id="94">
+                <source>This value should be between {{ min }} and {{ max }}.</source>
+                <target>Kjo vlerë duhet të jetë ndërmjet {{ min }} dhe {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>Kjo vlerë nuk është një emër i vlefshëm hosti.</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>Numri i elementeve në këtë koleksion duhet të jetë një shumëfish i {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target>Kjo vlerë duhet të plotësojë të paktën njërën nga kufizimet e mëposhtme:</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target>Secili element i këtij koleksioni duhet të përmbushë kufizimet e veta.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>Kjo vlerë nuk është një numër i vlefshëm identifikues ndërkombëtar i sigurisë (ISIN).</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sv.xlf
@@ -366,6 +366,27 @@
                 <source>This value should be between {{ min }} and {{ max }}.</source>
                 <target>Detta värde bör ligga mellan {{ min }} och {{ max }}.</target>
             </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>Värdet är inte ett giltigt servernamn.</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>Antalet element i samlingen ska vara en multipel av {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target>Det här värdet skall uppfylla minst ett av följande krav:</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target>Varje element i samlingen skall uppfylla sin egen uppsättning av krav.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>Det här värdet är inte ett giltigt "International Securities Identification Number" (ISIN).</target>
+            </trans-unit>
+
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tr.xlf
@@ -330,6 +330,62 @@
                 <source>This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.</source>
                 <target>Bu İşletme Tanımlayıcı Kodu (BIC), IBAN {{ iban }} ile ilişkili değildir.</target>
             </trans-unit>
+            <trans-unit id="86">
+                <source>This value should be valid JSON.</source>
+                <target>Bu değer için geçerli olmalıdır JSON.</target>
+            </trans-unit>
+            <trans-unit id="87">
+                <source>This collection should contain only unique elements.</source>
+                <target>Bu grup yalnızca benzersiz öğeler içermelidir.</target>
+            </trans-unit>
+            <trans-unit id="88">
+                <source>This value should be positive.</source>
+                <target>Bu değer pozitif olmalı.</target>
+            </trans-unit>
+            <trans-unit id="89">
+                <source>This value should be either positive or zero.</source>
+                <target>Bu değer pozitif veya sıfır olmalıdır.</target>
+            </trans-unit>
+            <trans-unit id="90">
+                <source>This value should be negative.</source>
+                <target>Bu değer negatif olmalıdır.</target>
+            </trans-unit>
+            <trans-unit id="91">
+                <source>This value should be either negative or zero.</source>
+                <target>Bu değer, negatif veya sıfır olmalıdır.</target>
+            </trans-unit>
+            <trans-unit id="92">
+                <source>This value is not a valid timezone.</source>
+                <target>Bu değer, geçerli bir saat dilimi değil.</target>
+            </trans-unit>
+            <trans-unit id="93">
+                <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
+                <target>Bu parola, bir veri ihlali nedeniyle sızdırılmıştır ve kullanılmamalıdır. Lütfen başka bir şifre kullanın.</target>
+            </trans-unit>
+            <trans-unit id="94">
+                <source>This value should be between {{ min }} and {{ max }}.</source>
+                <target>Bu değer arasında olmalıdır {{ min }} ve {{ max }}.</target>
+            </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>Bu değer, geçerli bir ana bilgisayar adı değil.</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>Bu gruptaki öğe sayısı birden fazla olmalıdır {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target>Bu değer aşağıdaki kısıtlamalardan birini karşılamalıdır:</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target>Bu gruptaki her öğe kendi kısıtlamalarını karşılamalıdır.</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>Bu değer geçerli bir Uluslararası Menkul Kıymetler Kimlik Numarası değil (ISIN).</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.uk.xlf
@@ -382,6 +382,10 @@
                 <source>Each element of this collection should satisfy its own set of constraints.</source>
                 <target>Кожен елемент цієї колекції повинен задовольняти власному набору обмежень.</target>
             </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>Це значення не є дійсним міжнародним ідентифікаційним номером цінних паперів (ISIN).</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
@@ -334,6 +334,58 @@
                 <source>This value should be valid JSON.</source>
                 <target>该值应该是有效的JSON。</target>
             </trans-unit>
+            <trans-unit id="87">
+                <source>This collection should contain only unique elements.</source>
+                <target>该集合应仅包含独一无二的元素。</target>
+            </trans-unit>
+            <trans-unit id="88">
+                <source>This value should be positive.</source>
+                <target>数值应为正数。</target>
+            </trans-unit>
+            <trans-unit id="89">
+                <source>This value should be either positive or zero.</source>
+                <target>数值应是正数，或为零。</target>
+            </trans-unit>
+            <trans-unit id="90">
+                <source>This value should be negative.</source>
+                <target>数值应为负数。</target>
+            </trans-unit>
+            <trans-unit id="91">
+                <source>This value should be either negative or zero.</source>
+                <target>数值应是负数，或为零。</target>
+            </trans-unit>
+            <trans-unit id="92">
+                <source>This value is not a valid timezone.</source>
+                <target>无效时区。</target>
+            </trans-unit>
+            <trans-unit id="93">
+                <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
+                <target>此密码已被泄露，切勿使用。请更换密码。</target>
+            </trans-unit>
+            <trans-unit id="94">
+                <source>This value should be between {{ min }} and {{ max }}.</source>
+                <target>该数值应在 {{ min }} 和 {{ max }} 之间。</target>
+            </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>该数值不是有效的主机名称。</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>该集合内的元素数量得是 {{ compared_value }} 的倍数。</target>
+            </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target>该数值需符合以下其中一个约束：</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target>该集合内的每个元素需符合元素本身规定的约束。</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>该数值不是有效的国际证券识别码 （ISIN）。</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_TW.xlf
@@ -344,7 +344,7 @@
             </trans-unit>
             <trans-unit id="89">
                 <source>This value should be either positive or zero.</source>
-                <target>數值應或未正數，或為零。</target>
+                <target>數值應是正數，或為零。</target>
             </trans-unit>
             <trans-unit id="90">
                 <source>This value should be negative.</source>
@@ -352,7 +352,7 @@
             </trans-unit>
             <trans-unit id="91">
                 <source>This value should be either negative or zero.</source>
-                <target>數值應或未負數，或為零。</target>
+                <target>數值應是負數，或為零。</target>
             </trans-unit>
             <trans-unit id="92">
                 <source>This value is not a valid timezone.</source>
@@ -360,11 +360,31 @@
             </trans-unit>
             <trans-unit id="93">
                 <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
-                <target>依據您的密碼，發生數據泄露，請勿使用改密碼。請更換密碼。</target>
+                <target>此密碼已被泄露，切勿使用。請更換密碼。</target>
             </trans-unit>
             <trans-unit id="94">
                 <source>This value should be between {{ min }} and {{ max }}.</source>
                 <target>該數值應在 {{ min }} 和 {{ max }} 之間。</target>
+            </trans-unit>
+            <trans-unit id="95">
+                <source>This value is not a valid hostname.</source>
+                <target>該數值不是有效的主機名稱。</target>
+            </trans-unit>
+            <trans-unit id="96">
+                <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
+                <target>該集合內的元素數量得是 {{ compared_value }} 的倍數。</target>
+            </trans-unit>
+            <trans-unit id="97">
+                <source>This value should satisfy at least one of the following constraints:</source>
+                <target>該數值需符合以下其中一個約束：</target>
+            </trans-unit>
+            <trans-unit id="98">
+                <source>Each element of this collection should satisfy its own set of constraints.</source>
+                <target>該集合內的每個元素需符合元素本身規定的約束。</target>
+            </trans-unit>
+            <trans-unit id="99">
+                <source>This value is not a valid International Securities Identification Number (ISIN).</source>
+                <target>該數值不是有效的國際證券識別碼 （ISIN）。</target>
             </trans-unit>
         </body>
     </file>

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -45,7 +45,7 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
         }
 
         if (file_exists($this->path)) {
-            unlink($this->path);
+            @unlink($this->path);
         }
 
         $this->path = null;

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -129,11 +129,11 @@ YAML;
     {
         foreach ($this->files as $file) {
             if (file_exists($file)) {
-                unlink($file);
+                @unlink($file);
             }
         }
 
-        rmdir(sys_get_temp_dir().'/framework-yml-lint-test');
+        @rmdir(sys_get_temp_dir().'/framework-yml-lint-test');
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | no <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Allow to serialize
```php
final class Php74DummyPrivate
{
    private string $uninitializedProperty;

    private string $initializedProperty = 'defaultValue';

    public function getUninitializedProperty(): string
    {
        return $this->uninitializedProperty;
    }

    public function getInitializedProperty(): string
    {
        return $this->initializedProperty;
    }
}
```

Similar to #34791