### PR TITLE
[Security] more defensive PasswordMigratingListener

### DIFF
--- a/src/Symfony/Component/Security/Http/EventListener/PasswordMigratingListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/PasswordMigratingListener.php
@@ -56,7 +56,12 @@ class PasswordMigratingListener implements EventSubscriberInterface
         }
 
         $passwordUpgrader = $badge->getPasswordUpgrader();
+
         if (null === $passwordUpgrader) {
+            if (!$passport->hasBadge(UserBadge::class)) {
+                return;
+            }
+
             /** @var UserBadge $userBadge */
             $userBadge = $passport->getBadge(UserBadge::class);
             $userLoader = $userBadge->getUserLoader();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2 (bug not here in 5.1.x)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39262
| License       | MIT
| Doc PR        | /

This proposed fix makes `PasswordMigratingListener` code more robust. It should handle Passports which does not contain an `UserBadge`, as it is not enforced by `UserPassportInterface`. Developers should be free to implement different passports with different badges (as I did on my own project), and it shouldn't lead to a crash in *frameworkland*.

The issue became apparent in 5.2.0 exactly, as `PasswordMigratingListener` is now called in (almost) every login, as `PasswordUpgradeBadge` is automatically added.