### PR TITLE
[Security] Update password upgrader listener to work with the new UserBadge

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * Added `LoginThrottlingListener`.
  * Added `LoginLinkAuthenticator`.
  * Moved methods `supports()` and `authenticate()` from `AbstractListener` to `FirewallListenerInterface`.
+ * [BC break] `PasswordUpgradeBadge::getPasswordUpgrader()` changed its return type to return null or a `PasswordUpgraderInterface` implementation.
 
 5.1.0
 -----

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/PasswordUpgradeBadge.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/PasswordUpgradeBadge.php
@@ -30,10 +30,10 @@ class PasswordUpgradeBadge implements BadgeInterface
     private $passwordUpgrader;
 
     /**
-     * @param string                    $plaintextPassword The presented password, used in the rehash
-     * @param PasswordUpgraderInterface $passwordUpgrader  The password upgrader, usually the UserProvider
+     * @param string                         $plaintextPassword The presented password, used in the rehash
+     * @param PasswordUpgraderInterface|null $passwordUpgrader  The password upgrader, defaults to the UserProvider if null
      */
-    public function __construct(string $plaintextPassword, PasswordUpgraderInterface $passwordUpgrader)
+    public function __construct(string $plaintextPassword, ?PasswordUpgraderInterface $passwordUpgrader = null)
     {
         $this->plaintextPassword = $plaintextPassword;
         $this->passwordUpgrader = $passwordUpgrader;
@@ -51,7 +51,7 @@ class PasswordUpgradeBadge implements BadgeInterface
         return $password;
     }
 
-    public function getPasswordUpgrader(): PasswordUpgraderInterface
+    public function getPasswordUpgrader(): ?PasswordUpgraderInterface
     {
         return $this->passwordUpgrader;
     }

--- a/src/Symfony/Component/Security/Http/EventListener/UserProviderListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/UserProviderListener.php
@@ -16,6 +16,9 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 
 /**
+ * Configures the user provider as user loader, if no user load
+ * has been explicitly set.
+ *
  * @author Wouter de Jong <wouter@wouterj.nl>
  *
  * @final

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PasswordUpgradeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
@@ -34,9 +35,14 @@ class PasswordMigratingListenerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->encoderFactory = $this->createMock(EncoderFactoryInterface::class);
-        $this->listener = new PasswordMigratingListener($this->encoderFactory);
         $this->user = $this->createMock(UserInterface::class);
+        $this->user->expects($this->any())->method('getPassword')->willReturn('old-encoded-password');
+        $encoder = $this->createMock(PasswordEncoderInterface::class);
+        $encoder->expects($this->any())->method('needsRehash')->willReturn(true);
+        $encoder->expects($this->any())->method('encodePassword')->with('pa$$word', null)->willReturn('new-encoded-password');
+        $this->encoderFactory = $this->createMock(EncoderFactoryInterface::class);
+        $this->encoderFactory->expects($this->any())->method('getEncoder')->with($this->user)->willReturn($encoder);
+        $this->listener = new PasswordMigratingListener($this->encoderFactory);
     }
 
     /**
@@ -61,16 +67,8 @@ class PasswordMigratingListenerTest extends TestCase
         yield [$this->createEvent($this->createMock(PassportInterface::class))];
     }
 
-    public function testUpgrade()
+    public function testUpgradeWithUpgrader()
     {
-        $encoder = $this->createMock(PasswordEncoderInterface::class);
-        $encoder->expects($this->any())->method('needsRehash')->willReturn(true);
-        $encoder->expects($this->any())->method('encodePassword')->with('pa$$word', null)->willReturn('new-encoded-password');
-
-        $this->encoderFactory->expects($this->any())->method('getEncoder')->with($this->user)->willReturn($encoder);
-
-        $this->user->expects($this->any())->method('getPassword')->willReturn('old-encoded-password');
-
         $passwordUpgrader = $this->createPasswordUpgrader();
         $passwordUpgrader->expects($this->once())
             ->method('upgradePassword')
@@ -78,6 +76,20 @@ class PasswordMigratingListenerTest extends TestCase
         ;
 
         $event = $this->createEvent(new SelfValidatingPassport(new UserBadge('test', function () { return $this->user; }), [new PasswordUpgradeBadge('pa$$word', $passwordUpgrader)]));
+        $this->listener->onLoginSuccess($event);
+    }
+
+    public function testUpgradeWithoutUpgrader()
+    {
+        $userLoader = $this->createMock(MigratingUserProvider::class);
+        $userLoader->expects($this->any())->method('loadUserByUsername')->willReturn($this->user);
+
+        $userLoader->expects($this->once())
+            ->method('upgradePassword')
+            ->with($this->user, 'new-encoded-password')
+        ;
+
+        $event = $this->createEvent(new SelfValidatingPassport(new UserBadge('test', [$userLoader, 'loadUserByUsername']), [new PasswordUpgradeBadge('pa$$word')]));
         $this->listener->onLoginSuccess($event);
     }
 
@@ -90,4 +102,8 @@ class PasswordMigratingListenerTest extends TestCase
     {
         return new LoginSuccessEvent($this->createMock(AuthenticatorInterface::class), $passport, $this->createMock(TokenInterface::class), new Request(), null, 'main');
     }
+}
+
+abstract class MigratingUserProvider implements UserProviderInterface, PasswordUpgraderInterface
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While working on a new amazing `make:auth` maker, @jrushlow discovered that we forgot to update the `PasswordUpgradeBadge` with the 5.2 `UserBadge` changes (ref https://github.com/symfony/symfony/pull/37846).

This PR fixes it, by making the password upgrader optional and falling back to the user provider instead. Without these changes, each authenticator still needs to know the user repository/user provider in order to pass it to `PasswordUpgradeBadge`.

I'm sorry for catching this soo late in the release cycle. There is a BC break involved here, but it's (a) very unlikely to impact application code and (b) in an experimental class.