### PR TITLE
[Ldap] Fix undefined variable $con

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/EntryManager.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/EntryManager.php
@@ -151,8 +151,9 @@ class EntryManager implements EntryManagerInterface
             $operationsMapped[] = $modification->toArray();
         }
 
-        if (!@ldap_modify_batch($this->getConnectionResource(), $dn, $operationsMapped)) {
-            throw new UpdateOperationException(sprintf('Error executing UpdateOperation on "%s": "%s".', $dn, ldap_error($this->getConnectionResource())));
+        $con = $this->getConnectionResource();
+        if (!@ldap_modify_batch($con, $dn, $operationsMapped)) {
+            throw new UpdateOperationException(sprintf('Error executing UpdateOperation on "%s": "%s".', $dn, ldap_error($con)));
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/39030#issuecomment-728156901
| License       | MIT
| Doc PR        | N/A

This PR extracts the connection resource into a variable. This will fix an undefined variable error on 5.1.