### PR TITLE
[Console] Add input argument getters with typehint

### DIFF
--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -198,4 +198,19 @@ abstract class Input implements InputInterface, StreamableInputInterface
     {
         return $this->stream;
     }
+
+    public function getArgumentString(string $name): string
+    {
+        return (string) $this->getArgument($name);
+    }
+
+    public function getArgumentInt(string $name): int
+    {
+        return (int) $this->getArgument($name);
+    }
+
+    public function getArgumentBoolean(string $name): bool
+    {
+        return (bool) $this->getArgument($name);
+    }
 }

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -90,6 +90,27 @@ interface InputInterface
     public function getArgument(string $name);
 
     /**
+     * Returns the argument value for a given argument name as a string.
+     *
+     * @throws InvalidArgumentException When argument given doesn't exist
+     */
+    public function getArgumentString(string $name): string;
+
+    /**
+     * Returns the argument value for a given argument name as an integer.
+     *
+     * @throws InvalidArgumentException When argument given doesn't exist
+     */
+    public function getArgumentInt(string $name): int;
+
+    /**
+     * Returns the argument value for a given argument name as a boolean.
+     *
+     * @throws InvalidArgumentException When argument given doesn't exist
+     */
+    public function getArgumentBoolean(string $name): bool;
+
+    /**
      * Sets an argument value by name.
      *
      * @param string|string[]|null $value The argument value


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix adding typehint
| License       | MIT
| Doc PR        | If PR accepted

Mimic https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/HttpFoundation/ParameterBag.php#L159

It can help write commands with proper args typehints like when dealing with request args via the parameterbag

I do not know if this was proposed before, thus feel free to close