### PR TITLE
[Form] Changed DataMapperInterface $forms parameter type to \Traversable

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -1,0 +1,14 @@
+UPGRADE FROM 5.2 to 5.3
+=======================
+
+Form
+----
+
+ * Changed `$forms` parameter type of the `DataMapperInterface::mapDataToForms()` method from `iterable` to `\Traversable`.
+ * Changed `$forms` parameter type of the `DataMapperInterface::mapFormsToData()` method from `iterable` to `\Traversable`.
+ * Deprecated passing an array as the second argument of the `DataMapper::mapDataToForms()` method, pass `\Traversable` instead.
+ * Deprecated passing an array as the first argument of the `DataMapper::mapFormsToData()` method, pass `\Traversable` instead.
+ * Deprecated passing an array as the second argument of the `CheckboxListMapper::mapDataToForms()` method, pass `\Traversable` instead.
+ * Deprecated passing an array as the first argument of the `CheckboxListMapper::mapFormsToData()` method, pass `\Traversable` instead.
+ * Deprecated passing an array as the second argument of the `RadioListMapper::mapDataToForms()` method, pass `\Traversable` instead.
+ * Deprecated passing an array as the first argument of the `RadioListMapper::mapFormsToData()` method, pass `\Traversable` instead.

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -49,6 +49,12 @@ Form
  * The `Symfony\Component\Form\Extension\Validator\Util\ServerParams` class has been removed, use its parent `Symfony\Component\Form\Util\ServerParams` instead.
  * The `NumberToLocalizedStringTransformer::ROUND_*` constants have been removed, use `\NumberFormatter::ROUND_*` instead.
  * Removed `PropertyPathMapper` in favor of `DataMapper` and `PropertyPathAccessor`.
+ * Changed `$forms` parameter type of the `DataMapper::mapDataToForms()` method from `iterable` to `\Traversable`.
+ * Changed `$forms` parameter type of the `DataMapper::mapFormsToData()` method from `iterable` to `\Traversable`.
+ * Changed `$checkboxes` parameter type of the `CheckboxListMapper::mapDataToForms()` method from `iterable` to `\Traversable`.
+ * Changed `$checkboxes` parameter type of the `CheckboxListMapper::mapFormsToData()` method from `iterable` to `\Traversable`.
+ * Changed `$radios` parameter type of the `RadioListMapper::mapDataToForms()` method from `iterable` to `\Traversable`.
+ * Changed `$radios` parameter type of the `RadioListMapper::mapFormsToData()` method from `iterable` to `\Traversable`.
 
 FrameworkBundle
 ---------------

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,18 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+ * Changed `$forms` parameter type of the `DataMapperInterface::mapDataToForms()` method from `iterable` to `\Traversable`.
+ * Changed `$forms` parameter type of the `DataMapperInterface::mapFormsToData()` method from `iterable` to `\Traversable`.
+ * Deprecated passing an array as the second argument of the `DataMapper::mapDataToForms()` method, pass `\Traversable` instead.
+ * Deprecated passing an array as the first argument of the `DataMapper::mapFormsToData()` method, pass `\Traversable` instead.
+ * Deprecated passing an array as the second argument of the `CheckboxListMapper::mapDataToForms()` method, pass `\Traversable` instead.
+ * Deprecated passing an array as the first argument of the `CheckboxListMapper::mapFormsToData()` method, pass `\Traversable` instead.
+ * Deprecated passing an array as the second argument of the `RadioListMapper::mapDataToForms()` method, pass `\Traversable` instead.
+ * Deprecated passing an array as the first argument of the `RadioListMapper::mapFormsToData()` method, pass `\Traversable` instead.
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Form/DataMapperInterface.php
+++ b/src/Symfony/Component/Form/DataMapperInterface.php
@@ -22,12 +22,12 @@ interface DataMapperInterface
      * The method is responsible for calling {@link FormInterface::setData()}
      * on the children of compound forms, defining their underlying model data.
      *
