### PR TITLE
Add missing symfony/deprecation-contracts requirement - 5.x

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/composer.json
+++ b/src/Symfony/Bridge/PhpUnit/composer.json
@@ -18,10 +18,10 @@
     "require": {
         "php": ">=7.1.3 EVEN ON LATEST SYMFONY VERSIONS TO ALLOW USING",
         "php": "THIS BRIDGE WHEN TESTING LOWEST SYMFONY VERSIONS.",
-        "php": ">=7.1.3"
+        "php": ">=7.1.3",
+        "symfony/deprecation-contracts": "^2.1"
     },
     "require-dev": {
-        "symfony/deprecation-contracts": "^2.1",
         "symfony/error-handler": "^4.4|^5.0"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

same PR than #39494 for branch 5.x