### PR TITLE
[Messenger] Be able to get raw data when a message in not decodable by the PHP Serializer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -191,6 +191,7 @@ return static function (ContainerConfigurator $container) {
                 service('messenger.routable_message_bus'),
                 service('event_dispatcher'),
                 service('logger'),
+                service('messenger.transport.native_php_serializer')->nullOnInvalid(),
             ])
             ->tag('console.command')
 
@@ -198,6 +199,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 abstract_arg('Default failure receiver name'),
                 abstract_arg('Receivers'),
+                service('messenger.transport.native_php_serializer')->nullOnInvalid(),
             ])
             ->tag('console.command')
 
@@ -205,6 +207,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 abstract_arg('Default failure receiver name'),
                 abstract_arg('Receivers'),
+                service('messenger.transport.native_php_serializer')->nullOnInvalid(),
             ])
             ->tag('console.command')
 

--- a/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
+++ b/src/Symfony/Component/Messenger/Command/AbstractFailedMessagesCommand.php
@@ -21,12 +21,14 @@ use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\InvalidArgumentException;
 use Symfony\Component\Messenger\Stamp\ErrorDetailsStamp;
+use Symfony\Component\Messenger\Stamp\MessageDecodingFailedStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Stamp\SentToFailureTransportStamp;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\VarDumper\Caster\Caster;
 use Symfony\Component\VarDumper\Caster\TraceStub;
 use Symfony\Component\VarDumper\Cloner\ClonerInterface;
@@ -44,13 +46,15 @@ abstract class AbstractFailedMessagesCommand extends Command
     protected const DEFAULT_TRANSPORT_OPTION = 'choose';
 
     protected $failureTransports;
+    protected ?PhpSerializer $phpSerializer;
 
     private ?string $globalFailureReceiverName;
 
-    public function __construct(?string $globalFailureReceiverName, ServiceProviderInterface $failureTransports)
+    public function __construct(?string $globalFailureReceiverName, ServiceProviderInterface $failureTransports, PhpSerializer $phpSerializer = null)
     {
         $this->failureTransports = $failureTransports;
         $this->globalFailureReceiverName = $globalFailureReceiverName;
+        $this->phpSerializer = $phpSerializer;
 
         parent::__construct();
     }
@@ -78,6 +82,8 @@ abstract class AbstractFailedMessagesCommand extends Command
         $lastRedeliveryStamp = $envelope->last(RedeliveryStamp::class);
         /** @var ErrorDetailsStamp|null $lastErrorDetailsStamp */
         $lastErrorDetailsStamp = $envelope->last(ErrorDetailsStamp::class);
