### PR TITLE
Fix broken link to documentation in Lock and Semaphore components

### DIFF
--- a/src/Symfony/Component/Lock/README.md
+++ b/src/Symfony/Component/Lock/README.md
@@ -4,7 +4,7 @@ Lock Component
 Resources
 ---------
 
-  * [Documentation](https://symfony.com/doc/master/components/lock.html)
+  * [Documentation](https://symfony.com/doc/current/components/lock.html)
   * [Contributing](https://symfony.com/doc/current/contributing/index.html)
   * [Report issues](https://github.com/symfony/symfony/issues) and
     [send Pull Requests](https://github.com/symfony/symfony/pulls)

--- a/src/Symfony/Component/Semaphore/README.md
+++ b/src/Symfony/Component/Semaphore/README.md
@@ -13,7 +13,7 @@ are not covered by Symfony's
 Resources
 ---------
 
-  * [Documentation](https://symfony.com/doc/master/components/semaphore.html)
+  * [Documentation](https://symfony.com/doc/current/components/semaphore.html)
   * [Contributing](https://symfony.com/doc/current/contributing/index.html)
   * [Report issues](https://github.com/symfony/symfony/issues) and
     [send Pull Requests](https://github.com/symfony/symfony/pulls)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

