### PR TITLE
[Serializer] Migrate ArrayDenormalizer to DenormalizerAwareInterface

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -42,3 +42,8 @@ Security
 --------
 
  * Deprecated voters that do not return a valid decision when calling the `vote` method.
+
+Serializer
+----------
+
+ * Deprecated `ArrayDenormalizer::setSerializer()`, call `setDenormalizer()` instead.

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -167,6 +167,12 @@ Security
  * Removed the `AbstractRememberMeServices::$providerKey` property in favor of `AbstractRememberMeServices::$firewallName`
  * `AccessDecisionManager` now throw an exception when a voter does not return a valid decision.
 
+Serializer
+----------
+
+ * Removed `ArrayDenormalizer::setSerializer()`, call `setDenormalizer()` instead.
+ * `ArrayDenormalizer` does not implement `SerializerAwareInterface` anymore.
+
 TwigBundle
 ----------
 

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+ * deprecated `ArrayDenormalizer::setSerializer()`, call `setDenormalizer()` instead.
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ArrayDenormalizer.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Serializer\Normalizer;
 use Symfony\Component\Serializer\Exception\BadMethodCallException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerAwareInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -24,24 +25,19 @@ use Symfony\Component\Serializer\SerializerInterface;
  *
  * @final
  */
-class ArrayDenormalizer implements ContextAwareDenormalizerInterface, SerializerAwareInterface, CacheableSupportsMethodInterface
+class ArrayDenormalizer implements ContextAwareDenormalizerInterface, DenormalizerAwareInterface, SerializerAwareInterface, CacheableSupportsMethodInterface
 {
-    /**
-     * @var SerializerInterface|DenormalizerInterface
-     */
-    private $serializer;
+    use DenormalizerAwareTrait;
 
     /**
      * {@inheritdoc}
      *
      * @throws NotNormalizableValueException
-     *
-     * @return array
      */
-    public function denormalize($data, string $type, string $format = null, array $context = [])
+    public function denormalize($data, string $type, string $format = null, array $context = []): array
     {
-        if (null === $this->serializer) {
-            throw new BadMethodCallException('Please set a serializer before calling denormalize()!');
+        if (null === $this->denormalizer) {
+            throw new BadMethodCallException('Please set a denormalizer before calling denormalize()!');
         }
         if (!\is_array($data)) {
             throw new InvalidArgumentException('Data expected to be an array, '.get_debug_type($data).' given.');
@@ -50,7 +46,6 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Serializer
             throw new InvalidArgumentException('Unsupported class: '.$type);
         }
 
-        $serializer = $this->serializer;
         $type = substr($type, 0, -2);
 
         $builtinType = isset($context['key_type']) ? $context['key_type']->getBuiltinType() : null;
@@ -59,7 +54,7 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Serializer
                 throw new NotNormalizableValueException(sprintf('The type of the key "%s" must be "%s" ("%s" given).', $key, $builtinType, get_debug_type($key)));
             }
 
-            $data[$key] = $serializer->denormalize($value, $type, $format, $context);
+            $data[$key] = $this->denormalizer->denormalize($value, $type, $format, $context);
         }
 
         return $data;
@@ -70,16 +65,18 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Serializer
      */
     public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
     {
-        if (null === $this->serializer) {
-            throw new BadMethodCallException(sprintf('The serializer needs to be set to allow "%s()" to be used.', __METHOD__));
+        if (null === $this->denormalizer) {
+            throw new BadMethodCallException(sprintf('The nested denormalizer needs to be set to allow "%s()" to be used.', __METHOD__));
         }
 
         return '[]' === substr($type, -2)
-            && $this->serializer->supportsDenormalization($data, substr($type, 0, -2), $format, $context);
+            && $this->denormalizer->supportsDenormalization($data, substr($type, 0, -2), $format, $context);
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated call setDenormalizer() instead
      */
     public function setSerializer(SerializerInterface $serializer)
     {
@@ -87,7 +84,11 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Serializer
             throw new InvalidArgumentException('Expected a serializer that also implements DenormalizerInterface.');
         }
 
-        $this->serializer = $serializer;
+        if (Serializer::class !== debug_backtrace()[1]['class'] ?? null) {
+            trigger_deprecation('symfony/serializer', '5.3', 'Calling "%s" is deprecated. Please call setDenormalizer() instead.');
+        }
+
+        $this->setDenormalizer($serializer);
     }
 
     /**
@@ -95,6 +96,6 @@ class ArrayDenormalizer implements ContextAwareDenormalizerInterface, Serializer
      */
     public function hasCacheableSupportsMethod(): bool
     {
-        return $this->serializer instanceof CacheableSupportsMethodInterface && $this->serializer->hasCacheableSupportsMethod();
+        return $this->denormalizer instanceof CacheableSupportsMethodInterface && $this->denormalizer->hasCacheableSupportsMethod();
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ArrayDenormalizerTest.php
@@ -13,26 +13,30 @@ namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
-use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
+use Symfony\Component\Serializer\Serializer;
 
 class ArrayDenormalizerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var ArrayDenormalizer
      */
     private $denormalizer;
 
     /**
-     * @var SerializerInterface|MockObject
+     * @var ContextAwareDenormalizerInterface|MockObject
      */
     private $serializer;
 
     protected function setUp(): void
     {
-        $this->serializer = $this->getMockBuilder('Symfony\Component\Serializer\Serializer')->getMock();
+        $this->serializer = $this->getMockBuilder(ContextAwareDenormalizerInterface::class)->getMock();
         $this->denormalizer = new ArrayDenormalizer();
-        $this->denormalizer->setSerializer($this->serializer);
+        $this->denormalizer->setDenormalizer($this->serializer);
     }
 
     public function testDenormalize()
@@ -65,11 +69,51 @@ class ArrayDenormalizerTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
+    public function testDenormalizeLegacy()
+    {
+        $serializer = $this->getMockBuilder(Serializer::class)->getMock();
+
+        $serializer->expects($this->exactly(2))
+            ->method('denormalize')
+            ->withConsecutive(
+                [['foo' => 'one', 'bar' => 'two']],
+                [['foo' => 'three', 'bar' => 'four']]
+            )
+            ->willReturnOnConsecutiveCalls(
+                new ArrayDummy('one', 'two'),
+                new ArrayDummy('three', 'four')
+            );
+
+        $denormalizer = new ArrayDenormalizer();
+
+        $this->expectDeprecation('Since symfony/serializer 5.3: Calling "%s" is deprecated. Please call setDenormalizer() instead.');
+        $denormalizer->setSerializer($serializer);
+
+        $result = $denormalizer->denormalize(
+            [
+                ['foo' => 'one', 'bar' => 'two'],
+                ['foo' => 'three', 'bar' => 'four'],
+            ],
+            __NAMESPACE__.'\ArrayDummy[]'
+        );
+
+        $this->assertEquals(
+            [
+                new ArrayDummy('one', 'two'),
+                new ArrayDummy('three', 'four'),
+            ],
+            $result
+        );
+    }
+
     public function testSupportsValidArray()
     {
         $this->serializer->expects($this->once())
             ->method('supportsDenormalization')
-            ->with($this->anything(), ArrayDummy::class, $this->anything())
+            ->with($this->anything(), ArrayDummy::class, 'json', ['con' => 'text'])
             ->willReturn(true);
 
         $this->assertTrue(
@@ -78,7 +122,9 @@ class ArrayDenormalizerTest extends TestCase
                     ['foo' => 'one', 'bar' => 'two'],
                     ['foo' => 'three', 'bar' => 'four'],
                 ],
-                __NAMESPACE__.'\ArrayDummy[]'
+                __NAMESPACE__.'\ArrayDummy[]',
+                'json',
+                ['con' => 'text']
             )
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`ArrayDenormalizer` currently asks for a full-blown serializer while a simple denormalizer would be enough. I'd like to change this in Symfony 6. This PR prepares the removal of `SerializerAwareInterface` from this class.