### PR TITLE
[Yaml] Fix parsing multidimensional inline collections

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -1240,9 +1240,15 @@ class Parser
         }
 
         $value = $yaml;
+        $collectionLevel = 1;
 
         while ($this->moveToNextLine()) {
-            for ($i = 1; isset($this->currentLine[$i]) && ']' !== $this->currentLine[$i]; ++$i) {
+            for ($i = 1; isset($this->currentLine[$i]) && $collectionLevel >= 1; ++$i) {
+                if ('[' === $this->currentLine[$i]) {
+                    ++$collectionLevel;
+                } elseif (']' === $this->currentLine[$i]) {
+                    --$collectionLevel;
+                }
             }
 
             $trimmedValue = trim($this->currentLine);
@@ -1253,7 +1259,7 @@ class Parser
 
             $value .= $trimmedValue;
 
-            if (isset($this->currentLine[$i]) && ']' === $this->currentLine[$i]) {
+            if (0 === $collectionLevel) {
                 break;
             }
         }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2465,6 +2465,18 @@ YAML;
         // (before, there was no \n after row2)
         $this->assertSame(['a' => ['b' => "row\nrow2\n"], 'c' => 'd'], $this->parser->parse($longDocument));
     }
+
+    public function testParsingMultidimensionalCollectionOverMultipleLines()
+    {
+        $yaml = <<<YAML
+[
+    ["entry1", {}],
+    ["entry2"]
+]
+YAML;
+
+        $this->assertSame([['entry1', []], ['entry2']], $this->parser->parse($yaml));
+    }
 }
 
 class B


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39011 
| License       | MIT

Multidimensional yaml inline collections spread over multiple lines could not be parsed.
I could not find new problems fixing it that way. Also the thrown exceptions for incomplete collections are the same.