### PR TITLE
[Finder] Minor : Removed typo (extra "the" term) in hasResults() method documentation

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -616,7 +616,7 @@ class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Check if the any results were found.
+     * Check if any results were found.
      *
      * @return bool
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.4 (as recommended by https://symfony.com/doc/current/contributing/code/pull_requests.html#choose-the-right-branch)
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

