### PR TITLE
Fix transiant tests in 4.4

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -118,9 +118,9 @@ abstract class AdapterTestCase extends CachePoolTest
 
         $metadata = $item->getMetadata();
         $this->assertArrayHasKey(CacheItem::METADATA_CTIME, $metadata);
-        $this->assertEqualsWithDelta(1000, $metadata[CacheItem::METADATA_CTIME], 6);
+        $this->assertEqualsWithDelta(999, $metadata[CacheItem::METADATA_CTIME], 10);
         $this->assertArrayHasKey(CacheItem::METADATA_EXPIRY, $metadata);
-        $this->assertEqualsWithDelta(9.5 + time(), $metadata[CacheItem::METADATA_EXPIRY], 0.6);
+        $this->assertEqualsWithDelta(9 + time(), $metadata[CacheItem::METADATA_EXPIRY], 1);
     }
 
     public function testDefaultLifeTime()

--- a/src/Symfony/Component/Routing/Tests/Loader/DependencyInjection/ServiceRouterLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/DependencyInjection/ServiceRouterLoaderTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Routing\Tests\Loader;
+namespace Symfony\Component\Routing\Tests\Loader\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/SimpleAuthenticationHandlerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Security\Http\Tests;
+namespace Symfony\Component\Security\Http\Tests\Authentication;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response;
@@ -69,7 +69,7 @@ class SimpleAuthenticationHandlerTest extends TestCase
         $this->successHandler->expects($this->never())
             ->method('onAuthenticationSuccess');
 
-        $authenticator = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Tests\TestSuccessHandlerInterface');
+        $authenticator = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Tests\Authentication\TestSuccessHandlerInterface');
         $authenticator->expects($this->once())
             ->method('onAuthenticationSuccess')
             ->with($this->request, $this->token)
@@ -88,7 +88,7 @@ class SimpleAuthenticationHandlerTest extends TestCase
         $this->successHandler->expects($this->never())
             ->method('onAuthenticationSuccess');
 
-        $authenticator = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Tests\TestSuccessHandlerInterface');
+        $authenticator = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Tests\Authentication\TestSuccessHandlerInterface');
         $authenticator->expects($this->once())
             ->method('onAuthenticationSuccess')
             ->with($this->request, $this->token)
@@ -105,7 +105,7 @@ class SimpleAuthenticationHandlerTest extends TestCase
             ->with($this->request, $this->token)
             ->willReturn($this->response);
 
-        $authenticator = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Tests\TestSuccessHandlerInterface');
+        $authenticator = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Tests\Authentication\TestSuccessHandlerInterface');
         $authenticator->expects($this->once())
             ->method('onAuthenticationSuccess')
             ->with($this->request, $this->token)
@@ -137,7 +137,7 @@ class SimpleAuthenticationHandlerTest extends TestCase
         $this->failureHandler->expects($this->never())
             ->method('onAuthenticationFailure');
 
-        $authenticator = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Tests\TestFailureHandlerInterface');
+        $authenticator = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Tests\Authentication\TestFailureHandlerInterface');
         $authenticator->expects($this->once())
             ->method('onAuthenticationFailure')
             ->with($this->request, $this->authenticationException)
@@ -156,7 +156,7 @@ class SimpleAuthenticationHandlerTest extends TestCase
         $this->failureHandler->expects($this->never())
             ->method('onAuthenticationFailure');
 
-        $authenticator = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Tests\TestFailureHandlerInterface');
+        $authenticator = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Tests\Authentication\TestFailureHandlerInterface');
         $authenticator->expects($this->once())
             ->method('onAuthenticationFailure')
             ->with($this->request, $this->authenticationException)
@@ -173,7 +173,7 @@ class SimpleAuthenticationHandlerTest extends TestCase
             ->with($this->request, $this->authenticationException)
             ->willReturn($this->response);
 
-        $authenticator = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Tests\TestFailureHandlerInterface');
+        $authenticator = $this->getMockForAbstractClass('Symfony\Component\Security\Http\Tests\Authentication\TestFailureHandlerInterface');
         $authenticator->expects($this->once())
             ->method('onAuthenticationFailure')
             ->with($this->request, $this->authenticationException)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I noticed this week 2 currencies of this failure. in both case the `METADATA_EXPIRY` were 1.5 sec under the expected value