### PR TITLE
[DI] Fix Xdebug 3.0 detection

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Exception/AutowiringFailedException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/AutowiringFailedException.php
@@ -23,7 +23,10 @@ class AutowiringFailedException extends RuntimeException
     {
         $this->serviceId = $serviceId;
 
-        if ($message instanceof \Closure && \function_exists('xdebug_is_enabled') && xdebug_is_enabled()) {
+        if (
+            $message instanceof \Closure
+            && (\function_exists('xdebug_is_enabled') ? xdebug_is_enabled() : \function_exists('xdebug_info'))
+        ) {
             $message = $message();
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 (for bug fixes)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39195
| License       | MIT
| Doc PR        | n/a

Xdebug 3.0 removed the function `xdebug_is_enabled()`. To detect if Xdebug 3.0 is installed (it doesn't even need to be enabled to reproduce the bug) i added `function_exists('xdebug_info')`. AFAIS `xdebug_info()` is available in Xdebug >= 3.0 only.