### PR TITLE
[Form] TrasformationFailureExtension should act also when constraints option key is an empty array

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/TransformationFailureExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TransformationFailureExtension.php
@@ -30,7 +30,7 @@ class TransformationFailureExtension extends AbstractTypeExtension
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (!isset($options['constraints'])) {
+        if (empty($options['constraints'])) {
             $builder->addEventSubscriber(new TransformationFailureListener($this->translator));
         }
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TestTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TestTypeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Form\Tests\Extension\Core\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TestTypeTest extends TypeTestCase
+{
+    public function testInvalidSubmittedData(): void
+    {
+        $form = $this->factory->create(TestType::class);
+        $form->submit('foobar');
+
+        self::assertFalse($form->isSynchronized());
+        self::assertFalse($form->isValid());
+    }
+
+    protected function getExtensions(): array
+    {
+        return [
+            new PreloadedExtension([new TestType()], []),
+        ];
+    }
+}
+
+class TestType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addModelTransformer(new CallbackTransformer(
+            function ($value) {
+                if (null === $value) {
+                    return $value;
+                }
+
+                throw new TransformationFailedException('Error');
+            },
+            function ($value) {
+                if (null === $value) {
+                    return $value;
+                }
+
+                throw new TransformationFailedException('Error');
+            }
+        ));
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefault('constraints', []);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Hey there! Thank you for the Symfony 5.2 update! I have just discovered this bug:

if for some reason the constraint option is specified with an empty array, the `TransformationFailureExtension` won't act.

This PR aims to fix this behaviour.