### PR TITLE
[Messenger]  Allow InMemoryTransport to serialize message

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+* `InMemoryTransport` can perform message serialization through dsn `in-memory://?serialize=true`.
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Messenger/Transport/InMemoryTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/InMemoryTransportFactory.php
@@ -26,7 +26,9 @@ class InMemoryTransportFactory implements TransportFactoryInterface, ResetInterf
 
     public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
     {
-        return $this->createdTransports[] = new InMemoryTransport();
+        ['serialize' => $serialize] = $this->parseDsn($dsn);
+
+        return $this->createdTransports[] = new InMemoryTransport($serialize ? $serializer : null);
     }
 
     public function supports(string $dsn, array $options): bool
@@ -39,5 +41,17 @@ class InMemoryTransportFactory implements TransportFactoryInterface, ResetInterf
         foreach ($this->createdTransports as $transport) {
             $transport->reset();
         }
+    }
+
+    private function parseDsn(string $dsn): array
+    {
+        $query = [];
+        if ($queryAsString = strstr($dsn, '?')) {
+            parse_str(ltrim($queryAsString, '?'), $query);
+        }
+
+        return [
+            'serialize' => filter_var($query['serialize'] ?? false, \FILTER_VALIDATE_BOOLEAN),
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #38893
| License       | MIT
| Doc PR        | wip

This introduce a query parameter in dsn to enable serialization as @Nyholm has suggested in #38893 

`in-memory://?serialize=true`