+        /** @var MessageDecodingFailedStamp|null $lastMessageDecodingFailedStamp */
+        $lastMessageDecodingFailedStamp = $envelope->last(MessageDecodingFailedStamp::class);
 
         $rows = [
             ['Class', \get_class($envelope->getMessage())],
@@ -126,12 +132,18 @@ abstract class AbstractFailedMessagesCommand extends Command
 
         if ($io->isVeryVerbose()) {
             $io->title('Message:');
+            if (null !== $lastMessageDecodingFailedStamp) {
+                $io->error('The message could not be decoded. See below an APPROXIMATIVE representation of the class.');
+            }
             $dump = new Dumper($io, null, $this->createCloner());
             $io->writeln($dump($envelope->getMessage()));
             $io->title('Exception:');
             $flattenException = $lastErrorDetailsStamp?->getFlattenException();
             $io->writeln(null === $flattenException ? '(no data)' : $dump($flattenException));
         } else {
+            if (null !== $lastMessageDecodingFailedStamp) {
+                $io->error('The message could not be decoded.');
+            }
             $io->writeln(' Re-run command with <info>-vv</info> to see more message & error details.');
         }
     }

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRemoveCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRemoveCommand.php
@@ -74,7 +74,13 @@ EOF
         }
 
         foreach ($ids as $id) {
-            $envelope = $receiver->find($id);
+            $this->phpSerializer?->enableClassNotFoundCreation();
+            try {
+                $envelope = $receiver->find($id);
+            } finally {
+                $this->phpSerializer?->enableClassNotFoundCreation(false);
+            }
+
             if (null === $envelope) {
                 $io->error(sprintf('The message with id "%s" was not found.', $id));
                 continue;

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesRetryCommand.php
@@ -23,11 +23,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
-use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\MessageDecodingFailedStamp;
 use Symfony\Component\Messenger\Transport\Receiver\ListableReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\SingleMessageReceiver;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Worker;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
@@ -41,13 +42,13 @@ class FailedMessagesRetryCommand extends AbstractFailedMessagesCommand
     private MessageBusInterface $messageBus;
     private ?LoggerInterface $logger;
 
-    public function __construct(?string $globalReceiverName, ServiceProviderInterface $failureTransports, MessageBusInterface $messageBus, EventDispatcherInterface $eventDispatcher, LoggerInterface $logger = null)
+    public function __construct(?string $globalReceiverName, ServiceProviderInterface $failureTransports, MessageBusInterface $messageBus, EventDispatcherInterface $eventDispatcher, LoggerInterface $logger = null, PhpSerializer $phpSerializer = null)
     {
         $this->eventDispatcher = $eventDispatcher;
         $this->messageBus = $messageBus;
         $this->logger = $logger;
 
-        parent::__construct($globalReceiverName, $failureTransports);
+        parent::__construct($globalReceiverName, $failureTransports, $phpSerializer);
     }
 
     protected function configure(): void
@@ -133,23 +134,23 @@ EOF
             // to be temporarily "acked", even if the user aborts
             // handling the message
             while (true) {
-                $ids = [];
-                foreach ($receiver->all(1) as $envelope) {
-                    ++$count;
-
-                    $id = $this->getMessageId($envelope);
-                    if (null === $id) {
-                        throw new LogicException(sprintf('The "%s" receiver is able to list messages by id but the envelope is missing the TransportMessageIdStamp stamp.', $failureTransportName));
+                $envelopes = [];
+                $this->phpSerializer?->enableClassNotFoundCreation();
+                try {
+                    foreach ($receiver->all(1) as $envelope) {
+                        ++$count;
+                        $envelopes[] = $envelope;
                     }
-                    $ids[] = $id;
+                } finally {
+                    $this->phpSerializer?->enableClassNotFoundCreation(false);
                 }
 
                 // break the loop if all messages are consumed
-                if (0 === \count($ids)) {
+                if (0 === \count($envelopes)) {
                     break;
                 }
 
-                $this->retrySpecificIds($failureTransportName, $ids, $io, $shouldForce);
+                $this->retrySpecificEnvelops($envelopes, $failureTransportName, $io, $shouldForce);
             }
         } else {
             // get() and ask messages one-by-one
@@ -170,6 +171,10 @@ EOF
             $envelope = $messageReceivedEvent->getEnvelope();
 
             $this->displaySingleMessage($envelope, $io);
+
+            if ($envelope->last(MessageDecodingFailedStamp::class)) {
+                throw new \RuntimeException(sprintf('The message with id "%s" could not decoded, it can only be shown or removed.', $this->getMessageId($envelope) ?? '?'));
+            }
 
             $shouldHandle = $shouldForce || $io->confirm('Do you want to retry (yes) or delete this message (no)?');
 
@@ -207,11 +212,26 @@ EOF
         }
 
         foreach ($ids as $id) {
-            $envelope = $receiver->find($id);
+            $this->phpSerializer?->enableClassNotFoundCreation();
+            try {
+                $envelope = $receiver->find($id);
+            } finally {
+                $this->phpSerializer?->enableClassNotFoundCreation(false);
+            }
             if (null === $envelope) {
                 throw new RuntimeException(sprintf('The message "%s" was not found.', $id));
             }
 
+            $singleReceiver = new SingleMessageReceiver($receiver, $envelope);
+            $this->runWorker($failureTransportName, $singleReceiver, $io, $shouldForce);
+        }
+    }
+
+    private function retrySpecificEnvelops(array $envelopes, string $failureTransportName, SymfonyStyle $io, bool $shouldForce)
+    {
+        $receiver = $this->getReceiver($failureTransportName);
+
+        foreach ($envelopes as $envelope) {
             $singleReceiver = new SingleMessageReceiver($receiver, $envelope);
             $this->runWorker($failureTransportName, $singleReceiver, $io, $shouldForce);
         }

--- a/src/Symfony/Component/Messenger/Stamp/MessageDecodingFailedStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/MessageDecodingFailedStamp.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class MessageDecodingFailedStamp implements StampInterface
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
@@ -22,7 +22,7 @@ class PhpSerializerTest extends TestCase
 {
     public function testEncodedIsDecodable()
     {
-        $serializer = new PhpSerializer();
+        $serializer = $this->createPhpSerializer();
 
         $envelope = new Envelope(new DummyMessage('Hello'));
 
@@ -36,7 +36,7 @@ class PhpSerializerTest extends TestCase
         $this->expectException(MessageDecodingFailedException::class);
         $this->expectExceptionMessage('Encoded envelope should have at least a "body", or maybe you should implement your own serializer');
 
-        $serializer = new PhpSerializer();
+        $serializer = $this->createPhpSerializer();
 
         $serializer->decode([]);
     }
@@ -46,7 +46,7 @@ class PhpSerializerTest extends TestCase
         $this->expectException(MessageDecodingFailedException::class);
         $this->expectExceptionMessageMatches('/Could not decode/');
 
-        $serializer = new PhpSerializer();
+        $serializer = $this->createPhpSerializer();
 
         $serializer->decode([
             'body' => '{"message": "bar"}',
@@ -58,7 +58,7 @@ class PhpSerializerTest extends TestCase
         $this->expectException(MessageDecodingFailedException::class);
         $this->expectExceptionMessageMatches('/Could not decode/');
 
-        $serializer = new PhpSerializer();
+        $serializer = $this->createPhpSerializer();
 
         $serializer->decode([
             'body' => 'x',
@@ -70,7 +70,7 @@ class PhpSerializerTest extends TestCase
         $this->expectException(MessageDecodingFailedException::class);
         $this->expectExceptionMessageMatches('/class "ReceivedSt0mp" not found/');
 
-        $serializer = new PhpSerializer();
+        $serializer = $this->createPhpSerializer();
 
         $serializer->decode([
             'body' => 'O:13:"ReceivedSt0mp":0:{}',
@@ -79,7 +79,7 @@ class PhpSerializerTest extends TestCase
 
     public function testEncodedSkipsNonEncodeableStamps()
     {
-        $serializer = new PhpSerializer();
+        $serializer = $this->createPhpSerializer();
 
         $envelope = new Envelope(new DummyMessage('Hello'), [
             new DummyPhpSerializerNonSendableStamp(),
@@ -91,13 +91,18 @@ class PhpSerializerTest extends TestCase
 
     public function testNonUtf8IsBase64Encoded()
     {
-        $serializer = new PhpSerializer();
+        $serializer = $this->createPhpSerializer();
 
         $envelope = new Envelope(new DummyMessage("\xE9"));
 
         $encoded = $serializer->encode($envelope);
         $this->assertTrue((bool) preg_match('//u', $encoded['body']), 'Encodes non-UTF8 payloads');
         $this->assertEquals($envelope, $serializer->decode($encoded));
+    }
+
+    protected function createPhpSerializer(): PhpSerializer
+    {
+        return new PhpSerializer();
     }
 }
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerWithClassNotFoundSupportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerWithClassNotFoundSupportTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Transport\Serialization;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Stamp\MessageDecodingFailedStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
+
+class PhpSerializerWithClassNotFoundSupportTest extends PhpSerializerTest
+{
+    public function testDecodingFailsWithBadClass()
+    {
+        $this->expectException(MessageDecodingFailedException::class);
+
+        $serializer = $this->createPhpSerializer();
+
+        $serializer->decode([
+            'body' => 'O:13:"ReceivedSt0mp":0:{}',
+        ]);
+    }
+
+    public function testDecodingFailsButCreateClassNotFound()
+    {
+        $serializer = $this->createPhpSerializer();
+
+        $encodedEnvelope = $serializer->encode(new Envelope(new DummyMessage('Hello')));
+        // Simulate a change in the code base
+        $encodedEnvelope['body'] = str_replace('DummyMessage', 'OupsyMessage', $encodedEnvelope['body']);
+
+        $envelope = $serializer->decode($encodedEnvelope);
+
+        $lastMessageDecodingFailedStamp = $envelope->last(MessageDecodingFailedStamp::class);
+        $this->assertInstanceOf(MessageDecodingFailedStamp::class, $lastMessageDecodingFailedStamp);
+        $message = $envelope->getMessage();
+        // The class does not exist, so we cannot use anything else. The only
+        // purpose of this feature is to aim debugging (so dumping value)
+        ob_start();
+        var_dump($message);
+        $content = ob_get_clean();
+        // remove object ID
+        $content = preg_replace('/#\d+/', '', $content);
+        $expected = <<<EOT
+            object(__PHP_Incomplete_Class) (2) {
+              ["__PHP_Incomplete_Class_Name"]=>
+              string(55) "Symfony\Component\Messenger\Tests\Fixtures\OupsyMessage"
+              ["message":"Symfony\Component\Messenger\Tests\Fixtures\OupsyMessage":private]=>
+              string(5) "Hello"
+            }
+
+            EOT;
+        $this->assertEquals($expected, $content);
+    }
+
+    protected function createPhpSerializer(): PhpSerializer
+    {
+        $serializer = new PhpSerializer();
+        $serializer->enableClassNotFoundCreation();
+
+        return $serializer;
+    }
+}

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Transport\Serialization;
 
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Stamp\MessageDecodingFailedStamp;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 
 /**
@@ -20,6 +21,13 @@ use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
  */
 class PhpSerializer implements SerializerInterface
 {
+    private bool $createClassNotFound = false;
+
+    public function enableClassNotFoundCreation(bool $enable = true): void
+    {
+        $this->createClassNotFound = $enable;
+    }
+
     public function decode(array $encodedEnvelope): Envelope
     {
         if (empty($encodedEnvelope['body'])) {
@@ -50,14 +58,19 @@ class PhpSerializer implements SerializerInterface
         ];
     }
 
-    private function safelyUnserialize(string $contents)
+    private function safelyUnserialize(string $contents): Envelope
     {
         if ('' === $contents) {
             throw new MessageDecodingFailedException('Could not decode an empty message using PHP serialization.');
         }
 
         $signalingException = new MessageDecodingFailedException(sprintf('Could not decode message using PHP serialization: %s.', $contents));
-        $prevUnserializeHandler = ini_set('unserialize_callback_func', self::class.'::handleUnserializeCallback');
+
+        if ($this->createClassNotFound) {
+            $prevUnserializeHandler = ini_set('unserialize_callback_func', null);
+        } else {
+            $prevUnserializeHandler = ini_set('unserialize_callback_func', self::class.'::handleUnserializeCallback');
+        }
         $prevErrorHandler = set_error_handler(function ($type, $msg, $file, $line, $context = []) use (&$prevErrorHandler, $signalingException) {
             if (__FILE__ === $file) {
                 throw $signalingException;
@@ -67,13 +80,22 @@ class PhpSerializer implements SerializerInterface
         });
 
         try {
-            $meta = unserialize($contents);
+            /** @var Envelope */
+            $envelope = unserialize($contents);
         } finally {
             restore_error_handler();
             ini_set('unserialize_callback_func', $prevUnserializeHandler);
         }
 
-        return $meta;
+        if (!$envelope instanceof Envelope) {
+            throw $signalingException;
+        }
+
+        if ($envelope->getMessage() instanceof \__PHP_Incomplete_Class) {
+            $envelope = $envelope->with(new MessageDecodingFailedStamp());
+        }
+
+        return $envelope;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

---

It's easier to review the pr with [`?w=1`](https://github.com/symfony/symfony/pull/39622/files?w=1)

---

## Why?

This PR aimed to handle properly messaged that are already failed and also **not decodable** anymore.

This use case occurs when a Message class is renamed / moved to another namespace

## Reproducer

1. Publish many message of type `App\Message\Foobar`
1. Consume them all, but throw an Exception exception in the handler
1. Renamed `Foobar` to `Foo`

## Before / After

### command `messenger:failed:show`

#### Before

##### Without an ID

```
…abs/symfony/messenger-class-not-found(new) bin/console  messenger:failed:show
There are 94 messages pending in the failure transport.

In PhpSerializer.php line 84:

  Message class "App\Message\Foobar" not found during decoding.


messenger:failed:show [--max MAX] [--transport [TRANSPORT]] [--stats] [--class-filter CLASS-FILTER] [--] [<id>]
```

And this **message is lost**

##### With an ID

```
>…abs/symfony/messenger-class-not-found(new) bin/console  messenger:failed:show 68
There are 93 messages pending in the failure transport.

In PhpSerializer.php line 84:

  Message class "App\Message\Foobar" not found during decoding.


messenger:failed:show [--max MAX] [--transport [TRANSPORT]] [--stats] [--class-filter CLASS-FILTER] [--] [<id>]
```

**Message lost too**

#### After

##### Without an ID

```
>…goire/dev/labs/symfony/symfony-5.2(remaned) bin/console  messenger:failed:show
There are 94 messages pending in the failure transport.
 ----- ------------------------ --------------------- ---------------------------------------
  Id    Class                    Failed at             Error
 ----- ------------------------ --------------------- ---------------------------------------
  62    __PHP_Incomplete_Class   2022-08-12 16:26:06   FoobarHandler is not implemented yet.
  63    __PHP_Incomplete_Class   2022-08-12 16:26:06   FoobarHandler is not implemented yet.
  64    __PHP_Incomplete_Class   2022-08-12 16:26:06   FoobarHandler is not implemented yet.

 // Showing first 50 messages.

 // Run messenger:failed:show {id} --transport=failed -vv to see message details.

```

**No messages are lost**

##### With an ID

```
>…abs/symfony/messenger-class-not-found(new) bin/console  messenger:failed:show 69
There are 92 messages pending in the failure transport.

Failed Message Details
======================

 ------------- ---------------------------------------
  Class         __PHP_Incomplete_Class
  Message Id    69
  Failed at     2022-08-12 16:26:06
  Error         FoobarHandler is not implemented yet.
  Error Code    0
  Error Class   Exception
  Transport     async
 ------------- ---------------------------------------

 Message history:
  * Message failed at 2022-08-12 16:25:58 and was redelivered
  * Message failed at 2022-08-12 16:25:59 and was redelivered
  * Message failed at 2022-08-12 16:26:02 and was redelivered
  * Message failed at 2022-08-12 16:26:06 and was redelivered


 [ERROR] The message could not be decoded.


 Re-run command with -vv to see more message & error details.

 Run messenger:failed:retry 69 --transport=failed to retry this message.
 Run messenger:failed:remove 69 --transport=failed to delete it.
```

**messages not lost**

##### With an ID an -vv

```
>…abs/symfony/messenger-class-not-found(new) bin/console  messenger:failed:show 69 -vv
There are 92 messages pending in the failure transport.

Failed Message Details
======================

 ------------- ---------------------------------------
  Class         __PHP_Incomplete_Class
  Message Id    69
  Failed at     2022-08-12 16:26:06
  Error         FoobarHandler is not implemented yet.
  Error Code    0
  Error Class   Exception
  Transport     async
 ------------- ---------------------------------------

 Message history:
  * Message failed at 2022-08-12 16:25:58 and was redelivered
  * Message failed at 2022-08-12 16:25:59 and was redelivered
  * Message failed at 2022-08-12 16:26:02 and was redelivered
  * Message failed at 2022-08-12 16:26:06 and was redelivered

Message:
========


 [ERROR] The message could not be decoded. See below an APPROXIMATIVE representation of the class.


__PHP_Incomplete_Class(App\Message\Foobar) {}

Exception:
==========

Exception^ {
  message: "FoobarHandler is not implemented yet."
  code: 0
  file: "/home/gregoire/dev/labs/symfony/messenger-class-not-found/src/MessageHandler/FoobarHandler.php"
  line: 12
  trace: {
    /home/gregoire/dev/labs/symfony/messenger-class-not-found/src/MessageHandler/FoobarHandler.php:12
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php:95 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php:71 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Messenger/Middleware/FailedMessageProcessingMiddleware.php:34 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php:68 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Messenger/Middleware/RejectRedeliveredMessageMiddleware.php:41 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Messenger/Middleware/AddBusNameStampMiddleware.php:37 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Messenger/Middleware/TraceableMiddleware.php:43 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Messenger/MessageBus.php:73 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Messenger/TraceableMessageBus.php:41 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Messenger/RoutableMessageBus.php:54 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Messenger/Worker.php:156 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Messenger/Worker.php:105 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Messenger/Command/ConsumeMessagesCommand.php:223 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Console/Command/Command.php:309 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Console/Application.php:1019 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:94 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Console/Application.php:300 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:80 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Console/Application.php:172 { …}
    /home/gregoire/dev/github.com/lyrixx/symfony/src/Symfony/Component/Runtime/Runner/Symfony/ConsoleApplicationRunner.php:54 { …}
    ./vendor/autoload_runtime.php:29 { …}
    ./bin/console:11 { …}
  }
}

 Run messenger:failed:retry 69 --transport=failed to retry this message.
 Run messenger:failed:remove 69 --transport=failed to delete it.
```

<details>
<summary>screenshot with colors</summary>

![screenshot with colors](https://user-images.githubusercontent.com/408368/187463971-a5464683-f826-4dcb-a2c2-79f91cb00bc0.png)

</details>

**messages not lost**

### command `messenger:failed:retry`

#### Before

```
>…abs/symfony/messenger-class-not-found(new) bin/console  messenger:failed:retry 69

 // Quit this command with CONTROL-C.

 // Re-run the command with a -vv option to see logs about consumed messages.

There are 92 messages pending in the failure transport.
To retry all the messages, run messenger:consume failed

In PhpSerializer.php line 84:

  Message class "App\Message\Foobar" not found during decoding.


messenger:failed:retry [--force] [--transport [TRANSPORT]] [--] [<id>...]
```

**And the first message is lost**

Same if I use an ID

#### After

##### Without ID

```
>…abs/symfony/messenger-class-not-found(new) bin/console  messenger:failed:retry

 // Quit this command with CONTROL-C.

 // Re-run the command with a -vv option to see logs about consumed messages.

There are 91 messages pending in the failure transport.
To retry all the messages, run messenger:consume failed

Failed Message Details
======================

 ------------- ---------------------------------------
  Class         __PHP_Incomplete_Class
  Message Id    63
  Failed at     2022-08-12 16:26:06
  Error         FoobarHandler is not implemented yet.
  Error Code    0
  Error Class   Exception
  Transport     async
 ------------- ---------------------------------------

 Message history:
  * Message failed at 2022-08-12 16:25:58 and was redelivered
  * Message failed at 2022-08-12 16:25:59 and was redelivered
  * Message failed at 2022-08-12 16:26:02 and was redelivered
  * Message failed at 2022-08-12 16:26:06 and was redelivered


 [ERROR] The message could not be decoded.


 Re-run command with -vv to see more message & error details.

In FailedMessagesRetryCommand.php line 176:

  The message with id "63" could not decoded, it can only be shown or removed.


messenger:failed:retry [--force] [--transport [TRANSPORT]] [--] [<id>...]
```

**And the message is not lost**

##### With an ID

```
>…abs/symfony/messenger-class-not-found(new) bin/console  messenger:failed:retry  63

 // Quit this command with CONTROL-C.

 // Re-run the command with a -vv option to see logs about consumed messages.

There are 91 messages pending in the failure transport.
To retry all the messages, run messenger:consume failed

Failed Message Details
======================

 ------------- ---------------------------------------
  Class         __PHP_Incomplete_Class
  Message Id    63
  Failed at     2022-08-12 16:26:06
  Error         FoobarHandler is not implemented yet.
  Error Code    0
  Error Class   Exception
  Transport     async
 ------------- ---------------------------------------

 Message history:
  * Message failed at 2022-08-12 16:25:58 and was redelivered
  * Message failed at 2022-08-12 16:25:59 and was redelivered
  * Message failed at 2022-08-12 16:26:02 and was redelivered
  * Message failed at 2022-08-12 16:26:06 and was redelivered


 [ERROR] The message could not be decoded.


 Re-run command with -vv to see more message & error details.

In FailedMessagesRetryCommand.php line 176:

  The message with id "63" could not decoded, it can only be shown or removed.


messenger:failed:retry [--force] [--transport [TRANSPORT]] [--] [<id>...]
```

### command `messenger:failed:remove`

#### Before

```
>…abs/symfony/messenger-class-not-found(new) bin/console  messenger:failed:remove  63

In PhpSerializer.php line 84:

  Message class "App\Message\Foobar" not found during decoding.


messenger:failed:remove [--force] [--transport [TRANSPORT]] [--show-messages] [--] <id>...
```

The message is lost, but it's not an issue I guess :p

#### After

```
>…abs/symfony/messenger-class-not-found(new) bin/console  messenger:failed:remove  69


 [ERROR] The message with id "69" was not found.


>…abs/symfony/messenger-class-not-found(new) bin/console  messenger:failed:remove  79

Failed Message Details
======================

 ------------- ---------------------------------------
  Class         __PHP_Incomplete_Class
  Message Id    79
  Failed at     2022-08-12 16:26:06
  Error         FoobarHandler is not implemented yet.
  Error Code    0
  Error Class   Exception
  Transport     async
 ------------- ---------------------------------------

 Message history:
  * Message failed at 2022-08-12 16:25:58 and was redelivered
  * Message failed at 2022-08-12 16:25:59 and was redelivered
  * Message failed at 2022-08-12 16:26:02 and was redelivered
  * Message failed at 2022-08-12 16:26:06 and was redelivered


 [ERROR] The message could not be decoded.


 Re-run command with -vv to see more message & error details.

 Do you want to permanently remove this message? (yes/no) [no]:
 > yes


 [OK] Message with id 79 removed.
```

---

## Extra

### `messenger:consume` command

This command is not fixed on purpose: We keep the default behavior to keep a BC.

**BUT** I would like to use the same stamp system I introduce to avoid loosing a message.
Because ATM, when a DecodeException is thrown, the message is lost. Not cool!

```
>…goire/dev/labs/symfony/symfony-5.2(remaned) bin/console  messenger:consume failed


 [OK] Consuming messages from transports "failed".


 // The worker will automatically exit once it has received a stop signal via the messenger:stop-workers command.

 // Quit the worker with CONTROL-C.

 // Re-run the command with a -vv option to see logs about consumed messages.


In PhpSerializer.php line 92:

  Message class "App\Message\Foobar" not found during decoding.

```
