### PR TITLE
[Security] Fix event propagation for globally registered security events

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPass.php
@@ -13,14 +13,18 @@ namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Security\Core\AuthenticationEvents;
+use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\Event\LoginFailureEvent;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
 
 /**
  * Makes sure all event listeners on the global dispatcher are also listening
- * to events on the firewall-specific dipatchers.
+ * to events on the firewall-specific dispatchers.
  *
  * This compiler pass must be run after RegisterListenersPass of the
  * EventDispatcher component.
@@ -31,7 +35,18 @@ use Symfony\Component\Security\Http\Event\LogoutEvent;
  */
 class RegisterGlobalSecurityEventListenersPass implements CompilerPassInterface
 {
-    private static $eventBubblingEvents = [CheckPassportEvent::class, LoginFailureEvent::class, LoginSuccessEvent::class, LogoutEvent::class];
+    private static $eventBubblingEvents = [
+        CheckPassportEvent::class,
+        LoginFailureEvent::class,
+        LoginSuccessEvent::class,
+        LogoutEvent::class,
+        AuthenticationSuccessEvent::class,
+        InteractiveLoginEvent::class,
+
+        // When events are registered by their name
+        AuthenticationEvents::AUTHENTICATION_SUCCESS,
+        SecurityEvents::INTERACTIVE_LOGIN,
+    ];
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

When new authenticator security is enabled, the `AuthenticatorManager` is using its own firewall-specific event dispatcher. To allow security events being listened to on the global level, `RegisterGlobalSecurityEventListenersPass` is there to automatically add globally registered event listeners to the firewall-specific event dispatchers.

`RegisterGlobalSecurityEventListenersPass` contains a list of events that are propagated, but unfortunately this list is incomplete as there are other events in `AuthenticatorManager` that would need too be propagated. So I added the missing (older) security events. These older events may also be registered by their name, rather than the FQN of the class, so I've also added those.

As this is targeting 5.1, I'll file another PR for the `AuthenticationTokenCreatedEvent` that was introduced in 5.2, as soon as this change was merged into 5.x.

On a note, I feel this "whitelist" approach to propagate security events to the global dispatcher isn't that great, because it's prone to error. Additional security events may be added in the future and adding these to `RegisterGlobalSecurityEventListenersPass` can easily be missed. When I added `AuthenticationTokenCreatedEvent` in PR #37359 I wasn't aware of this propagation mechanic existed and also no one reviewing the PR noticed it.

Additional changes:
- Typo fix :)
- The `array_uintersect` in `RegisterGlobalSecurityEventListenersPassTest` wasn't implemented correctly *

\* That function's behavior is really odd and easy to be used in the wrong way. The callback function isn't intended to return true/false for matching items, but return -1/0/1 like sorting functions. The tests seemingly only worked by chance as returning true/false is doing pretty much the opposite of what the callback function is supposed to do.