### PR TITLE
Remove void return type from test methods

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
@@ -20,12 +20,12 @@ class DsnTest extends TestCase
     /**
      * @dataProvider fromStringProvider
      */
-    public function testFromString(string $string, Dsn $dsn): void
+    public function testFromString(string $string, Dsn $dsn)
     {
         $this->assertEquals($dsn, Dsn::fromString($string));
     }
 
-    public function testGetOption(): void
+    public function testGetOption()
     {
         $options = ['with_value' => 'some value', 'nullable' => null];
         $dsn = new Dsn('smtp', 'example.com', null, null, null, $options);
@@ -38,7 +38,7 @@ class DsnTest extends TestCase
     /**
      * @dataProvider invalidDsnProvider
      */
-    public function testInvalidDsn(string $dsn, string $exceptionMessage): void
+    public function testInvalidDsn(string $dsn, string $exceptionMessage)
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($exceptionMessage);

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsIntegrationTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\Connection;
  */
 class AmazonSqsIntegrationTest extends TestCase
 {
-    public function testConnectionSendToFifoQueueAndGet(): void
+    public function testConnectionSendToFifoQueueAndGet()
     {
         if (!getenv('MESSENGER_SQS_FIFO_QUEUE_DSN')) {
             $this->markTestSkipped('The "MESSENGER_SQS_FIFO_QUEUE_DSN" environment variable is required.');
@@ -30,7 +30,7 @@ class AmazonSqsIntegrationTest extends TestCase
         $this->execute(getenv('MESSENGER_SQS_FIFO_QUEUE_DSN'));
     }
 
-    public function testConnectionSendAndGet(): void
+    public function testConnectionSendAndGet()
     {
         if (!getenv('MESSENGER_SQS_DSN')) {
             $this->markTestSkipped('The "MESSENGER_SQS_DSN" environment variable is required.');

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnFailureLimitListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnFailureLimitListenerTest.php
@@ -26,7 +26,7 @@ class StopWorkerOnFailureLimitListenerTest extends TestCase
     /**
      * @dataProvider countProvider
      */
-    public function testWorkerStopsWhenMaximumCountReached(int $max, bool $shouldStop): void
+    public function testWorkerStopsWhenMaximumCountReached(int $max, bool $shouldStop)
     {
         $worker = $this->createMock(Worker::class);
         $worker->expects($shouldStop ? $this->atLeastOnce() : $this->never())->method('stop');
@@ -53,7 +53,7 @@ class StopWorkerOnFailureLimitListenerTest extends TestCase
         yield [4, false];
     }
 
-    public function testWorkerLogsMaximumCountReachedWhenLoggerIsGiven(): void
+    public function testWorkerLogsMaximumCountReachedWhenLoggerIsGiven()
     {
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())->method('info')

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
@@ -23,7 +23,7 @@ class ExpressionLanguageSyntaxValidatorTest extends ConstraintValidatorTestCase
         return new ExpressionLanguageSyntaxValidator(new ExpressionLanguage());
     }
 
-    public function testExpressionValid(): void
+    public function testExpressionValid()
     {
         $this->validator->validate('1 + 1', new ExpressionLanguageSyntax([
             'message' => 'myMessage',
@@ -33,7 +33,7 @@ class ExpressionLanguageSyntaxValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    public function testExpressionWithoutNames(): void
+    public function testExpressionWithoutNames()
     {
         $this->validator->validate('1 + 1', new ExpressionLanguageSyntax([
             'message' => 'myMessage',
@@ -42,7 +42,7 @@ class ExpressionLanguageSyntaxValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    public function testExpressionWithAllowedVariableName(): void
+    public function testExpressionWithAllowedVariableName()
     {
         $this->validator->validate('a + 1', new ExpressionLanguageSyntax([
             'message' => 'myMessage',
@@ -52,7 +52,7 @@ class ExpressionLanguageSyntaxValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    public function testExpressionIsNotValid(): void
+    public function testExpressionIsNotValid()
     {
         $this->validator->validate('a + 1', new ExpressionLanguageSyntax([
             'message' => 'myMessage',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

cc @nicolas-grekas 

Same like #39541 but for `5.1`