### PR TITLE
[HttpFoundation] Make sure we reuse the current PHP binary for the webserver process in functional tests.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
@@ -23,7 +23,7 @@ class ResponseFunctionalTest extends TestCase
             1 => ['file', '/dev/null', 'w'],
             2 => ['file', '/dev/null', 'w'],
         ];
-        if (!self::$server = @proc_open('exec php -S localhost:8054', $spec, $pipes, __DIR__.'/Fixtures/response-functional')) {
+        if (!self::$server = @proc_open('exec '.\PHP_BINARY.' -S localhost:8054', $spec, $pipes, __DIR__.'/Fixtures/response-functional')) {
             self::markTestSkipped('PHP server unable to start.');
         }
         sleep(1);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
@@ -23,7 +23,7 @@ class AbstractSessionHandlerTest extends TestCase
             1 => ['file', '/dev/null', 'w'],
             2 => ['file', '/dev/null', 'w'],
         ];
-        if (!self::$server = @proc_open('exec php -S localhost:8053', $spec, $pipes, __DIR__.'/Fixtures')) {
+        if (!self::$server = @proc_open('exec '.\PHP_BINARY.' -S localhost:8053', $spec, $pipes, __DIR__.'/Fixtures')) {
             self::markTestSkipped('PHP server unable to start.');
         }
         sleep(1);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

While debugging HttpFoundation's functional tests with different PHP binaries, I noticed that the webserver process that is started there would always use the `php` binary from my `$PATH` instead of the binary I'm running PHPUnit with.

This PR attempts to fix this by using the `PHP_BINARY` constant.