### PR TITLE
[FrameworkBundle] Fallback to the committed keys when SYMFONY_DECRYPTION_SECRET doesn't work

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
@@ -120,6 +120,14 @@ class SodiumVault extends AbstractVault implements EnvVarLoaderInterface
         }
 
         if (false === $value = sodium_crypto_box_seal_open(include $file, $this->decryptionKey)) {
+            if (null === $this->encryptionKey) {
+                $this->decryptionKey = null;
+
+                if (null !== $value = $this->reveal($name)) {
+                    return $value;
+                }
+            }
+
             $this->lastMessage = sprintf('Secret "%s" cannot be revealed as the wrong decryption key was provided for "%s".', $name, $this->getPrettyPath(\dirname($this->pathPrefix).\DIRECTORY_SEPARATOR));
 
             return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -