### PR TITLE
[PropertyInfo] Dont try to set null when argument is not nullable

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -86,7 +86,7 @@ class PropertyAccessor implements PropertyAccessorInterface
      *                          to specify the allowed magic methods (__get, __set, __call)
      *                          or self::DISALLOW_MAGIC_METHODS for none
      */
-    public function __construct(/*int */$magicMethods = self::MAGIC_GET | self::MAGIC_SET, bool $throwExceptionOnInvalidIndex = false, CacheItemPoolInterface $cacheItemPool = null, bool $throwExceptionOnInvalidPropertyPath = true, PropertyReadInfoExtractorInterface $readInfoExtractor = null, PropertyWriteInfoExtractorInterface $writeInfoExtractor = null)
+    public function __construct(/*int */ $magicMethods = self::MAGIC_GET | self::MAGIC_SET, bool $throwExceptionOnInvalidIndex = false, CacheItemPoolInterface $cacheItemPool = null, bool $throwExceptionOnInvalidPropertyPath = true, PropertyReadInfoExtractorInterface $readInfoExtractor = null, PropertyWriteInfoExtractorInterface $writeInfoExtractor = null)
     {
         if (\is_bool($magicMethods)) {
             trigger_deprecation('symfony/property-access', '5.2', 'Passing a boolean as the first argument to "%s()" is deprecated. Pass a combination of bitwise flags instead (i.e an integer).', __METHOD__);

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -612,6 +612,7 @@ class PropertyAccessor implements PropertyAccessorInterface
             'enable_magic_methods_extraction' => $this->magicMethodsFlags,
             'enable_constructor_extraction' => false,
             'enable_adder_remover_extraction' => $useAdderAndRemover,
+            'value' => $value,
         ]);
 
         if (isset($item)) {

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -388,6 +388,12 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             }
 
             $method = $reflClass->getMethod($methodName);
+            /** @var \ReflectionParameter $parameter */
+            $parameter = $method->getParameters()[0];
+            if (\array_key_exists('value', $context) && null === $context['value'] && !$parameter->allowsNull()) {
+                $errors[] = sprintf('The method "%s" in class "%s" was found but does not allow null.', $methodName, $class);
+                continue;
+            }
 
             if (!\in_array($mutatorPrefix, $this->arrayMutatorPrefixes, true)) {
                 return new PropertyWriteInfo(PropertyWriteInfo::TYPE_METHOD, $methodName, $this->getWriteVisiblityForMethod($method), $method->isStatic());

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -20,7 +20,6 @@ use Symfony\Component\PropertyInfo\Tests\Fixtures\AdderRemoverDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\DefaultValue;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\NotInstantiable;
-use Symfony\Component\PropertyInfo\Tests\Fixtures\ParentDummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71Dummy;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71DummyExtended;
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Php71DummyExtended2;
@@ -619,7 +618,7 @@ class ReflectionExtractorTest extends TestCase
             'value' => null,
         ]);
         $this->assertSame('none', $writeInfo->getType());
-        $this->assertTrue(in_array('The method "setDate" in class "Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy" was found but does not allow null.', $writeInfo->getErrors()));
+        $this->assertTrue(\in_array('The method "setDate" in class "Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy" was found but does not allow null.', $writeInfo->getErrors()));
 
         // If we dont pass a key "value", we should behave as if the value exists.
         $writeInfo = $extractor->getWriteInfo(Dummy::class, 'date', []);

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
@@ -237,4 +237,12 @@ class Dummy extends ParentDummy
     public function hasElement(string $element): bool
     {
     }
+
+    public function setOptionalDate(\DateTime $date = null)
+    {
+    }
+
+    public function addNothing()
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #38800
| License       | MIT
| Doc PR        | 

This will break up #38800 into two smaller pieces. 

If there is a method `setPreviousException(Throwable $t)` and we try to unserialise a value of ['previousException'=>null], we should not try to invoke this setter. It will cause an error. 