### PR TITLE
[DI] Fix not working if only "default_index_method" used

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/TaggedIteratorArgument.php
@@ -41,9 +41,9 @@ class TaggedIteratorArgument extends IteratorArgument
 
         $this->tag = $tag;
         $this->indexAttribute = $indexAttribute;
-        $this->defaultIndexMethod = $defaultIndexMethod ?: ('getDefault'.str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $indexAttribute ?? ''))).'Name');
+        $this->defaultIndexMethod = $defaultIndexMethod ?: ($indexAttribute ? 'getDefault'.str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $indexAttribute))).'Name' : null);
         $this->needsIndexes = $needsIndexes;
-        $this->defaultPriorityMethod = $defaultPriorityMethod ?: ('getDefault'.str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $indexAttribute ?? ''))).'Priority');
+        $this->defaultPriorityMethod = $defaultPriorityMethod ?: ($indexAttribute ? 'getDefault'.str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $indexAttribute))).'Priority' : null);
     }
 
     public function getTag()

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -46,7 +46,7 @@ trait PriorityTaggedServiceTrait
             $indexAttribute = $tagName->getIndexAttribute();
             $defaultIndexMethod = $tagName->getDefaultIndexMethod();
             $needsIndexes = $tagName->needsIndexes();
-            $defaultPriorityMethod = $tagName->getDefaultPriorityMethod();
+            $defaultPriorityMethod = $tagName->getDefaultPriorityMethod() ?? 'getDefaultPriority';
             $tagName = $tagName->getTag();
         }
 
@@ -69,15 +69,15 @@ trait PriorityTaggedServiceTrait
                 }
                 $priority = $priority ?? $defaultPriority ?? $defaultPriority = 0;
 
-                if (null === $indexAttribute && !$needsIndexes) {
+                if (null === $indexAttribute && !$defaultIndexMethod && !$needsIndexes) {
                     $services[] = [$priority, ++$i, null, $serviceId, null];
                     continue 2;
                 }
 
                 if (null !== $indexAttribute && isset($attribute[$indexAttribute])) {
                     $index = $attribute[$indexAttribute];
-                } elseif (null === $defaultIndex && $defaultIndexMethod && $class) {
-                    $defaultIndex = PriorityTaggedServiceUtil::getDefaultIndex($container, $serviceId, $class, $defaultIndexMethod, $tagName, $indexAttribute);
+                } elseif (null === $defaultIndex && $defaultPriorityMethod && $class) {
+                    $defaultIndex = PriorityTaggedServiceUtil::getDefaultIndex($container, $serviceId, $class, $defaultIndexMethod ?? 'getDefaultName', $tagName, $indexAttribute);
                 }
                 $index = $index ?? $defaultIndex ?? $defaultIndex = $serviceId;
 
@@ -116,24 +116,31 @@ class PriorityTaggedServiceUtil
     /**
      * Gets the index defined by the default index method.
      */
-    public static function getDefaultIndex(ContainerBuilder $container, string $serviceId, string $class, string $defaultIndexMethod, string $tagName, string $indexAttribute): ?string
+    public static function getDefaultIndex(ContainerBuilder $container, string $serviceId, string $class, string $defaultIndexMethod, string $tagName, ?string $indexAttribute): ?string
     {
         if (!($r = $container->getReflectionClass($class)) || !$r->hasMethod($defaultIndexMethod)) {
             return null;
         }
 
+        if (null !== $indexAttribute) {
+            $service = $class !== $serviceId ? sprintf('service "%s"', $serviceId) : 'on the corresponding service';
+            $message = [sprintf('Either method "%s::%s()" should ', $class, $defaultIndexMethod), sprintf(' or tag "%s" on %s is missing attribute "%s".', $tagName, $service, $indexAttribute)];
+        } else {
+            $message = [sprintf('Method "%s::%s()" should ', $class, $defaultIndexMethod), '.'];
+        }
+
         if (!($rm = $r->getMethod($defaultIndexMethod))->isStatic()) {
-            throw new InvalidArgumentException(sprintf('Either method "%s::%s()" should be static or tag "%s" on service "%s" is missing attribute "%s".', $class, $defaultIndexMethod, $tagName, $serviceId, $indexAttribute));
+            throw new InvalidArgumentException(implode('be static', $message));
         }
 
         if (!$rm->isPublic()) {
-            throw new InvalidArgumentException(sprintf('Either method "%s::%s()" should be public or tag "%s" on service "%s" is missing attribute "%s".', $class, $defaultIndexMethod, $tagName, $serviceId, $indexAttribute));
+            throw new InvalidArgumentException(implode('be public', $message));
         }
 
         $defaultIndex = $rm->invoke(null);
 
         if (!\is_string($defaultIndex)) {
-            throw new InvalidArgumentException(sprintf('Either method "%s::%s()" should return a string (got "%s") or tag "%s" on service "%s" is missing attribute "%s".', $class, $defaultIndexMethod, \gettype($defaultIndex), $tagName, $serviceId, $indexAttribute));
+            throw new InvalidArgumentException(implode(sprintf('return a string (got "%s")', \gettype($defaultIndex)), $message));
         }
 
         return $defaultIndex;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTaggedForInvalidDefaultMethodClass.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/FooTaggedForInvalidDefaultMethodClass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class FooTaggedForInvalidDefaultMethodClass
+{
+    public function getMethodShouldBeStatic()
+    {
+        return 'anonymous_foo_class_with_default_method';
+    }
+
+    protected static function getMethodShouldBePublicInsteadProtected()
+    {
+        return 'anonymous_foo_class_with_default_method';
+    }
+
+    private static function getMethodShouldBePublicInsteadPrivate()
+    {
+        return 'anonymous_foo_class_with_default_method';
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35349
| License       | MIT

The default index method wasn't used if the "index_by" attribute is missing. The documentation is showing an example, see https://symfony.com/doc/current/service_container/tags.html#tagged-services-with-index.

This problem also appears in symfony 5.

I created two example projects, the first in the current behaviour and the second with my bugfix branch.

Current 4.4: https://github.com/malteschlueter/symfony-reproducers/blob/bugfix/dependency-injection-default-index-method-not-working--not-fixed/tests/HandlerCollectionTest.php

This bugfix branch: https://github.com/malteschlueter/symfony-reproducers/blob/bugfix/dependency-injection-default-index-method-not-working--with-fix/tests/HandlerCollectionTest.php