### PR TITLE
[Messenger] Added more descriptive exception message when handling of a message failed

### DIFF
--- a/src/Symfony/Component/Messenger/Exception/HandlerFailedException.php
+++ b/src/Symfony/Component/Messenger/Exception/HandlerFailedException.php
@@ -25,10 +25,13 @@ class HandlerFailedException extends RuntimeException
     {
         $firstFailure = current($exceptions);
 
+        $message = sprintf('Handling "%s" failed: ', \get_class($envelope->getMessage()));
+
         parent::__construct(
-            1 === \count($exceptions)
+            $message.(1 === \count($exceptions)
                 ? $firstFailure->getMessage()
-                : sprintf('%d handlers failed. First failure is: "%s"', \count($exceptions), $firstFailure->getMessage()),
+                : sprintf('%d handlers failed. First failure is: %s', \count($exceptions), $firstFailure->getMessage())
+            ),
             (int) $firstFailure->getCode(),
             $firstFailure
         );


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no (more of a patch thing)
| New feature?  | no
| Deprecations? | no
| License       | MIT

I use Symfony Messenger extensively and I run into the `HandlerFailedException` from time to time. What bothers me is that the exception doesn't carry the name of the message that failed right there in the exception message.

Here is an example from Sentry:

![image](https://user-images.githubusercontent.com/2412177/101757346-572eda00-3ad7-11eb-9f57-6ba2b043594d.png)

As you can see I get the error message, but I have to look through all my messages (in different bundles etc) to find the sinner.

This PR adds the message name directly to the exception message.