### PR TITLE
[Security] fix #39249, default entry_point compiler pass was returning too early

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterEntryPointPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterEntryPointPass.php
@@ -50,7 +50,7 @@ class RegisterEntryPointPass implements CompilerPassInterface
             }
 
             if (!$entryPoints) {
-                return;
+                continue;
             }
 
             $config = $container->getDefinition('security.firewall.map.config.'.$firewallName);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2 (bug introduced in 5.2.0, after RC2)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39249
| License       | MIT
| Doc PR        | N/A

A `return` instead of `continue` was making compiler pass return after the first firewall. Hence subsequents firewalls never had a default entrypoint set.
This issue would occur with all firewalls, with any type of authenticator, though I saw it first with `http_basic` - because it is a bit more opaque and harder to debug.
