### PR TITLE
[Serializer] Fixed serialize and denormalize return types

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -32,7 +32,7 @@ interface DenormalizerInterface
      * @param string $format  Format the given data was extracted from
      * @param array  $context Options available to the denormalizer
      *
-     * @return object|array
+     * @return mixed
      *
      * @throws BadMethodCallException   Occurs when the normalizer is not called in an expected context
      * @throws InvalidArgumentException Occurs when the arguments are not coherent or not supported

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -32,7 +32,7 @@ interface SerializerInterface
      *
      * @param mixed $data
      *
-     * @return object|array
+     * @return mixed
      */
     public function deserialize($data, string $type, string $format, array $context = []);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Since #35235 `SerializerInterface::deserialize()` and `DenormalizerInterface::denormalize()` return types are no longer correct. 

I suggest using `mixed` to allow custom denormalizers to denormalize to any type. For instance, I might add `ClosureDenormalizer` or `NullDenormalizer` or `ResourceDenormalizer`, technically there are no limits.