### PR TITLE
[HttpFoundation] Use locking for file_put_contents in MockFileSessionStorage

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
@@ -103,7 +103,7 @@ class MockFileSessionStorage extends MockArraySessionStorage
 
         try {
             if ($data) {
-                file_put_contents($this->getFilePath(), serialize($data));
+                file_put_contents($this->getFilePath(), serialize($data), LOCK_EX);
             } else {
                 $this->destroy();
             }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
@@ -103,7 +103,7 @@ class MockFileSessionStorage extends MockArraySessionStorage
 
         try {
             if ($data) {
-                file_put_contents($this->getFilePath(), serialize($data), LOCK_EX);
+                file_put_contents($this->getFilePath(), serialize($data), \LOCK_EX);
             } else {
                 $this->destroy();
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

I am running tests with a headless browser, where there is quite some concurrency in hitting Symfony (several concurrent requests to API endpoints performed by the browser almost at the same time).

From time to time, these tests fail with

`request.CRITICAL: Uncaught PHP Exception ErrorException: "Notice: unserialize(): Error at offset 134 of 8192 bytes" at /var/www/vendor/symfony/http-foundation/Session/Storage/MockFileSessionStorage.php line 144`

Though I cannot really prove this and have no idea how to write a test case for it, my hypothesis is that several processes may try to write to the file concurrently and corrupt it.

Of course, it might also be that the problem is a read operation while another process is writing. I don't know how to tell.

The bigger solution would be to use a more involved scheme of creating the file and moving it in place, as it happens in other places in Symfony?
