### PR TITLE
[Mailer] send cloned Message to the bus

### DIFF
--- a/src/Symfony/Component/Mailer/Mailer.php
+++ b/src/Symfony/Component/Mailer/Mailer.php
@@ -45,9 +45,9 @@ final class Mailer implements MailerInterface
         }
 
         if (null !== $this->dispatcher) {
-            $clonedMessage = clone $message;
-            $clonedEnvelope = null !== $envelope ? clone $envelope : Envelope::create($clonedMessage);
-            $event = new MessageEvent($clonedMessage, $clonedEnvelope, (string) $this->transport, true);
+            $message = clone $message;
+            $clonedEnvelope = null !== $envelope ? clone $envelope : Envelope::create($message);
+            $event = new MessageEvent($message, $clonedEnvelope, (string) $this->transport, true);
             $this->dispatcher->dispatch($event);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37588
| License       | MIT

This more or less reverts 829566cdea, but it restores the behaviour in 4.4: The **cloned** Mime Message is dispatched to the messenger instead of the original Mime Message.

This allows us to change the message using an event listener and then get that *changed* instance in the message handler.