### PR TITLE
[Console] Added Invalid constant into Command Class

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -31,6 +31,7 @@ class Command
 {
     public const SUCCESS = 0;
     public const FAILURE = 1;
+    public const INVALID = 2;
 
     /**
      * @var string|null The default command name


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

Regarding into this [link](https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html#:~:text=A%20non%2Dzero%20exit%20status,N%20as%20the%20exit%20status), we have 3 exits status standard : 

- 0 is for success
- 1 is for error
- 2 is for _indicate incorrect usage, generally invalid options or missing arguments_

I think if we use a constant into Command class, we need to implement invalid exit status too. 