### PR TITLE
[Validator] Override the default option of the choice constraint

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Choice.php
+++ b/src/Symfony/Component/Validator/Constraints/Choice.php
@@ -69,7 +69,7 @@ class Choice extends Constraint
         if (\is_array($choices) && \is_string(key($choices))) {
             $options = array_merge($choices, $options);
         } elseif (null !== $choices) {
-            $options['choices'] = $choices;
+            $options['value'] = $choices;
         }
 
         parent::__construct($options, $groups, $payload);

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintChoiceWithPreset;
+
+class ChoiceTest extends TestCase
+{
+    public function testSetDefaultPropertyChoice()
+    {
+        $constraint = new ConstraintChoiceWithPreset('A');
+
+        self::assertEquals(['A', 'B', 'C'], $constraint->choices);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintChoiceWithPreset.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintChoiceWithPreset.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures;
+
+use Symfony\Component\Validator\Constraints\Choice;
+
+class ConstraintChoiceWithPreset extends Choice
+{
+    public $type;
+
+    public function __construct(string $type) {
+        parent::__construct($type);
+
+        if ($this->type === 'A') {
+            $this->choices = ['A', 'B', 'C'];
+        } else {
+            $this->choices = ['D', 'E', 'F'];
+        }
+    }
+
+    public function getDefaultOption(): ?string
+    {
+        return 'type';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A 
| License       | MIT
| Doc PR        | TODO

We have a bundle that run test against the last version of symfony and we detect BC Break when passing a string as the first argument of the class Choice

Our code extends the Choice class and change the defaultOption.

I saw that others constraints class had new construct signature (for php8 attributes), but only some of them kept the array options as their first arguments. Why ?

ping @ogizanagi @derrabus 

https://travis-ci.com/github/Elao/PhpEnums/jobs/410045368
```
1) Elao\Enum\Tests\Unit\Bridge\Symfony\Validator\Constraint\EnumTest::testDefaultValueIsEnumClass
Symfony\Component\Validator\Exception\MissingOptionsException: The options "class" must be set for constraint "Elao\Enum\Bridge\Symfony\Validator\Constraint\Enum".
/home/travis/build/Elao/PhpEnums/vendor/symfony/symfony/src/Symfony/Component/Validator/Constraint.php:171
/home/travis/build/Elao/PhpEnums/vendor/symfony/symfony/src/Symfony/Component/Validator/Constraint.php:110
/home/travis/build/Elao/PhpEnums/vendor/symfony/symfony/src/Symfony/Component/Validator/Constraints/Choice.php:75
/home/travis/build/Elao/PhpEnums/src/Bridge/Symfony/Validator/Constraint/Enum.php:39
/home/travis/build/Elao/PhpEnums/tests/Unit/Bridge/Symfony/Validator/Constraint/EnumTest.php:22
```



