### PR TITLE
[Notifier] Rework/streamline bridges (5.2)

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransportFactory.php
@@ -30,6 +30,11 @@ final class DiscordTransportFactory extends AbstractTransportFactory
     public function create(Dsn $dsn): TransportInterface
     {
         $scheme = $dsn->getScheme();
+
+        if ('discord' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'discord', $this->getSupportedSchemes());
+        }
+
         $token = $this->getUser($dsn);
         $webhookId = $dsn->getOption('webhook_id');
 
@@ -40,11 +45,7 @@ final class DiscordTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        if ('discord' === $scheme) {
-            return (new DiscordTransport($token, $webhookId, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
-        }
-
-        throw new UnsupportedSchemeException($dsn, 'discord', $this->getSupportedSchemes());
+        return (new DiscordTransport($token, $webhookId, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Discord/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/README.md
@@ -1,13 +1,12 @@
 Discord Notifier
 ================
 
-Provides Discord integration for Symfony Notifier.
+Provides [Discord](https://discord.com) integration for Symfony Notifier.
 
 DSN example
 -----------
 
 ```
-// .env file
 DISCORD_DSN=discord://TOKEN@default?webhook_id=ID
 ```
 

--- a/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/composer.json
@@ -30,5 +30,4 @@
         ]
     },
     "minimum-stability": "dev"
-
 }

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php
@@ -62,6 +62,7 @@ final class EsendexTransport extends AbstractTransport
             'to' => $message->getPhone(),
             'body' => $message->getSubject(),
         ];
+
         if (null !== $this->from) {
             $messageData['from'] = $this->from;
         }

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/README.md
@@ -1,21 +1,20 @@
 Esendex Notifier
 ================
 
-Provides Esendex integration for Symfony Notifier.
+Provides [Esendex](https://esendex.com) integration for Symfony Notifier.
 
 DSN example
 -----------
 
 ```
-// .env file
-ESENDEX_DSN='esendex://EMAIL:PASSWORD@default?accountreference=ACCOUNT_REFERENCE&from=FROM'
+ESENDEX_DSN=esendex://EMAIL:PASSWORD@default?accountreference=ACCOUNT_REFERENCE&from=FROM
 ```
 
 where:
  - `EMAIL` is your Esendex account email
  - `PASSWORD` is the Esendex API password
- - `ACCOUNT_REFERENCE` is the Esendex account reference that the messages should be sent from.
- - `FROM` is the alphanumeric originator for the message to appear to originate from.
+ - `ACCOUNT_REFERENCE` is the Esendex account reference that the messages should be sent from
+ - `FROM` is the alphanumeric originator for the message to appear to originate from
 
 See Esendex documentation at https://developers.esendex.com/api-reference#smsapis
 

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportFactoryTest.php
@@ -9,58 +9,55 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Notifier\Bridge\Mattermost\Tests;
+namespace Symfony\Component\Notifier\Bridge\Esendex\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
+use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
 use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
 
-/**
- * @author Oskar Stark <oskarstark@googlemail.com>
- */
-final class MattermostTransportFactoryTest extends TestCase
+final class EsendexTransportFactoryTest extends TestCase
 {
     public function testCreateWithDsn()
     {
         $factory = $this->createFactory();
 
-        $transport = $factory->create(Dsn::fromString('mattermost://accessToken@host.test?channel=testChannel'));
+        $transport = $factory->create(Dsn::fromString('esendex://email:password@host.test?accountreference=testAccountreference&from=testFrom'));
 
-        $this->assertSame('mattermost://host.test?channel=testChannel', (string) $transport);
+        $this->assertSame('esendex://host.test', (string) $transport);
     }
 
-    public function testCreateWithMissingOptionChannelThrowsIncompleteDsnException()
+    public function testCreateWithMissingOptionAccountreferenceThrowsIncompleteDsnException()
     {
         $factory = $this->createFactory();
 
         $this->expectException(IncompleteDsnException::class);
 
-        $factory->create(Dsn::fromString('mattermost://token@host'));
+        $factory->create(Dsn::fromString('esendex://email:password@host?from=FROM'));
     }
 
-    public function testCreateWithNoTokenThrowsIncompleteDsnException()
+    public function testCreateWithMissingOptionFromThrowsIncompleteDsnException()
     {
         $factory = $this->createFactory();
 
         $this->expectException(IncompleteDsnException::class);
 
-        $factory->create(Dsn::fromString('mattermost://host.test?channel=testChannel'));
+        $factory->create(Dsn::fromString('esendex://email:password@host?accountreference=ACCOUNTREFERENCE'));
     }
 
     public function testSupportsReturnsTrueWithSupportedScheme()
     {
         $factory = $this->createFactory();
 
-        $this->assertTrue($factory->supports(Dsn::fromString('mattermost://token@host?channel=testChannel')));
+        $this->assertTrue($factory->supports(Dsn::fromString('esendex://email:password@host?accountreference=ACCOUNTREFERENCE&from=FROM')));
     }
 
     public function testSupportsReturnsFalseWithUnsupportedScheme()
     {
         $factory = $this->createFactory();
 
-        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://token@host?channel=testChannel')));
+        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://email:password@host?accountreference=ACCOUNTREFERENCE&from=FROM')));
     }
 
     public function testUnsupportedSchemeThrowsUnsupportedSchemeException()
@@ -68,8 +65,7 @@ final class MattermostTransportFactoryTest extends TestCase
         $factory = $this->createFactory();
 
         $this->expectException(UnsupportedSchemeException::class);
-
-        $factory->create(Dsn::fromString('somethingElse://token@host?channel=testChannel'));
+        $factory->create(Dsn::fromString('somethingElse://email:password@host?accountreference=REFERENCE&from=FROM'));
     }
 
     public function testUnsupportedSchemeThrowsUnsupportedSchemeExceptionEvenIfRequiredOptionIsMissing()
@@ -78,12 +74,12 @@ final class MattermostTransportFactoryTest extends TestCase
 
         $this->expectException(UnsupportedSchemeException::class);
 
-        // unsupported scheme and missing "channel" option
-        $factory->create(Dsn::fromString('somethingElse://token@host'));
+        // unsupported scheme and missing "from" option
+        $factory->create(Dsn::fromString('somethingElse://email:password@host?accountreference=REFERENCE'));
     }
 
-    private function createFactory(): MattermostTransportFactory
+    private function createFactory(): EsendexTransportFactory
     {
-        return new MattermostTransportFactory();
+        return new EsendexTransportFactory();
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
@@ -25,23 +25,22 @@ final class EsendexTransportTest extends TestCase
 {
     public function testToString()
     {
-        $transport = new EsendexTransport('testToken', 'accountReference', 'from', $this->createMock(HttpClientInterface::class));
-        $transport->setHost('testHost');
+        $transport = $this->createTransport();
 
-        $this->assertSame(sprintf('esendex://%s', 'testHost'), (string) $transport);
+        $this->assertSame('esendex://host.test', (string) $transport);
     }
 
     public function testSupportsSmsMessage()
     {
-        $transport = new EsendexTransport('testToken', 'accountReference', 'from', $this->createMock(HttpClientInterface::class));
+        $transport = $this->createTransport();
 
         $this->assertTrue($transport->supports(new SmsMessage('phone', 'testSmsMessage')));
         $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
     }
 
-    public function testSendNonSmsMessageThrows()
+    public function testSendNonSmsMessageThrowsLogicException()
     {
-        $transport = new EsendexTransport('testToken', 'accountReference', 'from', $this->createMock(HttpClientInterface::class));
+        $transport = $this->createTransport();
 
         $this->expectException(LogicException::class);
         $transport->send($this->createMock(MessageInterface::class));
@@ -58,10 +57,11 @@ final class EsendexTransportTest extends TestCase
             return $response;
         });
 
-        $transport = new EsendexTransport('testToken', 'accountReference', 'from', $client);
+        $transport = $this->createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to send the SMS: error 500.');
+
         $transport->send(new SmsMessage('phone', 'testMessage'));
     }
 
@@ -79,10 +79,16 @@ final class EsendexTransportTest extends TestCase
             return $response;
         });
 
