### PR TITLE
[HttpFoundation] Make test pass without Xdebug

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_max_age.expected
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/response-functional/cookie_max_age.expected
@@ -1,6 +1,6 @@
 
 Warning: Expiry date cannot have a year greater than 9999 in %scookie_max_age.php on line 10
-%a
+%A
 Array
 (
     [0] => Content-Type: text/plain; charset=utf-8


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Fixup of #39293. This change should make the tests pass without Xdebug. Sorry for the messup. 🙈 