### PR TITLE
[TwigBridge] AppVariable add $strictVariables

### DIFF
--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Twig\Environment;
 
 /**
  * Exposes some Symfony parameters and services as an "app" global variable.
@@ -29,7 +28,6 @@ class AppVariable
     private $requestStack;
     private $environment;
     private $debug;
-    private $twig;
     private $strictVariables = true;
 
     public function setTokenStorage(TokenStorageInterface $tokenStorage)
@@ -50,12 +48,6 @@ class AppVariable
     public function setDebug(bool $debug)
     {
         $this->debug = $debug;
-    }
-
-    public function setTwig(Environment $twig)
-    {
-        $this->twig = $twig;
-        $this->setStrictVariables($twig->isStrictVariables());
     }
 
     public function setStrictVariables(bool $strictVariables)

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Twig\Environment;
 
 /**
  * Exposes some Symfony parameters and services as an "app" global variable.
@@ -28,6 +29,8 @@ class AppVariable
     private $requestStack;
     private $environment;
     private $debug;
+    private $twig;
+    private $strictVariables = true;
 
     public function setTokenStorage(TokenStorageInterface $tokenStorage)
     {
@@ -49,6 +52,17 @@ class AppVariable
         $this->debug = $debug;
     }
 
+    public function setTwig(Environment $twig)
+    {
+        $this->twig = $twig;
+        $this->setStrictVariables($twig->isStrictVariables());
+    }
+
+    public function setStrictVariables(bool $strictVariables)
+    {
+        $this->strictVariables = $strictVariables;
+    }
+
     /**
      * Returns the current token.
      *
@@ -59,7 +73,11 @@ class AppVariable
     public function getToken()
     {
         if (null === $tokenStorage = $this->tokenStorage) {
-            throw new \RuntimeException('The "app.token" variable is not available.');
+            if ($this->strictVariables) {
+                throw new \RuntimeException('The "app.token" variable is not available.');
+            }
+
+            return null;
         }
 
         return $tokenStorage->getToken();
@@ -75,7 +93,11 @@ class AppVariable
     public function getUser()
     {
         if (null === $tokenStorage = $this->tokenStorage) {
-            throw new \RuntimeException('The "app.user" variable is not available.');
+            if ($this->strictVariables) {
+                throw new \RuntimeException('The "app.user" variable is not available.');
+            }
+
+            return null;
         }
 
         if (!$token = $tokenStorage->getToken()) {
@@ -95,7 +117,11 @@ class AppVariable
     public function getRequest()
     {
         if (null === $this->requestStack) {
-            throw new \RuntimeException('The "app.request" variable is not available.');
+            if ($this->strictVariables) {
+                throw new \RuntimeException('The "app.request" variable is not available.');
+            }
+
+            return null;
         }
 
         return $this->requestStack->getCurrentRequest();
@@ -109,7 +135,11 @@ class AppVariable
     public function getSession()
     {
         if (null === $this->requestStack) {
-            throw new \RuntimeException('The "app.session" variable is not available.');
+            if ($this->strictVariables) {
+                throw new \RuntimeException('The "app.session" variable is not available.');
+            }
+
+            return null;
         }
         $request = $this->getRequest();
 
@@ -123,7 +153,7 @@ class AppVariable
      */
     public function getEnvironment()
     {
-        if (null === $this->environment) {
+        if (null === $this->environment && $this->strictVariables) {
             throw new \RuntimeException('The "app.environment" variable is not available.');
         }
 
@@ -137,7 +167,7 @@ class AppVariable
      */
     public function getDebug()
     {
-        if (null === $this->debug) {
+        if (null === $this->debug && $this->strictVariables) {
             throw new \RuntimeException('The "app.debug" variable is not available.');
         }
 

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Added support for extracting messages from the `t()` function
  * Added `field_*` Twig functions to access string values from Form fields
  * changed the `importance` context option of `NotificationEmail` to allow `null`
+ * added the `setTwig(\Twig\Environment $twig)` and `setStrictVariables(true|false)` methods for `AppVariable`, all `getXXX` methods should returns `null` if `AppVariable::$strictVariables === false`
 
 5.0.0
 -----

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+ * added `setStrictVariables(true|false)` method for `AppVariable`, all `getXXX` methods should returns `null` if `AppVariable::$strictVariables === false`
+
 5.2.0
 -----
 
@@ -11,7 +16,6 @@ CHANGELOG
  * Added support for extracting messages from the `t()` function
  * Added `field_*` Twig functions to access string values from Form fields
  * changed the `importance` context option of `NotificationEmail` to allow `null`
- * added the `setTwig(\Twig\Environment $twig)` and `setStrictVariables(true|false)` methods for `AppVariable`, all `getXXX` methods should returns `null` if `AppVariable::$strictVariables === false`
 
 5.0.0
 -----

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -120,10 +120,29 @@ class AppVariableTest extends TestCase
         $this->appVariable->getEnvironment();
     }
 
+    public function testEnvironmentNotSetNotStrictVariables()
+    {
+        $this->setTwig(false);
+        $this->assertNull($this->appVariable->getEnvironment());
+    }
+
     public function testDebugNotSet()
     {
         $this->expectException(\RuntimeException::class);
         $this->appVariable->getDebug();
+    }
+
+    public function testDebugNotSetStrictVariables()
+    {
+        $this->setTwig(true);
+        $this->expectException('RuntimeException');
+        $this->appVariable->getDebug();
+    }
+
+    public function testDebugNotSetNotStrictVariables()
+    {
+        $this->setTwig(false);
+        $this->assertNull($this->appVariable->getDebug());
     }
 
     public function testGetTokenWithTokenStorageNotSet()
@@ -132,10 +151,36 @@ class AppVariableTest extends TestCase
         $this->appVariable->getToken();
     }
 
+    public function testGetTokenWithTokenStorageNotSetStrictVariables()
+    {
+        $this->setTwig(true);
+        $this->expectException('RuntimeException');
+        $this->appVariable->getToken();
+    }
+
+    public function testGetTokenWithTokenStorageNotSetNotStrictVariables()
+    {
+        $this->setTwig(false);
+        $this->assertNull($this->appVariable->getToken());
+    }
+
     public function testGetUserWithTokenStorageNotSet()
     {
         $this->expectException(\RuntimeException::class);
         $this->appVariable->getUser();
+    }
+
+    public function testGetUserWithTokenStorageNotSetStrictVariables()
+    {
+        $this->setTwig(true);
+        $this->expectException('RuntimeException');
+        $this->appVariable->getUser();
+    }
+
+    public function testGetUserWithTokenStorageNotSetNotStrictVariables()
+    {
+        $this->setTwig(false);
+        $this->assertNull($this->appVariable->getUser());
     }
 
     public function testGetRequestWithRequestStackNotSet()
@@ -144,10 +189,36 @@ class AppVariableTest extends TestCase
         $this->appVariable->getRequest();
     }
 
+    public function testGetRequestWithRequestStackNotSetStrictVariables()
+    {
+        $this->setTwig(true);
+        $this->expectException('RuntimeException');
+        $this->appVariable->getRequest();
+    }
+
+    public function testGetRequestWithRequestStackNotSetNotStrictVariables()
+    {
+        $this->setTwig(false);
+        $this->assertNull($this->appVariable->getRequest());
+    }
+
     public function testGetSessionWithRequestStackNotSet()
     {
         $this->expectException(\RuntimeException::class);
         $this->appVariable->getSession();
+    }
+
+    public function testGetSessionWithRequestStackNotSetStrictVariables()
+    {
+        $this->setTwig(true);
+        $this->expectException('RuntimeException');
+        $this->appVariable->getSession();
+    }
+
+    public function testGetSessionWithRequestStackNotSetNotStrictVariables()
+    {
+        $this->setTwig(false);
+        $this->assertNull($this->appVariable->getSession());
     }
 
     public function testGetFlashesWithNoRequest()
@@ -261,5 +332,12 @@ class AppVariableTest extends TestCase
         $this->setRequestStack($request);
 
         return $flashMessages;
+    }
+
+    private function setTwig(bool $strictVariables = true)
+    {
+        $twig = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
+        $twig->method('isStrictVariables')->willReturn($strictVariables);
+        $this->appVariable->setTwig($twig);
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/AppVariableTest.php
@@ -122,7 +122,7 @@ class AppVariableTest extends TestCase
 
     public function testEnvironmentNotSetNotStrictVariables()
     {
-        $this->setTwig(false);
+        $this->appVariable->setStrictVariables(false);
         $this->assertNull($this->appVariable->getEnvironment());
     }
 
@@ -134,14 +134,14 @@ class AppVariableTest extends TestCase
 
     public function testDebugNotSetStrictVariables()
     {
-        $this->setTwig(true);
+        $this->appVariable->setStrictVariables(true);
         $this->expectException('RuntimeException');
         $this->appVariable->getDebug();
     }
 
     public function testDebugNotSetNotStrictVariables()
     {
-        $this->setTwig(false);
+        $this->appVariable->setStrictVariables(false);
         $this->assertNull($this->appVariable->getDebug());
     }
 
@@ -153,14 +153,14 @@ class AppVariableTest extends TestCase
 
     public function testGetTokenWithTokenStorageNotSetStrictVariables()
     {
-        $this->setTwig(true);
+        $this->appVariable->setStrictVariables(true);
         $this->expectException('RuntimeException');
         $this->appVariable->getToken();
     }
 
     public function testGetTokenWithTokenStorageNotSetNotStrictVariables()
     {
-        $this->setTwig(false);
+        $this->appVariable->setStrictVariables(false);
         $this->assertNull($this->appVariable->getToken());
     }
 
@@ -172,14 +172,14 @@ class AppVariableTest extends TestCase
 
     public function testGetUserWithTokenStorageNotSetStrictVariables()
     {
-        $this->setTwig(true);
+        $this->appVariable->setStrictVariables(true);
         $this->expectException('RuntimeException');
         $this->appVariable->getUser();
     }
 
     public function testGetUserWithTokenStorageNotSetNotStrictVariables()
     {
-        $this->setTwig(false);
+        $this->appVariable->setStrictVariables(false);
         $this->assertNull($this->appVariable->getUser());
     }
 
@@ -191,14 +191,14 @@ class AppVariableTest extends TestCase
 
     public function testGetRequestWithRequestStackNotSetStrictVariables()
     {
-        $this->setTwig(true);
+        $this->appVariable->setStrictVariables(true);
         $this->expectException('RuntimeException');
         $this->appVariable->getRequest();
     }
 
     public function testGetRequestWithRequestStackNotSetNotStrictVariables()
     {
-        $this->setTwig(false);
+        $this->appVariable->setStrictVariables(false);
         $this->assertNull($this->appVariable->getRequest());
     }
 
@@ -210,14 +210,14 @@ class AppVariableTest extends TestCase
 
     public function testGetSessionWithRequestStackNotSetStrictVariables()
     {
-        $this->setTwig(true);
+        $this->appVariable->setStrictVariables(true);
         $this->expectException('RuntimeException');
         $this->appVariable->getSession();
     }
 
     public function testGetSessionWithRequestStackNotSetNotStrictVariables()
     {
-        $this->setTwig(false);
+        $this->appVariable->setStrictVariables(false);
         $this->assertNull($this->appVariable->getSession());
     }
 
@@ -332,12 +332,5 @@ class AppVariableTest extends TestCase
         $this->setRequestStack($request);
 
         return $flashMessages;
-    }
-
-    private function setTwig(bool $strictVariables = true)
-    {
-        $twig = $this->getMockBuilder('Twig\Environment')->disableOriginalConstructor()->getMock();
-        $twig->method('isStrictVariables')->willReturn($strictVariables);
-        $this->appVariable->setTwig($twig);
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+ * Inject `twig` service on `AppVariable` by calling `setTwig`
+
 5.2.0
 -----
 

--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -1,11 +1,6 @@
 CHANGELOG
 =========
 
-5.3.0
------
-
- * Inject `twig` service on `AppVariable` by calling `setTwig`
-
 5.2.0
 -----
 

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
@@ -73,7 +73,7 @@ return static function (ContainerConfigurator $container) {
             ->call('setDebug', [param('kernel.debug')])
             ->call('setTokenStorage', [service('security.token_storage')->ignoreOnInvalid()])
             ->call('setRequestStack', [service('request_stack')->ignoreOnInvalid()])
-            ->call('setTwig', [service('twig')])
+            ->call('setStrictVariables', [param('twig.strict_variables')])
 
         ->set('twig.template_iterator', TemplateIterator::class)
             ->args([service('kernel'), abstract_arg('Twig paths'), param('twig.default_path')])

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
@@ -73,6 +73,7 @@ return static function (ContainerConfigurator $container) {
             ->call('setDebug', [param('kernel.debug')])
             ->call('setTokenStorage', [service('security.token_storage')->ignoreOnInvalid()])
             ->call('setRequestStack', [service('request_stack')->ignoreOnInvalid()])
+            ->call('setTwig', [service('twig')])
 
         ->set('twig.template_iterator', TemplateIterator::class)
             ->args([service('kernel'), abstract_arg('Twig paths'), param('twig.default_path')])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #39052 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | 

# To do
- [x] Update CHANGELOG
- [x] Add unit tests

# Description
D not throw exception on `AppVariable` if `twig.strict_variables=false` and `Security` components is not installed

# Example
![image](https://user-images.githubusercontent.com/7301643/98798380-1f684000-240e-11eb-96c8-af5613a2e2b3.png)

![image](https://user-images.githubusercontent.com/7301643/98798356-18413200-240e-11eb-8e93-453d7432d3fe.png)


# Before
![image](https://user-images.githubusercontent.com/7301643/98798291-03fd3500-240e-11eb-8f37-464357fb9acc.png)

# After
![image](https://user-images.githubusercontent.com/7301643/98798319-0b244300-240e-11eb-8b7f-4425cc17dbd1.png)


