### PR TITLE
[Form] ignore the pattern attribute for textareas

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
@@ -2379,7 +2379,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
 '/textarea
     [@name="name"]
-    [@pattern="foo"]
+    [not(@pattern)]
     [@class="my&class form-control"]
     [.="foo&bar"]
 '

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -26,7 +26,7 @@
         "symfony/dependency-injection": "^3.4|^4.0|^5.0",
         "symfony/error-handler": "^4.4|^5.0",
         "symfony/finder": "^3.4|^4.0|^5.0",
-        "symfony/form": "^4.3.5",
+        "symfony/form": "^4.4.17",
         "symfony/http-foundation": "^4.3|^5.0",
         "symfony/http-kernel": "^4.4",
         "symfony/mime": "^4.3|^5.0",

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
@@ -23,6 +23,7 @@ class TextareaType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['pattern'] = null;
+        unset($view->vars['attr']['pattern']);
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2068,7 +2068,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         $this->assertWidgetMatchesXpath($form->createView(), [],
 '/textarea
     [@name="name"]
-    [@pattern="foo"]
+    [not(@pattern)]
     [.="foo&bar"]
 '
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39066
| License       | MIT
| Doc PR        | 