### PR TITLE
[Security]  Move the handleAuthenticationSuccess logic outside try/catch block

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -185,18 +185,6 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
             if (null !== $this->logger) {
                 $this->logger->info('Authenticator successful!', ['token' => $authenticatedToken, 'authenticator' => \get_class($authenticator)]);
             }
-
-            // success! (sets the token on the token storage, etc)
-            $response = $this->handleAuthenticationSuccess($authenticatedToken, $passport, $request, $authenticator);
-            if ($response instanceof Response) {
-                return $response;
-            }
-
-            if (null !== $this->logger) {
-                $this->logger->debug('Authenticator set no success response: request continues.', ['authenticator' => \get_class($authenticator)]);
-            }
-
-            return null;
         } catch (AuthenticationException $e) {
             // oh no! Authentication failed!
             $response = $this->handleAuthenticationFailure($e, $request, $authenticator, $passport);
@@ -206,6 +194,18 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
 
             return null;
         }
+
+        // success! (sets the token on the token storage, etc)
+        $response = $this->handleAuthenticationSuccess($authenticatedToken, $passport, $request, $authenticator);
+        if ($response instanceof Response) {
+            return $response;
+        }
+
+        if (null !== $this->logger) {
+            $this->logger->debug('Authenticator set no success response: request continues.', ['authenticator' => \get_class($authenticator)]);
+        }
+
+        return null;
     }
 
     private function handleAuthenticationSuccess(TokenInterface $authenticatedToken, PassportInterface $passport, Request $request, AuthenticatorInterface $authenticator): ?Response

--- a/src/Symfony/Component/Security/Http/EventListener/UserCheckerListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/UserCheckerListener.php
@@ -12,11 +12,12 @@
 namespace Symfony\Component\Security\Http\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PreAuthenticatedUserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\UserPassportInterface;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
-use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
@@ -43,21 +44,21 @@ class UserCheckerListener implements EventSubscriberInterface
         $this->userChecker->checkPreAuth($passport->getUser());
     }
 
-    public function postCheckCredentials(LoginSuccessEvent $event): void
+    public function postCheckCredentials(AuthenticationSuccessEvent $event): void
     {
-        $passport = $event->getPassport();
-        if (!$passport instanceof UserPassportInterface || null === $passport->getUser()) {
+        $user = $event->getAuthenticationToken()->getUser();
+        if (!$user instanceof UserInterface) {
             return;
         }
 
-        $this->userChecker->checkPostAuth($passport->getUser());
+        $this->userChecker->checkPostAuth($user);
     }
 
     public static function getSubscribedEvents(): array
     {
         return [
             CheckPassportEvent::class => ['preCheckCredentials', 256],
-            LoginSuccessEvent::class => ['postCheckCredentials', 256],
+            AuthenticationSuccessEvent::class => ['postCheckCredentials', 256],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The current implementation of `AuthenticationManager` handle the `handleAuthenticationSuccess` logic in a try/catch block which triggers the `handleAuthenticationFailure` in case of failure.

Which could leads to inconsistency and unexpected behavior. The authentication is either successfully or failure, but can't be both in the same request.