-        $transport = new EsendexTransport('testToken', 'accountReference', 'from', $client);
+        $transport = $this->createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to send the SMS: error 500. Details from Esendex: accountreference_invalid: "Invalid Account Reference EX0000000".');
+
         $transport->send(new SmsMessage('phone', 'testMessage'));
+    }
+
+    private function createTransport(?HttpClientInterface $client = null): EsendexTransport
+    {
+        return (new EsendexTransport('testToken', 'testAccountReference', 'testFrom', $client ?: $this->createMock(HttpClientInterface::class)))->setHost('host.test');
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
@@ -88,9 +88,9 @@ final class FirebaseTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        $message = new SentMessage($message, (string) $this);
-        $message->setMessageId($success['results'][0]['message_id']);
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($success['results'][0]['message_id']);
 
-        return $message;
+        return $sentMessage;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportTest.php
@@ -38,7 +38,7 @@ final class FirebaseTransportTest extends TestCase
         $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
     }
 
-    public function testSendNonSmsMessageThrowsException()
+    public function testSendNonSmsMessageThrowsLogicException()
     {
         $transport = $this->createTransport();
 

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatOptions.php
@@ -40,6 +40,7 @@ final class GoogleChatOptions implements MessageOptionsInterface
         if ($notification->getContent()) {
             $text .= "\r\n".$notification->getContent();
         }
+
         if ($exception = $notification->getExceptionAsString()) {
             $text .= "\r\n".'```'.$notification->getExceptionAsString().'```';
         }

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
@@ -89,6 +89,7 @@ final class GoogleChatTransport extends AbstractTransport
         if (!$message instanceof ChatMessage) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, \get_class($message)));
         }
+
         if ($message->getOptions() && !$message->getOptions() instanceof GoogleChatOptions) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" for options.', __CLASS__, GoogleChatOptions::class));
         }

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransportFactory.php
@@ -32,21 +32,18 @@ final class GoogleChatTransportFactory extends AbstractTransportFactory
     {
         $scheme = $dsn->getScheme();
 
-        if ('googlechat' === $scheme) {
-            $space = explode('/', $dsn->getPath())[1];
-            $accessKey = $this->getUser($dsn);
-            $accessToken = $this->getPassword($dsn);
-            $threadKey = $dsn->getOption('threadKey');
-            $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
-            $port = $dsn->getPort();
-
-            return (new GoogleChatTransport($space, $accessKey, $accessToken, $this->client, $this->dispatcher))
-                ->setThreadKey($threadKey)
-                ->setHost($host)
-                ->setPort($port);
+        if ('googlechat' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'googlechat', $this->getSupportedSchemes());
         }
 
-        throw new UnsupportedSchemeException($dsn, 'googlechat', $this->getSupportedSchemes());
+        $space = explode('/', $dsn->getPath())[1];
+        $accessKey = $this->getUser($dsn);
+        $accessToken = $this->getPassword($dsn);
+        $threadKey = $dsn->getOption('threadKey');
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        return (new GoogleChatTransport($space, $accessKey, $accessToken, $this->client, $this->dispatcher))->setThreadKey($threadKey)->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/README.md
@@ -7,15 +7,14 @@ DSN example
 -----------
 
 ```
-// .env file
-INFOBIP_DSN=googlechat://ACCESS_KEY:ACCESS_TOKEN@default/SPACE?threadKey=THREAD_KEY
+GOOGLE_CHAT_DSN=googlechat://ACCESS_KEY:ACCESS_TOKEN@default/SPACE?threadKey=THREAD_KEY
 ```
 
 where:
  - `ACCESS_KEY` is your Google Chat access key
  - `ACCESS_TOKEN` is your Google Chat access token
  - `SPACE` is the Google Chat space
- - `THREAD_KEY` is the the Google Chat message thread to group messages into a single thread
+ - `THREAD_KEY` is the the Google Chat message thread to group messages into a single thread (optional)
 
 Resources
 ---------

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportFactoryTest.php
@@ -21,47 +21,55 @@ final class GoogleChatTransportFactoryTest extends TestCase
 {
     public function testCreateWithDsn()
     {
-        $factory = new GoogleChatTransportFactory();
+        $factory = $this->createFactory();
 
-        $dsn = 'googlechat://abcde-fghij:kl_mnopqrstwxyz%3D@chat.googleapis.com/AAAAA_YYYYY';
-        $transport = $factory->create(Dsn::fromString($dsn));
+        $transport = $factory->create(Dsn::fromString('googlechat://abcde-fghij:kl_mnopqrstwxyz%3D@chat.googleapis.com/AAAAA_YYYYY'));
 
         $this->assertSame('googlechat://chat.googleapis.com/AAAAA_YYYYY', (string) $transport);
     }
 
     public function testCreateWithThreadKeyInDsn()
     {
-        $factory = new GoogleChatTransportFactory();
+        $factory = $this->createFactory();
 
-        $dsn = 'googlechat://abcde-fghij:kl_mnopqrstwxyz%3D@chat.googleapis.com/AAAAA_YYYYY?threadKey=abcdefg';
-        $transport = $factory->create(Dsn::fromString($dsn));
+        $transport = $factory->create(Dsn::fromString('googlechat://abcde-fghij:kl_mnopqrstwxyz%3D@chat.googleapis.com/AAAAA_YYYYY?threadKey=abcdefg'));
 
         $this->assertSame('googlechat://chat.googleapis.com/AAAAA_YYYYY?threadKey=abcdefg', (string) $transport);
     }
 
     public function testCreateRequiresCredentials()
     {
-        $this->expectException(IncompleteDsnException::class);
-        $factory = new GoogleChatTransportFactory();
+        $factory = $this->createFactory();
 
-        $dsn = 'googlechat://chat.googleapis.com/v1/spaces/AAAAA_YYYYY/messages';
-        $factory->create(Dsn::fromString($dsn));
+        $this->expectException(IncompleteDsnException::class);
+
+        $factory->create(Dsn::fromString('googlechat://chat.googleapis.com/v1/spaces/AAAAA_YYYYY/messages'));
     }
 
-    public function testSupportsGoogleChatScheme()
+    public function testSupportsReturnsTrueWithSupportedScheme()
     {
-        $factory = new GoogleChatTransportFactory();
+        $factory = $this->createFactory();
 
         $this->assertTrue($factory->supports(Dsn::fromString('googlechat://host/path')));
+    }
+
+    public function testSupportsReturnsFalseWithUnsupportedScheme()
+    {
+        $factory = $this->createFactory();
+
         $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://host/path')));
     }
 
-    public function testNonGoogleChatSchemeThrows()
+    public function testUnsupportedSchemeThrowsUnsupportedSchemeException()
     {
-        $factory = new GoogleChatTransportFactory();
+        $factory = $this->createFactory();
 
         $this->expectException(UnsupportedSchemeException::class);
-
         $factory->create(Dsn::fromString('somethingElse://host/path'));
+    }
+
+    private function createFactory(): GoogleChatTransportFactory
+    {
+        return new GoogleChatTransportFactory();
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
@@ -28,7 +28,7 @@ class GoogleChatTransportTest extends TestCase
 {
     public function testToStringContainsProperties()
     {
-        $transport = new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $this->createMock(HttpClientInterface::class));
+        $transport = $this->createTransport();
         $transport->setHost(null);
 
         $this->assertSame('googlechat://chat.googleapis.com/My-Space', (string) $transport);
@@ -36,17 +36,17 @@ class GoogleChatTransportTest extends TestCase
 
     public function testSupportsChatMessage()
     {
-        $transport = new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $this->createMock(HttpClientInterface::class));
+        $transport = $this->createTransport();
 
         $this->assertTrue($transport->supports(new ChatMessage('testChatMessage')));
         $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
     }
 
-    public function testSendNonChatMessageThrows()
+    public function testSendNonChatMessageThrowsLogicException()
     {
-        $this->expectException(LogicException::class);
+        $transport = $this->createTransport();
 
-        $transport = new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $this->createMock(HttpClientInterface::class));
+        $this->expectException(LogicException::class);
 
         $transport->send($this->createMock(MessageInterface::class));
     }
@@ -69,7 +69,7 @@ class GoogleChatTransportTest extends TestCase
             return $response;
         });
 
