### PR TITLE
[ProxyManagerBridge] fix PHP notice, switch to "friendsofphp/proxy-manager-lts"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=7.1.3",
         "ext-xml": "*",
+        "friendsofphp/proxy-manager-lts": "^1.0",
         "doctrine/event-manager": "~1.0",
         "doctrine/persistence": "^1.3|^2",
         "twig/twig": "^1.41|^2.10|^3.0",
@@ -112,7 +113,6 @@
         "masterminds/html5": "^2.6",
         "monolog/monolog": "^1.25.1",
         "nyholm/psr7": "^1.0",
-        "ocramius/proxy-manager": "^2.1",
         "paragonie/sodium_compat": "^1.8",
         "php-http/httplug": "^1.0|^2.0",
         "predis/predis": "~1.1",

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/RuntimeInstantiator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/Instantiator/RuntimeInstantiator.php
@@ -48,7 +48,11 @@ class RuntimeInstantiator implements InstantiatorInterface
                 $proxy->setProxyInitializer(null);
 
                 return true;
-            }
+            },
+            [
+                'fluentSafe' => $definition->hasTag('proxy'),
+                'skipDestructor' => true,
+            ]
         );
     }
 }

--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/ProxyDumper.php
@@ -11,9 +11,7 @@
 
 namespace Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper;
 
-use ProxyManager\Exception\ExceptionInterface;
 use ProxyManager\Generator\ClassGenerator;
-use ProxyManager\Generator\MethodGenerator;
 use ProxyManager\GeneratorStrategy\BaseGeneratorStrategy;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\LazyProxy\PhpDumper\DumperInterface;
@@ -88,18 +86,6 @@ EOF;
         $code = $this->classGenerator->generate($this->generateProxyClass($definition));
         $code = preg_replace('/^(class [^ ]++ extends )([^\\\\])/', '$1\\\\$2', $code);
 
-        if (!method_exists(MethodGenerator::class, 'fromReflectionWithoutBodyAndDocBlock')) { // proxy-manager < 2.2
-            $code = preg_replace(
-                '/((?:\$(?:this|initializer|instance)->)?(?:publicProperties|initializer|valueHolder))[0-9a-f]++/',
-                '${1}'.$this->getIdentifierSuffix($definition),
-                $code
-            );
-        }
-
-        if (!is_subclass_of(ExceptionInterface::class, 'Throwable')) { // proxy-manager < 2.5
-            $code = preg_replace('/ \\\\Closure::bind\(function ((?:& )?\(\$instance(?:, \$value)?\))/', ' \Closure::bind(static function \1', $code);
-        }
-
         return $code;
     }
 
@@ -118,8 +104,10 @@ EOF;
         $generatedClass = new ClassGenerator($this->getProxyClassName($definition));
         $class = $this->proxyGenerator->getProxifiedClass($definition);
 
-        $this->proxyGenerator->setFluentSafe($definition->hasTag('proxy'));
-        $this->proxyGenerator->generate(new \ReflectionClass($class), $generatedClass);
+        $this->proxyGenerator->generate(new \ReflectionClass($class), $generatedClass, [
+            'fluentSafe' => $definition->hasTag('proxy'),
+            'skipDestructor' => true,
+        ]);
 
         return $generatedClass;
     }

--- a/src/Symfony/Bridge/ProxyManager/README.md
+++ b/src/Symfony/Bridge/ProxyManager/README.md
@@ -11,4 +11,4 @@ Resources
     [send Pull Requests](https://github.com/symfony/symfony/pulls)
     in the [main Symfony repository](https://github.com/symfony/symfony)
 
-[1]: https://github.com/Ocramius/ProxyManager
+[1]: https://github.com/FriendsOfPHP/proxy-manager-lts

--- a/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/Fixtures/proxy-implem.php
+++ b/src/Symfony/Bridge/ProxyManager/Tests/LazyProxy/PhpDumper/Fixtures/proxy-implem.php
@@ -16,7 +16,7 @@ class SunnyInterface_%s implements \ProxyManager\Proxy\VirtualProxyInterface, \S
         $this->initializer%s && ($this->initializer%s->__invoke($valueHolder%s, $this, 'dummy', array(), $this->initializer%s) || 1) && $this->valueHolder%s = $valueHolder%s;
 
         if ($this->valueHolder%s === $returnValue = $this->valueHolder%s->dummy()) {
-            $returnValue = $this;
+            return $this;
         }
 
         return $returnValue;
@@ -26,8 +26,8 @@ class SunnyInterface_%s implements \ProxyManager\Proxy\VirtualProxyInterface, \S
     {
         $this->initializer%s && ($this->initializer%s->__invoke($valueHolder%s, $this, 'dummyRef', array(), $this->initializer%s) || 1) && $this->valueHolder%s = $valueHolder%s;
 
-        if ($this->valueHolder%s === $returnValue = &$this->valueHolder%s->dummyRef()) {
-            $returnValue = $this;
+        if ($this->valueHolder%s === $returnValue = & $this->valueHolder%s->dummyRef()) {
+            return $this;
         }
 
         return $returnValue;
@@ -38,7 +38,7 @@ class SunnyInterface_%s implements \ProxyManager\Proxy\VirtualProxyInterface, \S
         $this->initializer%s && ($this->initializer%s->__invoke($valueHolder%s, $this, 'sunny', array(), $this->initializer%s) || 1) && $this->valueHolder%s = $valueHolder%s;
 
         if ($this->valueHolder%s === $returnValue = $this->valueHolder%s->sunny()) {
-            $returnValue = $this;
+            return $this;
         }
 
         return $returnValue;
@@ -96,7 +96,7 @@ class SunnyInterface_%s implements \ProxyManager\Proxy\VirtualProxyInterface, \S
 
         $targetObject = $this->valueHolder%s;
 
-        return $targetObject->$name = $value;
+        $targetObject->$name = $value; return $targetObject->$name;
     }
 
     public function __isset($name)

--- a/src/Symfony/Bridge/ProxyManager/composer.json
+++ b/src/Symfony/Bridge/ProxyManager/composer.json
@@ -18,14 +18,11 @@
     "require": {
         "php": ">=7.1.3",
         "composer/package-versions-deprecated": "^1.8",
-        "symfony/dependency-injection": "^4.0|^5.0",
-        "ocramius/proxy-manager": "~2.1"
+        "friendsofphp/proxy-manager-lts": "^1.0",
+        "symfony/dependency-injection": "^4.0|^5.0"
     },
     "require-dev": {
         "symfony/config": "^3.4|^4.0|^5.0"
-    },
-    "conflict": {
-        "zendframework/zend-eventmanager": "2.6.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Bridge\\ProxyManager\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39089
| License       | MIT
| Doc PR        | -

I submitted the fix for #39089 on the origin library at https://github.com/Ocramius/ProxyManager/pull/646.

Because of the [versioning policy](https://github.com/Ocramius/.github/blob/6d4561515513f6d59fb144d838971d4a7715e3e4/version-support.md#dependency-upgrades) in use at the origin library, this fix won't be available for PHP < 7.4.

We usually resort to monkey-patching to workaround the policy and still ship the fix for 4.4 (which supports PHP >= 7.1).

This time, and as explained in https://github.com/Ocramius/ProxyManager/issues/630, I propose to delegate the fix to [friendsofphp/proxy-manager-lts](https://github.com/FriendsOfPHP/proxy-manager-lts/). It already embeds the fix and a few others that allow us to remove most of the monkey-patching we had to accumulate over time.
