### PR TITLE
[Notifier] Add Amazon SNS bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,6 +122,7 @@
         "amphp/http-tunnel": "^1.0",
         "async-aws/ses": "^1.0",
         "async-aws/sqs": "^1.0",
+        "async-aws/sns": "^1.0",
         "cache/integration-tests": "dev-master",
         "composer/package-versions-deprecated": "^1.8",
         "doctrine/annotations": "^1.12",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -110,6 +110,7 @@ use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\MimeTypeGuesserInterface;
 use Symfony\Component\Mime\MimeTypes;
 use Symfony\Component\Notifier\Bridge\AllMySms\AllMySmsTransportFactory;
+use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Clickatell\ClickatellTransportFactory;
 use Symfony\Component\Notifier\Bridge\Discord\DiscordTransportFactory;
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
@@ -2420,6 +2421,7 @@ class FrameworkExtension extends Extension
 
         $classToServices = [
             AllMySmsTransportFactory::class => 'notifier.transport_factory.allmysms',
+            AmazonSnsTransportFactory::class => 'notifier.transport_factory.amazonsns',
             ClickatellTransportFactory::class => 'notifier.transport_factory.clickatell',
             DiscordTransportFactory::class => 'notifier.transport_factory.discord',
             EsendexTransportFactory::class => 'notifier.transport_factory.esendex',
@@ -2462,6 +2464,7 @@ class FrameworkExtension extends Extension
 
         foreach ($classToServices as $class => $service) {
             switch ($package = substr($service, \strlen('notifier.transport_factory.'))) {
+                case 'amazonsns': $package = 'amazon-sns'; break;
                 case 'fakechat': $package = 'fake-chat'; break;
                 case 'fakesms': $package = 'fake-sms'; break;
                 case 'freemobile': $package = 'free-mobile'; break;

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\Notifier\Bridge\AllMySms\AllMySmsTransportFactory;
+use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Clickatell\ClickatellTransportFactory;
 use Symfony\Component\Notifier\Bridge\Discord\DiscordTransportFactory;
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
@@ -176,6 +177,11 @@ return static function (ContainerConfigurator $container) {
         ->set('notifier.transport_factory.clickatell', ClickatellTransportFactory::class)
             ->parent('notifier.transport_factory.abstract')
             ->tag('texter.transport_factory')
+
+        ->set('notifier.transport_factory.amazonsns', AmazonSnsTransportFactory::class)
+            ->parent('notifier.transport_factory.abstract')
+            ->tag('texter.transport_factory')
+            ->tag('chatter.transport_factory')
 
         ->set('notifier.transport_factory.null', NullTransportFactory::class)
             ->parent('notifier.transport_factory.abstract')

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/.gitignore
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsOptions.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\AmazonSns;
+
+use AsyncAws\Sns\Input\PublishInput;
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+/**
+ * @author Adrien Chinour <github@chinour.fr>
+ */
+final class AmazonSnsOptions implements MessageOptionsInterface
+{
+    private $options = [];
+
+    private $recipient;
+
+    public function __construct(string $recipient, array $options = [])
+    {
+        $this->recipient = $recipient;
+        $this->options = $options;
+    }
+
+    public function toArray(): array
+    {
+        return $this->options;
+    }
+
+    public function getRecipientId(): ?string
+    {
+        return $this->recipient;
+    }
+
+    /**
+     * @param string $topic The Topic ARN for SNS message
+     *
+     * @return $this
+     */
+    public function recipient(string $topic): self
+    {
+        $this->recipient = $topic;
+
+        return $this;
+    }
+
+    /**
+     * @see PublishInput::$Subject
+     */
+    public function subject(string $subject): self
+    {
+        $this->options['Subject'] = $subject;
+
+        return $this;
+    }
+
+    /**
+     * @see PublishInput::$MessageStructure
+     */
+    public function messageStructure(string $messageStructure): self
+    {
+        $this->options['MessageStructure'] = $messageStructure;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsTransport.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\AmazonSns;
+
+use AsyncAws\Sns\SnsClient;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Adrien Chinour <github@chinour.fr>
+ */
+final class AmazonSnsTransport extends AbstractTransport
+{
+    private $snsClient;
+
+    public function __construct(SnsClient $snsClient, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    {
+        $this->snsClient = $snsClient;
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        $configuration = $this->snsClient->getConfiguration();
+
+        return sprintf('sns://%s?region=%s', $this->getEndpoint(), $configuration->get('region'));
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof SmsMessage || ($message instanceof ChatMessage && $message->getOptions() instanceof AmazonSnsOptions);
+    }
+
+    protected function doSend(MessageInterface $message): SentMessage
+    {
+        if (!$this->supports($message)) {
+            throw new UnsupportedMessageTypeException(__CLASS__, sprintf('"%s" or "%s"', SmsMessage::class, ChatMessage::class), $message);
+        }
+
+        if ($message instanceof ChatMessage && $message->getOptions() instanceof AmazonSnsOptions) {
+            $options = $message->getOptions()->toArray();
+        }
+        $options['Message'] = $message->getSubject();
+        $options[($message instanceof ChatMessage) ? 'TopicArn' : 'PhoneNumber'] = $message->getRecipientId();
+
+        try {
+            $response = $this->snsClient->publish($options);
+            $message = new SentMessage($message, (string) $this);
+            $message->setMessageId($response->getMessageId());
+        } catch (\Exception $exception) {
+            $info = isset($response) ? $response->info() : [];
+            throw new TransportException('Unable to send the message.', $info['response'] ?? null, $info['status'] ?? 0, $exception);
+        }
+
+        return $message;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsTransportFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\AmazonSns;
+
+use AsyncAws\Sns\SnsClient;
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+
+/**
+ * @author Adrien Chinour <github@chinour.fr>
+ */
+final class AmazonSnsTransportFactory extends AbstractTransportFactory
+{
+    public function create(Dsn $dsn): TransportInterface
+    {
+        $scheme = $dsn->getScheme();
+
+        if ('sns' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'sns', $this->getSupportedSchemes());
+        }
+
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        $options = null === $host ? [] : ['endpoint' => 'https://'.$host.($port ? ':'.$port : '')];
+
+        if ($dsn->getUser()) {
+            $options += [
+                'accessKeyId' => $dsn->getUser(),
+                'accessKeySecret' => $dsn->getPassword(),
+            ];
+        }
+
+        if ($dsn->getOption('region')) {
+            $options['region'] = $dsn->getOption('region');
+        }
+
+        if ($dsn->getOption('profile')) {
+            $options['profile'] = $dsn->getOption('profile');
+        }
+
+        return (new AmazonSnsTransport(new SnsClient($options, null, $this->client), $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['sns'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.4
+---
+
+ * Add the bridge

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2021 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/README.md
@@ -1,0 +1,19 @@
+Amazon Notifier
+===============
+
+Provides [Amazon SNS](https://aws.amazon.com/de/sns/) integration for Symfony Notifier.
+
+DSN example
+-----------
+
+```
+AMAZON_SNS_DSN=sns://ACCESS_ID:ACCESS_KEY@default?region=REGION
+```
+
+Resources
+---------
+
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsOptionsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\AmazonSns\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsOptions;
+
+class AmazonSnsOptionsTest extends TestCase
+{
+    public function testGetRecipientId()
+    {
+        $options = new AmazonSnsOptions('my-topic');
+        $this->assertSame('my-topic', $options->getRecipientId());
+    }
+
+    public function testToArray()
+    {
+        $options = new AmazonSnsOptions('my-topic');
+        $options->subject('value');
+        $this->assertSame(['Subject' => 'value'], $options->toArray());
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsTransportFactoryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\AmazonSns\Tests;
+
+use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsTransportFactory;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
+
+class AmazonSnsTransportFactoryTest extends TransportFactoryTestCase
+{
+    public function createFactory(): TransportFactoryInterface
+    {
+        return new AmazonSnsTransportFactory();
+    }
+
+    public function createProvider(): iterable
+    {
+        yield ['sns://host.test?region=us-east-1', 'sns://host.test'];
+        yield ['sns://host.test?region=us-east-1', 'sns://accessId:accessKey@host.test'];
+        yield ['sns://host.test?region=eu-west-3', 'sns://host.test?region=eu-west-3'];
+    }
+
+    public function supportsProvider(): iterable
+    {
+        yield [true, 'sns://default'];
+        yield [false, 'somethingElse://default'];
+    }
+
+    public function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://default'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/Tests/AmazonSnsTransportTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\AmazonSns\Tests;
+
+use AsyncAws\Sns\Result\PublishResponse;
+use AsyncAws\Sns\SnsClient;
+use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsOptions;
+use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsTransport;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class AmazonSnsTransportTest extends TransportTestCase
+{
+    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    {
+        return (new AmazonSnsTransport(new SnsClient(['region' => 'eu-west-3']), $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+    }
+
+    public function toStringProvider(): iterable
+    {
+        yield ['sns://host.test?region=eu-west-3', $this->createTransport()];
+    }
+
+    public function supportedMessagesProvider(): iterable
+    {
+        yield [new SmsMessage('0601020304', 'Hello!')];
+        yield [new ChatMessage('Hello', new AmazonSnsOptions('my-topic'))];
+    }
+
+    public function unsupportedMessagesProvider(): iterable
+    {
+        yield [$this->createMock(MessageInterface::class)];
+        yield [new ChatMessage('hello', $this->createMock(MessageOptionsInterface::class))];
+    }
+
+    public function testSmsMessageOptions()
+    {
+        $response = $this->createMock(PublishResponse::class);
+        $response
+            ->expects($this->once())
+            ->method('getMessageId')
+            ->willReturn('messageId');
+
+        $snsMock = $this->getMockBuilder(SnsClient::class)
+            ->setConstructorArgs([[]])
+            ->getMock();
+
+        $snsMock
+            ->expects($this->once())
+            ->method('publish')
+            ->with($this->equalTo(['PhoneNumber' => '0600000000', 'Message' => 'test']))
+            ->willReturn($response);
+
+        $transport = new AmazonSnsTransport($snsMock);
+        $transport->send(new SmsMessage('0600000000', 'test'));
+    }
+
+    public function testChatMessageOptions()
+    {
+        $response = $this->createMock(PublishResponse::class);
+        $response
+            ->expects($this->once())
+            ->method('getMessageId')
+            ->willReturn('messageId');
+
+        $snsMock = $this->getMockBuilder(SnsClient::class)
+            ->setConstructorArgs([[]])
+            ->getMock();
+
+        $snsMock
+            ->expects($this->once())
+            ->method('publish')
+            ->with($this->equalTo(['TopicArn' => 'my-topic', 'Subject' => 'subject', 'Message' => 'Hello World !']))
+            ->willReturn($response);
+
+        $options = new AmazonSnsOptions('my-topic');
+        $options->subject('subject');
+
+        $transport = new AmazonSnsTransport($snsMock);
+        $transport->send(new ChatMessage('Hello World !', $options));
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/composer.json
@@ -1,0 +1,31 @@
+{
+    "name": "symfony/amazon-sns-notifier",
+    "type": "symfony-bridge",
+    "description": "Provides Amazon SNS integration for Symfony Notifier.",
+    "keywords": ["amazon", "sns", "notifier", "chat", "sms"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Adrien Chinour",
+            "email": "github@chinour.fr"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=7.2.5",
+        "symfony/http-client": "^4.4|^5.2",
+        "symfony/notifier": "^5.4",
+        "async-aws/sns": "^1.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\AmazonSns\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Amazon SNS Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -148,6 +148,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Smsc\SmscTransportFactory::class,
             'package' => 'symfony/smsc-notifier',
         ],
+        'sns' => [
+            'class' => Bridge\AmazonSns\AmazonSnsTransportFactory::class,
+            'package' => 'symfony/amazon-sns-notifier',
+        ],
         'spothit' => [
             'class' => Bridge\SpotHit\SpotHitTransportFactory::class,
             'package' => 'symfony/spot-hit-notifier',

--- a/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Tests\Exception;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClassExistsMock;
 use Symfony\Component\Notifier\Bridge\AllMySms\AllMySmsTransportFactory;
+use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Clickatell\ClickatellTransportFactory;
 use Symfony\Component\Notifier\Bridge\Discord\DiscordTransportFactory;
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
@@ -63,6 +64,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
         ClassExistsMock::register(__CLASS__);
         ClassExistsMock::withMockedClasses([
             AllMySmsTransportFactory::class => false,
+            AmazonSnsTransportFactory::class => false,
             ClickatellTransportFactory::class => false,
             DiscordTransportFactory::class => false,
             EsendexTransportFactory::class => false,
@@ -118,6 +120,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
     public function messageWhereSchemeIsPartOfSchemeToPackageMapProvider(): \Generator
     {
         yield ['allmysms', 'symfony/allmysms-notifier'];
+        yield ['sns', 'symfony/amazon-sns-notifier'];
         yield ['clickatell', 'symfony/clickatell-notifier'];
         yield ['discord', 'symfony/discord-notifier'];
         yield ['esendex', 'symfony/esendex-notifier'];

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier;
 
 use Symfony\Component\Notifier\Bridge\AllMySms\AllMySmsTransportFactory;
+use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Clickatell\ClickatellTransportFactory;
 use Symfony\Component\Notifier\Bridge\Discord\DiscordTransportFactory;
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
@@ -60,6 +61,7 @@ class Transport
 {
     private const FACTORY_CLASSES = [
         AllMySmsTransportFactory::class,
+        AmazonSnsTransportFactory::class,
         ClickatellTransportFactory::class,
         DiscordTransportFactory::class,
         EsendexTransportFactory::class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | [symfony/symfony-docs#15486](https://github.com/symfony/symfony-docs/pull/15486)
| Recipe PR     | symfony/recipes#847

Hi,

This PR add a bridge on Notifier component for Amazon SNS.

This bridge use `async-aws/sns` and only work on actual dev-master version of `asyc-aws/core`.

I'm working on recipe and doc PR.
