### PR TITLE
[Notifier] [GoogleChat] [BC BREAK] Rename threadKey parameter to thread_key + set parameter via ctor

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/CHANGELOG.md
@@ -5,6 +5,12 @@ CHANGELOG
 ---
 
  * The bridge is not marked as `@experimental` anymore
+ * [BC BREAK] Remove `GoogleChatTransport::setThreadKey()` method, this parameter should now be provided via the constructor,
+   which has changed from:
+   `__construct(string $space, string $accessKey, string $accessToken, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)`
+   to:
+   `__construct(string $space, string $accessKey, string $accessToken, string $threadKey = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)`
+ * [BC BREAK] Rename the parameter `threadKey` to `thread_key` in DSN
 
 5.2.0
 -----

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransport.php
@@ -32,38 +32,25 @@ final class GoogleChatTransport extends AbstractTransport
     private $space;
     private $accessKey;
     private $accessToken;
-
-    /**
-     * @var ?string
-     */
     private $threadKey;
 
     /**
-     * @param string $space       The space name the the webhook url "/v1/spaces/<space>/messages"
-     * @param string $accessKey   The "key" parameter of the webhook url
-     * @param string $accessToken The "token" parameter of the webhook url
+     * @param string      $space       The space name the the webhook url "/v1/spaces/<space>/messages"
+     * @param string      $accessKey   The "key" parameter of the webhook url
+     * @param string      $accessToken The "token" parameter of the webhook url
+     * @param string|null $threadKey   Opaque thread identifier string that can be specified to group messages into a single thread.
+     *                                 If this is the first message with a given thread identifier, a new thread is created.
+     *                                 Subsequent messages with the same thread identifier will be posted into the same thread.
+     *                                 {@see https://developers.google.com/hangouts/chat/reference/rest/v1/spaces.messages/create#query-parameters}
      */
-    public function __construct(string $space, string $accessKey, string $accessToken, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $space, string $accessKey, string $accessToken, string $threadKey = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->space = $space;
         $this->accessKey = $accessKey;
         $this->accessToken = $accessToken;
-
-        parent::__construct($client, $dispatcher);
-    }
-
-    /**
-     * Opaque thread identifier string that can be specified to group messages into a single thread.
-     * If this is the first message with a given thread identifier, a new thread is created.
-     * Subsequent messages with the same thread identifier will be posted into the same thread.
-     *
-     * @see https://developers.google.com/hangouts/chat/reference/rest/v1/spaces.messages/create#query-parameters
-     */
-    public function setThreadKey(?string $threadKey): self
-    {
         $this->threadKey = $threadKey;
 
-        return $this;
+        parent::__construct($client, $dispatcher);
     }
 
     public function __toString(): string
@@ -71,7 +58,7 @@ final class GoogleChatTransport extends AbstractTransport
         return sprintf('googlechat://%s/%s%s',
             $this->getEndpoint(),
             $this->space,
-            $this->threadKey ? '?threadKey='.urlencode($this->threadKey) : ''
+            $this->threadKey ? '?thread_key='.urlencode($this->threadKey) : ''
         );
     }
 

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/README.md
@@ -7,7 +7,7 @@ DSN example
 -----------
 
 ```
-GOOGLE_CHAT_DSN=googlechat://ACCESS_KEY:ACCESS_TOKEN@default/SPACE?threadKey=THREAD_KEY
+GOOGLE_CHAT_DSN=googlechat://ACCESS_KEY:ACCESS_TOKEN@default/SPACE?thread_key=THREAD_KEY
 ```
 
 where:

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportFactoryTest.php
@@ -33,8 +33,8 @@ final class GoogleChatTransportFactoryTest extends TransportFactoryTestCase
         ];
 
         yield [
-            'googlechat://chat.googleapis.com/AAAAA_YYYYY?threadKey=abcdefg',
-            'googlechat://abcde-fghij:kl_mnopqrstwxyz%3D@chat.googleapis.com/AAAAA_YYYYY?threadKey=abcdefg',
+            'googlechat://chat.googleapis.com/AAAAA_YYYYY?thread_key=abcdefg',
+            'googlechat://abcde-fghij:kl_mnopqrstwxyz%3D@chat.googleapis.com/AAAAA_YYYYY?thread_key=abcdefg',
         ];
     }
 
@@ -46,7 +46,8 @@ final class GoogleChatTransportFactoryTest extends TransportFactoryTestCase
 
     public function incompleteDsnProvider(): iterable
     {
-        yield 'missing credentials' => ['googlechat://chat.googleapis.com/AAAAA_YYYYY'];
+        yield 'missing credentials' => ['googlechat://chat.googleapis.com/v1/spaces/AAAAA_YYYYY/messages'];
+        yield 'using old option: threadKey' => ['googlechat://abcde-fghij:kl_mnopqrstwxyz%3D@chat.googleapis.com/AAAAA_YYYYY?threadKey=abcdefg', 'GoogleChat DSN has changed since 5.3, use "thread_key" instead of "threadKey" parameter.']; // can be removed in Symfony 5.4
     }
 
     public function unsupportedSchemeProvider(): iterable

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
@@ -31,14 +31,15 @@ final class GoogleChatTransportTest extends TransportTestCase
     /**
      * @return GoogleChatTransport
      */
-    public function createTransport(?HttpClientInterface $client = null): TransportInterface
+    public function createTransport(?HttpClientInterface $client = null, string $threadKey = null): TransportInterface
     {
-        return new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $client ?: $this->createMock(HttpClientInterface::class));
+        return new GoogleChatTransport('My-Space', 'theAccessKey', 'theAccessToken=', $threadKey, $client ?: $this->createMock(HttpClientInterface::class));
     }
 
     public function toStringProvider(): iterable
     {
         yield ['googlechat://chat.googleapis.com/My-Space', $this->createTransport()];
+        yield ['googlechat://chat.googleapis.com/My-Space?thread_key=abcdefg', $this->createTransport(null, 'abcdefg')];
     }
 
     public function supportedMessagesProvider(): iterable
@@ -125,8 +126,7 @@ final class GoogleChatTransportTest extends TransportTestCase
             return $response;
         });
 
-        $transport = $this->createTransport($client);
-        $transport->setThreadKey('My-Thread');
+        $transport = $this->createTransport($client, 'My-Thread');
 
         $sentMessage = $transport->send(new ChatMessage('testMessage'));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x, but BC BREAK for experimental bridge
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/14834
| Recipe        | https://github.com/symfony/recipes/pull/871


All bridges receive their options via the `constructor` and use snake_case parameters. 

### Todos
* [x] Update recipe
* [x] Update documentation
 
cc @GromNaN as you provided the bridge