### PR TITLE
Remove void return type from test methods

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -156,7 +156,7 @@ class MyListener
     public $calledByInvokeCount = 0;
     public $calledByEventNameCount = 0;
 
-    public function __invoke(): void
+    public function __invoke()
     {
         ++$this->calledByInvokeCount;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1447,7 +1447,7 @@ abstract class FrameworkExtensionTest extends TestCase
     /**
      * @dataProvider provideMailer
      */
-    public function testMailer(string $configFile, array $expectedTransports): void
+    public function testMailer(string $configFile, array $expectedTransports)
     {
         $container = $this->createContainerFromFile($configFile);
 
@@ -1463,14 +1463,14 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals(new Reference('messenger.default_bus', ContainerInterface::NULL_ON_INVALID_REFERENCE), $container->getDefinition('mailer.mailer')->getArgument(1));
     }
 
-    public function testMailerWithDisabledMessageBus(): void
+    public function testMailerWithDisabledMessageBus()
     {
         $container = $this->createContainerFromFile('mailer_with_disabled_message_bus');
 
         $this->assertNull($container->getDefinition('mailer.mailer')->getArgument(1));
     }
 
-    public function testMailerWithSpecificMessageBus(): void
+    public function testMailerWithSpecificMessageBus()
     {
         $container = $this->createContainerFromFile('mailer_with_specific_message_bus');
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/EventAliasTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/EventAliasTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Http\SecurityEvents;
 
 final class EventAliasTest extends AbstractWebTestCase
 {
-    public function testAliasedEvents(): void
+    public function testAliasedEvents()
     {
         $client = $this->createClient(['test_case' => 'AliasedEvents', 'root_config' => 'config.yml']);
         $container = $client->getContainer();

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -872,7 +872,7 @@ class ProgressBarTest extends TestCase
         ];
     }
 
-    public function testIterate(): void
+    public function testIterate()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 0, 0);
 
@@ -887,7 +887,7 @@ class ProgressBarTest extends TestCase
         );
     }
 
-    public function testIterateUncountable(): void
+    public function testIterateUncountable()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 0, 0);
 
@@ -936,7 +936,7 @@ class ProgressBarTest extends TestCase
         putenv('COLUMNS=120');
     }
 
-    public function testMinAndMaxSecondsBetweenRedraws(): void
+    public function testMinAndMaxSecondsBetweenRedraws()
     {
         $bar = new ProgressBar($output = $this->getOutputStream());
         $bar->setRedrawFrequency(1);
@@ -959,7 +959,7 @@ class ProgressBarTest extends TestCase
         );
     }
 
-    public function testMaxSecondsBetweenRedraws(): void
+    public function testMaxSecondsBetweenRedraws()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 0, 0);
         $bar->setRedrawFrequency(4); // disable step based redraws
@@ -1014,7 +1014,7 @@ class ProgressBarTest extends TestCase
         );
     }
 
-    public function testNoWriteWhenMessageIsSame(): void
+    public function testNoWriteWhenMessageIsSame()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 2);
         $bar->start();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/StringToFloatTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/StringToFloatTransformerTest.php
@@ -30,21 +30,21 @@ class StringToFloatTransformerTest extends TestCase
     /**
      * @dataProvider provideTransformations
      */
-    public function testTransform($from, $to): void
+    public function testTransform($from, $to)
     {
         $transformer = new StringToFloatTransformer();
 
         $this->assertSame($to, $transformer->transform($from));
     }
 
-    public function testFailIfTransformingANonString(): void
+    public function testFailIfTransformingANonString()
     {
         $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new StringToFloatTransformer();
         $transformer->transform(1.0);
     }
 
-    public function testFailIfTransformingANonNumericString(): void
+    public function testFailIfTransformingANonNumericString()
     {
         $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new StringToFloatTransformer();
@@ -70,14 +70,14 @@ class StringToFloatTransformerTest extends TestCase
     /**
      * @dataProvider provideReverseTransformations
      */
-    public function testReverseTransform($from, $to, int $scale = null): void
+    public function testReverseTransform($from, $to, int $scale = null)
     {
         $transformer = new StringToFloatTransformer($scale);
 
         $this->assertSame($to, $transformer->reverseTransform($from));
     }
 
-    public function testFailIfReverseTransformingANonNumeric(): void
+    public function testFailIfReverseTransformingANonNumeric()
     {
         $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new StringToFloatTransformer();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -37,7 +37,7 @@ class NumberTypeTest extends BaseTypeTest
         \Locale::setDefault($this->defaultLocale);
     }
 
-    public function testDefaultFormatting(): void
+    public function testDefaultFormatting()
     {
         $form = $this->factory->create(static::TESTED_TYPE);
         $form->setData('12345.67890');
@@ -45,7 +45,7 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertSame('12345,679', $form->createView()->vars['value']);
     }
 
-    public function testDefaultFormattingWithGrouping(): void
+    public function testDefaultFormattingWithGrouping()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['grouping' => true]);
         $form->setData('12345.67890');
@@ -53,7 +53,7 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertSame('12.345,679', $form->createView()->vars['value']);
     }
 
-    public function testDefaultFormattingWithScale(): void
+    public function testDefaultFormattingWithScale()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['scale' => 2]);
         $form->setData('12345.67890');
@@ -61,7 +61,7 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertSame('12345,68', $form->createView()->vars['value']);
     }
 
-    public function testDefaultFormattingWithScaleFloat(): void
+    public function testDefaultFormattingWithScaleFloat()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['scale' => 2]);
         $form->setData(12345.67890);
@@ -69,7 +69,7 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertSame('12345,68', $form->createView()->vars['value']);
     }
 
-    public function testDefaultFormattingWithScaleAndStringInput(): void
+    public function testDefaultFormattingWithScaleAndStringInput()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['scale' => 2, 'input' => 'string']);
         $form->setData('12345.67890');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

This PR follows #39459 

cc @nicolas-grekas 
