### PR TITLE
[PropertyInfo][Serializer] Fixed extracting ignored properties for Serializer

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/SerializerExtractor.php
@@ -47,7 +47,7 @@ class SerializerExtractor implements PropertyListExtractorInterface
         $serializerClassMetadata = $this->classMetadataFactory->getMetadataFor($class);
 
         foreach ($serializerClassMetadata->getAttributesMetadata() as $serializerAttributeMetadata) {
-            $ignored = method_exists($serializerClassMetadata, 'isIgnored') && $serializerAttributeMetadata->isIgnored();
+            $ignored = method_exists($serializerAttributeMetadata, 'isIgnored') && $serializerAttributeMetadata->isIgnored();
             if (!$ignored && array_intersect($context['serializer_groups'], $serializerAttributeMetadata->getGroups())) {
                 $properties[] = $serializerAttributeMetadata->getName();
             }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/SerializerExtractorTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\PropertyInfo\Tests\Extractor;
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\SerializerExtractor;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\IgnorePropertyDummy;
+use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 
@@ -39,5 +41,14 @@ class SerializerExtractorTest extends TestCase
             ['collection'],
             $this->extractor->getProperties('Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy', ['serializer_groups' => ['a']])
         );
+    }
+
+    public function testGetPropertiesWithIgnoredProperties()
+    {
+        if (!class_exists(Ignore::class)) {
+            $this->markTestSkipped('Ignore annotation is not implemented in current symfony/serializer version');
+        }
+
+        $this->assertSame(['visibleProperty'], $this->extractor->getProperties(IgnorePropertyDummy::class, ['serializer_groups' => ['a']]));
     }
 }

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/IgnorePropertyDummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/IgnorePropertyDummy.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Annotation\Ignore;
+
+/**
+ * @author Vadim Borodavko <vadim.borodavko@gmail.com>
+ */
+class IgnorePropertyDummy
+{
+    /**
+     * @Groups({"a"})
+     */
+    public $visibleProperty;
+
+    /**
+     * @Groups({"a"})
+     * @Ignore
+     */
+    private $ignoredProperty;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fixed typo in `SerializerExtractor::getProperties()` introduced in https://github.com/symfony/symfony/commit/8526d7c0506c9dd7a57143357f1e5032e4c396b0 which leads to the error after https://github.com/symfony/symfony/pull/37040.
`$serializerClassMetadata` is instance of `Symfony\Component\Serializer\Mapping\ClassMetadata`, which doesn't contain `isIgnored` method, this methods is located in `Symfony\Component\Serializer\Mapping\AttributeMetadata` which is `$serializerAttributeMetadata` here. More over, it doesn't make sense to check the method existence in one class and call it for another.