-     * @param mixed                    $viewData View data of the compound form being initialized
-     * @param FormInterface[]|iterable $forms    A list of {@link FormInterface} instances
+     * @param mixed                        $viewData View data of the compound form being initialized
+     * @param FormInterface[]|\Traversable $forms    A list of {@link FormInterface} instances
      *
      * @throws Exception\UnexpectedTypeException if the type of the data parameter is not supported
      */
-    public function mapDataToForms($viewData, iterable $forms);
+    public function mapDataToForms($viewData, \Traversable $forms);
 
     /**
      * Maps the model data of a list of children forms into the view data of their parent.
@@ -52,11 +52,11 @@ interface DataMapperInterface
      * The model data can be an array or an object, so this second argument is always passed
      * by reference.
      *
-     * @param FormInterface[]|iterable $forms    A list of {@link FormInterface} instances
-     * @param mixed                    $viewData The compound form's view data that get mapped
-     *                                           its children model data
+     * @param FormInterface[]|\Traversable $forms    A list of {@link FormInterface} instances
+     * @param mixed                        $viewData The compound form's view data that get mapped
+     *                                               its children model data
      *
      * @throws Exception\UnexpectedTypeException if the type of the data parameter is not supported
      */
-    public function mapFormsToData(iterable $forms, &$viewData);
+    public function mapFormsToData(\Traversable $forms, &$viewData);
 }

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/CheckboxListMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/CheckboxListMapper.php
@@ -30,6 +30,10 @@ class CheckboxListMapper implements DataMapperInterface
      */
     public function mapDataToForms($choices, iterable $checkboxes)
     {
+        if (\is_array($checkboxes)) {
+            trigger_deprecation('symfony/form', '5.3', 'Passing an array as the second argument of the "%s()" method is deprecated, pass "\Traversable" instead.', __METHOD__);
+        }
+
         if (null === $choices) {
             $choices = [];
         }
@@ -49,6 +53,10 @@ class CheckboxListMapper implements DataMapperInterface
      */
     public function mapFormsToData(iterable $checkboxes, &$choices)
     {
+        if (\is_array($checkboxes)) {
+            trigger_deprecation('symfony/form', '5.3', 'Passing an array as the first argument of the "%s()" method is deprecated, pass "\Traversable" instead.', __METHOD__);
+        }
+
         if (!\is_array($choices)) {
             throw new UnexpectedTypeException($choices, 'array');
         }

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/DataMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/DataMapper.php
@@ -40,6 +40,10 @@ class DataMapper implements DataMapperInterface
      */
     public function mapDataToForms($data, iterable $forms): void
     {
+        if (\is_array($forms)) {
+            trigger_deprecation('symfony/form', '5.3', 'Passing an array as the second argument of the "%s()" method is deprecated, pass "\Traversable" instead.', __METHOD__);
+        }
+
         $empty = null === $data || [] === $data;
 
         if (!$empty && !\is_array($data) && !\is_object($data)) {
@@ -62,6 +66,10 @@ class DataMapper implements DataMapperInterface
      */
     public function mapFormsToData(iterable $forms, &$data): void
     {
+        if (\is_array($forms)) {
+            trigger_deprecation('symfony/form', '5.3', 'Passing an array as the first argument of the "%s()" method is deprecated, pass "\Traversable" instead.', __METHOD__);
+        }
+
         if (null === $data) {
             return;
         }

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/RadioListMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/RadioListMapper.php
@@ -30,6 +30,10 @@ class RadioListMapper implements DataMapperInterface
      */
     public function mapDataToForms($choice, iterable $radios)
     {
+        if (\is_array($radios)) {
+            trigger_deprecation('symfony/form', '5.3', 'Passing an array as the second argument of the "%s()" method is deprecated, pass "\Traversable" instead.', __METHOD__);
+        }
+
         if (!\is_string($choice)) {
             throw new UnexpectedTypeException($choice, 'string');
         }
@@ -45,6 +49,10 @@ class RadioListMapper implements DataMapperInterface
      */
     public function mapFormsToData(iterable $radios, &$choice)
     {
+        if (\is_array($radios)) {
+            trigger_deprecation('symfony/form', '5.3', 'Passing an array as the first argument of the "%s()" method is deprecated, pass "\Traversable" instead.', __METHOD__);
+        }
+
         if (null !== $choice && !\is_string($choice)) {
             throw new UnexpectedTypeException($choice, 'null or string');
         }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/DataMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/DataMapperTest.php
@@ -50,7 +50,7 @@ class DataMapperTest extends TestCase
         $config->setPropertyPath($propertyPath);
         $form = new Form($config);
 
-        $this->mapper->mapDataToForms($car, [$form]);
+        $this->mapper->mapDataToForms($car, new \ArrayIterator([$form]));
 
         self::assertSame($engine, $form->getData());
     }
@@ -68,7 +68,7 @@ class DataMapperTest extends TestCase
         $config->setPropertyPath($propertyPath);
         $form = new Form($config);
 
-        $this->mapper->mapDataToForms($car, [$form]);
+        $this->mapper->mapDataToForms($car, new \ArrayIterator([$form]));
 
         self::assertNotSame($engine, $form->getData());
         self::assertEquals($engine, $form->getData());
@@ -84,7 +84,7 @@ class DataMapperTest extends TestCase
 
         self::assertNull($form->getPropertyPath());
 
-        $this->mapper->mapDataToForms($car, [$form]);
+        $this->mapper->mapDataToForms($car, new \ArrayIterator([$form]));
 
         self::assertNull($form->getData());
     }
@@ -101,7 +101,7 @@ class DataMapperTest extends TestCase
         $config->setPropertyPath($propertyPath);
         $form = new Form($config);
 
-        $this->mapper->mapDataToForms($car, [$form]);
+        $this->mapper->mapDataToForms($car, new \ArrayIterator([$form]));
 
         self::assertNull($form->getData());
     }
@@ -117,7 +117,7 @@ class DataMapperTest extends TestCase
         $car = new TypehintedPropertiesCar();
         $car->engine = 'BMW';
 
-        $this->mapper->mapDataToForms($car, [$engineForm, $colorForm]);
+        $this->mapper->mapDataToForms($car, new \ArrayIterator([$engineForm, $colorForm]));
 
         self::assertSame($car->engine, $engineForm->getData());
         self::assertNull($colorForm->getData());
@@ -135,7 +135,7 @@ class DataMapperTest extends TestCase
 
         $form = new Form($config);
 
-        $this->mapper->mapDataToForms(null, [$form]);
+        $this->mapper->mapDataToForms(null, new \ArrayIterator([$form]));
 
         self::assertSame($default, $form->getData());
     }
@@ -152,7 +152,7 @@ class DataMapperTest extends TestCase
 
         $form = new Form($config);
 
-        $this->mapper->mapDataToForms([], [$form]);
+        $this->mapper->mapDataToForms([], new \ArrayIterator([$form]));
 
         self::assertSame($default, $form->getData());
     }
@@ -171,7 +171,7 @@ class DataMapperTest extends TestCase
         $config->setData($engine);
         $form = new SubmittedForm($config);
 
-        $this->mapper->mapFormsToData([$form], $car);
+        $this->mapper->mapFormsToData(new \ArrayIterator([$form]), $car);
 
         self::assertEquals($engine, $car->engine);
         self::assertNotSame($engine, $car->engine);
@@ -190,7 +190,7 @@ class DataMapperTest extends TestCase
         $config->setData($engine);
         $form = new SubmittedForm($config);
 
-        $this->mapper->mapFormsToData([$form], $car);
+        $this->mapper->mapFormsToData(new \ArrayIterator([$form]), $car);
 
         self::assertSame($engine, $car->engine);
     }
@@ -209,7 +209,7 @@ class DataMapperTest extends TestCase
 
         $car->engine = 'Rolls-Royce';
 
-        $this->mapper->mapFormsToData([$form], $car);
+        $this->mapper->mapFormsToData(new \ArrayIterator([$form]), $car);
 
         self::assertSame('Rolls-Royce', $car->engine);
     }
