### PR TITLE
[HttpClient] throw clearer error when no scheme is provided

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -377,6 +377,10 @@ trait HttpClientTrait
             throw new InvalidArgumentException(sprintf('Invalid "base_uri" option: host or scheme is missing in "%s".', implode('', $base)));
         }
 
+        if (null === $url['scheme'] && (null === $base || null === $base['scheme'])) {
+            throw new InvalidArgumentException(sprintf('Invalid URL: scheme is missing in "%s". Did you forget to add "http(s)://"?', implode('', $base ?? $url)));
+        }
+
         if (null === $base && '' === $url['scheme'].$url['authority']) {
             throw new InvalidArgumentException(sprintf('Invalid URL: no "base_uri" option was provided and host or scheme is missing in "%s".', implode('', $url)));
         }

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpClient\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\InvalidArgumentException;
 use Symfony\Component\HttpClient\HttpClientTrait;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -118,6 +119,20 @@ class HttpClientTraitTest extends TestCase
             [self::RFC3986_BASE, '?0',            'http://a/b/c/d;p?0'],
             [self::RFC3986_BASE, '#0',            'http://a/b/c/d;p?q#0'],
         ];
+    }
+
+    public function testResolveUrlWithoutScheme()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid URL: scheme is missing in "//localhost:8080". Did you forget to add "http(s)://"?');
+        self::resolveUrl(self::parseUrl('localhost:8080'), null);
+    }
+
+    public function testResolveBaseUrlWitoutScheme()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid URL: scheme is missing in "//localhost:8081". Did you forget to add "http(s)://"?');
+        self::resolveUrl(self::parseUrl('/foo'), self::parseUrl('localhost:8081'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #39285 
| License       | MIT
| Doc PR        | N/A

This could be considred a BC break, as previously this would've  a `TransportExcepiton`, instead of an `InvalidArgumentException`. But i see no reason to catch this specific error, as it would generally be a configuration error.
