### PR TITLE
[Config] ArrayNode duplicates config  with int key when using string key.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -364,7 +364,6 @@ class Configuration implements ConfigurationInterface
                                         ->end()
                                     ->end()
                                     ->arrayNode('supports')
-                                        ->performNoDeepMerging()
                                         ->beforeNormalization()
                                             ->ifString()
                                             ->then(function ($v) { return [$v]; })
@@ -381,7 +380,6 @@ class Configuration implements ConfigurationInterface
                                         ->cannotBeEmpty()
                                     ->end()
                                     ->arrayNode('initial_marking')
-                                    ->performNoDeepMerging()
                                         ->beforeNormalization()->castToArray()->end()
                                         ->defaultValue([])
                                         ->prototype('scalar')->end()
@@ -414,7 +412,6 @@ class Configuration implements ConfigurationInterface
                                         ->example(['workflow.enter', 'workflow.transition'])
                                     ->end()
                                     ->arrayNode('places')
-                                        ->performNoDeepMerging()
                                         ->beforeNormalization()
                                             ->always()
                                             ->then(function ($places) {
@@ -460,7 +457,6 @@ class Configuration implements ConfigurationInterface
                                         ->end()
                                     ->end()
                                     ->arrayNode('transitions')
-                                        ->performNoDeepMerging()
                                         ->beforeNormalization()
                                             ->always()
                                             ->then(function ($transitions) {
@@ -544,16 +540,16 @@ class Configuration implements ConfigurationInterface
                                     ->thenInvalid('"supports" or "support_strategy" should be configured.')
                                 ->end()
                                 ->beforeNormalization()
-                                        ->always()
-                                        ->then(function ($values) {
-                                            // Special case to deal with XML when the user wants an empty array
-                                            if (\array_key_exists('event_to_dispatch', $values) && null === $values['event_to_dispatch']) {
-                                                $values['events_to_dispatch'] = [];
-                                                unset($values['event_to_dispatch']);
-                                            }
+                                    ->always()
+                                    ->then(function ($values) {
+                                        // Special case to deal with XML when the user wants an empty array
+                                        if (\array_key_exists('event_to_dispatch', $values) && null === $values['event_to_dispatch']) {
+                                            $values['events_to_dispatch'] = [];
+                                            unset($values['event_to_dispatch']);
+                                        }
 
-                                            return $values;
-                                        })
+                                        return $values;
+                                    })
                                 ->end()
                             ->end()
                         ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -364,6 +364,7 @@ class Configuration implements ConfigurationInterface
                                         ->end()
                                     ->end()
                                     ->arrayNode('supports')
+                                        ->performNoDeepMerging()
                                         ->beforeNormalization()
                                             ->ifString()
                                             ->then(function ($v) { return [$v]; })
@@ -380,6 +381,7 @@ class Configuration implements ConfigurationInterface
                                         ->cannotBeEmpty()
                                     ->end()
                                     ->arrayNode('initial_marking')
+                                    ->performNoDeepMerging()
                                         ->beforeNormalization()->castToArray()->end()
                                         ->defaultValue([])
                                         ->prototype('scalar')->end()
@@ -412,6 +414,7 @@ class Configuration implements ConfigurationInterface
                                         ->example(['workflow.enter', 'workflow.transition'])
                                     ->end()
                                     ->arrayNode('places')
+                                        ->performNoDeepMerging()
                                         ->beforeNormalization()
                                             ->always()
                                             ->then(function ($places) {
@@ -457,6 +460,7 @@ class Configuration implements ConfigurationInterface
                                         ->end()
                                     ->end()
                                     ->arrayNode('transitions')
+                                        ->performNoDeepMerging()
                                         ->beforeNormalization()
                                             ->always()
                                             ->then(function ($transitions) {

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -397,6 +397,13 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
                 continue;
             }
 
+            // config already exists with a string key.
+            foreach ($leftSide as $key => $value) {
+                if (is_string($key) && $value === $v) {
+                    continue 2;
+                }
+            }
+
             $leftSide[$k] = $this->children[$k]->merge($leftSide[$k], $v);
         }
 

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -215,7 +215,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
                 if ($child->isRequired()) {
                     $message = sprintf('The child config "%s" under "%s" must be configured', $name, $this->getPath());
                     if ($child->getInfo()) {
-                        $message .= sprintf(": %s", $child->getInfo());
+                        $message .= sprintf(': %s', $child->getInfo());
                     } else {
                         $message .= '.';
                     }
@@ -399,7 +399,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
 
             // config already exists with a string key.
             foreach ($leftSide as $key => $value) {
-                if (is_string($key) && $value === $v) {
+                if (\is_string($key) && $value === $v) {
                     continue 2;
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This pull-request fixes a bug in workflow configuration that have as side-effect of triggering false positive `InvalidDefinitionException` with message `All transitions for a place must have an unique name. Multiple transitions named "%s" where found for place "%s" in workflow "%s".`.

**Observed bug :**

workflow.yaml configuration file :
```yaml
framework:
    workflows:
        dummy_lifecycle:
            type: 'workflow'
            marking_store:
                type: 'method'
                property: 'state'
            supports: App\Entity\Dummy
            initial_marking: start
            places:
                - start
                - a
            transitions:
                start_a:
                    from: start
                    to: a
                a_start:
                    from: a
                    to: start
```

**Observed configuration array result :** 
```
"workflows" => array:1 [
  "dummy_lifecycle" => array:6 [
    "type" => "workflow"
    "marking_store" => array:2 [
      "type" => "method"
      "property" => "state"
    ]
    "supports" => array:2 [
      0 => "App\Entity\Dummy" # Duplicated
      1 => "App\Entity\Dummy" # Duplicated
    ]
    "initial_marking" => array:2 [
      0 => "start" # Duplicated
      1 => "start" # Duplicated
    ]
    "places" => array:4 [
      0 => array:1 [
        "name" => "start"
      ]
      1 => array:1 [
        "name" => "a"
      ]
      2 => array:1 [  # Duplicated with both indexes above
        "name" => "start"
      ]
      3 => array:1 [
        "name" => "a"
      ]
    ]
    "transitions" => array:4 [
      "start_a" => array:3 [
        "from" => array:1 [
          0 => "start"
        ]
        "to" => array:1 [
          0 => "a"
        ]
        "name" => "start_a"
      ]
      "a_start" => array:3 [
        "from" => array:1 [
          0 => "a"
        ]
        "to" => array:1 [
          0 => "start"
        ]
        "name" => "a_start"
      ]
      0 => array:3 [ # Duplicated with both indexes above
        "from" => array:1 [
          0 => "start"
        ]
        "to" => array:1 [
          0 => "a"
        ]
        "name" => "start_a"
      ]
      1 => array:3 [
        "from" => array:1 [
          0 => "a"
        ]
        "to" => array:1 [
          0 => "start"
        ]
        "name" => "a_start"
      ]
    ]
  ]
]
```

**Expected configuration array result :** 
```
"workflows" => array:1 [
  "dummy_lifecycle" => array:6 [
    "type" => "workflow"
    "marking_store" => array:2 [
      "type" => "method"
      "property" => "state"
    ]
    "supports" => array:1 [
      0 => "App\Entity\Dummy"
    ]
    "initial_marking" => array:1 [
      0 => "start"
    ]
    "places" => array:2 [
      0 => array:1 [
        "name" => "start"
      ]
      1 => array:1 [
        "name" => "a"
      ]
    ]
    "transitions" => array:2 [
      "start_a" => array:3 [
        "from" => array:1 [
          0 => "start"
        ]
        "to" => array:1 [
          0 => "a"
        ]
        "name" => "start_a"
      ]
      "a_start" => array:3 [
        "from" => array:1 [
          0 => "a"
        ]
        "to" => array:1 [
          0 => "start"
        ]
        "name" => "a_start"
      ]
    ]
  ]
]
```

**Edit :**
Cause was not the Config Definition in FrameworkBundle but better a configuration de-duplication with an integer key when using string key in ArrayNode.