### PR TITLE
[FrameworkBundle] Fixed validation of php_errors.log

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+ * Added support for configuring PHP error level to log levels
+
 5.2.0
 -----
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -313,8 +313,16 @@
     </xsd:complexType>
 
     <xsd:complexType name="php-errors">
+        <xsd:sequence>
+            <xsd:element name="log" type="logLevel" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
         <xsd:attribute name="log" type="xsd:string" />
         <xsd:attribute name="throw" type="xsd:boolean" />
+    </xsd:complexType>
+
+    <xsd:complexType name="logLevel" mixed="true">
+        <xsd:attribute name="type" type="xsd:string" use="required" />
+        <xsd:attribute name="logLevel" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="marking_store">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_log_levels.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/php_errors_log_levels.php
@@ -1,0 +1,10 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'php_errors' => [
+        'log' => [
+            \E_NOTICE => \Psr\Log\LogLevel::ERROR,
+            \E_WARNING => \Psr\Log\LogLevel::ERROR,
+        ]
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_log_levels.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/php_errors_log_levels.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:php-errors>
+            <framework:log type="8" logLevel="error" />
+            <framework:log type="2" logLevel="error" />
+        </framework:php-errors>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_log_levels.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/php_errors_log_levels.yml
@@ -1,0 +1,5 @@
+framework:
+    php_errors:
+        log:
+            !php/const \E_NOTICE: !php/const Psr\Log\LogLevel::ERROR
+            !php/const \E_WARNING: !php/const Psr\Log\LogLevel::ERROR

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -498,6 +498,18 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertSame(8, $definition->getArgument(2));
     }
 
+    public function testPhpErrorsWithLogLevels()
+    {
+        $container = $this->createContainerFromFile('php_errors_log_levels');
+
+        $definition = $container->getDefinition('debug.debug_handlers_listener');
+        $this->assertEquals(new Reference('monolog.logger.php', ContainerInterface::NULL_ON_INVALID_REFERENCE), $definition->getArgument(1));
+        $this->assertSame([
+            \E_NOTICE => \Psr\Log\LogLevel::ERROR,
+            \E_WARNING => \Psr\Log\LogLevel::ERROR,
+        ], $definition->getArgument(2));
+    }
+
     public function testRouter()
     {
         $container = $this->createContainerFromFile('full');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

It's actually possible to pass a map or PHP errors => Log level like
following

```yaml
    php_errors:
        log:
            !php/const \E_DEPRECATED: !php/const Psr\Log\LogLevel::ERROR
            !php/const \E_USER_DEPRECATED: !php/const Psr\Log\LogLevel::ERROR
            !php/const \E_NOTICE: !php/const Psr\Log\LogLevel::ERROR
            !php/const \E_USER_NOTICE: !php/const Psr\Log\LogLevel::ERROR
            !php/const \E_STRICT: !php/const Psr\Log\LogLevel::ERROR
            !php/const \E_WARNING: !php/const Psr\Log\LogLevel::ERROR
            !php/const \E_USER_WARNING: !php/const Psr\Log\LogLevel::ERROR
            !php/const \E_COMPILE_WARNING: !php/const Psr\Log\LogLevel::ERROR
            !php/const \E_CORE_WARNING: !php/const Psr\Log\LogLevel::ERROR
            !php/const \E_USER_ERROR: !php/const Psr\Log\LogLevel::CRITICAL
            !php/const \E_RECOVERABLE_ERROR: !php/const Psr\Log\LogLevel::CRITICAL
            !php/const \E_COMPILE_ERROR: !php/const Psr\Log\LogLevel::CRITICAL
            !php/const \E_PARSE: !php/const Psr\Log\LogLevel::CRITICAL
            !php/const \E_ERROR: !php/const Psr\Log\LogLevel::CRITICAL
            !php/const \E_CORE_ERROR: !php/const Psr\Log\LogLevel::CRITICAL
```