### PR TITLE
[Config][TwigBundle] Fixed syntax error in config

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -88,7 +88,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('globals')
                     ->normalizeKeys(false)
                     ->useAttributeAsKey('key')
-                    ->example(['foo' => '"@bar"', 'pi' => 3.14])
+                    ->example(['foo' => '@bar', 'pi' => 3.14])
                     ->prototype('array')
                         ->normalizeKeys(false)
                         ->beforeNormalization()

--- a/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/YamlReferenceDumper.php
@@ -129,7 +129,7 @@ class YamlReferenceDumper
 
         // example
         if ($example && !\is_array($example)) {
-            $comments[] = 'Example: '.$example;
+            $comments[] = 'Example: '.Inline::dump($example);
         }
 
         $default = '' != (string) $default ? ' '.$default : '';
@@ -165,7 +165,7 @@ class YamlReferenceDumper
 
             $this->writeLine('# '.$message.':', $depth * 4 + 4);
 
-            $this->writeArray($example, $depth + 1);
+            $this->writeArray(array_map([Inline::class, 'dump'], $example), $depth + 1);
         }
 
         if ($children) {

--- a/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Dumper/YamlReferenceDumperTest.php
@@ -42,7 +42,7 @@ array:
     # this is a long
     # multi-line info text
     # which should be indented
-    child3:               ~ # Example: example setting
+    child3:               ~ # Example: 'example setting'
 EOL
             ],
             'Regular nested' => ['array.child2', <<<EOL
@@ -112,7 +112,7 @@ acme_root:
         # this is a long
         # multi-line info text
         # which should be indented
-        child3:               ~ # Example: example setting
+        child3:               ~ # Example: 'example setting'
     scalar_prototyped:    []
     parameters:
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Sorry for such small PR. I found this when I was parsing the yaml after running `bin/console config:dump-reference TwigBundle` 

#SymfonyHackday
