### PR TITLE
[Form] Errors Property Paths mismatch CollectionType children when removing an entry

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate not configuring the `default_protocol` option of the `UrlType`, it will default to `null` in 8.0
+ * Add a `keep_as_list` option to `CollectionType`
 
 7.0
 ---

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -45,7 +45,8 @@ class CollectionType extends AbstractType
             $options['allow_add'],
             $options['allow_delete'],
             $options['delete_empty'],
-            $resizePrototypeOptions
+            $resizePrototypeOptions,
+            $options['keep_as_list']
         );
 
         $builder->addEventSubscriber($resizeListener);
@@ -114,12 +115,14 @@ class CollectionType extends AbstractType
             'prototype_options' => [],
             'delete_empty' => false,
             'invalid_message' => 'The collection is invalid.',
+            'keep_as_list' => false,
         ]);
 
         $resolver->setNormalizer('entry_options', $entryOptionsNormalizer);
 
         $resolver->setAllowedTypes('delete_empty', ['bool', 'callable']);
         $resolver->setAllowedTypes('prototype_options', 'array');
+        $resolver->setAllowedTypes('keep_as_list', ['bool']);
     }
 
     public function getBlockPrefix(): string

--- a/src/Symfony/Component/Form/Tests/Fixtures/Organization.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Organization.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+class Organization
+{
+    public $authors = [];
+
+    public function __construct(array $authors = [])
+    {
+        $this->authors = $authors;
+    }
+
+    public function getAuthors(): array
+    {
+        return $this->authors;
+    }
+
+    public function addAuthor(Author $author): self
+    {
+        $this->authors[] = $author;
+        return $this;
+    }
+
+    public function removeAuthor(Author $author): self
+    {
+        if (false !== $key = array_search($author, $this->authors, true)) {
+            array_splice($this->authors, $key, 1);
+        }
+        return $this;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

**Description**  
When you remove an entry from `CollectionType` and you have errors on children, errors property paths generated by `ValidatorExtension` are matching final object collection indexes but do not match From children entries index/names.

**How to reproduce**  
_Unit test provided._

**Solution**  
Introduce new feature with `keep_as_list` (`boolean` default to `false`) option to reindex children on submit.