### PR TITLE
[Validator] - message as default option for some constraints

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Blank.php
+++ b/src/Symfony/Component/Validator/Constraints/Blank.php
@@ -36,4 +36,12 @@ class Blank extends Constraint
 
         $this->message = $message ?? $this->message;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Country.php
+++ b/src/Symfony/Component/Validator/Constraints/Country.php
@@ -49,4 +49,12 @@ class Country extends Constraint
         $this->message = $message ?? $this->message;
         $this->alpha3 = $alpha3 ?? $this->alpha3;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Currency.php
+++ b/src/Symfony/Component/Validator/Constraints/Currency.php
@@ -43,4 +43,12 @@ class Currency extends Constraint
 
         $this->message = $message ?? $this->message;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Date.php
+++ b/src/Symfony/Component/Validator/Constraints/Date.php
@@ -38,4 +38,12 @@ class Date extends Constraint
 
         $this->message = $message ?? $this->message;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -76,4 +76,12 @@ class Email extends Constraint
             throw new InvalidArgumentException(sprintf('The "normalizer" option must be a valid callable ("%s" given).', get_debug_type($this->normalizer)));
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Iban.php
+++ b/src/Symfony/Component/Validator/Constraints/Iban.php
@@ -46,4 +46,12 @@ class Iban extends Constraint
 
         $this->message = $message ?? $this->message;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Ip.php
+++ b/src/Symfony/Component/Validator/Constraints/Ip.php
@@ -101,4 +101,12 @@ class Ip extends Constraint
             throw new InvalidArgumentException(sprintf('The "normalizer" option must be a valid callable ("%s" given).', get_debug_type($this->normalizer)));
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/IsFalse.php
+++ b/src/Symfony/Component/Validator/Constraints/IsFalse.php
@@ -36,4 +36,12 @@ class IsFalse extends Constraint
 
         $this->message = $message ?? $this->message;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/IsNull.php
+++ b/src/Symfony/Component/Validator/Constraints/IsNull.php
@@ -36,4 +36,12 @@ class IsNull extends Constraint
 
         $this->message = $message ?? $this->message;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/IsTrue.php
+++ b/src/Symfony/Component/Validator/Constraints/IsTrue.php
@@ -36,4 +36,12 @@ class IsTrue extends Constraint
 
         $this->message = $message ?? $this->message;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Isin.php
+++ b/src/Symfony/Component/Validator/Constraints/Isin.php
@@ -43,4 +43,12 @@ class Isin extends Constraint
 
         $this->message = $message ?? $this->message;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Issn.php
+++ b/src/Symfony/Component/Validator/Constraints/Issn.php
@@ -57,4 +57,12 @@ class Issn extends Constraint
         $this->caseSensitive = $caseSensitive ?? $this->caseSensitive;
         $this->requireHyphen = $requireHyphen ?? $this->requireHyphen;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Json.php
+++ b/src/Symfony/Component/Validator/Constraints/Json.php
@@ -36,4 +36,12 @@ class Json extends Constraint
 
         $this->message = $message ?? $this->message;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Language.php
+++ b/src/Symfony/Component/Validator/Constraints/Language.php
@@ -49,4 +49,12 @@ class Language extends Constraint
         $this->message = $message ?? $this->message;
         $this->alpha3 = $alpha3 ?? $this->alpha3;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Locale.php
+++ b/src/Symfony/Component/Validator/Constraints/Locale.php
@@ -49,4 +49,12 @@ class Locale extends Constraint
         $this->message = $message ?? $this->message;
         $this->canonicalize = $canonicalize ?? $this->canonicalize;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Luhn.php
+++ b/src/Symfony/Component/Validator/Constraints/Luhn.php
@@ -46,4 +46,12 @@ class Luhn extends Constraint
 
         $this->message = $message ?? $this->message;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/NotBlank.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlank.php
