### PR TITLE
[Filesystem] File existence check before calling unlink method

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -695,7 +695,9 @@ class Filesystem
 
             $this->rename($tmpFile, $filename, true);
         } finally {
-            @unlink($tmpFile);
+            if (file_exists($tmpFile)) {
+                @unlink($tmpFile);
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/39235
| License       | MIT
| Doc PR        | symfony/symfony-docs#... 

Added additional file existence check on temporary file cleanup for `Filesystem::dumpFile()` method.
