### PR TITLE
[Lock] Add LockFactoryInterface

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -18,6 +18,11 @@ Form
  * Deprecated passing an array as the second argument of the `RadioListMapper::mapDataToForms()` method, pass `\Traversable` instead.
  * Deprecated passing an array as the first argument of the `RadioListMapper::mapFormsToData()` method, pass `\Traversable` instead.
 
+FrameworkBundle
+---------------
+
+ * Deprecated the `lock.factory` alias, use `LockFactoryInterface` instead.
+
 HttpKernel
 ----------
 

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Added support for configuring PHP error level to log levels
  * Added the `dispatcher` option to `debug:event-dispatcher`
  * Added the `event_dispatcher.dispatcher` tag
+ * Deprecated the `lock.factory` alias, use `LockFactoryInterface` instead.
 
 5.2.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -75,6 +75,7 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Lock\Lock;
 use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockFactoryInterface;
 use Symfony\Component\Lock\LockInterface;
 use Symfony\Component\Lock\PersistingStoreInterface;
 use Symfony\Component\Lock\Store\StoreFactory;
@@ -1705,16 +1706,22 @@ class FrameworkExtension extends Extension
 
             // provide alias for default resource
             if ('default' === $resourceName) {
-                $container->setAlias('lock.store', (new Alias($storeDefinitionId, false))->setDeprecated('symfony/framework-bundle', '5.2', 'The "%alias_id%" alias is deprecated, use "lock.factory" instead.'));
                 $container->setAlias('lock.factory', new Alias('lock.'.$resourceName.'.factory', false));
-                $container->setAlias('lock', (new Alias('lock.'.$resourceName, false))->setDeprecated('symfony/framework-bundle', '5.2', 'The "%alias_id%" alias is deprecated, use "lock.factory" instead.'));
-                $container->setAlias(PersistingStoreInterface::class, (new Alias($storeDefinitionId, false))->setDeprecated('symfony/framework-bundle', '5.2', 'The "%alias_id%" alias is deprecated, use "'.LockFactory::class.'" instead.'));
-                $container->setAlias(LockFactory::class, new Alias('lock.factory', false));
-                $container->setAlias(LockInterface::class, (new Alias('lock.'.$resourceName, false))->setDeprecated('symfony/framework-bundle', '5.2', 'The "%alias_id%" alias is deprecated, use "'.LockFactory::class.'" instead.'));
+                $container->setAlias(LockFactoryInterface::class, new Alias('lock.factory', false));
+
+                $deprecationMessage = 'The "%alias_id%" alias is deprecated, use "' . LockFactoryInterface::class . '" instead.';
+                $container->setAlias('lock.store', (new Alias($storeDefinitionId, false))->setDeprecated('symfony/framework-bundle', '5.2', $deprecationMessage));
+                $container->setAlias('lock', (new Alias('lock.'.$resourceName, false))->setDeprecated('symfony/framework-bundle', '5.2', $deprecationMessage));
+                $container->setAlias(PersistingStoreInterface::class, (new Alias($storeDefinitionId, false))->setDeprecated('symfony/framework-bundle', '5.2', $deprecationMessage));
+                $container->setAlias(LockFactory::class, (new Alias('lock.factory', false))->setDeprecated('symfony/framework-bundle', '5.3', $deprecationMessage));
+                $container->setAlias(LockInterface::class, (new Alias('lock.'.$resourceName, false))->setDeprecated('symfony/framework-bundle', '5.2', $deprecationMessage));
             } else {
-                $container->registerAliasForArgument($storeDefinitionId, PersistingStoreInterface::class, $resourceName.'.lock.store')->setDeprecated('symfony/framework-bundle', '5.2', 'The "%alias_id%" alias is deprecated, use "'.LockFactory::class.' '.$resourceName.'LockFactory" instead.');
-                $container->registerAliasForArgument('lock.'.$resourceName.'.factory', LockFactory::class, $resourceName.'.lock.factory');
-                $container->registerAliasForArgument('lock.'.$resourceName, LockInterface::class, $resourceName.'.lock')->setDeprecated('symfony/framework-bundle', '5.2', 'The "%alias_id%" alias is deprecated, use "'.LockFactory::class.' $'.$resourceName.'LockFactory" instead.');
+                $container->registerAliasForArgument('lock.'.$resourceName.'.factory', LockFactoryInterface::class, $resourceName.'.lock.factory');
+
+                $deprecationMessage = 'The "%alias_id%" alias is deprecated, use "' . LockFactoryInterface::class . ' $' . $resourceName . 'LockFactory" instead.';
+                $container->registerAliasForArgument($storeDefinitionId, PersistingStoreInterface::class, $resourceName.'.lock.store')->setDeprecated('symfony/framework-bundle', '5.2', $deprecationMessage);
+                $container->registerAliasForArgument('lock.'.$resourceName.'.factory', LockFactory::class, $resourceName.'.lock.factory')->setDeprecated('symfony/framework-bundle', '5.3', $deprecationMessage);
+                $container->registerAliasForArgument('lock.'.$resourceName, LockInterface::class, $resourceName.'.lock')->setDeprecated('symfony/framework-bundle', '5.2', $deprecationMessage);
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1709,7 +1709,7 @@ class FrameworkExtension extends Extension
                 $container->setAlias('lock.factory', new Alias('lock.'.$resourceName.'.factory', false));
                 $container->setAlias(LockFactoryInterface::class, new Alias('lock.factory', false));
 
-                $deprecationMessage = 'The "%alias_id%" alias is deprecated, use "' . LockFactoryInterface::class . '" instead.';
+                $deprecationMessage = 'The "%alias_id%" alias is deprecated, use "'.LockFactoryInterface::class.'" instead.';
                 $container->setAlias('lock.store', (new Alias($storeDefinitionId, false))->setDeprecated('symfony/framework-bundle', '5.2', $deprecationMessage));
                 $container->setAlias('lock', (new Alias('lock.'.$resourceName, false))->setDeprecated('symfony/framework-bundle', '5.2', $deprecationMessage));
                 $container->setAlias(PersistingStoreInterface::class, (new Alias($storeDefinitionId, false))->setDeprecated('symfony/framework-bundle', '5.2', $deprecationMessage));
@@ -1718,7 +1718,7 @@ class FrameworkExtension extends Extension
             } else {
                 $container->registerAliasForArgument('lock.'.$resourceName.'.factory', LockFactoryInterface::class, $resourceName.'.lock.factory');
 
-                $deprecationMessage = 'The "%alias_id%" alias is deprecated, use "' . LockFactoryInterface::class . ' $' . $resourceName . 'LockFactory" instead.';
+                $deprecationMessage = 'The "%alias_id%" alias is deprecated, use "'.LockFactoryInterface::class.' $'.$resourceName.'LockFactory" instead.';
                 $container->registerAliasForArgument($storeDefinitionId, PersistingStoreInterface::class, $resourceName.'.lock.store')->setDeprecated('symfony/framework-bundle', '5.2', $deprecationMessage);
                 $container->registerAliasForArgument('lock.'.$resourceName.'.factory', LockFactory::class, $resourceName.'.lock.factory')->setDeprecated('symfony/framework-bundle', '5.3', $deprecationMessage);
                 $container->registerAliasForArgument('lock.'.$resourceName, LockInterface::class, $resourceName.'.lock')->setDeprecated('symfony/framework-bundle', '5.2', $deprecationMessage);

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -45,7 +45,7 @@
         "symfony/form": "^5.2",
         "symfony/expression-language": "^4.4|^5.0",
         "symfony/http-client": "^4.4|^5.0",
-        "symfony/lock": "^4.4|^5.0",
+        "symfony/lock": "^5.3",
         "symfony/mailer": "^5.2",
         "symfony/messenger": "^5.2",
         "symfony/mime": "^4.4|^5.0",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -79,7 +79,7 @@
         "symfony/dom-crawler": "<4.4",
         "symfony/http-client": "<4.4",
         "symfony/form": "<5.2",
-        "symfony/lock": "<4.4",
+        "symfony/lock": "<5.3",
         "symfony/mailer": "<5.2",
         "symfony/messenger": "<4.4",
         "symfony/mime": "<4.4",

--- a/src/Symfony/Component/Lock/CHANGELOG.md
+++ b/src/Symfony/Component/Lock/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+ * Added `LockFactoryInterface`
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Lock/LockFactory.php
+++ b/src/Symfony/Component/Lock/LockFactory.php
@@ -21,7 +21,7 @@ use Psr\Log\NullLogger;
  *
  * @final since Symfony 5.3
  */
-class LockFactory implements LoggerAwareInterface, LockFactoryInterface
+class LockFactory implements LockFactoryInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 

--- a/src/Symfony/Component/Lock/LockFactory.php
+++ b/src/Symfony/Component/Lock/LockFactory.php
@@ -18,6 +18,8 @@ use Psr\Log\NullLogger;
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  * @author Hamza Amrouche <hamza.simperfit@gmail.com>
+ *
+ * @final since Symfony 5.3
  */
 class LockFactory implements LoggerAwareInterface, LockFactoryInterface
 {

--- a/src/Symfony/Component/Lock/LockFactory.php
+++ b/src/Symfony/Component/Lock/LockFactory.php
@@ -16,12 +16,10 @@ use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 
 /**
- * Factory provides method to create locks.
- *
  * @author Jérémy Derussé <jeremy@derusse.com>
  * @author Hamza Amrouche <hamza.simperfit@gmail.com>
  */
-class LockFactory implements LoggerAwareInterface
+class LockFactory implements LoggerAwareInterface, LockFactoryInterface
 {
     use LoggerAwareTrait;
 
@@ -34,25 +32,11 @@ class LockFactory implements LoggerAwareInterface
         $this->logger = new NullLogger();
     }
 
-    /**
-     * Creates a lock for the given resource.
-     *
-     * @param string     $resource    The resource to lock
-     * @param float|null $ttl         Maximum expected lock duration in seconds
-     * @param bool       $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
-     */
     public function createLock(string $resource, ?float $ttl = 300.0, bool $autoRelease = true): LockInterface
     {
         return $this->createLockFromKey(new Key($resource), $ttl, $autoRelease);
     }
 
-    /**
-     * Creates a lock from the given key.
-     *
-     * @param Key        $key         The key containing the lock's state
-     * @param float|null $ttl         Maximum expected lock duration in seconds
-     * @param bool       $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
-     */
     public function createLockFromKey(Key $key, ?float $ttl = 300.0, bool $autoRelease = true): LockInterface
     {
         $lock = new Lock($key, $this->store, $ttl, $autoRelease);

--- a/src/Symfony/Component/Lock/LockFactory.php
+++ b/src/Symfony/Component/Lock/LockFactory.php
@@ -32,11 +32,17 @@ class LockFactory implements LoggerAwareInterface, LockFactoryInterface
         $this->logger = new NullLogger();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function createLock(string $resource, ?float $ttl = 300.0, bool $autoRelease = true): LockInterface
     {
         return $this->createLockFromKey(new Key($resource), $ttl, $autoRelease);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function createLockFromKey(Key $key, ?float $ttl = 300.0, bool $autoRelease = true): LockInterface
     {
         $lock = new Lock($key, $this->store, $ttl, $autoRelease);

--- a/src/Symfony/Component/Lock/LockFactoryInterface.php
+++ b/src/Symfony/Component/Lock/LockFactoryInterface.php
@@ -22,18 +22,18 @@ interface LockFactoryInterface
     /**
      * Creates a lock for the given resource.
      *
-     * @param string $resource The resource to lock
-     * @param float|null $ttl Maximum expected lock duration in seconds
-     * @param bool $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
+     * @param string     $resource    The resource to lock
+     * @param float|null $ttl         Maximum expected lock duration in seconds
+     * @param bool       $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
      */
     public function createLock(string $resource, ?float $ttl = 300.0, bool $autoRelease = true): LockInterface;
 
     /**
      * Creates a lock from the given key.
      *
-     * @param Key $key The key containing the lock's state
-     * @param float|null $ttl Maximum expected lock duration in seconds
-     * @param bool $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
+     * @param Key        $key         The key containing the lock's state
+     * @param float|null $ttl         Maximum expected lock duration in seconds
+     * @param bool       $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
      */
     public function createLockFromKey(Key $key, ?float $ttl = 300.0, bool $autoRelease = true): LockInterface;
 }

--- a/src/Symfony/Component/Lock/LockFactoryInterface.php
+++ b/src/Symfony/Component/Lock/LockFactoryInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Lock;
+
+/**
+ * Factory provides method to create locks.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ * @author Hamza Amrouche <hamza.simperfit@gmail.com>
+ */
+interface LockFactoryInterface
+{
+    /**
+     * Creates a lock for the given resource.
+     *
+     * @param string $resource The resource to lock
+     * @param float|null $ttl Maximum expected lock duration in seconds
+     * @param bool $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
+     */
+    public function createLock(string $resource, ?float $ttl = 300.0, bool $autoRelease = true): LockInterface;
+
+    /**
+     * Creates a lock from the given key.
+     *
+     * @param Key $key The key containing the lock's state
+     * @param float|null $ttl Maximum expected lock duration in seconds
+     * @param bool $autoRelease Whether to automatically release the lock or not when the lock instance is destroyed
+     */
+    public function createLockFromKey(Key $key, ?float $ttl = 300.0, bool $autoRelease = true): LockInterface;
+}

--- a/src/Symfony/Component/RateLimiter/CHANGELOG.md
+++ b/src/Symfony/Component/RateLimiter/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+* Changed `$lockFactory` parameter type of the `RateLimiterFactory::__construct()` method from `LockFactory` to `LockFactoryInterface`.
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
+++ b/src/Symfony/Component/RateLimiter/RateLimiterFactory.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\RateLimiter;
 
-use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockFactoryInterface;
 use Symfony\Component\Lock\NoLock;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -33,7 +33,7 @@ final class RateLimiterFactory
     private $storage;
     private $lockFactory;
 
-    public function __construct(array $config, StorageInterface $storage, ?LockFactory $lockFactory = null)
+    public function __construct(array $config, StorageInterface $storage, ?LockFactoryInterface $lockFactory = null)
     {
         $this->storage = $storage;
         $this->lockFactory = $lockFactory;

--- a/src/Symfony/Component/RateLimiter/composer.json
+++ b/src/Symfony/Component/RateLimiter/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "symfony/lock": "^5.2",
+        "symfony/lock": "^5.3",
         "symfony/options-resolver": "^5.1"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | 
| License       | MIT
| Doc PR        |

I saw that the LockFactory does not have an interface. And the RateLimit component has a config option to "Add your own lock factory".

This PR includes a BC break to our experimental RateLimiter component. But it is a super minor so I am okey with it. 
