### PR TITLE
Set constant visibility in tests to private where possible

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Form\Test\FormPerformanceTestCase;
  */
 class EntityTypePerformanceTest extends FormPerformanceTestCase
 {
-    const ENTITY_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity';
+    private const ENTITY_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity';
 
     /**
      * @var \Doctrine\ORM\EntityManager

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -39,14 +39,14 @@ class EntityTypeTest extends BaseTypeTest
 {
     const TESTED_TYPE = 'Symfony\Bridge\Doctrine\Form\Type\EntityType';
 
-    const ITEM_GROUP_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\GroupableEntity';
-    const SINGLE_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity';
-    const SINGLE_IDENT_NO_TO_STRING_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity';
-    const SINGLE_STRING_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity';
-    const SINGLE_ASSOC_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleAssociationToIntIdEntity';
-    const SINGLE_STRING_CASTABLE_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringCastableIdEntity';
-    const COMPOSITE_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeIntIdEntity';
-    const COMPOSITE_STRING_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeStringIdEntity';
+    private const ITEM_GROUP_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\GroupableEntity';
+    private const SINGLE_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdEntity';
+    private const SINGLE_IDENT_NO_TO_STRING_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity';
+    private const SINGLE_STRING_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringIdEntity';
+    private const SINGLE_ASSOC_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleAssociationToIntIdEntity';
+    private const SINGLE_STRING_CASTABLE_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleStringCastableIdEntity';
+    private const COMPOSITE_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeIntIdEntity';
+    private const COMPOSITE_STRING_IDENT_CLASS = 'Symfony\Bridge\Doctrine\Tests\Fixtures\CompositeStringIdEntity';
 
     /**
      * @var EntityManager

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineFooType.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineFooType.php
@@ -23,7 +23,7 @@ class DoctrineFooType extends Type
     /**
      * Type name.
      */
-    const NAME = 'foo';
+    private const NAME = 'foo';
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -40,7 +40,7 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 {
-    const EM_NAME = 'foo';
+    private const EM_NAME = 'foo';
 
     /**
      * @var ObjectManager

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallMapTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Http\Firewall\LogoutListener;
 
 class FirewallMapTest extends TestCase
 {
-    const ATTRIBUTE_FIREWALL_CONTEXT = '_firewall_context';
+    private const ATTRIBUTE_FIREWALL_CONTEXT = '_firewall_context';
 
     public function testGetListenersWithEmptyMap()
     {

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -20,10 +20,9 @@ use Symfony\Contracts\EventDispatcher\Event as ContractsEvent;
 class EventDispatcherTest extends TestCase
 {
     /* Some pseudo events */
-    const preFoo = 'pre.foo';
-    const postFoo = 'post.foo';
-    const preBar = 'pre.bar';
-    const postBar = 'post.bar';
+    private const preFoo = 'pre.foo';
+    private const postFoo = 'post.foo';
+    private const preBar = 'pre.bar';
 
     /**
      * @var EventDispatcher

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/BooleanToStringTransformerTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\BooleanToStringTransfo
 
 class BooleanToStringTransformerTest extends TestCase
 {
-    const TRUE_VALUE = '1';
+    private const TRUE_VALUE = '1';
 
     /**
      * @var BooleanToStringTransformer

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -32,10 +32,10 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
  */
 class ViolationMapperTest extends TestCase
 {
-    const LEVEL_0 = 0;
-    const LEVEL_1 = 1;
-    const LEVEL_1B = 2;
-    const LEVEL_2 = 3;
+    private const LEVEL_0 = 0;
+    private const LEVEL_1 = 1;
+    private const LEVEL_1B = 2;
+    private const LEVEL_2 = 3;
 
     /**
      * @var EventDispatcherInterface

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MemcachedSessionHandlerTest.php
@@ -20,8 +20,8 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\MemcachedSessionHan
  */
 class MemcachedSessionHandlerTest extends TestCase
 {
-    const PREFIX = 'prefix_';
-    const TTL = 1000;
+    private const PREFIX = 'prefix_';
+    private const TTL = 1000;
 
     /**
      * @var MemcachedSessionHandler

--- a/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Bundle/Reader/BundleEntryReaderTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Intl\Exception\ResourceBundleNotFoundException;
  */
 class BundleEntryReaderTest extends TestCase
 {
-    const RES_DIR = '/res/dir';
+    private const RES_DIR = '/res/dir';
 
     /**
      * @var BundleEntryReader

--- a/src/Symfony/Component/Intl/Tests/Util/GitRepositoryTest.php
+++ b/src/Symfony/Component/Intl/Tests/Util/GitRepositoryTest.php
@@ -23,7 +23,7 @@ class GitRepositoryTest extends TestCase
 {
     private $targetDir;
 
-    const REPO_URL = 'https://github.com/symfony/intl.git';
+    private const REPO_URL = 'https://github.com/symfony/intl.git';
 
     /**
      * @before

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -25,7 +25,7 @@ use Symfony\Component\Ldap\Tests\LdapTestCase;
  */
 class AdapterTest extends LdapTestCase
 {
-    const PAGINATION_REQUIRED_CONFIG = [
+    private const PAGINATION_REQUIRED_CONFIG = [
         'options' => [
             'protocol_version' => 3,
         ],

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyPathBuilderTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyPathBuilderTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\PropertyAccess\PropertyPathBuilder;
  */
 class PropertyPathBuilderTest extends TestCase
 {
-    const PREFIX = 'old1[old2].old3[old4][old5].old6';
+    private const PREFIX = 'old1[old2].old3[old4][old5].old6';
 
     /**
      * @var PropertyPathBuilder

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/Argon2iPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/Argon2iPasswordEncoderTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Core\Encoder\Argon2iPasswordEncoder;
  */
 class Argon2iPasswordEncoderTest extends TestCase
 {
-    const PASSWORD = 'password';
+    private const PASSWORD = 'password';
 
     protected function setUp(): void
     {

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/BCryptPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/BCryptPasswordEncoderTest.php
@@ -21,8 +21,8 @@ use Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder;
  */
 class BCryptPasswordEncoderTest extends TestCase
 {
-    const PASSWORD = 'password';
-    const VALID_COST = '04';
+    private const PASSWORD = 'password';
+    private const VALID_COST = '04';
 
     public function testCostBelowRange()
     {

--- a/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Validator/Constraints/UserPasswordValidatorTest.php
@@ -23,8 +23,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 abstract class UserPasswordValidatorTest extends ConstraintValidatorTestCase
 {
-    const PASSWORD = 's3Cr3t';
-    const SALT = '^S4lt$';
+    private const PASSWORD = 's3Cr3t';
+    private const SALT = '^S4lt$';
 
     /**
      * @var TokenStorageInterface

--- a/src/Symfony/Component/Security/Csrf/Tests/TokenGenerator/UriSafeTokenGeneratorTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/TokenGenerator/UriSafeTokenGeneratorTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Csrf\TokenGenerator\UriSafeTokenGenerator;
  */
 class UriSafeTokenGeneratorTest extends TestCase
 {
-    const ENTROPY = 1000;
+    private const ENTROPY = 1000;
 
     /**
      * A non alpha-numeric byte string.

--- a/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/NativeSessionTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/NativeSessionTokenStorageTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Csrf\TokenStorage\NativeSessionTokenStorage;
  */
 class NativeSessionTokenStorageTest extends TestCase
 {
-    const SESSION_NAMESPACE = 'foobar';
+    private const SESSION_NAMESPACE = 'foobar';
 
     /**
      * @var NativeSessionTokenStorage

--- a/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/SessionTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/SessionTokenStorageTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
  */
 class SessionTokenStorageTest extends TestCase
 {
-    const SESSION_NAMESPACE = 'foobar';
+    private const SESSION_NAMESPACE = 'foobar';
 
     /**
      * @var Session

--- a/src/Symfony/Component/Security/Guard/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Guard/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -29,9 +29,8 @@ class FormLoginAuthenticatorTest extends TestCase
     private $requestWithSession;
     private $authenticator;
 
-    const LOGIN_URL = 'http://login';
-    const DEFAULT_SUCCESS_URL = 'http://defaultsuccess';
-    const CUSTOM_SUCCESS_URL = 'http://customsuccess';
+    private const LOGIN_URL = 'http://login';
+    private const DEFAULT_SUCCESS_URL = 'http://defaultsuccess';
 
     public function testAuthenticationFailureWithoutSession()
     {

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
@@ -16,9 +16,9 @@ use Symfony\Component\Serializer\Encoder\ChainDecoder;
 
 class ChainDecoderTest extends TestCase
 {
-    const FORMAT_1 = 'format1';
-    const FORMAT_2 = 'format2';
-    const FORMAT_3 = 'format3';
+    private const FORMAT_1 = 'format1';
+    private const FORMAT_2 = 'format2';
+    private const FORMAT_3 = 'format3';
 
     private $chainDecoder;
     private $decoder1;

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
@@ -18,9 +18,9 @@ use Symfony\Component\Serializer\Encoder\NormalizationAwareInterface;
 
 class ChainEncoderTest extends TestCase
 {
-    const FORMAT_1 = 'format1';
-    const FORMAT_2 = 'format2';
-    const FORMAT_3 = 'format3';
+    private const FORMAT_1 = 'format1';
+    private const FORMAT_2 = 'format2';
+    private const FORMAT_3 = 'format3';
 
     private $chainEncoder;
     private $encoder1;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DataUriNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DataUriNormalizerTest.php
@@ -20,9 +20,9 @@ use Symfony\Component\Serializer\Normalizer\DataUriNormalizer;
  */
 class DataUriNormalizerTest extends TestCase
 {
-    const TEST_GIF_DATA = 'data:image/gif;base64,R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=';
-    const TEST_TXT_DATA = 'data:text/plain,K%C3%A9vin%20Dunglas%0A';
-    const TEST_TXT_CONTENT = "Kévin Dunglas\n";
+    private const TEST_GIF_DATA = 'data:image/gif;base64,R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs=';
+    private const TEST_TXT_DATA = 'data:text/plain,K%C3%A9vin%20Dunglas%0A';
+    private const TEST_TXT_CONTENT = "Kévin Dunglas\n";
 
     /**
      * @var DataUriNormalizer

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Stopwatch\StopwatchEvent;
  */
 class StopwatchEventTest extends TestCase
 {
-    const DELTA = 37;
+    private const DELTA = 37;
 
     public function testGetOrigin()
     {

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Stopwatch\Stopwatch;
  */
 class StopwatchTest extends TestCase
 {
-    const DELTA = 20;
+    private const DELTA = 20;
 
     public function testStart()
     {

--- a/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/ClassMetadataTest.php
@@ -24,10 +24,10 @@ use Symfony\Component\Validator\Tests\Fixtures\PropertyConstraint;
 
 class ClassMetadataTest extends TestCase
 {
-    const CLASSNAME = 'Symfony\Component\Validator\Tests\Fixtures\Entity';
-    const PARENTCLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityParent';
-    const PROVIDERCLASS = 'Symfony\Component\Validator\Tests\Fixtures\GroupSequenceProviderEntity';
-    const PROVIDERCHILDCLASS = 'Symfony\Component\Validator\Tests\Fixtures\GroupSequenceProviderChildEntity';
+    private const CLASSNAME = 'Symfony\Component\Validator\Tests\Fixtures\Entity';
+    private const PARENTCLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityParent';
+    private const PROVIDERCLASS = 'Symfony\Component\Validator\Tests\Fixtures\GroupSequenceProviderEntity';
+    private const PROVIDERCHILDCLASS = 'Symfony\Component\Validator\Tests\Fixtures\GroupSequenceProviderChildEntity';
 
     protected $metadata;
 

--- a/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Factory/LazyLoadingMetadataFactoryTest.php
@@ -26,11 +26,9 @@ use Symfony\Component\Validator\Tests\Fixtures\PropertyGetterInterface;
 
 class LazyLoadingMetadataFactoryTest extends TestCase
 {
-    const CLASS_NAME = 'Symfony\Component\Validator\Tests\Fixtures\Entity';
-    const PARENT_CLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityParent';
-    const INTERFACE_A_CLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityInterfaceA';
-    const INTERFACE_B_CLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityInterfaceB';
-    const PARENT_INTERFACE_CLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityParentInterface';
+    private const CLASS_NAME = 'Symfony\Component\Validator\Tests\Fixtures\Entity';
+    private const PARENT_CLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityParent';
+    private const INTERFACE_A_CLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityInterfaceA';
 
     public function testLoadClassMetadataWithInterface()
     {

--- a/src/Symfony/Component/Validator/Tests/Mapping/GetterMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/GetterMetadataTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Validator\Tests\Fixtures\Entity;
 
 class GetterMetadataTest extends TestCase
 {
-    const CLASSNAME = 'Symfony\Component\Validator\Tests\Fixtures\Entity';
+    private const CLASSNAME = 'Symfony\Component\Validator\Tests\Fixtures\Entity';
 
     public function testInvalidPropertyName()
     {

--- a/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/PropertyMetadataTest.php
@@ -19,10 +19,10 @@ use Symfony\Component\Validator\Tests\Fixtures\Entity_74_Proxy;
 
 class PropertyMetadataTest extends TestCase
 {
-    const CLASSNAME = 'Symfony\Component\Validator\Tests\Fixtures\Entity';
-    const CLASSNAME_74 = 'Symfony\Component\Validator\Tests\Fixtures\Entity_74';
-    const CLASSNAME_74_PROXY = 'Symfony\Component\Validator\Tests\Fixtures\Entity_74_Proxy';
-    const PARENTCLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityParent';
+    private const CLASSNAME = 'Symfony\Component\Validator\Tests\Fixtures\Entity';
+    private const CLASSNAME_74 = 'Symfony\Component\Validator\Tests\Fixtures\Entity_74';
+    private const CLASSNAME_74_PROXY = 'Symfony\Component\Validator\Tests\Fixtures\Entity_74_Proxy';
+    private const PARENTCLASS = 'Symfony\Component\Validator\Tests\Fixtures\EntityParent';
 
     public function testInvalidPropertyName()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

As discussed on Slack, this PR prepares the introduction of a CS fixer rule to enforce explicit visibility declarations for constants. I've checked class constants in test and fixture classes and if I only found usages within the same class, I've declared them `private`. This way, I also found a few constants that weren't used at all anymore, so I've removed those.