### PR TITLE
[Console] Add Aborted const for main exit codes

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -32,6 +32,7 @@ class Command
     public const SUCCESS = 0;
     public const FAILURE = 1;
     public const INVALID = 2;
+    public const ABORTED = 3;
 
     /**
      * @var string|null The default command name


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

**Usage example :** 


```php

if (self::ACTION_CANCEL === $selectedActionId) {
      $output->writeln('<info>Action canceled</info>');
      return Command::ABORTED;
 }
```

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->
