### PR TITLE
[Notifier] [Slack] Fix incorrect check for path of Slack dsn if path is null

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransportFactory.php
@@ -33,7 +33,7 @@ final class SlackTransportFactory extends AbstractTransportFactory
             throw new UnsupportedSchemeException($dsn, 'slack', $this->getSupportedSchemes());
         }
 
-        if ('/' !== $dsn->getPath()) {
+        if (null !== $dsn->getPath() && '/' !== $dsn->getPath()) {
             throw new IncompleteDsnException('Support for Slack webhook DSN has been dropped since 5.2 (maybe you haven\'t updated the DSN when upgrading from 5.1).');
         }
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportFactoryTest.php
@@ -20,13 +20,22 @@ use Symfony\Component\Notifier\Transport\Dsn;
 
 final class SlackTransportFactoryTest extends TestCase
 {
-    public function testCreateWithDsn()
+    /**
+     * @dataProvider provideValidDsn
+     */
+    public function testCreateWithDsn(string $dsn)
     {
         $factory = $this->createFactory();
 
-        $transport = $factory->create(Dsn::fromString('slack://testUser@host.test/?channel=testChannel'));
+        $transport = $factory->create(Dsn::fromString($dsn));
 
         $this->assertSame('slack://host.test?channel=testChannel', (string) $transport);
+    }
+
+    public function provideValidDsn(): iterable
+    {
+        yield ['slack://testUser@host.test?channel=testChannel'];
+        yield ['slack://testUser@host.test/?channel=testChannel'];
     }
 
     public function testCreateWithDeprecatedDsn()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

It's possible that path of a dsn is null if the trailing slash is missing. Additional to the fix I also extended the test for this case.