### PR TITLE
[DependencyInjection] Fixed incorrect report for private services if required service does not exist

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -82,13 +82,14 @@ class PassConfig
             new ReplaceAliasByActualDefinitionPass(),
             new RemoveAbstractDefinitionsPass(),
             new RemoveUnusedDefinitionsPass(),
+            new AnalyzeServiceReferencesPass(),
+            new CheckExceptionOnInvalidReferenceBehaviorPass(),
             new InlineServiceDefinitionsPass(new AnalyzeServiceReferencesPass()),
             new AnalyzeServiceReferencesPass(),
             new DefinitionErrorExceptionPass(),
         ]];
 
         $this->afterRemovingPasses = [[
-            new CheckExceptionOnInvalidReferenceBehaviorPass(),
             new ResolveHotPathPass(),
         ]];
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1316,6 +1316,47 @@ class ContainerBuilderTest extends TestCase
         $container->compile();
     }
 
+    public function testGetThrownServiceNotFoundExceptionWithCorrectServiceId()
+    {
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('The service "child_service" has a dependency on a non-existent service "non_existent_service".');
+
+        $container = new ContainerBuilder();
+        $container->register('child_service', \stdClass::class)
+            ->setPublic(false)
+            ->addArgument([
+                'non_existent' => new Reference('non_existent_service'),
+            ])
+        ;
+        $container->register('parent_service', \stdClass::class)
+            ->setPublic(true)
+            ->addArgument([
+                'child_service' => new Reference('child_service'),
+            ])
+        ;
+
+        $container->compile();
+    }
+
+    public function testUnusedServiceRemovedByPassAndServiceNotFoundExceptionWasNotThrown()
+    {
+        $container = new ContainerBuilder();
+        $container->register('service', \stdClass::class)
+            ->setPublic(false)
+            ->addArgument([
+                'non_existent_service' => new Reference('non_existent_service'),
+            ])
+        ;
+
+        try {
+            $container->compile();
+        } catch (ServiceNotFoundException $e) {
+            $this->fail('Should not be thrown');
+        }
+
+        $this->addToAssertionCount(1);
+    }
+
     public function testServiceLocator()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
…does not exist

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #29359
| License       | MIT
| Doc PR        | no

looks like `CheckExceptionOnInvalidReferenceBehaviorPass` can be moved to `beforeRemovingPasses` section without any consequences. this solves the problem and all tests still pass
