### PR TITLE
[DependencyInjection] Fix circular in DI with lazy + byContruct loop

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -420,7 +420,7 @@ EOF;
         foreach ($edges as $edge) {
             $node = $edge->getDestNode();
             $id = $node->getId();
-            if (!($definition = $node->getValue()) instanceof Definition || $sourceId === $id || ($edge->isLazy() && ($this->proxyDumper ?? $this->getProxyDumper())->isProxyCandidate($definition)) || $edge->isWeak()) {
+            if ($sourceId === $id || !$node->getValue() instanceof Definition || $edge->isLazy() || $edge->isWeak()) {
                 continue;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1374,11 +1374,17 @@ class ContainerBuilderTest extends TestCase
         $container = include __DIR__.'/Fixtures/containers/container_almost_circular.php';
         $container->compile();
 
+        $entityManager = $container->get('doctrine.entity_manager');
+        $this->assertEquals(new \stdClass(), $entityManager);
+
         $pA = $container->get('pA');
         $this->assertEquals(new \stdClass(), $pA);
 
         $logger = $container->get('monolog.logger');
         $this->assertEquals(new \stdClass(), $logger->handler);
+
+        $logger_inline = $container->get('monolog_inline.logger');
+        $this->assertEquals(new \stdClass(), $logger_inline->handler);
 
         $foo = $container->get('foo');
         $this->assertSame($foo, $foo->bar->foobar->foo);

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -1054,11 +1054,17 @@ class PhpDumperTest extends TestCase
 
         $container = new $container();
 
+        $entityManager = $container->get('doctrine.entity_manager');
+        $this->assertEquals(new \stdClass(), $entityManager);
+
         $pA = $container->get('pA');
         $this->assertEquals(new \stdClass(), $pA);
 
         $logger = $container->get('monolog.logger');
         $this->assertEquals(new \stdClass(), $logger->handler);
+
+        $logger_inline = $container->get('monolog_inline.logger');
+        $this->assertEquals(new \stdClass(), $logger_inline->handler);
 
         $foo = $container->get('foo');
         $this->assertSame($foo, $foo->bar->foobar->foo);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/includes/classes.php
@@ -128,6 +128,18 @@ class FactoryCircular
     }
 }
 
+class FactoryChecker
+{
+    public static function create($config)
+    {
+        if (!isset($config->flag)) {
+            throw new \LogicException('The injected config must contain a "flag" property.');
+        }
+
+        return new stdClass();
+    }
+}
+
 class FoobarCircular
 {
     public function __construct(FooCircular $foo)

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_almost_circular_private.php
@@ -28,6 +28,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             'baz6' => 'getBaz6Service',
             'connection' => 'getConnectionService',
             'connection2' => 'getConnection2Service',
+            'doctrine.entity_manager' => 'getDoctrine_EntityManagerService',
             'foo' => 'getFooService',
             'foo2' => 'getFoo2Service',
             'foo5' => 'getFoo5Service',
@@ -40,6 +41,7 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             'manager2' => 'getManager2Service',
             'manager3' => 'getManager3Service',
             'monolog.logger' => 'getMonolog_LoggerService',
+            'monolog_inline.logger' => 'getMonologInline_LoggerService',
             'pA' => 'getPAService',
             'root' => 'getRootService',
             'subscriber' => 'getSubscriberService',
@@ -72,6 +74,9 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             'connection4' => true,
             'dispatcher' => true,
             'dispatcher2' => true,
+            'doctrine.config' => true,
+            'doctrine.entity_listener_resolver' => true,
+            'doctrine.listener' => true,
             'foo4' => true,
             'foobar' => true,
             'foobar2' => true,
@@ -85,8 +90,12 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
             'mailer.transport' => true,
             'mailer.transport_factory' => true,
             'mailer.transport_factory.amazon' => true,
+            'mailer_inline.mailer' => true,
+            'mailer_inline.transport_factory' => true,
+            'mailer_inline.transport_factory.amazon' => true,
             'manager4' => true,
             'monolog.logger_2' => true,
+            'monolog_inline.logger_2' => true,
             'multiuse1' => true,
             'pB' => true,
             'pC' => true,
@@ -183,6 +192,22 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
         $a->subscriber2 = new \stdClass($d);
 
         return $instance;
+    }
+
+    /**
+     * Gets the public 'doctrine.entity_manager' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getDoctrine_EntityManagerService()
+    {
+        $a = new \stdClass();
+        $a->resolver = new \stdClass(new RewindableGenerator(function () {
+            yield 0 => ($this->privates['doctrine.listener'] ?? $this->getDoctrine_ListenerService());
+        }, 1));
+        $a->flag = 'ok';
+
+        return $this->services['doctrine.entity_manager'] = \FactoryChecker::create($a);
     }
 
     /**
@@ -379,6 +404,20 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
     }
 
     /**
+     * Gets the public 'monolog_inline.logger' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getMonologInline_LoggerService()
+    {
+        $this->services['monolog_inline.logger'] = $instance = new \stdClass();
+
+        $instance->handler = ($this->privates['mailer_inline.mailer'] ?? $this->getMailerInline_MailerService());
+
+        return $instance;
+    }
+
+    /**
      * Gets the public 'pA' shared service.
      *
      * @return \stdClass
@@ -449,6 +488,16 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
     }
 
     /**
+     * Gets the private 'doctrine.listener' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getDoctrine_ListenerService()
+    {
+        return $this->privates['doctrine.listener'] = new \stdClass(($this->services['doctrine.entity_manager'] ?? $this->getDoctrine_EntityManagerService()));
+    }
+
+    /**
      * Gets the private 'level5' shared service.
      *
      * @return \stdClass
@@ -473,7 +522,8 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
     {
         return $this->privates['mailer.transport'] = (new \FactoryCircular(new RewindableGenerator(function () {
             yield 0 => ($this->privates['mailer.transport_factory.amazon'] ?? $this->getMailer_TransportFactory_AmazonService());
-        }, 1)))->create();
+            yield 1 => $this->getMailerInline_TransportFactory_AmazonService();
+        }, 2)))->create();
     }
 
     /**
@@ -490,6 +540,31 @@ class Symfony_DI_PhpDumper_Test_Almost_Circular_Private extends Container
         $a->handler = ($this->privates['mailer.transport'] ?? $this->getMailer_TransportService());
 
         return $instance;
+    }
+
+    /**
+     * Gets the private 'mailer_inline.mailer' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getMailerInline_MailerService()
+    {
+        return $this->privates['mailer_inline.mailer'] = new \stdClass((new \FactoryCircular(new RewindableGenerator(function () {
+            return new \EmptyIterator();
+        }, 0)))->create());
+    }
+
+    /**
+     * Gets the private 'mailer_inline.transport_factory.amazon' shared service.
+     *
+     * @return \stdClass
+     */
+    protected function getMailerInline_TransportFactory_AmazonService()
+    {
+        $a = new \stdClass();
+        $a->handler = ($this->privates['mailer_inline.mailer'] ?? $this->getMailerInline_MailerService());
+
+        return new \stdClass($a);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39120
| License       | MIT
| Doc PR        | -

This fix another issue lazy service.
It partially revert #38980 and #39021

Initially, we trusted lazy services to be lazy and not beeing called while building the services graph
=> bug #38970 when lazy deps is injected in a factory, it may be consumed directly to build the object before the graph is fully built
Fixed by #38980 => lazy service are considered as "normal service"
=> bug #39015 some loop are not resolvable with "normal service", but it shouldn't be an issue when servie proxifyied
Fixed by #39021 => lazy service are considered as "normal service" except when proxyfied
=> bug #39120 some loop are not resolvable with "normal service", but it shouldn't be an issue because the lazy service is injected in the constructor and user 

Fixed by this PR => that revert to the initial state. lazy service are trusted.
But now, The IterratorArgument injected in a factory (single exception) is not more considered as lazy


