### PR TITLE
[Workflow] Don't use VariableNode for ArrayNode

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -384,13 +384,9 @@ class Configuration implements ConfigurationInterface
                                         ->defaultValue([])
                                         ->prototype('scalar')->end()
                                     ->end()
-                                    ->variableNode('events_to_dispatch')
-                                        ->defaultValue(null)
+                                    ->arrayNode('events_to_dispatch')
                                         ->validate()
                                             ->ifTrue(function ($v) {
-                                                if (null === $v) {
-                                                    return false;
-                                                }
                                                 if (!\is_array($v)) {
                                                     return true;
                                                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

This change could break some applications that have defined: 

```yaml
framework:
    workflows:
        acme:
            events_to_dispatch: null
```

They should just remove the `events_to_dispatch` line or define it as an empty array. 

I don't see why it was defined as a VariableNode in the first place. It was introduced here #37815, maybe @lyrixx can help me here?

#SymfonyHackday