### PR TITLE
Run intl-data tests on resources change

### DIFF
--- a/.github/workflows/intl-data-tests.yml
+++ b/.github/workflows/intl-data-tests.yml
@@ -1,0 +1,47 @@
+name: Intl data tests
+
+on:
+    push:
+        paths:
+          - 'src/Symfony/Component/Intl/Resources/data/**'
+    pull_request:
+        paths:
+          - 'src/Symfony/Component/Intl/Resources/data/**'
+
+jobs:
+
+    tests:
+        name: Tests (intl-data)
+        runs-on: ubuntu-latest
+
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v2
+
+            -   name: Define the ICU version
+                run: |
+                    SYMFONY_ICU_VERSION=$(php -r 'require "src/Symfony/Component/Intl/Intl.php"; echo Symfony\Component\Intl\Intl::getIcuStubVersion();')
+                    echo "SYMFONY_ICU_VERSION=$SYMFONY_ICU_VERSION" >> $GITHUB_ENV
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    coverage: "none"
+                    extensions: "zip,intl-${{env.SYMFONY_ICU_VERSION}}"
+                    ini-values: "memory_limit=-1"
+                    php-version: "7.4"
+
+            -   name: Install dependencies
+                run: |
+                    echo "::group::composer update"
+                    composer update --no-progress --no-suggest --ansi
+                    echo "::endgroup::"
+                    echo "::group::install phpunit"
+                    ./phpunit install
+                    echo "::endgroup::"
+
+            -   name: Report the ICU version
+                run: icu-config --version && php -i | grep 'ICU version'
+
+            -   name: Run intl-data tests
+                run: ./phpunit --group intl-data -v


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? |no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`intl-data` tests are run whenever we update ICU data as they're rather time-consuming.

This proposal automates intl-data test runs with Github Actions. Tests will only be run on pull requests or pushes that modifyy ICU data. Full run on Github Actions takes 6-7mins. Example run: https://github.com/jakzal/symfony/actions/runs/406526765

<img width="1204" alt="image" src="https://user-images.githubusercontent.com/190447/101393171-92a28c00-38be-11eb-9efa-8f0a75ff04b0.png">

