### PR TITLE
[Serializer] Fix DenormalizableInterface::denormalize() return type declaration in docblock

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.php
@@ -33,8 +33,6 @@ interface DenormalizableInterface
      * @param string|null                 $format       The format is optionally given to be able to denormalize
      *                                                  differently based on different input formats
      * @param array                       $context      Options for denormalizing
-     *
-     * @return object|object[]
      */
     public function denormalize(DenormalizerInterface $denormalizer, $data, $format = null, array $context = []);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N.A.
| License       | MIT
| Doc PR        | N.A.

DenormalizableInterface::denormalize() should not return anything, so the `@return` declaration should be removed. If you look at the usage in `CustomNormalizer::denormalize()`, it becomes clear that this method shouldn't return anything:
```php
    public function denormalize($data, $type, $format = null, array $context = [])
    {
        $object = $this->extractObjectToPopulate($type, $context) ?: new $type();
        $object->denormalize($this->serializer, $data, $format, $context);

        return $object;
    }
```