### PR TITLE
[Serializer] Add `@Mapping` Annotation

### DIFF
--- a/src/Symfony/Component/Serializer/Annotation/AttributeConfiguration.php
+++ b/src/Symfony/Component/Serializer/Annotation/AttributeConfiguration.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Annotation;
+
+/**
+ * Value object used to store an attribute configuration.
+ *
+ * @internal
+ *
+ * @author Bertrand Seurot <b.seurot@gmail.com>
+ */
+class AttributeConfiguration
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string[]
+     */
+    private $groups;
+
+    /**
+     * @var int|null
+     */
+    private $maxDepth;
+
+    /**
+     * @var string|null
+     */
+    private $serializedName;
+
+    /**
+     * AttributeConfiguration constructor.
+     *
+     * @param string[]|null $groups
+     */
+    public function __construct(string $name, ?array $groups = null, ?int $maxDepth = null, ?string $serializedName = null)
+    {
+        $this->name = $name;
+        $this->groups = $groups ?? [];
+        $this->maxDepth = $maxDepth;
+        $this->serializedName = $serializedName;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getGroups(): array
+    {
+        return $this->groups;
+    }
+
+    public function getMaxDepth(): ?int
+    {
+        return $this->maxDepth;
+    }
+
+    public function getSerializedName(): ?string
+    {
+        return $this->serializedName;
+    }
+}

