### PR TITLE
[Yaml] Unexpected character when whitespace ends the line

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2671,6 +2671,29 @@ YAML;
         );
     }
 
+    public function testMultipleWhitespaceAtEndOfLine()
+    {
+        $yaml = "\nfoo:\n    arguments: [ '@bar' ]  \n";
+        $this->assertSame(
+            [
+                'foo' => [
+                    'arguments' => ['@bar'],
+                ],
+            ],
+            $this->parser->parse($yaml)
+        );
+
+        $yaml = "\nfoo:\n    bar: {}\n";
+        $this->assertSame(
+            [
+                'foo' => [
+                    'bar' => [],
+                ],
+            ],
+            $this->parser->parse($yaml)
+        );
+    }
+
     /**
      * This is a regression test for a bug where a YAML block with a nested multiline string using | was parsed without
      * a trailing \n when a shorter YAML document was parsed before.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39229
| License       | MIT
| Doc PR        | 

Adding test for issue #39229. These will only fail on windows.. or at least that is the rumour. 