### PR TITLE
[HttpFoundation] Ignore stack trace printed by Xdebug 3

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_max_age.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_max_age.expected
@@ -1,6 +1,6 @@
 
 Warning: Expiry date cannot have a year greater than 9999 in %scookie_max_age.php on line 10
-
+%a
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

If we're running HttpFoundation's functional tests with Xdebug 3, a stack trace will be printed when a warning is emitted. This confuses our `cookie_max_age` test currently where we perform a `setcookie()` call that will emit a warning.

I have patched the corresponding fixture so the printed stack trace is ignored.

A failed test can be seen here: https://travis-ci.com/github/symfony/symfony/jobs/452077515#L11078