--- a/src/Symfony/Component/Serializer/Annotation/Mapping.php
+++ b/src/Symfony/Component/Serializer/Annotation/Mapping.php
@@ -1,0 +1,200 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Annotation;
+
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * Annotation class for @Mapping().
+ *
+ * @Annotation
+ * @Target({"CLASS"})
+ *
+ * @author Bertrand Seurot <b.seurot@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class Mapping
+{
+    /**
+     * @var AttributeConfiguration[]
+     */
+    private $attributes;
+
+    /**
+     * @var string[]
+     */
+    private $groups;
+
+    /**
+     * @var int | null
+     */
+    private $maxDepth;
+
+    public const SUPPORTED_ATTRIBUTE_OPTIONS = ['name', 'groups', 'serializedName', 'maxDepth'];
+
+    /**
+     * @param string|array         $attributes
+     * @param string|string[]|null $groups
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct($attributes, $groups = null, int $maxDepth = null)
+    {
+        if (\is_array($attributes) && isset($attributes['attributes'])) {
+            $groups = $attributes['groups'] ?? null;
+            $maxDepth = $attributes['maxDepth'] ?? null;
+            $attributes = $attributes['attributes'] ?? null;
+        }
+
+        if (null !== $attributes) {
+            if (\is_string($attributes)) {
+                $attributes = [new AttributeConfiguration($attributes)];
+            } elseif (\is_array($attributes)) {
+                $attributes = $this->getValidAttributesArray($attributes);
+            } else {
+                throw new \TypeError(sprintf('"%s": Argument "$attributes" was expected to be a string or array, got "%s".', __METHOD__, get_debug_type($attributes)));
+            }
+        }
+
+        if (null !== $groups) {
+            if (\is_string($groups)) {
+                if (empty($groups)) {
+                    throw new InvalidArgumentException(sprintf('Parameter "groups" of annotation "%s" must be a non-empty string or an array of non-empty strings.', static::class));
+                }
+                $groups = [$groups];
+            } elseif (\is_array($groups)) {
+                if (false === $this->isArrayOfNonEmptyStrings($groups)) {
+                    throw new InvalidArgumentException(sprintf('Parameter "groups" of annotation "%s" must be a non-empty string or an array of non-empty strings.', static::class));
+                }
+            } else {
+                throw new \TypeError(sprintf('"%s": Argument "$groups" was expected to be a string or array, got "%s".', __METHOD__, get_debug_type($groups)));
+            }
+        }
+
+        if (null !== $maxDepth) {
+            if (!\is_int($maxDepth)) {
+                throw new \TypeError(sprintf('"%s": Argument $maxDepth was expected to be a string or array, got "%s".', __METHOD__, get_debug_type($maxDepth)));
+            } elseif ($maxDepth <= 0) {
+                throw new InvalidArgumentException(sprintf('Parameter "maxDepth" of annotation "%s" must be a positive integer.', static::class));
+            }
+        }
+
+        if (empty($groups) && !$maxDepth) {
+            foreach ($attributes as $attribute) {
+                if (
+                    empty($attribute->getGroups())
+                    && null === $attribute->getMaxDepth()
+                    && null === $attribute->getSerializedName()
+                ) {
+                    $parametersWithEffects = array_filter(self::SUPPORTED_ATTRIBUTE_OPTIONS, function ($item) {
+                        return 'name' !== $item;
+                    });
+                    throw new InvalidArgumentException(sprintf('Attribute "%s" defined in annotation "%s" has none of the following parameters : "%s". Defining it will so have no effect.', $attribute->getName(), static::class, implode('", "', $parametersWithEffects)));
+                }
+            }
+        }
+
+        $this->attributes = $attributes;
+        $this->groups = $groups ?? [];
+        $this->maxDepth = $maxDepth;
+    }
+
+    /**
+     * @return AttributeConfiguration[]
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    public function getGroups()
+    {
+        return $this->groups;
+    }
+
+    public function getMaxDepth()
+    {
+        return $this->maxDepth;
+    }
+
+    private function isArrayOfNonEmptyStrings(array $array): bool
+    {
+        foreach ($array as $item) {
+            if (!\is_string($item) || empty($item)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return AttributeConfiguration[]
+     */
+    private function getValidAttributesArray(array $attributes): array
+    {
+        $validAttributes = [];
+        foreach ($attributes as $attribute) {
+            if (\is_string($attribute)) {
+                $validAttributes[] = new AttributeConfiguration($attribute);
+                continue;
+            }
+
+            if (\is_array($attribute)) {
+                $validAttributes[] = $this->getValidAttributeConfiguration($attribute);
+                continue;
+            }
+
+            throw new InvalidArgumentException(sprintf('Parameter "groups" of annotation "%s" must be a string or an array. "%s" was met.', static::class, get_debug_type($attribute)));
+        }
+
+        return $validAttributes;
+    }
+
+    private function getValidAttributeConfiguration(array $attribute): AttributeConfiguration
+    {
+        $unsupportedKeys = array_diff(array_keys($attribute), self::SUPPORTED_ATTRIBUTE_OPTIONS);
+        if (\count($unsupportedKeys)) {
+            throw new InvalidArgumentException(sprintf('Unknown option found: [%s]. Allowed options are [%s].', implode(', ', $unsupportedKeys), implode(', ', self::SUPPORTED_ATTRIBUTE_OPTIONS)));
+        }
+
+        $attributeName = $attribute['name'] ?? null;
+        if (empty($attributeName)) {
+            throw new InvalidArgumentException(sprintf('In array defined attributes of annotation "%s", parameter "name" is required and cannot be empty.', static::class));
+        }
+
+        if (!\is_string($attributeName)) {
+            throw new InvalidArgumentException(sprintf('In array defined attributes of annotation "%s", parameter "name" must be a string.', static::class));
+        }
+
+        $groups = $attribute['groups'] ?? null;
+        if (null !== $groups) {
+            if (\is_string($groups)) {
+                $groups = [$groups];
+            } elseif (!\is_array($groups) && !$this->isArrayOfNonEmptyStrings($groups)) {
+                throw new InvalidArgumentException(sprintf('In array defined attributes of annotation "%s", parameter "groups" must be a string or an array of strings.', static::class));
+            }
+        }
+
+        $serializedName = $attribute['serializedName'] ?? null;
+        if (null !== $serializedName && (empty($serializedName) || !\is_string($serializedName))) {
+            throw new InvalidArgumentException(sprintf('In array defined attributes of annotation "%s", parameter "serializedName" must be a non-empty string.', static::class));
+        }
+
+        $maxDepth = $attribute['maxDepth'] ?? null;
+        if (null !== $maxDepth && (empty($maxDepth) || !\is_int($maxDepth))) {
+            throw new InvalidArgumentException(sprintf('In array defined attributes of annotation "%s", parameter "maxDepth" must be a positive integer.', static::class));
+        }
+
+        return new AttributeConfiguration($attributeName, $groups, $maxDepth, $serializedName);
+    }
+}

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\Reader;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\Ignore;
+use Symfony\Component\Serializer\Annotation\Mapping;
 use Symfony\Component\Serializer\Annotation\MaxDepth;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 use Symfony\Component\Serializer\Exception\MappingException;
