### PR TITLE
[Serializer] Fix denormalizing scalar with UnwrappingDenormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -189,7 +189,10 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
      */
     public function denormalize($data, string $type, string $format = null, array $context = [])
     {
-        if (isset(self::SCALAR_TYPES[$type])) {
+        $normalizer = $this->getDenormalizer($data, $type, $format, $context);
+
+        // Check for a denormalizer first, e.g. the data is wrapped
+        if (!$normalizer && isset(self::SCALAR_TYPES[$type])) {
             if (!('is_'.$type)($data)) {
                 throw new NotNormalizableValueException(sprintf('Data expected to be of type "%s" ("%s" given).', $type, get_debug_type($data)));
             }
@@ -201,7 +204,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
             throw new LogicException('You must register at least one normalizer to be able to denormalize objects.');
         }
 
-        if ($normalizer = $this->getDenormalizer($data, $type, $format, $context)) {
+        if ($normalizer) {
             return $normalizer->denormalize($data, $type, $format, $context);
         }
 

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -613,6 +613,13 @@ class SerializerTest extends TestCase
         $serializer->deserialize('["42"]', 'int[]', 'json');
     }
 
+    public function testDeserializeWrappedScalar()
+    {
+        $serializer = new Serializer([new UnwrappingDenormalizer()], ['json' => new JsonEncoder()]);
+
+        $this->assertSame(42, $serializer->deserialize('{"wrapper": 42}', 'int', 'json', [UnwrappingDenormalizer::UNWRAP_PATH => '[wrapper]']));
+    }
+
     private function serializerWithClassDiscriminator()
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38983 
| License       | MIT
| Doc PR        | none

In order to work the `UnwrappingDenormlizer` needs to be called first to unwrap the data so that it can be handled by other denormalizers.
To not introduce any BC break this PR does not move the logic into it's own class, instead it checks if a denormalizer supports the data and only denormalize scalar values if there is none.