### PR TITLE
[Security] Add `FirewallUserAuthenticator` - authenticate users in any firewall

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -266,6 +266,9 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
         // load firewall map
         $mapDef = $container->getDefinition('security.firewall.map');
+        if ($this->authenticatorManagerEnabled = $config['enable_authenticator_manager']) {
+            $firewallUserAuthenticatorDef = $container->getDefinition('security.firewall_user_authenticator');
+        }
         $map = $authenticationProviders = $contextRefs = [];
         foreach ($firewalls as $name => $firewall) {
             if (isset($firewall['user_checker']) && 'security.user_checker' !== $firewall['user_checker']) {
@@ -292,6 +295,9 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         }
         $mapDef->replaceArgument(0, ServiceLocatorTagPass::register($container, $contextRefs));
         $mapDef->replaceArgument(1, new IteratorArgument($map));
+        if ($this->authenticatorManagerEnabled = $config['enable_authenticator_manager']) {
+            $firewallUserAuthenticatorDef->replaceArgument(0, ServiceLocatorTagPass::register($container, $contextRefs));
+        }
 
         if (!$this->authenticatorManagerEnabled) {
             // add authentication providers to authentication manager

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Bundle\SecurityBundle\Security\FirewallUserAuthenticator;
 use Symfony\Bundle\SecurityBundle\Security\UserAuthenticator;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
@@ -59,6 +60,13 @@ return static function (ContainerConfigurator $container) {
                 service('request_stack'),
             ])
         ->alias(UserAuthenticatorInterface::class, 'security.user_authenticator')
+
+        ->set('security.firewall_user_authenticator', FirewallUserAuthenticator::class)
+            ->args([
+                abstract_arg('Firewall context locator'),
+                service('event_dispatcher'),
+            ])
+        ->alias(FirewallUserAuthenticator::class, 'security.firewall_user_authenticator')
 
         ->set('security.authentication.manager', NoopAuthenticationManager::class)
         ->alias(AuthenticationManagerInterface::class, 'security.authentication.manager')

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallUserAuthenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallUserAuthenticator.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Security;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\Event\AuthenticationTokenCreatedEvent;
+use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @author Martin Kirilov <wucdbm@gmail.com>
+ *
+ * @final
+ * @experimental in 5.2
+ */
+class FirewallUserAuthenticator
+{
+    private $firewallLocator;
+    private $eventDispatcher;
+
+    public function __construct(ContainerInterface $firewallLocator, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->firewallLocator = $firewallLocator;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * @param BadgeInterface[] $badges Optionally, pass some Passport badges to use for the manual login
+     */
+    public function authenticateUser(UserInterface $user, Request $request, string $firewallName, array $badges = []): void
+    {
+        // TODO Tests
+        // TODO Throw if not master request?
+        if (!$request->hasSession()) {
+            return;
+        }
+
+        if (!$this->firewallLocator->has('security.firewall.map.context.'.$firewallName)) {
+            throw new \LogicException(sprintf('Firewall "%s" not found. Did you register your firewall?', $firewallName));
+        }
+
+        /** @var FirewallContext $firewallContext */
+        $firewallContext = $this->firewallLocator->get('security.firewall.map.context.'.$firewallName);
+        // todo can firewall config ever be null?
+        $firewallConfig = $firewallContext->getConfig();
+
+        // Note: We're only using PreAuthenticatedAuthenticator because of Symfony\Component\Security\Http\EventListener\RememberMeListener
+        $authenticator = new PreAuthenticatedAuthenticator();
+        // create PreAuthenticatedToken token for the User
+        $token = $authenticator->createAuthenticatedToken($passport = new SelfValidatingPassport(new UserBadge($user->getUsername(), function () use ($user) { return $user; }), $badges), $firewallName);
+
+        // announce the authenticated token
+        $token = $this->eventDispatcher->dispatch(new AuthenticationTokenCreatedEvent($token))->getAuthenticatedToken();
+
+        $this->eventDispatcher->dispatch($loginSuccessEvent = new LoginSuccessEvent($authenticator, $passport, $token, $request, null, $firewallName));
+
+        $sessionKey = '_security_'.$firewallConfig->getContext();
+        $session = $request->getSession();
+        // increments the internal session usage index
+        $session->getMetadataBag();
+        $session->set($sessionKey, serialize($token));
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Security/PreAuthenticatedAuthenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/PreAuthenticatedAuthenticator.php
@@ -38,7 +38,7 @@ class PreAuthenticatedAuthenticator implements AuthenticatorInterface
 
     public function authenticate(Request $request): PassportInterface
     {
-        throw new \LogicException(sprintf('"%s" does not support %s::authenticate() calls', static::class, AuthenticatorInterface::class));
+        throw new \LogicException(sprintf('"%s" does not support "%s::authenticate()" calls.', static::class, AuthenticatorInterface::class));
     }
 
     public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface

--- a/src/Symfony/Bundle/SecurityBundle/Security/PreAuthenticatedAuthenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/PreAuthenticatedAuthenticator.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Security;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
+
+/**
+ * This class is only used in FirewallUserAuthenticator.
+ * Its sole reason if existence is LoginSuccessEvent requiring an authenticator.
+ *
+ * @author Martin Kirilov <wucdbm@gmail.com>
+ *
+ * @internal
+ *
+ * @experimental in 5.2
+ */
+class PreAuthenticatedAuthenticator implements AuthenticatorInterface
+{
+    public function supports(Request $request): ?bool
+    {
+        return true;
+    }
+
+    public function authenticate(Request $request): PassportInterface
+    {
+        throw new \LogicException(sprintf('"%s" does not support %s::authenticate() calls', static::class, AuthenticatorInterface::class));
+    }
+
+    public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
+    {
+        // TODO Tests
+        return new PreAuthenticatedToken($passport->getUser(), null, $firewallName, $passport->getUser()->getRoles());
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | https://github.com/symfony/symfony/issues/37575 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | not yet <!-- required for new features -->

As per https://github.com/symfony/symfony/issues/37575#issuecomment-739448822

I've added a `Symfony\Bundle\SecurityBundle\Security\FirewallUserAuthenticator` to allow authenticating users in another firewall, different to the one the user is currently at.
For a broader reasoning, please refer to the above comment link.

TODO:
- Tests
- Documentation
- can `FirewallContext` ever return a null `FirewallConfig`?

I'll need to know under which section to document the new feature in CHANGELOG.md. 5.x?
And possibly some guidance for Docs, I didn't have a look there yet.

@wouterj Have a look :)

<!--



Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->
