### PR TITLE
Fix critical extension when reseting paged control

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -100,7 +100,7 @@ class Query extends AbstractQuery
             $cookie = '';
             do {
                 if ($pageControl) {
-                    $this->controlPagedResult($con, $pageSize, $cookie);
+                    $this->controlPagedResult($con, $pageSize, true, $cookie);
                 }
                 $sizeLimit = $itemsLeft;
                 if ($pageSize > 0 && $sizeLimit >= $pageSize) {
@@ -174,7 +174,7 @@ class Query extends AbstractQuery
     private function resetPagination()
     {
         $con = $this->connection->getResource();
-        $this->controlPagedResult($con, 0, '');
+        $this->controlPagedResult($con, 0, false, '');
         $this->serverctrls = [];
 
         // This is a workaround for a bit of a bug in the above invocation
@@ -204,15 +204,15 @@ class Query extends AbstractQuery
      *
      * @param resource $con
      */
-    private function controlPagedResult($con, int $pageSize, string $cookie): bool
+    private function controlPagedResult($con, int $pageSize, bool $critical, string $cookie): bool
     {
         if (\PHP_VERSION_ID < 70300) {
-            return ldap_control_paged_result($con, $pageSize, true, $cookie);
+            return ldap_control_paged_result($con, $pageSize, $critical, $cookie);
         }
         $this->serverctrls = [
             [
                 'oid' => \LDAP_CONTROL_PAGEDRESULTS,
-                'isCritical' => true,
+                'isCritical' => $critical,
                 'value' => [
                     'size' => $pageSize,
                     'cookie' => $cookie,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The issue has been introduced here in #38392 and prevent performing an operation after fetched a paginated result => ldap throws an `Could not XXX: Critical extension is unavailable`

At this line: https://github.com/symfony/symfony/pull/38392/files#diff-24b79f3ac1a99938f5acb158a450e38d30c1984a5d333b5b20f2c38a73d10e31L183, the previous code called `ldap_control_paged_result($con, 0);` using the default value (`false`) for the `$critical` argument.
The replaced version always use `true`.

This PR restore the previous behavior by using `false` when reseting the pagination.

