### PR TITLE
Add missing `@return` annotations to fix deprecations on PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,7 @@ before_install:
           if [[ $PHP = 8.* ]]; then
               tfold ext.memcached tpecl memcached-3.1.5 memcached.so $INI
           else
-              tfold ext.mongodb tpecl mongodb-1.6.16 mongodb.so $INI
+              tfold ext.mongodb tpecl mongodb-1.8.1 mongodb.so $INI
               tfold ext.zookeeper tpecl zookeeper-0.7.2 zookeeper.so $INI
               tfold ext.amqp tpecl amqp-1.10.2 amqp.so $INI
           fi
@@ -216,13 +216,6 @@ install:
       fi
 
     - |
-      # Set composer's platform to php 7.4 if we're on php 8.
-      if [[ $PHP = 8.* ]]; then
-          composer config platform.php 7.4.99
-          export SYMFONY_DEPRECATIONS_HELPER=max[total]=999
-      fi
-
-    - |
       # Install symfony/flex
       if [[ $deps = low ]]; then
           export SYMFONY_REQUIRE='>=2.3'
@@ -262,7 +255,7 @@ install:
           fi
           phpenv global $PHP
           rm vendor/composer/package-versions-deprecated -Rf
-          ([[ $deps ]] && cd src/Symfony/Component/HttpFoundation; cp composer.json composer.bak; composer config platform.ext-mongodb 1.6.99; composer require --dev --no-update mongodb/mongodb ~1.5.0)
+          ([[ $deps ]] && cd src/Symfony/Component/HttpFoundation; cp composer.json composer.bak; composer config platform.ext-mongodb 1.8.99; composer require --dev --no-update mongodb/mongodb ^1.8.1)
           tfold 'composer update' $COMPOSER_UP
           tfold 'phpunit install' ./phpunit install
           if [[ $deps = high ]]; then
@@ -279,7 +272,7 @@ install:
                   git fetch --depth=2 origin $SYMFONY_VERSION
                   git checkout -m FETCH_HEAD
                   COMPONENTS=$(echo "$COMPONENTS" | xargs dirname | xargs -n1 -I{} bash -c "[ -e '{}/phpunit.xml.dist' ] && echo '{}'" | sort)
