### PR TITLE
[Cache] Support Redis Sentinel mode when using phpredis/phpredis extension

### DIFF
--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+* added support for connecting to Redis Sentinel clusters when using the Redis PHP extension
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterSentinelTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterSentinelTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
-use Symfony\Component\Cache\Adapter\RedisAdapter;
 
 /**
  * @group integration
@@ -32,13 +31,5 @@ class PredisAdapterSentinelTest extends AbstractRedisAdapterTest
         }
 
         self::$redis = AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['redis_sentinel' => $service, 'class' => \Predis\Client::class]);
-    }
-
-    public function testInvalidDSNHasBothClusterAndSentinel()
-    {
-        $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
-        $this->expectExceptionMessage('Cannot use both "redis_cluster" and "redis_sentinel" at the same time:');
-        $dsn = 'redis:?host[redis1]&host[redis2]&host[redis3]&redis_cluster=1&redis_sentinel=mymaster';
-        RedisAdapter::createConnection($dsn);
     }
 }

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterSentinelTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisAdapterSentinelTest.php
@@ -17,12 +17,12 @@ use Symfony\Component\Cache\Adapter\RedisAdapter;
 /**
  * @group integration
  */
-class RedisAdapterSentinelTest extends AbstractRedisAdapterTest
+class PredisAdapterSentinelTest extends AbstractRedisAdapterTest
 {
     public static function setUpBeforeClass(): void
     {
-        if (!class_exists(\RedisSentinel::class)) {
-            self::markTestSkipped('The RedisSentinel class is required.');
+        if (!class_exists(\Predis\Client::class)) {
+            self::markTestSkipped('The Predis\Client class is required.');
         }
         if (!$hosts = getenv('REDIS_SENTINEL_HOSTS')) {
             self::markTestSkipped('REDIS_SENTINEL_HOSTS env var is not defined.');
@@ -31,7 +31,7 @@ class RedisAdapterSentinelTest extends AbstractRedisAdapterTest
             self::markTestSkipped('REDIS_SENTINEL_SERVICE env var is not defined.');
         }
 
-        self::$redis = AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['redis_sentinel' => $service]);
+        self::$redis = AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['redis_sentinel' => $service, 'class' => \Predis\Client::class]);
     }
 
     public function testInvalidDSNHasBothClusterAndSentinel()

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -186,7 +186,7 @@ trait RedisTrait
                 if (isset($params['redis_sentinel'])) {
                     $sentinel = new \RedisSentinel($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval']);
 
-                    if (!([$host, $port] = $sentinel->getMasterAddrByName($params['redis_sentinel']))) {
+                    if (![$host, $port] = $sentinel->getMasterAddrByName($params['redis_sentinel'])) {
                         throw new InvalidArgumentException(sprintf('Failed to retrieve master information from master name "%s" and address "%s:%d".', $params['redis_sentinel'], $host, $port));
                     }
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #39362
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/14668

The version 5.2.0 of the [Redis PHP extension](http://pecl.php.net/package/redis), released back in March 2020, added support for Redis Sentinel mode with the help of the `RedisSentinel` class.

Usage of the `Symfony/Cache RedisAdapter` can continue to be the same, thus relying on the `$options['redis_persistent']` option to both enable and define the master name.