### PR TITLE
[Console] Add the typehint on Command class, to be coherent with BC Break on 4.4

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -159,7 +159,7 @@ class Command
      *
      * @see setCode()
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         throw new LogicException('You must override the execute() method in the concrete command class.');
     }
@@ -256,10 +256,6 @@ class Command
             $statusCode = ($this->code)($input, $output);
         } else {
             $statusCode = $this->execute($input, $output);
-
-            if (!\is_int($statusCode)) {
-                throw new \TypeError(sprintf('Return value of "%s::execute()" must be of the type int, "%s" returned.', static::class, get_debug_type($statusCode)));
-            }
         }
 
         return is_numeric($statusCode) ? (int) $statusCode : 0;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1 <!-- see below -->
| Bug fix?      | no (not really)
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

There was a deprecation on 4.4, stating that the `execute` method should only return an int (`0` for success). It wasn't applied on 5.1, so here goes.

I also removed the `TypeError` if the `execute` method doesn't return an `int`, as php should do the job if the typehint is not set.
