### PR TITLE
[Notifier] [DX] Dsn::getRequiredOption()

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/DiscordTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Discord;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -34,12 +33,7 @@ final class DiscordTransportFactory extends AbstractTransportFactory
         }
 
         $token = $this->getUser($dsn);
-        $webhookId = $dsn->getOption('webhook_id');
-
-        if (!$webhookId) {
-            throw new IncompleteDsnException('Missing webhook_id.', $dsn->getOriginalDsn());
-        }
-
+        $webhookId = $dsn->getRequiredOption('webhook_id');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportFactoryTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\Discord\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Discord\DiscordTransportFactory;
 use Symfony\Component\Notifier\Exception\IncompleteDsnException;
+use Symfony\Component\Notifier\Exception\MissingRequiredOptionException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
 
@@ -28,11 +29,11 @@ final class DiscordTransportFactoryTest extends TestCase
         $this->assertSame('discord://host.test?webhook_id=testWebhookId', (string) $transport);
     }
 
-    public function testCreateWithMissingOptionWebhookIdThrowsIncompleteDsnException()
+    public function testCreateWithMissingOptionWebhookIdThrowsMissingRequiredOptionException()
     {
         $factory = $this->createFactory();
 
-        $this->expectException(IncompleteDsnException::class);
+        $this->expectException(MissingRequiredOptionException::class);
 
         $factory->create(Dsn::fromString('discord://token@host'));
     }

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Esendex;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -32,18 +31,8 @@ final class EsendexTransportFactory extends AbstractTransportFactory
 
         $email = $this->getUser($dsn);
         $password = $this->getPassword($dsn);
-        $accountReference = $dsn->getOption('accountreference');
-
-        if (!$accountReference) {
-            throw new IncompleteDsnException('Missing accountreference.', $dsn->getOriginalDsn());
-        }
-
-        $from = $dsn->getOption('from');
-
-        if (!$from) {
-            throw new IncompleteDsnException('Missing from.', $dsn->getOriginalDsn());
-        }
-
+        $accountReference = $dsn->getRequiredOption('accountreference');
+        $from = $dsn->getRequiredOption('from');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportFactoryTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\Esendex\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
 use Symfony\Component\Notifier\Exception\IncompleteDsnException;
+use Symfony\Component\Notifier\Exception\MissingRequiredOptionException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
 
@@ -46,20 +47,20 @@ final class EsendexTransportFactoryTest extends TestCase
         $factory->create(Dsn::fromString('esendex://email:@host?accountreference=testAccountreference&from=FROM'));
     }
 
-    public function testCreateWithMissingOptionAccountreferenceThrowsIncompleteDsnException()
+    public function testCreateWithMissingOptionAccountreferenceThrowsMissingRequiredOptionException()
     {
         $factory = $this->createFactory();
 
-        $this->expectException(IncompleteDsnException::class);
+        $this->expectException(MissingRequiredOptionException::class);
 
         $factory->create(Dsn::fromString('esendex://email:password@host?from=FROM'));
     }
 
-    public function testCreateWithMissingOptionFromThrowsIncompleteDsnException()
+    public function testCreateWithMissingOptionFromThrowsMissingRequiredOptionException()
     {
         $factory = $this->createFactory();
 
-        $this->expectException(IncompleteDsnException::class);
+        $this->expectException(MissingRequiredOptionException::class);
 
         $factory->create(Dsn::fromString('esendex://email:password@host?accountreference=ACCOUNTREFERENCE'));
     }

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\FreeMobile;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -35,11 +34,7 @@ final class FreeMobileTransportFactory extends AbstractTransportFactory
 
         $login = $this->getUser($dsn);
         $password = $this->getPassword($dsn);
-        $phone = $dsn->getOption('phone');
-
-        if (!$phone) {
-            throw new IncompleteDsnException('Missing phone.', $dsn->getOriginalDsn());
-        }
+        $phone = $dsn->getRequiredOption('phone');
 
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportFactoryTest.php
@@ -39,7 +39,7 @@ final class FreeMobileTransportFactoryTest extends TransportFactoryTestCase
         yield [false, 'somethingElse://login:pass@default?phone=0611223344'];
     }
 
