### PR TITLE
[Lock] Handle store exception on exists check

### DIFF
--- a/src/Symfony/Component/Lock/Store/CombinedStore.php
+++ b/src/Symfony/Component/Lock/Store/CombinedStore.php
@@ -199,9 +199,14 @@ class CombinedStore implements SharedLockStoreInterface, LoggerAwareInterface
         $storesCount = \count($this->stores);
 
         foreach ($this->stores as $store) {
-            if ($store->exists($key)) {
-                ++$successCount;
-            } else {
+            try {
+                if ($store->exists($key)) {
+                    ++$successCount;
+                } else {
+                    ++$failureCount;
+                }
+            } catch (\Exception $e) {
+                $this->logger->debug('One store failed to check the "{resource}" lock.', ['resource' => $key, 'store' => $store, 'exception' => $e]);
                 ++$failureCount;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #39470 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Handle exception to preserve expected behavior - one or multiple stores could be unreachable in a moment and combined store will handle this according to strategy.
