### PR TITLE
[SecurityBundle] Don't use the container as resource type in fixtures

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/argon2i_encoder.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/argon2i_encoder.php
@@ -1,6 +1,6 @@
 <?php
 
-$this->load('container1.php', $container);
+$this->load('container1.php');
 
 $container->loadFromExtension('security', [
     'encoders' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/bcrypt_encoder.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/bcrypt_encoder.php
@@ -1,6 +1,6 @@
 <?php
 
-$this->load('container1.php', $container);
+$this->load('container1.php');
 
 $container->loadFromExtension('security', [
     'encoders' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/migrating_encoder.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/migrating_encoder.php
@@ -1,6 +1,6 @@
 <?php
 
-$this->load('container1.php', $container);
+$this->load('container1.php');
 
 $container->loadFromExtension('security', [
     'encoders' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Discovered while working on #39292: Some fixtures of SecurityBundle call config loaders and pass the whole container as resource type. This does not really make sense.