### PR TITLE
[HttpKernel] Fix session initialized several times

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -56,7 +56,8 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
         $session = null;
         $request = $event->getRequest();
         if (!$request->hasSession()) {
-            $request->setSessionFactory(function () { return $this->getSession(); });
+            $sess = null;
+            $request->setSessionFactory(function () use (&$sess) { return $sess ?? $sess = $this->getSession(); });
         }
 
         $session = $session ?? ($this->container && $this->container->has('initialized_session') ? $this->container->get('initialized_session') : null);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -20,11 +20,13 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 use Symfony\Component\HttpKernel\EventListener\SessionListener;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 class SessionListenerTest extends TestCase
 {
@@ -177,5 +179,37 @@ class SessionListenerTest extends TestCase
 
         $this->assertTrue($response->headers->has('Expires'));
         $this->assertLessThanOrEqual((new \DateTime('now', new \DateTimeZone('UTC'))), (new \DateTime($response->headers->get('Expires'))));
+    }
+
+    public function testGetSessionIsCalledOnce()
+    {
+        $session = $this->getMockBuilder(Session::class)->disableOriginalConstructor()->getMock();
+        $sessionStorage = $this->getMockBuilder(NativeSessionStorage::class)->getMock();
+        $kernel = $this->getMockBuilder(KernelInterface::class)->getMock();
+
+        $sessionStorage->expects($this->once())
+            ->method('setOptions')
+            ->with(['cookie_secure' => true]);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($masterRequest = new Request([], [], [], [], [], ['HTTPS' => 'on']));
+
+        $container = new Container();
+        $container->set('session_storage', $sessionStorage);
+        $container->set('session', $session);
+        $container->set('request_stack', $requestStack);
+
+        $event = new GetResponseEvent($kernel, $masterRequest, HttpKernelInterface::MASTER_REQUEST);
+
+        $listener = new SessionListener($container);
+        $listener->onKernelRequest($event);
+
+        $subRequest = $masterRequest->duplicate();
+        // at this point both master and subrequest have a closure to build the session
+
+        $masterRequest->getSession();
+
+        // calling the factory on the subRequest should not trigger a second call to storage->sesOptions()
+        $subRequest->getSession();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The session injected in the request is a factory. When the request is **cloned** (ie sub-request) while the session is not yet used in the master request (the session is still a factory), both Master and Sub request will have a factory.
If both requests attempt to read the session afterward, they both triggers the factory, and both initialize the session.

It's not a dead end for the `SessionListener` because the session come from the container and is shared, but:
- the session is initialized ($storage->setOptions(['cookie_secure' => true])) twice
- if we replace the sesssion from container to a factory, it could be an issue