### PR TITLE
Remove check for unsupported PHP version

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -305,7 +305,7 @@ final class CurlResponse implements ResponseInterface
      */
     private static function select(ClientState $multi, float $timeout): int
     {
-        if (\PHP_VERSION_ID < 70123 || (70200 <= \PHP_VERSION_ID && \PHP_VERSION_ID < 70211)) {
+        if (\PHP_VERSION_ID < 70211) {
             // workaround https://bugs.php.net/76480
             $timeout = min($timeout, 0.01);
         }

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/Verification/IntlDateFormatterTest.php
@@ -31,18 +31,6 @@ class IntlDateFormatterTest extends AbstractIntlDateFormatterTest
     }
 
     /**
-     * @dataProvider formatProvider
-     */
-    public function testFormat($pattern, $timestamp, $expected)
-    {
-        if (\PHP_VERSION_ID < 70105 && $timestamp instanceof \DateTimeImmutable) {
-            $this->markTestSkipped('PHP >= 7.1.5 required for DateTimeImmutable.');
-        }
-
-        parent::testFormat($pattern, $timestamp, $expected);
-    }
-
-    /**
      * @dataProvider formatTimezoneProvider
      */
     public function testFormatTimezone($pattern, $timezone, $expected)

--- a/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
+++ b/src/Symfony/Component/Ldap/Tests/Adapter/ExtLdap/AdapterTest.php
@@ -148,19 +148,17 @@ class AdapterTest extends LdapTestCase
             $this->assertEquals(\count($fully_paged_query->getResources()), 1);
             $this->assertEquals(\count($paged_query->getResources()), 5);
 
-            if (\PHP_VERSION_ID >= 70200) {
-                // This last query is to ensure that we haven't botched the state of our connection
-                // by not resetting pagination properly. extldap <= PHP 7.1 do not implement the necessary
-                // bits to work around an implementation flaw, so we simply can't guarantee this to work there.
-                $final_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
-                    'scope' => Query::SCOPE_ONE,
-                ]);
+            // This last query is to ensure that we haven't botched the state of our connection
+            // by not resetting pagination properly. extldap <= PHP 7.1 do not implement the necessary
+            // bits to work around an implementation flaw, so we simply can't guarantee this to work there.
+            $final_query = $ldap->createQuery('dc=symfony,dc=com', '(&(objectClass=applicationProcess)(cn=user*))', [
+                'scope' => Query::SCOPE_ONE,
+            ]);
 
-                $final_results = $final_query->execute();
+            $final_results = $final_query->execute();
 
-                $this->assertEquals($final_results->count(), 25);
-                $this->assertEquals(\count($final_query->getResources()), 1);
-            }
+            $this->assertEquals($final_results->count(), 25);
+            $this->assertEquals(\count($final_query->getResources()), 1);
         } catch (LdapException $exc) {
             $this->markTestSkipped('Test LDAP server does not support pagination');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Remove check for PHP 7.1 since it's not supported anymore