### PR TITLE
[Yaml] Fix sequence with following mapping

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -1242,7 +1242,7 @@ class Parser
         $value = $yaml;
 
         while ($this->moveToNextLine()) {
-            for ($i = 1; isset($this->currentLine[$i]) && ']' !== $this->currentLine[$i]; ++$i) {
+            for ($i = 0; isset($this->currentLine[$i]) && ']' !== $this->currentLine[$i]; ++$i) {
             }
 
             $trimmedValue = trim($this->currentLine);

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -1699,6 +1699,22 @@ foobar: [foo,
 YAML
                 ,
             ],
+            'sequence spanning multiple lines nested in mapping with a following mapping' => [
+                [
+                    'foobar' => [
+                        'foo',
+                        'bar',
+                    ],
+                    'bar' => 'baz',
+                ],
+                <<<YAML
+foobar: [
+    foo,
+    bar,
+]
+bar: baz
+YAML
+            ],
             'nested sequence nested in mapping starting on the same line' => [
                 [
                     'foo' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4  <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | 

When handling a sequence (array) on a root level, the closing bracket is not detected (it it is the first character) and every following mapping will throw a `ParseException: Unexpected characters near "XXX" at line X`
