### PR TITLE
Switch nightly run to 8.0snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,11 @@ matrix:
           env: deps=high
         - php: 7.4
           env: deps=low
-        - php: nightly
+        - php: 8.0snapshot
           services: [memcached]
     fast_finish: true
     allow_failures:
-        - php: nightly
+        - php: 8.0snapshot
           services: [memcached]
 
 cache:
@@ -140,7 +140,7 @@ before_install:
           echo session.gc_probability = 0 >> $INI
           echo opcache.enable_cli = 1 >> $INI
           echo apc.enable_cli = 1 >> $INI
-          if [[ $PHP != nightly ]]; then
+          if [[ $PHP != 8.* ]]; then
               echo extension = memcached.so >> $INI
           fi
       done
@@ -156,7 +156,7 @@ before_install:
           if ! php --ri sodium > /dev/null; then
               tfold ext.libsodium tpecl libsodium sodium.so $INI
           fi
-          if [[ $PHP = nightly ]]; then
+          if [[ $PHP = 8.* ]]; then
               tfold ext.memcached tpecl memcached-3.1.5 memcached.so $INI
           else
               tfold ext.mongodb tpecl mongodb-1.6.16 mongodb.so $INI
@@ -234,7 +234,7 @@ install:
 
     - |
       # Set composer's platform to php 7.4 if we're on php 8.
-      if [[ $PHP = nightly ]]; then
+      if [[ $PHP = 8.* ]]; then
           composer config platform.php 7.4.99
           export SYMFONY_DEPRECATIONS_HELPER=max[total]=999
       fi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

It's too early to test on php 8.1, so let's switch to 8.0 instead.