### PR TITLE
[Security] [DX] Automatically add PasswordUpgradeBadge + default support() impl in AbstractFormLoginAuthenticator

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractLoginFormAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractLoginFormAuthenticator.php
@@ -33,6 +33,20 @@ abstract class AbstractLoginFormAuthenticator extends AbstractAuthenticator impl
     abstract protected function getLoginUrl(Request $request): string;
 
     /**
+     * {@inheritdoc}
+     *
+     * Override to change the request conditions that have to be
+     * matched in order to handle the login form submit.
+     *
+     * This default implementation handles all POST requests to the
+     * login path (@see getLoginUrl()).
+     */
+    public function supports(Request $request): bool
+    {
+        return $request->isMethod('POST') && $this->getLoginUrl($request) === $request->getPathInfo();
+    }
+
+    /**
      * Override to change what happens after a bad username/password is submitted.
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response

--- a/src/Symfony/Component/Security/Http/EventListener/CheckCredentialsListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/CheckCredentialsListener.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Http\EventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PasswordUpgradeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\CustomCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Authenticator\Passport\UserPassportInterface;
@@ -64,6 +65,10 @@ class CheckCredentialsListener implements EventSubscriberInterface
             }
 
             $badge->markResolved();
+
+            if (!$passport->hasBadge(PasswordUpgradeBadge::class)) {
+                $passport->addBadge(new PasswordUpgradeBadge($presentedPassword));
+            }
 
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2 (hopefully? sorry to keep pushing the barrier here)
| Bug fix?      | no
| New feature?  | yes (sort of)
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

These are 2 suggestions we found while implementing `make:auth` for the new system (https://github.com/symfony/maker-bundle/pull/736):

Impact on a custom login form authenticator ([as generated by the new maker](https://github.com/symfony/maker-bundle/pull/736/files#diff-528164b6c24778d5e81fa3819b0552f0e68a9fea33c7d3446a012f3da7d0af60)):

* **Automatically add `PasswordUpgradeBadge`** if there is a user password with valid password credentials.
   ```diff
    // ...
    return new Passport(
        new UserBadge($userIdentifier),
        new PasswordCredentials($password),
        [
   -        new PasswordUpgradeBadge($password),
            new CsrfTokenBadge('authenticate', $csrf),
        ]
    )
   ```
   Note that this does not automatically migrate all passwords: it still relies on `PasswordUpgraderInterface` to be implemented on the user loader/provider.
* **Add default implementation of `AbstractFormLoginAuthenticator::support()`**
   ```diff
   - public function supports(Request $request): ?bool
   -  {
   -      return self::LOGIN_ROUTE === $request->attributes->get('_route')
   -          && $request->isMethod('POST');
   - }
   ```

cc @weaverryan @jrushlow 