### PR TITLE
[Console] Fix console closing tag

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -25,6 +25,14 @@ class OutputFormatter implements WrappableOutputFormatterInterface
     private $styles = [];
     private $styleStack;
 
+    public function __clone()
+    {
+        $this->styleStack = clone $this->styleStack;
+        foreach ($this->styles as $key => $value) {
+            $this->styles[$key] = clone $value;
+        }
+    }
+
     /**
      * Escapes "<" special char in given text.
      *

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_20.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_20.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+// Ensure that closing tag is applied once
+return function (InputInterface $input, OutputInterface $output) {
+    $output->setDecorated(true);
+    $output = new SymfonyStyle($input, $output);
+    $output->write('<question>do you want <comment>something</>');
+    $output->writeln('?</>');
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_20.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_20.txt
@@ -1,0 +1,1 @@
+[30;46mdo you want [39;49m[33msomething[39m[30;46m?[39;49m


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


When using SymfonyStyle, in some cases, closing a tag, is called twice.
In the following code `<question>do you want <comment>something</>?</>` the first `</>` close both the `comment` and the `question` tags.

![Screenshot from 2020-11-25 01-21-06](https://user-images.githubusercontent.com/578547/100166475-191d9d80-2ebd-11eb-991a-6541210c479b.png)

The reason is, part of the content is sent in 2 Outputs (see #39160 for another issue), and both outputs share the same `$styleStack`.
This PR updates the `OutputFormatter::__clone` method to prevent sharing the same state.