### PR TITLE
[Mailer] Fix parsing Dsn with empty user/password

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
@@ -52,6 +52,26 @@ class DsnTest extends TestCase
             new Dsn('smtp', 'example.com'),
         ];
 
+        yield 'simple dsn including @ sign, but no user/password/token' => [
+            'scheme://@localhost',
+            new Dsn('scheme', 'localhost', null, null),
+        ];
+
+        yield 'simple dsn including : sign and @ sign, but no user/password/token' => [
+            'scheme://:@localhost',
+            new Dsn('scheme', 'localhost', null, null),
+        ];
+
+        yield 'simple dsn including user, : sign and @ sign, but no password' => [
+            'scheme://user1:@localhost',
+            new Dsn('scheme', 'localhost', 'user1', null),
+        ];
+
+        yield 'simple dsn including : sign, password, and @ sign, but no user' => [
+            'scheme://:pass@localhost',
+            new Dsn('scheme', 'localhost', null, 'pass'),
+        ];
+
         yield 'simple smtp with custom port' => [
             'smtp://user1:pass2@example.com:99',
             new Dsn('smtp', 'example.com', 'user1', 'pass2', 99),

--- a/src/Symfony/Component/Mailer/Transport/Dsn.php
+++ b/src/Symfony/Component/Mailer/Transport/Dsn.php
@@ -49,8 +49,8 @@ final class Dsn
             throw new InvalidArgumentException(sprintf('The "%s" mailer DSN must contain a host (use "default" by default).', $dsn));
         }
 
-        $user = isset($parsedDsn['user']) ? urldecode($parsedDsn['user']) : null;
-        $password = isset($parsedDsn['pass']) ? urldecode($parsedDsn['pass']) : null;
+        $user = '' !== ($parsedDsn['user'] ?? '') ? urldecode($parsedDsn['user']) : null;
+        $password = '' !== ($parsedDsn['pass'] ?? '') ? urldecode($parsedDsn['pass']) : null;
         $port = $parsedDsn['port'] ?? null;
         parse_str($parsedDsn['query'] ?? '', $query);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

While working on a PR for Notifier that user and password would be parsed as an empty string, which is not wrong, but not expected IMO. Thi

`scheme://@symfony.com` and `scheme://:@symfony.com` should be a valid scheme with user and pass `null`

Another fix would be to check for `://@` and `://:@` and throw an `InvalidArgumentException` WDYT?

The final solution will then be applied to the Notifier DSN in `5.1`