### PR TITLE
[Serializer][Validator] Mention annotation loaders handle PHP8 attributes

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -23,7 +23,7 @@ use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
 use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
 
 /**
- * Annotation loader.
+ * Loader for Doctrine annotations and PHP 8 attributes.
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
  * @author Alexander M. Turek <me@derrabus.de>

--- a/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Exception\MappingException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 /**
- * Loads validation metadata using a Doctrine annotation {@link Reader}.
+ * Loads validation metadata using a Doctrine annotation {@link Reader} or using PHP 8 attributes.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Alexander M. Turek <me@derrabus.de>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A

Just a small note for the ones reading docblocks first and expecting to find a PhpAttributeLoader or whatever: the annotation loaders handle both doctrine annotations & PHP 8 attributes.
The route loader already mentions this.