-    public function incompleteDsnProvider(): iterable
+    public function missingRequiredOptionProvider(): iterable
     {
         yield 'missing option: phone' => ['freemobile://login:pass@default'];
     }

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/InfobipTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/InfobipTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Infobip;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -35,13 +34,9 @@ final class InfobipTransportFactory extends AbstractTransportFactory
         }
 
         $authToken = $this->getUser($dsn);
-        $from = $dsn->getOption('from');
+        $from = $dsn->getRequiredOption('from');
         $host = $dsn->getHost();
         $port = $dsn->getPort();
-
-        if (!$from) {
-            throw new IncompleteDsnException('Missing from.', $dsn->getOriginalDsn());
-        }
 
         return (new InfobipTransport($authToken, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/Tests/InfobipTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/Tests/InfobipTransportFactoryTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Infobip\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Infobip\InfobipTransportFactory;
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
+use Symfony\Component\Notifier\Exception\MissingRequiredOptionException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
 
@@ -28,11 +28,11 @@ final class InfobipTransportFactoryTest extends TestCase
         $this->assertSame('infobip://host.test?from=0611223344', (string) $transport);
     }
 
-    public function testCreateWithNoFromThrowsIncompleteDsnException()
+    public function testCreateWithNoFromThrowsMissingRequiredOptionException()
     {
         $factory = $this->createFactory();
 
-        $this->expectException(IncompleteDsnException::class);
+        $this->expectException(MissingRequiredOptionException::class);
         $factory->create(Dsn::fromString('infobip://authtoken@default'));
     }
 

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/IqsmsTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Iqsms;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -35,12 +34,7 @@ final class IqsmsTransportFactory extends AbstractTransportFactory
 
         $login = $this->getUser($dsn);
         $password = $this->getPassword($dsn);
-        $from = $dsn->getOption('from');
-
-        if (!$from) {
-            throw new IncompleteDsnException('Missing from.', $dsn->getOriginalDsn());
-        }
-
+        $from = $dsn->getRequiredOption('from');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Mattermost;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -32,12 +31,7 @@ final class MattermostTransportFactory extends AbstractTransportFactory
 
         $path = $dsn->getPath();
         $token = $this->getUser($dsn);
-        $channel = $dsn->getOption('channel');
-
-        if (!$channel) {
-            throw new IncompleteDsnException('Missing channel.', $dsn->getOriginalDsn());
-        }
-
+        $channel = $dsn->getRequiredOption('channel');
         $host = $dsn->getHost();
         $port = $dsn->getPort();
 

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportFactoryTest.php
@@ -59,7 +59,11 @@ final class MattermostTransportFactoryTest extends TransportFactoryTestCase
 
     public function incompleteDsnProvider(): iterable
     {
-        yield 'missing option: token' => ['mattermost://host.test?channel=testChannel'];
+        yield 'missing token' => ['mattermost://host.test?channel=testChannel'];
+    }
+
+    public function missingRequiredOptionProvider(): iterable
+    {
         yield 'missing option: channel' => ['mattermost://token@host'];
     }
 

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Mobyt;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -35,12 +34,7 @@ final class MobytTransportFactory extends AbstractTransportFactory
 
         $accountSid = $this->getUser($dsn);
         $authToken = $this->getPassword($dsn);
-        $from = $dsn->getOption('from');
-
-        if (!$from) {
-            throw new IncompleteDsnException('Missing from.', $dsn->getOriginalDsn());
-        }
-
+        $from = $dsn->getRequiredOption('from');
         $typeQuality = $dsn->getOption('type_quality', MobytOptions::MESSAGE_TYPE_QUALITY_LOW);
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/NexmoTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/NexmoTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Nexmo;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -35,12 +34,7 @@ final class NexmoTransportFactory extends AbstractTransportFactory
 
         $apiKey = $this->getUser($dsn);
         $apiSecret = $this->getPassword($dsn);
-        $from = $dsn->getOption('from');
-
-        if (!$from) {
-            throw new IncompleteDsnException('Missing from.', $dsn->getOriginalDsn());
-        }
-
+        $from = $dsn->getRequiredOption('from');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/Tests/NexmoTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/Tests/NexmoTransportFactoryTest.php
@@ -39,7 +39,7 @@ final class NexmoTransportFactoryTest extends TransportFactoryTestCase
         yield [false, 'somethingElse://apiKey:apiSecret@default?from=0611223344'];
     }
 
