### PR TITLE
[ProxyManagerBridge] replace "ocramius/proxy-manager" by a more convenient fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,7 +122,7 @@
         "masterminds/html5": "^2.6",
         "monolog/monolog": "^1.25.1|^2",
         "nyholm/psr7": "^1.0",
-        "ocramius/proxy-manager": "^2.1",
+        "suimarco/proxy-manager": "^1.0",
         "paragonie/sodium_compat": "^1.8",
         "pda/pheanstalk": "^4.0",
         "php-http/httplug": "^1.0|^2.0",
@@ -143,7 +143,6 @@
         "masterminds/html5": "<2.6",
         "phpdocumentor/reflection-docblock": "<3.2.2",
         "phpdocumentor/type-resolver": "<0.3.0",
-        "ocramius/proxy-manager": "<2.1",
         "phpunit/phpunit": "<5.4.3"
     },
     "autoload": {

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -11,9 +11,7 @@
 
 namespace Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper;
 
-use ProxyManager\Exception\ExceptionInterface;
 use ProxyManager\Generator\ClassGenerator;
-use ProxyManager\Generator\MethodGenerator;
 use ProxyManager\GeneratorStrategy\BaseGeneratorStrategy;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface;
@@ -83,18 +81,6 @@ EOF;
     {
         $code = $this->classGenerator->generate($this->generateProxyClass($definition));
         $code = preg_replace('/^(class [^ ]++ extends )([^\\\\])/', '$1\\\\$2', $code);
-
-        if (!method_exists(MethodGenerator::class, 'fromReflectionWithoutBodyAndDocBlock')) { // proxy-manager < 2.2
-            $code = preg_replace(
-                '/((?:\$(?:this|initializer|instance)->)?(?:publicProperties|initializer|valueHolder))[0-9a-f]++/',
-                '${1}'.$this->getIdentifierSuffix($definition),
-                $code
-            );
-        }
-
-        if (!is_subclass_of(ExceptionInterface::class, 'Throwable')) { // proxy-manager < 2.5
-            $code = preg_replace('/ \\\\Closure::bind\(function ((?:& )?\(\$instance(?:, \$value)?\))/', ' \Closure::bind(static function \1', $code);
-        }
 
         return $code;
     }

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/Fixtures/proxy-implem.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/Fixtures/proxy-implem.php
@@ -76,7 +76,7 @@ class SunnyInterface_%s implements \ProxyManager\Proxy\VirtualProxyInterface, \S
 
         $targetObject = $this->valueHolder%s;
 
-        $backtrace = debug_backtrace(false);
+        $backtrace = debug_backtrace(false%S);
         trigger_error(
             sprintf(
                 'Undefined property: %s::$%s in %s on line %s',
@@ -115,8 +115,7 @@ class SunnyInterface_%s implements \ProxyManager\Proxy\VirtualProxyInterface, \S
         $targetObject = $this->valueHolder%s;
 
         unset($targetObject->$name);
-return;
-    }
+%a  }
 
     public function __clone()
     {

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -17,15 +17,11 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "composer/package-versions-deprecated": "^1.8",
-        "symfony/dependency-injection": "^5.0",
-        "ocramius/proxy-manager": "~2.1"
+        "suimarco/proxy-manager": "^1.0",
+        "symfony/dependency-injection": "^5.0"
     },
     "require-dev": {
         "symfony/config": "^4.4|^5.0"
-    },
-    "conflict": {
-        "zendframework/zend-eventmanager": "2.6.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bridge\\ProxyManager\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

*EDIT: Although I didn't intend any harm at all, this PR wasn't well-received (see comments below). I invite the reader to check https://github.com/Ocramius/ProxyManager/issues/630 for a possible follow up.*

The versioning policy of `ocramius/proxy-manager` has been proven quite painful over the years.
Everybody can feel it hard in various ways these days with Composer 2 and PHP 8 coming.

I created the [`suimarco/proxy-manager`](https://github.com/suimarco/proxy-manager) fork to provide the same code and API, but with a versioning policy that is friendly to continuous migrations.

This fork is a drop-in replacement for `ocramius/proxy-manager` that is tested from PHP 7.1 to 8.0.
It also ships with a few fixes that were not merged upstream but are still needed, and that we had to monkey-patch. The related monkey-patching can now be removed.