### PR TITLE
[Serializer] improve usefulness of ExtraAttributesException message by including the class name being deserialized

### DIFF
--- a/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
+++ b/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
@@ -20,9 +20,9 @@ class ExtraAttributesException extends RuntimeException
 {
     private $extraAttributes;
 
-    public function __construct(array $extraAttributes, \Throwable $previous = null)
+    public function __construct(string $class, array $extraAttributes, \Throwable $previous = null)
     {
-        $msg = sprintf('Extra attributes are not allowed ("%s" are unknown).', implode('", "', $extraAttributes));
+        $msg = sprintf('Cannot create an instance of "%s" from serialized data because extra attributes are not allowed ("%s" are unknown).', $class, implode('", "', $extraAttributes));
 
         $this->extraAttributes = $extraAttributes;
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -340,7 +340,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
         }
 
         if (!empty($extraAttributes)) {
-            throw new ExtraAttributesException($extraAttributes);
+            throw new ExtraAttributesException($type, $extraAttributes);
         }
 
         return $object;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -62,7 +62,7 @@ class AbstractObjectNormalizerTest extends TestCase
     public function testDenormalizeWithExtraAttributes()
     {
         $this->expectException('Symfony\Component\Serializer\Exception\ExtraAttributesException');
-        $this->expectExceptionMessage('Extra attributes are not allowed ("fooFoo", "fooBar" are unknown).');
+        $this->expectExceptionMessage('Cannot create an instance of "Symfony\Component\Serializer\Tests\Normalizer\Dummy" from serialized data because extra attributes are not allowed ("fooFoo", "fooBar" are unknown).');
         $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
         $normalizer = new AbstractObjectNormalizerDummy($factory);
         $normalizer->denormalize(
@@ -76,7 +76,7 @@ class AbstractObjectNormalizerTest extends TestCase
     public function testDenormalizeWithExtraAttributesAndNoGroupsWithMetadataFactory()
     {
         $this->expectException('Symfony\Component\Serializer\Exception\ExtraAttributesException');
-        $this->expectExceptionMessage('Extra attributes are not allowed ("fooFoo", "fooBar" are unknown).');
+        $this->expectExceptionMessage('Cannot create an instance of "Symfony\Component\Serializer\Tests\Normalizer\Dummy" from serialized data because extra attributes are not allowed ("fooFoo", "fooBar" are unknown).');
         $normalizer = new AbstractObjectNormalizerWithMetadata();
         $normalizer->denormalize(
             ['fooFoo' => 'foo', 'fooBar' => 'bar', 'bar' => 'bar'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | unsure.
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The current message thrown with `ExtraAttributesException` is almost useless when deserializing nested data structures - this is no way to determine which class is failing to be deserialized. 

This PR improves the message by including the class failing to be being deserialized.

Can this PR be targeted at an earlier branch, or does changing the constructor of `ExtraAttributesException` dictate it has to go into `5.x`?
