### PR TITLE
[Yaml] fix lexing inline sequences/mappings with trailing whitespaces

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -741,11 +741,11 @@ class Parser
 
         try {
             if ('' !== $value && '{' === $value[0]) {
-                $cursor = \strlen($this->currentLine) - \strlen($value);
+                $cursor = \strlen(rtrim($this->currentLine)) - \strlen(rtrim($value));
 
                 return Inline::parse($this->lexInlineMapping($cursor), $flags, $this->refs);
             } elseif ('' !== $value && '[' === $value[0]) {
-                $cursor = \strlen($this->currentLine) - \strlen($value);
+                $cursor = \strlen(rtrim($this->currentLine)) - \strlen(rtrim($value));
 
                 return Inline::parse($this->lexInlineSequence($cursor), $flags, $this->refs);
             }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2671,6 +2671,29 @@ YAML;
         );
     }
 
+    public function testMultipleWhitespaceAtEndOfLine()
+    {
+        $yaml = "\nfoo:\n    arguments: [ '@bar' ]  \n";
+        $this->assertSame(
+            [
+                'foo' => [
+                    'arguments' => ['@bar'],
+                ],
+            ],
+            $this->parser->parse($yaml)
+        );
+
+        $yaml = "\nfoo:\n    bar: {}\n";
+        $this->assertSame(
+            [
+                'foo' => [
+                    'bar' => [],
+                ],
+            ],
+            $this->parser->parse($yaml)
+        );
+    }
+
     /**
      * This is a regression test for a bug where a YAML block with a nested multiline string using | was parsed without
      * a trailing \n when a shorter YAML document was parsed before.

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2683,7 +2683,7 @@ YAML;
             $this->parser->parse($yaml)
         );
 
-        $yaml = "\nfoo:\n    bar: {}\n";
+        $yaml = "\nfoo:\n    bar: {} \n";
         $this->assertSame(
             [
                 'foo' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39229
| License       | MIT
| Doc PR        | 