### PR TITLE
Remove :void in test function signatures

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/EventAliasTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/EventAliasTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Http\SecurityEvents;
 
 final class EventAliasTest extends AbstractWebTestCase
 {
-    public function testAliasedEvents(): void
+    public function testAliasedEvents()
     {
         $client = $this->createClient(['test_case' => 'AliasedEvents', 'root_config' => 'config.yml']);
         $container = $client->getContainer();

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/ExceptionListenerPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/ExceptionListenerPassTest.php
@@ -31,7 +31,7 @@ class ExceptionListenerPassTest extends TestCase
         $this->assertTrue($builder->hasDefinition('twig.exception_listener'));
     }
 
-    public function testRemovesTwigExceptionListenerWhenNoExceptionListenerControllerExists(): void
+    public function testRemovesTwigExceptionListenerWhenNoExceptionListenerControllerExists()
     {
         $builder = new ContainerBuilder();
         $builder->register('twig', Environment::class);
@@ -45,7 +45,7 @@ class ExceptionListenerPassTest extends TestCase
         $this->assertFalse($builder->hasDefinition('twig.exception_listener'));
     }
 
-    public function testRemovesTwigExceptionListenerIfTwigIsNotUsedAsTemplateEngine(): void
+    public function testRemovesTwigExceptionListenerIfTwigIsNotUsedAsTemplateEngine()
     {
         $builder = new ContainerBuilder();
         $builder->register('twig', Environment::class);
@@ -60,7 +60,7 @@ class ExceptionListenerPassTest extends TestCase
         $this->assertFalse($builder->hasDefinition('twig.exception_listener'));
     }
 
-    public function testRemovesKernelExceptionListenerIfTwigIsUsedAsTemplateEngine(): void
+    public function testRemovesKernelExceptionListenerIfTwigIsUsedAsTemplateEngine()
     {
         $builder = new ContainerBuilder();
         $builder->register('twig', Environment::class);

--- a/src/Symfony/Component/BrowserKit/Tests/Test/Constraint/BrowserCookieValueSameTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/Test/Constraint/BrowserCookieValueSameTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\BrowserKit\Test\Constraint\BrowserCookieValueSame;
 
 class BrowserCookieValueSameTest extends TestCase
 {
-    public function testConstraint(): void
+    public function testConstraint()
     {
         $browser = $this->getBrowser();
         $constraint = new BrowserCookieValueSame('foo', 'bar', false, '/path');

--- a/src/Symfony/Component/BrowserKit/Tests/Test/Constraint/BrowserHasCookieTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/Test/Constraint/BrowserHasCookieTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\BrowserKit\Test\Constraint\BrowserHasCookie;
 
 class BrowserHasCookieTest extends TestCase
 {
-    public function testConstraint(): void
+    public function testConstraint()
     {
         $browser = $this->getBrowser();
         $constraint = new BrowserHasCookie('foo', '/path');
@@ -42,7 +42,7 @@ class BrowserHasCookieTest extends TestCase
         $this->fail();
     }
 
-    public function testConstraintWithWrongPath(): void
+    public function testConstraintWithWrongPath()
     {
         $browser = $this->getBrowser();
         $constraint = new BrowserHasCookie('foo', '/other');
@@ -57,7 +57,7 @@ class BrowserHasCookieTest extends TestCase
         $this->fail();
     }
 
-    public function testConstraintWithWrongDomain(): void
+    public function testConstraintWithWrongDomain()
     {
         $browser = $this->getBrowser();
         $constraint = new BrowserHasCookie('foo', '/path', 'example.org');

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -872,7 +872,7 @@ class ProgressBarTest extends TestCase
         ];
     }
 
-    public function testIterate(): void
+    public function testIterate()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 0, 0);
 
@@ -887,7 +887,7 @@ class ProgressBarTest extends TestCase
         );
     }
 
-    public function testIterateUncountable(): void
+    public function testIterateUncountable()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 0, 0);
 
@@ -936,7 +936,7 @@ class ProgressBarTest extends TestCase
         putenv('COLUMNS=120');
     }
 
-    public function testMinAndMaxSecondsBetweenRedraws(): void
+    public function testMinAndMaxSecondsBetweenRedraws()
     {
         $bar = new ProgressBar($output = $this->getOutputStream());
         $bar->setRedrawFrequency(1);
@@ -959,7 +959,7 @@ class ProgressBarTest extends TestCase
         );
     }
 
-    public function testMaxSecondsBetweenRedraws(): void
+    public function testMaxSecondsBetweenRedraws()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 0, 0);
         $bar->setRedrawFrequency(4); // disable step based redraws
