### PR TITLE
Fix transiant tests

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
@@ -110,6 +110,7 @@ class FormLoginTest extends AbstractWebTestCase
 
     /**
      * @dataProvider provideInvalidCredentials
+     * @group time-sensitive
      */
     public function testLoginThrottling($username, $password)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I've seen 1 occurency of this failure, because of rounded time(), the delay where 2 minutes instead of 1