### PR TITLE
[FrameworkBundle] [minor] adjust KernelBrowser::getProfile() typehint

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -65,7 +65,7 @@ class KernelBrowser extends HttpKernelBrowser
     /**
      * Gets the profile associated with the current Response.
      *
-     * @return HttpProfile|false A Profile instance
+     * @return HttpProfile|false|null A Profile instance
      */
     public function getProfile()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

`Profiler::loadProfileFromResponse()` can return `null`. Obviously having a return of `null|false` is unfortunate. Not sure what we can do about that...
