### PR TITLE
[Cache] Fix CI because of Couchbase version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,17 +93,12 @@ jobs:
 
             -   name: Install system dependencies
                 run: |
-                    echo "::group::add apt sources"
-                    sudo wget -O - http://packages.couchbase.com/ubuntu/couchbase.key | sudo apt-key add -
-                    echo "deb http://packages.couchbase.com/ubuntu bionic bionic/main" | sudo tee /etc/apt/sources.list.d/couchbase.list
-                    echo "::endgroup::"
-
                     echo "::group::apt-get update"
                     sudo apt-get update
                     echo "::endgroup::"
 
                     echo "::group::install tools & libraries"
-                    sudo apt-get install libcouchbase-dev librdkafka-dev
+                    sudo apt-get install librdkafka-dev
                     echo "::endgroup::"
 
             -   name: Configure Couchbase
@@ -121,6 +116,11 @@ jobs:
                     ini-values: "memory_limit=-1"
                     php-version: "${{ matrix.php }}"
                     tools: pecl
+
+            -   name: Display versions
+                run: |
+                    php -r 'foreach (get_loaded_extensions() as $extension) echo $extension . " " . phpversion($extension) . PHP_EOL;'
+                    php -i
 
             -   name: Load fixtures
                 uses: docker://bitnami/openldap

--- a/src/Symfony/Component/Cache/Adapter/CouchbaseBucketAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/CouchbaseBucketAdapter.php
@@ -42,7 +42,7 @@ class CouchbaseBucketAdapter extends AbstractAdapter
     public function __construct(\CouchbaseBucket $bucket, string $namespace = '', int $defaultLifetime = 0, MarshallerInterface $marshaller = null)
     {
         if (!static::isSupported()) {
-            throw new CacheException('Couchbase >= 2.6.0 is required.');
+            throw new CacheException('Couchbase >= 2.6.0 < 3.0.0 is required.');
         }
 
         $this->maxIdLength = static::MAX_KEY_LENGTH;
@@ -66,7 +66,7 @@ class CouchbaseBucketAdapter extends AbstractAdapter
         }
 
         if (!static::isSupported()) {
-            throw new CacheException('Couchbase >= 2.6.0 is required.');
+            throw new CacheException('Couchbase >= 2.6.0 < 3.0.0 is required.');
         }
 
         set_error_handler(function ($type, $msg, $file, $line) { throw new \ErrorException($msg, 0, $type, $file, $line); });
@@ -125,7 +125,7 @@ class CouchbaseBucketAdapter extends AbstractAdapter
 
     public static function isSupported(): bool
     {
-        return \extension_loaded('couchbase') && version_compare(phpversion('couchbase'), '2.6.0', '>=');
+        return \extension_loaded('couchbase') && version_compare(phpversion('couchbase'), '2.6.0', '>=') && version_compare(phpversion('couchbase'), '3.0', '<');
     }
 
     private static function getOptions(string $options): array

--- a/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseBucketAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/CouchbaseBucketAdapterTest.php
@@ -16,7 +16,8 @@ use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\CouchbaseBucketAdapter;
 
 /**
- * @requires extension couchbase 2.6.0
+ * @requires extension couchbase <3.0.0
+ * @requires extension couchbase >=2.6.0
  * @group integration
  *
  * @author Antonio Jose Cerezo Aranda <aj.cerezo@gmail.com>
@@ -32,6 +33,10 @@ class CouchbaseBucketAdapterTest extends AdapterTestCase
 
     public static function setupBeforeClass(): void
     {
+        if (!CouchbaseBucketAdapter::isSupported()) {
+            self::markTestSkipped('Couchbase >= 2.6.0 < 3.0.0 is required.');
+        }
+
         self::$client = AbstractAdapter::createConnection('couchbase://'.getenv('COUCHBASE_HOST').'/cache',
             ['username' => getenv('COUCHBASE_USER'), 'password' => getenv('COUCHBASE_PASS')]
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

It looks likes the version 3.0 of the couchbase extension does not exposes the `\CouchbaseCluster` class anymore.
I didn't find documentaiton about the BC break, but their documentation changes
version 2.6 => https://docs.couchbase.com/php-sdk/2.6/managing-connections.html
version 3.0 => https://docs.couchbase.com/php-sdk/current/howtos/managing-connections.html

It wasn't reported before, because `shivammathur/setup-php` added the extension 3days ago https://github.com/shivammathur/setup-php/pull/337

Sounds like the adapter were never tested, because the extension where missing and phpunit skipped the tests.