### PR TITLE
[Notifier] remove conflicts in composer.json

### DIFF
--- a/src/Symfony/Component/Notifier/composer.json
+++ b/src/Symfony/Component/Notifier/composer.json
@@ -25,17 +25,7 @@
         "symfony/http-client-contracts": "^2"
     },
     "conflict": {
-        "symfony/http-kernel": "<4.4",
-        "symfony/firebase-notifier": "<5.2",
-        "symfony/free-mobile-notifier": "<5.2",
-        "symfony/mattermost-notifier": "<5.2",
-        "symfony/nexmo-notifier": "<5.2",
-        "symfony/ovh-cloud-notifier": "<5.2",
-        "symfony/rocket-chat-notifier": "<5.2",
-        "symfony/sinch-notifier": "<5.2",
-        "symfony/slack-notifier": "<5.2",
-        "symfony/telegram-notifier": "<5.2",
-        "symfony/twilio-notifier": "<5.2"
+        "symfony/http-kernel": "<4.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Related to #39559

These lines don't make sense: all bridges in 5.1 already exclude notifier >=5.2, thanks to the `~5.1.0` requirement.