### PR TITLE
[Notifier] Check for maximum number of buttons in slack action block

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackActionsBlock.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackActionsBlock.php
@@ -26,6 +26,10 @@ final class SlackActionsBlock extends AbstractSlackBlock
      */
     public function button(string $text, string $url, string $style = null): self
     {
+        if (25 === \count($this->options['elements'] ?? [])) {
+            throw new \LogicException('Maximum number of buttons should not exceed 25.');
+        }
+
         $element = [
             'type' => 'button',
             'text' => [

--- a/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+ * Check for maximum number of buttons in Slack action block
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/Block/SlackActionsBlockTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/Block/SlackActionsBlockTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Slack\Tests\Block;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\Slack\Block\SlackActionsBlock;
+
+final class SlackActionsBlockTest extends TestCase
+{
+    public function testCanBeInstantiated(): void
+    {
+        $actions = new SlackActionsBlock();
+        $actions->button('first button text', 'https://example.org')
+            ->button('second button text', 'https://example.org/slack', 'danger')
+        ;
+
+        $this->assertSame([
+            'type' => 'actions',
+            'elements' => [
+                [
+                    'type' => 'button',
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => 'first button text',
+                    ],
+                    'url' => 'https://example.org',
+                ],
+                [
+                    'type' => 'button',
+                    'text' => [
+                        'type' => 'plain_text',
+                        'text' => 'second button text',
+                    ],
+                    'url' => 'https://example.org/slack',
+                    'style' => 'danger',
+                ],
+            ],
+        ], $actions->toArray());
+    }
+
+    public function testThrowsWhenFieldsLimitReached(): void
+    {
+        $section = new SlackActionsBlock();
+        for ($i = 0; $i < 25; ++$i) {
+            $section->button($i, $i);
+        }
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Maximum number of buttons should not exceed 25.');
+
+        $section->button('fail', 'fail');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x |
| Bug fix?      | no |
| New feature?  | yes |
| Deprecations? | no |
| Tickets       | - |
| License       | MIT |
| Doc PR        | - |

After having problems with the SlackSectionBlock (https://github.com/symfony/symfony/pull/39236) i thought it would be helpful to also have a check for the maximum elements in the SlackActionsBlock and a test. https://api.slack.com/reference/block-kit/blocks#actions
Edit: The actual documentation says that the maximum are 5 elements but this is outdated. The actual number is 25. The slack support confirmed that.

Can this be added to 5.2 or better to the 5.x branch?

There are also some other implementations of slack blocks like the SlackDividerBlock but they have only a constructor and no additional methods. Should we also add some tests for them even if they have no extra logic?