### PR TITLE
[HttpFoundation] fix parsing some special chars with HeaderUtils::parseQuery()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderUtils.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderUtils.php
@@ -228,7 +228,7 @@ class HeaderUtils
             if (false === $i = strpos($k, '[')) {
                 $q[] = bin2hex($k).$v;
             } else {
-                $q[] = substr_replace($k, bin2hex(substr($k, 0, $i)), 0, $i).$v;
+                $q[] = bin2hex(substr($k, 0, $i)).rawurlencode(substr($k, $i)).$v;
             }
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/HeaderUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HeaderUtilsTest.php
@@ -151,6 +151,7 @@ class HeaderUtilsTest extends TestCase
             ['a[b]=c', 'a%5Bb%5D=c'],
             ['a[b][c.d]=c', 'a%5Bb%5D%5Bc.d%5D=c'],
             ['a%5Bb%5D=c'],
+            ['f[%2525][%26][%3D][p.c]=d', 'f%5B%2525%5D%5B%26%5D%5B%3D%5D%5Bp.c%5D=d'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39307
| License       | MIT
| Doc PR        | -

Same as #39357 for 5.2