@@ -229,7 +229,7 @@ class DataMapperTest extends TestCase
         $config->setMapped(false);
         $form = new SubmittedForm($config);
 
-        $this->mapper->mapFormsToData([$form], $car);
+        $this->mapper->mapFormsToData(new \ArrayIterator([$form]), $car);
 
         self::assertSame($initialEngine, $car->engine);
     }
@@ -248,7 +248,7 @@ class DataMapperTest extends TestCase
         $config->setData($engine);
         $form = new Form($config);
 
-        $this->mapper->mapFormsToData([$form], $car);
+        $this->mapper->mapFormsToData(new \ArrayIterator([$form]), $car);
 
         self::assertSame($initialEngine, $car->engine);
     }
@@ -266,7 +266,7 @@ class DataMapperTest extends TestCase
         $config->setData(null);
         $form = new Form($config);
 
-        $this->mapper->mapFormsToData([$form], $car);
+        $this->mapper->mapFormsToData(new \ArrayIterator([$form]), $car);
 
         self::assertSame($initialEngine, $car->engine);
     }
@@ -285,7 +285,7 @@ class DataMapperTest extends TestCase
         $config->setData($engine);
         $form = new NotSynchronizedForm($config);
 
-        $this->mapper->mapFormsToData([$form], $car);
+        $this->mapper->mapFormsToData(new \ArrayIterator([$form]), $car);
 
         self::assertSame($initialEngine, $car->engine);
     }
