### PR TITLE
[Semaphore] Allow symfony/semaphore on PHP8

### DIFF
--- a/src/Symfony/Component/Semaphore/composer.json
+++ b/src/Symfony/Component/Semaphore/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": ">=7.2.5",
         "psr/log": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

On `PHP8` we can't install new component.

```
composer prohibits php:8
symfony/semaphore                    v5.2.0-RC2  requires  php (^7.2.5)
```