-        $transport = new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $client);
+        $transport = $this->createTransport($client);
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 
@@ -93,7 +93,7 @@ class GoogleChatTransportTest extends TestCase
             return $response;
         });
 
-        $transport = new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $client);
+        $transport = $this->createTransport($client);
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 
@@ -124,7 +124,7 @@ class GoogleChatTransportTest extends TestCase
             return $response;
         });
 
-        $transport = new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $client);
+        $transport = $this->createTransport($client);
         $transport->setThreadKey('My-Thread');
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
@@ -157,7 +157,7 @@ class GoogleChatTransportTest extends TestCase
             return $response;
         });
 
-        $transport = new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $client);
+        $transport = $this->createTransport($client);
 
         $sentMessage = $transport->send($chatMessage);
 
@@ -173,7 +173,7 @@ class GoogleChatTransportTest extends TestCase
             return $this->createMock(ResponseInterface::class);
         });
 
-        $transport = new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $client);
+        $transport = $this->createTransport($client);
 
         $transport->send(new ChatMessage('testMessage', $this->createMock(MessageOptionsInterface::class)));
     }
@@ -202,10 +202,15 @@ class GoogleChatTransportTest extends TestCase
             return $response;
         });
 
-        $transport = new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $client);
+        $transport = $this->createTransport($client);
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 
         $this->assertSame('spaces/My-Space/messages/abcdefg.hijklmno', $sentMessage->getMessageId());
+    }
+
+    private function createTransport(?HttpClientInterface $client = null): GoogleChatTransport
+    {
+        return new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $client ?: $this->createMock(HttpClientInterface::class));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/InfobipTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/InfobipTransportFactory.php
@@ -31,6 +31,11 @@ final class InfobipTransportFactory extends AbstractTransportFactory
     public function create(Dsn $dsn): TransportInterface
     {
         $scheme = $dsn->getScheme();
+
+        if ('infobip' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'infobip', $this->getSupportedSchemes());
+        }
+
         $authToken = $this->getUser($dsn);
         $from = $dsn->getOption('from');
         $host = $dsn->getHost();
@@ -40,11 +45,7 @@ final class InfobipTransportFactory extends AbstractTransportFactory
             throw new IncompleteDsnException('Missing from.', $dsn->getOriginalDsn());
         }
 
