### PR TITLE
[Notifier] [Free Mobile] Rename method to match other bridges

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportFactoryTest.php
@@ -21,7 +21,7 @@ final class FreeMobileTransportFactoryTest extends TestCase
 {
     public function testCreateWithDsn(): void
     {
-        $factory = $this->initFactory();
+        $factory = $this->createFactory();
 
         $dsn = 'freemobile://login:pass@default?phone=0611223344';
         $transport = $factory->create(Dsn::fromString($dsn));
@@ -32,7 +32,7 @@ final class FreeMobileTransportFactoryTest extends TestCase
 
     public function testCreateWithNoPhoneThrowsMalformed(): void
     {
-        $factory = $this->initFactory();
+        $factory = $this->createFactory();
 
         $this->expectException(IncompleteDsnException::class);
 
@@ -42,7 +42,7 @@ final class FreeMobileTransportFactoryTest extends TestCase
 
     public function testSupportsFreeMobileScheme(): void
     {
-        $factory = $this->initFactory();
+        $factory = $this->createFactory();
 
         $dsn = 'freemobile://login:pass@default?phone=0611223344';
         $dsnUnsupported = 'foobarmobile://login:pass@default?phone=0611223344';
@@ -53,7 +53,7 @@ final class FreeMobileTransportFactoryTest extends TestCase
 
     public function testNonFreeMobileSchemeThrows(): void
     {
-        $factory = $this->initFactory();
+        $factory = $this->createFactory();
 
         $this->expectException(UnsupportedSchemeException::class);
 
@@ -61,7 +61,7 @@ final class FreeMobileTransportFactoryTest extends TestCase
         $factory->create(Dsn::fromString($dsnUnsupported));
     }
 
-    private function initFactory(): FreeMobileTransportFactory
+    private function createFactory(): FreeMobileTransportFactory
     {
         return new FreeMobileTransportFactory();
     }

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportTest.php
@@ -56,8 +56,6 @@ final class FreeMobileTransportTest extends TestCase
 
     private function initTransport(): FreeMobileTransport
     {
-        return (new FreeMobileTransport(
-            'login', 'pass', '0611223344', $this->createMock(HttpClientInterface::class)
-        ))->setHost('host.test');
+        return (new FreeMobileTransport('login', 'pass', '0611223344', $this->createMock(HttpClientInterface::class)))->setHost('host.test');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

All other bridges use `create*` instead of `init*`