### PR TITLE
Add missing entries in gitattributes

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Beanstalkd/.gitattributes
+++ b/src/Symfony/Component/Messenger/Bridge/Beanstalkd/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
 /.gitignore export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Discord/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
 /.gitignore export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
 /.gitignore export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
 /.gitignore export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
 /.gitignore export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
 /.gitignore export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/.gitattributes
@@ -1,3 +1,4 @@
 /Tests export-ignore
 /phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
 /.gitignore export-ignore

--- a/src/Symfony/Component/Semaphore/.gitattributes
+++ b/src/Symfony/Component/Semaphore/.gitattributes
@@ -1,3 +1,4 @@
-/.gitignore export-ignore
-/phpunit.xml.dist export-ignore
 /Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Adds `/.gitattributes export-ignore` in some bridges