### PR TITLE
[Messenger] Add `rediss://` DSN scheme support for TLS to Redis transport

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -50,6 +50,7 @@ Messenger
 ---------
 
  * Deprecated the `prefetch_count` parameter in the AMQP bridge, it has no effect and will be removed in Symfony 6.0
+ * Deprecated the use of TLS option for Redis Bridge, use `rediss://127.0.0.1` instead of `redis://127.0.0.1?tls=1`
 
 Notifier
 --------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -122,6 +122,7 @@ Messenger
  * The signature of method `RetryStrategyInterface::isRetryable()` has been updated to `RetryStrategyInterface::isRetryable(Envelope $message, \Throwable $throwable = null)`.
  * The signature of method `RetryStrategyInterface::getWaitingTime()` has been updated to `RetryStrategyInterface::getWaitingTime(Envelope $message, \Throwable $throwable = null)`.
  * Removed the `prefetch_count` parameter in the AMQP bridge.
+ * Removed the use of TLS option for Redis Bridge, use `rediss://127.0.0.1` instead of `redis://127.0.0.1?tls=1`
 
 Mime
 ----

--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.3
+---
+
+ * Add `rediss://` DSN scheme support for TLS protocol
+ * Deprecate TLS option, use `rediss://127.0.0.1` instead of `redis://127.0.0.1?tls=1`
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -86,6 +86,9 @@ class ConnectionTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
     public function testFromDsnWithTls()
     {
         $redis = $this->createMock(\Redis::class);
@@ -97,6 +100,9 @@ class ConnectionTest extends TestCase
         Connection::fromDsn('redis://127.0.0.1?tls=1', [], $redis);
     }
 
+    /**
+     * @group legacy
+     */
     public function testFromDsnWithTlsOption()
     {
         $redis = $this->createMock(\Redis::class);
@@ -106,6 +112,17 @@ class ConnectionTest extends TestCase
             ->willReturn(null);
 
         Connection::fromDsn('redis://127.0.0.1', ['tls' => true], $redis);
+    }
+
+    public function testFromDsnWithRedissScheme()
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects($this->once())
+            ->method('connect')
+            ->with('tls://127.0.0.1', 6379)
+            ->willReturn(null);
+
+        Connection::fromDsn('rediss://127.0.0.1', [], $redis);
     }
 
     public function testFromDsnWithQueryOptions()

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -119,9 +119,10 @@ class Connection
     public static function fromDsn(string $dsn, array $redisOptions = [], \Redis $redis = null): self
     {
         $url = $dsn;
+        $scheme = 0 === strpos($dsn, 'rediss:') ? 'rediss' : 'redis';
 
-        if (preg_match('#^redis:///([^:@])+$#', $dsn)) {
-            $url = str_replace('redis:', 'file:', $dsn);
+        if (preg_match('#^'.$scheme.':///([^:@])+$#', $dsn)) {
+            $url = str_replace($scheme.':', 'file:', $dsn);
         }
 
         if (false === $parsedUrl = parse_url($url)) {
@@ -164,8 +165,9 @@ class Connection
             unset($redisOptions['dbindex']);
         }
 
-        $tls = false;
+        $tls = 'rediss' === $scheme;
         if (\array_key_exists('tls', $redisOptions)) {
+            trigger_deprecation('symfony/redis-messenger', '5.3', 'Providing "tls" parameter is deprecated, use "rediss://" DSN scheme instead');
             $tls = filter_var($redisOptions['tls'], \FILTER_VALIDATE_BOOLEAN);
             unset($redisOptions['tls']);
         }

--- a/src/Symfony/Component/Messenger/Transport/TransportFactory.php
+++ b/src/Symfony/Component/Messenger/Transport/TransportFactory.php
@@ -43,7 +43,7 @@ class TransportFactory implements TransportFactoryInterface
             $packageSuggestion = ' Run "composer require symfony/amqp-messenger" to install AMQP transport.';
         } elseif (0 === strpos($dsn, 'doctrine://')) {
             $packageSuggestion = ' Run "composer require symfony/doctrine-messenger" to install Doctrine transport.';
-        } elseif (0 === strpos($dsn, 'redis://')) {
+        } elseif (0 === strpos($dsn, 'redis://') || 0 === strpos($dsn, 'rediss://')) {
             $packageSuggestion = ' Run "composer require symfony/redis-messenger" to install Redis transport.';
         } elseif (0 === strpos($dsn, 'sqs://') || preg_match('#^https://sqs\.[\w\-]+\.amazonaws\.com/.+#', $dsn)) {
             $packageSuggestion = ' Run "composer require symfony/amazon-sqs-messenger" to install Amazon SQS transport.';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | 
| License       | MIT
| Doc PR        | 

This adds a support for `rediss://` DSN (as discussed in https://github.com/symfony/symfony/pull/39599) and deprecates the use of `tls` parameter introduced in https://github.com/symfony/symfony/pull/35503 so it can be standardized to single format.
