### PR TITLE
[Serializer] Improve return value for phpdoc of Normalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -35,6 +35,8 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Serializer
      * {@inheritdoc}
      *
      * @throws NotNormalizableValueException
+     *
+     * @return array
      */
     public function denormalize($data, $type, $format = null, array $context = [])
     {

--- a/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ConstraintViolationListNormalizer.php
@@ -40,6 +40,8 @@ class ConstraintViolationListNormalizer implements NormalizerInterface, Cacheabl
 
     /**
      * {@inheritdoc}
+     *
+     * @return array
      */
     public function normalize($object, $format = null, array $context = [])
     {

--- a/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DataUriNormalizer.php
@@ -61,6 +61,8 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
 
     /**
      * {@inheritdoc}
+     *
+     * @return string
      */
     public function normalize($object, $format = null, array $context = [])
     {
@@ -102,6 +104,8 @@ class DataUriNormalizer implements NormalizerInterface, DenormalizerInterface, C
      *
      * @throws InvalidArgumentException
      * @throws NotNormalizableValueException
+     *
+     * @return \SplFileInfo
      */
     public function denormalize($data, $type, $format = null, array $context = [])
     {

--- a/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
@@ -46,6 +46,8 @@ class DateIntervalNormalizer implements NormalizerInterface, DenormalizerInterfa
      * {@inheritdoc}
      *
      * @throws InvalidArgumentException
+     *
+     * @return string
      */
     public function normalize($object, $format = null, array $context = [])
     {
@@ -77,6 +79,8 @@ class DateIntervalNormalizer implements NormalizerInterface, DenormalizerInterfa
      *
      * @throws InvalidArgumentException
      * @throws UnexpectedValueException
+     *
+     * @return \DateInterval
      */
     public function denormalize($data, $type, $format = null, array $context = [])
     {

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeNormalizer.php
@@ -57,6 +57,8 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
      * {@inheritdoc}
      *
      * @throws InvalidArgumentException
+     *
+     * @return string
      */
     public function normalize($object, $format = null, array $context = [])
     {
@@ -87,6 +89,8 @@ class DateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, 
      * {@inheritdoc}
      *
      * @throws NotNormalizableValueException
+     *
+     * @return \DateTimeInterface
      */
     public function denormalize($data, $type, $format = null, array $context = [])
     {

--- a/src/Symfony/Component/Serializer/Normalizer/DateTimeZoneNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateTimeZoneNormalizer.php
@@ -25,6 +25,8 @@ class DateTimeZoneNormalizer implements NormalizerInterface, DenormalizerInterfa
      * {@inheritdoc}
      *
      * @throws InvalidArgumentException
+     *
+     * @return string
      */
     public function normalize($object, $format = null, array $context = [])
     {
@@ -47,6 +49,8 @@ class DateTimeZoneNormalizer implements NormalizerInterface, DenormalizerInterfa
      * {@inheritdoc}
      *
      * @throws NotNormalizableValueException
+     *
+     * @return \DateTimeZone
      */
     public function denormalize($data, $type, $format = null, array $context = [])
     {

--- a/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
@@ -37,6 +37,8 @@ class ProblemNormalizer implements NormalizerInterface, CacheableSupportsMethodI
 
     /**
      * {@inheritdoc}
+     *
+     * @return array
      */
     public function normalize($exception, $format = null, array $context = [])
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | Phpdoc
| New feature?  | no
| Deprecations? | no
| License       | MIT

The inheritdoc return type is too large.
The return type type can be more precise for lot of Normalizer.
