### PR TITLE
[Notifier]  [Free Mobile] Could not use custom host in DSN

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransport.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class FreeMobileTransport extends AbstractTransport
 {
-    protected const HOST = 'https://smsapi.free-mobile.fr/sendmsg';
+    protected const HOST = 'smsapi.free-mobile.fr/sendmsg';
 
     private $login;
     private $password;
@@ -57,7 +57,9 @@ final class FreeMobileTransport extends AbstractTransport
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" (instance of "%s" given) and configured with your phone number.', __CLASS__, SmsMessage::class, \get_class($message)));
         }
 
-        $response = $this->client->request('POST', $this->getEndpoint(), [
+        $endpoint = sprintf('https://%s', $this->getEndpoint());
+
+        $response = $this->client->request('POST', $endpoint, [
             'json' => [
                 'user' => $this->login,
                 'pass' => $this->password,

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/FreeMobileTransportFactory.php
@@ -43,7 +43,10 @@ final class FreeMobileTransportFactory extends AbstractTransportFactory
             throw new IncompleteDsnException('Missing phone.', $dsn->getOriginalDsn());
         }
 
-        return new FreeMobileTransport($login, $password, $phone, $this->client, $this->dispatcher);
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        return (new FreeMobileTransport($login, $password, $phone, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportFactoryTest.php
@@ -23,9 +23,7 @@ final class FreeMobileTransportFactoryTest extends TestCase
     {
         $factory = $this->createFactory();
 
-        $dsn = 'freemobile://login:pass@default?phone=0611223344';
-        $transport = $factory->create(Dsn::fromString($dsn));
-        $transport->setHost('host.test');
+        $transport = $factory->create(Dsn::fromString('freemobile://login:pass@host.test?phone=0611223344'));
 
         $this->assertSame('freemobile://host.test?phone=0611223344', (string) $transport);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

While working on #39509 I discovered, that you cannot set a custom host through the DSN string itself, only by calling `setHost()` method in the transport, which is only possible by **not** using the factory....

I changed it the way all other bridges work. I don't add a testcase for the port, because non of the others have that test.
I plan to implement it in #39495

As this is a bugfix I created an extra PR.

Cheers

EDIT:

Also the host is not allowed to contain `https://` otherwise calling `__toString()` will result in: `freemobile://https://......`