-        if ('infobip' === $scheme) {
-            return (new InfobipTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
-        }
-
-        throw new UnsupportedSchemeException($dsn, 'infobip', $this->getSupportedSchemes());
+        return (new InfobipTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/README.md
@@ -7,7 +7,6 @@ DSN example
 -----------
 
 ```
-// .env file
 INFOBIP_DSN=infobip://AUTH_TOKEN@INFOBIP_HOST?from=FROM
 ```
 

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/Tests/InfobipTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/Tests/InfobipTransportFactoryTest.php
@@ -21,43 +21,55 @@ final class InfobipTransportFactoryTest extends TestCase
 {
     public function testCreateWithDsn()
     {
-        $factory = new InfobipTransportFactory();
+        $factory = $this->createFactory();
 
-        $dsn = 'infobip://authtoken@default?from=0611223344';
-        $transport = $factory->create(Dsn::fromString($dsn));
-        $transport->setHost('host.test');
+        $transport = $factory->create(Dsn::fromString('infobip://authtoken@host.test?from=0611223344'));
 
         $this->assertSame('infobip://host.test?from=0611223344', (string) $transport);
     }
 
-    public function testCreateWithNoFromThrowsMalformed()
+    public function testCreateWithNoFromThrowsIncompleteDsnException()
     {
-        $factory = new InfobipTransportFactory();
+        $factory = $this->createFactory();
 
         $this->expectException(IncompleteDsnException::class);
-
-        $dsnIncomplete = 'infobip://authtoken@default';
-        $factory->create(Dsn::fromString($dsnIncomplete));
+        $factory->create(Dsn::fromString('infobip://authtoken@default'));
     }
 
-    public function testSupportsInfobipScheme()
+    public function testSupportsReturnsTrueWithSupportedScheme()
     {
-        $factory = new InfobipTransportFactory();
+        $factory = $this->createFactory();
 
-        $dsn = 'infobip://authtoken@default?from=0611223344';
-        $dsnUnsupported = 'unsupported://authtoken@default?from=0611223344';
-
-        $this->assertTrue($factory->supports(Dsn::fromString($dsn)));
-        $this->assertFalse($factory->supports(Dsn::fromString($dsnUnsupported)));
+        $this->assertTrue($factory->supports(Dsn::fromString('infobip://authtoken@default?from=0611223344')));
     }
 
-    public function testNonInfobipSchemeThrows()
+    public function testSupportsReturnsFalseWithUnsupportedScheme()
     {
-        $factory = new InfobipTransportFactory();
+        $factory = $this->createFactory();
+
+        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://authtoken@default?from=0611223344')));
+    }
+
+    public function testUnsupportedSchemeThrowsUnsupportedSchemeException()
+    {
+        $factory = $this->createFactory();
+
+        $this->expectException(UnsupportedSchemeException::class);
+        $factory->create(Dsn::fromString('somethingElse://authtoken@default?from=FROM'));
+    }
+
+    public function testUnsupportedSchemeThrowsUnsupportedSchemeExceptionEvenIfRequiredOptionIsMissing()
+    {
+        $factory = $this->createFactory();
 
         $this->expectException(UnsupportedSchemeException::class);
 
-        $dsnUnsupported = 'unsupported://authtoken@default?from=0611223344';
-        $factory->create(Dsn::fromString($dsnUnsupported));
+        // unsupported scheme and missing "from" option
+        $factory->create(Dsn::fromString('somethingElse://authtoken@default'));
+    }
+
+    private function createFactory(): InfobipTransportFactory
+    {
+        return new InfobipTransportFactory();
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/Tests/InfobipTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/Tests/InfobipTransportTest.php
@@ -22,34 +22,30 @@ final class InfobipTransportTest extends TestCase
 {
     public function testToStringContainsProperties()
     {
-        $transport = $this->getTransport();
+        $transport = $this->createTransport();
 
         $this->assertSame('infobip://host.test?from=0611223344', (string) $transport);
     }
 
     public function testSupportsMessageInterface()
     {
-        $transport = $this->getTransport();
+        $transport = $this->createTransport();
 
         $this->assertTrue($transport->supports(new SmsMessage('0611223344', 'Hello!')));
         $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
     }
 
-    public function testSendNonSmsMessageThrowsException()
+    public function testSendNonSmsMessageThrowsLogicException()
     {
-        $transport = $this->getTransport();
+        $transport = $this->createTransport();
 
         $this->expectException(LogicException::class);
 
         $transport->send($this->createMock(MessageInterface::class));
     }
 
-    private function getTransport(): InfobipTransport
+    private function createTransport(): InfobipTransport
     {
-        return (new InfobipTransport(
-            'authtoken',
-            '0611223344',
-            $this->createMock(HttpClientInterface::class)
-        ))->setHost('host.test');
+        return (new InfobipTransport('authtoken', '0611223344', $this->createMock(HttpClientInterface::class)))->setHost('host.test');
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransport.php
@@ -63,6 +63,7 @@ final class LinkedInTransport extends AbstractTransport
         if (!$message instanceof ChatMessage) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, \get_class($message)));
         }
+
         if ($message->getOptions() && !$message->getOptions() instanceof LinkedInOptions) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" for options.', __CLASS__, LinkedInOptions::class));
         }
@@ -87,7 +88,7 @@ final class LinkedInTransport extends AbstractTransport
         $result = $response->toArray(false);
 
         if (!$result['id']) {
-            throw new TransportException(sprintf('Unable to post the Linkedin message : "%s".', $result['error']), $response);
+            throw new TransportException(sprintf('Unable to post the Linkedin message: "%s".', $result['error']), $response);
         }
 
         $sentMessage = new SentMessage($message, (string) $this);

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInTransportFactory.php
@@ -26,16 +26,17 @@ class LinkedInTransportFactory extends AbstractTransportFactory
     public function create(Dsn $dsn): TransportInterface
     {
         $scheme = $dsn->getScheme();
+
+        if ('linkedin' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'linkedin', $this->getSupportedSchemes());
+        }
+
         $authToken = $this->getUser($dsn);
         $accountId = $this->getPassword($dsn);
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        if ('linkedin' === $scheme) {
-            return (new LinkedInTransport($authToken, $accountId, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
-        }
-
-        throw new UnsupportedSchemeException($dsn, 'linkedin', $this->getSupportedSchemes());
+        return (new LinkedInTransport($authToken, $accountId, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/README.md
@@ -7,8 +7,7 @@ DSN example
 -----------
 
 ```
-// .env file
-LINKEDIN_DSN='linkedin://ACCESS_TOKEN:USER_ID@default'
+LINKEDIN_DSN=linkedin://ACCESS_TOKEN:USER_ID@default
 ```
 
 where:

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportFactoryTest.php
@@ -12,39 +12,45 @@ final class LinkedInTransportFactoryTest extends TestCase
 {
     public function testCreateWithDsn()
     {
-        $factory = new LinkedInTransportFactory();
+        $factory = $this->createFactory();
 
-        $dsn = 'linkedin://login:pass@default';
-        $transport = $factory->create(Dsn::fromString($dsn));
-        $transport->setHost('testHost');
+        $transport = $factory->create(Dsn::fromString('linkedin://accessToken:UserId@host.test'));
 
-        $this->assertSame('linkedin://testHost', (string) $transport);
+        $this->assertSame('linkedin://host.test', (string) $transport);
     }
 
-    public function testSupportsLinkedinScheme()
+    public function testCreateWithOnlyAccessTokenOrUserIdThrowsIncompleteDsnException()
     {
-        $factory = new LinkedInTransportFactory();
+        $factory = $this->createFactory();
+
+        $this->expectException(IncompleteDsnException::class);
+        $factory->create(Dsn::fromString('linkedin://AccessTokenOrUserId@default'));
+    }
+
+    public function testSupportsReturnsTrueWithSupportedScheme()
+    {
+        $factory = $this->createFactory();
 
         $this->assertTrue($factory->supports(Dsn::fromString('linkedin://host/path')));
+    }
+
+    public function testSupportsReturnsFalseWithUnsupportedScheme()
+    {
+        $factory = $this->createFactory();
+
         $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://host/path')));
     }
 
-    public function testNonLinkedinSchemeThrows()
+    public function testUnsupportedSchemeThrowsUnsupportedSchemeException()
     {
-        $factory = new LinkedInTransportFactory();
+        $factory = $this->createFactory();
 
         $this->expectException(UnsupportedSchemeException::class);
-
-        $dsn = 'foo://login:pass@default';
-        $factory->create(Dsn::fromString($dsn));
+        $factory->create(Dsn::fromString('somethingElse://accessToken:UserId@default'));
     }
 
-    public function testIncompleteDsnMissingUserThrows()
+    private function createFactory(): LinkedInTransportFactory
     {
-        $factory = new LinkedInTransportFactory();
-
-        $this->expectException(IncompleteDsnException::class);
-
-        $factory->create(Dsn::fromString('somethingElse://host/path'));
+        return new LinkedInTransportFactory();
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportTest.php
@@ -16,14 +16,16 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class LinkedInTransportTest extends TestCase
 {
-    public function testToString()
+    public function testToStringContainsProperties()
     {
-        $this->assertSame(sprintf('linkedin://host.test'), (string) $this->getTransport());
+        $transport = $this->createTransport();
+
+        $this->assertSame('linkedin://host.test', (string) $transport);
     }
 
     public function testSupportsChatMessage()
     {
-        $transport = $this->getTransport();
+        $transport = $this->createTransport();
 
         $this->assertTrue($transport->supports(new ChatMessage('testChatMessage')));
         $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
@@ -31,10 +33,9 @@ final class LinkedInTransportTest extends TestCase
 
     public function testSendNonChatMessageThrows()
     {
+        $transport = $this->createTransport();
+
         $this->expectException(LogicException::class);
-
-        $transport = $this->getTransport();
-
         $transport->send($this->createMock(MessageInterface::class));
     }
 
@@ -54,7 +55,7 @@ final class LinkedInTransportTest extends TestCase
             return $response;
         });
 
-        $transport = $this->getTransport($client);
+        $transport = $this->createTransport($client);
 
         $transport->send(new ChatMessage('testMessage'));
     }
@@ -77,7 +78,7 @@ final class LinkedInTransportTest extends TestCase
             return $response;
         });
 
-        $transport = $this->getTransport($client);
+        $transport = $this->createTransport($client);
 
         $transport->send(new ChatMessage('testMessage'));
     }
@@ -98,19 +99,19 @@ final class LinkedInTransportTest extends TestCase
 
         $expectedBody = json_encode([
             'specificContent' => [
-                    'com.linkedin.ugc.ShareContent' => [
-                            'shareCommentary' => [
-                                    'attributes' => [],
-                                    'text' => 'testMessage',
-                                ],
-                            'shareMediaCategory' => 'NONE',
-                        ],
+                'com.linkedin.ugc.ShareContent' => [
+                    'shareCommentary' => [
+                        'attributes' => [],
+                        'text' => 'testMessage',
                     ],
-            'visibility' => [
-                    'com.linkedin.ugc.MemberNetworkVisibility' => 'PUBLIC',
+                    'shareMediaCategory' => 'NONE',
                 ],
+            ],
+            'visibility' => [
+                'com.linkedin.ugc.MemberNetworkVisibility' => 'PUBLIC',
+            ],
             'lifecycleState' => 'PUBLISHED',
-            'author' => 'urn:li:person:MyLogin',
+            'author' => 'urn:li:person:AccountId',
         ]);
 
         $client = new MockHttpClient(function (string $method, string $url, array $options = []) use (
@@ -121,7 +122,7 @@ final class LinkedInTransportTest extends TestCase
 
             return $response;
         });
-        $transport = $this->getTransport($client);
+        $transport = $this->createTransport($client);
 
         $transport->send(new ChatMessage($message));
     }
@@ -145,19 +146,19 @@ final class LinkedInTransportTest extends TestCase
 
         $expectedBody = json_encode([
             'specificContent' => [
-                    'com.linkedin.ugc.ShareContent' => [
-                            'shareCommentary' => [
-                                    'attributes' => [],
-                                    'text' => 'testMessage',
-                                ],
-                            'shareMediaCategory' => 'NONE',
-                        ],
+                'com.linkedin.ugc.ShareContent' => [
+                    'shareCommentary' => [
+                        'attributes' => [],
+                        'text' => 'testMessage',
                     ],
-            'visibility' => [
-                    'com.linkedin.ugc.MemberNetworkVisibility' => 'PUBLIC',
+                    'shareMediaCategory' => 'NONE',
                 ],
+            ],
+            'visibility' => [
+                'com.linkedin.ugc.MemberNetworkVisibility' => 'PUBLIC',
+            ],
             'lifecycleState' => 'PUBLISHED',
-            'author' => 'urn:li:person:MyLogin',
+            'author' => 'urn:li:person:AccountId',
         ]);
 
         $client = new MockHttpClient(function (string $method, string $url, array $options = []) use (
@@ -169,7 +170,7 @@ final class LinkedInTransportTest extends TestCase
             return $response;
         });
 
-        $transport = $this->getTransport($client);
+        $transport = $this->createTransport($client);
 
         $transport->send($chatMessage);
     }
@@ -182,17 +183,13 @@ final class LinkedInTransportTest extends TestCase
             return $this->createMock(ResponseInterface::class);
         });
 
-        $transport = $this->getTransport($client);
+        $transport = $this->createTransport($client);
 
         $transport->send(new ChatMessage('testMessage', $this->createMock(MessageOptionsInterface::class)));
     }
 
-    public function getTransport($client = null)
+    private function createTransport(?HttpClientInterface $client = null): LinkedInTransport
     {
-        return (new LinkedInTransport(
-            'MyToken',
-            'MyLogin',
-            $client ?? $this->createMock(HttpClientInterface::class)
-        ))->setHost('host.test');
+        return (new LinkedInTransport('AuthToken', 'AccountId', $client ?? $this->createMock(HttpClientInterface::class)))->setHost('host.test');
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransport.php
@@ -78,9 +78,9 @@ final class MattermostTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        $message = new SentMessage($message, (string) $this);
-        $message->setMessageId($success['id']);
+        $sentMessage = new SentMessage($sentMessage, (string) $this);
+        $sentMessage->setMessageId($success['id']);
 
-        return $message;
+        return $sentMessage;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytOptions.php
@@ -25,7 +25,7 @@ final class MobytOptions implements MessageOptionsInterface
     public const MESSAGE_TYPE_QUALITY_MEDIUM = 'L';
     public const MESSAGE_TYPE_QUALITY_LOW = 'LL';
 
-    private $options = [];
+    private $options;
 
     public function __construct(array $options = [])
     {

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransport.php
@@ -34,7 +34,7 @@ final class MobytTransport extends AbstractTransport
     private $from;
     private $typeQuality;
 
-    public function __construct(string $accountSid, string $authToken, $from, string $typeQuality, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $accountSid, string $authToken, string $from, string $typeQuality, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->accountSid = $accountSid;
         $this->authToken = $authToken;
@@ -93,9 +93,9 @@ final class MobytTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        $message = new SentMessage($message, (string) $this);
-        $message->setMessageId($success['order_id']);
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($success['order_id']);
 
-        return $message;
+        return $sentMessage;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Mobyt;
 
+use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -29,18 +30,24 @@ final class MobytTransportFactory extends AbstractTransportFactory
     public function create(Dsn $dsn): TransportInterface
     {
         $scheme = $dsn->getScheme();
+
+        if ('mobyt' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'mobyt', $this->getSupportedSchemes());
+        }
+
         $accountSid = $this->getUser($dsn);
         $authToken = $this->getPassword($dsn);
         $from = $dsn->getOption('from');
+
+        if (!$from) {
+            throw new IncompleteDsnException('Missing from.', $dsn->getOriginalDsn());
+        }
+
         $typeQuality = $dsn->getOption('type_quality', MobytOptions::MESSAGE_TYPE_QUALITY_LOW);
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        if ('mobyt' === $scheme) {
-            return (new MobytTransport($accountSid, $authToken, $from, $typeQuality, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
-        }
-
-        throw new UnsupportedSchemeException($dsn, 'mobyt', $this->getSupportedSchemes());
+        return (new MobytTransport($accountSid, $authToken, $from, $typeQuality, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/README.md
@@ -7,15 +7,14 @@ DSN example
 -----------
 
 ```
-// .env file
 MOBYT_DSN=mobyt://USER_KEY:ACCESS_TOKEN@default?from=FROM&type_quality=TYPE_QUALITY
 ```
 
 where:
  - `USER_KEY` is your Mobyt user key
  - `ACCESS_TOKEN` is your Mobyt access token
- - `TYPE_QUALITY` is the quality : `N` for high, `L` for medium, `LL` for low (default: `L`)
  - `FROM` is the sender
+ - `TYPE_QUALITY` is the quality : `N` for high, `L` for medium, `LL` for low (default: `L`)
 
 Resources
 ---------

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/Tests/MobytOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/Tests/MobytOptionsTest.php
@@ -6,29 +6,23 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Mobyt\MobytOptions;
 use Symfony\Component\Notifier\Notification\Notification;
 
-class MobytOptionsTest extends TestCase
+final class MobytOptionsTest extends TestCase
 {
     /**
      * @dataProvider fromNotificationDataProvider
      */
-    public function testFromNotification($importance, $expectedMessageType)
+    public function testFromNotification(string $importance, string $expectedMessageType)
     {
         $notification = (new Notification('Foo'))->importance($importance);
 
         $options = (MobytOptions::fromNotification($notification))->toArray();
 
-        $this->assertEquals($expectedMessageType, $options['message_type']);
+        $this->assertSame($expectedMessageType, $options['message_type']);
     }
 
-    public function testFromNotificationDefaultLevel()
-    {
-        $notification = (new Notification('Foo'))->importance('Bar');
-
-        $options = (MobytOptions::fromNotification($notification))->toArray();
-
-        $this->assertEquals(MobytOptions::MESSAGE_TYPE_QUALITY_HIGH, $options['message_type']);
-    }
-
+    /**
+     * @return \Generator<array{0: string, 1: string}>
+     */
     public function fromNotificationDataProvider(): \Generator
     {
         yield [Notification::IMPORTANCE_URGENT, MobytOptions::MESSAGE_TYPE_QUALITY_HIGH];
@@ -37,14 +31,22 @@ class MobytOptionsTest extends TestCase
         yield [Notification::IMPORTANCE_LOW, MobytOptions::MESSAGE_TYPE_QUALITY_LOW];
     }
 
+    public function testFromNotificationDefaultLevel()
+    {
+        $notification = (new Notification('Foo'))->importance('Bar');
+
+        $options = (MobytOptions::fromNotification($notification))->toArray();
+
+        $this->assertSame(MobytOptions::MESSAGE_TYPE_QUALITY_HIGH, $options['message_type']);
+    }
+
     public function testGetRecipientIdWhenSet()
     {
-        $options = [
+        $mobytOptions = new MobytOptions([
             'recipient' => 'foo',
-        ];
-        $mobytOptions = new MobytOptions($options);
+        ]);
 
-        $this->assertEquals('foo', $mobytOptions->getRecipientId());
+        $this->assertSame('foo', $mobytOptions->getRecipientId());
     }
 
     public function testGetRecipientIdWhenNotSet()
@@ -54,11 +56,12 @@ class MobytOptionsTest extends TestCase
 
     public function testToArray()
     {
-        $options = [
+        $mobytOptions = new MobytOptions([
             'message' => 'foo',
             'recipient' => 'bar',
-        ];
-        $this->assertEmpty((new MobytOptions($options))->toArray());
+        ]);
+
+        $this->assertEmpty($mobytOptions->toArray());
     }
 
     public function testMessageType()
@@ -66,6 +69,6 @@ class MobytOptionsTest extends TestCase
         $mobytOptions = new MobytOptions();
         $mobytOptions->messageType('foo');
 
-        $this->assertEquals(['message_type' => 'foo'], $mobytOptions->toArray());
+        $this->assertSame(['message_type' => 'foo'], $mobytOptions->toArray());
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/NexmoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/NexmoTransport.php
@@ -77,9 +77,9 @@ final class NexmoTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        $message = new SentMessage($message, (string) $this);
-        $message->setMessageId($success['messages'][0]['message-id']);
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($success['messages'][0]['message-id']);
 
-        return $message;
+        return $sentMessage;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/Tests/NexmoTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/Tests/NexmoTransportTest.php
@@ -35,7 +35,7 @@ final class NexmoTransportTest extends TestCase
         $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
     }
 
-    public function testSendNonSmsMessageThrowsException()
+    public function testSendNonSmsMessageThrowsLogicException()
     {
         $transport = $this->createTransport();
 

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -94,10 +94,10 @@ final class OvhCloudTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        $message = new SentMessage($message, (string) $this);
-        $message->setMessageId($success['ids'][0]);
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($success['ids'][0]);
 
-        return $message;
+        return $sentMessage;
     }
 
     /**

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
@@ -35,7 +35,7 @@ final class OvhCloudTransportTest extends TestCase
         $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
     }
 
-    public function testSendNonSmsMessageThrowsException()
+    public function testSendNonSmsMessageThrowsLogicException()
     {
         $transport = $this->createTransport();
 

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatTransport.php
@@ -92,9 +92,9 @@ final class RocketChatTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        $message = new SentMessage($message, (string) $this);
-        $message->setMessageId($success['message']['_id']);
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($success['message']['_id']);
 
-        return $message;
+        return $sentMessage;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportFactoryTest.php
@@ -36,6 +36,7 @@ final class RocketChatTransportFactoryTest extends TestCase
         $factory = $this->createFactory();
 
         $this->expectException(IncompleteDsnException::class);
+
         $factory->create(Dsn::fromString('rocketchat://host.test?channel=testChannel'));
     }
 

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/README.md
@@ -1,19 +1,18 @@
 Sendinblue Notifier
 ===================
 
-Provides Sendinblue integration for Symfony Notifier.
+Provides [Sendinblue](https://sendinblue.com) integration for Symfony Notifier.
 
 DSN example
 -----------
 
 ```
-// .env file
-SENDINBLUE_DSN=sendinblue://API_KEY@default?sender=PHONE
+SENDINBLUE_DSN=sendinblue://API_KEY@default?sender=SENDER
 ```
 
 where:
  - `API_KEY` is your api key from your Sendinblue account
- - `PHONE` is your sender's phone number
+ - `SENDER` is your sender's phone number
 
 See more info at https://developers.sendinblue.com/reference#sendtransacsms
 

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/SendinblueTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/SendinblueTransport.php
@@ -75,9 +75,9 @@ final class SendinblueTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        $message = new SentMessage($message, (string) $this);
-        $message->setMessageId($success['messageId']);
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($success['messageId']);
 
-        return $message;
+        return $sentMessage;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/SendinblueTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/SendinblueTransportFactory.php
@@ -29,20 +29,23 @@ final class SendinblueTransportFactory extends AbstractTransportFactory
      */
     public function create(Dsn $dsn): TransportInterface
     {
-        if (!$sender = $dsn->getOption('sender')) {
+        $scheme = $dsn->getScheme();
+
+        if ('sendinblue' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'sendinblue', $this->getSupportedSchemes());
+        }
+
+        $apiKey = $this->getUser($dsn);
+        $sender = $dsn->getOption('sender');
+
+        if (!$sender) {
             throw new IncompleteDsnException('Missing sender.', $dsn->getOriginalDsn());
         }
 
-        $scheme = $dsn->getScheme();
-        $apiKey = $this->getUser($dsn);
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        if ('sendinblue' === $scheme) {
-            return (new SendinblueTransport($apiKey, $sender, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
-        }
-
-        throw new UnsupportedSchemeException($dsn, 'sendinblue', $this->getSupportedSchemes());
+        return (new SendinblueTransport($apiKey, $sender, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportTest.php
@@ -25,22 +25,22 @@ final class SendinblueTransportTest extends TestCase
 {
     public function testToStringContainsProperties()
     {
-        $transport = $this->initTransport();
+        $transport = $this->createTransport();
 
         $this->assertSame('sendinblue://host.test?sender=0611223344', (string) $transport);
     }
 
     public function testSupportsMessageInterface()
     {
-        $transport = $this->initTransport();
+        $transport = $this->createTransport();
 
         $this->assertTrue($transport->supports(new SmsMessage('0611223344', 'Hello!')));
         $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
     }
 
-    public function testSendNonSmsMessageThrowsException()
+    public function testSendNonSmsMessageThrowsLogicException()
     {
-        $transport = $this->initTransport();
+        $transport = $this->createTransport();
 
         $this->expectException(LogicException::class);
         $transport->send($this->createMock(MessageInterface::class));
@@ -60,17 +60,15 @@ final class SendinblueTransportTest extends TestCase
             return $response;
         });
 
-        $transport = $this->initTransport($client);
+        $transport = $this->createTransport($client);
 
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to send the SMS: bad request');
         $transport->send(new SmsMessage('phone', 'testMessage'));
     }
 
-    private function initTransport(?HttpClientInterface $client = null): SendinblueTransport
+    private function createTransport(?HttpClientInterface $client = null): SendinblueTransport
     {
-        return (new SendinblueTransport(
-            'api-key', '0611223344', $client ?: $this->createMock(HttpClientInterface::class)
-        ))->setHost('host.test');
+        return (new SendinblueTransport('api-key', '0611223344', $client ?: $this->createMock(HttpClientInterface::class)))->setHost('host.test');
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransport.php
@@ -76,9 +76,9 @@ final class SinchTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        $message = new SentMessage($message, (string) $this);
-        $message->setMessageId($success['id']);
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($success['id']);
 
-        return $message;
+        return $sentMessage;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/README.md
@@ -7,28 +7,24 @@ DSN example
 -----------
 
 ```
-SLACK_DSN=slack://default/ID
-```
-
-where:
-- `ID` is your webhook id (e.g. `/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX`)
-
-in this case:
-```
-SLACK_DSN=slack://default/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX
-```
-
-DSN example
------------
-
-```
-// .env file
 SLACK_DSN=slack://TOKEN@default?channel=CHANNEL
 ```
 
 where:
-- `TOKEN` is your Bot User OAuth Access Token
-- `CHANNEL` is a Channel, private group, or IM channel to send message to. Can be an encoded ID, or a name
+- `TOKEN` is your Bot User OAuth Access Token (they begin with `xoxb-`)
+- `CHANNEL` is a channel, private group, or IM channel to send message to, it can be an encoded ID, or a name.
+
+valid DSN's are:
+```
+SLACK_DSN=slack://xoxb-......@default?channel=my-channel-name
+SLACK_DSN=slack://xoxb-......@default?channel=@fabien
+```
+
+invalid DSN's are:
+```
+SLACK_DSN=slack://xoxb-......@default?channel=#my-channel-name
+SLACK_DSN=slack://xoxb-......@default?channel=fabien
+```
 
 Resources
 ---------

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
@@ -59,6 +59,7 @@ final class SlackTransport extends AbstractTransport
         if (!$message instanceof ChatMessage) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given).', __CLASS__, ChatMessage::class, get_debug_type($message)));
         }
+
         if ($message->getOptions() && !$message->getOptions() instanceof SlackOptions) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" for options.', __CLASS__, SlackOptions::class));
         }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/Block/SlackSectionBlockTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/Block/SlackSectionBlockTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
 
 final class SlackSectionBlockTest extends TestCase
 {
-    public function testCanBeInstantiated(): void
+    public function testCanBeInstantiated()
     {
         $section = new SlackSectionBlock();
         $section->text('section text');
@@ -44,7 +44,7 @@ final class SlackSectionBlockTest extends TestCase
         ], $section->toArray());
     }
 
-    public function testThrowsWhenFieldsLimitReached(): void
+    public function testThrowsWhenFieldsLimitReached()
     {
         $section = new SlackSectionBlock();
         for ($i = 0; $i < 10; ++$i) {

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
@@ -31,9 +31,9 @@ final class SlackTransportTest extends TestCase
         $channel = 'test Channel'; // invalid channel name to test url encoding of the channel
 
         $transport = new SlackTransport('testToken', $channel, $this->createMock(HttpClientInterface::class));
-        $transport->setHost('testHost');
+        $transport->setHost('host.test');
 
-        $this->assertSame('slack://testHost?channel=test+Channel', (string) $transport);
+        $this->assertSame('slack://host.test?channel=test+Channel', (string) $transport);
     }
 
     public function testSupportsChatMessage()
@@ -46,9 +46,9 @@ final class SlackTransportTest extends TestCase
 
     public function testSendNonChatMessageThrowsLogicException()
     {
-        $this->expectException(LogicException::class);
-
         $transport = new SlackTransport('testToken', 'testChannel', $this->createMock(HttpClientInterface::class));
+
+        $this->expectException(LogicException::class);
 
         $transport->send($this->createMock(MessageInterface::class));
     }

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/README.md
@@ -1,19 +1,18 @@
 SMSAPI Notifier
 ===============
 
-Provides Smsapi integration for Symfony Notifier.
+Provides [Smsapi](https://ssl.smsapi.pl) integration for Symfony Notifier.
 
 DSN example
 -----------
 
 ```
-// .env file
 SMSAPI_DSN=smsapi://TOKEN@default?from=FROM
 ```
 
 where:
- - `TOKEN` is API Token (OAuth)
- - `FROM` is sender name
+ - `TOKEN` is your API Token (OAuth)
+ - `FROM` is the sender name
 
 See your account info at https://ssl.smsapi.pl/
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransport.php
@@ -22,6 +22,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @author Marcin Szepczynski <szepczynski@gmail.com>
+ *
  * @experimental in 5.2
  */
 final class SmsapiTransport extends AbstractTransport

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Smsapi;
 
+use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -18,6 +19,7 @@ use Symfony\Component\Notifier\Transport\TransportInterface;
 
 /**
  * @author Marcin Szepczynski <szepczynski@gmail.com>
+ *
  * @experimental in 5.2
  */
 class SmsapiTransportFactory extends AbstractTransportFactory
@@ -28,16 +30,22 @@ class SmsapiTransportFactory extends AbstractTransportFactory
     public function create(Dsn $dsn): TransportInterface
     {
         $scheme = $dsn->getScheme();
-        $authToken = $dsn->getUser();
-        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
-        $from = $dsn->getOption('from');
-        $port = $dsn->getPort();
 
-        if ('smsapi' === $scheme) {
-            return (new SmsapiTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        if ('smsapi' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'smsapi', $this->getSupportedSchemes());
         }
 
-        throw new UnsupportedSchemeException($dsn, 'smsapi', $this->getSupportedSchemes());
+        $authToken = $this->getUser($dsn);
+        $from = $dsn->getOption('from');
+
+        if (!$from) {
+            throw new IncompleteDsnException('Missing from.', $dsn->getOriginalDsn());
+        }
+
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        return (new SmsapiTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportFactoryTest.php
@@ -9,35 +9,32 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Notifier\Bridge\Mattermost\Tests;
+namespace Symfony\Component\Notifier\Bridge\Smsapi\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
+use Symfony\Component\Notifier\Bridge\Smsapi\SmsapiTransportFactory;
 use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
 
-/**
- * @author Oskar Stark <oskarstark@googlemail.com>
- */
-final class MattermostTransportFactoryTest extends TestCase
+final class SmsapiTransportFactoryTest extends TestCase
 {
     public function testCreateWithDsn()
     {
         $factory = $this->createFactory();
 
-        $transport = $factory->create(Dsn::fromString('mattermost://accessToken@host.test?channel=testChannel'));
+        $transport = $factory->create(Dsn::fromString('smsapi://token@host.test?from=testFrom'));
 
-        $this->assertSame('mattermost://host.test?channel=testChannel', (string) $transport);
+        $this->assertSame('smsapi://host.test?from=testFrom', (string) $transport);
     }
 
-    public function testCreateWithMissingOptionChannelThrowsIncompleteDsnException()
+    public function testCreateWithMissingOptionFromThrowsIncompleteDsnException()
     {
         $factory = $this->createFactory();
 
         $this->expectException(IncompleteDsnException::class);
 
-        $factory->create(Dsn::fromString('mattermost://token@host'));
+        $factory->create(Dsn::fromString('smsapi://token@host'));
     }
 
     public function testCreateWithNoTokenThrowsIncompleteDsnException()
@@ -45,22 +42,21 @@ final class MattermostTransportFactoryTest extends TestCase
         $factory = $this->createFactory();
 
         $this->expectException(IncompleteDsnException::class);
-
-        $factory->create(Dsn::fromString('mattermost://host.test?channel=testChannel'));
+        $factory->create(Dsn::fromString('smsapi://host.test?from=testFrom'));
     }
 
     public function testSupportsReturnsTrueWithSupportedScheme()
     {
         $factory = $this->createFactory();
 
-        $this->assertTrue($factory->supports(Dsn::fromString('mattermost://token@host?channel=testChannel')));
+        $this->assertTrue($factory->supports(Dsn::fromString('smsapi://host?from=testFrom')));
     }
 
     public function testSupportsReturnsFalseWithUnsupportedScheme()
     {
         $factory = $this->createFactory();
 
-        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://token@host?channel=testChannel')));
+        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://host?from=testFrom')));
     }
 
     public function testUnsupportedSchemeThrowsUnsupportedSchemeException()
@@ -68,8 +64,7 @@ final class MattermostTransportFactoryTest extends TestCase
         $factory = $this->createFactory();
 
         $this->expectException(UnsupportedSchemeException::class);
-
-        $factory->create(Dsn::fromString('somethingElse://token@host?channel=testChannel'));
+        $factory->create(Dsn::fromString('somethingElse://token@host?from=testFrom'));
     }
 
     public function testUnsupportedSchemeThrowsUnsupportedSchemeExceptionEvenIfRequiredOptionIsMissing()
@@ -78,12 +73,12 @@ final class MattermostTransportFactoryTest extends TestCase
 
         $this->expectException(UnsupportedSchemeException::class);
 
-        // unsupported scheme and missing "channel" option
+        // unsupported scheme and missing "from" option
         $factory->create(Dsn::fromString('somethingElse://token@host'));
     }
 
-    private function createFactory(): MattermostTransportFactory
+    private function createFactory(): SmsapiTransportFactory
     {
-        return new MattermostTransportFactory();
+        return new SmsapiTransportFactory();
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
@@ -9,22 +9,22 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Notifier\Bridge\Sinch\Tests;
+namespace Symfony\Component\Notifier\Bridge\Smsapi\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Notifier\Bridge\Sinch\SinchTransport;
+use Symfony\Component\Notifier\Bridge\Smsapi\SmsapiTransport;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class SinchTransportTest extends TestCase
+final class SmsapiTransportTest extends TestCase
 {
     public function testToStringContainsProperties()
     {
         $transport = $this->createTransport();
 
-        $this->assertSame('sinch://host.test?from=sender', (string) $transport);
+        $this->assertSame('smsapi://test.host?from=testFrom', (string) $transport);
     }
 
     public function testSupportsMessageInterface()
@@ -35,17 +35,16 @@ final class SinchTransportTest extends TestCase
         $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
     }
 
-    public function testSendNonSmsMessageThrowsLogicException()
+    public function testSendNonChatMessageThrows()
     {
         $transport = $this->createTransport();
 
         $this->expectException(LogicException::class);
-
         $transport->send($this->createMock(MessageInterface::class));
     }
 
-    private function createTransport(): SinchTransport
+    private function createTransport(): SmsapiTransport
     {
-        return (new SinchTransport('accountSid', 'authToken', 'sender', $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new SmsapiTransport('testToken', 'testFrom', $this->createMock(HttpClientInterface::class)))->setHost('test.host');
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Smsapi Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -21,10 +21,9 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
- * TelegramTransport.
- *
  * To get the chat id, send a message in Telegram with the user you want
- * and then curl 'https://api.telegram.org/bot%token%/getUpdates' | json_pp
+ * and then execute curl 'https://api.telegram.org/bot%token%/getUpdates' | json_pp
+ * command.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
@@ -96,9 +95,9 @@ final class TelegramTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        $message = new SentMessage($message, (string) $this);
-        $message->setMessageId($success['result']['message_id']);
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($success['result']['message_id']);
 
-        return $message;
+        return $sentMessage;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportFactoryTest.php
@@ -33,6 +33,7 @@ final class TelegramTransportFactoryTest extends TestCase
         $factory = $this->createFactory();
 
         $this->expectException(IncompleteDsnException::class);
+
         $factory->create(Dsn::fromString('telegram://simpleToken@host.test?channel=testChannel'));
     }
 
@@ -41,6 +42,7 @@ final class TelegramTransportFactoryTest extends TestCase
         $factory = $this->createFactory();
 
         $this->expectException(IncompleteDsnException::class);
+
         $factory->create(Dsn::fromString('telegram://host.test?channel=testChannel'));
     }
 

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportTest.php
@@ -35,7 +35,7 @@ final class TwilioTransportTest extends TestCase
         $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
     }
 
-    public function testSendNonSmsMessageThrowsException()
+    public function testSendNonSmsMessageThrowsLogicException()
     {
         $transport = $this->createTransport();
 

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
@@ -76,9 +76,9 @@ final class TwilioTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        $message = new SentMessage($message, (string) $this);
-        $message->setMessageId($success['sid']);
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($success['sid']);
 
-        return $message;
+        return $sentMessage;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/README.md
@@ -1,20 +1,19 @@
 Zulip Notifier
 ==============
 
-Provides Zulip integration for Symfony Notifier.
+Provides [Zulip](https://zulip.comw) integration for Symfony Notifier.
 
 DSN example
 -----------
 
 ```
-// .env file
-ZULIP_DSN=zulip://EMAIL:TOKEN@default?channel=Channel
+ZULIP_DSN=zulip://EMAIL:TOKEN@default?channel=CHANNEL
 ```
 
 where:
  - `EMAIL` is your Zulip email
  - `TOKEN` is your Zulip token
- - `Channel` is the channel
+ - `CHANNEL` is the channel
 
 Resources
 ---------

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/Tests/ZulipTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/Tests/ZulipTransportFactoryTest.php
@@ -9,26 +9,23 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Notifier\Bridge\Mattermost\Tests;
+namespace Symfony\Component\Notifier\Bridge\Zulip\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
+use Symfony\Component\Notifier\Bridge\Zulip\ZulipTransportFactory;
 use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
 
-/**
- * @author Oskar Stark <oskarstark@googlemail.com>
- */
-final class MattermostTransportFactoryTest extends TestCase
+final class ZulipTransportFactoryTest extends TestCase
 {
     public function testCreateWithDsn()
     {
         $factory = $this->createFactory();
 
-        $transport = $factory->create(Dsn::fromString('mattermost://accessToken@host.test?channel=testChannel'));
+        $transport = $factory->create(Dsn::fromString('zulip://email:token@host.test?channel=testChannel'));
 
-        $this->assertSame('mattermost://host.test?channel=testChannel', (string) $transport);
+        $this->assertSame('zulip://host.test?channel=testChannel', (string) $transport);
     }
 
     public function testCreateWithMissingOptionChannelThrowsIncompleteDsnException()
@@ -37,30 +34,29 @@ final class MattermostTransportFactoryTest extends TestCase
 
         $this->expectException(IncompleteDsnException::class);
 
-        $factory->create(Dsn::fromString('mattermost://token@host'));
+        $factory->create(Dsn::fromString('zulip://email:token@host'));
     }
 
-    public function testCreateWithNoTokenThrowsIncompleteDsnException()
+    public function testCreateWithOnlyEmailOrTokenThrowsIncompleteDsnException()
     {
         $factory = $this->createFactory();
 
         $this->expectException(IncompleteDsnException::class);
-
-        $factory->create(Dsn::fromString('mattermost://host.test?channel=testChannel'));
+        $factory->create(Dsn::fromString('zulip://testOneOfEmailOrToken@host.test?channel=testChannel'));
     }
 
     public function testSupportsReturnsTrueWithSupportedScheme()
     {
         $factory = $this->createFactory();
 
-        $this->assertTrue($factory->supports(Dsn::fromString('mattermost://token@host?channel=testChannel')));
+        $this->assertTrue($factory->supports(Dsn::fromString('zulip://host?channel=testChannel')));
     }
 
     public function testSupportsReturnsFalseWithUnsupportedScheme()
     {
         $factory = $this->createFactory();
 
-        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://token@host?channel=testChannel')));
+        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://host?channel=testChannel')));
     }
 
     public function testUnsupportedSchemeThrowsUnsupportedSchemeException()
@@ -68,8 +64,7 @@ final class MattermostTransportFactoryTest extends TestCase
         $factory = $this->createFactory();
 
         $this->expectException(UnsupportedSchemeException::class);
-
-        $factory->create(Dsn::fromString('somethingElse://token@host?channel=testChannel'));
+        $factory->create(Dsn::fromString('somethingElse://email:token@host?channel=testChannel'));
     }
 
     public function testUnsupportedSchemeThrowsUnsupportedSchemeExceptionEvenIfRequiredOptionIsMissing()
@@ -79,11 +74,11 @@ final class MattermostTransportFactoryTest extends TestCase
         $this->expectException(UnsupportedSchemeException::class);
 
         // unsupported scheme and missing "channel" option
-        $factory->create(Dsn::fromString('somethingElse://token@host'));
+        $factory->create(Dsn::fromString('somethingElse://email:token@host'));
     }
 
-    private function createFactory(): MattermostTransportFactory
+    private function createFactory(): ZulipTransportFactory
     {
-        return new MattermostTransportFactory();
+        return new ZulipTransportFactory();
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/Tests/ZulipTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/Tests/ZulipTransportTest.php
@@ -9,43 +9,42 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Notifier\Bridge\Sinch\Tests;
+namespace Symfony\Component\Notifier\Bridge\Zulip\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Notifier\Bridge\Sinch\SinchTransport;
+use Symfony\Component\Notifier\Bridge\Zulip\ZulipTransport;
 use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
-use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class SinchTransportTest extends TestCase
+final class ZulipTransportTest extends TestCase
 {
     public function testToStringContainsProperties()
     {
         $transport = $this->createTransport();
 
-        $this->assertSame('sinch://host.test?from=sender', (string) $transport);
+        $this->assertSame('zulip://test.host?channel=testChannel', (string) $transport);
     }
 
-    public function testSupportsMessageInterface()
+    public function testSupportsChatMessage()
     {
         $transport = $this->createTransport();
 
-        $this->assertTrue($transport->supports(new SmsMessage('0611223344', 'Hello!')));
+        $this->assertTrue($transport->supports(new ChatMessage('testChatMessage')));
         $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
     }
 
-    public function testSendNonSmsMessageThrowsLogicException()
+    public function testSendNonChatMessageThrows()
     {
         $transport = $this->createTransport();
 
         $this->expectException(LogicException::class);
-
         $transport->send($this->createMock(MessageInterface::class));
     }
 
-    private function createTransport(): SinchTransport
+    private function createTransport(): ZulipTransport
     {
-        return (new SinchTransport('accountSid', 'authToken', 'sender', $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new ZulipTransport('testEmail', 'testToken', 'testChannel', $this->createMock(HttpClientInterface::class)))->setHost('test.host');
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransport.php
@@ -93,9 +93,9 @@ class ZulipTransport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        $message = new SentMessage($message, (string) $this);
-        $message->setMessageId($success['id']);
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($success['id']);
 
-        return $message;
+        return $sentMessage;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Zulip;
 
+use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -24,27 +25,30 @@ use Symfony\Component\Notifier\Transport\TransportInterface;
 class ZulipTransportFactory extends AbstractTransportFactory
 {
     /**
-     * {@inheritdoc}
+     * @return ZulipTransport
      */
     public function create(Dsn $dsn): TransportInterface
     {
         $scheme = $dsn->getScheme();
+
+        if ('zulip' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'zulip', $this->getSupportedSchemes());
+        }
+
         $email = $this->getUser($dsn);
         $token = $this->getPassword($dsn);
         $channel = $dsn->getOption('channel');
+
+        if (!$channel) {
+            throw new IncompleteDsnException('Missing channel.', $dsn->getOriginalDsn());
+        }
+
         $host = $dsn->getHost();
         $port = $dsn->getPort();
 
-        if ('zulip' === $scheme) {
-            return (new ZulipTransport($email, $token, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
-        }
-
-        throw new UnsupportedSchemeException($dsn, 'zulip', $this->getSupportedSchemes());
+        return (new ZulipTransport($email, $token, $channel, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function getSupportedSchemes(): array
     {
         return ['zulip'];

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Zulip Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

This PR

* add missing tests
* pull up scheme check (check scheme first and then for required options)
* streamlines README.md files

While working on adding tests for `symfony/esendex-notifier` I noticed that the `EsendexTransport` has the following signature:
https://github.com/symfony/symfony/blob/613ac0c0e9686b59383e99209fede496c2eb765b/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransport.php#L36

and is resolved by the `EsendexTransportFactory` like:
https://github.com/symfony/symfony/blob/613ac0c0e9686b59383e99209fede496c2eb765b/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransportFactory.php#L30

but the `README` exposes the DSN like:
```
esendex://EMAIL:PASSWORD@default?accountreference=ACCOUNT_REFERENCE&from=FROM
```
as this Bridge is experimental in `5.2`I propose to change the transport signature like, because to me it is more email/password like described in the readme than a "token":
```diff
- public function __construct(string $token, string $accountReference, string $from, HttpClientInterface $client = null, 
EventDispatcherInterface $dispatcher = null)
+ public function __construct(string $email, string $password, string $accountReference, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
```

What do you think?

cc @odolbeau as you provided the Esendex bridge.