### PR TITLE
[Finder] Force set access time in test

### DIFF
--- a/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
@@ -35,9 +35,10 @@ class SortableIteratorTest extends RealIteratorTestCase
                 case SortableIterator::SORT_BY_ACCESSED_TIME:
                     touch(self::toAbsolute('.git'));
                     sleep(1);
-                    file_get_contents(self::toAbsolute('.bar'));
+                    touch(self::toAbsolute('.bar'), time());
                     break;
                 case SortableIterator::SORT_BY_CHANGED_TIME:
+                    sleep(1);
                     file_put_contents(self::toAbsolute('test.php'), 'foo');
                     sleep(1);
                     file_put_contents(self::toAbsolute('test.py'), 'foo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no, it only updates the tests
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38942
| License       | MIT
| Doc PR        | 

OSX don't really update atime (access time). They claim it is because performance reasons. So this PR will update the test to make PHP force access time on a file. 

The different runs of `testAccept` depends on each other because each test modifies the filesystem a bit. That is why I added the extra `sleep(1)`.