### PR TITLE
[Notifier] Remove @internal annotation from notifier transports

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransport.php
@@ -22,8 +22,6 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Jeroen Spee <https://github.com/Jeroeny>
  *
- * @internal
- *
  * @experimental in 5.1
  */
 final class RocketChatTransport extends AbstractTransport

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
@@ -25,8 +25,6 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Daniel Stancu <birkof@birkof.ro>
  *
- * @internal
- *
  * @see https://api.slack.com/messaging/webhooks
  *
  * @experimental in 5.1

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -27,8 +27,6 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @internal
- *
  * @experimental in 5.1
  */
 final class TelegramTransport extends AbstractTransport


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

All other transports does not have the `@internal` annotation, so I think we can safely remove it.

I consider this a bugfix, as this does not break BC.

cc @fabpot 