### PR TITLE
[Workflow] Fixed case when the marking store is not defined

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -810,9 +810,7 @@ class FrameworkExtension extends Extension
             // Create Workflow
             $workflowDefinition = new ChildDefinition(sprintf('%s.abstract', $type));
             $workflowDefinition->replaceArgument(0, new Reference(sprintf('%s.definition', $workflowId)));
-            if (isset($markingStoreDefinition)) {
-                $workflowDefinition->replaceArgument(1, $markingStoreDefinition);
-            }
+            $workflowDefinition->replaceArgument(1, $markingStoreDefinition ?? null);
             $workflowDefinition->replaceArgument(3, $name);
             $workflowDefinition->replaceArgument(4, $workflow['events_to_dispatch']);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -226,7 +226,13 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertTrue($container->hasDefinition('workflow.article'), 'Workflow is registered as a service');
         $this->assertSame('workflow.abstract', $container->getDefinition('workflow.article')->getParent());
-        $this->assertNull($container->getDefinition('workflow.article')->getArgument('index_4'), 'Workflows has eventsToDispatch=null');
+
+        $args = $container->getDefinition('workflow.article')->getArguments();
+        $this->assertArrayHasKey('index_0', $args);
+        $this->assertArrayHasKey('index_1', $args);
+        $this->assertArrayHasKey('index_3', $args);
+        $this->assertArrayHasKey('index_4', $args);
+        $this->assertNull($args['index_4'], 'Workflows has eventsToDispatch=null');
 
         $this->assertTrue($container->hasDefinition('workflow.article.definition'), 'Workflow definition is registered as a service');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39242
| License       | MIT
| Doc PR        |

---

Since we are using `abstract_arg()` in the [service definition](https://github.com/symfony/symfony/blob/v5.2.0/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.php#L25) (where we used `null` before), and since there is a validation mechanism that ensure all abstract arg are resolved, the container compilation failed. 
But if the marking store is not defined (which is legit), we want to fallback on the raw PHP implementation.
That's why, now, I replace the abstract arg by null, and everything seems OK