### PR TITLE
[Notifier] Remove @internal annotation from notifier transports

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransport.php
@@ -23,8 +23,6 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Mathieu Piot <math.piot@gmail.com>
  *
- * @internal
- *
  * @experimental in 5.2
  */
 final class DiscordTransport extends AbstractTransport

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
@@ -24,8 +24,6 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * @author Jérôme Tamarelle <jerome@tamarelle.net>
  *
- * @internal
- *
  * @experimental in 5.2
  */
 final class GoogleChatTransport extends AbstractTransport


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

Same like https://github.com/symfony/symfony/pull/39380 but for `5.2`