### PR TITLE
[FrameworkBundle] Add validator.expression_language service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\ValidatorCacheWarmer;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Validator\Constraints\EmailValidator;
 use Symfony\Component\Validator\Constraints\ExpressionValidator;
 use Symfony\Component\Validator\Constraints\NotCompromisedPasswordValidator;
@@ -66,9 +67,17 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('validator.expression', ExpressionValidator::class)
+            ->args([service('validator.expression_language')->nullOnInvalid()])
             ->tag('validator.constraint_validator', [
                 'alias' => 'validator.expression',
             ])
+
+        ->set('validator.expression_language', ExpressionLanguage::class)
+            ->args([service('cache.validator_expression_language')->nullOnInvalid()])
+
+        ->set('cache.validator_expression_language')
+            ->parent('cache.system')
+            ->tag('cache.pool')
 
         ->set('validator.email', EmailValidator::class)
             ->args([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This add a `validator.expression_language` service to allow better than in-memory caching of validation expression.

This also opens possibilities to extend the expression language available in validation expression through the use of `ExpressionFunctionProviderInterface` and a compiler pass.

I tried to do something close as what exists for `security.expression_language` service but I still have some questions.

- Which kind of tests should I write for this feature?
- Does it deserve having it's own child `ExpressionLanguage` class?


#SymfonyHackday