### PR TITLE
Optimization: Remove unnecessary else and elseif blocks

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -141,7 +141,9 @@ EOF
     {
         if (is_file($filename)) {
             return [$filename];
-        } elseif (is_dir($filename)) {
+        }
+
+        if (is_dir($filename)) {
             return Finder::create()->files()->in($filename)->name('*.twig');
         }
 

--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationDefaultDomainNodeVisitor.php
@@ -51,13 +51,13 @@ final class TranslationDefaultDomainNodeVisitor extends AbstractNodeVisitor
                 $this->scope->set('domain', $node->getNode('expr'));
 
                 return $node;
-            } else {
-                $var = $this->getVarName();
-                $name = new AssignNameExpression($var, $node->getTemplateLine());
-                $this->scope->set('domain', new NameExpression($var, $node->getTemplateLine()));
-
-                return new SetNode(false, new Node([$name]), new Node([$node->getNode('expr')]), $node->getTemplateLine());
             }
+
+            $var = $this->getVarName();
+            $name = new AssignNameExpression($var, $node->getTemplateLine());
+            $this->scope->set('domain', new NameExpression($var, $node->getTemplateLine()));
+
+            return new SetNode(false, new Node([$name]), new Node([$node->getNode('expr')]), $node->getTemplateLine());
         }
 
         if (!$this->scope->has('domain')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -207,7 +207,9 @@ EOF
         $name = $input->getArgument('name');
         if ((null !== $name) && ($optionsCount > 0)) {
             throw new InvalidArgumentException('The options tags, tag, parameters & parameter can not be combined with the service name argument.');
-        } elseif ((null === $name) && $optionsCount > 1) {
+        }
+
+        if ((null === $name) && $optionsCount > 1) {
             throw new InvalidArgumentException('The options tags, tag, parameters & parameter can not be combined together.');
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
@@ -37,9 +37,9 @@ class ControllerResolver extends ContainerControllerResolver
         if ($controller instanceof AbstractController) {
             if (null === $previousContainer = $controller->setContainer($this->container)) {
                 throw new \LogicException(sprintf('"%s" has no container set, did you forget to define it as a service subscriber?', $class));
-            } else {
-                $controller->setContainer($previousContainer);
             }
+
+            $controller->setContainer($previousContainer);
         }
 
         return $controller;

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -224,7 +224,9 @@ class PrototypedArrayNode extends ArrayNode
                     $ex->setPath($this->getPath());
 
                     throw $ex;
-                } elseif (isset($v[$this->keyAttribute])) {
+                }
+
+                if (isset($v[$this->keyAttribute])) {
                     $k = $v[$this->keyAttribute];
 
                     // remove the key attribute when required

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1108,7 +1108,9 @@ class Application implements ResetInterface
                 if (!isset($parts[$i]) && $exists) {
                     $alternatives[$collectionName] += $threshold;
                     continue;
-                } elseif (!isset($parts[$i])) {
+                }
+
+                if (!isset($parts[$i])) {
                     continue;
                 }
 

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -168,7 +168,9 @@ class QuestionHelper extends Helper
 
         if ($validator = $question->getValidator()) {
             return \call_user_func($question->getValidator(), $default);
-        } elseif ($question instanceof ChoiceQuestion) {
+        }
+
+        if ($question instanceof ChoiceQuestion) {
             $choices = $question->getChoices();
 
             if (!$question->isMultiselect()) {
@@ -268,7 +270,9 @@ class QuestionHelper extends Helper
             if (false === $c || ('' === $ret && '' === $c && null === $question->getDefault())) {
                 shell_exec(sprintf('stty %s', $sttyMode));
                 throw new MissingInputException('Aborted.');
-            } elseif ("\177" === $c) { // Backspace Character
+            }
+
+            if ("\177" === $c) { // Backspace Character
                 if (0 === $numMatches && 0 !== $i) {
                     --$i;
                     $cursor->moveLeft(s($fullChoice)->slice(-1)->width(false));

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -120,9 +120,9 @@ class ArgvInput extends Input
                 $this->addLongOption($option->getName(), $i === $len - 1 ? null : substr($name, $i + 1));
 
                 break;
-            } else {
-                $this->addLongOption($option->getName(), null);
             }
+
+            $this->addLongOption($option->getName(), null);
         }
     }
 

--- a/src/Symfony/Component/CssSelector/Parser/Parser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Parser.php
@@ -317,7 +317,9 @@ class Parser implements ParserInterface
 
             if ($next->isDelimiter([']'])) {
                 return new Node\AttributeNode($selector, $namespace, $attribute, 'exists', null);
-            } elseif ($next->isDelimiter(['='])) {
+            }
+
+            if ($next->isDelimiter(['='])) {
                 $operator = '=';
             } elseif ($next->isDelimiter(['^', '$', '*', '~', '|', '!'])
                 && $stream->getPeek()->isDelimiter(['='])

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -436,7 +436,9 @@ class AutowirePass extends AbstractRecursivePass
         $servicesAndAliases = $container->getServiceIds();
         if (!$container->has($type) && false !== $key = array_search(strtolower($type), array_map('strtolower', $servicesAndAliases))) {
             return sprintf(' Did you mean "%s"?', $servicesAndAliases[$key]);
-        } elseif (isset($this->ambiguousServiceTypes[$type])) {
+        }
+
+        if (isset($this->ambiguousServiceTypes[$type])) {
             $message = sprintf('one of these existing services: "%s"', implode('", "', $this->ambiguousServiceTypes[$type]));
         } elseif (isset($this->types[$type])) {
             $message = sprintf('the existing "%s" service', $this->types[$type]);

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -123,7 +123,9 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass
 
         if (!$value instanceof Reference) {
             return parent::processValue($value, $isRoot);
-        } elseif (!$this->container->hasDefinition($id = (string) $value)) {
+        }
+
+        if (!$this->container->hasDefinition($id = (string) $value)) {
             return $value;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterEnvVarProcessorsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterEnvVarProcessorsPass.php
@@ -35,7 +35,9 @@ class RegisterEnvVarProcessorsPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds('container.env_var_processor') as $id => $tags) {
             if (!$r = $container->getReflectionClass($class = $container->getDefinition($id)->getClass())) {
                 throw new InvalidArgumentException(sprintf('Class "%s" used for service "%s" cannot be found.', $class, $id));
-            } elseif (!$r->isSubclassOf(EnvVarProcessorInterface::class)) {
+            }
+
+            if (!$r->isSubclassOf(EnvVarProcessorInterface::class)) {
                 throw new InvalidArgumentException(sprintf('Service "%s" must implement interface "%s".', $id, EnvVarProcessorInterface::class));
             }
             foreach ($class::getProvidedTypes() as $prefix => $type) {

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -244,7 +244,9 @@ class Container implements ContainerInterface, ResetInterface
         try {
             if (isset($this->fileMap[$id])) {
                 return /* self::IGNORE_ON_UNINITIALIZED_REFERENCE */ 4 === $invalidBehavior ? null : $this->load($this->fileMap[$id]);
-            } elseif (isset($this->methodMap[$id])) {
+            }
+
+            if (isset($this->methodMap[$id])) {
                 return /* self::IGNORE_ON_UNINITIALIZED_REFERENCE */ 4 === $invalidBehavior ? null : $this->{$this->methodMap[$id]}();
             }
         } catch (\Exception $e) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1732,7 +1732,9 @@ EOF;
             }
 
             return sprintf('[%s]', implode(', ', $code));
-        } elseif ($value instanceof ArgumentInterface) {
+        }
+
+        if ($value instanceof ArgumentInterface) {
             $scope = [$this->definitionVariables, $this->referenceVariables];
             $this->definitionVariables = $this->referenceVariables = null;
 
@@ -1854,15 +1856,15 @@ EOF;
                 // we do this to deal with non string values (Boolean, integer, ...)
                 // the preg_replace_callback converts them to strings
                 return $this->dumpParameter($match[1]);
-            } else {
-                $replaceParameters = function ($match) {
-                    return "'.".$this->dumpParameter($match[2]).".'";
-                };
-
-                $code = str_replace('%%', '%', preg_replace_callback('/(?<!%)(%)([^%]+)\1/', $replaceParameters, $this->export($value)));
-
-                return $code;
             }
+
+            $replaceParameters = function ($match) {
+                return "'.".$this->dumpParameter($match[2]).".'";
+            };
+
+            $code = str_replace('%%', '%', preg_replace_callback('/(?<!%)(%)([^%]+)\1/', $replaceParameters, $this->export($value)));
+
+            return $code;
         } elseif ($value instanceof AbstractArgument) {
             throw new RuntimeException($value->getTextWithContext());
         } elseif (\is_object($value) || \is_resource($value)) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -296,17 +296,29 @@ class YamlDumper extends Dumper
             }
 
             return $code;
-        } elseif ($value instanceof Reference) {
+        }
+
+        if ($value instanceof Reference) {
             return $this->getServiceCall((string) $value, $value);
-        } elseif ($value instanceof Parameter) {
+        }
+
+        if ($value instanceof Parameter) {
             return $this->getParameterCall((string) $value);
-        } elseif ($value instanceof Expression) {
+        }
+
+        if ($value instanceof Expression) {
             return $this->getExpressionCall((string) $value);
-        } elseif ($value instanceof Definition) {
+        }
+
+        if ($value instanceof Definition) {
             return new TaggedValue('service', (new Parser())->parse("_:\n".$this->addService('_', $value), Yaml::PARSE_CUSTOM_TAGS)['_']['_']);
-        } elseif ($value instanceof AbstractArgument) {
+        }
+
+        if ($value instanceof AbstractArgument) {
             return new TaggedValue('abstract', $value->getText());
-        } elseif (\is_object($value) || \is_resource($value)) {
+        }
+
+        if (\is_object($value) || \is_resource($value)) {
             throw new RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
         }
 

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -120,9 +120,9 @@ class EnvVarProcessor implements EnvVarProcessorInterface
 
             if ('file' === $prefix) {
                 return file_get_contents($file);
-            } else {
-                return require $file;
             }
+
+            return require $file;
         }
 
         if (false !== $i || 'string' !== $prefix) {

--- a/src/Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php
@@ -44,7 +44,9 @@ class FileTypeFilterIterator extends \FilterIterator
         $fileinfo = $this->current();
         if (self::ONLY_DIRECTORIES === (self::ONLY_DIRECTORIES & $this->mode) && $fileinfo->isFile()) {
             return false;
-        } elseif (self::ONLY_FILES === (self::ONLY_FILES & $this->mode) && $fileinfo->isDir()) {
+        }
+
+        if (self::ONLY_FILES === (self::ONLY_FILES & $this->mode) && $fileinfo->isDir()) {
             return false;
         }
 

--- a/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
@@ -101,9 +101,9 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
             if ($this->ignoreUnreadableDirs) {
                 // If directory is unreadable and finder is set to ignore it, a fake empty content is returned.
                 return new \RecursiveArrayIterator([]);
-            } else {
-                throw new AccessDeniedException($e->getMessage(), $e->getCode(), $e);
             }
+
+            throw new AccessDeniedException($e->getMessage(), $e->getCode(), $e);
         }
     }
 

