### PR TITLE
[DoctrineBridge][Validator] Expose all fields for message validation failure

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueEntityValidatorTest.php
@@ -197,6 +197,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation('myMessage')
             ->atPath('property.path.name')
             ->setParameter('{{ value }}', '"Foo"')
+            ->setParameter('{{ name }}', '"Foo"')
             ->setInvalidValue($entity2)
             ->setCause([$entity1])
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
@@ -223,6 +224,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation('myMessage')
             ->atPath('property.path.bar')
             ->setParameter('{{ value }}', '"Foo"')
+            ->setParameter('{{ name }}', '"Foo"')
             ->setInvalidValue($entity2)
             ->setCause([$entity1])
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
@@ -277,6 +279,8 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation('myMessage')
             ->atPath('property.path.name')
             ->setParameter('{{ value }}', '"Foo"')
+            ->setParameter('{{ name }}', '"Foo"')
+            ->setParameter('{{ name2 }}', '')
             ->setInvalidValue('Foo')
             ->setCause([$entity1])
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
@@ -354,6 +358,8 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation('myMessage')
             ->atPath('property.path.name2')
             ->setParameter('{{ value }}', '"Bar"')
+            ->setParameter('{{ name }}', '"Foo"')
+            ->setParameter('{{ name2 }}', '"Bar"')
             ->setInvalidValue('Bar')
             ->setCause([$entity1])
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
@@ -489,6 +495,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation('myMessage')
             ->atPath('property.path.single')
             ->setParameter('{{ value }}', 'foo')
+            ->setParameter('{{ single }}', 'foo')
             ->setInvalidValue($entity1)
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->setCause([$associated, $associated2])
@@ -527,6 +534,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation('myMessage')
             ->atPath('property.path.single')
             ->setParameter('{{ value }}', $expectedValue)
+            ->setParameter('{{ single }}', $expectedValue)
             ->setInvalidValue($entity1)
             ->setCause([$associated, $associated2])
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
@@ -586,6 +594,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation('myMessage')
             ->atPath('property.path.phoneNumbers')
             ->setParameter('{{ value }}', 'array')
+            ->setParameter('{{ phoneNumbers }}', 'array')
             ->setInvalidValue([123])
             ->setCause([$entity1])
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
@@ -690,7 +699,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
             ->setInvalidValue('Foo')
             ->setCode('23bd9dbf-6b9b-41cd-a99e-4844bcf3077f')
             ->setCause([$entity1])
-            ->setParameters(['{{ value }}' => '"Foo"'])
+            ->setParameters(['{{ value }}' => '"Foo"', '{{ name }}' => '"Foo"'])
             ->assertRaised();
     }
 
@@ -733,11 +742,14 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
 
         $this->validator->validate($newEntity, $constraint);
 
-        $expectedValue = 'object("Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity") identified by (id => 1)';
+        $expectedValueForObjectOne = 'object("Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity") identified by (id => 1)';
+        $expectedValueForObjectTwo = 'object("Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIntIdNoToStringEntity") identified by (id => 2)';
 
         $this->buildViolation('myMessage')
             ->atPath('property.path.objectOne')
-            ->setParameter('{{ value }}', $expectedValue)
+            ->setParameter('{{ value }}', $expectedValueForObjectOne)
+            ->setParameter('{{ objectOne }}', $expectedValueForObjectOne)
+            ->setParameter('{{ objectTwo }}', $expectedValueForObjectTwo)
             ->setInvalidValue($objectOne)
             ->setCause([$entity])
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
@@ -766,6 +778,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation('myMessage')
             ->atPath('property.path.name')
             ->setParameter('{{ value }}', $expectedValue)
+            ->setParameter('{{ name }}', $expectedValue)
             ->setInvalidValue($existingEntity->name)
             ->setCause([$existingEntity])
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
@@ -802,6 +815,7 @@ class UniqueEntityValidatorTest extends ConstraintValidatorTestCase
         $this->buildViolation('myMessage')
             ->atPath('property.path.name')
             ->setParameter('{{ value }}', '"Foo"')