-                  (cd src/Symfony/Component/HttpFoundation; composer config platform.ext-mongodb 1.6.99; composer require --dev --no-update mongodb/mongodb)
+                  (cd src/Symfony/Component/HttpFoundation; composer config platform.ext-mongodb 1.8.99; composer require --dev --no-update mongodb/mongodb)
                   [[ ! $COMPONENTS ]] || tfold 'phpunit install' SYMFONY_PHPUNIT_REMOVE_RETURN_TYPEHINT=1 ./phpunit install
                   [[ ! $COMPONENTS ]] || echo "$COMPONENTS" | parallel --gnu "tfold {} 'cd {} && rm composer.lock vendor/ -Rf && $COMPOSER_UP && $PHPUNIT_X$LEGACY'" || X=1
               fi

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/StringWrapperType.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Type/StringWrapperType.php
@@ -18,6 +18,8 @@ class StringWrapperType extends StringType
 {
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -26,6 +28,8 @@ class StringWrapperType extends StringType
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineFooType.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineFooType.php
@@ -43,6 +43,8 @@ class DoctrineFooType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -58,6 +60,8 @@ class DoctrineFooType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {

--- a/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/ConsoleFormatter.php
@@ -83,6 +83,8 @@ class ConsoleFormatter implements FormatterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function formatBatch(array $records)
     {
@@ -95,6 +97,8 @@ class ConsoleFormatter implements FormatterInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function format(array $record)
     {

--- a/src/Symfony/Bridge/Monolog/Formatter/VarDumperFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/VarDumperFormatter.php
@@ -26,6 +26,11 @@ class VarDumperFormatter implements FormatterInterface
         $this->cloner = $cloner ?: new VarCloner();
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return mixed
+     */
     public function format(array $record)
     {
         $record['context'] = $this->cloner->cloneVar($record['context']);
@@ -34,6 +39,11 @@ class VarDumperFormatter implements FormatterInterface
         return $record;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return mixed
+     */
     public function formatBatch(array $records)
     {
         foreach ($records as $k => $record) {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -58,7 +58,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
     /**
      * Gets a container parameter by its name.
      *
-     * @return mixed
+     * @return array|bool|float|int|string|null
      *
      * @final
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -31,7 +31,7 @@ abstract class Controller implements ContainerAwareInterface
     /**
      * Gets a container configuration parameter by its name.
      *
-     * @return mixed
+     * @return array|bool|float|int|string|null
      *
      * @final
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/LegacyRouteLoaderContainer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/LegacyRouteLoaderContainer.php
@@ -29,6 +29,8 @@ class LegacyRouteLoaderContainer implements ContainerInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function get($id)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
@@ -58,6 +58,8 @@ class TestContainer extends Container
 
     /**
      * {@inheritdoc}
+     *
+     * @return array|bool|float|int|string|null
      */
     public function getParameter($name)
     {

--- a/src/Symfony/Component/Cache/CacheItem.php
+++ b/src/Symfony/Component/Cache/CacheItem.php
@@ -43,6 +43,8 @@ final class CacheItem implements ItemInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function get()
     {

--- a/src/Symfony/Component/Cache/Psr16Cache.php
+++ b/src/Symfony/Component/Cache/Psr16Cache.php
@@ -66,6 +66,8 @@ class Psr16Cache implements CacheInterface, PruneableInterface, ResettableInterf
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function get($key, $default = null)
     {

--- a/src/Symfony/Component/DependencyInjection/Argument/ServiceLocator.php
+++ b/src/Symfony/Component/DependencyInjection/Argument/ServiceLocator.php
@@ -34,6 +34,8 @@ class ServiceLocator extends BaseServiceLocator
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function get($id)
     {

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -109,7 +109,7 @@ class Container implements ResettableContainerInterface
      *
      * @param string $name The parameter name
      *
-     * @return mixed The parameter value
+     * @return array|bool|float|int|string|null The parameter value
      *
      * @throws InvalidArgumentException if the parameter is not defined
      */

--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -76,7 +76,7 @@ interface ContainerInterface extends PsrContainerInterface
      *
      * @param string $name The parameter name
      *
-     * @return mixed The parameter value
+     * @return array|bool|float|int|string|null The parameter value
      *
      * @throws InvalidArgumentException if the parameter is not defined
      */

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1449,6 +1449,9 @@ EOF;
 
         $code = <<<'EOF'
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/ServiceLocator.php
+++ b/src/Symfony/Component/DependencyInjection/ServiceLocator.php
@@ -33,6 +33,11 @@ class ServiceLocator implements ServiceProviderInterface
     private $externalId;
     private $container;
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return mixed
+     */
     public function get($id)
     {
         if (!$this->externalId) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -537,6 +537,9 @@ class DecoratedServiceLocator implements ServiceProviderInterface
         $this->locator = $locator;
     }
 
+    /**
+     * @return mixed
+     */
     public function get($id)
     {
         return $this->locator->get($id);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -59,6 +59,9 @@ class ProjectServiceContainer extends Container
         return $this->services['test'] = new \stdClass(['only dot' => '.', 'concatenation as value' => '.\'\'.', 'concatenation from the start value' => '\'\'.', '.' => 'dot as a key', '.\'\'.' => 'concatenation as a key', '\'\'.' => 'concatenation from the start key', 'optimize concatenation' => 'string1-string2', 'optimize concatenation with empty string' => 'string1string2', 'optimize concatenation from the start' => 'start', 'optimize concatenation at the end' => 'end', 'new line' => 'string with '."\n".'new line']);
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services12.php
@@ -59,6 +59,9 @@ class ProjectServiceContainer extends Container
         return $this->services['test'] = new \stdClass(('file://'.\dirname(__DIR__, 1)), [('file://'.\dirname(__DIR__, 1)) => (\dirname(__DIR__, 2).'/')]);
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services19.php
@@ -74,6 +74,9 @@ class ProjectServiceContainer extends Container
         return $instance;
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services26.php
@@ -70,6 +70,9 @@ class Symfony_DI_PhpDumper_Test_EnvParameters extends Container
         return $this->services['test'] = new ${($_ = $this->getEnv('FOO')) && false ?: "_"}($this->getEnv('Bar'), 'foo'.$this->getEnv('string:FOO').'baz', $this->getEnv('int:Baz'));
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
@@ -46,6 +46,9 @@ class ProjectServiceContainer extends Container
         ];
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -460,6 +460,9 @@ class ProjectServiceContainer extends Container
         return $instance;
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_compiled.php
@@ -409,6 +409,9 @@ class ProjectServiceContainer extends Container
         return new \SimpleFactoryClass('foo');
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
@@ -458,6 +458,9 @@ class ProjectServiceContainer extends Container
         return new \SimpleFactoryClass('foo');
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -94,6 +94,9 @@ class ProjectServiceContainer extends Container
         return new \Bar\FooClass(new \Bar\FooLazyClass());
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_array_params.php
@@ -63,6 +63,9 @@ class ProjectServiceContainer extends Container
         return $instance;
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_base64_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_base64_env.php
@@ -46,6 +46,9 @@ class Symfony_DI_PhpDumper_Test_Base64Parameters extends Container
         ];
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_csv_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_csv_env.php
@@ -46,6 +46,9 @@ class Symfony_DI_PhpDumper_Test_CsvParameters extends Container
         ];
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_default_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_default_env.php
@@ -46,6 +46,9 @@ class Symfony_DI_PhpDumper_Test_DefaultParameters extends Container
         ];
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_env_in_id.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_env_in_id.php
@@ -72,6 +72,9 @@ class ProjectServiceContainer extends Container
         return $this->services['foo'] = new \stdClass(($this->privates['bar_%env(BAR)%'] ?? ($this->privates['bar_%env(BAR)%'] = new \stdClass())), ['baz_'.$this->getEnv('string:BAR') => new \stdClass()]);
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_errored_definition.php
@@ -409,6 +409,9 @@ class Symfony_DI_PhpDumper_Errored_Definition extends Container
         return new \SimpleFactoryClass('foo');
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_requires.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_inline_requires.php
@@ -92,6 +92,9 @@ class ProjectServiceContainer extends Container
         return $this->services['Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\includes\\HotPath\\C2'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C2(new \Symfony\Component\DependencyInjection\Tests\Fixtures\includes\HotPath\C3());
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_json_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_json_env.php
@@ -46,6 +46,9 @@ class Symfony_DI_PhpDumper_Test_JsonParameters extends Container
         ];
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_query_string_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_query_string_env.php
@@ -46,6 +46,9 @@ class Symfony_DI_PhpDumper_Test_QueryStringParameters extends Container
         ];
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_rot13_env.php
@@ -77,6 +77,9 @@ class Symfony_DI_PhpDumper_Test_Rot13Parameters extends Container
         ]);
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_unsupported_characters.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_unsupported_characters.php
@@ -81,6 +81,9 @@ class Symfony_DI_PhpDumper_Test_Unsupported_Characters extends Container
         return $this->services['foo*/oh-no'] = new \FooClass();
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_url_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_url_env.php
@@ -46,6 +46,9 @@ class Symfony_DI_PhpDumper_Test_UrlParameters extends Container
         ];
     }
 
+    /**
+     * @return array|bool|float|int|string|null
+     */
     public function getParameter($name)
     {
         $name = (string) $name;

--- a/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Form/Tests/Resources/TranslationFilesTest.php
@@ -37,7 +37,9 @@ class TranslationFilesTest extends TestCase
     {
         $document = new \DOMDocument();
         $document->loadXML(file_get_contents($filePath));
-        libxml_disable_entity_loader(true);
+        if (\LIBXML_VERSION < 20900) {
+            libxml_disable_entity_loader(true);
+        }
 
         $errors = XliffUtils::validateSchema($document);
 

--- a/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Resources/TranslationFilesTest.php
@@ -36,7 +36,9 @@ class TranslationFilesTest extends TestCase
     {
         $document = new \DOMDocument();
         $document->loadXML(file_get_contents($filePath));
-        libxml_disable_entity_loader(true);
+        if (\LIBXML_VERSION < 20900) {
+            libxml_disable_entity_loader(true);
+        }
 
         $errors = XliffUtils::validateSchema($document);
 

--- a/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
+++ b/src/Symfony/Component/Validator/Tests/Resources/TranslationFilesTest.php
@@ -36,7 +36,9 @@ class TranslationFilesTest extends TestCase
     {
         $document = new \DOMDocument();
         $document->loadXML(file_get_contents($filePath));
-        libxml_disable_entity_loader(true);
+        if (\LIBXML_VERSION < 20900) {
+            libxml_disable_entity_loader(true);
+        }
 
         $errors = XliffUtils::validateSchema($document);
 

--- a/src/Symfony/Contracts/Service/ServiceLocatorTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceLocatorTrait.php
@@ -50,6 +50,8 @@ trait ServiceLocatorTrait
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function get($id)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -