### PR TITLE
[Serializer] Fix EncoderInterface::encode() return type

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
@@ -25,7 +25,7 @@ interface EncoderInterface
      * @param string $format  Format name
      * @param array  $context Options that normalizers/encoders have access to
      *
-     * @return string|int|float|bool
+     * @return string
      *
      * @throws UnexpectedValueException
      */

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
@@ -67,9 +67,9 @@ class ChainEncoderTest extends TestCase
     public function testEncode()
     {
         $this->encoder1->expects($this->never())->method('encode');
-        $this->encoder2->expects($this->once())->method('encode');
+        $this->encoder2->expects($this->once())->method('encode')->willReturn('foo:123');
 
-        $this->chainEncoder->encode(['foo' => 123], self::FORMAT_2);
+        $this->assertSame('foo:123', $this->chainEncoder->encode(['foo' => 123], self::FORMAT_2));
     }
 
     public function testEncodeUnsupportedFormat()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N.A.
| License       | MIT
| Doc PR        | N.A.

I might have missed something (in that case, please let me know), but I believe that `EncoderInterface::encode()` will and should always return a `string`. This makes more sense because `DecoderInterface::decode()` only accepts a string as input.