### PR TITLE
[Config] Recheck glob brace support after GlobResource was serialized

### DIFF
--- a/src/Symfony/Component/Config/Resource/GlobResource.php
+++ b/src/Symfony/Component/Config/Resource/GlobResource.php
@@ -95,6 +95,14 @@ class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface
     }
 
     /**
+     * @internal
+     */
+    public function __wakeup(): void
+    {
+        $this->globBrace = \defined('GLOB_BRACE') ? \GLOB_BRACE : 0;
+    }
+
+    /**
      * @return \Traversable
      */
     public function getIterator()

--- a/src/Symfony/Component/Config/Tests/Resource/GlobResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/GlobResourceTest.php
@@ -194,4 +194,17 @@ class GlobResourceTest extends TestCase
 
         $this->assertSame([], array_keys(iterator_to_array($resource)));
     }
+
+    public function testSerializeUnserialize()
+    {
+        $dir = \dirname(__DIR__).\DIRECTORY_SEPARATOR.'Fixtures';
+        $resource = new GlobResource($dir, '/Resource', true);
+
+        $newResource = unserialize(serialize($resource));
+
+        $p = new \ReflectionProperty($resource, 'globBrace');
+        $p->setAccessible(true);
+
+        $this->assertEquals($p->getValue($resource), $p->getValue($newResource));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

cc @bastnic

This bug was reported on Symfony Slack: `$this->globBrace` is set to `null` after unserialization from the `.meta` file.

Instead of serializing this property, I decided to reinitialize the property after unserialization. I think that's a safer option (e.g. it works when the cache is build on a different server with different globBrace support than the one running the application).