@@ -35,6 +36,7 @@ class AnnotationLoader implements LoaderInterface
         Groups::class => true,
         Ignore:: class => true,
         MaxDepth::class => true,
+        Mapping::class => true,
         SerializedName::class => true,
     ];
 
@@ -55,15 +57,6 @@ class AnnotationLoader implements LoaderInterface
         $loaded = false;
 
         $attributesMetadata = $classMetadata->getAttributesMetadata();
-
-        foreach ($this->loadAnnotations($reflectionClass) as $annotation) {
-            if ($annotation instanceof DiscriminatorMap) {
-                $classMetadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping(
-                    $annotation->getTypeProperty(),
-                    $annotation->getMapping()
-                ));
-            }
-        }
 
         foreach ($reflectionClass->getProperties() as $property) {
             if (!isset($attributesMetadata[$property->name])) {
@@ -133,6 +126,38 @@ class AnnotationLoader implements LoaderInterface
                 }
 
                 $loaded = true;
+            }
+        }
+
+        foreach ($this->loadAnnotations($reflectionClass) as $annotation) {
+            if ($annotation instanceof DiscriminatorMap) {
+                $classMetadata->setClassDiscriminatorMapping(new ClassDiscriminatorMapping(
+                    $annotation->getTypeProperty(),
+                    $annotation->getMapping()
+                ));
+            } elseif ($annotation instanceof Mapping) {
+                foreach ($annotation->getAttributes() as $attribute) {
+                    if (!isset($attributesMetadata[$attribute->getName()])) {
+                        $attributesMetadata[$attribute->getName()] = new AttributeMetadata($attribute->getName());
+                        $classMetadata->addAttributeMetadata($attributesMetadata[$attribute->getName()]);
+                    }
+
+                    foreach ($attribute->getGroups() as $group) {
+                        $attributesMetadata[$attribute->getName()]->addGroup($group);
+                    }
+                    foreach ($annotation->getGroups() as $group) {
+                        $attributesMetadata[$attribute->getName()]->addGroup($group);
+                    }
+
+                    if (null === $attributesMetadata[$attribute->getName()]->getMaxDepth()) {
+                        $attributesMetadata[$attribute->getName()]
+                            ->setMaxDepth($attribute->getMaxDepth() ?? $annotation->getMaxDepth());
+                    }
+
+                    if (null === $attributesMetadata[$attribute->getName()]->getSerializedName()) {
+                        $attributesMetadata[$attribute->getName()]->setSerializedName($attribute->getSerializedName());
+                    }
+                }
             }
         }
 

