### PR TITLE
Remove the default values from setters with a nullable parameter

### DIFF
--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -1,10 +1,30 @@
 UPGRADE FROM 6.1 to 6.2
 =======================
 
+Config
+------
+
+ * Deprecate calling `NodeBuilder::setParent()` without any arguments
+
+Console
+-------
+
+ * Deprecate calling `*Command::setApplication()`, `*FormatterStyle::setForeground/setBackground()`, `Helper::setHelpSet()`, `Input*::setDefault()`, `Question::setAutocompleterCallback/setValidator()`without    any arguments
+ * Change the signature of `OutputFormatterStyleInterface::setForeground/setBackground()` to `setForeground/setBackground(?string)`
+ * Change the signature of `HelperInterface::setHelperSet()` to `setHelperSet(?HelperSet)`
+
 DependencyInjection
 -------------------
 
- * The signature of `ContainerAwareInterface::setContainer()` has been updated to `setContainer(?ContainerInterface $container)`; explicitly pass `null` if you want to unset the container
+ * Change the signature of `ContainerAwareInterface::setContainer()` to `setContainer(?ContainerInterface)`
+ * Deprecate calling `ContainerAwareTrait::setContainer()` without arguments
+
+Form
+----
+
+ * Deprecate calling `Button/Form::setParent()`, `ButtonBuilder/FormConfigBuilder::setDataMapper()`, `TransformationFailedException::setInvalidMessage()` without arguments
+ * Change the signature of `FormConfigBuilderInterface::setDataMapper()` to `setDataMapper(?DataMapperInterface)`
+ * Change the signature of `FormInterface::setParent()` to `setParent(?self)`
 
 FrameworkBundle
 ---------------
@@ -18,11 +38,13 @@ HttpFoundation
 --------------
 
  * Deprecate `Request::getContentType()`, use `Request::getContentTypeFormat()` instead
+ * Deprecate calling `JsonResponse::setCallback()`, `Response::setExpires/setLastModified/setEtag()`, `MockArraySessionStorage/NativeSessionStorage::setMetadataBag()`, `NativeSessionStorage::setSaveHandler()`   without arguments
 
 HttpKernel
 ----------
 
  * Deprecate `ArgumentValueResolverInterface`, use `ValueResolverInterface` instead
+ * Deprecate calling `ConfigDataCollector::setKernel()`, `RouterListener::setCurrentRequest()` without arguments
 
 Ldap
 ----
@@ -34,6 +56,16 @@ Mailer
 
  * Deprecate the `OhMySMTP` transport, use `MailPace` instead
 
+Mime
+----
+
+ * Deprecate calling `Message::setBody()` without arguments
+
+PropertyAccess
+--------------
+
+ * Deprecate calling `PropertyAccessorBuilder::setCacheItemPool()` without arguments
+
 Security
 --------
 
@@ -42,12 +74,25 @@ Security
  * Deprecate the `Symfony\Component\Security\Core\Security` class and service, use `Symfony\Bundle\SecurityBundle\Security\Security` instead
  * Passing empty username or password parameter when using `JsonLoginAuthenticator` is not supported anymore
  * Add `$lifetime` parameter to `LoginLinkHandlerInterface::createLoginLink()`
- * The signature of `TokenStorageInterface::setToken()` has been updated to `setToken(?TokenInterface $token)`; explicitly pass `null` if you want to unset the token
+ * Change the signature of `TokenStorageInterface::setToken()` to `setToken(?TokenInterface $token)`
+ * Deprecate calling `TokenStorage::setToken()` or `UsageTrackingTokenStorage::setToken()` without arguments
+
+Serializer
+----------
+
+ * Deprecate calling `AttributeMetadata::setSerializedName()`, `ClassMetadata::setClassDiscriminatorMapping()` without arguments
+ * Change the signature of `AttributeMetadataInterface::setSerializedName()` to `setSerializedName(?string)`
+ * Change the signature of `ClassMetadataInterface::setClassDiscriminatorMapping()` to `setClassDiscriminatorMapping(?ClassDiscriminatorMapping)`
 
 Validator
 ---------
 
  * Deprecate the `loose` e-mail validation mode, use `html5` instead
+
+VarDumper
+---------
+
+ * Deprecate calling `VarDumper::setHandler()` without arguments
 
 Workflow
 --------
