### PR TITLE
[PropertyInfo] Support multiple builtinType (union types)

### DIFF
--- a/src/Symfony/Component/PropertyInfo/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyInfo/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+* Added ability to have union types in `Type` class.
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/PropertyInfo/UnionType.php
+++ b/src/Symfony/Component/PropertyInfo/UnionType.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo;
+
+/**
+ * Union type value object (immutable).
+ *
+ * @author Baptiste Leduc <baptiste.leduc@gmail.com>
+ */
+final class UnionType
+{
+    private $types;
+
+    /**
+     * @param Type[] $types
+     */
+    public function __construct(array $types)
+    {
+        foreach ($types as $type) {
+            if (!$type instanceof Type) {
+                throw new \TypeError(sprintf('"%s()": Argument #1 ($types) must be an array with items of type "%s", "%s" given.', __METHOD__, Type::class, get_debug_type($type)));
+            }
+        }
+
+        $this->types = $types;
+    }
+
+    /**
+     * @return Type[]
+     */
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #38093
| License       | MIT
| Doc PR        | N/A

First step for #38093, before parsing union types in phpDoc, we need to handle union types correctly in the `Type` class.

I changed the `$builtinType` type in the `Type` construct in order to handle multiple builtin types.
