### PR TITLE
[Notifier] add `SentMessageEvent` and `FailedMessageEvent`

### DIFF
--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+5.4
+---
+ * Add `SentMessageEvent` and `FailedMessageEvent`
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Event/FailedMessageEvent.php
+++ b/src/Symfony/Component/Notifier/Event/FailedMessageEvent.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Event;
+
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @author Smaïne Milianni <smaine.milianni@gmail.com>
+ */
+final class FailedMessageEvent extends Event
+{
+    private $message;
+    private $error;
+
+    public function __construct(MessageInterface $message, \Throwable $error)
+    {
+        $this->message = $message;
+        $this->error = $error;
+    }
+
+    public function getMessage(): MessageInterface
+    {
+        return $this->message;
+    }
+
+    public function getError(): \Throwable
+    {
+        return $this->error;
+    }
+}

--- a/src/Symfony/Component/Notifier/Event/SentMessageEvent.php
+++ b/src/Symfony/Component/Notifier/Event/SentMessageEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Event;
+
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @author Smaïne Milianni <smaine.milianni@gmail.com>
+ */
+final class SentMessageEvent extends Event
+{
+    private $message;
+
+    public function __construct(SentMessage $message)
+    {
+        $this->message = $message;
+    }
+
+    public function getMessage(): SentMessage
+    {
+        return $this->message;
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Event/FailedMessageEventTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Event/FailedMessageEventTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Symfony\Component\Notifier\Tests\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Event\FailedMessageEvent;
+use Symfony\Component\Notifier\Event\MessageEvent;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Component\Notifier\Transport\NullTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Smaïne Milianni <smaine.milianni@gmail.com>
+ */
+final class FailedMessageEventTest extends TestCase
+{
+    /**
+     * @dataProvider messagesProvider
+     */
+    public function testConstruct(MessageInterface $message, \Throwable $error, FailedMessageEvent $event)
+    {
+        $this->assertEquals($event, new FailedMessageEvent($message, $error));
+    }
+
+    /**
+     * @dataProvider messagesProvider
+     */
+    public function testGetMessage(MessageInterface $message, \Throwable $error, FailedMessageEvent $event)
+    {
+        $this->assertSame($message, $event->getMessage());
+    }
+
+    /**
+     * @dataProvider messagesProvider
+     */
+    public function testGetError(MessageInterface $message, \Throwable $error, FailedMessageEvent $event)
+    {
+        $this->assertSame($error, $event->getError());
+    }
+
+    public function testFailedMessageEventIsDisptachIfError()
+    {
+        $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
+        $clientMock = $this->createMock(HttpClientInterface::class);
+
+        $transport = new class($clientMock, $eventDispatcherMock) extends AbstractTransport {
+            public function __construct($client, EventDispatcherInterface $dispatcher = null)
+            {
+                $this->exception = new NullTransportException();
+                parent::__construct($client, $dispatcher);
+            }
+
+            public function doSend(MessageInterface $message): SentMessage
+            {
+                throw $this->exception;
+            }
+
+            public function supports(MessageInterface $message): bool
+            {
+                return true;
+            }
+
+            public function __toString(): string
+            {
+            }
+        };
+
+        $message = new DummyMessage();
+
+        $eventDispatcherMock->expects($this->exactly(2))
+            ->method('dispatch')
+            ->withConsecutive(
+                [new MessageEvent($message)],
+                [new FailedMessageEvent($message, $transport->exception)]
+            );
+        try {
+            $transport->send($message);
+        } catch (NullTransportException $exception) {
+            // catch Exception that is voluntary thrown in NullTransport::send
+        }
+    }
+
+    public function messagesProvider(): iterable
+    {
+        yield [$message = new ChatMessage('subject'), $error = new \RuntimeException(), new FailedMessageEvent($message, $error)];
+        yield [$message = new SmsMessage('+3312345678', 'subject'), $error = new \Exception(), new FailedMessageEvent($message, $error)];
+    }
+}
+
+class NullTransportException extends \Exception
+{
+}

--- a/src/Symfony/Component/Notifier/Tests/Event/SentMessageEventTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Event/SentMessageEventTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Symfony\Component\Notifier\Tests\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Event\SentMessageEvent;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+
+/**
+ * @author Smaïne Milianni <smaine.milianni@gmail.com>
+ */
+final class SentMessageEventTest extends TestCase
+{
+    /**
+     * @dataProvider messagesProvider
+     */
+    public function testConstruct(SentMessage $message, SentMessageEvent $event)
+    {
+        $this->assertEquals($event, new SentMessageEvent($message));
+    }
+
+    /**
+     * @dataProvider messagesProvider
+     */
+    public function testGetMessage(SentMessage $message, SentMessageEvent $event)
+    {
+        $this->assertSame($message, $event->getMessage());
+    }
+
+    public function messagesProvider(): iterable
+    {
+        yield [$message = new SentMessage(new ChatMessage('subject'), 'null_transport'), new SentMessageEvent($message)];
+        yield [$message = new SentMessage(new SmsMessage('+3312345678', 'subject'), 'null_transport'), new SentMessageEvent($message)];
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/Transport/NullTransportTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/NullTransportTest.php
@@ -31,7 +31,7 @@ class NullTransportTest extends TestCase
             $eventDispatcherMock = $this->createMock(EventDispatcherInterface::class)
         );
 
-        $eventDispatcherMock->expects($this->once())->method('dispatch');
+        $eventDispatcherMock->expects($this->exactly(2))->method('dispatch');
         $nullTransport->send(new DummyMessage());
     }
 }

--- a/src/Symfony/Component/Notifier/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Notifier/Transport/AbstractTransport.php
@@ -14,7 +14,9 @@ namespace Symfony\Component\Notifier\Transport;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\Notifier\Event\FailedMessageEvent;
 use Symfony\Component\Notifier\Event\MessageEvent;
+use Symfony\Component\Notifier\Event\SentMessageEvent;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
@@ -70,11 +72,23 @@ abstract class AbstractTransport implements TransportInterface
 
     public function send(MessageInterface $message): SentMessage
     {
-        if (null !== $this->dispatcher) {
-            $this->dispatcher->dispatch(new MessageEvent($message));
+        if (null === $this->dispatcher) {
+            return $this->doSend($message);
         }
 
-        return $this->doSend($message);
+        $this->dispatcher->dispatch(new MessageEvent($message));
+
+        try {
+            $sentMessage = $this->doSend($message);
+        } catch (\Throwable $error) {
+            $this->dispatcher->dispatch(new FailedMessageEvent($message, $error));
+
+            throw $error;
+        }
+
+        $this->dispatcher->dispatch(new SentMessageEvent($sentMessage));
+
+        return $sentMessage;
     }
 
     abstract protected function doSend(MessageInterface $message): SentMessage;

--- a/src/Symfony/Component/Notifier/Transport/NullTransport.php
+++ b/src/Symfony/Component/Notifier/Transport/NullTransport.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Transport;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\Notifier\Event\MessageEvent;
+use Symfony\Component\Notifier\Event\SentMessageEvent;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\NullMessage;
 use Symfony\Component\Notifier\Message\SentMessage;
@@ -34,12 +35,16 @@ class NullTransport implements TransportInterface
     public function send(MessageInterface $message): SentMessage
     {
         $message = new NullMessage($message);
+        $sentMessage = new SentMessage($message, (string) $this);
 
-        if (null !== $this->dispatcher) {
-            $this->dispatcher->dispatch(new MessageEvent($message));
+        if (null === $this->dispatcher) {
+            return $sentMessage;
         }
 
-        return new SentMessage($message, (string) $this);
+        $this->dispatcher->dispatch(new MessageEvent($message));
+        $this->dispatcher->dispatch(new SentMessageEvent($sentMessage));
+
+        return $sentMessage;
     }
 
     public function __toString(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| License       | MIT
| Doc PR        | 


Dispatch a new event  `SentMessageEvent` **which is dispatched once the notification is sent**.  The `Symfony\Component\Notifier\Transport\AbstractTransport`  return an instance of `SentMessage` that contains the original message + an id that [can be returned by the API](https://github.com/symfony/linked-in-notifier/blob/5.x/LinkedInTransport.php#L96) it can be helpful to pass this object to the event. 

Dispatch a new event `FailedMessageEvent`  **which is dispatched if sending the notification fails** it can be helpful for a retry strategy