--- a/src/Symfony/Component/Serializer/Tests/Annotation/MappingTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/MappingTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Annotation;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Annotation\AttributeConfiguration;
+use Symfony\Component\Serializer\Annotation\Mapping;
+
+/**
+ * @author Bertrand Seurot <b.seurot@gmail.com>
+ */
+class MappingTest extends TestCase
+{
+    public function testGetAttributesAndGroupsAndMaxDepth()
+    {
+        $annotation = new Mapping(['foo', 'bar'], ['read', 'write'], 2);
+
+        $this->assertEquals(
+            [new AttributeConfiguration('foo'), new AttributeConfiguration('bar')],
+            $annotation->getAttributes()
+        );
+        $this->assertSame(['read', 'write'], $annotation->getGroups());
+        $this->assertSame(2, $annotation->getMaxDepth());
+    }
+
+    public function testGetAttributesAndGroupsAndMaxDepthWithArrayInput()
+    {
+        $annotation = new Mapping([
+            'attributes' => ['foo', 'bar'],
+            'groups' => ['read', 'write'],
+            'maxDepth' => 2,
+        ]);
+
+        $this->assertEquals(
+            [new AttributeConfiguration('foo'), new AttributeConfiguration('bar')],
+            $annotation->getAttributes()
+        );
+        $this->assertSame(['read', 'write'], $annotation->getGroups());
+        $this->assertSame(2, $annotation->getMaxDepth());
+    }
+
+    public function testGetAttributesWithPerAttributeConfiguration()
+    {
+        $attributes = [
+            [
+                'name' => 'foo',
+                'groups' => ['read', 'write'],
+                'maxDepth' => 2,
+                'serializedName' => 'fooBar',
+            ],
+            [
+                'name' => 'bar',
+                'maxDepth' => 3,
+            ],
+            [
+                'name' => 'baz',
+                'groups' => ['read', 'write'],
+            ],
+            [
+                'name' => 'qux',
+                'serializedName' => 'quux',
+            ],
+        ];
+
+        $expectedResult = array_map(
+            function ($item) {
+                return new AttributeConfiguration(
+                    $item['name'] ?? null,
+                    $item['groups'] ?? null,
+                    $item['maxDepth'] ?? null,
+                    $item['serializedName'] ?? null
+                );
+            },
+            $attributes
+        );
+
+        $annotation = new Mapping(['attributes' => $attributes]);
+        $this->assertEquals($expectedResult, $annotation->getAttributes());
+    }
+
+    public function testGetAttributesAndGroupsAcceptStrings()
+    {
+        $annotation = new Mapping([
+            'attributes' => 'foo',
+            'groups' => 'read',
+        ]);
+
+        $this->assertEquals([new AttributeConfiguration('foo')], $annotation->getAttributes());
+        $this->assertEquals(['read'], $annotation->getGroups());
+    }
+
+    public function testExceptionWithEmptyAttributes()
+    {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
+        new Mapping(['attributes' => []]);
+        new Mapping(['attributes' => '']);
+    }
+
+    public function testExceptionWithUnnamedAttributes()
+    {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
+        new Mapping(['attributes' => ['maxDepth' => 2]]);
+    }
+
+    public function provideUselessConfigurations()
+    {
+        return [
+            [['attributes' => 'foo']],
+            [['attributes' => [
+                ['name' => 'bar', 'maxDepth' => 1],
+                ['name' => 'foo'],
+                ],
+            ]],
+        ];
+    }
+
+    /**
+     * @dataProvider provideUselessConfigurations
+     */
+    public function testExceptionIfUselessConfiguration($value)
+    {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Attribute "foo" defined in annotation "Symfony\Component\Serializer\Annotation\Mapping" has none of the following parameters : "groups", "serializedName", "maxDepth". Defining it will so have no effect.');
+        new Mapping($value);
+    }
+
+    public function testExceptionWithEmptyGroups()
+    {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Parameter "groups" of annotation "Symfony\Component\Serializer\Annotation\Mapping" must be a non-empty string or an array of non-empty strings.');
+        new Mapping(['attributes' => 'foo', 'groups' => '']);
+        new Mapping(['attributes' => 'foo', 'groups' => []]);
+    }
+
+    public function provideInvalidTypesMaxDepthValues()
+    {
+        return [
+            [''],
+            ['foo'],
+            ['1'],
+            [[1]],
+            [1.5],
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidTypesMaxDepthValues
+     */
+    public function testMaxDepthParameterType($value)
+    {
+        $this->expectException('\TypeError');
+        new Mapping(['attributes' => 'foo', 'maxDepth' => $value]);
+    }
+
+    public function provideInvalidMaxDepthValues()
+    {
+        return [
+            [0],
+            [-1],
+        ];
+    }
+
+    /**
+     * @dataProvider provideInvalidMaxDepthValues
+     */
+    public function testNotAnIntMaxDepthParameter($value)
+    {
+        $this->expectException('Symfony\Component\Serializer\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Parameter "maxDepth" of annotation "Symfony\Component\Serializer\Annotation\Mapping" must be a positive integer.');
+        new Mapping(['attributes' => 'foo', 'maxDepth' => $value]);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/MappingDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/MappingDummy.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Annotation\MaxDepth;
+use Symfony\Component\Serializer\Annotation\Mapping;
+use Symfony\Component\Serializer\Annotation\SerializedName;
+
+/**
+ * @author Bertrand Seurot <b.seurot@gmail.com>
+ *
+ * @Mapping(
+ *     attributes={"foo", "bar", {"name": "baz", "groups"="groupAttribute"}, {"name": "qux", "groups"="groupAttribute"}, "quux", {"name": "quuz", "groups"="groupAttribute"}},
+ *     groups="groupAttributes"
+ * )
+ * @Mapping(
+ *     attributes={"foo", "bar", {"name": "baz", "maxDepth"=3}, {"name": "qux", "maxDepth"=99}, "quux", {"name": "quuz", "maxDepth"=99}},
+ *     maxDepth=1
+ * )
+ * @Mapping(
+ *     attributes={{"name": "bar", "serializedName"="barError"}, {"name": "baz", "serializedName"="bazOk"}, {"name": "quux", "serializedName"="quuxOk"}, {"name": "quuz", "serializedName"="quuzError"}}
+ * )
+ */
+class MappingDummy
+{
+    public $foo;
+
+    /**
+     * @SerializedName("barOk")
+     * @Groups("groupProperty")
+     * @MaxDepth(2)
+     */
+    public $bar;
+
+    public $baz;
+
+    /**
+     * @Groups("groupProperty")
+     * @MaxDepth(4)
+     */
+    public $qux;
+
+    public $quux;
+    public $quuz;
+
+    /**
+     * @Groups("groupMethod")
+     * @MaxDepth(5)
+     */
+    public function getQuux()
+    {
+        return $this->quux;
+    }
+
+    /**
+     * @SerializedName("quuzOk")
+     * @Groups("groupMethod")
+     * @MaxDepth(6)
+     */
+    public function getQuuz()
+    {
+        return $this->quuz;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/MappingDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/MappingDummy.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Annotation\MaxDepth;
+use Symfony\Component\Serializer\Annotation\Mapping;
+use Symfony\Component\Serializer\Annotation\SerializedName;
+
+#[Mapping(attributes: ['foo', 'bar', ['name' => 'baz', 'groups' => 'groupAttribute'], ['name'=> 'qux', 'groups' => 'groupAttribute'], 'quux', ['name' => 'quuz', 'groups' => 'groupAttribute'], groups: 'groupAttributes']
+#[Mapping(attributes: ['foo', 'bar', ['name' => 'baz', 'maxDepth' => 3], ['name'=> 'qux', 'maxDepth' => 99], 'quux', ['name' => 'quuz', 'maxDepth' => 99], maxDepth: 1]
+#[Mapping(attributes: [['name' => 'bar', 'serializedName' => 'barError'], ['name' => 'baz', 'serializedName' => 'bazOk'], ['name' => 'quux', 'serializedName' => 'quuxOk'], ['name' => 'quuz', 'serializedName' => 'quuzError']]
+class MappingDummy
+{
+    public $foo;
+
+    #[SerializedName(['barOk'])]
+    #[Groups('groupProperty')]
+    #[MaxDepth(2)]
+    public $bar;
+
+    public $baz;
+
+    #[Groups('groupProperty')]
+    #[MaxDepth(4)]
+    public $qux;
+
+    public $quux;
+    public $quuz;
+
+    #[Groups('groupMethod')]
+    #[MaxDepth(5)]
+    public function getQuux()
+    {
+        return $this->quux;
+    }
+
+    #[SerializedName(['quuzOk'])]
+    #[Groups('groupMethod')]
+    #[MaxDepth(6)]
+    public function getQuuz()
+    {
+        return $this->quuz;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/MappingDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/MappingDummy.php
@@ -16,9 +16,9 @@ use Symfony\Component\Serializer\Annotation\MaxDepth;
 use Symfony\Component\Serializer\Annotation\Mapping;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 
-#[Mapping(attributes: ['foo', 'bar', ['name' => 'baz', 'groups' => 'groupAttribute'], ['name'=> 'qux', 'groups' => 'groupAttribute'], 'quux', ['name' => 'quuz', 'groups' => 'groupAttribute'], groups: 'groupAttributes']
-#[Mapping(attributes: ['foo', 'bar', ['name' => 'baz', 'maxDepth' => 3], ['name'=> 'qux', 'maxDepth' => 99], 'quux', ['name' => 'quuz', 'maxDepth' => 99], maxDepth: 1]
-#[Mapping(attributes: [['name' => 'bar', 'serializedName' => 'barError'], ['name' => 'baz', 'serializedName' => 'bazOk'], ['name' => 'quux', 'serializedName' => 'quuxOk'], ['name' => 'quuz', 'serializedName' => 'quuzError']]
+#[Mapping(attributes: ['foo', 'bar', ['name' => 'baz', 'groups' => 'groupAttribute'], ['name'=> 'qux', 'groups' => 'groupAttribute'], 'quux', ['name' => 'quuz', 'groups' => 'groupAttribute']], groups: 'groupAttributes')]
+#[Mapping(attributes: ['foo', 'bar', ['name' => 'baz', 'maxDepth' => 3], ['name'=> 'qux', 'maxDepth' => 99], 'quux', ['name' => 'quuz', 'maxDepth' => 99]], maxDepth: 1)]
+#[Mapping(attributes: [['name' => 'bar', 'serializedName' => 'barError'], ['name' => 'baz', 'serializedName' => 'bazOk'], ['name' => 'quux', 'serializedName' => 'quuxOk'], ['name' => 'quuz', 'serializedName' => 'quuzError']])]
 class MappingDummy
 {
     public $foo;

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -90,6 +90,32 @@ abstract class AnnotationLoaderTest extends TestCase
         $this->assertEquals('qux', $attributesMetadata['bar']->getSerializedName());
     }
 
+    public function testLoadSerialize()
+    {
+        $classMetadata = new ClassMetadata($this->getNamespace().'\MappingDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertEquals(1, $attributesMetadata['foo']->getMaxDepth());
+        $this->assertEquals(2, $attributesMetadata['bar']->getMaxDepth());
+        $this->assertEquals(3, $attributesMetadata['baz']->getMaxDepth());
+        $this->assertEquals(4, $attributesMetadata['qux']->getMaxDepth());
+        $this->assertEquals(5, $attributesMetadata['quux']->getMaxDepth());
+        $this->assertEquals(6, $attributesMetadata['quuz']->getMaxDepth());
+
+        $this->assertEquals(['groupAttributes'], $attributesMetadata['foo']->getGroups());
+        $this->assertEquals(['groupProperty', 'groupAttributes'], $attributesMetadata['bar']->getGroups());
+        $this->assertEquals(['groupAttribute', 'groupAttributes'], $attributesMetadata['baz']->getGroups());
+        $this->assertEquals(['groupProperty', 'groupAttribute', 'groupAttributes'], $attributesMetadata['qux']->getGroups());
+        $this->assertEquals(['groupMethod', 'groupAttributes'], $attributesMetadata['quux']->getGroups());
+        $this->assertEquals(['groupMethod', 'groupAttribute', 'groupAttributes'], $attributesMetadata['quuz']->getGroups());
+
+        $this->assertEquals('barOk', $attributesMetadata['bar']->getSerializedName());
+        $this->assertEquals('bazOk', $attributesMetadata['baz']->getSerializedName());
+        $this->assertEquals('quuxOk', $attributesMetadata['quux']->getSerializedName());
+        $this->assertEquals('quuzOk', $attributesMetadata['quuz']->getSerializedName());
+    }
+
     public function testLoadClassMetadataAndMerge()
     {
         $classMetadata = new ClassMetadata($this->getNamespace().'\GroupDummy');
@@ -114,5 +140,6 @@ abstract class AnnotationLoaderTest extends TestCase
     }
 
     abstract protected function createLoader(): AnnotationLoader;
+
     abstract protected function getNamespace(): string;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | None yet
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

- [ ] update CHANGELOG
- [ ] PR for documentation

Add a @Mapping annotation applicable to a class to configure the groups, the maxDepth, and the serializedName of a set of attributes.

It allows you to configure the serialization of attributes from traits, when specific to each class, or when the trait comes from a third party library (or from an hexagone of your code you don't want to depend on the serializer)

The "ignore" metadata is currently not supported, simply for readability reasons (an @IgnoreAttributes annotation would probably be better) but could easily implemented.

The "maxDepth" parameter on the root of the annotation could also be removed, to avoid unnecessary metadata storage for attributes not using it.

This annotation also allows you to configure the class attributes at the same place, even if yaml or xml would be a better choice for that in a fresh project.

Let me know if there is any chance this feature to be merged, so I will start working on the documentation.
Note : the fabbot does not accept the php8 attribute, is it too soon for that ?

### Main use case example
Let say you want to use a vendor trait, or a very common behavior trait from your application. Sometimes you want some properties to be serialized, sometimes not. Here an example with BlameableEntity from Gedmo DoctrineExtension (you probably want to write your own trait, it just illustrates the confidentiality need):

```php
<?php
namespace Gedmo\Blameable\Traits;

use Doctrine\ORM\Mapping as ORM;
use Gedmo\Mapping\Annotation as Gedmo;

/**
 * Blameable Trait, usable with PHP >= 5.4
 *
 * @author David Buchmann <mail@davidbu.ch>
 * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
 */
trait BlameableEntity
{
    /**
     * @var string
     * @Gedmo\Blameable(on="create")
     * @ORM\Column(nullable=true)
     */
    protected $createdBy;

    /**
     * @var string
     * @Gedmo\Blameable(on="update")
     * @ORM\Column(nullable=true)
     */
    protected $updatedBy;

   // ...
}
```
For a BlogPost, you may want expose thoses properties

```php
/**
 * @Mapping(
 *     attributes={"createdBy", "updatedBy"},
 *     groups="BlogPost:read"
 * )
*/
class BlogPost{
    use BlameableEntity;

    // ...
}
```

For an AnonymousSuggestion, you probably don't want to leak those informations:
```php
class AnonymousSuggestion{
    use BlameableEntity;

    // ...
}
```

For a DisruptiveIdeaDraft, you may want to expose updatedBy, but createdBy only for the managers (because in a first time, you want your team not to be influenced by who created the thing)

```php
/**
 * @Mapping(
 *     attributes={ "updatedBy"},
 *     groups="DisruptiveIdeaDraft:read"
 * )
 * @Mapping(
 *     attributes={"createdBy"},
 *     groups="DisruptiveIdeaDraft:managers:read"
 * )
*/
class DisruptiveIdeaDraft{
    use BlameableEntity;

    // ...
}
```
or
```php
/**
 * @Mapping(
 *     attributes={
 *        {"name": "updatedBy", "groups"="DisruptiveIdeaDraft:read"},
 *        {"name": "createdBy", "groups"="DisruptiveIdeaDraft:managers:read"},
 *     }
 * )
*/
class DisruptiveIdeaDraft{
    use BlameableEntity;

    // ...
}
```

## How it works

### Full usage example to configure groups :
```php
/**
 * @Mapping(
 *     attributes={"foo", "bar", {"name": "baz", "groups"="foobar:special"}},
 *     groups="fooBar:read"
 * )
 * @Mapping(
 *     attributes={"qux", "quux", "quuz", "propertyFromSomeTrait"},
 *     groups={"fooBar:read", "foobar:write"}
 * )
*/
class Foobar{
    use SomeTrait;

    // ...
}
```

### you can configure maxDepth generally, or per attribute :
```php
/**
 * @Mapping(
 *     attributes={"foo", "bar", {"name": "baz", "groups"="foobar:special", maxDepth=3}},
 *     groups="fooBar:read",
 *     maxDepth=2
 * )
*/
```

### you can specify a serializedName per attribute :
```php
/**
 * @Mapping(
 *     attributes={"foo", "bar", {"name": "baz", "groups"="foobar:special", maxDepth=3, serializedName="fromFooBar"}},
 *     groups="fooBar:read",
 *     maxDepth=2
 * )
*/
```

### Annotations priorities

#### Currently, how it works :

**For maxDepth & serializedName:**
method annotation > property annotation > method annotation from parent class > property annotation from parent class > method annotation from interfaces

**For groups:**
groups from any annotation are cumulated, not replaced

#### How it works with this annotation:

**For maxDepth & serializedName:**
method annotation > property annotation > class annotation (attribute specific) > class annotation (root parameter for maxDepth) > method annotation from parent class > property annotation from parent class > class annotation from parent class (attribute specific) > class annotation from parent class (root parameter for maxDepth) > method annotation from interface > class annotation from interface (attribute specific) > class annotation from interface (root parameter for maxDepth)

_NOTE : looks complicated, but it's the same logic sequence_

**For groups:**
groups from any annotation are cumulated, not replaced
