### PR TITLE
[ProxyManagerBridge] Fix test error

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/Fixtures/proxy-implem.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/Fixtures/proxy-implem.php
@@ -76,7 +76,7 @@ class SunnyInterface_%s implements \ProxyManager\Proxy\VirtualProxyInterface, \S
 
         $targetObject = $this->valueHolder%s;
 
-        $backtrace = debug_backtrace(false);
+        $backtrace = debug_backtrace(false, 1);
         trigger_error(
             sprintf(
                 'Undefined property: %s::$%s in %s on line %s',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Since https://github.com/Ocramius/ProxyManager/pull/629 and exactly this https://github.com/Ocramius/ProxyManager/pull/629/files#diff-7c2c417759f4d7983fc425bac4e03d07c7b62314417b5890e5d6cf922976e46aR82

The fixture in the bridge component is invalid and is failing the test suite.
