### PR TITLE
[Messenger] Fixed tests with doctrine 3

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineReceiverTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Tests\Transport\Doctrine;
 use Doctrine\DBAL\Driver\PDO\Exception;
 use Doctrine\DBAL\Driver\PDOException;
 use Doctrine\DBAL\Exception\DeadlockException;
+use Doctrine\DBAL\Version;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
@@ -77,7 +78,14 @@ class DoctrineReceiverTest extends TestCase
         $serializer = $this->createSerializer();
         $connection = $this->createMock(Connection::class);
         $driverException = class_exists(Exception::class) ? Exception::new(new \PDOException('Deadlock', 40001)) : new PDOException(new \PDOException('Deadlock', 40001));
-        $connection->method('get')->willThrowException(new DeadlockException('Deadlock', $driverException));
+        if (!class_exists(Version::class)) {
+            // This is doctrine/dbal 3.x
+            $deadlockException = new DeadlockException($driverException, null);
+        } else {
+            $deadlockException = new DeadlockException('Deadlock', $driverException);
+        }
+
+        $connection->method('get')->willThrowException($deadlockException);
         $receiver = new DoctrineReceiver($connection, $serializer);
         $this->assertSame([], $receiver->get());
         $this->assertSame([], $receiver->get());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Tests on 4.4 is failing with: 

>1) Symfony\Component\Messenger\Tests\Transport\Doctrine\DoctrineReceiverTest::testOccursRetryableExceptionFromConnection
TypeError: Argument 1 passed to Doctrine\DBAL\Exception\DriverException::__construct() must implement interface Doctrine\DBAL\Driver\Exception, string given, called in /home/travis/build/symfony/symfony/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineReceiverTest.php on line 80

This will make sure the tests supports doctrine/dbal 3. 