### PR TITLE
Remove Xdebug from php-extra runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ before_install:
       export PHPUNIT_X="$PHPUNIT --exclude-group tty,benchmark,intl-data"
       export COMPOSER_UP='composer update --no-progress --ansi'
       export COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -printf '%h\n' | sort)
-      find ~/.phpenv -name xdebug.ini -delete
 
       nanoseconds () {
           local cmd="date"
@@ -137,6 +136,7 @@ before_install:
               echo extension = memcached.so >> $INI
           fi
       done
+      find ~/.phpenv -name xdebug.ini -delete
 
     - |
       # Install extra PHP extensions


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Apparently, Travis already bundles Xdebug 3 with their PHP 7.4 binaries. This causes a lot of segfaults in our CI at the moment. This PR removes the Xdebug configuration files from all PHP tarballs that we download for our Travis build.