### PR TITLE
[FrameworkBundle] acces public-deprecated services via the private container to remove false-positive deprecations

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
@@ -22,6 +22,13 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class TestServiceContainerWeakRefPass implements CompilerPassInterface
 {
+    private $privateTagName;
+
+    public function __construct(string $privateTagName = 'container.private')
+    {
+        $this->privateTagName = $privateTagName;
+    }
+
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition('test.private_services_locator')) {
@@ -33,7 +40,7 @@ class TestServiceContainerWeakRefPass implements CompilerPassInterface
         $hasErrors = method_exists(Definition::class, 'hasErrors') ? 'hasErrors' : 'getErrors';
 
         foreach ($definitions as $id => $definition) {
-            if ($id && '.' !== $id[0] && (!$definition->isPublic() || $definition->isPrivate()) && !$definition->$hasErrors() && !$definition->isAbstract()) {
+            if ($id && '.' !== $id[0] && (!$definition->isPublic() || $definition->isPrivate() || $definition->hasTag($this->privateTagName)) && !$definition->$hasErrors() && !$definition->isAbstract()) {
                 $privateServices[$id] = new Reference($id, ContainerBuilder::IGNORE_ON_UNINITIALIZED_REFERENCE);
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/TestServiceContainerRefPassesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/TestServiceContainerRefPassesTest.php
@@ -36,6 +36,12 @@ class TestServiceContainerRefPassesTest extends TestCase
             ->setPublic(true)
             ->addArgument(new Reference('Test\private_used_shared_service'))
             ->addArgument(new Reference('Test\private_used_non_shared_service'))
+            ->addArgument(new Reference('Test\soon_private_service'))
+        ;
+
+        $container->register('Test\soon_private_service')
+            ->setPublic(true)
+            ->addTag('container.private', ['package' => 'foo/bar', 'version' => '1.42'])
         ;
 
         $container->register('Test\private_used_shared_service');
@@ -48,6 +54,7 @@ class TestServiceContainerRefPassesTest extends TestCase
         $expected = [
             'Test\private_used_shared_service' => new ServiceClosureArgument(new Reference('Test\private_used_shared_service')),
             'Test\private_used_non_shared_service' => new ServiceClosureArgument(new Reference('Test\private_used_non_shared_service')),
+            'Test\soon_private_service' => new ServiceClosureArgument(new Reference('.container.private.Test\soon_private_service')),
             'Psr\Container\ContainerInterface' => new ServiceClosureArgument(new Reference('service_container')),
             'Symfony\Component\DependencyInjection\ContainerInterface' => new ServiceClosureArgument(new Reference('service_container')),
         ];

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -29,12 +29,14 @@ class AddConsoleCommandPass implements CompilerPassInterface
     private $commandLoaderServiceId;
     private $commandTag;
     private $noPreloadTag;
+    private $privateTagName;
 
-    public function __construct(string $commandLoaderServiceId = 'console.command_loader', string $commandTag = 'console.command', string $noPreloadTag = 'container.no_preload')
+    public function __construct(string $commandLoaderServiceId = 'console.command_loader', string $commandTag = 'console.command', string $noPreloadTag = 'container.no_preload', string $privateTagName = 'container.private')
     {
         $this->commandLoaderServiceId = $commandLoaderServiceId;
         $this->commandTag = $commandTag;
         $this->noPreloadTag = $noPreloadTag;
+        $this->privateTagName = $privateTagName;
     }
 
     public function process(ContainerBuilder $container)
@@ -62,7 +64,7 @@ class AddConsoleCommandPass implements CompilerPassInterface
             }
 
             if (null === $commandName) {
-                if (!$definition->isPublic() || $definition->isPrivate()) {
+                if (!$definition->isPublic() || $definition->isPrivate() || $definition->hasTag($this->privateTagName)) {
                     $commandId = 'console.command.public_alias.'.$id;
                     $container->setAlias($commandId, $id)->setPublic(true);
                     $id = $commandId;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Something we missed in #36470 apparently.