### PR TITLE
[Lock] Prevent store exception break combined store

### DIFF
--- a/src/Symfony/Component/Lock/Store/CombinedStore.php
+++ b/src/Symfony/Component/Lock/Store/CombinedStore.php
@@ -171,9 +171,14 @@ class CombinedStore implements StoreInterface, LoggerAwareInterface
         $storesCount = \count($this->stores);
 
         foreach ($this->stores as $store) {
-            if ($store->exists($key)) {
-                ++$successCount;
-            } else {
+            try {
+                if ($store->exists($key)) {
+                    ++$successCount;
+                } else {
+                    ++$failureCount;
+                }
+            } catch (\Exception $e) {
+                $this->logger->debug('One store failed to check the "{resource}" lock.', ['resource' => $key, 'store' => $store, 'exception' => $e]);
                 ++$failureCount;
             }
 

--- a/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/CombinedStoreTest.php
@@ -351,4 +351,29 @@ class CombinedStoreTest extends AbstractStoreTest
 
         $this->store->delete($key);
     }
+
+    public function testExistsDontStopOnFailure()
+    {
+        $key = new Key(uniqid(__METHOD__, true));
+
+        $this->strategy
+            ->expects($this->any())
+            ->method('canBeMet')
+            ->willReturn(true);
+        $this->strategy
+            ->expects($this->any())
+            ->method('isMet')
+            ->willReturn(false);
+        $this->store1
+            ->expects($this->once())
+            ->method('exists')
+            ->willThrowException(new \Exception());
+        $this->store2
+            ->expects($this->once())
+            ->method('exists')
+            ->with($key)
+            ->willReturn(false);
+
+        $this->assertFalse($this->store->exists($key));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #39470 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Handle exception to preserve expected behavior - one or multiple stores could be unreachable in a moment and combined store will handle this according to strategy.
