### PR TITLE
[FrameworkBundle] TextDescriptor::formatControllerLink checked method…

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -504,7 +504,9 @@ class TextDescriptor extends Descriptor
         }
 
         try {
-            if (\is_array($controller)) {
+            if (null === $controller) {
+                return $anchorText;
+            } elseif (\is_array($controller)) {
                 $r = new \ReflectionMethod($controller[0], $controller[1]);
             } elseif ($controller instanceof \Closure) {
                 $r = new \ReflectionFunction($controller);


### PR DESCRIPTION
…_exists method before it ensures that $controller is not null

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Today I tried PHP8 with Symfony 5.2. - by checking my routes with
```
bin/console debug:router
```

It throws
```
 method_exists(): Argument #1 ($object_or_class) must be of type object|string, null given
```

The reason is the configured auth route for the login API defined in routes.yaml:
```
authorization::login:
  path: '/login'
```
This route has no controller configured and the value of $controller in `TextDescriptor::formatControllerLink` in the FrameworkBundle is `null`. This method has a elseif condition with `method_exists` without a check if $controller is a string or object. 
In PHP8 this throws an exception/error and did not work. This PR checks that `$controller` is not null before the method_exists check to prevent this failure.

I'm not sure how to test this in the existing Testsuite