### PR TITLE
[Notifier] [BC BREAK] Change constructor signature for Mattermost and Esendex transport

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Esendex/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/CHANGELOG.md
@@ -5,6 +5,10 @@ CHANGELOG
 -----
 
  * The bridge is not marked as `@experimental` anymore
+* [BC BREAK] Changed signature of `EsendexTransport::__construct()` method from:
+  `public function __construct(string $token, string $accountReference, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)`
+  to:
+  `public function __construct(string $email, string $password, string $accountReference, string $from, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)`
 
 5.2.0
 -----

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/EsendexTransportFactory.php
@@ -30,7 +30,8 @@ final class EsendexTransportFactory extends AbstractTransportFactory
             throw new UnsupportedSchemeException($dsn, 'esendex', $this->getSupportedSchemes());
         }
 
-        $token = $this->getUser($dsn).':'.$this->getPassword($dsn);
+        $email = $this->getUser($dsn);
+        $password = $this->getPassword($dsn);
         $accountReference = $dsn->getOption('accountreference');
 
         if (!$accountReference) {
@@ -46,7 +47,7 @@ final class EsendexTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new EsendexTransport($token, $accountReference, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new EsendexTransport($email, $password, $accountReference, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportFactoryTest.php
@@ -25,7 +25,25 @@ final class EsendexTransportFactoryTest extends TestCase
 
         $transport = $factory->create(Dsn::fromString('esendex://email:password@host.test?accountreference=testAccountreference&from=testFrom'));
 
-        $this->assertSame('esendex://host.test', (string) $transport);
+        $this->assertSame('esendex://host.test?accountreference=testAccountreference&from=testFrom', (string) $transport);
+    }
+
+    public function testCreateWithMissingEmailThrowsIncompleteDsnException()
+    {
+        $factory = $this->createFactory();
+
+        $this->expectException(IncompleteDsnException::class);
+
+        $factory->create(Dsn::fromString('esendex://:password@host?accountreference=testAccountreference&from=FROM'));
+    }
+
+    public function testCreateWithMissingPasswordThrowsIncompleteDsnException()
+    {
+        $factory = $this->createFactory();
+
+        $this->expectException(IncompleteDsnException::class);
+
+        $factory->create(Dsn::fromString('esendex://email:@host?accountreference=testAccountreference&from=FROM'));
     }
 
     public function testCreateWithMissingOptionAccountreferenceThrowsIncompleteDsnException()

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
@@ -27,7 +27,7 @@ final class EsendexTransportTest extends TestCase
     {
         $transport = $this->createTransport();
 
-        $this->assertSame('esendex://host.test', (string) $transport);
+        $this->assertSame('esendex://host.test?accountreference=testAccountReference&from=testFrom', (string) $transport);
     }
 
     public function testSupportsSmsMessage()
@@ -90,6 +90,6 @@ final class EsendexTransportTest extends TestCase
 
     private function createTransport(?HttpClientInterface $client = null): EsendexTransport
     {
-        return (new EsendexTransport('testToken', 'testAccountReference', 'testFrom', $client ?: $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new EsendexTransport('testEmail', 'testPassword', 'testAccountReference', 'testFrom', $client ?: $this->createMock(HttpClientInterface::class)))->setHost('host.test');
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/CHANGELOG.md
@@ -5,6 +5,10 @@ CHANGELOG
 -----
 
  * The bridge is not marked as `@experimental` anymore
+* [BC BREAK] Changed signature of `MattermostTransport::__construct()` method from:
+  `public function __construct(string $token, string $channel, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, string $path = null)`
+  to:
+  `public function __construct(string $token, string $channel, ?string $path = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)`
 
 5.1.0
 -----

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransport.php
@@ -29,7 +29,7 @@ final class MattermostTransport extends AbstractTransport
     private $channel;
     private $path;
 
-    public function __construct(string $token, string $channel, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null, string $path = null)
+    public function __construct(string $token, string $channel, ?string $path = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->token = $token;
         $this->channel = $channel;

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/MattermostTransportFactory.php
@@ -41,7 +41,7 @@ final class MattermostTransportFactory extends AbstractTransportFactory
         $host = $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new MattermostTransport($token, $channel, $this->client, $this->dispatcher, $path))->setHost($host)->setPort($port);
+        return (new MattermostTransport($token, $channel, $path, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportTest.php
@@ -29,7 +29,7 @@ final class MattermostTransportTest extends TransportTestCase
      */
     public function createTransport(?HttpClientInterface $client = null): TransportInterface
     {
-        return (new MattermostTransport('testAccessToken', 'testChannel', $client ?: $this->createMock(HttpClientInterface::class)))->setHost('host.test');
+        return (new MattermostTransport('testAccessToken', 'testChannel', null, $client ?: $this->createMock(HttpClientInterface::class)))->setHost('host.test');
     }
 
     public function toStringProvider(): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x, but BC BREAK for experimental bridge
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

Based on https://github.com/symfony/symfony/pull/39428#issue-535936925

cc @odolbeau as you provided the bridge
