### PR TITLE
[PhpUnitBridge] Fix disabling DeprecationErrorHandler from PHPUnit configuration file

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -146,6 +146,10 @@ foreach ($defaultEnvs as $envName => $envValue) {
     }
 }
 
+if ('disabled' === $getEnvVar('SYMFONY_DEPRECATIONS_HELPER')) {
+    putenv('SYMFONY_DEPRECATIONS_HELPER=disabled');
+}
+
 $COMPOSER = file_exists($COMPOSER = $oldPwd.'/composer.phar')
     || ($COMPOSER = rtrim('\\' === \DIRECTORY_SEPARATOR ? preg_replace('/[\r\n].*/', '', `where.exe composer.phar`) : `which composer.phar 2> /dev/null`))
     || ($COMPOSER = rtrim('\\' === \DIRECTORY_SEPARATOR ? preg_replace('/[\r\n].*/', '', `where.exe composer`) : `which composer 2> /dev/null`))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/38239
| License       | MIT
| Doc PR        | -

The linked issue description is right, the bridge's bootstrap is hit before the env variables from the phpunit.xml file are read and set. So the easiest solution is to read it ourselves in the root script (like we already do for some of them).