--- a/src/Symfony/Component/Finder/Iterator/SortableIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SortableIterator.php
@@ -52,7 +52,9 @@ class SortableIterator implements \IteratorAggregate
             $this->sort = static function (\SplFileInfo $a, \SplFileInfo $b) use ($order) {
                 if ($a->isDir() && $b->isFile()) {
                     return -$order;
-                } elseif ($a->isFile() && $b->isDir()) {
+                }
+
+                if ($a->isFile() && $b->isDir()) {
                     return $order;
                 }
 

--- a/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/ChoiceList/ArrayChoiceList.php
@@ -219,7 +219,9 @@ class ArrayChoiceList implements ChoiceListInterface
                 }
 
                 continue;
-            } elseif (!is_scalar($choice)) {
+            }
+
+            if (!is_scalar($choice)) {
                 return false;
             }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -127,7 +127,9 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
 
         if (0 != intl_get_error_code()) {
             throw new TransformationFailedException(intl_get_error_message(), intl_get_error_code());
-        } elseif ($timestamp > 253402214400) {
+        }
+
+        if ($timestamp > 253402214400) {
             // This timestamp represents UTC midnight of 9999-12-31 to prevent 5+ digit years
             throw new TransformationFailedException('Years beyond 9999 are not supported.');
         }

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -289,13 +289,19 @@ class ChoiceType extends AbstractType
             if ($options['multiple']) {
                 // never use an empty value for this case
                 return null;
-            } elseif ($options['required'] && ($options['expanded'] || isset($options['attr']['size']) && $options['attr']['size'] > 1)) {
+            }
+
+            if ($options['required'] && ($options['expanded'] || isset($options['attr']['size']) && $options['attr']['size'] > 1)) {
                 // placeholder for required radio buttons or a select with size > 1 does not make sense
                 return null;
-            } elseif (false === $placeholder) {
+            }
+
+            if (false === $placeholder) {
                 // an empty value should be added but the user decided otherwise
                 return null;
-            } elseif ($options['expanded'] && '' === $placeholder) {
+            }
+
+            if ($options['expanded'] && '' === $placeholder) {
                 // never use an empty label for radio buttons
                 return 'None';
             }

