### PR TITLE
Add missing symfony/deprecation-contracts requirement

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -19,6 +19,7 @@
         "php": ">=7.2.5",
         "doctrine/event-manager": "~1.0",
         "doctrine/persistence": "^1.3|^2",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php80": "^1.15",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -21,6 +21,7 @@
         "symfony/cache": "^4.4|^5.0",
         "symfony/config": "^5.0",
         "symfony/dependency-injection": "^5.1",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/event-dispatcher": "^5.1",
         "symfony/error-handler": "^4.4.1|^5.0.1",
         "symfony/http-foundation": "^4.4|^5.0",

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -20,6 +20,7 @@
         "ext-xml": "*",
         "symfony/config": "^4.4|^5.0",
         "symfony/dependency-injection": "^5.1",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/event-dispatcher": "^5.1",
         "symfony/http-kernel": "^5.0",
         "symfony/polyfill-php80": "^1.15",

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/messenger": "^5.1"
     },
     "require-dev": {

--- a/src/Symfony/Component/Messenger/Bridge/Redis/composer.json
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/messenger": "^5.1"
     },
     "require-dev": {

--- a/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/http-client": "^4.3|^5.0",
         "symfony/notifier": "~5.1.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

We should require the `symfony/deprecation-contracts` package in components that call `trigger_deprecated`.