### PR TITLE
[Notifier] Rename test method names

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportFactoryTest.php
@@ -40,7 +40,7 @@ final class FreeMobileTransportFactoryTest extends TestCase
         $factory->create(Dsn::fromString($dsnIncomplete));
     }
 
-    public function testSupportsFreeMobileScheme()
+    public function testSupportsScheme()
     {
         $factory = $this->createFactory();
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportFactoryTest.php
@@ -29,7 +29,7 @@ final class SlackTransportFactoryTest extends TestCase
         $this->assertSame(sprintf('slack://%s/%s', $host, $path), (string) $transport);
     }
 
-    public function testSupportsSlackScheme()
+    public function testSupportsScheme()
     {
         $factory = new SlackTransportFactory();
 

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportFactoryTest.php
@@ -47,7 +47,7 @@ final class TelegramTransportFactoryTest extends TestCase
         $factory->create(Dsn::fromString(sprintf('telegram://%s/?channel=%s', 'testHost', 'testChannel')));
     }
 
-    public function testSupportsTelegramScheme()
+    public function testSupportsScheme()
     {
         $factory = new TelegramTransportFactory();
 

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportFactoryTest.php
@@ -40,7 +40,7 @@ final class TwilioTransportFactoryTest extends TestCase
         $factory->create(Dsn::fromString($dsnIncomplete));
     }
 
-    public function testSupportsTwilioScheme()
+    public function testSupportsScheme()
     {
         $factory = $this->createFactory();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

To stay consistent

This is a small fix just for `5.1` (sorry for the extra PR), the other methods are renamed in the big PR #39428 👍 