@@ -58,3 +103,4 @@ Workflow
     ```
  * The first argument of `WorkflowDumpCommand` should be a `ServiceLocator` of
    all workflows indexed by names
+ * Deprecate calling `Definition::setInitialPlaces()` without arguments

--- a/UPGRADE-6.2.md
+++ b/UPGRADE-6.2.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 6.1 to 6.2
 =======================
 
+DependencyInjection
+-------------------
+
+ * The signature of `ContainerAwareInterface::setContainer()` has been updated to `setContainer(?ContainerInterface $container)`; explicitly pass `null` if you want to unset the container
+
 FrameworkBundle
 ---------------
 
@@ -37,6 +42,7 @@ Security
  * Deprecate the `Symfony\Component\Security\Core\Security` class and service, use `Symfony\Bundle\SecurityBundle\Security\Security` instead
  * Passing empty username or password parameter when using `JsonLoginAuthenticator` is not supported anymore
  * Add `$lifetime` parameter to `LoginLinkHandlerInterface::createLoginLink()`
+ * The signature of `TokenStorageInterface::setToken()` has been updated to `setToken(?TokenInterface $token)`; explicitly pass `null` if you want to unset the token
 
 Validator
 ---------

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ContainerAwareFixture.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/ContainerAwareFixture.php
@@ -20,7 +20,7 @@ class ContainerAwareFixture implements FixtureInterface, ContainerAwareInterface
 {
     public $container;
 
-    public function setContainer(ContainerInterface $container = null)
+    public function setContainer(?ContainerInterface $container)
     {
         $this->container = $container;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerResolverTest.php
@@ -172,7 +172,7 @@ class ContainerAwareController implements ContainerAwareInterface
 {
     private $container;
 
-    public function setContainer(ContainerInterface $container = null)
+    public function setContainer(?ContainerInterface $container)
     {
         $this->container = $container;
     }

--- a/src/Symfony/Component/Config/CHANGELOG.md
+++ b/src/Symfony/Component/Config/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Deprecate calling `NodeBuilder::setParent()` without any arguments
+
 6.1
 ---
 

--- a/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeBuilder.php
@@ -41,6 +41,9 @@ class NodeBuilder implements NodeParentInterface
      */
     public function setParent(ParentNodeDefinitionInterface $parent = null): static
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/form', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         $this->parent = $parent;
 
         return $this;

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,8 +4,11 @@ CHANGELOG
 6.2
 ---
 
-* Improve truecolor terminal detection in some cases
-* Add support for 256 color terminals (conversion from Ansi24 to Ansi8 if terminal is capable of it)
+ * Improve truecolor terminal detection in some cases
+ * Add support for 256 color terminals (conversion from Ansi24 to Ansi8 if terminal is capable of it)
+ * Deprecate calling `*Command::setApplication()`, `*FormatterStyle::setForeground/setBackground()`, `Helper::setHelpSet()`, `Input*::setDefault()`, `Question::setAutocompleterCallback/setValidator()`without any arguments
+ * Change the signature of `OutputFormatterStyleInterface::setForeground/setBackground()` to `setForeground/setBackground(?string)`
+ * Change the signature of `HelperInterface::setHelperSet()` to `setHelperSet(?HelperSet)`
 
 6.1
 ---

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -149,6 +149,9 @@ class Command
 
     public function setApplication(Application $application = null)
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/console', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         $this->application = $application;
         if ($application) {
             $this->setHelperSet($application->getHelperSet());

--- a/src/Symfony/Component/Console/Command/LazyCommand.php
+++ b/src/Symfony/Component/Console/Command/LazyCommand.php
@@ -47,6 +47,9 @@ final class LazyCommand extends Command
 
     public function setApplication(Application $application = null): void
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/console', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         if ($this->command instanceof parent) {
             $this->command->setApplication($application);
         }

--- a/src/Symfony/Component/Console/Formatter/NullOutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/NullOutputFormatterStyle.php
@@ -23,11 +23,17 @@ final class NullOutputFormatterStyle implements OutputFormatterStyleInterface
 
     public function setBackground(string $color = null): void
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/console', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         // do nothing
     }
 
     public function setForeground(string $color = null): void
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/console', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         // do nothing
     }
 

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -40,11 +40,17 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
 
     public function setForeground(string $color = null)
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/console', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         $this->color = new Color($this->foreground = $color ?: '', $this->background, $this->options);
     }
 
     public function setBackground(string $color = null)
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/console', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         $this->color = new Color($this->foreground, $this->background = $color ?: '', $this->options);
     }
 

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyleInterface.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyleInterface.php
@@ -21,12 +21,12 @@ interface OutputFormatterStyleInterface
     /**
      * Sets style foreground color.
      */
-    public function setForeground(string $color = null);
+    public function setForeground(?string $color);
 
     /**
      * Sets style background color.
      */
-    public function setBackground(string $color = null);
+    public function setBackground(?string $color);
 
     /**
      * Sets some specific style option.

--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -25,6 +25,9 @@ abstract class Helper implements HelperInterface
 
     public function setHelperSet(HelperSet $helperSet = null)
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/console', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         $this->helperSet = $helperSet;
     }
 

--- a/src/Symfony/Component/Console/Helper/HelperInterface.php
+++ b/src/Symfony/Component/Console/Helper/HelperInterface.php
@@ -21,7 +21,7 @@ interface HelperInterface
     /**
      * Sets the helper set associated with this helper.
      */
-    public function setHelperSet(HelperSet $helperSet = null);
+    public function setHelperSet(?HelperSet $helperSet);
 
     /**
      * Gets the helper set associated with this helper.

--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -95,6 +95,9 @@ class InputArgument
      */
     public function setDefault(string|bool|int|float|array $default = null)
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/console', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         if ($this->isRequired() && null !== $default) {
             throw new LogicException('Cannot set a default value except for InputArgument::OPTIONAL mode.');
         }

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -180,6 +180,9 @@ class InputOption
 
     public function setDefault(string|bool|int|float|array $default = null)
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/console', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         if (self::VALUE_NONE === (self::VALUE_NONE & $this->mode) && null !== $default) {
             throw new LogicException('Cannot set a default value when using InputOption::VALUE_NONE mode.');
         }

--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -178,6 +178,9 @@ class Question
      */
     public function setAutocompleterCallback(callable $callback = null): static
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/console', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         if ($this->hidden && null !== $callback) {
             throw new LogicException('A hidden question cannot use the autocompleter.');
         }
@@ -194,6 +197,9 @@ class Question
      */
     public function setValidator(callable $validator = null): static
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/console', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         $this->validator = null === $validator ? null : $validator(...);
 
         return $this;

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -9,6 +9,8 @@ CHANGELOG
  * Add `enum` env var processor
  * Add `shuffle` env var processor
  * Allow #[When] to be extended
+ * Change the signature of `ContainerAwareInterface::setContainer()` to `setContainer(?ContainerInterface $container)`
+ * Deprecate calling `ContainerAwareTrait::setContainer()` without arguments
 
 6.1
 ---

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -9,7 +9,7 @@ CHANGELOG
  * Add `enum` env var processor
  * Add `shuffle` env var processor
  * Allow #[When] to be extended
- * Change the signature of `ContainerAwareInterface::setContainer()` to `setContainer(?ContainerInterface $container)`
+ * Change the signature of `ContainerAwareInterface::setContainer()` to `setContainer(?ContainerInterface)`
  * Deprecate calling `ContainerAwareTrait::setContainer()` without arguments
 
 6.1

--- a/src/Symfony/Component/DependencyInjection/ContainerAwareInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerAwareInterface.php
@@ -21,5 +21,5 @@ interface ContainerAwareInterface
     /**
      * Sets the container.
      */
-    public function setContainer(ContainerInterface $container = null);
+    public function setContainer(?ContainerInterface $container);
 }

--- a/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php
@@ -25,6 +25,10 @@ trait ContainerAwareTrait
 
     public function setContainer(ContainerInterface $container = null)
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/dependency-injection', '6.2', 'Calling "%s::%s()" without any arguments is deprecated. Please explicitly pass null if you want to unset the container.', static::class, __FUNCTION__);
+        }
+
         $this->container = $container;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerAwareTrait.php
@@ -26,7 +26,7 @@ trait ContainerAwareTrait
     public function setContainer(ContainerInterface $container = null)
     {
         if (1 > \func_num_args()) {
-            trigger_deprecation('symfony/dependency-injection', '6.2', 'Calling "%s::%s()" without any arguments is deprecated. Please explicitly pass null if you want to unset the container.', static::class, __FUNCTION__);
+            trigger_deprecation('symfony/dependency-injection', '6.2', 'Calling "%s::%s()" without any arguments is deprecated, pass null explicitly instead.', __CLASS__, __FUNCTION__);
         }
 
         $this->container = $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerAwareTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerAwareTraitTest.php
@@ -33,7 +33,7 @@ class ContainerAwareTraitTest extends TestCase
 
         self::assertSame($container, $dummy->getContainer());
 
-        $this->expectDeprecation('Since symfony/dependency-injection 6.2: Calling "Symfony\Component\DependencyInjection\Tests\ContainerAwareDummy::setContainer()" without any arguments is deprecated. Please explicitly pass null if you want to unset the container.');
+        $this->expectDeprecation('Since symfony/dependency-injection 6.2: Calling "Symfony\Component\DependencyInjection\Tests\ContainerAwareDummy::setContainer()" without any arguments is deprecated, pass null explicitly instead.');
 
         $dummy->setContainer();
         self::assertNull($dummy->getContainer());

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerAwareTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerAwareTraitTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class ContainerAwareTraitTest extends TestCase
+{
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
+    public function testSetContainerLegacy()
+    {
+        $container = $this->createMock(ContainerInterface::class);
+
+        $dummy = new ContainerAwareDummy();
+        $dummy->setContainer($container);
+
+        self::assertSame($container, $dummy->getContainer());
+
+        $this->expectDeprecation('Since symfony/dependency-injection 6.2: Calling "Symfony\Component\DependencyInjection\Tests\ContainerAwareDummy::setContainer()" without any arguments is deprecated. Please explicitly pass null if you want to unset the container.');
+
+        $dummy->setContainer();
+        self::assertNull($dummy->getContainer());
+    }
+
+    public function testSetContainer()
+    {
+        $container = $this->createMock(ContainerInterface::class);
+
+        $dummy = new ContainerAwareDummy();
+        $dummy->setContainer($container);
+
+        self::assertSame($container, $dummy->getContainer());
+
+        $dummy->setContainer(null);
+        self::assertNull($dummy->getContainer());
+    }
+}
+
+class ContainerAwareDummy implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    public function getContainer(): ?ContainerInterface
+    {
+        return $this->container;
+    }
+}

--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -83,6 +83,9 @@ class Button implements \IteratorAggregate, FormInterface
 
     public function setParent(FormInterface $parent = null): static
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/form', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         if ($this->submitted) {
             throw new AlreadySubmittedException('You cannot set the parent of a submitted button.');
         }

--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -194,6 +194,10 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      */
     public function setDataMapper(DataMapperInterface $dataMapper = null): static
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/form', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
+
         throw new BadMethodCallException('Buttons do not support data mappers.');
     }
 

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,8 +4,11 @@ CHANGELOG
 6.2
 ---
 
-* Allow passing `TranslatableInterface` objects to the `ChoiceView` label
-* Allow passing `TranslatableInterface` objects to the `help` option
+ * Allow passing `TranslatableInterface` objects to the `ChoiceView` label
+ * Allow passing `TranslatableInterface` objects to the `help` option
+ * Deprecate calling `Button/Form::setParent()`, `ButtonBuilder/FormConfigBuilder::setDataMapper()`, `TransformationFailedException::setInvalidMessage()` without arguments
+ * Change the signature of `FormConfigBuilderInterface::setDataMapper()` to `setDataMapper(?DataMapperInterface)`
+ * Change the signature of `FormInterface::setParent()` to `setParent(?self)`
 
 6.1
 ---

--- a/src/Symfony/Component/Form/Exception/TransformationFailedException.php
+++ b/src/Symfony/Component/Form/Exception/TransformationFailedException.php
@@ -36,6 +36,9 @@ class TransformationFailedException extends RuntimeException
      */
     public function setInvalidMessage(string $invalidMessage = null, array $invalidMessageParameters = []): void
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/form', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         $this->invalidMessage = $invalidMessage;
         $this->invalidMessageParameters = $invalidMessageParameters;
     }

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -220,6 +220,10 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
 
     public function setParent(FormInterface $parent = null): static
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/form', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
+
         if ($this->submitted) {
             throw new AlreadySubmittedException('You cannot set the parent of a submitted form.');
         }

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -340,6 +340,9 @@ class FormConfigBuilder implements FormConfigBuilderInterface
 
     public function setDataMapper(DataMapperInterface $dataMapper = null): static
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/form', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         if ($this->locked) {
             throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -100,7 +100,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      *
      * @return $this
      */
-    public function setDataMapper(DataMapperInterface $dataMapper = null): static;
+    public function setDataMapper(?DataMapperInterface $dataMapper): static;
 
     /**
      * Sets whether the form is disabled.

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -34,7 +34,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      * @throws Exception\LogicException            when trying to set a parent for a form with
      *                                             an empty name
      */
-    public function setParent(self $parent = null): static;
+    public function setParent(?self $parent): static;
 
     /**
      * Returns the parent form.

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * The HTTP cache store uses the `xxh128` algorithm
+ * Deprecate calling `JsonResponse::setCallback()`, `Response::setExpires/setLastModified/setEtag()`, `MockArraySessionStorage/NativeSessionStorage::setMetadataBag()`, `NativeSessionStorage::setSaveHandler()` without arguments
 
 6.1
 ---

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -79,6 +79,9 @@ class JsonResponse extends Response
      */
     public function setCallback(string $callback = null): static
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/http-foundation', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         if (null !== $callback) {
             // partially taken from https://geekality.net/2011/08/03/valid-javascript-identifier/
             // partially taken from https://github.com/willdurand/JsonpCallbackValidator

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -720,6 +720,9 @@ class Response
      */
     public function setExpires(\DateTimeInterface $date = null): static
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/http-foundation', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         if (null === $date) {
             $this->headers->remove('Expires');
 
@@ -899,6 +902,9 @@ class Response
      */
     public function setLastModified(\DateTimeInterface $date = null): static
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/http-foundation', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         if (null === $date) {
             $this->headers->remove('Last-Modified');
 
@@ -937,6 +943,9 @@ class Response
      */
     public function setEtag(string $etag = null, bool $weak = false): static
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/http-foundation', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         if (null === $etag) {
             $this->headers->remove('Etag');
         } else {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
@@ -173,6 +173,9 @@ class MockArraySessionStorage implements SessionStorageInterface
 
     public function setMetadataBag(MetadataBag $bag = null)
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/http-foundation', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         if (null === $bag) {
             $bag = new MetadataBag();
         }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -301,6 +301,9 @@ class NativeSessionStorage implements SessionStorageInterface
 
     public function setMetadataBag(MetadataBag $metaBag = null)
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/http-foundation', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         if (null === $metaBag) {
             $metaBag = new MetadataBag();
         }
@@ -377,10 +380,8 @@ class NativeSessionStorage implements SessionStorageInterface
      */
     public function setSaveHandler(AbstractProxy|\SessionHandlerInterface $saveHandler = null)
     {
-        if (!$saveHandler instanceof AbstractProxy &&
-            !$saveHandler instanceof \SessionHandlerInterface &&
-            null !== $saveHandler) {
-            throw new \InvalidArgumentException('Must be instance of AbstractProxy; implement \SessionHandlerInterface; or be null.');
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/http-foundation', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
         }
 
         // Wrap $saveHandler in proxy and prevent double wrapping of proxy

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -995,7 +995,7 @@ class ResponseTest extends ResponseTestCase
     public function testSetEtag()
     {
         $response = new Response('', 200, ['ETag' => '"12345"']);
-        $response->setEtag();
+        $response->setEtag(null);
 
         $this->assertNull($response->headers->get('Etag'), '->setEtag() removes Etags when call with null');
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -206,8 +206,6 @@ class NativeSessionStorageTest extends TestCase
     {
         $this->iniSet('session.save_handler', 'files');
         $storage = $this->getStorage();
-        $storage->setSaveHandler();
-        $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
         $storage->setSaveHandler(null);
         $this->assertInstanceOf(SessionHandlerProxy::class, $storage->getSaveHandler());
         $storage->setSaveHandler(new SessionHandlerProxy(new NativeFileSessionHandler()));

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * Add `absolute_uri` option to surrogate fragment renderers
  * Add `ValueResolverInterface` and deprecate `ArgumentValueResolverInterface`
  * Add argument `$reflector` to `ArgumentResolverInterface` and `ArgumentMetadataFactoryInterface`
+ * Deprecate calling `ConfigDataCollector::setKernel()`, `RouterListener::setCurrentRequest()` without arguments
 
 6.1
 ---

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -31,6 +31,10 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
      */
     public function setKernel(KernelInterface $kernel = null)
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/http-kernel', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
+
         $this->kernel = $kernel;
     }
 

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -68,7 +68,7 @@ class RouterListener implements EventSubscriberInterface
         $this->debug = $debug;
     }
 
-    private function setCurrentRequest(Request $request = null)
+    private function setCurrentRequest(?Request $request)
     {
         if (null !== $request) {
             try {

--- a/src/Symfony/Component/HttpKernel/HttpCache/ResponseCacheStrategy.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/ResponseCacheStrategy.php
@@ -110,7 +110,7 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
         $response->headers->set('Age', $this->age);
 
         if ($this->isNotCacheableResponseEmbedded) {
-            $response->setLastModified();
+            $response->setLastModified(null);
 
             if ($this->flagDirectives['no-store']) {
                 $response->headers->set('Cache-Control', 'no-cache, no-store, must-revalidate');

--- a/src/Symfony/Component/Mime/CHANGELOG.md
+++ b/src/Symfony/Component/Mime/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Deprecate calling `Message::setBody()` without arguments
+
 6.1
 ---
 

--- a/src/Symfony/Component/Mime/Message.php
+++ b/src/Symfony/Component/Mime/Message.php
@@ -44,6 +44,9 @@ class Message extends RawMessage
      */
     public function setBody(AbstractPart $body = null): static
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/mime', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         $this->body = $body;
 
         return $this;

--- a/src/Symfony/Component/PropertyAccess/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyAccess/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.2
+---
+
+ * Deprecate calling `PropertyAccessorBuilder::setCacheItemPool()` without arguments
+
 6.0
 ---
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
@@ -241,6 +241,9 @@ class PropertyAccessorBuilder
      */
     public function setCacheItemPool(CacheItemPoolInterface $cacheItemPool = null): static
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/property-access', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         $this->cacheItemPool = $cacheItemPool;
 
         return $this;

--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/TestClass.php
@@ -49,7 +49,7 @@ class TestClass
         $this->publicAccessor = $value;
     }
 
-    public function setPublicAccessorWithDefaultValue($value = null)
+    public function setPublicAccessorWithDefaultValue($value)
     {
         $this->publicAccessorWithDefaultValue = $value;
     }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorage.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorage.php
@@ -39,6 +39,10 @@ class TokenStorage implements TokenStorageInterface, ResetInterface
 
     public function setToken(TokenInterface $token = null)
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/security-core', '6.2', 'Calling "%s()" without any arguments is deprecated. Please explicitly pass null if you want to unset the token.', __METHOD__);
+        }
+
         if ($token) {
             // ensure any initializer is called
             $this->getToken();

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorage.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorage.php
@@ -40,7 +40,7 @@ class TokenStorage implements TokenStorageInterface, ResetInterface
     public function setToken(TokenInterface $token = null)
     {
         if (1 > \func_num_args()) {
-            trigger_deprecation('symfony/security-core', '6.2', 'Calling "%s()" without any arguments is deprecated. Please explicitly pass null if you want to unset the token.', __METHOD__);
+            trigger_deprecation('symfony/security-core', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
         }
 
         if ($token) {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorageInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorageInterface.php
@@ -30,5 +30,5 @@ interface TokenStorageInterface
      *
      * @param TokenInterface|null $token A TokenInterface token, or null if no further authentication information should be stored
      */
-    public function setToken(TokenInterface $token = null);
+    public function setToken(?TokenInterface $token);
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/UsageTrackingTokenStorage.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/UsageTrackingTokenStorage.php
@@ -46,6 +46,10 @@ final class UsageTrackingTokenStorage implements TokenStorageInterface, ServiceS
 
     public function setToken(TokenInterface $token = null): void
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/security-core', '6.2', 'Calling "%s()" without any arguments is deprecated. Please explicitly pass null if you want to unset the token.', __METHOD__);
+        }
+
         $this->storage->setToken($token);
 
         if ($token && $this->shouldTrackUsage()) {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/UsageTrackingTokenStorage.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/UsageTrackingTokenStorage.php
@@ -46,10 +46,6 @@ final class UsageTrackingTokenStorage implements TokenStorageInterface, ServiceS
 
     public function setToken(TokenInterface $token = null): void
     {
-        if (1 > \func_num_args()) {
-            trigger_deprecation('symfony/security-core', '6.2', 'Calling "%s()" without any arguments is deprecated. Please explicitly pass null if you want to unset the token.', __METHOD__);
-        }
-
         $this->storage->setToken($token);
 
         if ($token && $this->shouldTrackUsage()) {

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -4,7 +4,9 @@ CHANGELOG
 6.2
 ---
 
-* Deprecate the `Security` class, use `Symfony\Bundle\SecurityBundle\Security\Security` instead
+ * Deprecate the `Security` class, use `Symfony\Bundle\SecurityBundle\Security\Security` instead
+ * Change the signature of `TokenStorageInterface::setToken()` to `setToken(?TokenInterface $token)`
+ * Deprecate calling `TokenStorage::setToken()` or `UsageTrackingTokenStorage::setToken()` without arguments
 
 6.0
 ---

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * Deprecate the `Security` class, use `Symfony\Bundle\SecurityBundle\Security\Security` instead
  * Change the signature of `TokenStorageInterface::setToken()` to `setToken(?TokenInterface $token)`
- * Deprecate calling `TokenStorage::setToken()` or `UsageTrackingTokenStorage::setToken()` without arguments
+ * Deprecate calling `TokenStorage::setToken()` without arguments
 
 6.0
 ---

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/TokenStorageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/TokenStorageTest.php
@@ -27,11 +27,11 @@ class TokenStorageTest extends TestCase
     public function testGetSetTokenLegacy()
     {
         $tokenStorage = new TokenStorage();
-        $token = new UsernamePasswordToken('username', 'password', 'provider');
+        $token = new UsernamePasswordToken(new InMemoryUser('username', 'password'), 'provider');
         $tokenStorage->setToken($token);
         $this->assertSame($token, $tokenStorage->getToken());
 
-        $this->expectDeprecation('Since symfony/security-core 6.2: Calling "Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage::setToken()" without any arguments is deprecated. Please explicitly pass null if you want to unset the token.');
+        $this->expectDeprecation('Since symfony/security-core 6.2: Calling "Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage::setToken()" without any arguments is deprecated, pass null explicitly instead.');
 
         $tokenStorage->setToken();
         $this->assertNull($tokenStorage->getToken());

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/TokenStorageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/Storage/TokenStorageTest.php
@@ -12,12 +12,31 @@
 namespace Symfony\Component\Security\Core\Tests\Authentication\Token\Storage;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 
 class TokenStorageTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
+    public function testGetSetTokenLegacy()
+    {
+        $tokenStorage = new TokenStorage();
+        $token = new UsernamePasswordToken('username', 'password', 'provider');
+        $tokenStorage->setToken($token);
+        $this->assertSame($token, $tokenStorage->getToken());
+
+        $this->expectDeprecation('Since symfony/security-core 6.2: Calling "Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage::setToken()" without any arguments is deprecated. Please explicitly pass null if you want to unset the token.');
+
+        $tokenStorage->setToken();
+        $this->assertNull($tokenStorage->getToken());
+    }
+
     public function testGetSetToken()
     {
         $tokenStorage = new TokenStorage();
@@ -25,5 +44,7 @@ class TokenStorageTest extends TestCase
         $token = new UsernamePasswordToken(new InMemoryUser('username', 'password'), 'provider');
         $tokenStorage->setToken($token);
         $this->assertSame($token, $tokenStorage->getToken());
+        $tokenStorage->setToken(null);
+        $this->assertNull($tokenStorage->getToken());
     }
 }

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -4,9 +4,12 @@ CHANGELOG
 6.2
 ---
 
-* Add support for constructor promoted properties to `Context` attribute
-* Add context option `PropertyNormalizer::NORMALIZE_VISIBILITY` with bitmask flags `PropertyNormalizer::NORMALIZE_PUBLIC`, `PropertyNormalizer::NORMALIZE_PROTECTED`, `PropertyNormalizer::NORMALIZE_PRIVATE`
-* Add method `withNormalizeVisibility` to `PropertyNormalizerContextBuilder`
+ * Add support for constructor promoted properties to `Context` attribute
+ * Add context option `PropertyNormalizer::NORMALIZE_VISIBILITY` with bitmask flags `PropertyNormalizer::NORMALIZE_PUBLIC`, `PropertyNormalizer::NORMALIZE_PROTECTED`, `PropertyNormalizer::NORMALIZE_PRIVATE`
+ * Add method `withNormalizeVisibility` to `PropertyNormalizerContextBuilder`
+ * Deprecate calling `AttributeMetadata::setSerializedName()`, `ClassMetadata::setClassDiscriminatorMapping()` without arguments
+ * Change the signature of `AttributeMetadataInterface::setSerializedName()` to `setSerializedName(?string)`
+ * Change the signature of `ClassMetadataInterface::setClassDiscriminatorMapping()` to `setClassDiscriminatorMapping(?ClassDiscriminatorMapping)`
 
 6.1
 ---

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -109,6 +109,10 @@ class AttributeMetadata implements AttributeMetadataInterface
 
     public function setSerializedName(string $serializedName = null)
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/serializer', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
+
         $this->serializedName = $serializedName;
     }
 

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -52,7 +52,7 @@ interface AttributeMetadataInterface
     /**
      * Sets the serialization name for this attribute.
      */
-    public function setSerializedName(string $serializedName = null);
+    public function setSerializedName(?string $serializedName);
 
     /**
      * Gets the serialization name for this attribute.

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadata.php
@@ -97,6 +97,9 @@ class ClassMetadata implements ClassMetadataInterface
 
     public function setClassDiscriminatorMapping(ClassDiscriminatorMapping $mapping = null)
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/serializer', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         $this->classDiscriminatorMapping = $mapping;
     }
 

--- a/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/ClassMetadataInterface.php
@@ -53,5 +53,5 @@ interface ClassMetadataInterface
 
     public function getClassDiscriminatorMapping(): ?ClassDiscriminatorMapping;
 
-    public function setClassDiscriminatorMapping(ClassDiscriminatorMapping $mapping = null);
+    public function setClassDiscriminatorMapping(?ClassDiscriminatorMapping $mapping);
 }

--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for `FFI\CData` and `FFI\CType`
+ * Deprecate calling `VarDumper::setHandler()` without arguments
 
 5.4
 ---

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -48,6 +48,9 @@ class VarDumper
 
     public static function setHandler(callable $callable = null): ?callable
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/va-dumper', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         $prevHandler = self::$handler;
 
         // Prevent replacing the handler with expected format as soon as the env var was set:

--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Mark `Symfony\Component\Workflow\Registry` as internal
+ * Deprecate calling `Definition::setInitialPlaces()` without arguments
 
 6.0
 ---

--- a/src/Symfony/Component/Workflow/Definition.php
+++ b/src/Symfony/Component/Workflow/Definition.php
@@ -78,6 +78,9 @@ final class Definition
 
     private function setInitialPlaces(string|array $places = null)
     {
+        if (1 > \func_num_args()) {
+            trigger_deprecation('symfony/workflow', '6.2', 'Calling "%s()" without any arguments is deprecated, pass null explicitly instead.', __METHOD__);
+        }
         if (!$places) {
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Setters with a default value are a bit odd: I want to set a value, but I won't tell you which one!

We do have this kind of setters, like this example from `TokenStorageInterface`:

```php
public function setToken(TokenInterface $token = null);
```

This means that those to calls are equivalent:

```php
$tokenStorage->setToken(null);
$tokenStorage->setToken();
```

The reason for this is actually a php 5 quirk: On php 5, we did not have nullable parameter type declarations – those we added in php 7.1. The only workaround was to declare `null` as default value because then php would accept passing null despite the type declaration demanding an instance of a specific class/interface.

Because the days of php 5 are over, I'd like to change this. Our method signature would then look like this.

```php
public function setToken(?TokenInterface $token);
```

We can do this for interfaces and abstract methods because an implementation may add a default value. Thus, removing the default value from the interface alone is not a BC break.

For the implementations of that interface, this is a different story because removing the default breaks calling code that omits the parameter entirely. This is why for the implementations I trigger a deprecation if the method is called without arguments. This enables us to remove the default in Symfony 6.

This PR performs the suggested changes for `TokenStorageInterface` and `ContainerAwareInterface`, but we have a few more setters like this. But before I continue, I'd like to collect some feedback if this is something you would want to change.