--- a/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
@@ -98,7 +98,9 @@ abstract class AbstractSurrogateFragmentRenderer extends RoutableFragmentRendere
         foreach ($values as $value) {
             if (\is_array($value)) {
                 return $this->containsNonScalars($value);
-            } elseif (!is_scalar($value) && null !== $value) {
+            }
+
+            if (!is_scalar($value) && null !== $value) {
                 return true;
             }
         }

--- a/src/Symfony/Component/Mime/Header/ParameterizedHeader.php
+++ b/src/Symfony/Component/Mime/Header/ParameterizedHeader.php
@@ -146,9 +146,9 @@ final class ParameterizedHeader extends UnstructuredHeader
             }
 
             return implode(";\r\n ", $paramLines);
-        } else {
-            return $name.$this->getEndOfParameterValue($valueLines[0], $encoded, true);
         }
+
+        return $name.$this->getEndOfParameterValue($valueLines[0], $encoded, true);
     }
 
     /**

--- a/src/Symfony/Component/Mime/Test/Constraint/EmailAddressContains.php
+++ b/src/Symfony/Component/Mime/Test/Constraint/EmailAddressContains.php
@@ -49,7 +49,9 @@ final class EmailAddressContains extends Constraint
         $header = $message->getHeaders()->get($this->headerName);
         if ($header instanceof MailboxHeader) {
             return $this->expectedValue === $header->getAddress()->getAddress();
-        } elseif ($header instanceof MailboxListHeader) {
+        }
+
+        if ($header instanceof MailboxListHeader) {
             foreach ($header->getAddresses() as $address) {
                 if ($this->expectedValue === $address->getAddress()) {
                     return true;

--- a/src/Symfony/Component/Process/Tests/PipeStdinInStdoutStdErrStreamSelect.php
+++ b/src/Symfony/Component/Process/Tests/PipeStdinInStdoutStdErrStreamSelect.php
@@ -30,7 +30,9 @@ while ($read || $write) {
 
     if (false === $n) {
         exit(ERR_SELECT_FAILED);
-    } elseif ($n < 1) {
+    }
+
+    if ($n < 1) {
         exit(ERR_TIMEOUT);
     }
 

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -128,7 +128,9 @@ class AnnotationFileLoader extends FileLoader
                     if (\T_DOUBLE_COLON === $tokens[$j][0] || \T_NEW === $tokens[$j][0]) {
                         $skipClassToken = true;
                         break;
-                    } elseif (!\in_array($tokens[$j][0], [\T_WHITESPACE, \T_DOC_COMMENT, \T_COMMENT])) {
+                    }
+
+                    if (!\in_array($tokens[$j][0], [\T_WHITESPACE, \T_DOC_COMMENT, \T_COMMENT])) {
                         break;
                     }
                 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
@@ -65,12 +65,16 @@ class AuthenticatedVoterTest extends TestCase
     {
         if ('fully' === $authenticated) {
             return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')->getMock();
-        } elseif ('remembered' === $authenticated) {
-            return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')->setMethods(['setPersistent'])->disableOriginalConstructor()->getMock();
-        } elseif ('impersonated' === $authenticated) {
-            return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken')->disableOriginalConstructor()->getMock();
-        } else {
-            return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken')->setConstructorArgs(['', ''])->getMock();
         }
+
+        if ('remembered' === $authenticated) {
+            return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')->setMethods(['setPersistent'])->disableOriginalConstructor()->getMock();
+        }
+
+        if ('impersonated' === $authenticated) {
+            return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken')->disableOriginalConstructor()->getMock();
+        }
+
+        return $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken')->setConstructorArgs(['', ''])->getMock();
     }
 }

--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -90,9 +90,9 @@ class ChainUserProvider implements UserProviderInterface, PasswordUpgraderInterf
             $e = new UsernameNotFoundException(sprintf('There is no user with name "%s".', $user->getUsername()));
             $e->setUsername($user->getUsername());
             throw $e;
-        } else {
-            throw new UnsupportedUserException(sprintf('There is no user provider for user "%s". Shouldn\'t the "supportsClass()" method of your user provider return true for this classname?', get_debug_type($user)));
         }
+
+        throw new UnsupportedUserException(sprintf('There is no user provider for user "%s". Shouldn\'t the "supportsClass()" method of your user provider return true for this classname?', get_debug_type($user)));
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -472,7 +472,9 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
     {
         if (\is_array($val)) {
             return $this->buildXml($node, $val);
-        } elseif ($val instanceof \SimpleXMLElement) {
+        }
+
+        if ($val instanceof \SimpleXMLElement) {
             $child = $this->dom->importNode(dom_import_simplexml($val), true);
             $node->appendChild($child);
         } elseif ($val instanceof \Traversable) {

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -397,9 +397,9 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
 
             if ($constructor->isConstructor()) {
                 return $reflectionClass->newInstanceArgs($params);
-            } else {
-                return $constructor->invokeArgs(null, $params);
             }
+
+            return $constructor->invokeArgs(null, $params);
         }
 
         return new $class();

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -147,7 +147,9 @@ class PhpEngine implements EngineInterface, \ArrayAccess
             $this->evalTemplate = null;
 
             return ob_get_clean();
-        } elseif ($this->evalTemplate instanceof StringStorage) {
+        }
+
+        if ($this->evalTemplate instanceof StringStorage) {
             extract($this->evalParameters, \EXTR_SKIP);
             $this->evalParameters = null;
 

--- a/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PoFileDumper.php
@@ -103,9 +103,9 @@ EOF;
             if (preg_match($intervalRegexp, $part)) {
                 // Explicit rule is not a standard rule.
                 return [];
-            } else {
-                $standardRules[] = $part;
             }
+
+            $standardRules[] = $part;
         }
 
         return $standardRules;

--- a/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
@@ -269,7 +269,9 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
                     if ($this->normalizeToken($tokenIterator->current()) === $item) {
                         $tokenIterator->next();
                         continue;
-                    } elseif (self::MESSAGE_TOKEN === $item) {
+                    }
+
+                    if (self::MESSAGE_TOKEN === $item) {
                         $message = $this->getValue($tokenIterator);
 
                         if (\count($sequence) === ($sequenceKey + 1)) {

--- a/src/Symfony/Component/Translation/Extractor/PhpStringTokenParser.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpStringTokenParser.php
@@ -80,9 +80,9 @@ class PhpStringTokenParser
                 ['\\', '\''],
                 substr($str, $bLength + 1, -1)
             );
-        } else {
-            return self::parseEscapeSequences(substr($str, $bLength + 1, -1), '"');
         }
+
+        return self::parseEscapeSequences(substr($str, $bLength + 1, -1), '"');
     }
 
     /**
@@ -112,11 +112,13 @@ class PhpStringTokenParser
 
         if (isset(self::$replacements[$str])) {
             return self::$replacements[$str];
-        } elseif ('x' === $str[0] || 'X' === $str[0]) {
-            return \chr(hexdec($str));
-        } else {
-            return \chr(octdec($str));
         }
+
+        if ('x' === $str[0] || 'X' === $str[0]) {
+            return \chr(hexdec($str));
+        }
+
+        return \chr(octdec($str));
     }
 
     /**

--- a/src/Symfony/Component/Translation/Loader/IcuDatFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/IcuDatFileLoader.php
@@ -44,7 +44,9 @@ class IcuDatFileLoader extends IcuResFileLoader
 
         if (!$rb) {
             throw new InvalidResourceException(sprintf('Cannot load resource "%s".', $resource));
-        } elseif (intl_is_failure($rb->getErrorCode())) {
+        }
+
+        if (intl_is_failure($rb->getErrorCode())) {
             throw new InvalidResourceException($rb->getErrorMessage(), $rb->getErrorCode());
         }
 

--- a/src/Symfony/Component/Translation/Loader/IcuResFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/IcuResFileLoader.php
@@ -44,7 +44,9 @@ class IcuResFileLoader implements LoaderInterface
 
         if (!$rb) {
             throw new InvalidResourceException(sprintf('Cannot load resource "%s".', $resource));
-        } elseif (intl_is_failure($rb->getErrorCode())) {
+        }
+
+        if (intl_is_failure($rb->getErrorCode())) {
             throw new InvalidResourceException($rb->getErrorMessage(), $rb->getErrorCode());
         }
 

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -86,7 +86,9 @@ class EmailValidator extends ConstraintValidator
                     ->addViolation();
 
                 return;
-            } elseif (!interface_exists(EmailValidation::class) && !$strictValidator->isValid($value, false, true)) {
+            }
+
+            if (!interface_exists(EmailValidation::class) && !$strictValidator->isValid($value, false, true)) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
                     ->setCode(Email::INVALID_FORMAT_ERROR)

--- a/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IsbnValidator.php
@@ -174,9 +174,13 @@ class IsbnValidator extends ConstraintValidator
     {
         if (null !== $constraint->message) {
             return $constraint->message;
-        } elseif (Isbn::ISBN_10 === $type) {
+        }
+
+        if (Isbn::ISBN_10 === $type) {
             return $constraint->isbn10Message;
-        } elseif (Isbn::ISBN_13 === $type) {
+        }
+
+        if (Isbn::ISBN_13 === $type) {
             return $constraint->isbn13Message;
         }
 

--- a/src/Symfony/Component/VarDumper/Dumper/ContextProvider/SourceContextProvider.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ContextProvider/SourceContextProvider.php
@@ -61,7 +61,9 @@ final class SourceContextProvider implements ContextProviderInterface
                         $line = $trace[$i]['line'];
 
                         break;
-                    } elseif (isset($trace[$i]['object']) && $trace[$i]['object'] instanceof Template) {
+                    }
+
+                    if (isset($trace[$i]['object']) && $trace[$i]['object'] instanceof Template) {
                         $template = $trace[$i]['object'];
                         $name = $template->getTemplateName();
                         $src = method_exists($template, 'getSourceContext') ? $template->getSourceContext()->getCode() : (method_exists($template, 'getSource') ? $template->getSource() : false);

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -637,9 +637,9 @@ class Inline
 
                 if ('-' === $scalar[0]) {
                     return -octdec($value);
-                } else {
-                    return octdec($value);
                 }
+
+                return octdec($value);
 
             // Optimize for returning strings.
             // no break

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -745,7 +745,9 @@ class Parser
         try {
             if ('' !== $value && '{' === $value[0]) {
                 return Inline::parse($this->lexInlineMapping($value), $flags, $this->refs);
-            } elseif ('' !== $value && '[' === $value[0]) {
+            }
+
+            if ('' !== $value && '[' === $value[0]) {
                 return Inline::parse($this->lexInlineSequence($value), $flags, $this->refs);
             }
 

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -93,7 +93,9 @@ EOF;
                 $test = $this->parser->parse($yaml);
                 if (isset($test['dump_skip']) && $test['dump_skip']) {
                     continue;
-                } elseif (isset($test['todo']) && $test['todo']) {
+                }
+
+                if (isset($test['todo']) && $test['todo']) {
                     // TODO
                 } else {
                     eval('$expected = '.trim($test['php']).';');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | _N/A_
| License       | MIT
| Doc PR        | _N/A_


---

This is a rather big PR, but makes the same change throughout the code base.
In all changes in this PR, it removes `else` and `elseif` blocks where they are not necessary.

```php
if ($x === 1) {
	return 'Foo';
}
else {
	return 'Bar';
}
```

In the snippet above, we don't really need to use an `else` block because the block right above it stops the code flow with the `return` statement.

```diff
if ($x === 1) {
	return 'Foo';
}
-else {
-	return 'Bar';
-}
+
+ return 'Bar';
}

```

This makes the code more cleaner and more easier to read.

Throughout this PR, it simplifies `else` and `elseif` blocks if the previous block stops the code flow with `return`, `throw`, `continue`, `break`, or `yield` statements.

This optimization is more pronounced when elseif chains are removed.

```php

if ($value instanceof Parameter) {
    return $this->getParameterCall((string) $value);
} elseif ($value instanceof Expression) {
    return $this->getExpressionCall((string) $value);
} elseif ($value instanceof Definition) {
    return new TaggedValue('service', (new Parser())->parse("_:\n".$this->addService('_', $value), Yaml::PARSE_CUSTOM_TAGS)['_']['_']);
} elseif ($value instanceof AbstractArgument) {
    return new TaggedValue('abstract', $value->getText());
} elseif (\is_object($value) || \is_resource($value)) {
    throw new RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
}
```

This block, without a lot of breathing room, and seemingly connected chain is not exactly "connected" because all blocks halt the flow with their `return` calls.

```php
if ($value instanceof Reference) {
    return $this->getServiceCall((string) $value, $value);
}

if ($value instanceof Parameter) {
    return $this->getParameterCall((string) $value);
}

if ($value instanceof Expression) {
    return $this->getExpressionCall((string) $value);
}

if ($value instanceof Definition) {
    return new TaggedValue('service', (new Parser())->parse("_:\n".$this->addService('_', $value), Yaml::PARSE_CUSTOM_TAGS)['_']['_']);
}

if ($value instanceof AbstractArgument) {
    return new TaggedValue('abstract', $value->getText());
}

if (\is_object($value) || \is_resource($value)) {
    throw new RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
}
```

With more breathing room and clear separation, it is more easier for eyes to scan through individual cases.
