### PR TITLE
[Serializer] Add ability to collect denormalization errors

### DIFF
--- a/src/Symfony/Component/Serializer/Exception/AggregableExceptionInterface.php
+++ b/src/Symfony/Component/Serializer/Exception/AggregableExceptionInterface.php
@@ -11,9 +11,6 @@
 
 namespace Symfony\Component\Serializer\Exception;
 
-/**
- * @author Maxime VEBER <maxime.veber@nekland.fr>
- */
-class MissingConstructorArgumentsException extends RuntimeException implements AggregableExceptionInterface
+interface AggregableExceptionInterface extends ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Serializer/Exception/AggregatedException.php
+++ b/src/Symfony/Component/Serializer/Exception/AggregatedException.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+final class AggregatedException extends RuntimeException implements AggregableExceptionInterface
+{
+    /**
+     * This property is public for performance reasons to reduce the number of hot path function calls.
+     *
+     * @var bool
+     *
+     * @internal
+     */
+    public $isEmpty = true;
+
+    /**
+     * @var array<string, AggregableExceptionInterface>
+     */
+    private $collection;
+
+    public function __construct()
+    {
+        parent::__construct('Errors occurred during the denormalization process');
+    }
+
+    public function put(string $param, AggregableExceptionInterface $exception): self
+    {
+        $this->isEmpty = false;
+        $this->collection[$param] = $exception;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, AggregableExceptionInterface>
+     */
+    public function all(): array
+    {
+        $result = [];
+
+        foreach ($this->collection as $param => $exception) {
+            if ($exception instanceof self) {
+                foreach ($exception->all() as $nestedParams => $nestedException) {
+                    $result["$param.$nestedParams"] = $nestedException;
+                }
+
+                continue;
+            }
+
+            $result[$param] = $exception;
+        }
+
+        return $result;
+    }
+}

--- a/src/Symfony/Component/Serializer/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/Serializer/Exception/InvalidArgumentException.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Serializer\Exception;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface, AggregableExceptionInterface
 {
 }

--- a/src/Symfony/Component/Serializer/Exception/NotNormalizableValueException.php
+++ b/src/Symfony/Component/Serializer/Exception/NotNormalizableValueException.php
@@ -14,6 +14,6 @@ namespace Symfony\Component\Serializer\Exception;
 /**
  * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
  */
-class NotNormalizableValueException extends UnexpectedValueException
+class NotNormalizableValueException extends UnexpectedValueException implements AggregableExceptionInterface
 {
 }

--- a/src/Symfony/Component/Serializer/Exception/VariadicConstructorArgumentsException.php
+++ b/src/Symfony/Component/Serializer/Exception/VariadicConstructorArgumentsException.php
@@ -11,9 +11,6 @@
 
 namespace Symfony\Component\Serializer\Exception;
 
-/**
- * @author Maxime VEBER <maxime.veber@nekland.fr>
- */
-class MissingConstructorArgumentsException extends RuntimeException implements AggregableExceptionInterface
+final class VariadicConstructorArgumentsException extends RuntimeException implements AggregableExceptionInterface
 {
 }

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -25,6 +25,11 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 interface DenormalizerInterface
 {
     /**
+     * Collects denormalization exceptions instead of throwing out the first one.
+     */
+    public const COLLECT_EXCEPTIONS = 'collect_exceptions';
+
+    /**
      * Denormalizes data back into an object of the given class.
      *
      * @param mixed  $data    Data to restore

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/CollectErrorsArrayDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/CollectErrorsArrayDummy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class CollectErrorsArrayDummy
+{
+    /**
+     * @var \DateTimeImmutable
+     */
+    public $date;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/CollectErrorsDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/CollectErrorsDummy.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class CollectErrorsDummy
+{
+    /**
+     * @var int
+     */
+    public $int;
+
+    /**
+     * @var array
+     */
+    public $array;
+
+    /**
+     * @var CollectErrorsArrayDummy[]
+     */
+    public $arrayOfObjects;
+
+    /**
+     * @var CollectErrorsArrayDummy[]
+     */
+    public $stringArrayOfObjects;
+
+    /**
+     * @var CollectErrorsObjectDummy
+     */
+    public $object;
+
+    /**
+     * @var CollectErrorsVariadicObjectDummy
+     */
+    public $variadicObject;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/CollectErrorsObjectDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/CollectErrorsObjectDummy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class CollectErrorsObjectDummy
+{
+    public $foo;
+    public $bar;
+    public $baz;
+
+    public function __construct(int $foo, int $bar, int $baz)
+    {
+        $this->foo = $foo;
+        $this->bar = $bar;
+        $this->baz = $baz;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/CollectErrorsVariadicObjectDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/CollectErrorsVariadicObjectDummy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class CollectErrorsVariadicObjectDummy
+{
+    public $foo;
+
+    /** @var CollectErrorsVariadicObjectDummy[]  */
+    public $args;
+
+    public function __construct(int $foo, CollectErrorsVariadicObjectDummy ...$args)
+    {
+        $this->foo = $foo;
+        $this->args = $args;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #37419
| License       | MIT
| Doc PR        | 

This PR is a similar with  #38472 (for unknown reason that is a draft) but there is a slightly different approach.

This implementation is more to show how the exceptions that are thrown during denormalization can be collected.

It has two part.

In the first part it is collected `NotNormalizableValueException`s in `AbstractObjectNormalizer`.

The second part is a collect exceptions from `AbstractNormalizer::instantiateObject`

 