-    public function incompleteDsnProvider(): iterable
+    public function missingRequiredOptionProvider(): iterable
     {
         yield 'missing option: from' => ['nexmo://apiKey:apiSecret@default'];
     }

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\OvhCloud;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -32,18 +31,8 @@ final class OvhCloudTransportFactory extends AbstractTransportFactory
 
         $applicationKey = $this->getUser($dsn);
         $applicationSecret = $this->getPassword($dsn);
-        $consumerKey = $dsn->getOption('consumer_key');
-
-        if (!$consumerKey) {
-            throw new IncompleteDsnException('Missing consumer_key.', $dsn->getOriginalDsn());
-        }
-
-        $serviceName = $dsn->getOption('service_name');
-
-        if (!$serviceName) {
-            throw new IncompleteDsnException('Missing service_name.', $dsn->getOriginalDsn());
-        }
-
+        $consumerKey = $dsn->getRequiredOption('consumer_key');
+        $serviceName = $dsn->getRequiredOption('service_name');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportFactoryTest.php
@@ -39,7 +39,7 @@ final class OvhCloudTransportFactoryTest extends TransportFactoryTestCase
         yield [false, 'somethingElse://key:secret@default?consumer_key=consumerKey&service_name=serviceName'];
     }
 
-    public function incompleteDsnProvider(): iterable
+    public function missingRequiredOptionProvider(): iterable
     {
         yield 'missing option: consumer_key' => ['ovhcloud://key:secret@default?service_name=serviceName'];
         yield 'missing option: service_name' => ['ovhcloud://key:secret@default?consumer_key=consumerKey'];

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportFactoryTest.php
@@ -44,7 +44,7 @@ final class RocketChatTransportFactoryTest extends TransportFactoryTestCase
 
     public function incompleteDsnProvider(): iterable
     {
-        yield 'missing option: token' => ['rocketchat://host.test?channel=testChannel'];
+        yield 'missing token' => ['rocketchat://host.test?channel=testChannel'];
     }
 
     public function unsupportedSchemeProvider(): iterable

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/SendinblueTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/SendinblueTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Sendinblue;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -34,12 +33,7 @@ final class SendinblueTransportFactory extends AbstractTransportFactory
         }
 
         $apiKey = $this->getUser($dsn);
-        $sender = $dsn->getOption('sender');
-
-        if (!$sender) {
-            throw new IncompleteDsnException('Missing sender.', $dsn->getOriginalDsn());
-        }
-
+        $sender = $dsn->getRequiredOption('sender');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportFactoryTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\Sendinblue\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Sendinblue\SendinblueTransportFactory;
 use Symfony\Component\Notifier\Exception\IncompleteDsnException;
+use Symfony\Component\Notifier\Exception\MissingRequiredOptionException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
 
@@ -28,11 +29,11 @@ final class SendinblueTransportFactoryTest extends TestCase
         $this->assertSame('sendinblue://host.test?sender=0611223344', (string) $transport);
     }
 
-    public function testCreateWithMissingOptionSenderThrowsIncompleteDsnException()
+    public function testCreateWithMissingOptionSenderThrowsMissingRequiredOptionException()
     {
         $factory = $this->createFactory();
 
-        $this->expectException(IncompleteDsnException::class);
+        $this->expectException(MissingRequiredOptionException::class);
 
         $factory->create(Dsn::fromString('sendinblue://apiKey@host.test'));
     }

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/SinchTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Sinch;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -32,12 +31,7 @@ final class SinchTransportFactory extends AbstractTransportFactory
 
         $accountSid = $this->getUser($dsn);
         $authToken = $this->getPassword($dsn);
