### PR TITLE
[Console] Make error message more verbose

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -165,11 +165,25 @@ class ArgvInput extends Input
         // unexpected argument
         } else {
             $all = $this->definition->getArguments();
-            if (\count($all)) {
-                throw new RuntimeException(sprintf('Too many arguments, expected arguments "%s".', implode('" "', array_keys($all))));
+            $symfonyCommandName = null;
+            if (($inputArgument = $all[$key = array_key_first($all)] ?? null) && 'command' === $inputArgument->getName()) {
+                $symfonyCommandName = $this->arguments['command'] ?? null;
+                unset($all[$key]);
             }
 
-            throw new RuntimeException(sprintf('No arguments expected, got "%s".', $token));
+            if (\count($all)) {
+                if ($symfonyCommandName) {
+                    $message = sprintf('Too many arguments to "%s" command, expected arguments "%s".', $symfonyCommandName, implode('" "', array_keys($all)));
+                } else {
+                    $message = sprintf('Too many arguments, expected arguments "%s".', implode('" "', array_keys($all)));
+                }
+            } elseif ($symfonyCommandName) {
+                $message = sprintf('No arguments expected for "%s" command, got "%s".', $symfonyCommandName, $token);
+            } else {
+                $message = sprintf('No arguments expected, got "%s".', $token);
+            }
+
+            throw new RuntimeException($message);
         }
     }
 

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -247,6 +247,16 @@ class ArgvInputTest extends TestCase
                 new InputDefinition([new InputOption('foo', 'f', InputOption::VALUE_NONE)]),
                 'The "-Щ" option does not exist.',
             ],
+            [
+                ['cli.php', 'acme:foo', 'bar'],
+                new InputDefinition([new InputArgument('command', InputArgument::REQUIRED)]),
+                'No arguments expected for "acme:foo" command, got "bar"',
+            ],
+            [
+                ['cli.php', 'acme:foo', 'bar'],
+                new InputDefinition([new InputArgument('name', InputArgument::REQUIRED)]),
+                'Too many arguments, expected arguments "name".',
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #38904
| License       | MIT
| Doc PR        | no

This will make the error message a bit more verbose when you are using too many or too few arguments. 