### PR TITLE
Adds constants for YamlEncoder options

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -28,9 +28,17 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
 
     public const PRESERVE_EMPTY_OBJECTS = 'preserve_empty_objects';
 
+    public const YAML_INLINE = 'yaml_inline';
+    public const YAML_INDENT = 'yaml_indent';
+    public const YAML_FLAGS = 'yaml_flags';
+
     private $dumper;
     private $parser;
-    private $defaultContext = ['yaml_inline' => 0, 'yaml_indent' => 0, 'yaml_flags' => 0];
+    private $defaultContext = [
+        self::YAML_INLINE => 0,
+        self::YAML_INDENT => 0,
+        self::YAML_FLAGS => 0,
+    ];
 
     public function __construct(Dumper $dumper = null, Parser $parser = null, array $defaultContext = [])
     {
@@ -51,10 +59,10 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
         $context = array_merge($this->defaultContext, $context);
 
         if (isset($context[self::PRESERVE_EMPTY_OBJECTS])) {
-            $context['yaml_flags'] |= Yaml::DUMP_OBJECT_AS_MAP;
+            $context[self::YAML_FLAGS] |= Yaml::DUMP_OBJECT_AS_MAP;
         }
 
-        return $this->dumper->dump($data, $context['yaml_inline'], $context['yaml_indent'], $context['yaml_flags']);
+        return $this->dumper->dump($data, $context[self::YAML_INLINE], $context[self::YAML_INDENT], $context[self::YAML_FLAGS]);
     }
 
     /**
@@ -72,7 +80,7 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
     {
         $context = array_merge($this->defaultContext, $context);
 
-        return $this->parser->parse($data, $context['yaml_flags']);
+        return $this->parser->parse($data, $context[self::YAML_FLAGS]);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Encoder/YamlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/YamlEncoderTest.php
@@ -60,7 +60,7 @@ class YamlEncoderTest extends TestCase
 
     public function testContext()
     {
-        $encoder = new YamlEncoder(new Dumper(), new Parser(), ['yaml_inline' => 1, 'yaml_indent' => 4, 'yaml_flags' => Yaml::DUMP_OBJECT | Yaml::PARSE_OBJECT]);
+        $encoder = new YamlEncoder(new Dumper(), new Parser(), [YamlEncoder::YAML_INLINE => 1, YamlEncoder::YAML_INDENT => 4, YamlEncoder::YAML_FLAGS => Yaml::DUMP_OBJECT | Yaml::PARSE_OBJECT]);
 
         $obj = new \stdClass();
         $obj->bar = 2;
@@ -68,8 +68,8 @@ class YamlEncoderTest extends TestCase
         $legacyTag = "    foo: !php/object:O:8:\"stdClass\":1:{s:3:\"bar\";i:2;}\n";
         $spacedTag = "    foo: !php/object 'O:8:\"stdClass\":1:{s:3:\"bar\";i:2;}'\n";
         $this->assertThat($encoder->encode(['foo' => $obj], 'yaml'), $this->logicalOr($this->equalTo($legacyTag), $this->equalTo($spacedTag)));
-        $this->assertEquals('  { foo: null }', $encoder->encode(['foo' => $obj], 'yaml', ['yaml_inline' => 0, 'yaml_indent' => 2, 'yaml_flags' => 0]));
+        $this->assertEquals('  { foo: null }', $encoder->encode(['foo' => $obj], 'yaml', [YamlEncoder::YAML_INLINE => 0, YamlEncoder::YAML_INDENT => 2, YamlEncoder::YAML_FLAGS => 0]));
         $this->assertEquals(['foo' => $obj], $encoder->decode("foo: !php/object 'O:8:\"stdClass\":1:{s:3:\"bar\";i:2;}'", 'yaml'));
-        $this->assertEquals(['foo' => null], $encoder->decode("foo: !php/object 'O:8:\"stdClass\":1:{s:3:\"bar\";i:2;}'", 'yaml', ['yaml_flags' => 0]));
+        $this->assertEquals(['foo' => null], $encoder->decode("foo: !php/object 'O:8:\"stdClass\":1:{s:3:\"bar\";i:2;}'", 'yaml', [YamlEncoder::YAML_FLAGS => 0]));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

As I understand it encoders and normalizers use (public) constants for context keys so IDEs can help by providing autocomplete. I added these constants for the YamlEncoder where they are missing right now. For reference see other encoders like CsvEncoder or XmlEncoder.
