### PR TITLE
[Asset] prefix asset name by slash if not found in manifest.json

### DIFF
--- a/src/Symfony/Component/Asset/CHANGELOG.md
+++ b/src/Symfony/Component/Asset/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.2.0
+-----
+
+ * prepend or trim "/" from asset name if not found in `JsonManifestVersionStrategy`
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
+++ b/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
@@ -30,6 +30,14 @@ class JsonManifestVersionStrategyTest extends TestCase
         $this->assertSame('css/styles.555def.css', $strategy->getVersion('css/styles.css'));
     }
 
+    public function testGetVersionWithoutSlash()
+    {
+        $strategy = $this->createStrategy('manifest-valid.json');
+
+        $this->assertSame('css/slash.856sh.css', $strategy->getVersion('css/slash.css'));
+        $this->assertSame('css/slash.856sh.css', $strategy->getVersion('/css/slash.css'));
+    }
+
     public function testApplyVersionWhenKeyDoesNotExistInManifest()
     {
         $strategy = $this->createStrategy('manifest-valid.json');

--- a/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
+++ b/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
@@ -28,9 +28,10 @@ class JsonManifestVersionStrategyTest extends TestCase
         $strategy = $this->createStrategy('manifest-valid.json');
 
         $this->assertSame('css/styles.555def.css', $strategy->getVersion('css/styles.css'));
+        $this->assertSame('css/styles.555def.css', $strategy->getVersion('/css/styles.css'));
     }
 
-    public function testGetVersionWithoutSlash()
+    public function testGetVersionWithSlash()
     {
         $strategy = $this->createStrategy('manifest-valid.json');
 

--- a/src/Symfony/Component/Asset/Tests/fixtures/manifest-valid.json
+++ b/src/Symfony/Component/Asset/Tests/fixtures/manifest-valid.json
@@ -1,4 +1,5 @@
 {
   "main.js": "main.123abc.js",
-  "css/styles.css": "css/styles.555def.css"
+  "css/styles.css": "css/styles.555def.css",
+  "/css/slash.css": "css/slash.856sh.css"
 }

--- a/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
@@ -63,6 +63,16 @@ class JsonManifestVersionStrategy implements VersionStrategyInterface
             }
         }
 
-        return isset($this->manifestData[$path]) ? $this->manifestData[$path] : null;
+        return $this->manifestData[$path] ?? $this->getPossiblePath($path);
+    }
+
+    private function getPossiblePath(string $path): ?string
+    {
+        return $this->manifestData[$this->generatePossiblePath($path)] ?? null;
+    }
+
+    private function generatePossiblePath(string $path): string
+    {
+        return 0 === strpos($path, '/') ? ltrim($path, '/') : '/'.$path;
     }
 }

--- a/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
@@ -63,12 +63,7 @@ class JsonManifestVersionStrategy implements VersionStrategyInterface
             }
         }
 
-        return $this->manifestData[$path] ?? $this->getPossiblePath($path);
-    }
-
-    private function getPossiblePath(string $path): ?string
-    {
-        return $this->manifestData[$this->guessPath($path)] ?? null;
+        return $this->manifestData[$path] ?? $this->manifestData[$this->guessPath($path)] ?? null;
     }
 
     private function guessPath(string $path): string

--- a/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
@@ -68,10 +68,10 @@ class JsonManifestVersionStrategy implements VersionStrategyInterface
 
     private function getPossiblePath(string $path): ?string
     {
-        return $this->manifestData[$this->generatePossiblePath($path)] ?? null;
+        return $this->manifestData[$this->guessPath($path)] ?? null;
     }
 
-    private function generatePossiblePath(string $path): string
+    private function guessPath(string $path): string
     {
         return 0 === strpos($path, '/') ? ltrim($path, '/') : '/'.$path;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #39084 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

# Modifs
- [x] unit tests
- [x] CHANGELOG

# Description
get the generated asset calling `main.css` or `/main.css` if not found
```json
{
  "main.css": "buil/css/app.b916426ea1d10021f3f17ce8031f93c2.css"
}
```
```php
$package = new Package(new  JsonManifestVersionStrategy(__DIR__.'/manifest.json'));

dump($package->getUrl('main.css'));
dump($package->getUrl('/main.css'));
```