### PR TITLE
[String] Fix Notice when argument is empty string

### DIFF
--- a/src/Symfony/Component/String/Inflector/EnglishInflector.php
+++ b/src/Symfony/Component/String/Inflector/EnglishInflector.php
@@ -305,6 +305,7 @@ final class EnglishInflector implements InflectorInterface
      * A list of words which should not be inflected, reversed.
      */
     private static $uninflected = [
+        '',
         'atad',
         'reed',
         'kcabdeef',

--- a/src/Symfony/Component/String/Tests/EnglishInflectorTest.php
+++ b/src/Symfony/Component/String/Tests/EnglishInflectorTest.php
@@ -306,4 +306,16 @@ class EnglishInflectorTest extends TestCase
     {
         $this->assertSame(\is_array($plural) ? $plural : [$plural], (new EnglishInflector())->pluralize($singular));
     }
+
+    public function testPluralizeEmptyString()
+    {
+        $plural = (new EnglishInflector())->pluralize('');
+        $this->assertSame([''], $plural);
+    }
+
+    public function testSingularizeEmptyString()
+    {
+        $singular = (new EnglishInflector())->singularize('');
+        $this->assertSame([''], $singular);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

PHP Notice is generated when we pass empty string to `singularize` or `pluralize` method.
```
$inflector = new \Symfony\Component\String\Inflector\EnglishInflector();
$inflector->singularize('');
```
```
Notice: Uninitialized string offset: 0 in vendor/symfony/string/Inflector/EnglishInflector.php on line 344
PHP Notice:  Uninitialized string offset: 0 in vendor/symfony/string/Inflector/EnglishInflector.php on line 344
```
```
$inflector = new \Symfony\Component\String\Inflector\EnglishInflector();
$inflector->pluralize('');
```
```
Notice: Uninitialized string offset: 0 in vendor/symfony/string/Inflector/EnglishInflector.php on line 424
PHP Notice:  Uninitialized string offset: 0 in vendor/symfony/string/Inflector/EnglishInflector.php on line 424
```

**Background**:
When `\Symfony\Component\PropertyAccess\PropertyAccessorInterface::setValue` is used with `_` property, then it calls \Symfony\Component\String\Inflector\EnglishInflector::singularize with empty string.
```
class Check
{
    public $_;
}
$check = new Check();
$pr = PropertyAccess::createPropertyAccessorBuilder()
    ->getPropertyAccessor();
if($pr->isWritable($check, '_')){
    $pr->setValue($check, '_', 'test');
}
var_dump($check);
``` 
```
Notice: Uninitialized string offset: 0 in vendor/symfony/string/Inflector/EnglishInflector.php on line 344
PHP Notice:  Uninitialized string offset: 0 in vendor/symfony/string/Inflector/EnglishInflector.php on line 344
...
Notice: Uninitialized string offset: 0 in vendor/symfony/string/Inflector/EnglishInflector.php on line 344
PHP Notice:  Uninitialized string offset: 0 in vendor/symfony/string/Inflector/EnglishInflector.php on line 344

Notice: Uninitialized string offset: 0 in vendor/symfony/string/Inflector/EnglishInflector.php on line 344
object(Check)#6 (1) {
  ["_"]=>
  string(4) "test"
}
```

P.S.
Another solution is to include empty string in \Symfony\Component\String\Inflector\EnglishInflector::$uninflected
```
    private static $uninflected = [
        '',
        'atad',
        'reed',
        'kcabdeef',
        'hsif',
        'ofni',
        'esoom',
        'seires',
        'peehs',
        'seiceps',
    ];
```

If this PR is not relevant please close and sorry for inconvenience.