### PR TITLE
[Security] Add RememberMe Badge to LoginLinkAuthenticator

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
@@ -69,7 +70,7 @@ final class LoginLinkAuthenticator extends AbstractAuthenticator implements Inte
 
                 return $user;
             }),
-            []
+            [new RememberMeBadge()]
         );
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/LoginLinkAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/LoginLinkAuthenticatorTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\Authenticator\LoginLinkAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\HttpUtils;
@@ -103,6 +104,17 @@ class LoginLinkAuthenticatorTest extends TestCase
             ->method('consumeLoginLink');
 
         $this->authenticator->authenticate($request);
+    }
+
+    public function testPassportBadges()
+    {
+        $this->setUpAuthenticator();
+
+        $request = Request::create('/login/link/check?stuff=1&user=weaverryan');
+
+        $passport = $this->authenticator->authenticate($request);
+
+        $this->assertTrue($passport->hasBadge(RememberMeBadge::class));
     }
 
     private function setUpAuthenticator(array $options = [])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I'm replacing a custom home-made magic link authenticator by the Symfony one, and I missed this behavior. I had to use a EventListener to add the badge to the passeport.

I'm not sure, if the badge were missing on purpose /cc @weaverryan @wouterj 