### PR TITLE
[Messenger] Implement MessageCountAwareInterface in RedisTransport

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+ * Implement `MessageCountAwareInterface`
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -399,4 +399,21 @@ class ConnectionTest extends TestCase
         $connection->reject($message['id']);
         $redis->del('messenger-lazy');
     }
+
+    public function testGetMessageCount()
+    {
+        $redis = new \Redis();
+        $connection = Connection::fromDsn('redis://localhost/message-count?delete_after_ack=true', [], $redis);
+        $redis->del('message-count');
+
+        $connection->add('first', []);
+        $this->assertEquals(1, $messageCountStart = $connection->getMessageCount());
+        $connection->add('second', []);
+        $this->assertEquals($messageCountStart + 1, $connection->getMessageCount());
+
+        $this->assertNotEmpty($message = $connection->get());
+        $connection->ack($message['id']);
+        $this->assertEquals($messageCountStart, $connection->getMessageCount());
+        $redis->del('message-count');
+    }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -474,6 +474,19 @@ class Connection
         $this->autoSetup = false;
     }
 
+    public function getMessageCount(): int
+    {
+        if ($this->autoSetup) {
+            $this->setup();
+        }
+
+        try {
+            return $this->connection->xLen($this->stream);
+        } catch (\RedisException $e) {
+            throw new TransportException($e->getMessage(), 0, $e);
+        }
+    }
+
     private function getCurrentTimeInMilliseconds(): int
     {
         return (int) (microtime(true) * 1000);

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Bridge\Redis\Transport;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -22,7 +23,7 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
  * @author Alexander Schranz <alexander@sulu.io>
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-class RedisReceiver implements ReceiverInterface
+class RedisReceiver implements ReceiverInterface, MessageCountAwareInterface
 {
     private $connection;
     private $serializer;
@@ -72,6 +73,14 @@ class RedisReceiver implements ReceiverInterface
     public function reject(Envelope $envelope): void
     {
         $this->connection->reject($this->findRedisReceivedStamp($envelope)->getId());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageCount(): int
+    {
+        return $this->connection->getMessageCount();
     }
 
     private function findRedisReceivedStamp(Envelope $envelope): RedisReceivedStamp

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransport.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Bridge\Redis\Transport;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\SetupableTransportInterface;
@@ -21,7 +22,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
  * @author Alexander Schranz <alexander@sulu.io>
  * @author Antoine Bluchet <soyuka@gmail.com>
  */
-class RedisTransport implements TransportInterface, SetupableTransportInterface
+class RedisTransport implements TransportInterface, SetupableTransportInterface, MessageCountAwareInterface
 {
     private $serializer;
     private $connection;
@@ -56,6 +57,14 @@ class RedisTransport implements TransportInterface, SetupableTransportInterface
     public function reject(Envelope $envelope): void
     {
         ($this->receiver ?? $this->getReceiver())->reject($envelope);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageCount(): int
+    {
+        return ($this->receiver ?? $this->getReceiver())->getMessageCount();
     }
 
     /**

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
 * `InMemoryTransport` can perform message serialization through dsn `in-memory://?serialize=true`.
+* `RedisTransport` implement `MessageCountAwareInterface`
 
 5.2.0
 -----


### PR DESCRIPTION
[Messenger] Implement MessageCountAwareInterface in RedisTransport

| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      |no
| New feature?  | yes
| Deprecations? |no
| Tickets       | 
| License       | MIT
| Doc PR        | n/a

Implement MessageCountAwareInterface in RedisTransport by providing the getMessageCount() method in the Connection class.  This calls xLen() on the Redis steam to return the number of items left to process.