### PR TITLE
[Mailer] Suggest installing HttpClient for Mailer transports that support it

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
@@ -22,6 +22,9 @@
     "require-dev": {
         "symfony/http-client": "^4.3|^5.0"
     },
+    "suggest": {
+        "symfony/http-client": "To enable the \"ses+api\" and \"ses+https\" transports."
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Amazon\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailchimp/composer.json
@@ -22,6 +22,9 @@
     "require-dev": {
         "symfony/http-client": "^4.3|^5.0"
     },
+    "suggest": {
+        "symfony/http-client": "To enable the \"mandrill+api\" and \"mandrill+https\" transports."
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Mailchimp\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
@@ -22,6 +22,9 @@
     "require-dev": {
         "symfony/http-client": "^4.3|^5.0"
     },
+    "suggest": {
+        "symfony/http-client": "To enable the \"mailgun+api\" and \"mailgun+https\" transports."
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Mailgun\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/composer.json
@@ -22,6 +22,9 @@
     "require-dev": {
         "symfony/http-client": "^4.3|^5.0"
     },
+    "suggest": {
+        "symfony/http-client": "To enable the \"postmark+api\" transport."
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Postmark\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/composer.json
@@ -22,6 +22,9 @@
     "require-dev": {
         "symfony/http-client": "^4.3|^5.0"
     },
+    "suggest": {
+        "symfony/http-client": "To enable the \"sendgrid+api\" transport."
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Mailer\\Bridge\\Sendgrid\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39081
| License       | MIT
| Doc PR        | N/A

The idea behind this PR is to give the developer some guidance on how to get a certain mailer transport package to work. Without the HttpClient component, those packages only support SMTP, which might be obvious to us, but not necessarily to a developer who just wants to connect an email service.

This is why I'd like to add `symfony/http-client` to the `suggest` section of those packages.

If this PR is accepted, I'll create a follow-up for Mailjet and Sendinblue on 5.2.