### PR TITLE
[Notifier] Add exception for deprecated slack dsn

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/README.md
@@ -3,6 +3,18 @@ Slack Notifier
 
 Provides Slack integration for Symfony Notifier.
 
+DSN example
+-----------
+
+```
+// .env file
+SLACK_DSN=slack://TOKEN@default?channel=CHANNEL
+```
+
+where:
+- `TOKEN` is your Bot User OAuth Access Token
+- `CHANNEL` is a Channel, private group, or IM channel to send message to. Can be an encoded ID, or a name
+
 Resources
 ---------
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Slack;
 
+use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -28,17 +29,20 @@ final class SlackTransportFactory extends AbstractTransportFactory
      */
     public function create(Dsn $dsn): TransportInterface
     {
-        $scheme = $dsn->getScheme();
+        if ('slack' !== $dsn->getScheme()) {
+            throw new UnsupportedSchemeException($dsn, 'slack', $this->getSupportedSchemes());
+        }
+
+        if ('/' !== $dsn->getPath()) {
+            throw new IncompleteDsnException('Support for Slack webhook DSN has been dropped since 5.2 (maybe you haven\'t updated the DSN when upgrading from 5.1).');
+        }
+
         $accessToken = $this->getUser($dsn);
         $channel = $dsn->getOption('channel');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        if ('slack' === $scheme) {
-            return (new SlackTransport($accessToken, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
-        }
-
-        throw new UnsupportedSchemeException($dsn, 'slack', $this->getSupportedSchemes());
+        return (new SlackTransport($accessToken, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportFactoryTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\Slack\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
 use Symfony\Component\Notifier\Exception\IncompleteDsnException;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
 
@@ -28,6 +29,15 @@ final class SlackTransportFactoryTest extends TestCase
         $transport = $factory->create(Dsn::fromString(sprintf('slack://testUser@%s/?channel=%s', $host, $channel)));
 
         $this->assertSame(sprintf('slack://%s?channel=%s', $host, $channel), (string) $transport);
+    }
+
+    public function testCreateWithDeprecatedDsn(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Support for Slack webhook DSN has been dropped since 5.2 (maybe you haven\'t updated the DSN when upgrading from 5.1).');
+
+        $factory = new SlackTransportFactory();
+        $factory->create(Dsn::fromString('slack://default/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX'));
     }
 
     public function testCreateWithNoTokenThrowsMalformed(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #39204 
| License       | MIT
| Doc PR        | -

The DSN for the Slack integration changed again from 5.1 to 5.2. There was the idea to output an exception for that.
