### PR TITLE
[Console] Extracting ProgressBar's format's magic strings into const

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -26,6 +26,16 @@ use Symfony\Component\Console\Terminal;
  */
 final class ProgressBar
 {
+    public const FORMAT_VERBOSE = 'verbose';
+    public const FORMAT_VERY_VERBOSE = 'very_verbose';
+    public const FORMAT_DEBUG = 'debug';
+    public const FORMAT_NORMAL = 'normal';
+
+    private const FORMAT_VERBOSE_NOMAX = 'verbose_nomax';
+    private const FORMAT_VERY_VERBOSE_NOMAX = 'very_verbose_nomax';
+    private const FORMAT_DEBUG_NOMAX = 'debug_nomax';
+    private const FORMAT_NORMAL_NOMAX = 'normal_nomax';
+
     private $barWidth = 28;
     private $barChar;
     private $emptyBarChar = '-';
@@ -489,13 +499,13 @@ final class ProgressBar
         switch ($this->output->getVerbosity()) {
             // OutputInterface::VERBOSITY_QUIET: display is disabled anyway
             case OutputInterface::VERBOSITY_VERBOSE:
-                return $this->max ? 'verbose' : 'verbose_nomax';
+                return $this->max ? self::FORMAT_VERBOSE : self::FORMAT_VERBOSE_NOMAX;
             case OutputInterface::VERBOSITY_VERY_VERBOSE:
-                return $this->max ? 'very_verbose' : 'very_verbose_nomax';
+                return $this->max ? self::FORMAT_VERY_VERBOSE : self::FORMAT_VERY_VERBOSE_NOMAX;
             case OutputInterface::VERBOSITY_DEBUG:
-                return $this->max ? 'debug' : 'debug_nomax';
+                return $this->max ? self::FORMAT_DEBUG : self::FORMAT_DEBUG_NOMAX;
             default:
-                return $this->max ? 'normal' : 'normal_nomax';
+                return $this->max ? self::FORMAT_NORMAL : self::FORMAT_NORMAL_NOMAX;
         }
     }
 
@@ -547,17 +557,17 @@ final class ProgressBar
     private static function initFormats(): array
     {
         return [
-            'normal' => ' %current%/%max% [%bar%] %percent:3s%%',
-            'normal_nomax' => ' %current% [%bar%]',
+            self::FORMAT_NORMAL => ' %current%/%max% [%bar%] %percent:3s%%',
+            self::FORMAT_NORMAL_NOMAX => ' %current% [%bar%]',
 
-            'verbose' => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%',
-            'verbose_nomax' => ' %current% [%bar%] %elapsed:6s%',
+            self::FORMAT_VERBOSE => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%',
+            self::FORMAT_VERBOSE_NOMAX => ' %current% [%bar%] %elapsed:6s%',
 
-            'very_verbose' => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s%',
-            'very_verbose_nomax' => ' %current% [%bar%] %elapsed:6s%',
+            self::FORMAT_VERY_VERBOSE => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s%',
+            self::FORMAT_VERY_VERBOSE_NOMAX => ' %current% [%bar%] %elapsed:6s%',
 
-            'debug' => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%',
-            'debug_nomax' => ' %current% [%bar%] %elapsed:6s% %memory:6s%',
+            self::FORMAT_DEBUG => ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%',
+            self::FORMAT_DEBUG_NOMAX => ' %current% [%bar%] %elapsed:6s% %memory:6s%',
         ];
     }
 

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -210,7 +210,7 @@ class ProgressBarTest extends TestCase
 
         // max in construct, explicit format before
         $bar = new ProgressBar($output = $this->getOutputStream(), 10, 0);
-        $bar->setFormat('normal');
+        $bar->setFormat(ProgressBar::FORMAT_NORMAL);
         $bar->start();
         $bar->advance(10);
         $bar->finish();
@@ -220,7 +220,7 @@ class ProgressBarTest extends TestCase
 
         // max in start, explicit format before
         $bar = new ProgressBar($output = $this->getOutputStream(), 0, 0);
-        $bar->setFormat('normal');
+        $bar->setFormat(ProgressBar::FORMAT_NORMAL);
         $bar->start(10);
         $bar->advance(10);
         $bar->finish();
@@ -828,7 +828,7 @@ class ProgressBarTest extends TestCase
     public function testSetFormat()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 0, 0);
-        $bar->setFormat('normal');
+        $bar->setFormat(ProgressBar::FORMAT_NORMAL);
         $bar->start();
         rewind($output->getStream());
         $this->assertEquals(
@@ -837,7 +837,7 @@ class ProgressBarTest extends TestCase
         );
 
         $bar = new ProgressBar($output = $this->getOutputStream(), 10, 0);
-        $bar->setFormat('normal');
+        $bar->setFormat(ProgressBar::FORMAT_NORMAL);
         $bar->start();
         rewind($output->getStream());
         $this->assertEquals(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The existence of these magic string is propagating outside the project on the user land while constructing a command:

```php
$bar->setFormat('very_verbose');
```

Objective is to provide reusability and resilience to miss naming:
```php
$bar->setFormat(ProgressBar::VERBOSE);
```