### PR TITLE
[Cache] Provide default arguments to error handler

### DIFF
--- a/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
+++ b/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php
@@ -155,7 +155,7 @@ trait FilesystemCommonTrait
     /**
      * @internal
      */
-    public static function throwError($type, $message, $file, $line)
+    public static function throwError($type, $message, $file = '', $line = 0)
     {
         throw new \ErrorException($message, 0, $type, $file, $line);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39010 
| License       | MIT

Both `$file` and `$line` are [optional](https://www.php.net/manual/en/function.set-error-handler.php) and may not be passed. This only seems to happen in the newest version of PHP when the opcache preloader is used as documented [in this comment](https://github.com/symfony/symfony/issues/39010#issuecomment-722749730), but in that case it is a show stopping error.