### PR TITLE
[HttpClient] don't fallback to HTTP/1.1 when HTTP/2 streams break

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -283,10 +283,7 @@ final class CurlResponse implements ResponseInterface
                     curl_multi_remove_handle($multi->handle, $ch);
                     $waitFor[1] = (string) ((int) $waitFor[1] - 1); // decrement the retry counter
                     curl_setopt($ch, \CURLOPT_PRIVATE, $waitFor);
-
-                    if ('1' === $waitFor[1]) {
-                        curl_setopt($ch, \CURLOPT_HTTP_VERSION, \CURL_HTTP_VERSION_1_1);
-                    }
+                    curl_setopt($ch, \CURLOPT_FORBID_REUSE, true);
 
                     if (0 === curl_multi_add_handle($multi->handle, $ch)) {
                         continue;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/composer/composer/issues/9481
| License       | MIT
| Doc PR        | -

With this change, I don't reproduce the failures that I describe in https://github.com/composer/composer/issues/9481 when running the script in #38690

Apparently curl has an issue when both h1.1 and h2 connections are open to the same host.

Instead of switching to HTTP/1.1 when retrying requests that failed because of an HTTP/2 stream error, I propose to close the http/2 connection when issuing a retry.

With this change, running the mirroring script of packagist works like a charm.

No need to investigate your mirrors @Seldaek, this was definitely a data corruption issue.