### PR TITLE
[HttpFoundation] Drop int return type from parseFilesize()

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,6 +26,8 @@ install:
     - echo memory_limit=-1 >> php.ini-min
     - echo serialize_precision=14 >> php.ini-min
     - echo max_execution_time=1200 >> php.ini-min
+    - echo post_max_size=4G >> php.ini-min
+    - echo upload_max_filesize=4G >> php.ini-min
     - echo date.timezone="America/Los_Angeles" >> php.ini-min
     - echo extension_dir=ext >> php.ini-min
     - echo extension=php_xsl.dll >> php.ini-min

--- a/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
@@ -178,8 +178,10 @@ class FileType extends AbstractType
      * Returns the maximum size of an uploaded file as configured in php.ini.
      *
      * This method should be kept in sync with Symfony\Component\HttpFoundation\File\UploadedFile::getMaxFilesize().
+     *
+     * @return int|float The maximum size of an uploaded file in bytes (returns float if size > PHP_INT_MAX)
      */
-    private static function getMaxFilesize(): int
+    private static function getMaxFilesize()
     {
         $iniMax = strtolower(ini_get('upload_max_filesize'));
 
@@ -214,8 +216,10 @@ class FileType extends AbstractType
      * (i.e. try "MB", then "kB", then "bytes").
      *
      * This method should be kept in sync with Symfony\Component\Validator\Constraints\FileValidator::factorizeSizes().
+     *
+     * @param int|float $limit
      */
-    private function factorizeSizes(int $size, int $limit)
+    private function factorizeSizes(int $size, $limit)
     {
         $coef = self::MIB_BYTES;
         $coefFactor = self::KIB_BYTES;

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -239,7 +239,7 @@ class UploadedFile extends File
     /**
      * Returns the maximum size of an uploaded file as configured in php.ini.
      *
-     * @return int The maximum size of an uploaded file in bytes
+     * @return int|float The maximum size of an uploaded file in bytes (returns float if size > PHP_INT_MAX)
      */
     public static function getMaxFilesize()
     {
@@ -251,8 +251,10 @@ class UploadedFile extends File
 
     /**
      * Returns the given size from an ini value in bytes.
+     *
+     * @return int|float Returns float if size > PHP_INT_MAX
      */
-    private static function parseFilesize($size): int
+    private static function parseFilesize($size)
     {
         if ('' === $size) {
             return 0;

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\File\Exception\CannotWriteFileException;
 use Symfony\Component\HttpFoundation\File\Exception\ExtensionFileException;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
+use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 use Symfony\Component\HttpFoundation\File\Exception\FormSizeFileException;
 use Symfony\Component\HttpFoundation\File\Exception\IniSizeFileException;
 use Symfony\Component\HttpFoundation\File\Exception\NoFileException;
@@ -33,7 +34,7 @@ class UploadedFileTest extends TestCase
 
     public function testConstructWhenFileNotExists()
     {
-        $this->expectException(\Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException::class);
+        $this->expectException(FileNotFoundException::class);
 
         new UploadedFile(
             __DIR__.'/Fixtures/not_here',
@@ -358,13 +359,16 @@ class UploadedFileTest extends TestCase
     {
         $size = UploadedFile::getMaxFilesize();
 
-        $this->assertIsInt($size);
+        if ($size > \PHP_INT_MAX) {
+            $this->assertIsFloat($size);
+        } else {
+            $this->assertIsInt($size);
+        }
+
         $this->assertGreaterThan(0, $size);
 
         if (0 === (int) ini_get('post_max_size') && 0 === (int) ini_get('upload_max_filesize')) {
             $this->assertSame(\PHP_INT_MAX, $size);
-        } else {
-            $this->assertLessThan(\PHP_INT_MAX, $size);
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -214,8 +214,10 @@ class FileValidator extends ConstraintValidator
     /**
      * Convert the limit to the smallest possible number
      * (i.e. try "MB", then "kB", then "bytes").
+     *
+     * @param int|float $limit
      */
-    private function factorizeSizes(int $size, int $limit, bool $binaryFormat): array
+    private function factorizeSizes(int $size, $limit, bool $binaryFormat): array
     {
         if ($binaryFormat) {
             $coef = self::MIB_BYTES;

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -459,14 +459,12 @@ abstract class FileValidatorTest extends ConstraintValidatorTestCase
             [, $limit, $suffix] = $method->invokeArgs(new FileValidator(), [0, UploadedFile::getMaxFilesize(), false]);
 
             // it correctly parses the maxSize option and not only uses simple string comparison
-            // 1000M should be bigger than the ini value
+            // 1000G should be bigger than the ini value
             $tests[] = [(string) \UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', [
                 '{{ limit }}' => $limit,
                 '{{ suffix }}' => $suffix,
-            ], '1000M'];
+            ], '1000G'];
 
-            // it correctly parses the maxSize option and not only uses simple string comparison
-            // 1000M should be bigger than the ini value
             $tests[] = [(string) \UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', [
                 '{{ limit }}' => '0.1',
                 '{{ suffix }}' => 'MB',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix [octobercms/october#5410](https://github.com/octobercms/october/issues/5410)
| License       | MIT
| Doc PR        | 

Related: #34516, #34508, https://github.com/symfony/symfony/commit/93685026b0d91ecdc0959b8a971a5c8985ee405c, https://github.com/octobercms/october/issues/5410

