### PR TITLE
[Messenger] Change defaults name like Doctrine one

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -107,7 +107,7 @@ class Connection
 
         $this->connectionOptions = array_replace_recursive([
             'delay' => [
-                'exchange_name' => 'delays',
+                'exchange_name' => 'messenger_delays',
                 'queue_name_pattern' => 'delay_%exchange_name%_%routing_key%_%delay%',
             ],
         ], $connectionOptions);
@@ -143,7 +143,7 @@ class Connection
      *     * arguments: Extra arguments
      *   * delay:
      *     * queue_name_pattern: Pattern to use to create the queues (Default: "delay_%exchange_name%_%routing_key%_%delay%")
-     *     * exchange_name: Name of the exchange to be used for the delayed/retried messages (Default: "delays")
+     *     * exchange_name: Name of the exchange to be used for the delayed/retried messages (Default: "messenger_delays")
      *   * auto_setup: Enable or not the auto-setup of queues and exchanges (Default: true)
      *   * prefetch_count: set channel prefetch count
      *
@@ -176,7 +176,7 @@ class Connection
 
         $useAmqps = 0 === strpos($dsn, 'amqps://');
         $pathParts = isset($parsedUrl['path']) ? explode('/', trim($parsedUrl['path'], '/')) : [];
-        $exchangeName = $pathParts[1] ?? 'messages';
+        $exchangeName = $pathParts[1] ?? 'messenger_messages';
         parse_str($parsedUrl['query'] ?? '', $parsedQuery);
         $port = $useAmqps ? 5671 : 5672;
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -28,7 +28,7 @@ use Symfony\Component\Messenger\Exception\TransportException;
 class Connection
 {
     private const DEFAULT_OPTIONS = [
-        'stream' => 'messages',
+        'stream' => 'messenger_messages',
         'group' => 'symfony',
         'consumer' => 'consumer',
         'auto_setup' => true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | If PR approved, as well as changing recipes

Hi

After playing with messenger, testing doctrine first as sync and then rabbitmq/redis for async, I found it weird that doctrine defaults to storage prefixed with `messenger_` but not others (https://github.com/symfony/symfony/blob/050f3e43a5f01296f48545c7598850311469395a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php#L41)

That is why I propose this PR

If accepted:
- question: should I target 4.4?
- I will change doc and `manifest.json` inside recipes as well

Thank you