@@ -305,7 +305,7 @@ class DataMapperTest extends TestCase
         $config->setDisabled(true);
         $form = new SubmittedForm($config);
 
-        $this->mapper->mapFormsToData([$form], $car);
+        $this->mapper->mapFormsToData(new \ArrayIterator([$form]), $car);
 
         self::assertSame($initialEngine, $car->engine);
     }
@@ -320,7 +320,7 @@ class DataMapperTest extends TestCase
         $config->setData('BMW');
         $form = new SubmittedForm($config);
 
-        $this->mapper->mapFormsToData([$form], $car);
+        $this->mapper->mapFormsToData(new \ArrayIterator([$form]), $car);
 
         self::assertSame('BMW', $car->engine);
     }
@@ -342,7 +342,7 @@ class DataMapperTest extends TestCase
         $config->setData($publishedAt);
         $form = new SubmittedForm($config);
 
-        $this->mapper->mapFormsToData([$form], $article);
+        $this->mapper->mapFormsToData(new \ArrayIterator([$form]), $article);
 
         self::assertSame($publishedAtValue, $article['publishedAt']);
     }
@@ -367,7 +367,7 @@ class DataMapperTest extends TestCase
         ]);
         $form = new Form($config);
 
-        $this->mapper->mapDataToForms($person, [$form]);
+        $this->mapper->mapDataToForms($person, new \ArrayIterator([$form]));
 
         self::assertSame($initialName, $form->getData());
     }
@@ -384,7 +384,7 @@ class DataMapperTest extends TestCase
         $config->setData('Jane Doe');
         $form = new SubmittedForm($config);
 
-        $this->mapper->mapFormsToData([$form], $person);
+        $this->mapper->mapFormsToData(new \ArrayIterator([$form]), $person);
 
         self::assertSame('Jane Doe', $person->myName());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #39311
| License       | MIT
| Doc PR        | no

Didn't touch `PropertyPathMapper` because it's deprecated anyway.