### PR TITLE
[Messenger] Add options to `FailedMessagesShowCommand`

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `StopWorkerExceptionInterface` and its implementation `StopWorkerException` to stop the worker.
+ * Add the options `group` and `class-filter` to `FailedMessagesShowCommand`
 
 5.3
 ---

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Add `StopWorkerExceptionInterface` and its implementation `StopWorkerException` to stop the worker.
- * Add the options `group` and `class-filter` to `FailedMessagesShowCommand`
+* Add the options `stats` and `class-filter` to `FailedMessagesShowCommand`
 
 5.3
 ---

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Add `StopWorkerExceptionInterface` and its implementation `StopWorkerException` to stop the worker.
-* Add the options `stats` and `class-filter` to `FailedMessagesShowCommand`
+ * Add the options `stats` and `class-filter` to `FailedMessagesShowCommand`
 
 5.3
 ---

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -42,6 +42,8 @@ class FailedMessagesShowCommand extends AbstractFailedMessagesCommand
                 new InputArgument('id', InputArgument::OPTIONAL, 'Specific message id to show'),
                 new InputOption('max', null, InputOption::VALUE_REQUIRED, 'Maximum number of messages to list', 50),
                 new InputOption('transport', null, InputOption::VALUE_OPTIONAL, 'Use a specific failure transport', self::DEFAULT_TRANSPORT_OPTION),
+                new InputOption('group', null, InputOption::VALUE_NONE, 'Group by message class'),
+                new InputOption('class-filter', null, InputOption::VALUE_REQUIRED, 'Filter by a specific class name'),
             ])
             ->setDescription(self::$defaultDescription)
             ->setHelp(<<<'EOF'
@@ -81,7 +83,9 @@ EOF
             throw new RuntimeException(sprintf('The "%s" receiver does not support listing or showing specific messages.', $failureTransportName));
         }
 
-        if (null === $id = $input->getArgument('id')) {
+        if ($input->getOption('group')) {
+            $this->listMessagesPerClass($failureTransportName, $io);
+        } elseif (null === $id = $input->getArgument('id')) {
             $this->listMessages($failureTransportName, $io, $input->getOption('max'));
         } else {
             $this->showMessage($failureTransportName, $id, $io);
@@ -90,7 +94,7 @@ EOF
         return 0;
     }
 
-    private function listMessages(?string $failedTransportName, SymfonyStyle $io, int $max)
+    private function listMessages(?string $failedTransportName, SymfonyStyle $io, int $max, ?string $classFilter)
     {
         /** @var ListableReceiverInterface $receiver */
         $receiver = $this->getReceiver($failedTransportName);
@@ -112,12 +116,18 @@ EOF
                 $errorMessage = $lastRedeliveryStampWithException->getExceptionMessage();
             }
 
-            $rows[] = [
-                $this->getMessageId($envelope),
-                \get_class($envelope->getMessage()),
-                null === $lastRedeliveryStamp ? '' : $lastRedeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s'),
-                $errorMessage,
-            ];
+            $currentClassName = str_replace('\\', '', \get_class($envelope->getMessage()));
+
+            if (!$classFilter || $classFilter === $currentClassName) {
+                $rows[] = [
+                    $this->getMessageId($envelope),
+                    $currentClassName,
+                    null === $lastRedeliveryStamp ? '' : $lastRedeliveryStamp->getRedeliveredAt()->format(
+                        'Y-m-d H:i:s'
+                    ),
+                    $errorMessage,
+                ];
+            }
         }
 
         if (0 === \count($rows)) {
@@ -133,6 +143,38 @@ EOF
         }
 
         $io->comment(sprintf('Run <comment>messenger:failed:show {id} --transport=%s -vv</comment> to see message details.', $failedTransportName));
+    }
+
+    private function listMessagesPerClass(?string $failedTransportName, SymfonyStyle $io)
+    {
+        /** @var ListableReceiverInterface $receiver */
+        $this->getReceiver($failedTransportName);
+        $envelopes = $receiver->all();
+
+        $countPerClass = [];
+
+        foreach ($envelopes as $envelope) {
+            if (!isset($countPerClass[\get_class($envelope->getMessage())])) {
+                $countPerClass[\get_class($envelope->getMessage())] = 0;
+            }
+
+            $countPerClass[\get_class($envelope->getMessage())]++;
+        }
+
+        if (0 === \count($countPerClass)) {
+            $io->success('No failed messages were found.');
+
+            return;
+        }
+
+        array_walk(
+            $countPerClass,
+            function (&$count, $class) {
+                $count = [$class, $count];
+            }
+        );
+
+        $io->table(['Class', 'Count'], $countPerClass);
     }
 
     private function showMessage(?string $failedTransportName, string $id, SymfonyStyle $io)

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -101,6 +101,11 @@ EOF
         $envelopes = $receiver->all($max);
 
         $rows = [];
