### PR TITLE
[Notifier] [Discord] Make webhookId argument required

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
@@ -32,7 +32,7 @@ final class DiscordTransport extends AbstractTransport
     private $token;
     private $webhookId;
 
-    public function __construct(string $token, string $webhookId = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $token, string $webhookId, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->token = $token;
         $this->webhookId = $webhookId;

--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Discord;
 
+use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -31,6 +32,11 @@ final class DiscordTransportFactory extends AbstractTransportFactory
         $scheme = $dsn->getScheme();
         $token = $this->getUser($dsn);
         $webhookId = $dsn->getOption('webhook_id');
+
+        if (!$webhookId) {
+            throw new IncompleteDsnException('Missing webhook_id.', $dsn->getOriginalDsn());
+        }
+
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportFactoryTest.php
@@ -31,6 +31,15 @@ final class DiscordTransportFactoryTest extends TestCase
         $this->assertSame(sprintf('discord://%s?webhook_id=%s', $host, $webhookId), (string) $transport);
     }
 
+    public function testCreateWithNoWebhookIdThrowsMalformed(): void
+    {
+        $factory = new DiscordTransportFactory();
+
+        $this->expectException(IncompleteDsnException::class);
+
+        $factory->create(Dsn::fromString('discord://token@host'));
+    }
+
     public function testCreateWithNoTokenThrowsMalformed()
     {
         $factory = new DiscordTransportFactory();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes (but the code was introduced in 5.x)
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

From the code perspective it looks like `$webhookId` cannot be `null` so I removed that and added a test.

cc @mpiot 