### PR TITLE
[HttpFoundation] Unquote the request ETag values before comparing to the response ETag values.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -234,7 +234,7 @@ class Response
      */
     public static function create(?string $content = '', int $status = 200, array $headers = [])
     {
-        trigger_deprecation('symfony/http-foundation', '5.1', 'The "%s()" method is deprecated, use "new %s()" instead.', __METHOD__, \get_called_class());
+        trigger_deprecation('symfony/http-foundation', '5.1', 'The "%s()" method is deprecated, use "new %s()" instead.', __METHOD__, static::class);
 
         return new static($content, $status, $headers);
     }

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -1090,7 +1090,7 @@ class Response
         $lastModified = $this->headers->get('Last-Modified');
         $modifiedSince = $request->headers->get('If-Modified-Since');
 
-        if ($etags = $request->getETags()) {
+        if ($etags = array_map('\stripslashes', $request->getETags())) {
             $notModified = \in_array($this->getEtag(), $etags) || \in_array('*', $etags);
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -211,6 +211,29 @@ class ResponseTest extends ResponseTestCase
         $this->assertFalse($response->isNotModified($request));
     }
 
+    public function testIsNotModifiedEtagWithResponseSetter()
+    {
+        $etag = 'random_etag';
+        $weakEtag = 'weak_etag';
+
+        $request = new Request();
+        $request->headers->set('if_none_match', sprintf('\\"%s\\", W/\\"%s\\"', $etag, $weakEtag));
+
+        $response = new Response();
+
+        $response->setEtag($etag);
+        $this->assertTrue($response->isNotModified($request));
+
+        $response->setEtag($weakEtag);
+        $this->assertFalse($response->isNotModified($request));
+
+        $response->setEtag($weakEtag, true);
+        $this->assertTrue($response->isNotModified($request));
+
+        $response->setEtag();
+        $this->assertFalse($response->isNotModified($request));
+    }
+
     public function testIsNotModifiedLastModifiedAndEtag()
     {
         $before = 'Sun, 25 Aug 2013 18:32:31 GMT';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #38815 
| License       | MIT
| Doc PR        | /

The value of ETag header is quoted  in PHP `$_SERVER` global array (e.g, `"etag value"` becomes `"\"etag value\""`). The current implementation of the `isNotModified` method of the `Response` class returns incorrectly because the quoted strings in the request header are compared with the unquoted strings in the response header.

This MR fixes the issue by applying the `stripslashes` function to each element of the parsed value of the request ETag before doing the comparison.
