### PR TITLE
[VarDumper] Fix display of nullable union return types

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ReflectionCaster.php
@@ -183,7 +183,7 @@ class ReflectionCaster
         if (isset($a[$prefix.'returnType'])) {
             $v = $a[$prefix.'returnType'];
             $v = $v instanceof \ReflectionNamedType ? $v->getName() : (string) $v;
-            $a[$prefix.'returnType'] = new ClassStub($a[$prefix.'returnType']->allowsNull() && 'mixed' !== $v ? '?'.$v : $v, [class_exists($v, false) || interface_exists($v, false) || trait_exists($v, false) ? $v : '', '']);
+            $a[$prefix.'returnType'] = new ClassStub($a[$prefix.'returnType'] instanceof \ReflectionNamedType && $a[$prefix.'returnType']->allowsNull() && 'mixed' !== $v ? '?'.$v : $v, [class_exists($v, false) || interface_exists($v, false) || trait_exists($v, false) ? $v : '', '']);
         }
         if (isset($a[$prefix.'class'])) {
             $a[$prefix.'class'] = new ClassStub($a[$prefix.'class']);

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ReflectionCasterTest.php
@@ -149,6 +149,68 @@ EOTXT
         );
     }
 
+    /**
+     * @requires PHP 8
+     */
+    public function testReflectionParameterMixed()
+    {
+        $f = eval('return function (mixed $a) {};');
+        $var = new \ReflectionParameter($f, 0);
+
+        $this->assertDumpMatchesFormat(
+            <<<'EOTXT'
+ReflectionParameter {
+  +name: "a"
+  position: 0
+  allowsNull: true
+  typeHint: "mixed"
+}
+EOTXT
+            , $var
+        );
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testReflectionParameterUnion()
+    {
+        $f = eval('return function (int|float $a) {};');
+        $var = new \ReflectionParameter($f, 0);
+
+        $this->assertDumpMatchesFormat(
+            <<<'EOTXT'
+ReflectionParameter {
+  +name: "a"
+  position: 0
+  typeHint: "int|float"
+}
+EOTXT
+            , $var
+        );
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testReflectionParameterNullableUnion()
+    {
+        $f = eval('return function (int|float|null $a) {};');
+        $var = new \ReflectionParameter($f, 0);
+
+        $this->assertDumpMatchesFormat(
+            <<<'EOTXT'
+ReflectionParameter {
+  +name: "a"
+  position: 0
+  allowsNull: true
+  typeHint: "int|float|null"
+}
+EOTXT
+            , $var
+        );
+    }
+
     public function testReturnType()
     {
         $f = eval('return function ():int {};');
@@ -158,6 +220,72 @@ EOTXT
             <<<EOTXT
 Closure(): int {
   returnType: "int"
+  class: "Symfony\Component\VarDumper\Tests\Caster\ReflectionCasterTest"
+  this: Symfony\Component\VarDumper\Tests\Caster\ReflectionCasterTest { …}
+  file: "%sReflectionCasterTest.php($line) : eval()'d code"
+  line: "1 to 1"
+}
+EOTXT
+            , $f
+        );
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testMixedReturnType()
+    {
+        $f = eval('return function (): mixed {};');
+        $line = __LINE__ - 1;
+
+        $this->assertDumpMatchesFormat(
+            <<<EOTXT
+Closure(): mixed {
+  returnType: "mixed"
+  class: "Symfony\Component\VarDumper\Tests\Caster\ReflectionCasterTest"
+  this: Symfony\Component\VarDumper\Tests\Caster\ReflectionCasterTest { …}
+  file: "%sReflectionCasterTest.php($line) : eval()'d code"
+  line: "1 to 1"
+}
+EOTXT
+            , $f
+        );
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testUnionReturnType()
+    {
+        $f = eval('return function (): int|float {};');
+        $line = __LINE__ - 1;
+
+        $this->assertDumpMatchesFormat(
+            <<<EOTXT
+Closure(): int|float {
+  returnType: "int|float"
+  class: "Symfony\Component\VarDumper\Tests\Caster\ReflectionCasterTest"
+  this: Symfony\Component\VarDumper\Tests\Caster\ReflectionCasterTest { …}
+  file: "%sReflectionCasterTest.php($line) : eval()'d code"
+  line: "1 to 1"
+}
+EOTXT
+            , $f
+        );
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testNullableUnionReturnType()
+    {
+        $f = eval('return function (): int|float|null {};');
+        $line = __LINE__ - 1;
+
+        $this->assertDumpMatchesFormat(
+            <<<EOTXT
+Closure(): int|float|null {
+  returnType: "int|float|null"
   class: "Symfony\Component\VarDumper\Tests\Caster\ReflectionCasterTest"
   this: Symfony\Component\VarDumper\Tests\Caster\ReflectionCasterTest { …}
   file: "%sReflectionCasterTest.php($line) : eval()'d code"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/39629#pullrequestreview-558863674
| License       | MIT
| Doc PR        | N/A