### PR TITLE
[Messenger] Test generated SQL

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -12,9 +12,14 @@
 namespace Symfony\Component\Messenger\Tests\Transport\Doctrine;
 
 use Doctrine\DBAL\Abstraction\Result as AbstractionResult;
+use Doctrine\DBAL\Connection as DBALConnection;
 use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Driver\Result as DriverResult;
+use Doctrine\DBAL\Driver\ResultStatement;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\MySQL57Platform;
+use Doctrine\DBAL\Platforms\SQLServer2012Platform;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
@@ -117,7 +122,7 @@ class ConnectionTest extends TestCase
 
     private function getDBALConnectionMock()
     {
-        $driverConnection = $this->createMock(\Doctrine\DBAL\Connection::class);
+        $driverConnection = $this->createMock(DBALConnection::class);
         $platform = $this->createMock(AbstractPlatform::class);
         $platform->method('getWriteLockSQL')->willReturn('FOR UPDATE');
         $configuration = $this->createMock(\Doctrine\DBAL\Configuration::class);
@@ -344,5 +349,54 @@ class ConnectionTest extends TestCase
         $this->assertEquals(2, $doctrineEnvelopes[1]['id']);
         $this->assertEquals('{"message":"Hi again"}', $doctrineEnvelopes[1]['body']);
         $this->assertEquals(['type' => DummyMessage::class], $doctrineEnvelopes[1]['headers']);
+    }
+
+    /**
+     * @dataProvider providePlatformSql
+     */
+    public function testGeneratedSql(AbstractPlatform $platform, string $expectedSql)
+    {
+        $driverConnection = $this->createMock(DBALConnection::class);
+        $driverConnection->method('getDatabasePlatform')->willReturn($platform);
+        $driverConnection->method('createQueryBuilder')->willReturnCallback(function () use ($driverConnection) {
+            return new QueryBuilder($driverConnection);
+        });
+
+        if (interface_exists(DriverResult::class)) {
+            $result = $this->createMock(DriverResult::class);
+            $result->method('fetchAssociative')->willReturn(false);
+
+            if (class_exists(Result::class)) {
+                $result = new Result($result, $driverConnection);
+            }
+        } else {
+            $result = $this->createMock(ResultStatement::class);
+            $result->method('fetch')->willReturn(false);
+        }
+
+        $driverConnection->expects($this->once())->method('beginTransaction');
+        $driverConnection
+            ->expects($this->once())
+            ->method('executeQuery')
+            ->with($expectedSql)
+            ->willReturn($result)
+        ;
+        $driverConnection->expects($this->once())->method('commit');
+
+        $connection = new Connection([], $driverConnection);
+        $connection->get();
+    }
+
+    public function providePlatformSql(): iterable
+    {
+        yield 'MySQL' => [
+            new MySQL57Platform(),
+            'SELECT m.* FROM messenger_messages m WHERE (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) AND (m.queue_name = ?) ORDER BY available_at ASC LIMIT 1 FOR UPDATE',
+        ];
+
+        yield 'SQL Server' => [
+            new SQLServer2012Platform(),
+            'SELECT m.* FROM messenger_messages m WITH (UPDLOCK, ROWLOCK) WHERE (m.delivered_at is null OR m.delivered_at < ?) AND (m.available_at <= ?) AND (m.queue_name = ?) ORDER BY available_at ASC OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY  ',
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Follow-up to #39166.

This is an attempt to the SQL generated by the `Symfony\Component\Messenger\Transport\Doctrine\Connection::get()` method. The challange was to create a locking SELECT statement, taking into account the different ways to create a lock in different SQL dialects.

This test verifies if the correct lock statements are generated for MySQL and SQL Server.