### PR TITLE
Added const to cs-fixer rule visibility_required

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -16,6 +16,7 @@ return PhpCsFixer\Config::create()
         'native_constant_invocation' => true,
         'combine_nested_dirname' => true,
         'list_syntax' => ['syntax' => 'short'],
+        'visibility_required' => ['property', 'method', 'const']
     ])
     ->setRiskyAllowed(true)
     ->setFinder(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Instead of adding the `const` default visibility `public` to all constants as I did in #38913 here a PR to just activate the check in php-cs-fixer config. Keeping the option to run it on all classes in multiple branches.

A test run of ...
```
php-cs-fixer fix --rules={\"visibility_required\":[\"const\"]} -v
```
... looked good.

The `visibility_required` rule is activated with the elements `property` and `method` by default. This adds `const` on top.
https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.16/doc/rules/class_notation/visibility_required.rst