### PR TITLE
[Notifier] Fix slack section block

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackSectionBlock.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackSectionBlock.php
@@ -39,7 +39,7 @@ final class SlackSectionBlock extends AbstractSlackBlock
      */
     public function field(string $text, bool $markdown = true): self
     {
-        if (10 === \count($this->options['fields'])) {
+        if (10 === \count($this->options['fields'] ?? [])) {
             throw new \LogicException('Maximum number of fields should not exceed 10.');
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/Block/SlackSectionBlockTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/Block/SlackSectionBlockTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Slack\Tests\Block;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\Slack\Block\SlackImageBlockElement;
+use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
+
+final class SlackSectionBlockTest extends TestCase
+{
+    public function testCanBeInstantiated(): void
+    {
+        $section = new SlackSectionBlock();
+        $section->text('section text');
+        $section->field('section field');
+        $section->accessory(new SlackImageBlockElement('https://example.com/image.jpg', 'an image'));
+
+        $this->assertSame([
+            'type' => 'section',
+            'text' => [
+                'type' => 'mrkdwn',
+                'text' => 'section text',
+            ],
+            'fields' => [
+                [
+                    'type' => 'mrkdwn',
+                    'text' => 'section field',
+                ],
+            ],
+            'accessory' => [
+                'type' => 'image',
+                'image_url' => 'https://example.com/image.jpg',
+                'alt_text' => 'an image',
+            ],
+        ], $section->toArray());
+    }
+
+    public function testThrowsWhenFieldsLimitReached(): void
+    {
+        $section = new SlackSectionBlock();
+        for ($i = 0; $i < 10; ++$i) {
+            $section->field($i);
+        }
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Maximum number of fields should not exceed 10.');
+
+        $section->field('fail');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #...
| License       | MIT
| Doc PR        | symfony/symfony-docs#...

In SlackSectionBlock fields array is not initialized directly in the constructor so when running tests and trying to add a field to  it throws `Undefined index: fields`.

