### PR TITLE
[Inflector] Fix Notice when argument is empty string

### DIFF
--- a/src/Symfony/Component/Inflector/Inflector.php
+++ b/src/Symfony/Component/Inflector/Inflector.php
@@ -310,6 +310,7 @@ final class Inflector
      * A list of words which should not be inflected, reversed.
      */
     private static $uninflected = [
+        '',
         'atad',
         'reed',
         'kcabdeef',

--- a/src/Symfony/Component/Inflector/Tests/InflectorTest.php
+++ b/src/Symfony/Component/Inflector/Tests/InflectorTest.php
@@ -320,4 +320,16 @@ class InflectorTest extends TestCase
 
         $this->assertEquals($expectedPlural, $plural);
     }
+
+    public function testPluralizeEmptyString()
+    {
+        $plural = Inflector::pluralize('');
+        $this->assertSame('', $plural);
+    }
+
+    public function testSingularizeEmptyString()
+    {
+        $singular = Inflector::singularize('');
+        $this->assertSame('', $singular);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT


Fixing issue when we call `Inflector` with empty string:

```
\Symfony\Component\Inflector\Inflector::singularize('');
```
```
Notice: Uninitialized string offset: 0 in src/Symfony/Component/Inflector/Inflector.php on line 363
PHP Notice:  Uninitialized string offset: 0 in src/Symfony/Component/Inflector/Inflector.php on line 363
...
Notice: Uninitialized string offset: 0 in src/Symfony/Component/Inflector/Inflector.php on line 363
PHP Notice:  Uninitialized string offset: 0 in src/Symfony/Component/Inflector/Inflector.php on line 363
```

Fix for 5.1 https://github.com/symfony/symfony/pull/39244