### PR TITLE
[CI] Fix invalid Doctrine parameter syntax

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
@@ -62,7 +62,7 @@ class DoctrineIntegrationTest extends TestCase
             ->select('m.available_at')
             ->from('messenger_messages', 'm')
             ->where('m.body = :body')
-            ->setParameter(':body', '{"message": "Hi i am delayed"}')
+            ->setParameter('body', '{"message": "Hi i am delayed"}')
             ->execute();
 
         $available_at = new \DateTime($stmt instanceof Result || $stmt instanceof DriverResult ? $stmt->fetchOne() : $stmt->fetchColumn());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39008 
| License       | MIT
| Doc PR        | no

~~I cannot reproduce locally.. So Im trying to fix this with the help of the CI~~

I have reproduced locally. This fix will help. 


```
❯ phpunit Tests/Transport/DoctrineIntegrationTest.php
PHPUnit 8.5.8 by Sebastian Bergmann and contributors.

.E....                                                              6 / 6 (100%)

Time: 111 ms, Memory: 6.00 MB

There was 1 error:

1) Symfony\Component\Messenger\Bridge\Doctrine\Tests\Transport\DoctrineIntegrationTest::testSendWithDelay
Doctrine\DBAL\SQLParserUtilsException: Value for :body not found in params array. Params array key should be "body"

src/Symfony/Component/Messenger/Bridge/Doctrine/vendor/doctrine/dbal/src/SQLParserUtilsException.php:21
src/Symfony/Component/Messenger/Bridge/Doctrine/vendor/doctrine/dbal/src/SQLParserUtils.php:277
src/Symfony/Component/Messenger/Bridge/Doctrine/vendor/doctrine/dbal/src/SQLParserUtils.php:203
src/Symfony/Component/Messenger/Bridge/Doctrine/vendor/doctrine/dbal/src/Connection.php:1019
src/Symfony/Component/Messenger/Bridge/Doctrine/vendor/doctrine/dbal/src/Query/QueryBuilder.php:210
src/Symfony/Component/Messenger/Bridge/Doctrine/Tests/Transport/DoctrineIntegrationTest.php:66

ERRORS!
Tests: 6, Assertions: 8, Errors: 1.
```

Apply patch: 

```
❯ phpunit Tests/Transport/DoctrineIntegrationTest.php
PHPUnit 8.5.8 by Sebastian Bergmann and contributors.

......                                                              6 / 6 (100%)

Time: 94 ms, Memory: 6.00 MB

OK (6 tests, 9 assertions)

```