+            ->setParameter('{{ name }}', '"Foo"')
             ->setInvalidValue($entity2)
             ->setCause([$entity1])
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -167,13 +167,19 @@ class UniqueEntityValidator extends ConstraintValidator
         $errorPath = null !== $constraint->errorPath ? $constraint->errorPath : $fields[0];
         $invalidValue = isset($criteria[$errorPath]) ? $criteria[$errorPath] : $criteria[$fields[0]];
 
-        $this->context->buildViolation($constraint->message)
+        $constraintViolationBuilder = $this->context->buildViolation($constraint->message)
             ->atPath($errorPath)
             ->setParameter('{{ value }}', $this->formatWithIdentifiers($em, $class, $invalidValue))
             ->setInvalidValue($invalidValue)
             ->setCode(UniqueEntity::NOT_UNIQUE_ERROR)
             ->setCause($result)
-            ->addViolation();
+        ;
+        foreach ($fields as $field) {
+            $invalidValue = ($criteria[$field]) ? $this->formatWithIdentifiers($em, $class, $criteria[$field]) : "";
+            $constraintViolationBuilder->setParameter(\sprintf('{{ %s }}', $field), $invalidValue);
+        }
+
+        $constraintViolationBuilder->addViolation();
     }
 
     private function formatWithIdentifiers($em, $class, $value)

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -175,8 +175,10 @@ class UniqueEntityValidator extends ConstraintValidator
             ->setCause($result)
         ;
         foreach ($fields as $field) {
-            $invalidValue = ($criteria[$field]) ? $this->formatWithIdentifiers($em, $class, $criteria[$field]) : '';
-            $constraintViolationBuilder->setParameter(sprintf('{{ %s }}', $field), $invalidValue);
+            $constraintViolationBuilder->setParameter(
+                sprintf('{{ %s }}', $field),
+                ($criteria[$field]) ? $this->formatWithIdentifiers($em, $class, $criteria[$field]) : ''
+            );
         }
 
         $constraintViolationBuilder->addViolation();

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -175,8 +175,8 @@ class UniqueEntityValidator extends ConstraintValidator
             ->setCause($result)
         ;
         foreach ($fields as $field) {
-            $invalidValue = ($criteria[$field]) ? $this->formatWithIdentifiers($em, $class, $criteria[$field]) : "";
-            $constraintViolationBuilder->setParameter(\sprintf('{{ %s }}', $field), $invalidValue);
+            $invalidValue = ($criteria[$field]) ? $this->formatWithIdentifiers($em, $class, $criteria[$field]) : '';
+            $constraintViolationBuilder->setParameter(sprintf('{{ %s }}', $field), $invalidValue);
         }
 
         $constraintViolationBuilder->addViolation();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | In progress

The main reason of the pull request is to improve the way ``UniqueEntity`` validator provide invalide values for us.
Unfortunately, if we use the validator with more than one field, we will only have the first value at our disposal to customize the message that’s displayed when the constraint fails, cause, according to this line:
``$invalidValue = isset($criteria[$errorPath]) ? $criteria[$errorPath] : $criteria[$fields[0]];``  the message is always mapped to the first field causing the violation.

Imagine we have an entity `Dummy` class, and we post a `json` data that looks like this: `{"foo": "space", "bar": "github"}`.

```yaml
/**
 * @ORM\Entity()
 * @UniqueEntity(fields={ "foo", "bar"}, message="Registration failed, the foo *{{ foo }}* is already exist for *{{ bar }}*")
 */
class Dummy
{
    /**
     * @ORM\Column(type="string", length=255)
     */
    private $foo;

    /**
     * @ORM\Column(type="string", length=255)
     */
    private $bar;
..
}
```

The result that will be displayed is: ``Registration failed, the foo *space* is already exist for *github*"`` and that's more specific and friendly.

Any way, just let me know if this requires to add some unit tests or some documentation, (if it'is an interesting idea).
Best regards,