### PR TITLE
[Ldap] Incorrect determination of RelativeDistinguishedName for the "move" operation

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/EntryManager.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/EntryManager.php
@@ -79,7 +79,7 @@ class EntryManager implements EntryManagerInterface
         $con = $this->getConnectionResource();
 
         if (!@ldap_mod_add($con, $entry->getDn(), [$attribute => $values])) {
-            throw new LdapException(sprintf('Could not add values to entry "%s", attribute %s: ', $entry->getDn(), $attribute).ldap_error($con));
+            throw new LdapException(sprintf('Could not add values to entry "%s", attribute "%s": ', $entry->getDn(), $attribute).ldap_error($con));
         }
     }
 
@@ -94,7 +94,7 @@ class EntryManager implements EntryManagerInterface
         $con = $this->getConnectionResource();
 
         if (!@ldap_mod_del($con, $entry->getDn(), [$attribute => $values])) {
-            throw new LdapException(sprintf('Could not remove values from entry "%s", attribute %s: ', $entry->getDn(), $attribute).ldap_error($con));
+            throw new LdapException(sprintf('Could not remove values from entry "%s", attribute "%s": ', $entry->getDn(), $attribute).ldap_error($con));
         }
     }
 
@@ -159,7 +159,7 @@ class EntryManager implements EntryManagerInterface
 
     private function parseRdnFromEntry(Entry $entry): string
     {
-        if (!preg_match('/^([^,]+),/', $entry->getDn(), $matches)) {
+        if (!preg_match('/(^[^,\\\\]*(?:\\\\.[^,\\\\]*)*),/', $entry->getDn(), $matches)) {
             throw new LdapException(sprintf('Entry "%s" malformed, could not parse RDN.', $entry->getDn()));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

If the specified "DistinguishedName" contains a comma in the first value, the first "RelativeDistinguishedName" was determined incorrectly.
The regular expression now matches up to the first comma which was not escaped with backslash.

Testing private methods is a bit messy here. However, I thought it was better than testing this against an LDAP server.

Source: https://tools.ietf.org/html/rfc4514#section-3
