### PR TITLE
[Notifier] [Zulip] Host is required

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransport.php
@@ -83,4 +83,9 @@ final class MattermostTransport extends AbstractTransport
 
         return $sentMessage;
     }
+
+    protected function getEndpoint(): ?string
+    {
+        return $this->host.($this->port ? ':'.$this->port : '');
+    }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/README.md
@@ -7,12 +7,13 @@ DSN example
 -----------
 
 ```
-ZULIP_DSN=zulip://EMAIL:TOKEN@default?channel=CHANNEL
+ZULIP_DSN=zulip://EMAIL:TOKEN@URL?channel=CHANNEL
 ```
 
 where:
  - `EMAIL` is your Zulip email
  - `TOKEN` is your Zulip token
+ - `URL` is your Zulip url
  - `CHANNEL` is the channel
 
 Resources

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/ZulipTransport.php
@@ -63,8 +63,6 @@ class ZulipTransport extends AbstractTransport
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" for options.', __CLASS__, ZulipOptions::class));
         }
 
-        $endpoint = sprintf('https://%s/api/v1/messages', $this->getEndpoint());
-
         $options = ($opts = $message->getOptions()) ? $opts->toArray() : [];
         $options['content'] = $message->getSubject();
 
@@ -79,6 +77,8 @@ class ZulipTransport extends AbstractTransport
             $options['type'] = 'private';
             $options['to'] = $message->getRecipientId();
         }
+
+        $endpoint = sprintf('https://%s/api/v1/messages', $this->getEndpoint());
 
         $response = $this->client->request('POST', $endpoint, [
             'auth_basic' => $this->email.':'.$this->token,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

This bridge is the only one right now which cannot use `default` as host in the DSN, otherwise it would fall back to:
https://github.com/symfony/symfony/blob/090b4256f0032e1309d086b873743b330fd21df1/src/Symfony/Component/Notifier/Transport/AbstractTransport.php#L30

it could also not use: 
https://github.com/symfony/symfony/blob/090b4256f0032e1309d086b873743b330fd21df1/src/Symfony/Component/Notifier/Transport/AbstractTransport.php#L83-L86

Based on the [documentation](https://zulip.com/api/send-message) you must use your specific url like:
`POST https://yourZulipDomain.zulipchat.com/api/v1/messages`

Using `localhost` would have weird side-effects.

Can you confirm this @phpfour , as you provided the bridge?

### Todos after merge
* [ ] adjust recipes with new DSN
* [ ] update the docs