### PR TITLE
Supports empty path for slack DSN

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
@@ -33,7 +33,7 @@ final class SlackTransportFactory extends AbstractTransportFactory
             throw new UnsupportedSchemeException($dsn, 'slack', $this->getSupportedSchemes());
         }
 
-        if ('/' !== $dsn->getPath()) {
+        if ('/' !== $dsn->getPath() && null !== $dsn->getPath()) {
             throw new IncompleteDsnException('Support for Slack webhook DSN has been dropped since 5.2 (maybe you haven\'t updated the DSN when upgrading from 5.1).');
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportFactoryTest.php
@@ -29,6 +29,15 @@ final class SlackTransportFactoryTest extends TestCase
         $this->assertSame('slack://host.test?channel=testChannel', (string) $transport);
     }
 
+    public function testCreateWithDsnWithoutPath()
+    {
+        $factory = $this->createFactory();
+
+        $transport = $factory->create(Dsn::fromString('slack://testUser@host.test?channel=testChannel'));
+
+        $this->assertSame('slack://host.test?channel=testChannel', (string) $transport);
+    }
+
     public function testCreateWithDeprecatedDsn()
     {
         $factory = $this->createFactory();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

It's actually not possible to use a Slack DSN inspired by [the documentation](https://symfony.com/doc/current/notifier.html#chat-channel), ie: `slack://TOKEN@default?channel=CHANNEL` cause the path is null (must be `/`).

This PR allows to not specify a path.