### PR TITLE
Fix jsonRequest in `AbstractBrowser` for GET methods

### DIFF
--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -173,7 +173,7 @@ abstract class AbstractBrowser
             case 'PUT':
             case 'DELETE':
             case 'PATCH':
-                $content = json_encode($parameters, \defined('JSON_THROW_ON_ERROR') ? \JSON_THROW_ON_ERROR : 0);
+                $content = json_encode($parameters);
                 $query = [];
                 break;
             default:

--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -166,16 +166,42 @@ abstract class AbstractBrowser
      */
     public function jsonRequest(string $method, string $uri, array $parameters = [], array $server = [], bool $changeHistory = true): Crawler
     {
-        $content = json_encode($parameters);
+        // Based on https://github.com/symfony/symfony/blob/v5.2.0/src/Symfony/Component/HttpFoundation/Request.php#L388-L404
+        // the logic in symfony/http-foundation we convert parameters to json content.
+        switch (strtoupper($method)) {
+            case 'POST':
+            case 'PUT':
+            case 'DELETE':
+            case 'PATCH':
+                $content = json_encode($parameters, \defined('JSON_THROW_ON_ERROR') ? \JSON_THROW_ON_ERROR : 0);
+                $query = [];
+                break;
+            default:
+                $content = null;
+                $query = $parameters;
+                break;
+        }
+
+        $serverContentType = $this->getServerParameter('CONTENT_TYPE', null);
+        $serverHttpAccept = $this->getServerParameter('HTTP_ACCEPT', null);
 
         $this->setServerParameter('CONTENT_TYPE', 'application/json');
         $this->setServerParameter('HTTP_ACCEPT', 'application/json');
 
         try {
-            return $this->request($method, $uri, [], [], $server, $content, $changeHistory);
+            return $this->request($method, $uri, $query, [], $server, $content, $changeHistory);
         } finally {
-            unset($this->server['CONTENT_TYPE']);
-            unset($this->server['HTTP_ACCEPT']);
+            if (null === $serverContentType) {
+                unset($this->server['CONTENT_TYPE']);
+            } else {
+                $this->setServerParameter('CONTENT_TYPE', $serverContentType);
+            }
+
+            if (null === $serverHttpAccept) {
+                unset($this->server['HTTP_ACCEPT']);
+            } else {
+                $this->setServerParameter('HTTP_ACCEPT', $serverHttpAccept);
+            }
         }
     }
 

--- a/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/AbstractBrowserTest.php
@@ -63,12 +63,34 @@ class AbstractBrowserTest extends TestCase
     public function testJsonRequest()
     {
         $client = $this->getBrowser();
-        $client->jsonRequest('GET', 'http://example.com/', ['param' => 1], [], true);
+        $client->jsonRequest('POST', 'http://example.com/', ['param' => 1], [], true);
         $this->assertSame('application/json', $client->getRequest()->getServer()['CONTENT_TYPE']);
         $this->assertSame('application/json', $client->getRequest()->getServer()['HTTP_ACCEPT']);
         $this->assertFalse($client->getServerParameter('CONTENT_TYPE', false));
         $this->assertFalse($client->getServerParameter('HTTP_ACCEPT', false));
         $this->assertSame('{"param":1}', $client->getRequest()->getContent());
+    }
+
+    public function testJsonRequestPredefinedServerVariables()
+    {
+        $client = $this->getBrowser(['HTTP_ACCEPT' => 'application/xml', 'CONTENT_TYPE' => 'application/xml']);
+        $client->jsonRequest('POST', 'http://example.com/', ['param' => 1], [], true);
+        $this->assertSame('application/json', $client->getRequest()->getServer()['CONTENT_TYPE']);
+        $this->assertSame('application/json', $client->getRequest()->getServer()['HTTP_ACCEPT']);
+        $this->assertSame('application/xml', $client->getServerParameter('HTTP_ACCEPT'));
+        $this->assertSame('application/xml', $client->getServerParameter('CONTENT_TYPE'));
+    }
+
+    public function testJsonRequestGet()
+    {
+        $client = $this->getBrowser();
+        $client->jsonRequest('GET', 'http://example.com/', ['param' => 1], [], true);
+        $this->assertSame('application/json', $client->getRequest()->getServer()['CONTENT_TYPE']);
+        $this->assertSame('application/json', $client->getRequest()->getServer()['HTTP_ACCEPT']);
+        $this->assertFalse($client->getServerParameter('CONTENT_TYPE', false));
+        $this->assertFalse($client->getServerParameter('HTTP_ACCEPT', false));
+        $this->assertNull($client->getRequest()->getContent());
+        $this->assertSame(['param' => '1'], $client->getRequest()->getParameters());
     }
 
     public function testGetRequestWithIpAsHttpHost()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

When implementing #38596 I was not aware of that $parameters are also used as queryParameters and are converted based on the Method [here](https://github.com/symfony/symfony/blob/v5.2.0/src/Symfony/Component/HttpFoundation/Request.php#L388-L404) into query or request data. This I think should be handled the same way for the jsonRequest also instead of just unset the server variables we should to reset to the predefined server variables.
