### PR TITLE
[Serializer] Exclude non-initialized properties accessed with getters

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -106,9 +106,19 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         $checkPropertyInitialization = \PHP_VERSION_ID >= 70400;
 
         // properties
-        foreach ($reflClass->getProperties(\ReflectionProperty::IS_PUBLIC) as $reflProperty) {
-            if ($checkPropertyInitialization && !$reflProperty->isInitialized($object)) {
-                continue;
+        foreach ($reflClass->getProperties() as $reflProperty) {
+            if ($checkPropertyInitialization) {
+                $isPublic = $reflProperty->isPublic();
+                if (!$isPublic) {
+                    $reflProperty->setAccessible(true);
+                }
+                if (!$reflProperty->isInitialized($object)) {
+                    unset($attributes[$reflProperty->name]);
+                    continue;
+                }
+                if (!$isPublic) {
+                    continue;
+                }
             }
 
             if ($reflProperty->isStatic() || !$this->isAllowedAttribute($object, $reflProperty->name, $format, $context)) {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Php74DummyPrivate.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Php74DummyPrivate.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+/**
+ * @author Alexander Borisov <boshurik@gmail.com>
+ */
+final class Php74DummyPrivate
+{
+    private string $uninitializedProperty;
+
+    private string $initializedProperty = 'defaultValue';
+
+    public function getUninitializedProperty(): string
+    {
+        return $this->uninitializedProperty;
+    }
+
+    public function getInitializedProperty(): string
+    {
+        return $this->initializedProperty;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\Serializer\Tests\Fixtures\GroupDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\MaxDepthDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\OtherSerializedNameDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Php74Dummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Php74DummyPrivate;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\AttributesTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CallbacksObject;
@@ -121,6 +122,18 @@ class ObjectNormalizerTest extends TestCase
     public function testNormalizeObjectWithUninitializedProperties()
     {
         $obj = new Php74Dummy();
+        $this->assertEquals(
+            ['initializedProperty' => 'defaultValue'],
+            $this->normalizer->normalize($obj, 'any')
+        );
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testNormalizeObjectWithUninitializedPrivateProperties()
+    {
+        $obj = new Php74DummyPrivate();
         $this->assertEquals(
             ['initializedProperty' => 'defaultValue'],
             $this->normalizer->normalize($obj, 'any')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | no <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Allow to serialize
```php
final class Php74DummyPrivate
{
    private string $uninitializedProperty;

    private string $initializedProperty = 'defaultValue';

    public function getUninitializedProperty(): string
    {
        return $this->uninitializedProperty;
    }

    public function getInitializedProperty(): string
    {
        return $this->initializedProperty;
    }
}
```

Similar to #34791