### PR TITLE
Fix mixed type with explicit union with null

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
@@ -392,6 +392,7 @@ class DebugClassLoaderTest extends TestCase
         ], \PHP_VERSION_ID >= 80000 ? [
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::this()" will return "static" as of its next major version. Doing the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" will be required when upgrading.',
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::mixed()" will return "mixed" as of its next major version. Doing the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" will be required when upgrading.',
+            'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::nullableMixed()" will return "mixed" as of its next major version. Doing the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" will be required when upgrading.',
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::static()" will return "static" as of its next major version. Doing the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" will be required when upgrading.',
         ] : [
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::this()" will return "object" as of its next major version. Doing the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" will be required when upgrading.',

--- a/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php
@@ -392,7 +392,6 @@ class DebugClassLoaderTest extends TestCase
         ], \PHP_VERSION_ID >= 80000 ? [
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::this()" will return "static" as of its next major version. Doing the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" will be required when upgrading.',
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::mixed()" will return "mixed" as of its next major version. Doing the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" will be required when upgrading.',
-            'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::nullableMixed()" will return "mixed" as of its next major version. Doing the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" will be required when upgrading.',
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::static()" will return "static" as of its next major version. Doing the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" will be required when upgrading.',
         ] : [
             'Method "Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeParent::this()" will return "object" as of its next major version. Doing the same in child class "Test\Symfony\Component\ErrorHandler\Tests\ReturnType" will be required when upgrading.',

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnType.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnType.php
@@ -43,7 +43,6 @@ class ReturnType extends ReturnTypeParent implements ReturnTypeInterface, Fixtur
     public function arrayWithLessThanSignNormalization() { }
     public function this() { }
     public function mixed() { }
-    public function nullableMixed() { }
     public function static() { }
     public function outsideMethod() { }
 }

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeParent.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeParent.php
@@ -200,13 +200,6 @@ abstract class ReturnTypeParent extends ReturnTypeGrandParent implements ReturnT
     }
 
     /**
-     * @return mixed|null
-     */
-    public function nullableMixed()
-    {
-    }
-
-    /**
      * @return static
      */
     public function static()

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeParent.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeParent.php
@@ -202,7 +202,8 @@ abstract class ReturnTypeParent extends ReturnTypeGrandParent implements ReturnT
     /**
      * @return mixed
      *
-     * Will be removed in Symfony 6.x, see https://github.com/symfony/symfony/pull/39282 discussion.
+     * @deprecated annotated with mixed|null originally, but that is not valid php type,
+     *             see https://github.com/symfony/symfony/pull/39282 discussion.
      */
     public function nullableMixed()
     {

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeParent.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeParent.php
@@ -200,6 +200,15 @@ abstract class ReturnTypeParent extends ReturnTypeGrandParent implements ReturnT
     }
 
     /**
+     * @return mixed
+     *
+     * Will be removed in Symfony 6.x, see https://github.com/symfony/symfony/pull/39282 discussion.
+     */
+    public function nullableMixed()
+    {
+    }
+
+    /**
      * @return static
      */
     public function static()

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -255,7 +255,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      *
      * @param string $key The directive name
      *
-     * @return mixed|null The directive value if defined, null otherwise
+     * @return mixed The directive value if defined, null otherwise
      */
     public function getCacheControlDirective($key)
     {

--- a/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
@@ -45,7 +45,7 @@ abstract class AbstractFailedMessagesCommand extends Command
     }
 
     /**
-     * @return mixed|null
+     * @return mixed
      */
     protected function getMessageId(Envelope $envelope)
     {

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -132,7 +132,7 @@ class Process implements \IteratorAggregate
      * @param array          $command The command to run and its arguments listed as separate entries
      * @param string|null    $cwd     The working directory or null to use the working dir of the current PHP process
      * @param array|null     $env     The environment variables or null to use the same environment as the current PHP process
-     * @param mixed|null     $input   The input as stream resource, scalar or \Traversable, or null for no input
+     * @param mixed          $input   The input as stream resource, scalar or \Traversable, or null for no input
      * @param int|float|null $timeout The timeout in seconds or null to disable
      *
      * @throws LogicException When proc_open is not installed
@@ -183,7 +183,7 @@ class Process implements \IteratorAggregate
      * @param string         $command The command line to pass to the shell of the OS
      * @param string|null    $cwd     The working directory or null to use the working dir of the current PHP process
      * @param array|null     $env     The environment variables or null to use the same environment as the current PHP process
-     * @param mixed|null     $input   The input as stream resource, scalar or \Traversable, or null for no input
+     * @param mixed          $input   The input as stream resource, scalar or \Traversable, or null for no input
      * @param int|float|null $timeout The timeout in seconds or null to disable
      *
      * @return static

--- a/src/Symfony/Contracts/HttpClient/ResponseInterface.php
+++ b/src/Symfony/Contracts/HttpClient/ResponseInterface.php
@@ -88,24 +88,24 @@ interface ResponseInterface
      * another, as the request/response progresses.
      *
      * The following info MUST be returned:
-     *  - canceled (bool) - true if the response was canceled using ResponseInterface::cancel(), false otherwise
-     *  - error (string|null) - the error message when the transfer was aborted, null otherwise
-     *  - http_code (int) - the last response code or 0 when it is not known yet
-     *  - http_method (string) - the HTTP verb of the last request
-     *  - redirect_count (int) - the number of redirects followed while executing the request
+     *  - canceled (bool)            - true if the response was canceled using ResponseInterface::cancel(), false otherwise
+     *  - error (string|null)        - the error message when the transfer was aborted, null otherwise
+     *  - http_code (int)            - the last response code or 0 when it is not known yet
+     *  - http_method (string)       - the HTTP verb of the last request
+     *  - redirect_count (int)       - the number of redirects followed while executing the request
      *  - redirect_url (string|null) - the resolved location of redirect responses, null otherwise
-     *  - response_headers (array) - an array modelled after the special $http_response_header variable
-     *  - start_time (float) - the time when the request was sent or 0.0 when it's pending
-     *  - url (string) - the last effective URL of the request
-     *  - user_data (mixed|null) - the value of the "user_data" request option, null if not set
+     *  - response_headers (array)   - an array modelled after the special $http_response_header variable
+     *  - start_time (float)         - the time when the request was sent or 0.0 when it's pending
+     *  - url (string)               - the last effective URL of the request
+     *  - user_data (mixed)          - the value of the "user_data" request option, null if not set
      *
      * When the "capture_peer_cert_chain" option is true, the "peer_certificate_chain"
      * attribute SHOULD list the peer certificates as an array of OpenSSL X.509 resources.
      *
      * Other info SHOULD be named after curl_getinfo()'s associative return value.
      *
-     * @return array|mixed|null An array of all available info, or one of them when $type is
-     *                          provided, or null when an unsupported type is requested
+     * @return mixed An array of all available info, or one of them when $type is provided,
+     *               or null when an unsupported type is requested
      */
     public function getInfo(string $type = null);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

`mixed` type already includes `null`, see https://3v4l.org/n1PTl

when mergin up, use `mvorisek/fix_mixed_with_null_5.x` branch (there are more fixes needed, or search for `mixed|null` string)