@@ -1014,7 +1014,7 @@ class ProgressBarTest extends TestCase
         );
     }
 
-    public function testNoWriteWhenMessageIsSame(): void
+    public function testNoWriteWhenMessageIsSame()
     {
         $bar = new ProgressBar($output = $this->getOutputStream(), 2);
         $bar->start();

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -1263,7 +1263,7 @@ EOTXT;
         return str_replace(\PHP_EOL, "\n", stream_get_contents($output->getStream()));
     }
 
-    public function testWithColspanAndMaxWith(): void
+    public function testWithColspanAndMaxWith()
     {
         $table = new Table($output = $this->getOutputStream());
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ValidateEnvPlaceholdersPassTest.php
@@ -206,7 +206,7 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
         $this->assertSame($expected, $container->resolveEnvPlaceholders($ext->getConfig()));
     }
 
-    public function testEmptyEnvWhichCannotBeEmptyForScalarNode(): void
+    public function testEmptyEnvWhichCannotBeEmptyForScalarNode()
     {
         $container = new ContainerBuilder();
         $container->registerExtension($ext = new EnvExtension());
@@ -225,7 +225,7 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
      * @group legacy
      * @expectedDeprecation Setting path "env_extension.scalar_node_not_empty_validated" to an environment variable is deprecated since Symfony 4.3. Remove "cannotBeEmpty()", "validate()" or include a prefix/suffix value instead.
      */
-    public function testEmptyEnvWhichCannotBeEmptyForScalarNodeWithValidation(): void
+    public function testEmptyEnvWhichCannotBeEmptyForScalarNodeWithValidation()
     {
         $container = new ContainerBuilder();
         $container->registerExtension($ext = new EnvExtension());
@@ -238,7 +238,7 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
         $this->assertSame($expected, $container->resolveEnvPlaceholders($ext->getConfig()));
     }
 
-    public function testPartialEnvWhichCannotBeEmptyForScalarNode(): void
+    public function testPartialEnvWhichCannotBeEmptyForScalarNode()
     {
         $container = new ContainerBuilder();
         $container->registerExtension($ext = new EnvExtension());
@@ -251,7 +251,7 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
         $this->assertSame($expected, $container->resolveEnvPlaceholders($ext->getConfig()));
     }
 
-    public function testEnvWithVariableNode(): void
+    public function testEnvWithVariableNode()
     {
         $container = new ContainerBuilder();
         $container->registerExtension($ext = new EnvExtension());
@@ -268,7 +268,7 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
      * @group legacy
      * @expectedDeprecation A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.
      */
-    public function testConfigurationWithoutRootNode(): void
+    public function testConfigurationWithoutRootNode()
     {
         $container = new ContainerBuilder();
         $container->registerExtension(new EnvExtension(new EnvConfigurationWithoutRootNode()));
@@ -288,7 +288,7 @@ class ValidateEnvPlaceholdersPassTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    public function testDiscardedEnvInConfig(): void
+    public function testDiscardedEnvInConfig()
     {
         $container = new ContainerBuilder();
         $container->setParameter('env(BOOLISH)', '1');

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorAttributeValueSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorAttributeValueSameTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorAttributeValueSa
 
 class CrawlerSelectorAttributeValueSameTest extends TestCase
 {
-    public function testConstraint(): void
+    public function testConstraint()
     {
         $constraint = new CrawlerSelectorAttributeValueSame('input[name="username"]', 'value', 'Fabien');
         $this->assertTrue($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username" value="Fabien">'), '', true));

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorExistsTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorExistsTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorExists;
 
 class CrawlerSelectorExistsTest extends TestCase
 {
-    public function testConstraint(): void
+    public function testConstraint()
     {
         $constraint = new CrawlerSelectorExists('title');
         $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>'), '', true));

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorTextContains;
 
 class CrawlerSelectorTextContainsTest extends TestCase
 {
-    public function testConstraint(): void
+    public function testConstraint()
     {
         $constraint = new CrawlerSelectorTextContains('title', 'Foo');
         $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>Foobar'), '', true));

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextSameTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\DomCrawler\Test\Constraint\CrawlerSelectorTextSame;
 
 class CrawlerSelectorTextSameTest extends TestCase
 {
-    public function testConstraint(): void
+    public function testConstraint()
     {
         $constraint = new CrawlerSelectorTextSame('title', 'Foo');
         $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>Foo'), '', true));

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -61,7 +61,7 @@ class RegisterListenersPassTest extends TestCase
         $this->assertEquals($expectedCalls, $eventDispatcherDefinition->getMethodCalls());
     }
 
-    public function testAliasedEventSubscriber(): void
+    public function testAliasedEventSubscriber()
     {
         $builder = new ContainerBuilder();
         $builder->setParameter('event_dispatcher.event_aliases', [AliasedEvent::class => 'aliased_event']);
@@ -210,7 +210,7 @@ class RegisterListenersPassTest extends TestCase
         $this->assertEquals($expectedCalls, $definition->getMethodCalls());
     }
 
-    public function testAliasedEventListener(): void
+    public function testAliasedEventListener()
     {
         $container = new ContainerBuilder();
         $eventAliases = [AliasedEvent::class => 'aliased_event'];
@@ -251,7 +251,7 @@ class RegisterListenersPassTest extends TestCase
         $this->assertEquals($expectedCalls, $definition->getMethodCalls());
     }
 
-    public function testOmitEventNameOnTypedListener(): void
+    public function testOmitEventNameOnTypedListener()
     {
         $container = new ContainerBuilder();
         $container->setParameter('event_dispatcher.event_aliases', [AliasedEvent::class => 'aliased_event']);
@@ -284,7 +284,7 @@ class RegisterListenersPassTest extends TestCase
         $this->assertEquals($expectedCalls, $definition->getMethodCalls());
     }
 
-    public function testOmitEventNameOnUntypedListener(): void
+    public function testOmitEventNameOnUntypedListener()
     {
         $container = new ContainerBuilder();
         $container->register('foo', InvokableListenerService::class)->addTag('kernel.event_listener', ['method' => 'onEvent']);
@@ -297,7 +297,7 @@ class RegisterListenersPassTest extends TestCase
         $registerListenersPass->process($container);
     }
 
-    public function testOmitEventNameAndMethodOnUntypedListener(): void
+    public function testOmitEventNameAndMethodOnUntypedListener()
     {
         $container = new ContainerBuilder();
         $container->register('foo', InvokableListenerService::class)->addTag('kernel.event_listener');
@@ -313,7 +313,7 @@ class RegisterListenersPassTest extends TestCase
     /**
      * @requires PHP 7.2
      */
-    public function testOmitEventNameAndMethodOnGenericListener(): void
+    public function testOmitEventNameAndMethodOnGenericListener()
     {
         $container = new ContainerBuilder();
         $container->register('foo', GenericListener::class)->addTag('kernel.event_listener');
@@ -326,7 +326,7 @@ class RegisterListenersPassTest extends TestCase
         $registerListenersPass->process($container);
     }
 
-    public function testOmitEventNameOnSubscriber(): void
+    public function testOmitEventNameOnSubscriber()
     {
         $container = new ContainerBuilder();
         $container->register('subscriber', IncompleteSubscriber::class)

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/StringToFloatTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/StringToFloatTransformerTest.php
@@ -37,14 +37,14 @@ class StringToFloatTransformerTest extends TestCase
         $this->assertSame($to, $transformer->transform($from));
     }
 
-    public function testFailIfTransformingANonString(): void
+    public function testFailIfTransformingANonString()
     {
         $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new StringToFloatTransformer();
         $transformer->transform(1.0);
     }
 
-    public function testFailIfTransformingANonNumericString(): void
+    public function testFailIfTransformingANonNumericString()
     {
         $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new StringToFloatTransformer();
@@ -77,7 +77,7 @@ class StringToFloatTransformerTest extends TestCase
         $this->assertSame($to, $transformer->reverseTransform($from));
     }
 
-    public function testFailIfReverseTransformingANonNumeric(): void
+    public function testFailIfReverseTransformingANonNumeric()
     {
         $this->expectException('Symfony\Component\Form\Exception\TransformationFailedException');
         $transformer = new StringToFloatTransformer();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -729,7 +729,7 @@ class DateTimeTypeTest extends BaseTypeTest
         ];
     }
 
-    public function testSubmitStringWithCustomInputFormat(): void
+    public function testSubmitStringWithCustomInputFormat()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'model_timezone' => 'UTC',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -1048,7 +1048,7 @@ class DateTypeTest extends BaseTypeTest
         ];
     }
 
-    public function testSubmitStringWithCustomInputFormat(): void
+    public function testSubmitStringWithCustomInputFormat()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
             'model_timezone' => 'UTC',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/NumberTypeTest.php
@@ -37,7 +37,7 @@ class NumberTypeTest extends BaseTypeTest
         \Locale::setDefault($this->defaultLocale);
     }
 
-    public function testDefaultFormatting(): void
+    public function testDefaultFormatting()
     {
         $form = $this->factory->create(static::TESTED_TYPE);
         $form->setData('12345.67890');
@@ -45,7 +45,7 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertSame('12345,679', $form->createView()->vars['value']);
     }
 
-    public function testDefaultFormattingWithGrouping(): void
+    public function testDefaultFormattingWithGrouping()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['grouping' => true]);
         $form->setData('12345.67890');
@@ -53,7 +53,7 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertSame('12.345,679', $form->createView()->vars['value']);
     }
 
-    public function testDefaultFormattingWithScale(): void
+    public function testDefaultFormattingWithScale()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['scale' => 2]);
         $form->setData('12345.67890');
@@ -61,7 +61,7 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertSame('12345,68', $form->createView()->vars['value']);
     }
 
-    public function testDefaultFormattingWithScaleFloat(): void
+    public function testDefaultFormattingWithScaleFloat()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['scale' => 2]);
         $form->setData(12345.67890);
@@ -69,7 +69,7 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertSame('12345,68', $form->createView()->vars['value']);
     }
 
-    public function testDefaultFormattingWithScaleAndStringInput(): void
+    public function testDefaultFormattingWithScaleAndStringInput()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['scale' => 2, 'input' => 'string']);
         $form->setData('12345.67890');
@@ -81,7 +81,7 @@ class NumberTypeTest extends BaseTypeTest
      * @group legacy
      * @expectedDeprecation Using the Symfony\Component\Form\Extension\Core\Type\NumberType with float or int data when the "input" option is set to "string" is deprecated since Symfony 4.4 and will throw an exception in 5.0.
      */
-    public function testStringInputWithFloatData(): void
+    public function testStringInputWithFloatData()
     {
         $form = $this->factory->create(static::TESTED_TYPE, 12345.6789, [
             'input' => 'string',
@@ -95,7 +95,7 @@ class NumberTypeTest extends BaseTypeTest
      * @group legacy
      * @expectedDeprecation Using the Symfony\Component\Form\Extension\Core\Type\NumberType with float or int data when the "input" option is set to "string" is deprecated since Symfony 4.4 and will throw an exception in 5.0.
      */
-    public function testStringInputWithIntData(): void
+    public function testStringInputWithIntData()
     {
         $form = $this->factory->create(static::TESTED_TYPE, 12345, [
             'input' => 'string',
@@ -105,7 +105,7 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertSame('12345,00', $form->createView()->vars['value']);
     }
 
-    public function testDefaultFormattingWithRounding(): void
+    public function testDefaultFormattingWithRounding()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['scale' => 0, 'rounding_mode' => \NumberFormatter::ROUND_UP]);
         $form->setData('12345.54321');
@@ -145,7 +145,7 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertNull($form->getData());
     }
 
-    public function testSubmitNumericInput(): void
+    public function testSubmitNumericInput()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['input' => 'number']);
         $form->submit('1,234');
@@ -155,7 +155,7 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertSame('1,234', $form->getViewData());
     }
 
-    public function testSubmitNumericInputWithScale(): void
+    public function testSubmitNumericInputWithScale()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['input' => 'number', 'scale' => 2]);
         $form->submit('1,234');
@@ -165,7 +165,7 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertSame('1,23', $form->getViewData());
     }
 
-    public function testSubmitStringInput(): void
+    public function testSubmitStringInput()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['input' => 'string']);
         $form->submit('1,234');
