### PR TITLE
[Cache] Add TLS query parameter to Redis connection DSN

### DIFF
--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added support for connecting to Redis Sentinel clusters when using the Redis PHP extension
+ * added TLS support for \Redis connection in the DNS. Example: `redis://127.0.0.1?tls=1`
 
 5.2.0
 -----

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -181,10 +181,10 @@ trait RedisTrait
 
             $initializer = static function ($redis) use ($connect, $params, $dsn, $auth, $hosts, $query) {
                 $host = $hosts[0]['host'] ?? $hosts[0]['path'];
-                if (array_key_exists('tls', $query)) {
-                    $tls = filter_var($query['tls'], FILTER_VALIDATE_BOOLEAN);
+                if (\array_key_exists('tls', $query)) {
+                    $tls = filter_var($query['tls'], \FILTER_VALIDATE_BOOLEAN);
                     if ($tls) {
-                        $host = 'tls://' . $host;
+                        $host = 'tls://'.$host;
                     }
                 }
                 $port = $hosts[0]['port'] ?? null;

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -179,8 +179,14 @@ trait RedisTrait
             $connect = $params['persistent'] || $params['persistent_id'] ? 'pconnect' : 'connect';
             $redis = new $class();
 
-            $initializer = static function ($redis) use ($connect, $params, $dsn, $auth, $hosts) {
+            $initializer = static function ($redis) use ($connect, $params, $dsn, $auth, $hosts, $query) {
                 $host = $hosts[0]['host'] ?? $hosts[0]['path'];
+                if (array_key_exists('tls', $query)) {
+                    $tls = filter_var($query['tls'], FILTER_VALIDATE_BOOLEAN);
+                    if ($tls) {
+                        $host = 'tls://' . $host;
+                    }
+                }
                 $port = $hosts[0]['port'] ?? null;
 
                 if (isset($params['redis_sentinel'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A (will create it tomorrow)

As already fixed in https://github.com/symfony/symfony/pull/35503, this enables the use of TLS protocol within the DSN string. 
An example DSN string 
```
redis://127.0.0.1?tls=1
``` 
will result in 
```
tls://127.0.0.1
```

