### PR TITLE
[ProxyManagerBridge] replace ProxyManager\Version by feature detection

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -11,9 +11,10 @@
 
 namespace Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper;
 
+use ProxyManager\Exception\ExceptionInterface;
 use ProxyManager\Generator\ClassGenerator;
+use ProxyManager\Generator\MethodGenerator;
 use ProxyManager\GeneratorStrategy\BaseGeneratorStrategy;
-use ProxyManager\Version;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface;
 
@@ -87,7 +88,7 @@ EOF;
         $code = $this->classGenerator->generate($this->generateProxyClass($definition));
         $code = preg_replace('/^(class [^ ]++ extends )([^\\\\])/', '$1\\\\$2', $code);
 
-        if (version_compare(self::getProxyManagerVersion(), '2.2', '<')) {
+        if (!method_exists(MethodGenerator::class, 'fromReflectionWithoutBodyAndDocBlock')) { // proxy-manager < 2.2
             $code = preg_replace(
                 '/((?:\$(?:this|initializer|instance)->)?(?:publicProperties|initializer|valueHolder))[0-9a-f]++/',
                 '${1}'.$this->getIdentifierSuffix($definition),
@@ -95,20 +96,11 @@ EOF;
             );
         }
 
-        if (version_compare(self::getProxyManagerVersion(), '2.5', '<')) {
+        if (!is_subclass_of(ExceptionInterface::class, 'Throwable')) { // proxy-manager < 2.5
             $code = preg_replace('/ \\\\Closure::bind\(function ((?:& )?\(\$instance(?:, \$value)?\))/', ' \Closure::bind(static function \1', $code);
         }
 
         return $code;
-    }
-
-    private static function getProxyManagerVersion(): string
-    {
-        if (!class_exists(Version::class)) {
-            return '0.0.1';
-        }
-
-        return \defined(Version::class.'::VERSION') ? Version::VERSION : Version::getVersion();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I'd like to get rid of this `Version` class, which is the source of so many issues with deps.
This won't remove the class from ocramius/proxy-manager, but that's a separate story that this change could enable in the end :)