### PR TITLE
[Dotenv] Don't load .env.local.php when APP_RUNTIME_ENV doesn't match APP_ENV

### DIFF
--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -493,7 +493,16 @@ class DotenvTest extends TestCase
         $this->assertSame('1', $_SERVER['TEST_APP_DEBUG']);
 
         unset($_SERVER['FOO'], $_ENV['FOO']);
+        // keep .env.local.php around
+        file_put_contents($path, 'FOO=BUZ');
+
+        $_SERVER['TEST_APP_RUNTIME_ENV'] = 'test';
+        (new Dotenv('TEST_APP_ENV', 'TEST_APP_DEBUG', 'TEST_APP_RUNTIME_ENV'))->bootEnv($path);
+        $this->assertSame('BUZ', $_SERVER['FOO']);
+
+        unset($_SERVER['FOO'], $_ENV['FOO']);
         unlink($path.'.local.php');
+        unlink($path);
         rmdir($tmpdir);
     }
 }


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When both `APP_RUNTIME_ENV` and `APP_ENV` are set as real env var, I propose to skip loading `.env.local.php`. This enables using `bin/console secrets:decrypt-to-local` to build an immutable image, while still allowing to use the committed vaults when using that image in non-production runtime envs.

I'm submitting this on 5.2 because it completes the introduction of the `APP_RUNTIME_ENV` var.