### PR TITLE
[DoctrineBridge] no-op RegisterUidTypePass if DBAL types aren't loaded

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterUidTypePass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterUidTypePass.php
@@ -28,6 +28,10 @@ final class RegisterUidTypePass implements CompilerPassInterface
             return;
         }
 
+        if (!$container->hasParameter('doctrine.dbal.connection_factory.types')) {
+            return;
+        }
+
         $typeDefinition = $container->getParameter('doctrine.dbal.connection_factory.types');
 
         if (!isset($typeDefinition['uuid'])) {

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterUidTypePassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterUidTypePassTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Symfony\Bridge\Doctrine\Tests\DependencyInjection\CompilerPass;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterUidTypePass;
+use Symfony\Bridge\Doctrine\Types\UlidType;
+use Symfony\Bridge\Doctrine\Types\UuidType;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RegisterUidTypePassTest extends TestCase
+{
+    public function testRegistered()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('doctrine.dbal.connection_factory.types', ['foo' => 'bar']);
+        (new RegisterUidTypePass())->process($container);
+
+        $expected = [
+            'foo' => 'bar',
+            'uuid' => ['class' => UuidType::class],
+            'ulid' => ['class' => UlidType::class],
+        ];
+        $this->assertSame($expected, $container->getParameter('doctrine.dbal.connection_factory.types'));
+    }
+
+    public function testRegisteredDontFail()
+    {
+        $container = new ContainerBuilder();
+        (new RegisterUidTypePass())->process($container);
+
+        $this->expectNotToPerformAssertions();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39400
| License       | MIT
