### PR TITLE
Fix enabled key for ratelimiter config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1816,7 +1816,7 @@ class Configuration implements ConfigurationInterface
                         ->ifTrue(function ($v) { return \is_array($v) && !isset($v['limiters']) && !isset($v['limiter']); })
                         ->then(function (array $v) {
                             $newV = [
-                                'enabled' => $v['enabled'],
+                                'enabled' => $v['enabled'] ?? true,
                             ];
                             unset($v['enabled']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The `enabled` key doesn't always exist in the config when using the ratelimiter component, which causes an undefined index error