### PR TITLE
[Notifier] add iqsms bridge

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -107,6 +107,7 @@ use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransportFactory;
 use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransportFactory;
 use Symfony\Component\Notifier\Bridge\GoogleChat\GoogleChatTransportFactory;
 use Symfony\Component\Notifier\Bridge\Infobip\InfobipTransportFactory;
+use Symfony\Component\Notifier\Bridge\Iqsms\IqsmsTransportFactory;
 use Symfony\Component\Notifier\Bridge\LinkedIn\LinkedInTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mobyt\MobytTransportFactory;
@@ -2220,6 +2221,7 @@ class FrameworkExtension extends Extension
             MattermostTransportFactory::class => 'notifier.transport_factory.mattermost',
             GoogleChatTransportFactory::class => 'notifier.transport_factory.googlechat',
             NexmoTransportFactory::class => 'notifier.transport_factory.nexmo',
+            IqsmsTransportFactory::class => 'notifier.transport_factory.iqsms',
             RocketChatTransportFactory::class => 'notifier.transport_factory.rocketchat',
             InfobipTransportFactory::class => 'notifier.transport_factory.infobip',
             TwilioTransportFactory::class => 'notifier.transport_factory.twilio',

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -17,6 +17,7 @@ use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransportFactory;
 use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransportFactory;
 use Symfony\Component\Notifier\Bridge\GoogleChat\GoogleChatTransportFactory;
 use Symfony\Component\Notifier\Bridge\Infobip\InfobipTransportFactory;
+use Symfony\Component\Notifier\Bridge\Iqsms\IqsmsTransportFactory;
 use Symfony\Component\Notifier\Bridge\LinkedIn\LinkedInTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mobyt\MobytTransportFactory;
