### PR TITLE
[Messenger] Fix stopwach usage if it has been reset

### DIFF
--- a/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php
@@ -71,7 +71,7 @@ class TraceableStack implements StackInterface
      */
     public function next(): MiddlewareInterface
     {
-        if (null !== $this->currentEvent) {
+        if (null !== $this->currentEvent && $this->stopwatch->isStarted($this->currentEvent)) {
             $this->stopwatch->stop($this->currentEvent);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

I'm slowly migrating an application to messenger (from swarrot) and I
hit a strange bug. My message was well processeed **BUT** retry!

It comes from two things

* I manually reset the application (via the service resetter, to keep a
low memory usage)
* symfony/messenger try to collect some information, but since the
stopwatch has been reset, an exception occurs and the message has been
retried

So this patch avoid throwing an exception when everything works well

<details>

<summary>the trace:</summary>

```

18:45:41 INFO      [messenger] Message AppBundle\Crawler\Messenger\Message\CrawlSitemapMessage handled by AppBundle\Crawler\Messenger\MessageHandler\CrawlSitemapMessageHa
ndler::__invoke                                                                                                                                                           
[                                                                                                                                                                         
  "message" => AppBundle\Crawler\Messenger\Message\CrawlSitemapMessage^ {                                                                                                 
    -crawlId: "885d23a7-8ad5-4935-a2b3-1c114ac76ded"                                                                                                                      
  },                                                                                                                                                                      
  "class" => "AppBundle\Crawler\Messenger\Message\CrawlSitemapMessage",                                                                                                   
  "handler" => "AppBundle\Crawler\Messenger\MessageHandler\CrawlSitemapMessageHandler::__invoke"                                                                          
]                                                                                                                                                                         
18:45:41 ERROR     [messenger] Error thrown while handling message AppBundle\Crawler\Messenger\Message\CrawlSitemapMessage. Sending for retry #1 using 1000 ms delay. Erro
r: "Event ""Symfony\Component\Messenger\Middleware\HandleMessageMiddleware" on "messenger.bus.default"" is not started."                                                  
[                                                                                                                                                                         
  "message" => AppBundle\Crawler\Messenger\Message\CrawlSitemapMessage^ {                                                                                                 
    -crawlId: "885d23a7-8ad5-4935-a2b3-1c114ac76ded"                                                                                                                      
  },                                                                                                                                                                      
  "class" => "AppBundle\Crawler\Messenger\Message\CrawlSitemapMessage",                                                                                                   
  "retryCount" => 1,                                                                                                                                                      
  "delay" => 1000,                                                                                                                                                        
  "error" => "Event ""Symfony\Component\Messenger\Middleware\HandleMessageMiddleware" on "messenger.bus.default"" is not started.",                                       
  "exception" => LogicException {                                                                                                                                         
    #message: "Event ""Symfony\Component\Messenger\Middleware\HandleMessageMiddleware" on "messenger.bus.default"" is not started."                                       
    #code: 0                                                                                                                                                              
    #file: "./vendor/symfony/symfony/src/Symfony/Component/Stopwatch/Section.php"                                                                                         
    #line: 142                                                                                                                                                            
    trace: {                                                                                                                                                              
      ./vendor/symfony/symfony/src/Symfony/Component/Stopwatch/Section.php:142 { …}                                                                                       
      ./vendor/symfony/symfony/src/Symfony/Component/Stopwatch/Stopwatch.php:126 { …}                                                                                     
      ./vendor/symfony/symfony/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php:75 { …}                                                                 
      ./vendor/symfony/symfony/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php:83 { …}                                                             
      ./vendor/symfony/symfony/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php:74 { …}                                                               
      ./src/Middleware/ResetApplicationMiddlerwareMiddleware.php:14 {                                                                                                     
        AppBundle\Middleware\ResetApplicationMiddlerwareMiddleware->handle(Envelope $envelope, StackInterface $stack): Envelope^                                          
        ›     echo "couocu";                                                                                                                                              
        ›     return $stack->next()->handle($envelope, $stack);                                                                                                           
        › }                                                                                                                                                               
      }                                                                                                                                                                   
      ./vendor/symfony/symfony/src/Symfony/Bridge/Doctrine/Messenger/DoctrinePingConnectionMiddleware.php:34 { …}                                                         
      ./vendor/symfony/symfony/src/Symfony/Bridge/Doctrine/Messenger/AbstractDoctrineMiddleware.php:45 { …}                                                               
      ./vendor/symfony/symfony/src/Symfony/Component/Messenger/Middleware/FailedMessageProcessingMiddleware.php:34 { …}                                                   
      ./vendor/symfony/symfony/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php:68 { …}                                                   
      ./vendor/symfony/symfony/src/Symfony/Component/Messenger/Middleware/RejectRedeliveredMessageMiddleware.php:48 { …}                                                  
      ./vendor/symfony/symfony/src/Symfony/Component/Messenger/Middleware/AddBusNameStampMiddleware.php:37 { …}                                                           
      ./vendor/symfony/symfony/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php:43 { …}                                                                 
      ./vendor/symfony/symfony/src/Symfony/Component/Messenger/MessageBus.php:80 { …}                                                                                     
      ./vendor/symfony/symfony/src/Symfony/Component/Messenger/TraceableMessageBus.php:41 { …}                                                                            
      ./vendor/symfony/symfony/src/Symfony/Component/Messenger/RoutableMessageBus.php:54 { …}                                                                             
      ./vendor/symfony/symfony/src/Symfony/Component/Messenger/Worker.php:114 { …}                                                                                        
      ./vendor/symfony/symfony/src/Symfony/Component/Messenger/Worker.php:77 { …}                                                                                         
      ./vendor/symfony/symfony/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php:198 { …}                                                                
      ./vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:255 { …}                                                                                 
      ./vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:989 { …}                                                                                     
      ./vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:96 { …}                                                                         
      ./vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:290 { …}                                                                                     
      ./vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:82 { …}                                                                         
      ./vendor/symfony/symfony/src/Symfony/Component/Console/Application.php:166 { …}                                                                                     
      ./bin/console:29 { …}
    }
  }
]

```

</details>