### PR TITLE
[Cache] Make use of `read_timeout` in `\RedisSentinel` and `\Redis`

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -184,7 +184,7 @@ trait RedisTrait
                 $port = $hosts[0]['port'] ?? null;
 
                 if (isset($params['redis_sentinel'])) {
-                    $sentinel = new \RedisSentinel($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval']);
+                    $sentinel = new \RedisSentinel($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout']);
 
                     if (![$host, $port] = $sentinel->getMasterAddrByName($params['redis_sentinel'])) {
                         throw new InvalidArgumentException(sprintf('Failed to retrieve master information from master name "%s" and address "%s:%d".', $params['redis_sentinel'], $host, $port));
@@ -192,7 +192,7 @@ trait RedisTrait
                 }
 
                 try {
-                    @$redis->{$connect}($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval']);
+                    @$redis->{$connect}($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout']);
 
                     set_error_handler(function ($type, $msg) use (&$error) { $error = $msg; });
                     $isConnected = $redis->isConnected();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39429
| License       | MIT

This is a bugfix for #39363 a feature introduced in 5.x

As described in issue #39429, `\RedisSentinel` accepts an optional read timeout value during construction. 
`read_timeout` is already part of the connection options, this PR just make use of it.