@@ -108,6 +109,10 @@ return static function (ContainerConfigurator $container) {
             ->tag('texter.transport_factory')
 
         ->set('notifier.transport_factory.sendinblue', SendinblueTransportFactory::class)
+            ->parent('notifier.transport_factory.abstract')
+            ->tag('texter.transport_factory')
+
+        ->set('notifier.transport_factory.iqsms', IqsmsTransportFactory::class)
             ->parent('notifier.transport_factory.abstract')
             ->tag('texter.transport_factory')
 

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.3.0
+-----
+
+ * Added the bridge

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransport.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Iqsms;
+
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Oleksandr Barabolia <alexandrbarabolya@gmail.com>
+ *
+ * @experimental in 5.3
+ */
+final class IqsmsTransport extends AbstractTransport
+{
+    protected const HOST = 'api.iqsms.ru';
+
+    private $login;
+    private $password;
+    private $from;
+
+    public function __construct(string $login, string $password, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    {
+        $this->login = $login;
+        $this->password = $password;
+        $this->from = $from;
+
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('iqsms://%s?from=%s', $this->getEndpoint(), $this->from);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof SmsMessage;
+    }
+
+    protected function doSend(MessageInterface $message): SentMessage
+    {
+        if (!$message instanceof SmsMessage) {
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
+        }
+
+        $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/messages/v2/send.json', [
+            'json' => [
+                'messages' => [
+                    [
+                        'phone' => $message->getPhone(),
+                        'text' => $message->getSubject(),
+                        'sender' => $this->from,
+                        'clientId' => uniqid(),
+                    ],
+                ],
+                'login' => $this->login,
+                'password' => $this->password,
+            ],
+        ]);
+
+        $result = $response->toArray(false);
+        foreach ($result['messages'] as $msg) {
+            if ('accepted' !== $msg['status']) {
+                throw new TransportException(sprintf('Unable to send the SMS: "%s".', $msg['status']), $response);
+            }
+        }
+
+        $message = new SentMessage($message, (string) $this);
+        $message->setMessageId($result['messages'][0]['smscId']);
+
+        return $message;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransportFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Iqsms;
+
+use Symfony\Component\Notifier\Exception\IncompleteDsnException;
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+
+/**
+ * @author Oleksandr Barabolia <alexandrbarabolya@gmail.com>
+ *
+ * @experimental in 5.3
+ */
+final class IqsmsTransportFactory extends AbstractTransportFactory
+{
+    /**
+     * @return IqsmsTransport
+     */
+    public function create(Dsn $dsn): TransportInterface
+    {
+        $scheme = $dsn->getScheme();
+
+        if ('iqsms' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'iqsms', $this->getSupportedSchemes());
+        }
+
+        $login = $this->getUser($dsn);
+        $password = $this->getPassword($dsn);
+        $from = $dsn->getOption('from');
+
+        if (!$from) {
+            throw new IncompleteDsnException('Missing from.', $dsn->getOriginalDsn());
+        }
+
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        return (new IqsmsTransport($login, $password, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['iqsms'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/README.md
@@ -1,0 +1,24 @@
+Iqsms Notifier
+==============
+
+Provides [Iqsms[(https://iqsms.ru) integration for Symfony Notifier.
+
+DSN example
+-----------
+
+```
+IQSMS_DSN=iqsms://LOGIN:PASSWORD@default?from=FROM
+```
+
+where:
+ - `LOGIN` is your IQSMS login
+ - `PASSWORD` is your IQSMS password
+ - `FROM` is the sender
+
+Resources
+---------
+
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/Tests/IqsmsTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/Tests/IqsmsTransportFactoryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Iqsms\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\Iqsms\IqsmsTransportFactory;
+use Symfony\Component\Notifier\Exception\IncompleteDsnException;
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\Dsn;
+
+final class IqsmsTransportFactoryTest extends TestCase
+{
+    public function testCreateWithDsn()
+    {
+        $factory = $this->createFactory();
+
+        $transport = $factory->create(Dsn::fromString('iqsms://login:password@host.test?from=some'));
+        $this->assertSame('iqsms://host.test?from=some', (string) $transport);
+    }
+
+    public function testCreateWithMissingOptionFromThrowsIncompleteDsnException()
+    {
+        $factory = $this->createFactory();
+
+        $this->expectException(IncompleteDsnException::class);
+
+        $factory->create(Dsn::fromString('iqsms://login:password@default'));
+    }
+
+    public function testSupportsReturnsTrueWithSupportedScheme()
+    {
+        $factory = $this->createFactory();
+
+        $this->assertTrue($factory->supports(Dsn::fromString('iqsms://login:password@default?from=some')));
+    }
+
+    public function testSupportsReturnsFalseWithUnsupportedScheme()
+    {
+        $factory = $this->createFactory();
+
+        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://login:password@default?from=some')));
+    }
+
+    public function testUnsupportedSchemeThrowsUnsupportedSchemeException()
+    {
+        $factory = $this->createFactory();
+
+        $this->expectException(UnsupportedSchemeException::class);
+
+        $factory->create(Dsn::fromString('somethingElse://login:password@default?from=some'));
+    }
+
+    public function testUnsupportedSchemeThrowsUnsupportedSchemeExceptionEvenIfRequiredOptionIsMissing()
+    {
+        $factory = $this->createFactory();
+
+        $this->expectException(UnsupportedSchemeException::class);
+
+        // unsupported scheme and missing "from" option
+        $factory->create(Dsn::fromString('somethingElse://login:password@default'));
+    }
+
+    private function createFactory(): IqsmsTransportFactory
+    {
+        return new IqsmsTransportFactory();
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/Tests/IqsmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/Tests/IqsmsTransportTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Iqsms\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\Iqsms\IqsmsTransport;
+use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class IqsmsTransportTest extends TestCase
+{
+    public function testToStringContainsProperties()
+    {
+        $transport = $this->createTransport();
+
+        $this->assertSame('iqsms://host.test?from=sender', (string) $transport);
+    }
+
+    public function testSupportsMessageInterface()
+    {
+        $transport = $this->createTransport();
+
+        $this->assertTrue($transport->supports(new SmsMessage('9031223344', 'Hello!')));
+        $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
+    }
+
+    public function testSendNonSmsMessageThrowsException()
+    {
+        $transport = $this->createTransport();
+
+        $this->expectException(LogicException::class);
+
+        $transport->send($this->createMock(MessageInterface::class));
+    }
+
+    private function createTransport(): IqsmsTransport
+    {
+        return (new IqsmsTransport('login', 'password', 'sender', $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/composer.json
@@ -1,0 +1,34 @@
+{
+    "name": "symfony/iqsms-notifier",
+    "type": "symfony-bridge",
+    "description": "Symfony Iqsms Notifier Bridge",
+    "keywords": ["sms", "iqsms", "notifier"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Oleksandr Barabolia",
+            "email": "alexandrbarabolya@gmail.com"
+        },
+        {
+            "name": "Fabien Potencier",
+            "email": "fabien@symfony.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=7.2.5",
+        "symfony/http-client": "^4.3|^5.0",
+        "symfony/notifier": "^5.3"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Iqsms\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Iqsms Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -42,6 +42,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Nexmo\NexmoTransportFactory::class,
             'package' => 'symfony/nexmo-notifier',
         ],
+        'iqsms' => [
+            'class' => Bridge\Iqsms\IqsmsTransportFactory::class,
+            'package' => 'symfony/iqsms-notifier',
+        ],
         'rocketchat' => [
             'class' => Bridge\RocketChat\RocketChatTransportFactory::class,
             'package' => 'symfony/rocket-chat-notifier',

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -16,6 +16,7 @@ use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransportFactory;
 use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransportFactory;
 use Symfony\Component\Notifier\Bridge\Infobip\InfobipTransportFactory;
+use Symfony\Component\Notifier\Bridge\Iqsms\IqsmsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mobyt\MobytTransportFactory;
 use Symfony\Component\Notifier\Bridge\Nexmo\NexmoTransportFactory;
@@ -51,6 +52,7 @@ class Transport
         TelegramTransportFactory::class,
         MattermostTransportFactory::class,
         NexmoTransportFactory::class,
+        IqsmsTransportFactory::class,
         RocketChatTransportFactory::class,
         TwilioTransportFactory::class,
         InfobipTransportFactory::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/14555
Hi,

I've created integration to notifier to support russian sms operator - [iqsms](https://iqsms.ru)

Can you grab this code and make as symfony/iqsms-notifier?

This PR includes changes in notifier and framework-bundle to support smsapi transport as well as other included in notifier component.

Could someone integrate this into notifier component?
