### PR TITLE
[Cache] Bugfix provide the correct host and port when throwing the exception

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
@@ -41,4 +41,13 @@ class RedisAdapterSentinelTest extends AbstractRedisAdapterTest
         $dsn = 'redis:?host[redis1]&host[redis2]&host[redis3]&redis_cluster=1&redis_sentinel=mymaster';
         RedisAdapter::createConnection($dsn);
     }
+
+    public function testExceptionMessageWhenFailingToRetrieveMasterInformation()
+    {
+        $hosts = getenv('REDIS_SENTINEL_HOSTS');
+        $firstHost = explode(' ', $hosts)[0];
+        $this->expectException('Symfony\Component\Cache\Exception\InvalidArgumentException');
+        $this->expectExceptionMessage('Failed to retrieve master information from master name "invalid-masterset-name" and address "'.$firstHost.'".');
+        AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['redis_sentinel' => 'invalid-masterset-name']);
+    }
 }

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -186,9 +186,11 @@ trait RedisTrait
                 if (isset($params['redis_sentinel'])) {
                     $sentinel = new \RedisSentinel($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout']);
 
-                    if (![$host, $port] = $sentinel->getMasterAddrByName($params['redis_sentinel'])) {
+                    if (!$address = $sentinel->getMasterAddrByName($params['redis_sentinel'])) {
                         throw new InvalidArgumentException(sprintf('Failed to retrieve master information from master name "%s" and address "%s:%d".', $params['redis_sentinel'], $host, $port));
                     }
+
+                    [$host, $port] = $address;
                 }
 
                 try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | none

The message before was including the result of the `getMasterAddrByName` call of which ended with:
```
Failed to retrieve master information from master name "mymaster" and address ":0".
```