@@ -175,7 +175,7 @@ class NumberTypeTest extends BaseTypeTest
         $this->assertSame('1,234', $form->getViewData());
     }
 
-    public function testSubmitStringInputWithScale(): void
+    public function testSubmitStringInputWithScale()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, ['input' => 'string', 'scale' => 2]);
         $form->submit('1,234');

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/RequestAttributeValueSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/RequestAttributeValueSameTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Test\Constraint\RequestAttributeValueSame;
 
 class RequestAttributeValueSameTest extends TestCase
 {
-    public function testConstraint(): void
+    public function testConstraint()
     {
         $request = new Request();
         $request->attributes->set('foo', 'bar');

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseCookieValueSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseCookieValueSameTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Test\Constraint\ResponseCookieValueSame;
 
 class ResponseCookieValueSameTest extends TestCase
 {
-    public function testConstraint(): void
+    public function testConstraint()
     {
         $response = new Response();
         $response->headers->setCookie(Cookie::create('foo', 'bar', 0, '/path'));

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHasCookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHasCookieTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Test\Constraint\ResponseHasCookie;
 
 class ResponseHasCookieTest extends TestCase
 {
-    public function testConstraint(): void
+    public function testConstraint()
     {
         $response = new Response();
         $response->headers->setCookie(Cookie::create('foo', 'bar'));

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHasHeaderTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHasHeaderTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Test\Constraint\ResponseHasHeader;
 
 class ResponseHasHeaderTest extends TestCase
 {
-    public function testConstraint(): void
+    public function testConstraint()
     {
         $constraint = new ResponseHasHeader('Date');
         $this->assertTrue($constraint->evaluate(new Response(), '', true));

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHeaderSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseHeaderSameTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Test\Constraint\ResponseHeaderSame;
 
 class ResponseHeaderSameTest extends TestCase
 {
-    public function testConstraint(): void
+    public function testConstraint()
     {
         $constraint = new ResponseHeaderSame('Cache-Control', 'no-cache, private');
         $this->assertTrue($constraint->evaluate(new Response(), '', true));

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseIsRedirectedTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseIsRedirectedTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Test\Constraint\ResponseIsRedirected;
 
 class ResponseIsRedirectedTest extends TestCase
 {
-    public function testConstraint(): void
+    public function testConstraint()
     {
         $constraint = new ResponseIsRedirected();
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseIsSuccessfulTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseIsSuccessfulTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Test\Constraint\ResponseIsSuccessful;
 
 class ResponseIsSuccessfulTest extends TestCase
 {
-    public function testConstraint(): void
+    public function testConstraint()
     {
         $constraint = new ResponseIsSuccessful();
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseStatusCodeSameTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Test/Constraint/ResponseStatusCodeSameTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Test\Constraint\ResponseStatusCodeSame;
 
 class ResponseStatusCodeSameTest extends TestCase
 {
-    public function testConstraint(): void
+    public function testConstraint()
     {
         $constraint = new ResponseStatusCodeSame(200);
         $this->assertTrue($constraint->evaluate(new Response(), '', true));

--- a/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
@@ -25,7 +25,7 @@ class DsnTest extends TestCase
         $this->assertEquals($dsn, Dsn::fromString($string));
     }
 
-    public function testGetOption(): void
+    public function testGetOption()
     {
         $options = ['with_value' => 'some value', 'nullable' => null];
         $dsn = new Dsn('smtp', 'example.com', null, null, null, $options);

--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
@@ -31,7 +31,7 @@ class SmtpTransportTest extends TestCase
         $this->assertEquals('smtp://127.0.0.1:2525', (string) $t);
     }
 
-    public function testSendDoesNotPingBelowThreshold(): void
+    public function testSendDoesNotPingBelowThreshold()
     {
         $stream = new DummyStream();
         $envelope = new Envelope(new Address('sender@example.org'), [new Address('recipient@example.org')]);
@@ -44,7 +44,7 @@ class SmtpTransportTest extends TestCase
         $this->assertNotContains("NOOP\r\n", $stream->getCommands());
     }
 
-    public function testSendPingAfterTransportException(): void
+    public function testSendPingAfterTransportException()
     {
         $stream = new DummyStream();
         $envelope = new Envelope(new Address('sender@example.org'), [new Address('recipient@example.org')]);
@@ -67,7 +67,7 @@ class SmtpTransportTest extends TestCase
         $this->assertFalse($stream->isClosed());
     }
 
-    public function testSendDoesPingAboveThreshold(): void
+    public function testSendDoesPingAboveThreshold()
     {
         $stream = new DummyStream();
         $envelope = new Envelope(new Address('sender@example.org'), [new Address('recipient@example.org')]);

--- a/src/Symfony/Component/Serializer/Tests/Extractor/ObjectPropertyListExtractorTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Extractor/ObjectPropertyListExtractorTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Serializer\Extractor\ObjectPropertyListExtractor;
 
 class ObjectPropertyListExtractorTest extends TestCase
 {
-    public function testGetPropertiesWithoutObjectClassResolver(): void
+    public function testGetPropertiesWithoutObjectClassResolver()
     {
         $object = new \stdClass();
         $context = ['bar' => true];
@@ -35,7 +35,7 @@ class ObjectPropertyListExtractorTest extends TestCase
         );
     }
 
-    public function testGetPropertiesWithObjectClassResolver(): void
+    public function testGetPropertiesWithObjectClassResolver()
     {
         $object = new \stdClass();
         $classResolver = function ($objectArg) use ($object): string {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a<!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a

I've added a new rule in fabbot to detect usage of `: void` in test method signatures to please @nicolas-grekas :)
