### PR TITLE
[Console] Fail will different exit codes

### DIFF
--- a/src/Symfony/Component/Console/Exception/CommandNotFoundException.php
+++ b/src/Symfony/Component/Console/Exception/CommandNotFoundException.php
@@ -26,7 +26,7 @@ class CommandNotFoundException extends \InvalidArgumentException implements Exce
      * @param int        $code         Exception code
      * @param \Throwable $previous     Previous exception used for the exception chaining
      */
-    public function __construct(string $message, array $alternatives = [], int $code = 0, \Throwable $previous = null)
+    public function __construct(string $message, array $alternatives = [], int $code = 11, \Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/Symfony/Component/Console/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/Console/Exception/InvalidArgumentException.php
@@ -11,9 +11,15 @@
 
 namespace Symfony\Component\Console\Exception;
 
+use Throwable;
+
 /**
  * @author Jérôme Tamarelle <jerome@tamarelle.net>
  */
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
+    public function __construct($message = '', $code = 12, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Symfony/Component/Console/Exception/InvalidOptionException.php
+++ b/src/Symfony/Component/Console/Exception/InvalidOptionException.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Console\Exception;
 
+use Throwable;
+
 /**
  * Represents an incorrect option name typed in the console.
  *
@@ -18,4 +20,8 @@ namespace Symfony\Component\Console\Exception;
  */
 class InvalidOptionException extends \InvalidArgumentException implements ExceptionInterface
 {
+    public function __construct($message = '', $code = 13, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/src/Symfony/Component/Console/Exception/MissingInputException.php
+++ b/src/Symfony/Component/Console/Exception/MissingInputException.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Console\Exception;
 
+use Throwable;
+
 /**
  * Represents failure to read input from stdin.
  *
@@ -18,4 +20,8 @@ namespace Symfony\Component\Console\Exception;
  */
 class MissingInputException extends RuntimeException implements ExceptionInterface
 {
+    public function __construct($message = '', $code = 14, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix 
| License       | MIT
| Doc PR        | 

I have a situation where I want to know if the command failed because of poor logic or runtime exception, or if it failed because the command was not defined. 

Ie consider a CI job that will run one of these commands to make sure the fixtures work properly. 

```
bin/console hautelook:fixtures:load --no-interaction
bin/console doctrine:fixtures:load --no-interaction
```

Does the command exit code fall under our BC promise?