### PR TITLE
[Messenger] Setup queues once in AMQP

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -118,7 +118,7 @@ class Connection
             'wait_time' => (int) $options['wait_time'],
             'poll_timeout' => $options['poll_timeout'],
             'visibility_timeout' => $options['visibility_timeout'],
-            'auto_setup' => (bool) $options['auto_setup'],
+            'auto_setup' => filter_var($options['auto_setup'], \FILTER_VALIDATE_BOOLEAN),
             'queue_name' => (string) $options['queue_name'],
         ];
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -421,6 +421,24 @@ class ConnectionTest extends TestCase
         $connection->publish('body');
     }
 
+    public function testItSetupQueuesOnce()
+    {
+        $factory = new TestAmqpFactory(
+            $amqpConnection = $this->createMock(\AMQPConnection::class),
+            $amqpChannel = $this->createMock(\AMQPChannel::class),
+            $amqpQueue = $this->createMock(\AMQPQueue::class),
+            $amqpExchange = $this->createMock(\AMQPExchange::class)
+        );
+
+        $amqpExchange->expects($this->once())->method('declareExchange');
+        $amqpQueue->expects($this->once())->method('declareQueue');
+        $amqpQueue->expects($this->once())->method('bind');
+
+        $connection = Connection::fromDsn('amqp://localhost', ['auto_setup' => true], $factory);
+        $connection->publish('body');
+        $connection->publish('body');
+    }
+
     public function testSetChannelPrefetchWhenSetup()
     {
         $factory = new TestAmqpFactory(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #39605, Fix #38092, Fix #32172
| License       | MIT
| Doc PR        | -

To ease the setup, this PR also merge setup of exchange AND delayExchange. 

/cc @Nyholm 