@@ -46,4 +46,12 @@ class NotBlank extends Constraint
             throw new InvalidArgumentException(sprintf('The "normalizer" option must be a valid callable ("%s" given).', get_debug_type($this->normalizer)));
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/NotCompromisedPassword.php
+++ b/src/Symfony/Component/Validator/Constraints/NotCompromisedPassword.php
@@ -46,4 +46,12 @@ class NotCompromisedPassword extends Constraint
         $this->threshold = $threshold ?? $this->threshold;
         $this->skipOnError = $skipOnError ?? $this->skipOnError;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/NotNull.php
+++ b/src/Symfony/Component/Validator/Constraints/NotNull.php
@@ -36,4 +36,12 @@ class NotNull extends Constraint
 
         $this->message = $message ?? $this->message;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Time.php
+++ b/src/Symfony/Component/Validator/Constraints/Time.php
@@ -42,4 +42,12 @@ class Time extends Constraint
 
         $this->message = $message ?? $this->message;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Ulid.php
+++ b/src/Symfony/Component/Validator/Constraints/Ulid.php
@@ -45,4 +45,12 @@ class Ulid extends Constraint
 
         $this->message = $message ?? $this->message;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Unique.php
+++ b/src/Symfony/Component/Validator/Constraints/Unique.php
@@ -40,4 +40,12 @@ class Unique extends Constraint
 
         $this->message = $message ?? $this->message;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Url.php
+++ b/src/Symfony/Component/Validator/Constraints/Url.php
@@ -54,4 +54,12 @@ class Url extends Constraint
             throw new InvalidArgumentException(sprintf('The "normalizer" option must be a valid callable ("%s" given).', get_debug_type($this->normalizer)));
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Uuid.php
+++ b/src/Symfony/Component/Validator/Constraints/Uuid.php
@@ -108,4 +108,12 @@ class Uuid extends Constraint
             throw new InvalidArgumentException(sprintf('The "normalizer" option must be a valid callable ("%s" given).', get_debug_type($this->normalizer)));
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'message';
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      |no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #39000
| License       | MIT
| Doc PR        | Not Yet

# What Next
- [ ] Update CHANGELOG.md
- [ ] Unit tests
- [ ] Doc pull request

# Description
Declare `message` as the default option for some constraints (list bellow) don't have a default option

# List of constraints
- [x] [`Blank`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Blank.php)
- [x] [`NotBlank`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/NotBlank.php)
- [x] [`IsTrue`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/IsTrue.php)
- [x] [`IsFalse`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/IsFalse.php)
- [x] [`IsNull`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/IsNull.php)
- [x] [`NotNull`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/NotNull.php)
- [x] [`Email`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Email.php)
- [x] [`Date`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Date.php)
- [x] [`Country`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Country.php)
- [x] [`Currency`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Currency.php)
- [x] [`Iban`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Iban.php)
- [x] [`Ip`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Ip.php)
- [x] [`Issn`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Issn.php)
- [x] [`Isin`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Isin.php)
- [x] [`Json`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Json.php)
- [x] [`Language`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Language.php)
- [x] [`Locale`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Locale.php)
- [x] [`Luhn`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Luhn.php)
- [x] [`NotCompromisedPassword`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/NotCompromisedPassword.php)
- [x] [`Time`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Time.php)
- [x] [`Unique`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Unique.php)
- [x] [`Url`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Url.php)
- [x] [`Uuid`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Uuid.php)
- [x] [`Ulid`](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Validator/Constraints/Ulid.php)

# Example
```diff

    /**
-     * @Assert\NotBlank(message="The name accepts only a non blank string, '{{ value }}' is given")
+     * @Assert\NotBlank("The name accepts only a non blank string, '{{ value }}' is given")
     */
    public ?string $name = null;

    /**
-     * @Assert\Country(message="The given country is not in Alpha2 nor Alpha3 format")
+     * @Assert\Country("The given country is not in Alpha2 nor Alpha3 format")
     */
    public ?string $countryCode = null;
``` 
