### PR TITLE
[MimeType] Add missing alias for service @mime_type

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mime_type.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mime_type.xml
@@ -12,5 +12,7 @@
                 <argument type="service" id="mime_types" />
             </call>
         </service>
+        <service id="Symfony\Component\Mime\MimeTypesInterface" alias="mime_types" />
+        <service id="Symfony\Component\Mime\MimeTypeGuesserInterface" alias="mime_types" />
     </services>
 </container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I found that this was missing. Im not sure why these have not been added before. Was it intentional?
