### PR TITLE
[Console] Decouple generic helpers from SymfonyStyle

### DIFF
--- a/src/Symfony/Component/Console/Output/SyncOutputDecorator.php
+++ b/src/Symfony/Component/Console/Output/SyncOutputDecorator.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Output;
+
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+
+/**
+ * Synchronize one output with another.
+ *
+ * @author Vadim Zharkov <hushker@gmail.com>
+ */
+class SyncOutputDecorator implements OutputInterface
+{
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    /**
+     * @var OutputInterface
+     */
+    private $syncOutput;
+
+    public function __construct(OutputInterface $output, OutputInterface $syncOutput)
+    {
+        $this->output = $output;
+        $this->syncOutput = $syncOutput;
+    }
+
+    public function write($messages, bool $newline = false, int $options = 0)
+    {
+        $this->output->write($messages, $newline, $options);
+        $this->syncOutput->write($messages, $newline, $options);
+    }
+
+    public function writeln($messages, int $options = 0)
+    {
+        $this->output->writeln($messages, $options);
+        $this->syncOutput->writeln($messages, $options);
+    }
+
+    public function setVerbosity(int $level)
+    {
+        $this->output->setVerbosity($level);
+        $this->syncOutput->setVerbosity($level);
+    }
+
+    public function getVerbosity()
+    {
+        return $this->output->getVerbosity();
+    }
+
+    public function isQuiet()
+    {
+        return $this->output->isQuiet();
+    }
+
+    public function isVerbose()
+    {
+        return $this->output->isVerbose();
+    }
+
+    public function isVeryVerbose()
+    {
+        return $this->output->isVeryVerbose();
+    }
+
+    public function isDebug()
+    {
+        return $this->output->isDebug();
+    }
+
+    public function setDecorated(bool $decorated)
+    {
+        $this->output->setDecorated($decorated);
+        $this->syncOutput->setDecorated($decorated);
+    }
+
+    public function isDecorated()
+    {
+        return $this->output->isDecorated();
+    }
+
+    public function setFormatter(OutputFormatterInterface $formatter)
+    {
+        $this->output->setFormatter($formatter);
+        $this->syncOutput->setFormatter($formatter);
+    }
+
+    public function getFormatter()
+    {
+        return $this->output->getFormatter();
+    }
+}

--- a/src/Symfony/Component/Console/Style/MessageBlock.php
+++ b/src/Symfony/Component/Console/Style/MessageBlock.php
@@ -1,0 +1,201 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Style;
+
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Helper\Helper;
+
+/**
+ * Generates formatted block lines.
+ *
+ * @author Vadim Zharkov <hushker@gmail.com>
+ */
+class MessageBlock
+{
+    /**
+     * @var OutputFormatterInterface
+     */
+    private $formatter;
+
+    /**
+     * @var int
+     */
+    private $lineLength;
+
+    /**
+     * @var iterable
+     */
+    private $messages;
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $style;
+
+    /**
+     * @var string
+     */
+    private $prefix = ' ';
+
+    /**
+     * @var bool
+     */
+    private $padding = false;
+
+    /**
+     * @var bool
+     */
+    private $escape = false;
+
+    /**
+     * @return MessageBlock
+     */
+    public function setFormatter(OutputFormatterInterface $formatter): self
+    {
+        $this->formatter = $formatter;
+
+        return $this;
+    }
+
+    /**
+     * @return MessageBlock
+     */
+    public function setLineLength(int $lineLength): self
+    {
+        $this->lineLength = $lineLength;
+
+        return $this;
+    }
+
+    /**
+     * @return MessageBlock
+     */
+    public function setMessages(iterable $messages): self
+    {
+        $this->messages = $messages;
+
+        return $this;
+    }
+
+    /**
+     * @return MessageBlock
+     */
+    public function setType(?string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @param string $style
+     *
+     * @return MessageBlock
+     */
+    public function setStyle(?string $style): self
+    {
+        $this->style = $style;
+
+        return $this;
+    }
+
+    /**
+     * @param string $prefix
+     *
+     * @return MessageBlock
+     */
+    public function setPrefix(?string $prefix): self
+    {
+        $this->prefix = $prefix;
+
+        return $this;
+    }
+
+    /**
+     * @return MessageBlock
+     */
+    public function setPadding(bool $padding): self
+    {
+        $this->padding = $padding;
+
+        return $this;
+    }
+
+    /**
+     * @return MessageBlock
+     */
+    public function setEscape(bool $escape): self
+    {
+        $this->escape = $escape;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLines(): array
+    {
+        $indentLength = 0;
+        $prefixLength = Helper::strlenWithoutDecoration($this->formatter, $this->prefix);
+        $lines = [];
+
+        $lineIndentation = '';
+        if (null !== $this->type) {
+            $this->type = sprintf('[%s] ', $this->type);
+            $indentLength = \strlen($this->type);
+            $lineIndentation = str_repeat(' ', $indentLength);
+        }
+
+        // wrap and add newlines for each element
+        foreach ($this->messages as $key => $message) {
+            if ($this->escape) {
+                $message = OutputFormatter::escape($message);
+            }
+
+            $lines = array_merge($lines, explode(\PHP_EOL,
+                wordwrap($message, $this->lineLength - $prefixLength - $indentLength, \PHP_EOL, true)));
+
+            if (\count($this->messages) > 1 && $key < \count($this->messages) - 1) {
+                $lines[] = '';
+            }
+        }
+
+        $firstLineIndex = 0;
+        if ($this->padding) {
+            $firstLineIndex = 1;
+            array_unshift($lines, '');
+            $lines[] = '';
+        }
+
+        foreach ($lines as $i => &$line) {
+            if (null !== $this->type) {
+                $line = $firstLineIndex === $i ? $this->type.$line : $lineIndentation.$line;
+            }
+
+            $line = $this->prefix.$line;
+            $line .= str_repeat(' ', $this->lineLength - Helper::strlenWithoutDecoration($this->formatter, $line));
+
+            if ($this->style) {
+                $line = sprintf('<%s>%s</>', $this->style, $line);
+            }
+        }
+
+        return $lines;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #39184 
| License       | MIT
| Doc PR        | 

I've extracted the new class BufferedOutputStyle which provides helper functions based on buffered output.
SymfonyStyle now extends BufferedOutputStyle and contains less code related to helpers and more related to style.
This also fixes the problem with customization - the user may extend SymfonyStyle and rewrite some methods (or extend BuffereOutputStyle directly which may have less sense as SymfonyStyle provides a lot of useful code).
