### PR TITLE
Fix small typos

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -4,8 +4,8 @@ CHANGELOG
 5.0.0
 -----
 
-* Added argument `$selector` to ``Crawler::children()`
-* Added argument `$default` to ``Crawler::text()` and `html()`
+* Added argument `$selector` to `Crawler::children()`
+* Added argument `$default` to `Crawler::text()` and `html()`
 
 4.4.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.0
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Fixing a small typos in CHANGELOG.
As these typos were introduced in 5.0 I target the 5.0 branch. But as 5.0 is no longer maintained should I target 5.1 instead?