-        $from = $dsn->getOption('from');
-
-        if (!$from) {
-            throw new IncompleteDsnException('Missing from.', $dsn->getOriginalDsn());
-        }
-
+        $from = $dsn->getRequiredOption('from');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/Tests/SinchTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/Tests/SinchTransportFactoryTest.php
@@ -39,7 +39,7 @@ final class SinchTransportFactoryTest extends TransportFactoryTestCase
         yield [false, 'somethingElse://accountSid:authToken@default?from=0611223344'];
     }
 
-    public function incompleteDsnProvider(): iterable
+    public function missingRequiredOptionProvider(): iterable
     {
         yield 'missing option: from' => ['sinch://accountSid:authToken@default'];
     }

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/SmsapiTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Smsapi;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -36,12 +35,7 @@ final class SmsapiTransportFactory extends AbstractTransportFactory
         }
 
         $authToken = $this->getUser($dsn);
-        $from = $dsn->getOption('from');
-
-        if (!$from) {
-            throw new IncompleteDsnException('Missing from.', $dsn->getOriginalDsn());
-        }
-
+        $from = $dsn->getRequiredOption('from');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportFactoryTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\Smsapi\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Smsapi\SmsapiTransportFactory;
 use Symfony\Component\Notifier\Exception\IncompleteDsnException;
+use Symfony\Component\Notifier\Exception\MissingRequiredOptionException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
 
@@ -28,11 +29,11 @@ final class SmsapiTransportFactoryTest extends TestCase
         $this->assertSame('smsapi://host.test?from=testFrom', (string) $transport);
     }
 
-    public function testCreateWithMissingOptionFromThrowsIncompleteDsnException()
+    public function testCreateWithMissingOptionFromThrowsMissingRequiredOptionException()
     {
         $factory = $this->createFactory();
 
-        $this->expectException(IncompleteDsnException::class);
+        $this->expectException(MissingRequiredOptionException::class);
 
         $factory->create(Dsn::fromString('smsapi://token@host'));
     }

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportFactoryTest.php
@@ -39,7 +39,7 @@ final class TwilioTransportFactoryTest extends TransportFactoryTestCase
         yield [false, 'somethingElse://accountSid:authToken@default?from=0611223344'];
     }
 
-    public function incompleteDsnProvider(): iterable
+    public function missingRequiredOptionProvider(): iterable
     {
         yield 'missing option: from' => ['twilio://accountSid:authToken@default'];
     }

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Twilio;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -35,12 +34,7 @@ final class TwilioTransportFactory extends AbstractTransportFactory
 
         $accountSid = $this->getUser($dsn);
         $authToken = $this->getPassword($dsn);
-        $from = $dsn->getOption('from');
-
-        if (!$from) {
-            throw new IncompleteDsnException('Missing from.', $dsn->getOriginalDsn());
-        }
-
+        $from = $dsn->getRequiredOption('from');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/Tests/ZulipTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/Tests/ZulipTransportFactoryTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\Zulip\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Zulip\ZulipTransportFactory;
 use Symfony\Component\Notifier\Exception\IncompleteDsnException;
+use Symfony\Component\Notifier\Exception\MissingRequiredOptionException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
 
@@ -28,11 +29,11 @@ final class ZulipTransportFactoryTest extends TestCase
         $this->assertSame('zulip://host.test?channel=testChannel', (string) $transport);
     }
 
-    public function testCreateWithMissingOptionChannelThrowsIncompleteDsnException()
+    public function testCreateWithMissingOptionChannelThrowsMissingRequiredOptionException()
     {
         $factory = $this->createFactory();
 
-        $this->expectException(IncompleteDsnException::class);
+        $this->expectException(MissingRequiredOptionException::class);
 
         $factory->create(Dsn::fromString('zulip://email:token@host'));
     }

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\Zulip;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -35,12 +34,7 @@ final class ZulipTransportFactory extends AbstractTransportFactory
 
         $email = $this->getUser($dsn);
         $token = $this->getPassword($dsn);
