### PR TITLE
[HttpKernel] Fix bug with whitespace in Kernel::stripComments()

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -858,6 +858,9 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
                 // replace multiple new lines with a single newline
                 $rawChunk .= preg_replace(['/\n{2,}/S'], "\n", $token[1]);
             } elseif (\in_array($token[0], [\T_COMMENT, \T_DOC_COMMENT])) {
+                if (!\in_array($rawChunk[\strlen($rawChunk) - 1], [' ', "\n", "\r", "\t"], true)) {
+                    $rawChunk .= ' ';
+                }
                 $ignoreSpace = true;
             } else {
                 $rawChunk .= $token[1];
@@ -865,6 +868,8 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
                 // The PHP-open tag already has a new-line
                 if (\T_OPEN_TAG === $token[0]) {
                     $ignoreSpace = true;
+                } else {
+                    $ignoreSpace = false;
                 }
             }
         }

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -239,10 +239,37 @@ class KernelTest extends TestCase
         $kernel->handle($request, $type, $catch);
     }
 
-    public function testStripComments()
+    /**
+     * @dataProvider getStripCommentsCodes
+     */
+    public function testStripComments(string $source, string $expected)
     {
-        $source = <<<'EOF'
+        $output = Kernel::stripComments($source);
+
+        // Heredocs are preserved, making the output mixing Unix and Windows line
+        // endings, switching to "\n" everywhere on Windows to avoid failure.
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $expected = str_replace("\r\n", "\n", $expected);
+            $output = str_replace("\r\n", "\n", $output);
+        }
+
+        $this->assertEquals($expected, $output);
+    }
+
+    public function getStripCommentsCodes(): array
+    {
+        return [
+            ['<?php echo foo();', '<?php echo foo();'],
+            ['<?php echo/**/foo();', '<?php echo foo();'],
+            ['<?php echo/** bar */foo();', '<?php echo foo();'],
+            ['<?php /**/echo foo();', '<?php echo foo();'],
+            ['<?php echo \foo();', '<?php echo \foo();'],
+            ['<?php echo/**/\foo();', '<?php echo \foo();'],
+            ['<?php echo/** bar */\foo();', '<?php echo \foo();'],
+            ['<?php /**/echo \foo();', '<?php echo \foo();'],
+            [<<<'EOF'
 <?php
+include_once \dirname(__DIR__).'/foo.php';
 
 $string = 'string should not be   modified';
 
@@ -280,9 +307,10 @@ class TestClass
         // inline comment
     }
 }
-EOF;
-        $expected = <<<'EOF'
+EOF
+, <<<'EOF'
 <?php
+include_once \dirname(__DIR__).'/foo.php';
 $string = 'string should not be   modified';
 $string = 'string should not be
 
@@ -307,18 +335,9 @@ class TestClass
     {
         }
 }
-EOF;
-
-        $output = Kernel::stripComments($source);
-
-        // Heredocs are preserved, making the output mixing Unix and Windows line
-        // endings, switching to "\n" everywhere on Windows to avoid failure.
-        if ('\\' === \DIRECTORY_SEPARATOR) {
-            $expected = str_replace("\r\n", "\n", $expected);
-            $output = str_replace("\r\n", "\n", $output);
-        }
-
-        $this->assertEquals($expected, $output);
+EOF
+            ],
+        ];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

`Kernel::stripComments()` removes significant whitespace in some cases. 

I noticed this in one of the generated classes, the code `<?php include_once \dirname(__DIR__).'/file.php';` got replaced with `<?php include_once\dirname(__DIR__).'/file.php';` which is a syntax error.