### PR TITLE
[DoctrineBridge] accept converting Uid-as-strings to db-values

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Types/UlidBinaryTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/UlidBinaryTypeTest.php
@@ -52,11 +52,12 @@ class UlidBinaryTypeTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testNotSupportedStringUlidConversionToDatabaseValue()
+    public function testStringUlidConvertsToDatabaseValue()
     {
-        $this->expectException(ConversionException::class);
+        $expected = Ulid::fromString(self::DUMMY_ULID)->toBinary();
+        $actual = $this->type->convertToDatabaseValue(self::DUMMY_ULID, $this->platform);
 
-        $this->type->convertToDatabaseValue(self::DUMMY_ULID, $this->platform);
+        $this->assertEquals($expected, $actual);
     }
 
     public function testNotSupportedTypeConversionForDatabaseValue()

--- a/src/Symfony/Bridge/Doctrine/Tests/Types/UlidTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/UlidTypeTest.php
@@ -68,11 +68,14 @@ final class UlidTypeTest extends TestCase
         $this->assertEquals('foo', $actual);
     }
 
-    public function testNotSupportedUlidStringConversionToDatabaseValue()
+    public function testUlidStringConvertsToDatabaseValue()
     {
-        $this->expectException(ConversionException::class);
+        $actual = $this->type->convertToDatabaseValue(self::DUMMY_ULID, $this->platform);
+        $ulid = Ulid::fromString(self::DUMMY_ULID);
 
-        $this->type->convertToDatabaseValue(self::DUMMY_ULID, $this->platform);
+        $expected = $ulid->toRfc4122();
+
+        $this->assertEquals($expected, $actual);
     }
 
     public function testNotSupportedTypeConversionForDatabaseValue()

--- a/src/Symfony/Bridge/Doctrine/Tests/Types/UuidBinaryTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/UuidBinaryTypeTest.php
@@ -52,11 +52,21 @@ class UuidBinaryTypeTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    public function testNotSupportedStringUuidConversionToDatabaseValue()
+    public function testStringUuidConvertsToDatabaseValue()
+    {
+        $uuid = self::DUMMY_UUID;
+
+        $expected = uuid_parse(self::DUMMY_UUID);
+        $actual = $this->type->convertToDatabaseValue($uuid, $this->platform);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testInvalidUuidConversionForDatabaseValue()
     {
         $this->expectException(ConversionException::class);
 
-        $this->type->convertToDatabaseValue(self::DUMMY_UUID, $this->platform);
+        $this->type->convertToDatabaseValue('abcdefg', $this->platform);
     }
 
     public function testNullConversionForDatabaseValue()

--- a/src/Symfony/Bridge/Doctrine/Tests/Types/UuidTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Types/UuidTypeTest.php
@@ -68,11 +68,11 @@ final class UuidTypeTest extends TestCase
         $this->assertEquals('foo', $actual);
     }
 
-    public function testNotSupportedUuidStringConversionToDatabaseValue()
+    public function testUuidStringConvertsToDatabaseValue()
     {
-        $this->expectException(ConversionException::class);
+        $actual = $this->type->convertToDatabaseValue(self::DUMMY_UUID, $this->platform);
 
-        $this->type->convertToDatabaseValue(self::DUMMY_UUID, $this->platform);
+        $this->assertEquals(self::DUMMY_UUID, $actual);
     }
 
     public function testNotSupportedTypeConversionForDatabaseValue()

--- a/src/Symfony/Bridge/Doctrine/Types/AbstractBinaryUidType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/AbstractBinaryUidType.php
@@ -61,11 +61,19 @@ abstract class AbstractBinaryUidType extends Type
             return $value->toBinary();
         }
 
-        if (null === $value) {
+        if (null === $value || '' === $value) {
             return null;
         }
 
-        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', AbstractUid::class]);
+        if (!\is_string($value)) {
+            throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'string', AbstractUid::class]);
+        }
+
+        try {
+            return $this->getUidClass()::fromString($value)->toBinary();
+        } catch (\InvalidArgumentException $e) {
+            throw ConversionException::conversionFailed($value, $this->getName());
+        }
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Types/AbstractUidType.php
+++ b/src/Symfony/Bridge/Doctrine/Types/AbstractUidType.php
@@ -61,11 +61,19 @@ abstract class AbstractUidType extends Type
             return $value->toRfc4122();
         }
 
-        if (null === $value) {
+        if (null === $value || '' === $value) {
             return null;
         }
 
-        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', AbstractUid::class]);
+        if (!\is_string($value)) {
+            throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', 'string', AbstractUid::class]);
+        }
+
+        try {
+            return $this->getUidClass()::fromString($value)->toRfc4122();
+        } catch (\InvalidArgumentException $e) {
+            throw ConversionException::conversionFailed($value, $this->getName());
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38929
| License       | MIT
| Doc PR        | -

In #38605 I made Uid types stricter by taking inspiration from native Doctrine types. But https://github.com/symfony/symfony/issues/38929#issuecomment-720108301 made me realize this doesn't work with ParamConverters. Here is the fix.