### PR TITLE
Validate XLIFF files in tests using the XSD

### DIFF
--- a/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Form\Tests\Resources;
 
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Util\Xml\Loader;
+use Symfony\Component\Translation\Util\XliffUtils;
 
 class TranslationFilesTest extends TestCase
 {
@@ -21,13 +21,12 @@ class TranslationFilesTest extends TestCase
      */
     public function testTranslationFileIsValid($filePath)
     {
-        $loader = class_exists(Loader::class)
-            ? [new Loader(), 'loadFile']
-            : ['PHPUnit\Util\XML', 'loadfile'];
+        $document = new \DOMDocument();
+        $document->loadXML(file_get_contents($filePath));
 
-        $loader($filePath, false, false, true);
+        $errors = XliffUtils::validateSchema($document);
 
-        $this->addToAssertionCount(1);
+        $this->assertCount(0, $errors, sprintf('"%s" is invalid:%s', $filePath, \PHP_EOL.implode(\PHP_EOL, array_column($errors, 'message'))));
     }
 
     public function provideTranslationFiles()

--- a/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Resources;
 
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Util\Xml\Loader;
+use Symfony\Component\Translation\Util\XliffUtils;
 
 class TranslationFilesTest extends TestCase
 {
@@ -21,13 +21,12 @@ class TranslationFilesTest extends TestCase
      */
     public function testTranslationFileIsValid($filePath)
     {
-        $loader = class_exists(Loader::class)
-            ? [new Loader(), 'loadFile']
-            : ['PHPUnit\Util\XML', 'loadfile'];
+        $document = new \DOMDocument();
+        $document->loadXML(file_get_contents($filePath));
 
-        $loader($filePath, false, false, true);
+        $errors = XliffUtils::validateSchema($document);
 
-        $this->addToAssertionCount(1);
+        $this->assertCount(0, $errors, sprintf('"%s" is invalid:%s', $filePath, \PHP_EOL.implode(\PHP_EOL, array_column($errors, 'message'))));
     }
 
     public function provideTranslationFiles()

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -26,6 +26,7 @@
         "symfony/expression-language": "^3.4|^4.0|^5.0",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",
         "symfony/ldap": "^4.4|^5.0",
+        "symfony/translation": "^4.4|^5.0",
         "symfony/validator": "^3.4.31|^4.3.4|^5.0",
         "psr/log": "~1.0"
     },

--- a/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Resources;
 
 use PHPUnit\Framework\TestCase;
-use PHPUnit\Util\Xml\Loader;
+use Symfony\Component\Translation\Util\XliffUtils;
 
 class TranslationFilesTest extends TestCase
 {
@@ -21,13 +21,12 @@ class TranslationFilesTest extends TestCase
      */
     public function testTranslationFileIsValid($filePath)
     {
-        $loader = class_exists(Loader::class)
-            ? [new Loader(), 'loadFile']
-            : ['PHPUnit\Util\XML', 'loadfile'];
+        $document = new \DOMDocument();
+        $document->loadXML(file_get_contents($filePath));
 
-        $loader($filePath, false, false, true);
+        $errors = XliffUtils::validateSchema($document);
 
-        $this->addToAssertionCount(1);
+        $this->assertCount(0, $errors, sprintf('"%s" is invalid:%s', $filePath, \PHP_EOL.implode(\PHP_EOL, array_column($errors, 'message'))));
     }
 
     public function provideTranslationFiles()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The current tests only validated that the Xliff files were valid XML. This improves it to also validate the Xliff files against the correct XSD. This will avoid issues like https://github.com/symfony/symfony/issues/38935 in the future.

cc @Nyholm 