### PR TITLE
[Console] Fix ANSI when stdErr is not a tty

### DIFF
--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -41,6 +41,13 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
     {
         parent::__construct($this->openOutputStream(), $verbosity, $decorated, $formatter);
 
+        if (null === $formatter) {
+            // for BC reasons, stdErr has it own Formatter only when user don't inject a specific formatter.
+            $this->stderr = new StreamOutput($this->openErrorStream(), $verbosity, $decorated);
+
+            return;
+        }
+
         $actualDecorated = $this->isDecorated();
         $this->stderr = new StreamOutput($this->openErrorStream(), $verbosity, $decorated, $this->getFormatter());
 

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleOutputTest.php
@@ -18,11 +18,19 @@ use Symfony\Component\Console\Output\Output;
 
 class ConsoleOutputTest extends TestCase
 {
-    public function testConstructor()
+    public function testConstructorWithoutFormatter()
     {
         $output = new ConsoleOutput(Output::VERBOSITY_QUIET, true);
         $this->assertEquals(Output::VERBOSITY_QUIET, $output->getVerbosity(), '__construct() takes the verbosity as its first argument');
-        $this->assertSame($output->getFormatter(), $output->getErrorOutput()->getFormatter(), '__construct() takes a formatter or null as the third argument');
+        $this->assertNotSame($output->getFormatter(), $output->getErrorOutput()->getFormatter(), 'ErrorOutput should use it own formatter');
+    }
+
+    public function testConstructorWithFormatter()
+    {
+        $output = new ConsoleOutput(Output::VERBOSITY_QUIET, true, $formatter = new OutputFormatter());
+        $this->assertEquals(Output::VERBOSITY_QUIET, $output->getVerbosity(), '__construct() takes the verbosity as its first argument');
+        $this->assertSame($formatter, $output->getFormatter());
+        $this->assertSame($formatter, $output->getErrorOutput()->getFormatter(), 'Output and ErrorOutput should use the same provided formatter');
     }
 
     public function testSetFormatter()
@@ -31,6 +39,7 @@ class ConsoleOutputTest extends TestCase
         $outputFormatter = new OutputFormatter();
         $output->setFormatter($outputFormatter);
         $this->assertSame($outputFormatter, $output->getFormatter());
+        $this->assertSame($outputFormatter, $output->getErrorOutput()->getFormatter());
     }
 
     public function testSetVerbosity()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38981
| License       | MIT
| Doc PR        | -

Taking the @wouterj 's comment into account (https://github.com/symfony/symfony/issues/38981#issuecomment-721915428)

This PR prevents using the same Formatter for stdOut and stdErr when possible.

When user send a custom formatter (or call `setFormatter`) the previous logic is kept.
Otherwise, symfony is asked to create the Formatter, and thus is able to clone the formatter.

In a future PR targeting 5.3, we could improve the constructor to let people inject 2 distinguished formatters