### PR TITLE
[Notifier] [Free Mobile] Fix wrong scheme in mapping

### DIFF
--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -50,7 +50,7 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Firebase\FirebaseTransportFactory::class,
             'package' => 'symfony/firebase-notifier',
         ],
-        'free-mobile' => [
+        'freemobile' => [
             'class' => Bridge\FreeMobile\FreeMobileTransportFactory::class,
             'package' => 'symfony/free-mobile-notifier',
         ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

The scheme is `freemobile`, not `free-mobile`

For reference:
https://github.com/symfony/symfony/blob/134af39538aed24c37810b605bea736c64a37b49/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransportFactory.php#L41-L43