### PR TITLE
[Notifier] [DX] Abstract test cases

### DIFF
--- a/.github/composer-config.json
+++ b/.github/composer-config.json
@@ -4,6 +4,7 @@
         "preferred-install": {
             "symfony/form": "source",
             "symfony/http-kernel": "source",
+            "symfony/notifier": "source",
             "symfony/validator": "source",
             "*": "dist"
         }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportFactoryTest.php
@@ -11,50 +11,39 @@
 
 namespace Symfony\Component\Notifier\Bridge\Firebase\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransportFactory;
-use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
-use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class FirebaseTransportFactoryTest extends TestCase
+final class FirebaseTransportFactoryTest extends TransportFactoryTestCase
 {
-    public function testCreateWithDsn()
-    {
-        $factory = $this->createFactory();
-
-        $transport = $factory->create(Dsn::fromString('firebase://username:password@host.test'));
-
-        $this->assertSame('firebase://host.test', (string) $transport);
-    }
-
-    public function testSupportsReturnsTrueWithSupportedScheme()
-    {
-        $factory = $this->createFactory();
-
-        $this->assertTrue($factory->supports(Dsn::fromString('firebase://username:password@default')));
-    }
-
-    public function testSupportsReturnsFalseWithUnsupportedScheme()
-    {
-        $factory = $this->createFactory();
-
-        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://username:password@default')));
-    }
-
-    public function testUnsupportedSchemeThrowsUnsupportedSchemeException()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(UnsupportedSchemeException::class);
-
-        $factory->create(Dsn::fromString('somethingElse://username:password@default'));
-    }
-
-    private function createFactory(): FirebaseTransportFactory
+    /**
+     * @return FirebaseTransportFactory
+     */
+    public function createFactory(): TransportFactoryInterface
     {
         return new FirebaseTransportFactory();
+    }
+
+    public function createProvider(): iterable
+    {
+        yield [
+            'firebase://host.test',
+            'firebase://username:password@host.test',
+        ];
+    }
+
+    public function supportsProvider(): iterable
+    {
+        yield [true, 'firebase://username:password@default'];
+        yield [false, 'somethingElse://username:password@default'];
+    }
+
+    public function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://username:password@default'];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportTest.php
@@ -11,44 +11,40 @@
 
 namespace Symfony\Component\Notifier\Bridge\Firebase\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransport;
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class FirebaseTransportTest extends TestCase
+final class FirebaseTransportTest extends TransportTestCase
 {
-    public function testToStringContainsProperties()
+    /**
+     * @return FirebaseTransport
+     */
+    public function createTransport(?HttpClientInterface $client = null): TransportInterface
     {
-        $transport = $this->createTransport();
-
-        $this->assertSame('firebase://host.test', (string) $transport);
+        return new FirebaseTransport('username:password', $client ?: $this->createMock(HttpClientInterface::class));
     }
 
-    public function testSupportsMessageInterface()
+    public function toStringProvider(): iterable
     {
-        $transport = $this->createTransport();
-
-        $this->assertTrue($transport->supports(new ChatMessage('testChatMessage')));
-        $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
+        yield ['firebase://fcm.googleapis.com/fcm/send', $this->createTransport()];
     }
 
-    public function testSendNonSmsMessageThrowsException()
+    public function supportedMessagesProvider(): iterable
     {
-        $transport = $this->createTransport();
-
-        $this->expectException(LogicException::class);
-
-        $transport->send($this->createMock(MessageInterface::class));
+        yield [new ChatMessage('Hello!')];
     }
 
-    private function createTransport(): FirebaseTransport
+    public function unsupportedMessagesProvider(): iterable
     {
-        return (new FirebaseTransport('username:password', $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        yield [new SmsMessage('0611223344', 'Hello!')];
+        yield [$this->createMock(MessageInterface::class)];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "~5.1.0"
+        "symfony/notifier": "~5.1.11"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Firebase\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportFactoryTest.php
@@ -11,67 +11,42 @@
 
 namespace Symfony\Component\Notifier\Bridge\FreeMobile\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransportFactory;
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
-use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
-use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
-final class FreeMobileTransportFactoryTest extends TestCase
+final class FreeMobileTransportFactoryTest extends TransportFactoryTestCase
 {
-    public function testCreateWithDsn()
-    {
-        $factory = $this->createFactory();
-
-        $transport = $factory->create(Dsn::fromString('freemobile://login:pass@host.test?phone=0611223344'));
-
-        $this->assertSame('freemobile://host.test?phone=0611223344', (string) $transport);
-    }
-
-    public function testCreateWithNoPhoneThrowsIncompleteDsnException()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(IncompleteDsnException::class);
-
-        $factory->create(Dsn::fromString('freemobile://login:pass@default'));
-    }
-
-    public function testSupportsReturnsTrueWithSupportedScheme()
-    {
-        $factory = $this->createFactory();
-
-        $this->assertTrue($factory->supports(Dsn::fromString('freemobile://login:pass@default?phone=0611223344')));
-    }
-
-    public function testSupportsReturnsFalseWithUnsupportedScheme()
-    {
-        $factory = $this->createFactory();
-
-        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://login:pass@default?phone=0611223344')));
-    }
-
-    public function testUnsupportedSchemeThrowsUnsupportedSchemeException()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(UnsupportedSchemeException::class);
-
-        $factory->create(Dsn::fromString('somethingElse://login:pass@default?phone=0611223344'));
-    }
-
-    public function testUnsupportedSchemeThrowsUnsupportedSchemeExceptionEvenIfRequiredOptionIsMissing()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(UnsupportedSchemeException::class);
-
-        // unsupported scheme and missing "phone" option
-        $factory->create(Dsn::fromString('somethingElse://login:pass@default'));
-    }
-
-    private function createFactory(): FreeMobileTransportFactory
+    /**
+     * @return FreeMobileTransportFactory
+     */
+    public function createFactory(): TransportFactoryInterface
     {
         return new FreeMobileTransportFactory();
+    }
+
+    public function createProvider(): iterable
+    {
+        yield [
+            'freemobile://host.test?phone=0611223344',
+            'freemobile://login:pass@host.test?phone=0611223344',
+        ];
+    }
+
+    public function supportsProvider(): iterable
+    {
+        yield [true, 'freemobile://login:pass@default?phone=0611223344'];
+        yield [false, 'somethingElse://login:pass@default?phone=0611223344'];
+    }
+
+    public function incompleteDsnProvider(): iterable
+    {
+        yield 'missing option: phone' => ['freemobile://login:pass@default'];
+    }
+
+    public function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://login:pass@default?phone=0611223344'];
+        yield ['somethingElse://login:pass@default']; // missing "phone" option
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.1",
-        "symfony/notifier": "~5.1.0"
+        "symfony/notifier": "~5.1.11"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\FreeMobile\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportFactoryTest.php
@@ -11,96 +11,61 @@
 
 namespace Symfony\Component\Notifier\Bridge\Mattermost\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
-use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
-use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class MattermostTransportFactoryTest extends TestCase
+final class MattermostTransportFactoryTest extends TransportFactoryTestCase
 {
-    public function testCreateWithDsn()
-    {
-        $factory = $this->createFactory();
-
-        $transport = $factory->create(Dsn::fromString('mattermost://accessToken@host.test?channel=testChannel'));
-
-        $this->assertSame('mattermost://host.test?channel=testChannel', (string) $transport);
-    }
-
-    public function testCreateWithDsnHostWithSubfolder()
-    {
-        $factory = $this->createFactory();
-
-        $transport = $factory->create(Dsn::fromString('mattermost://accessToken@example.com/sub?channel=testChannel'));
-
-        $this->assertSame('mattermost://example.com/sub?channel=testChannel', (string) $transport);
-    }
-
-    public function testCreateWithDsnHostWithSubfolderWithTrailingSlash()
-    {
-        $factory = $this->createFactory();
-
-        $transport = $factory->create(Dsn::fromString('mattermost://accessToken@example.com/sub/?channel=testChannel'));
-
-        $this->assertSame('mattermost://example.com/sub?channel=testChannel', (string) $transport);
-    }
-
-    public function testCreateWithMissingOptionChannelThrowsIncompleteDsnException()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(IncompleteDsnException::class);
-
-        $factory->create(Dsn::fromString('mattermost://token@host'));
-    }
-
-    public function testCreateWithNoTokenThrowsIncompleteDsnException()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(IncompleteDsnException::class);
-        $factory->create(Dsn::fromString('mattermost://host.test?channel=testChannel'));
-    }
-
-    public function testSupportsReturnsTrueWithSupportedScheme()
-    {
-        $factory = $this->createFactory();
-
-        $this->assertTrue($factory->supports(Dsn::fromString('mattermost://token@host?channel=testChannel')));
-    }
-
-    public function testSupportsReturnsFalseWithUnsupportedScheme()
-    {
-        $factory = $this->createFactory();
-
-        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://token@host?channel=testChannel')));
-    }
-
-    public function testUnsupportedSchemeThrowsUnsupportedSchemeException()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(UnsupportedSchemeException::class);
-
-        $factory->create(Dsn::fromString('somethingElse://token@host?channel=testChannel'));
-    }
-
-    public function testUnsupportedSchemeThrowsUnsupportedSchemeExceptionEvenIfRequiredOptionIsMissing()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(UnsupportedSchemeException::class);
-
-        // unsupported scheme and missing "channel" option
-        $factory->create(Dsn::fromString('somethingElse://token@host'));
-    }
-
-    private function createFactory(): MattermostTransportFactory
+    /**
+     * @return MattermostTransportFactory
+     */
+    public function createFactory(): TransportFactoryInterface
     {
         return new MattermostTransportFactory();
+    }
+
+    public function createProvider(): iterable
+    {
+        yield [
+            'mattermost://host.test?channel=testChannel',
+            'mattermost://accessToken@host.test?channel=testChannel',
+        ];
+
+        yield [
+            'mattermost://example.com/sub?channel=testChannel',
+            'mattermost://accessToken@example.com/sub?channel=testChannel',
+        ];
+
+        yield [
+            'mattermost://example.com/sub?channel=testChannel',
+            'mattermost://accessToken@example.com/sub/?channel=testChannel',
+        ];
+
+        yield [
+            'mattermost://example.com/sub/sub-2?channel=testChannel',
+            'mattermost://accessToken@example.com/sub/sub-2?channel=testChannel',
+        ];
+    }
+
+    public function supportsProvider(): iterable
+    {
+        yield [true, 'mattermost://token@host?channel=testChannel'];
+        yield [false, 'somethingElse://token@host?channel=testChannel'];
+    }
+
+    public function incompleteDsnProvider(): iterable
+    {
+        yield 'missing option: token' => ['mattermost://host.test?channel=testChannel'];
+        yield 'missing option: channel' => ['mattermost://token@host'];
+    }
+
+    public function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://token@host?channel=testChannel'];
+        yield ['somethingElse://token@host']; // missing "channel" option
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportTest.php
@@ -11,44 +11,40 @@
 
 namespace Symfony\Component\Notifier\Bridge\Mattermost\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransport;
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class MattermostTransportTest extends TestCase
+final class MattermostTransportTest extends TransportTestCase
 {
-    public function testToStringContainsProperties()
+    /**
+     * @return MattermostTransport
+     */
+    public function createTransport(?HttpClientInterface $client = null): TransportInterface
     {
-        $transport = $this->createTransport();
-
-        $this->assertSame('mattermost://host.test?channel=testChannel', (string) $transport);
+        return (new MattermostTransport('testAccessToken', 'testChannel', $client ?: $this->createMock(HttpClientInterface::class)))->setHost('host.test');
     }
 
-    public function testSupportsChatMessage()
+    public function toStringProvider(): iterable
     {
-        $transport = $this->createTransport();
-
-        $this->assertTrue($transport->supports(new ChatMessage('testChatMessage')));
-        $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
+        yield ['mattermost://host.test?channel=testChannel', $this->createTransport()];
     }
 
-    public function testSendNonChatMessageThrowsLogicException()
+    public function supportedMessagesProvider(): iterable
     {
-        $transport = $this->createTransport();
-
-        $this->expectException(LogicException::class);
-        $transport->send($this->createMock(MessageInterface::class));
+        yield [new ChatMessage('Hello!')];
     }
 
-    private function createTransport(): MattermostTransport
+    public function unsupportedMessagesProvider(): iterable
     {
-        return (new MattermostTransport('testAccessToken', 'testChannel', $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        yield [new SmsMessage('0611223344', 'Hello!')];
+        yield [$this->createMock(MessageInterface::class)];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "~5.1.0"
+        "symfony/notifier": "~5.1.11"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Mattermost\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/Tests/NexmoTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/Tests/NexmoTransportTest.php
@@ -11,41 +11,37 @@
 
 namespace Symfony\Component\Notifier\Bridge\Nexmo\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Nexmo\NexmoTransport;
-use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class NexmoTransportTest extends TestCase
+final class NexmoTransportTest extends TransportTestCase
 {
-    public function testToStringContainsProperties()
+    /**
+     * @return NexmoTransport
+     */
+    public function createTransport(?HttpClientInterface $client = null): TransportInterface
     {
-        $transport = $this->createTransport();
-
-        $this->assertSame('nexmo://host.test?from=sender', (string) $transport);
+        return new NexmoTransport('apiKey', 'apiSecret', 'sender', $client ?: $this->createMock(HttpClientInterface::class));
     }
 
-    public function testSupportsMessageInterface()
+    public function toStringProvider(): iterable
     {
-        $transport = $this->createTransport();
-
-        $this->assertTrue($transport->supports(new SmsMessage('0611223344', 'Hello!')));
-        $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
+        yield ['nexmo://rest.nexmo.com?from=sender', $this->createTransport()];
     }
 
-    public function testSendNonSmsMessageThrowsException()
+    public function supportedMessagesProvider(): iterable
     {
-        $transport = $this->createTransport();
-
-        $this->expectException(LogicException::class);
-
-        $transport->send($this->createMock(MessageInterface::class));
+        yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    private function createTransport(): NexmoTransport
+    public function unsupportedMessagesProvider(): iterable
     {
-        return (new NexmoTransport('apiKey', 'apiSecret', 'sender', $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        yield [new ChatMessage('Hello!')];
+        yield [$this->createMock(MessageInterface::class)];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "~5.1.0"
+        "symfony/notifier": "~5.1.11"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Nexmo\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
@@ -11,41 +11,37 @@
 
 namespace Symfony\Component\Notifier\Bridge\OvhCloud\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\OvhCloud\OvhCloudTransport;
-use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class OvhCloudTransportTest extends TestCase
+final class OvhCloudTransportTest extends TransportTestCase
 {
-    public function testToStringContainsProperties()
+    /**
+     * @return OvhCloudTransport
+     */
+    public function createTransport(?HttpClientInterface $client = null): TransportInterface
     {
-        $transport = $this->createTransport();
-
-        $this->assertSame('ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName', (string) $transport);
+        return new OvhCloudTransport('applicationKey', 'applicationSecret', 'consumerKey', 'serviceName', $client ?: $this->createMock(HttpClientInterface::class));
     }
 
-    public function testSupportsMessageInterface()
+    public function toStringProvider(): iterable
     {
-        $transport = $this->createTransport();
-
-        $this->assertTrue($transport->supports(new SmsMessage('0611223344', 'Hello!')));
-        $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
+        yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName', $this->createTransport()];
     }
 
-    public function testSendNonSmsMessageThrowsException()
+    public function supportedMessagesProvider(): iterable
     {
-        $transport = $this->createTransport();
-
-        $this->expectException(LogicException::class);
-
-        $transport->send($this->createMock(MessageInterface::class));
+        yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    private function createTransport(): OvhCloudTransport
+    public function unsupportedMessagesProvider(): iterable
     {
-        return (new OvhCloudTransport('applicationKey', 'applicationSecret', 'consumerKey', 'serviceName', $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        yield [new ChatMessage('Hello!')];
+        yield [$this->createMock(MessageInterface::class)];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "~5.1.0"
+        "symfony/notifier": "~5.1.11"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\OvhCloud\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportFactoryTest.php
@@ -11,59 +11,44 @@
 
 namespace Symfony\Component\Notifier\Bridge\RocketChat\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
-use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
-use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class RocketChatTransportFactoryTest extends TestCase
+final class RocketChatTransportFactoryTest extends TransportFactoryTestCase
 {
-    public function testCreateWithDsn()
-    {
-        $factory = $this->createFactory();
-
-        $transport = $factory->create(Dsn::fromString('rocketchat://accessToken@host.test?channel=testChannel'));
-
-        $this->assertSame('rocketchat://host.test?channel=testChannel', (string) $transport);
-    }
-
-    public function testCreateWithNoTokenThrowsIncompleteDsnException()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(IncompleteDsnException::class);
-        $factory->create(Dsn::fromString('rocketchat://host.test?channel=testChannel'));
-    }
-
-    public function testSupportsReturnsTrueWithSupportedScheme()
-    {
-        $factory = $this->createFactory();
-
-        $this->assertTrue($factory->supports(Dsn::fromString('rocketchat://token@host?channel=testChannel')));
-    }
-
-    public function testSupportsReturnsFalseWithUnsupportedScheme()
-    {
-        $factory = $this->createFactory();
-
-        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://token@host?channel=testChannel')));
-    }
-
-    public function testUnsupportedSchemeThrowsUnsupportedSchemeException()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(UnsupportedSchemeException::class);
-
-        $factory->create(Dsn::fromString('somethingElse://token@host?channel=testChannel'));
-    }
-
-    private function createFactory(): RocketChatTransportFactory
+    /**
+     * @return RocketChatTransportFactory
+     */
+    public function createFactory(): TransportFactoryInterface
     {
         return new RocketChatTransportFactory();
+    }
+
+    public function createProvider(): iterable
+    {
+        yield [
+            'rocketchat://host.test?channel=testChannel',
+            'rocketchat://accessToken@host.test?channel=testChannel',
+        ];
+    }
+
+    public function supportsProvider(): iterable
+    {
+        yield [true, 'rocketchat://token@host?channel=testChannel'];
+        yield [false, 'somethingElse://token@host?channel=testChannel'];
+    }
+
+    public function incompleteDsnProvider(): iterable
+    {
+        yield 'missing option: token' => ['rocketchat://host.test?channel=testChannel'];
+    }
+
+    public function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://token@host?channel=testChannel'];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportTest.php
@@ -11,43 +11,40 @@
 
 namespace Symfony\Component\Notifier\Bridge\RocketChat\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransport;
-use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
  */
-final class RocketChatTransportTest extends TestCase
+final class RocketChatTransportTest extends TransportTestCase
 {
-    public function testToStringContainsProperties()
+    /**
+     * @return RocketChatTransport
+     */
+    public function createTransport(?HttpClientInterface $client = null): TransportInterface
     {
-        $transport = $this->createTransport();
-
-        $this->assertSame('rocketchat://host.test?channel=testChannel', (string) $transport);
+        return new RocketChatTransport('testAccessToken', 'testChannel', $client ?: $this->createMock(HttpClientInterface::class));
     }
 
-    public function testSupportsChatMessage()
+    public function toStringProvider(): iterable
     {
-        $transport = $this->createTransport();
-
-        $this->assertTrue($transport->supports(new ChatMessage('testChatMessage')));
-        $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
+        yield ['rocketchat://rocketchat.com?channel=testChannel', $this->createTransport()];
     }
 
-    public function testSendNonChatMessageThrowsLogicException()
+    public function supportedMessagesProvider(): iterable
     {
-        $transport = $this->createTransport();
-
-        $this->expectException(LogicException::class);
-        $transport->send($this->createMock(MessageInterface::class));
+        yield [new ChatMessage('Hello!')];
     }
 
-    private function createTransport(): RocketChatTransport
+    public function unsupportedMessagesProvider(): iterable
     {
-        return (new RocketChatTransport('testAccessToken', 'testChannel', $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        yield [new SmsMessage('0611223344', 'Hello!')];
+        yield [$this->createMock(MessageInterface::class)];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "~5.1.0"
+        "symfony/notifier": "~5.1.11"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\RocketChat\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/Tests/SinchTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/Tests/SinchTransportTest.php
@@ -11,41 +11,37 @@
 
 namespace Symfony\Component\Notifier\Bridge\Sinch\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Sinch\SinchTransport;
-use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class SinchTransportTest extends TestCase
+final class SinchTransportTest extends TransportTestCase
 {
-    public function testToStringContainsProperties()
+    /**
+     * @return SinchTransport
+     */
+    public function createTransport(?HttpClientInterface $client = null): TransportInterface
     {
-        $transport = $this->createTransport();
-
-        $this->assertSame('sinch://host.test?from=sender', (string) $transport);
+        return new SinchTransport('accountSid', 'authToken', 'sender', $client ?: $this->createMock(HttpClientInterface::class));
     }
 
-    public function testSupportsMessageInterface()
+    public function toStringProvider(): iterable
     {
-        $transport = $this->createTransport();
-
-        $this->assertTrue($transport->supports(new SmsMessage('0611223344', 'Hello!')));
-        $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
+        yield ['sinch://sms.api.sinch.com?from=sender', $this->createTransport()];
     }
 
-    public function testSendNonSmsMessageThrowsException()
+    public function supportedMessagesProvider(): iterable
     {
-        $transport = $this->createTransport();
-
-        $this->expectException(LogicException::class);
-
-        $transport->send($this->createMock(MessageInterface::class));
+        yield [new SmsMessage('0611223344', 'Hello!')];
     }
 
-    private function createTransport(): SinchTransport
+    public function unsupportedMessagesProvider(): iterable
     {
-        return (new SinchTransport('accountSid', 'authToken', 'sender', $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        yield [new ChatMessage('Hello!')];
+        yield [$this->createMock(MessageInterface::class)];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "ext-json": "*",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "~5.1.0"
+        "symfony/notifier": "~5.1.11"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sinch\\": "" },

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportFactoryTest.php
@@ -11,67 +11,42 @@
 
 namespace Symfony\Component\Notifier\Bridge\Slack\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
-use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
-use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
-final class SlackTransportFactoryTest extends TestCase
+final class SlackTransportFactoryTest extends TransportFactoryTestCase
 {
-    public function testCreateWithDsn()
-    {
-        $factory = $this->createFactory();
-
-        $transport = $factory->create(Dsn::fromString('slack://host.test/testPath'));
-
-        $this->assertSame('slack://host.test/testPath', (string) $transport);
-    }
-
-    public function testCreateWithMissingOptionIdThrowsIncompleteDsnException()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(IncompleteDsnException::class);
-
-        $factory->create(Dsn::fromString('slack://host'));
-    }
-
-    public function testSupportsReturnsTrueWithSupportedScheme()
-    {
-        $factory = $this->createFactory();
-
-        $this->assertTrue($factory->supports(Dsn::fromString('slack://host/path')));
-    }
-
-    public function testSupportsReturnsFalseWithUnsupportedScheme()
-    {
-        $factory = $this->createFactory();
-
-        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://host/path')));
-    }
-
-    public function testUnsupportedSchemeThrowsUnsupportedSchemeException()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(UnsupportedSchemeException::class);
-
-        $factory->create(Dsn::fromString('somethingElse://host/path'));
-    }
-
-    public function testUnsupportedSchemeThrowsUnsupportedSchemeExceptionEvenIfRequiredOptionIsMissing()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(UnsupportedSchemeException::class);
-
-        // unsupported scheme and missing "id" option
-        $factory->create(Dsn::fromString('somethingElse://host'));
-    }
-
-    private function createFactory(): SlackTransportFactory
+    /**
+     * @return SlackTransportFactory
+     */
+    public function createFactory(): TransportFactoryInterface
     {
         return new SlackTransportFactory();
+    }
+
+    public function createProvider(): iterable
+    {
+        yield [
+            'slack://host.test/id',
+            'slack://host.test/id',
+        ];
+    }
+
+    public function supportsProvider(): iterable
+    {
+        yield [true, 'slack://host.test/id'];
+        yield [false, 'somethingElse://host.test/id'];
+    }
+
+    public function incompleteDsnProvider(): iterable
+    {
+        yield 'missing path' => ['slack://host.test'];
+    }
+
+    public function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://host.test/id'];
+        yield ['somethingElse://host.test']; // missing "id"
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.2.5",
         "symfony/deprecation-contracts": "^2.1",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "~5.1.0"
+        "symfony/notifier": "~5.1.11"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^4.3|^5.0"

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportFactoryTest.php
@@ -11,64 +11,42 @@
 
 namespace Symfony\Component\Notifier\Bridge\Telegram\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransportFactory;
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
-use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
-use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
-final class TelegramTransportFactoryTest extends TestCase
+final class TelegramTransportFactoryTest extends TransportFactoryTestCase
 {
-    public function testCreateWithDsn()
-    {
-        $factory = $this->createFactory();
-
-        $transport = $factory->create(Dsn::fromString('telegram://user:password@host.test?channel=testChannel'));
-
-        $this->assertSame('telegram://host.test?channel=testChannel', (string) $transport);
-    }
-
-    public function testCreateWithNoPasswordThrowsIncompleteDsnException()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(IncompleteDsnException::class);
-        $factory->create(Dsn::fromString('telegram://simpleToken@host.test?channel=testChannel'));
-    }
-
-    public function testCreateWithNoTokenThrowsIncompleteDsnException()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(IncompleteDsnException::class);
-        $factory->create(Dsn::fromString('telegram://host.test?channel=testChannel'));
-    }
-
-    public function testSupportsReturnsTrueWithSupportedScheme()
-    {
-        $factory = $this->createFactory();
-
-        $this->assertTrue($factory->supports(Dsn::fromString('telegram://host?channel=testChannel')));
-    }
-
-    public function testSupportsReturnsFalseWithUnsupportedScheme()
-    {
-        $factory = $this->createFactory();
-
-        $this->assertFalse($factory->supports(Dsn::fromString('somethingElse://host?channel=testChannel')));
-    }
-
-    public function testUnsupportedSchemeThrowsUnsupportedSchemeException()
-    {
-        $factory = $this->createFactory();
-
-        $this->expectException(UnsupportedSchemeException::class);
-
-        $factory->create(Dsn::fromString('somethingElse://user:pwd@host?channel=testChannel'));
-    }
-
-    private function createFactory(): TelegramTransportFactory
+    /**
+     * @return TelegramTransportFactory
+     */
+    public function createFactory(): TransportFactoryInterface
     {
         return new TelegramTransportFactory();
+    }
+
+    public function createProvider(): iterable
+    {
+        yield [
+            'telegram://host.test?channel=testChannel',
+            'telegram://user:password@host.test?channel=testChannel',
+        ];
+    }
+
+    public function supportsProvider(): iterable
+    {
+        yield [true, 'telegram://host?channel=testChannel'];
+        yield [false, 'somethingElse://host?channel=testChannel'];
+    }
+
+    public function incompleteDsnProvider(): iterable
+    {
+        yield 'missing password' => ['telegram://token@host.test?channel=testChannel'];
+        yield 'missing token' => ['telegram://host.test?channel=testChannel'];
+    }
+
+    public function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://user:pwd@host'];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "~5.1.0"
+        "symfony/notifier": "~5.1.11"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^4.3|^5.0"

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0",
-        "symfony/notifier": "~5.1.0"
+        "symfony/notifier": "~5.1.11"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Twilio\\": "" },

--- a/src/Symfony/Component/Notifier/Tests/TransportFactoryTestCase.php
+++ b/src/Symfony/Component/Notifier/Tests/TransportFactoryTestCase.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Exception\IncompleteDsnException;
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
+
+/**
+ * A test case to ease testing a notifier transport factory.
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+abstract class TransportFactoryTestCase extends TestCase
+{
+    abstract public function createFactory(): TransportFactoryInterface;
+
+    /**
+     * @return iterable<array{0: bool, 1: string}>
+     */
+    abstract public function supportsProvider(): iterable;
+
+    /**
+     * @return iterable<array{0: string, 1: string, 2: TransportInterface}>
+     */
+    abstract public function createProvider(): iterable;
+
+    /**
+     * @return iterable<array{0: string, 1: string|null}>
+     */
+    public function unsupportedSchemeProvider(): iterable
+    {
+        return [];
+    }
+
+    /**
+     * @return iterable<array{0: string, 1: string|null}>
+     */
+    public function incompleteDsnProvider(): iterable
+    {
+        return [];
+    }
+
+    /**
+     * @dataProvider supportsProvider
+     */
+    public function testSupports(bool $expected, string $dsn): void
+    {
+        $factory = $this->createFactory();
+
+        $this->assertSame($expected, $factory->supports(Dsn::fromString($dsn)));
+    }
+
+    /**
+     * @dataProvider createProvider
+     */
+    public function testCreate(string $expected, string $dsn): void
+    {
+        $factory = $this->createFactory();
+        $transport = $factory->create(Dsn::fromString($dsn));
+
+        $this->assertSame($expected, (string) $transport);
+    }
+
+    /**
+     * @dataProvider unsupportedSchemeProvider
+     */
+    public function testUnsupportedSchemeException(string $dsn, string $message = null): void
+    {
+        $factory = $this->createFactory();
+
+        $dsn = Dsn::fromString($dsn);
+
+        $this->expectException(UnsupportedSchemeException::class);
+        if (null !== $message) {
+            $this->expectExceptionMessage($message);
+        }
+
+        $factory->create($dsn);
+    }
+
+    /**
+     * @dataProvider incompleteDsnProvider
+     */
+    public function testIncompleteDsnException(string $dsn, string $message = null): void
+    {
+        $factory = $this->createFactory();
+
+        $dsn = Dsn::fromString($dsn);
+
+        $this->expectException(IncompleteDsnException::class);
+        if (null !== $message) {
+            $this->expectExceptionMessage($message);
+        }
+
+        $factory->create($dsn);
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/TransportTestCase.php
+++ b/src/Symfony/Component/Notifier/Tests/TransportTestCase.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * A test case to ease testing a Notifier transport.
+ *
+ * @author Oskar Stark <oskarstark@googlemail.com>
+ */
+abstract class TransportTestCase extends TestCase
+{
+    protected const CUSTOM_HOST = 'host.test';
+    protected const CUSTOM_PORT = 42;
+
+    abstract public function createTransport(?HttpClientInterface $client = null): TransportInterface;
+
+    /**
+     * @return iterable<array{0: string, 1: TransportInterface}>
+     */
+    abstract public function toStringProvider(): iterable;
+
+    /**
+     * @return iterable<array{0: MessageInterface, 1: TransportInterface}>
+     */
+    abstract public function supportedMessagesProvider(): iterable;
+
+    /**
+     * @return iterable<array{0: MessageInterface, 1: TransportInterface}>
+     */
+    abstract public function unsupportedMessagesProvider(): iterable;
+
+    /**
+     * @dataProvider toStringProvider
+     */
+    public function testToString(string $expected, TransportInterface $transport): void
+    {
+        $this->assertSame($expected, (string) $transport);
+    }
+
+    /**
+     * @dataProvider supportedMessagesProvider
+     */
+    public function testSupportedMessages(MessageInterface $message, ?TransportInterface $transport = null): void
+    {
+        if (null === $transport) {
+            $transport = $this->createTransport();
+        }
+
+        $this->assertTrue($transport->supports($message));
+    }
+
+    /**
+     * @dataProvider unsupportedMessagesProvider
+     */
+    public function testUnsupportedMessages(MessageInterface $message, ?TransportInterface $transport = null): void
+    {
+        if (null === $transport) {
+            $transport = $this->createTransport();
+        }
+
+        $this->assertFalse($transport->supports($message));
+    }
+
+    /**
+     * @dataProvider unsupportedMessagesProvider
+     */
+    public function testUnsupportedMessagesTrowLogicExceptionWhenSend(MessageInterface $message, ?TransportInterface $transport = null): void
+    {
+        if (null === $transport) {
+            $transport = $this->createTransport();
+        }
+
+        $this->expectException(LogicException::class);
+
+        $transport->send($message);
+    }
+
+    public function testCanSetCustomHost(): void
+    {
+        $transport = $this->createTransport();
+
+        $transport->setHost($customHost = self::CUSTOM_HOST);
+
+        $this->assertStringContainsString(sprintf('://%s', $customHost), (string) $transport);
+    }
+
+    public function testCanSetCustomPort(): void
+    {
+        $transport = $this->createTransport();
+
+        $transport->setPort($customPort = self::CUSTOM_PORT);
+
+        /*
+         * @see https://regex101.com/r/0xQKuY/2
+         */
+        $this->assertMatchesRegularExpression(sprintf('/^.*\/\/.*\:%s.*$/', $customPort), (string) $transport);
+    }
+
+    public function testCanSetCustomHostAndPort(): void
+    {
+        $transport = $this->createTransport();
+
+        $transport->setHost($customHost = self::CUSTOM_HOST);
+        $transport->setPort($customPort = self::CUSTOM_PORT);
+
+        $this->assertStringContainsString(sprintf('://%s:%s', $customHost, $customPort), (string) $transport);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

This PR

* [x] adds a new _abstract_ `TransportTestCase`
* [x] adds a new _abstract_ `TransportFactoryTestCase` (code is mainly taken from the `Mailer/TransportFactoryTestCase`)

We have a lot of code duplication in the notifier bridges

### Todos
* [x] check if we want this
* [x]  I would want to use Dsn strings (like already used in the notifier bridge tests) instead of objects for the providers, what do you think? For me it is more readably
* [x] update all bridges
* [x] Bump notifier to `~5.1.10`

### Questions
* [x] is it Ok to consider this a bugfix and merge into `5.1`?
* [x] shall I prefix the abstract test cases with `Abstract` ? As we did the same for Mailer, I would say no

@symfony/mergers have to change ^5.2 into ^5.2.1 