-        $channel = $dsn->getOption('channel');
-
-        if (!$channel) {
-            throw new IncompleteDsnException('Missing channel.', $dsn->getOriginalDsn());
-        }
-
+        $channel = $dsn->getRequiredOption('channel');
         $host = $dsn->getHost();
         $port = $dsn->getPort();
 

--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * The component is not marked as `@experimental` anymore
 * [BC BREAK] Changed the return type of `AbstractTransportFactory::getEndpoint()` from `?string` to `string`
+ * Added `DSN::getRequiredOption` method which throws a new `MissingRequiredOptionException`.
 
 5.2.0
 -----

--- a/src/Symfony/Component/Notifier/Exception/MissingRequiredOptionException.php
+++ b/src/Symfony/Component/Notifier/Exception/MissingRequiredOptionException.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Exception;
+
+/**
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ *
+ * @experimental in 5.3
+ */
+class MissingRequiredOptionException extends IncompleteDsnException
+{
+    public function __construct(string $option, string $dsn = null, ?\Throwable $previous = null)
+    {
+        $message = sprintf('The option "%s" is required but missing.', $option);
+
+        parent::__construct($message, $dsn, $previous);
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/TransportFactoryTestCase.php
+++ b/src/Symfony/Component/Notifier/Tests/TransportFactoryTestCase.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Exception\MissingRequiredOptionException;
 use Symfony\Component\Notifier\Transport\Dsn;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
@@ -48,6 +49,14 @@ abstract class TransportFactoryTestCase extends TestCase
      * @return iterable<array{0: string, 1: string|null}>
      */
     public function incompleteDsnProvider(): iterable
+    {
+        return [];
+    }
+
+    /**
+     * @return iterable<array{0: string, 1: string|null}>
+     */
+    public function missingRequiredOptionProvider(): iterable
     {
         return [];
     }
@@ -100,6 +109,23 @@ abstract class TransportFactoryTestCase extends TestCase
         $dsn = Dsn::fromString($dsn);
 
         $this->expectException(IncompleteDsnException::class);
+        if (null !== $message) {
+            $this->expectExceptionMessage($message);
+        }
+
+        $factory->create($dsn);
+    }
+
+    /**
+     * @dataProvider missingRequiredOptionProvider
+     */
+    public function testMissingRequiredOptionException(string $dsn, string $message = null): void
+    {
+        $factory = $this->createFactory();
+
+        $dsn = Dsn::fromString($dsn);
+
+        $this->expectException(MissingRequiredOptionException::class);
         if (null !== $message) {
             $this->expectExceptionMessage($message);
         }

--- a/src/Symfony/Component/Notifier/Transport/Dsn.php
+++ b/src/Symfony/Component/Notifier/Transport/Dsn.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Transport;
 
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
+use Symfony\Component\Notifier\Exception\MissingRequiredOptionException;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -92,6 +93,15 @@ final class Dsn
     public function getOption(string $key, $default = null)
     {
         return $this->options[$key] ?? $default;
+    }
+
+    public function getRequiredOption(string $key)
+    {
+        if (!\array_key_exists($key, $this->options) || '' === trim($this->options[$key])) {
+            throw new MissingRequiredOptionException($key);
+        }
+
+        return $this->options[$key];
     }
 
     public function getPath(): ?string

--- a/src/Symfony/Component/Notifier/Transport/TransportFactoryInterface.php
+++ b/src/Symfony/Component/Notifier/Transport/TransportFactoryInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Transport;
 
 use Symfony\Component\Notifier\Exception\IncompleteDsnException;
+use Symfony\Component\Notifier\Exception\MissingRequiredOptionException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 
 /**
@@ -22,6 +23,7 @@ interface TransportFactoryInterface
     /**
      * @throws UnsupportedSchemeException
      * @throws IncompleteDsnException
+     * @throws MissingRequiredOptionException
      */
     public function create(Dsn $dsn): TransportInterface;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

### Todo
* [x] use the new method in all available bridges and bump composer.json files to `notifer:5.3`
* [x] add tests

This will lead to a much cleaner "communication" between the factory and the transport which option is required and which is optional. This method will also reduce the code duplication in the bridges.

IMHO we should add more of those convenient "helpers" to lower the burden for new bridges.