### PR TITLE
[Routing] [UrlGenerator] Encode slashes and adapt closer to RFC 3986

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -33,7 +33,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     /**
      * these chars are only sub-delimiters that have no predefined meaning and can therefore be used literally
      * so URI producing applications can use these chars to delimit subcomponents in a path segment without being
-     * encoded for better readability
+     * encoded for better readability.
      *
      * @see https://tools.ietf.org/html/rfc3986#page-11 2
      */
@@ -52,14 +52,14 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     ];
 
     /**
-     * URL path segment separator
+     * URL path segment separator.
      *
      * @see https://tools.ietf.org/html/rfc3986#page-22 3.3
      */
     protected const PATH_SEPARATOR = ['%2F' => '/'];
 
     /**
-     * URL path allowed characters
+     * URL path allowed characters.
      *
      * the following chars are general delimiters in the URI specification but have only special meaning in the
      * authority component so they can safely be used in the path in unencoded form
@@ -72,7 +72,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     ];
 
     /**
-     * URL query and fragment allowed characters
+     * URL query and fragment allowed characters.
      *
      * @see https://tools.ietf.org/html/rfc3986#page-22 3.4 and 3.5
      */
@@ -84,7 +84,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     ];
 
     /**
-     * URL query and fragment special characters used as space respectively form urlencoded key value pairs
+     * URL query and fragment special characters used as space respectively form urlencoded key value pairs.
      */
     protected const QUERY_FRAGMENT_SPECIAL = [
         '%24' => '+',
@@ -223,12 +223,12 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
                         return '';
                     }
 
-                    $url = $token[1] . self::encodeVariable($mergedParams[$varName]) . $url;
+                    $url = $token[1].self::encodeVariable($mergedParams[$varName]).$url;
                     $optional = false;
                 }
             } else {
                 // static text
-                $url = self::encodePath($token[1]) . $url;
+                $url = self::encodePath($token[1]).$url;
                 $optional = false;
             }
         }
@@ -323,11 +323,11 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
         }
 
         if ($extra && $query = http_build_query($extra, '', '&', \PHP_QUERY_RFC3986)) {
-            $url .= '?' . strtr($query, self::decodeQueryFragmentChars());
+            $url .= '?'.strtr($query, self::decodeQueryFragmentChars());
         }
 
         if ('' !== $fragment) {
-            $url .= '#' . strtr(rawurlencode($fragment), self::decodeQueryFragmentChars());
+            $url .= '#'.strtr(rawurlencode($fragment), self::decodeQueryFragmentChars());
         }
 
         return $url;

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -443,9 +443,9 @@ class UrlGeneratorTest extends TestCase
 
     public function testUrlEncoding()
     {
-        $expectedPath = '/app.php/@:%5B%5D/%28%29*%27%22%20+,;-._~%26%24%3C%3E|%7B%7D%25%5C%5E%60!%3Ffoo=bar%23id'
-            .'/@:%5B%5D/%28%29*%27%22%20+,;-._~%26%24%3C%3E|%7B%7D%25%5C%5E%60!%3Ffoo=bar%23id'
-            .'?query=@:%5B%5D/%28%29*%27%22%20%2B,;-._~%26%24%3C%3E%7C%7B%7D%25%5C%5E%60!?foo%3Dbar%23id';
+        $expectedPath = '/app.php/@:%5B%5D/()*\'%22%20+,;-._~&$%3C%3E%7C%7B%7D%25%5C%5E%60!%3Ffoo=bar%23id'
+            .'/@:%5B%5D%2F()*\'%22%20+,;-._~&$%3C%3E%7C%7B%7D%25%5C%5E%60!%3Ffoo=bar%23id'
+            .'?query=@:%5B%5D/()*\'%22%20%2B,;-._~%26$%3C%3E%7C%7B%7D%25%5C%5E%60!?foo%3Dbar%23id';
 
         // This tests the encoding of reserved characters that are used for delimiting of URI components (defined in RFC 3986)
         // and other special ASCII chars. These chars are tested as static text path, variable path and query param.
@@ -465,6 +465,12 @@ class UrlGeneratorTest extends TestCase
         $this->assertSame('/app.php/dir/%2E/dir/%2E', $this->getGenerator($routes)->generate('test'));
         $routes = $this->getRoutes('test', new Route('/a./.a/a../..a/...'));
         $this->assertSame('/app.php/a./.a/a../..a/...', $this->getGenerator($routes)->generate('test'));
+    }
+
+    public function testEncodingOfSlashInPath()
+    {
+        $routes = $this->getRoutes('test', new Route('/dir/{path}/dir2', [], ['path' => '.+']));
+        $this->assertSame('/app.php/dir/foo%2Fbar/dir2', $this->getGenerator($routes)->generate('test', ['path' => 'foo/bar']));
     }
 
     public function testAdjacentVariables()
@@ -863,10 +869,10 @@ class UrlGeneratorTest extends TestCase
 
     public function provideLookAroundRequirementsInPath()
     {
-        yield ['/app.php/a/b/b%28ar/c/d/e', '/{foo}/b(ar/{baz}', '.+(?=/b\\(ar/)'];
-        yield ['/app.php/a/b/bar/c/d/e', '/{foo}/bar/{baz}', '.+(?!$)'];
-        yield ['/app.php/bar/a/b/bam/c/d/e', '/bar/{foo}/bam/{baz}', '(?<=/bar/).+'];
-        yield ['/app.php/bar/a/b/bam/c/d/e', '/bar/{foo}/bam/{baz}', '(?<!^).+'];
+        yield ['/app.php/a%2Fb/b(ar/c%2Fd%2Fe', '/{foo}/b(ar/{baz}', '.+(?=/b\\(ar/)'];
+        yield ['/app.php/a%2Fb/bar/c%2Fd%2Fe', '/{foo}/bar/{baz}', '.+(?!$)'];
+        yield ['/app.php/bar/a%2Fb/bam/c%2Fd%2Fe', '/bar/{foo}/bam/{baz}', '(?<=/bar/).+'];
+        yield ['/app.php/bar/a%2Fb/bam/c%2Fd%2Fe', '/bar/{foo}/bam/{baz}', '(?<!^).+'];
     }
 
     protected function getGenerator(RouteCollection $routes, array $parameters = [], $logger = null, string $defaultLocale = null)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #13017
| License       | MIT
| Doc PR        | 

I hope that just opening a PR ist appropriate to get some feedback on changing UrlGenerator. If this would be adapted in Symfony, the changed behaviour probably should become optional as some changes will break backwards compatibility.
For now this should be fine to focus on changed behaviour.

This is a proof of concept for https://github.com/symfony/symfony/issues/13017 and addresses some pressing issues when comparing the current implementation with RFC 3986.

This PR changes how urlencoding is performed. Instead of just encoding the whole URL after replacing parameters, the tokens are encoded while prepending them to the constructed URL. That allows changing the behaviour for different kinds of tokens, so that parameters are encoded included the slashes.

The character set that is reprsented unencoded has been altered while verifying the implementation against the RFC.