### PR TITLE
[Config] Stop treating multiline resources as globs

### DIFF
--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -78,7 +78,7 @@ abstract class FileLoader extends Loader
         }
         $exclude = \func_num_args() >= 5 ? func_get_arg(4) : null;
 
-        if (\is_string($resource) && \strlen($resource) !== $i = strcspn($resource, '*?{[')) {
+        if (\is_string($resource) && \strlen($resource) !== ($i = strcspn($resource, '*?{[')) && false === strpos($resource, "\n")) {
             $excluded = [];
             foreach ((array) $exclude as $pattern) {
                 foreach ($this->glob($pattern, true, $_, false, true) as $path => $info) {

--- a/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
@@ -77,6 +77,31 @@ class FileLoaderTest extends TestCase
         $this->assertSame('[foo]', $loader->import('[foo]'));
     }
 
+    public function testImportWithGlobLikeResourceWhichContainsSlashes()
+    {
+        $locatorMock = $this->getMockBuilder('Symfony\Component\Config\FileLocatorInterface')->getMock();
+        $locatorMock->expects($this->once())->method('locate')->willReturn('');
+        $loader = new TestFileLoader($locatorMock);
+
+        $this->assertNull($loader->import('foo/bar[foo]'));
+    }
+
+    public function testImportWithGlobLikeResourceWhichContainsMultipleLines()
+    {
+        $locatorMock = $this->getMockBuilder('Symfony\Component\Config\FileLocatorInterface')->getMock();
+        $loader = new TestFileLoader($locatorMock);
+
+        $this->assertSame("foo\nfoobar[foo]", $loader->import("foo\nfoobar[foo]"));
+    }
+
+    public function testImportWithGlobLikeResourceWhichContainsSlashesAndMultipleLines()
+    {
+        $locatorMock = $this->getMockBuilder('Symfony\Component\Config\FileLocatorInterface')->getMock();
+        $loader = new TestFileLoader($locatorMock);
+
+        $this->assertSame("foo\nfoo/bar[foo]", $loader->import("foo\nfoo/bar[foo]"));
+    }
+
     public function testImportWithNoGlobMatch()
     {
         $locatorMock = $this->getMockBuilder('Symfony\Component\Config\FileLocatorInterface')->getMock();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #23412
| License       | MIT

Would fix the linked issue.

In https://github.com/symfony/symfony/issues/22938 it was suggested to enhance the glob-detection logic by detecting newlines. 

Cons:
- it only solves an edge case
- it is not possible to use a multiline glob (like `bar\nbaz*.txt`) as a resource anymore - maybe in another edge case this is needed