### PR TITLE
[Messenger] Extract the creation of configuration from Connection::fromDsn to ConfigurationFactory

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+ * Made it possible to re-use the Connection configuration processing logic
+   outside the Connection class, e.g. to enable instantiating an SqsClient
+   on your own.
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/ConfigurationFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/ConfigurationFactory.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Transport;
+
+use Symfony\Component\Messenger\Exception\InvalidArgumentException;
+
+class ConfigurationFactory
+{
+    /**
+     * @internal
+     */
+    public const DEFAULT_OPTIONS = [
+        'buffer_size' => 9,
+        'wait_time' => 20,
+        'poll_timeout' => 0.1,
+        'visibility_timeout' => null,
+        'auto_setup' => true,
+        'access_key' => null,
+        'secret_key' => null,
+        'endpoint' => 'https://sqs.eu-west-1.amazonaws.com',
+        'region' => 'eu-west-1',
+        'queue_name' => 'messages',
+        'account' => null,
+        'sslmode' => null,
+    ];
+
+    /**
+     * Creates configuration based on the DSN and options.
+     *
+     * Available options:
+     *
+     * * endpoint: absolute URL to the SQS service (Default: https://sqs.eu-west-1.amazonaws.com)
+     * * region: name of the AWS region (Default: eu-west-1)
+     * * queue_name: name of the queue (Default: messages)
+     * * account: identifier of the AWS account
+     * * access_key: AWS access key
+     * * secret_key: AWS secret key
+     * * buffer_size: number of messages to prefetch (Default: 9)
+     * * wait_time: long polling duration in seconds (Default: 20)
+     * * poll_timeout: amount of seconds the transport should wait for new message
+     * * visibility_timeout: amount of seconds the message won't be visible
+     * * auto_setup: Whether the queue should be created automatically during send / get (Default: true)
+     */
+    public static function fromDsn(string $dsn, array $options = []): array
+    {
+        if (false === $parsedUrl = parse_url($dsn)) {
+            throw new InvalidArgumentException(sprintf('The given Amazon SQS DSN "%s" is invalid.', $dsn));
+        }
+
+        $query = [];
+        if (isset($parsedUrl['query'])) {
+            parse_str($parsedUrl['query'], $query);
+        }
+
+        // check for extra keys in options
+        $optionsExtraKeys = array_diff(array_keys($options), array_keys(self::DEFAULT_OPTIONS));
+        if (0 < \count($optionsExtraKeys)) {
+            throw new InvalidArgumentException(sprintf('Unknown option found: [%s]. Allowed options are [%s].', implode(', ', $optionsExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
+        }
+
+        // check for extra keys in options
+        $queryExtraKeys = array_diff(array_keys($query), array_keys(self::DEFAULT_OPTIONS));
+        if (0 < \count($queryExtraKeys)) {
+            throw new InvalidArgumentException(sprintf('Unknown option found in DSN: [%s]. Allowed options are [%s].', implode(', ', $queryExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
+        }
+
+        $options = $query + $options + self::DEFAULT_OPTIONS;
+        $configuration = [
+            'buffer_size' => (int) $options['buffer_size'],
+            'wait_time' => (int) $options['wait_time'],
+            'poll_timeout' => $options['poll_timeout'],
+            'visibility_timeout' => $options['visibility_timeout'],
+            'auto_setup' => (bool) $options['auto_setup'],
+            'queue_name' => (string) $options['queue_name'],
+        ];
+
+        $clientConfiguration = [
+            'region' => $options['region'],
+            'accessKeyId' => urldecode($parsedUrl['user'] ?? '') ?: $options['access_key'] ?? self::DEFAULT_OPTIONS['access_key'],
+            'accessKeySecret' => urldecode($parsedUrl['pass'] ?? '') ?: $options['secret_key'] ?? self::DEFAULT_OPTIONS['secret_key'],
+        ];
+        unset($query['region']);
+
+        if ('default' !== ($parsedUrl['host'] ?? 'default')) {
+            $clientConfiguration['endpoint'] = sprintf('%s://%s%s', ($query['sslmode'] ?? null) === 'disable' ? 'http' : 'https', $parsedUrl['host'], ($parsedUrl['port'] ?? null) ? ':'.$parsedUrl['port'] : '');
+            if (preg_match(';^sqs\.([^\.]++)\.amazonaws\.com$;', $parsedUrl['host'], $matches)) {
+                $clientConfiguration['region'] = $matches[1];
+            }
+        } elseif (self::DEFAULT_OPTIONS['endpoint'] !== $options['endpoint'] ?? self::DEFAULT_OPTIONS['endpoint']) {
+            $clientConfiguration['endpoint'] = $options['endpoint'];
+        }
+
+        $parsedPath = explode('/', ltrim($parsedUrl['path'] ?? '/', '/'));
+        if (\count($parsedPath) > 0 && !empty($queueName = end($parsedPath))) {
+            $configuration['queue_name'] = $queueName;
+        }
+        $configuration['account'] = 2 === \count($parsedPath) ? $parsedPath[0] : $options['account'] ?? self::DEFAULT_OPTIONS['account'];
+
+        // When the DNS looks like a QueueUrl, we can directly inject it in the connection
+        // https://sqs.REGION.amazonaws.com/ACCOUNT/QUEUE
+        $queueUrl = null;
+        if (
+            'https' === $parsedUrl['scheme']
+            && ($parsedUrl['host'] ?? 'default') === "sqs.{$clientConfiguration['region']}.amazonaws.com"
+            && ($parsedUrl['path'] ?? '/') === "/{$configuration['account']}/{$configuration['queue_name']}"
+        ) {
+            $queueUrl = 'https://'.$parsedUrl['host'].$parsedUrl['path'];
+        }
+
+        return [$configuration, $clientConfiguration, $queueUrl];
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -32,21 +32,6 @@ class Connection
     private const AWS_SQS_FIFO_SUFFIX = '.fifo';
     private const MESSAGE_ATTRIBUTE_NAME = 'X-Symfony-Messenger';
 
-    private const DEFAULT_OPTIONS = [
-        'buffer_size' => 9,
-        'wait_time' => 20,
-        'poll_timeout' => 0.1,
-        'visibility_timeout' => null,
-        'auto_setup' => true,
-        'access_key' => null,
-        'secret_key' => null,
-        'endpoint' => 'https://sqs.eu-west-1.amazonaws.com',
-        'region' => 'eu-west-1',
-        'queue_name' => 'messages',
-        'account' => null,
-        'sslmode' => null,
-    ];
-
     private $configuration;
     private $client;
 
@@ -59,7 +44,7 @@ class Connection
 
     public function __construct(array $configuration, SqsClient $client = null, string $queueUrl = null)
     {
-        $this->configuration = array_replace_recursive(self::DEFAULT_OPTIONS, $configuration);
+        $this->configuration = array_replace_recursive(ConfigurationFactory::DEFAULT_OPTIONS, $configuration);
         $this->client = $client ?? new SqsClient([]);
         $this->queueUrl = $queueUrl;
     }
@@ -70,87 +55,11 @@ class Connection
     }
 
     /**
-     * Creates a connection based on the DSN and options.
-     *
-     * Available options:
-     *
-     * * endpoint: absolute URL to the SQS service (Default: https://sqs.eu-west-1.amazonaws.com)
-     * * region: name of the AWS region (Default: eu-west-1)
-     * * queue_name: name of the queue (Default: messages)
-     * * account: identifier of the AWS account
-     * * access_key: AWS access key
-     * * secret_key: AWS secret key
-     * * buffer_size: number of messages to prefetch (Default: 9)
-     * * wait_time: long polling duration in seconds (Default: 20)
-     * * poll_timeout: amount of seconds the transport should wait for new message
-     * * visibility_timeout: amount of seconds the message won't be visible
-     * * auto_setup: Whether the queue should be created automatically during send / get (Default: true)
+     * Creates a connection based on the DSN and options. For available options, see ConfigurationFactory::fromDsn.
      */
     public static function fromDsn(string $dsn, array $options = [], HttpClientInterface $client = null): self
     {
-        if (false === $parsedUrl = parse_url($dsn)) {
-            throw new InvalidArgumentException(sprintf('The given Amazon SQS DSN "%s" is invalid.', $dsn));
-        }
-
-        $query = [];
-        if (isset($parsedUrl['query'])) {
-            parse_str($parsedUrl['query'], $query);
-        }
-
-        // check for extra keys in options
-        $optionsExtraKeys = array_diff(array_keys($options), array_keys(self::DEFAULT_OPTIONS));
-        if (0 < \count($optionsExtraKeys)) {
-            throw new InvalidArgumentException(sprintf('Unknown option found: [%s]. Allowed options are [%s].', implode(', ', $optionsExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
-        }
-
-        // check for extra keys in options
-        $queryExtraKeys = array_diff(array_keys($query), array_keys(self::DEFAULT_OPTIONS));
-        if (0 < \count($queryExtraKeys)) {
-            throw new InvalidArgumentException(sprintf('Unknown option found in DSN: [%s]. Allowed options are [%s].', implode(', ', $queryExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
-        }
-
-        $options = $query + $options + self::DEFAULT_OPTIONS;
-        $configuration = [
-            'buffer_size' => (int) $options['buffer_size'],
-            'wait_time' => (int) $options['wait_time'],
-            'poll_timeout' => $options['poll_timeout'],
-            'visibility_timeout' => $options['visibility_timeout'],
-            'auto_setup' => (bool) $options['auto_setup'],
-            'queue_name' => (string) $options['queue_name'],
-        ];
-
-        $clientConfiguration = [
-            'region' => $options['region'],
-            'accessKeyId' => urldecode($parsedUrl['user'] ?? '') ?: $options['access_key'] ?? self::DEFAULT_OPTIONS['access_key'],
-            'accessKeySecret' => urldecode($parsedUrl['pass'] ?? '') ?: $options['secret_key'] ?? self::DEFAULT_OPTIONS['secret_key'],
-        ];
-        unset($query['region']);
-
-        if ('default' !== ($parsedUrl['host'] ?? 'default')) {
-            $clientConfiguration['endpoint'] = sprintf('%s://%s%s', ($query['sslmode'] ?? null) === 'disable' ? 'http' : 'https', $parsedUrl['host'], ($parsedUrl['port'] ?? null) ? ':'.$parsedUrl['port'] : '');
-            if (preg_match(';^sqs\.([^\.]++)\.amazonaws\.com$;', $parsedUrl['host'], $matches)) {
-                $clientConfiguration['region'] = $matches[1];
-            }
-        } elseif (self::DEFAULT_OPTIONS['endpoint'] !== $options['endpoint'] ?? self::DEFAULT_OPTIONS['endpoint']) {
-            $clientConfiguration['endpoint'] = $options['endpoint'];
-        }
-
-        $parsedPath = explode('/', ltrim($parsedUrl['path'] ?? '/', '/'));
-        if (\count($parsedPath) > 0 && !empty($queueName = end($parsedPath))) {
-            $configuration['queue_name'] = $queueName;
-        }
-        $configuration['account'] = 2 === \count($parsedPath) ? $parsedPath[0] : $options['account'] ?? self::DEFAULT_OPTIONS['account'];
-
-        // When the DNS looks like a QueueUrl, we can directly inject it in the connection
-        // https://sqs.REGION.amazonaws.com/ACCOUNT/QUEUE
-        $queueUrl = null;
-        if (
-            'https' === $parsedUrl['scheme']
-            && ($parsedUrl['host'] ?? 'default') === "sqs.{$clientConfiguration['region']}.amazonaws.com"
-            && ($parsedUrl['path'] ?? '/') === "/{$configuration['account']}/{$configuration['queue_name']}"
-        ) {
-            $queueUrl = 'https://'.$parsedUrl['host'].$parsedUrl['path'];
-        }
+        [$configuration, $clientConfiguration, $queueUrl] = ConfigurationFactory::fromDsn($dsn, $options);
 
         return new self($configuration, new SqsClient($clientConfiguration, null, $client), $queueUrl);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #38640
| License       | MIT
| Doc PR        | The component doesn't have such low-level documentation.

## Problem
I had a case in my app where I wanted to use the same instance of `SqsClient` in my own code as well as via `Connection` from this package. While it is possible to inject an `SqsClient` into `Connection::__construct`, this makes us miss out on all the useful configuration processing that happens when using `Connection::fromDsn`, so I had to copy-paste all the code from `Connection::fromDsn` that's responsible for creating the client configuration.

## Solution
By separating the configuration processing logic from the instantiations done in the last line of `Connection::fromDsn`, we allow users to create an instance of `SqsClient` on their own without duplicating code.

## Usage
### Old usage
Backwards compatibility is preserved, i.e. a call to `Connection::fromDsn($dsn, $options)` will still give you a `Connection` with a created `SqsClient` inside it.

### New usage
If you want to create an `SqsClient` yourself, you can do it like this:
```php
[$connectionConfiguration, $clientConfiguration, $queueUrl] = ConfigurationFactory::fromDsn($dsn, $options);
$sqsClient = new SqsClient($clientConfiguration);
$connection = new Connection($connectionConfiguration, $sqsClient, $queueUrl);
```