+
+        if ($classFilter) {
+            $io->comment(sprintf('Displaying only \'%s\' messages', $classFilter));
+        }
+
         foreach ($envelopes as $envelope) {
             $currentClassName = \get_class($envelope->getMessage());
 
@@ -130,7 +135,9 @@ EOF
             ];
         }
 
-        if (0 === \count($rows)) {
+        $rowsCount = \count($rows);
+
+        if (0 === $rowsCount) {
             $io->success('No failed messages were found.');
 
             return;
@@ -138,8 +145,10 @@ EOF
 
         $io->table(['Id', 'Class', 'Failed at', 'Error'], $rows);
 
-        if (\count($rows) === $max) {
+        if ($rowsCount === $max) {
             $io->comment(sprintf('Showing first %d messages.', $max));
+        } elseif ($classFilter) {
+            $io->comment(sprintf('Showing %d message(s).', $rowsCount));
         }
 
         $io->comment(sprintf('Run <comment>messenger:failed:show {id} --transport=%s -vv</comment> to see message details.', $failedTransportName));

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -86,7 +86,7 @@ EOF
         if ($input->getOption('stats')) {
             $this->listMessagesPerClass($failureTransportName, $io, $input->getOption('max'));
         } elseif (null === $id = $input->getArgument('id')) {
-            $this->listMessages($failureTransportName, $io, $input->getOption('max'));
+            $this->listMessages($failureTransportName, $io, $input->getOption('max'), $input->getOption('class-filter'));
         } else {
             $this->showMessage($failureTransportName, $id, $io);
         }
@@ -154,11 +154,13 @@ EOF
         $countPerClass = [];
 
         foreach ($envelopes as $envelope) {
-            if (!isset($countPerClass[\get_class($envelope->getMessage())])) {
-                $countPerClass[$c = \get_class($envelope->getMessage())] = [$c, 0];
+            $c = \get_class($envelope->getMessage());
+
+            if (!isset($countPerClass[$c])) {
+                $countPerClass[$c] = [$c, 0];
             }
 
-            ++$countPerClass[\get_class($envelope->getMessage())][1];
+            ++$countPerClass[$c][1];
         }
 
         if (0 === \count($countPerClass)) {

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
@@ -68,14 +68,14 @@ class FailedMessagesShowCommandTest extends TestCase
         $tester->execute(['id' => 15]);
 
         $this->assertStringContainsString(sprintf(<<<EOF
-------------- ---------------------
-  Class         stdClass
-  Message Id    15
-  Failed at     %s
-  Error         Things are bad!
-  Error Code    123
-  Error Class   Exception
-  Transport     async
+------------- --------------------- 
+  Class         stdClass             
+  Message Id    15                   
+  Failed at     %s  
+  Error         Things are bad!      
+  Error Code    123                  
+  Error Class   Exception            
+  Transport     async                
 EOF
             ,
             $redeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s')),
@@ -110,14 +110,14 @@ EOF
         $tester->execute(['id' => 15]);
 
         $this->assertStringContainsString(sprintf(<<<EOF
-------------- ---------------------
-  Class         stdClass
-  Message Id    15
-  Failed at     %s
-  Error         Things are bad!
-  Error Code    123
-  Error Class   Exception
-  Transport     async
+------------- --------------------- 
+  Class         stdClass             
+  Message Id    15                   
+  Failed at     %s  
+  Error         Things are bad!      
+  Error Code    123                  
+  Error Class   Exception            
+  Transport     async                
 EOF
             ,
             $redeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s')),
@@ -149,14 +149,14 @@ EOF
         $tester = new CommandTester($command);
         $tester->execute(['id' => 15]);
         $this->assertStringContainsString(sprintf(<<<EOF
- ------------- ---------------------
-  Class         stdClass
-  Message Id    15
-  Failed at     %s
-  Error         Things are bad!
-  Error Code    123
-  Error Class   Exception
-  Transport     async
+ ------------- --------------------- 
+  Class         stdClass             
+  Message Id    15                   
+  Failed at     %s  
+  Error         Things are bad!      
+  Error Code    123                  
+  Error Class   Exception            
+  Transport     async                
 EOF
             ,
             $redeliveryStamp2->getRedeliveredAt()->format('Y-m-d H:i:s')),
@@ -191,14 +191,14 @@ EOF
         $tester = new CommandTester($command);
         $tester->execute(['id' => 15]);
         $this->assertStringContainsString(sprintf(<<<EOF
- ------------- ---------------------
-  Class         stdClass
-  Message Id    15
-  Failed at     %s
-  Error         Things are bad!
-  Error Code    123
-  Error Class   Exception
-  Transport     async
+ ------------- --------------------- 
+  Class         stdClass             
+  Message Id    15                   
+  Failed at     %s  
+  Error         Things are bad!      
+  Error Code    123                  
+  Error Class   Exception            
+  Transport     async                
 EOF
             ,
             $redeliveryStamp2->getRedeliveredAt()->format('Y-m-d H:i:s')),
@@ -226,14 +226,14 @@ EOF
         $tester = new CommandTester($command);
         $tester->execute(['id' => 15]);
         $this->assertStringContainsString(sprintf(<<<EOF
- ------------- ---------------------
-  Class         stdClass
-  Message Id    15
-  Failed at     %s
-  Error         Things are bad!
-  Error Code
-  Error Class   (unknown)
-  Transport     async
+ ------------- --------------------- 
+  Class         stdClass             
+  Message Id    15                   
+  Failed at     %s  
+  Error         Things are bad!      
+  Error Code                         
+  Error Class   (unknown)            
+  Transport     async                
 EOF
             ,
             $redeliveryStamp->getRedeliveredAt()->format('Y-m-d H:i:s')),
@@ -455,10 +455,12 @@ EOF;
         $receiver = $this->createMock(ListableReceiverInterface::class);
         $receiver->method('all')->with()->willReturn([$envelope]);
 
-        $command = new FailedMessagesShowCommand(
-            'failure_receiver',
-            $receiver
-        );
+        $failureTransportName = 'failure_receiver';
+        $serviceLocator = $this->createMock(ServiceLocator::class);
+        $serviceLocator->method('has')->with($failureTransportName)->willReturn(true);
+        $serviceLocator->method('get')->with($failureTransportName)->willReturn($receiver);
+
+        $command = new FailedMessagesShowCommand('failure_receiver', $serviceLocator);
 
         $tester = new CommandTester($command);
         $tester->execute([]);
@@ -481,10 +483,12 @@ EOF;
         $receiver = $this->createMock(ListableReceiverInterface::class);
         $receiver->method('all')->with()->willReturn([$envelope, $envelope]);
 
-        $command = new FailedMessagesShowCommand(
-            'failure_receiver',
-            $receiver
-        );
+        $failureTransportName = 'failure_receiver';
+        $serviceLocator = $this->createMock(ServiceLocator::class);
+        $serviceLocator->method('has')->with($failureTransportName)->willReturn(true);
+        $serviceLocator->method('get')->with($failureTransportName)->willReturn($receiver);
+
+        $command = new FailedMessagesShowCommand('failure_receiver', $serviceLocator);
 
         $tester = new CommandTester($command);
         $tester->execute(['--stats' => 1]);

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
@@ -469,7 +469,7 @@ EOF;
         $this->assertStringContainsString('[OK] No failed messages were found.', $tester->getDisplay(true));
     }
 
-    public function testListMessagesReturnsGroupByClassName()
+    public function testListMessagesReturnsCountByClassName()
     {
         $sentToFailureStamp = new SentToFailureTransportStamp('async');
         $envelope = new Envelope(new \stdClass(), [
@@ -487,7 +487,7 @@ EOF;
         );
 
         $tester = new CommandTester($command);
-        $tester->execute(['--group' => 1]);
+        $tester->execute(['--stats' => 1]);
         $this->assertStringContainsString('stdClass   2', $tester->getDisplay(true));
     }
 

--- a/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/FailedMessagesShowCommandTest.php
@@ -467,8 +467,12 @@ EOF;
         $this->assertStringContainsString('Things are bad!', $tester->getDisplay(true));
         $tester->execute(['--class-filter' => 'stdClass']);
         $this->assertStringContainsString('Things are bad!', $tester->getDisplay(true));
+        $this->assertStringContainsString('Showing 1 message(s).', $tester->getDisplay(true));
+        $this->assertStringContainsString('Displaying only \'stdClass\' messages', $tester->getDisplay(true));
+
         $tester->execute(['--class-filter' => 'namespace\otherClass']);
         $this->assertStringContainsString('[OK] No failed messages were found.', $tester->getDisplay(true));
+        $this->assertStringContainsString('Displaying only \'namespace\otherClass\' messages', $tester->getDisplay(true));
     }
 
     public function testListMessagesReturnsCountByClassName()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/14689

The goal to this PR is to improve the FailedMessagesShowCommand usability by adding two options:
- The `stats` option allows to display the number of messages by the class name and have a summary of all the failed messages.
* The `class-filter` option is a filter to only display the messages matching with the given class name.
