### PR TITLE
Use more explicit variable name

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -37,19 +37,19 @@ trait MicroKernelTrait
      *
      * You can register extensions:
      *
-     *     $c->loadFromExtension('framework', [
+     *     $container->loadFromExtension('framework', [
      *         'secret' => '%secret%'
      *     ]);
      *
      * Or services:
      *
-     *     $c->register('halloween', 'FooBundle\HalloweenProvider');
+     *     $container->register('halloween', 'FooBundle\HalloweenProvider');
      *
      * Or parameters:
      *
-     *     $c->setParameter('halloween', 'lot of fun');
+     *     $container->setParameter('halloween', 'lot of fun');
      */
-    abstract protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader);
+    abstract protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader);
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files --> -->
| License       | MIT

- This is called `$container` in https://symfony.com/blog/new-in-symfony-5-1-improved-microkernel.
- In the same file, in `registerContainerConfiguration` we're doing `$this->configureContainer($container, $loader);`.

So I think that `$container` is better than `$c`.