### PR TITLE
[PhpUnitBridge] Restore SetUpTearDownTraitForV5

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -18,6 +18,11 @@ HttpKernel
 
  * Marked the class `Symfony\Component\HttpKernel\EventListener\DebugHandlersListener` as internal
 
+PhpunitBridge
+-------------
+
+ * Deprecated the `SetUpTearDownTrait` trait, use original methods with "void" return typehint.
+
 Security
 --------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -129,6 +129,7 @@ PhpUnitBridge
 -------------
 
  * Removed support for `@expectedDeprecation` annotations, use the `ExpectDeprecationTrait::expectDeprecation()` method instead.
+ * Removed the `SetUpTearDownTrait` trait, use original methods with "void" return typehint.
 
 PropertyAccess
 --------------

--- a/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
+++ b/src/Symfony/Bridge/PhpUnit/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * bumped the minimum PHP version to 7.1.3
  * bumped the minimum PHPUnit version to 7.5
+ * deprecated the `SetUpTearDownTrait` trait, use original methods with "void" return typehint.
 
 5.1.0
 -----

--- a/src/Symfony/Bridge/PhpUnit/Legacy/SetUpTearDownTraitForV7.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SetUpTearDownTraitForV7.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Legacy;
+
+/**
+ * @internal
+ */
+trait SetUpTearDownTraitForV7
+{
+    /**
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        self::doSetUpBeforeClass();
+    }
+
+    /**
+     * @return void
+     */
+    public static function tearDownAfterClass()
+    {
+        self::doTearDownAfterClass();
+    }
+
+    /**
+     * @return void
+     */
+    protected function setUp()
+    {
+        self::doSetUp();
+    }
+
+    /**
+     * @return void
+     */
+    protected function tearDown()
+    {
+        self::doTearDown();
+    }
+
+    private static function doSetUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+    }
+
+    private static function doTearDownAfterClass()
+    {
+        parent::tearDownAfterClass();
+    }
+
+    private function doSetUp()
+    {
+        parent::setUp();
+    }
+
+    private function doTearDown()
+    {
+        parent::tearDown();
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/SetUpTearDownTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/SetUpTearDownTrait.php
@@ -13,12 +13,14 @@ namespace Symfony\Bridge\PhpUnit;
 
 use PHPUnit\Framework\TestCase;
 
+trigger_deprecation('symfony/phpunit-bridge', '5.3', 'The "%s" trait is deprecated, use original methods with "void" return typehint.', SetUpTearDownTrait::class);
+
 // A trait to provide forward compatibility with newest PHPUnit versions
 $r = new \ReflectionClass(TestCase::class);
-if (\PHP_VERSION_ID < 70000 || !$r->getMethod('setUp')->hasReturnType()) {
+if (!$r->getMethod('setUp')->hasReturnType()) {
     trait SetUpTearDownTrait
     {
-        use Legacy\SetUpTearDownTraitForV5;
+        use Legacy\SetUpTearDownTraitForV7;
     }
 } else {
     trait SetUpTearDownTrait

--- a/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/CoverageListenerTest.php
@@ -14,7 +14,7 @@ class CoverageListenerTest extends TestCase
 
         exec('type phpdbg 2> /dev/null', $output, $returnCode);
 
-        if (\PHP_VERSION_ID >= 70000 && 0 === $returnCode) {
+        if (0 === $returnCode) {
             $php = 'phpdbg -qrr';
         } else {
             exec('php --ri xdebug -d zend_extension=xdebug.so 2> /dev/null', $output, $returnCode);

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
@@ -14,13 +14,10 @@ namespace Symfony\Bridge\PhpUnit\Tests\DeprecationErrorHandler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler\Deprecation;
-use Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerForV5;
-use Symfony\Bridge\PhpUnit\SetUpTearDownTrait;
+use Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerForV7;
 
 class DeprecationTest extends TestCase
 {
-    use SetUpTearDownTrait;
-
     private static $vendorDir;
     private static $prefixDirsPsr4;
 
@@ -164,7 +161,7 @@ class DeprecationTest extends TestCase
                     'triggering_file' => 'dummy_vendor_path',
                     'files_stack' => [],
                 ]),
-                SymfonyTestsListenerForV5::class,
+                SymfonyTestsListenerForV7::class,
                 '',
             ],
         ];
@@ -208,7 +205,7 @@ class DeprecationTest extends TestCase
                         $vendorDir.'/myfakevendor/myfakepackage1/MyFakeFile2.php',
                     ],
                 ]),
-                [['function' => 'myfunc1'], ['class' => SymfonyTestsListenerForV5::class, 'method' => 'mymethod']],
+                [['function' => 'myfunc1'], ['class' => SymfonyTestsListenerForV7::class, 'method' => 'mymethod']],
             ],
             'serialized_stack_files_from_various_packages' => [
                 Deprecation::TYPE_INDIRECT,
@@ -221,7 +218,7 @@ class DeprecationTest extends TestCase
                         $vendorDir.'/myfakevendor/myfakepackage2/MyFakeFile.php',
                     ],
                 ]),
-                [['function' => 'myfunc1'], ['class' => SymfonyTestsListenerForV5::class, 'method' => 'mymethod']],
+                [['function' => 'myfunc1'], ['class' => SymfonyTestsListenerForV7::class, 'method' => 'mymethod']],
             ],
         ];
     }
@@ -261,7 +258,7 @@ class DeprecationTest extends TestCase
         rmdir($dir);
     }
 
-    private static function doSetupBeforeClass()
+    public static function setupBeforeClass(): void
     {
         foreach (get_declared_classes() as $class) {
             if ('C' === $class[0] && 0 === strpos($class, 'ComposerAutoloaderInit')) {
@@ -281,7 +278,7 @@ class DeprecationTest extends TestCase
         }
     }
 
-    private static function doTearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         foreach (self::$prefixDirsPsr4 as [$prop, $loader, $prefixDirsPsr4]) {
             $prop->setValue($loader, $prefixDirsPsr4);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The class `SetUpTearDownTraitForV5` removed in #39419 is still needed when using PHPUNIT 7.5 (PHP 7.1) that does not have return type: 

https://github.com/sebastianbergmann/phpunit/blob/520723129e2b3fc1dc4c0953e43c9d40e1ecb352/src/Framework/TestCase.php#L407