### PR TITLE
[Notifier] [DX] UnsupportedMessageTypeException for notifier transports

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Discord;
 
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
@@ -57,7 +58,7 @@ final class DiscordTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof ChatMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
         }
 
         $messageOptions = $message->getOptions();

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportTest.php
@@ -14,8 +14,8 @@ namespace Symfony\Component\Notifier\Bridge\Discord\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\Discord\DiscordTransport;
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -43,8 +43,9 @@ final class DiscordTransportTest extends TestCase
 
     public function testSendNonChatMessageThrows()
     {
-        $this->expectException(LogicException::class);
         $transport = new DiscordTransport('testToken', 'testChannel', $this->createMock(HttpClientInterface::class));
+
+        $this->expectException(UnsupportedMessageTypeException::class);
 
         $transport->send($this->createMock(MessageInterface::class));
     }

--- a/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^4.3|^5.0"

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php
@@ -13,8 +13,8 @@ namespace Symfony\Component\Notifier\Bridge\Esendex;
 
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\HttpClient\Exception\TransportException as HttpClientTransportException;
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -55,7 +55,7 @@ final class EsendexTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof SmsMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, SmsMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
         $messageData = [

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
@@ -14,8 +14,8 @@ namespace Symfony\Component\Notifier\Bridge\Esendex\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransport;
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -43,7 +43,8 @@ final class EsendexTransportTest extends TestCase
     {
         $transport = new EsendexTransport('testToken', 'accountReference', 'from', $this->createMock(HttpClientInterface::class));
 
-        $this->expectException(LogicException::class);
+        $this->expectException(UnsupportedMessageTypeException::class);
+
         $transport->send($this->createMock(MessageInterface::class));
     }
 

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.4|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Esendex\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Notifier\Bridge\Firebase;
 
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
@@ -54,7 +54,7 @@ final class FirebaseTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof ChatMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
         }
 
         $endpoint = sprintf('https://%s', $this->getEndpoint());

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Firebase\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Notifier\Bridge\FreeMobile;
 
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -55,7 +55,7 @@ final class FreeMobileTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$this->supports($message)) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given) and configured with your phone number.', __CLASS__, SmsMessage::class, \get_class($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
         $response = $this->client->request('POST', $this->getEndpoint(), [

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\FreeMobile\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransport;
-use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -46,7 +46,7 @@ final class FreeMobileTransportTest extends TestCase
     {
         $transport = $this->getTransport('0611223344');
 
-        $this->expectException(LogicException::class);
+        $this->expectException(UnsupportedMessageTypeException::class);
 
         $transport->send($this->createMock(MessageInterface::class));
     }
@@ -55,7 +55,7 @@ final class FreeMobileTransportTest extends TestCase
     {
         $transport = $this->getTransport('0611223344');
 
-        $this->expectException(LogicException::class);
+        $this->expectException(UnsupportedMessageTypeException::class);
 
         $transport->send(new SmsMessage('0699887766', 'Hello!'));
     }

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.1",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\FreeMobile\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\GoogleChat;
 use Symfony\Component\HttpClient\Exception\JsonException;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
@@ -87,7 +88,7 @@ final class GoogleChatTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof ChatMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, \get_class($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
         }
         if ($message->getOptions() && !$message->getOptions() instanceof GoogleChatOptions) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" for options.', __CLASS__, GoogleChatOptions::class));

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Notifier\Bridge\GoogleChat\GoogleChatOptions;
 use Symfony\Component\Notifier\Bridge\GoogleChat\GoogleChatTransport;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
@@ -44,9 +45,9 @@ class GoogleChatTransportTest extends TestCase
 
     public function testSendNonChatMessageThrows(): void
     {
-        $this->expectException(LogicException::class);
-
         $transport = new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $this->createMock(HttpClientInterface::class));
+
+        $this->expectException(UnsupportedMessageTypeException::class);
 
         $transport->send($this->createMock(MessageInterface::class));
     }

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\GoogleChat\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/InfobipTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/InfobipTransport.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Notifier\Bridge\Infobip;
 
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -52,7 +52,7 @@ final class InfobipTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof SmsMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, SmsMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
         $endpoint = sprintf('https://%s/sms/2/text/advanced', $this->getEndpoint());

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Infobip\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransport.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\LinkedIn;
 use Symfony\Component\Notifier\Bridge\LinkedIn\Share\AuthorShare;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
@@ -61,7 +62,7 @@ final class LinkedInTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof ChatMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, \get_class($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
         }
         if ($message->getOptions() && !$message->getOptions() instanceof LinkedInOptions) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" for options.', __CLASS__, LinkedInOptions::class));

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportTest.php
@@ -7,6 +7,7 @@ use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\LinkedIn\LinkedInTransport;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
@@ -31,9 +32,9 @@ final class LinkedInTransportTest extends TestCase
 
     public function testSendNonChatMessageThrows(): void
     {
-        $this->expectException(LogicException::class);
-
         $transport = $this->getTransport();
+
+        $this->expectException(UnsupportedMessageTypeException::class);
 
         $transport->send($this->createMock(MessageInterface::class));
     }

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\LinkedIn\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransport.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Notifier\Bridge\Mattermost;
 
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
@@ -54,7 +54,7 @@ final class MattermostTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof ChatMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
         }
 
         $endpoint = sprintf('https://%s/api/v4/posts', $this->getEndpoint());

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mattermost\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransport.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Mobyt;
 
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -57,7 +58,7 @@ final class MobytTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof SmsMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, SmsMessage::class, \get_class($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
         if ($message->getOptions() && !$message->getOptions() instanceof MobytOptions) {

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/composer.json
@@ -19,7 +19,7 @@
         "ext-json": "*",
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mobyt\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/NexmoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/NexmoTransport.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Notifier\Bridge\Nexmo;
 
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -55,7 +55,7 @@ final class NexmoTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof SmsMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, SmsMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/sms/json', [

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Nexmo\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Notifier\Bridge\OvhCloud;
 
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -57,7 +57,7 @@ final class OvhCloudTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof SmsMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, SmsMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
         $endpoint = sprintf('https://%s/1.0/sms/%s/jobs', $this->getEndpoint(), $this->serviceName);

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\OvhCloud\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransport.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\RocketChat;
 
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
@@ -57,7 +58,7 @@ final class RocketChatTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof ChatMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
         }
         if ($message->getOptions() && !$message->getOptions() instanceof RocketChatOptions) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" for options.', __CLASS__, RocketChatOptions::class));

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\RocketChat\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/SendinblueTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/SendinblueTransport.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Notifier\Bridge\Sendinblue;
 
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -53,7 +53,7 @@ final class SendinblueTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof SmsMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, SmsMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/v3/transactionalSMS/sms', [

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportTest.php
@@ -14,8 +14,8 @@ namespace Symfony\Component\Notifier\Bridge\Sendinblue\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\Sendinblue\SendinblueTransport;
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -42,7 +42,8 @@ final class SendinblueTransportTest extends TestCase
     {
         $transport = $this->initTransport();
 
-        $this->expectException(LogicException::class);
+        $this->expectException(UnsupportedMessageTypeException::class);
+
         $transport->send($this->createMock(MessageInterface::class));
     }
 

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/composer.json
@@ -19,7 +19,7 @@
         "ext-json": "*",
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sendinblue\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransport.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Notifier\Bridge\Sinch;
 
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -55,7 +55,7 @@ final class SinchTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof SmsMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, SmsMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
         $endpoint = sprintf('https://%s/xms/v1/%s/batches', $this->getEndpoint(), $this->accountSid);

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sinch\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Slack;
 
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
@@ -57,7 +58,7 @@ final class SlackTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof ChatMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
         }
         if ($message->getOptions() && !$message->getOptions() instanceof SlackOptions) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" for options.', __CLASS__, SlackOptions::class));

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransport;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
@@ -47,9 +48,9 @@ final class SlackTransportTest extends TestCase
 
     public function testSendNonChatMessageThrows(): void
     {
-        $this->expectException(LogicException::class);
-
         $transport = new SlackTransport('testToken', 'testChannel', $this->createMock(HttpClientInterface::class));
+
+        $this->expectException(UnsupportedMessageTypeException::class);
 
         $transport->send($this->createMock(MessageInterface::class));
     }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^4.3|^5.0"

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Notifier\Bridge\Smsapi;
 
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -52,7 +52,7 @@ final class SmsapiTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof SmsMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, SmsMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
         $endpoint = sprintf('https://%s/sms.do', $this->getEndpoint());

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Smsapi\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Telegram;
 
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
@@ -62,7 +63,7 @@ final class TelegramTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof ChatMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
         }
 
         if ($message->getOptions() && !$message->getOptions() instanceof TelegramOptions) {

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -15,8 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramOptions;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransport;
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -44,8 +44,9 @@ final class TelegramTransportTest extends TestCase
 
     public function testSendNonChatMessageThrows(): void
     {
-        $this->expectException(LogicException::class);
         $transport = new TelegramTransport('testToken', 'testChannel', $this->createMock(HttpClientInterface::class));
+
+        $this->expectException(UnsupportedMessageTypeException::class);
 
         $transport->send($this->createMock(MessageInterface::class));
     }

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^4.3|^5.0"

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Notifier\Bridge\Twilio;
 
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -55,7 +55,7 @@ final class TwilioTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof SmsMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, SmsMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
         }
 
         $endpoint = sprintf('https://%s/2010-04-01/Accounts/%s/Messages.json', $this->getEndpoint(), $this->accountSid);

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Twilio\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransport.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Zulip;
 
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
@@ -56,7 +57,7 @@ class ZulipTransport extends AbstractTransport
     protected function doSend(MessageInterface $message): SentMessage
     {
         if (!$message instanceof ChatMessage) {
-            throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, get_debug_type($message)));
+            throw new UnsupportedMessageTypeException(__CLASS__, ChatMessage::class, $message);
         }
 
         if (null !== $message->getOptions() && !($message->getOptions() instanceof ZulipOptions)) {

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "^5.2"
+        "symfony/notifier": "^5.3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Zulip\\": "" },

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedMessageTypeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedMessageTypeException.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Exception;
+
+use Symfony\Component\Notifier\Message\MessageInterface;
+
+/**
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ *
+ * @experimental in 5.3
+ */
+class UnsupportedMessageTypeException extends LogicException
+{
+    public function __construct(string $transport, string $supported, MessageInterface $given)
+    {
+        $message = sprintf(
+            'The "%s" transport only supports instances of "%s" (instance of "%s" given).',
+            $transport,
+            $supported,
+            get_debug_type($given)
+        );
+
+        parent::__construct($message);
+    }
+}

--- a/src/Symfony/Component/Notifier/Transport/TransportInterface.php
+++ b/src/Symfony/Component/Notifier/Transport/TransportInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Transport;
 
 use Symfony\Component\Notifier\Exception\TransportExceptionInterface;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | --
| License       | MIT
| Doc PR        | --

I want to streamline the experience, creating new notifier transports. Maybe such exceptions fit well, as we are planing to get more and more transports and don't want to "pollute" the transports itself with repeatable code.

Please let me know if you are open to have such exceptions as I would like to introduce more of them for unsupported options for example and if this should be considered a new feature or it should be applied against `5.1`?

I am not sure about the signature and the name of the new `UnsupportedMessageTypeException`.

Cheers