### PR TITLE
[Uid] Handle ValueErrors triggered by ext-uuid on PHP 8

### DIFF
--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -26,12 +26,21 @@ class UuidTest extends TestCase
     private const A_UUID_V1 = 'd9e7a184-5d5b-11ea-a62a-3499710062d0';
     private const A_UUID_V4 = 'd6b3345b-2905-4048-a83c-b5988e765d98';
 
-    public function testConstructorWithInvalidUuid()
+    /**
+     * @dataProvider provideInvalidUuids
+     */
+    public function testConstructorWithInvalidUuid(string $uuid)
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid UUID: "this is not a uuid".');
+        $this->expectExceptionMessage('Invalid UUID: "'.$uuid.'".');
 
-        Uuid::fromString('this is not a uuid');
+        Uuid::fromString($uuid);
+    }
+
+    public function provideInvalidUuids(): iterable
+    {
+        yield ['this is not a uuid'];
+        yield ['these are just thirty-six characters'];
     }
 
     public function testConstructorWithValidUuid()

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -22,7 +22,11 @@ class Uuid extends AbstractUid
 
     public function __construct(string $uuid)
     {
-        $type = uuid_type($uuid);
+        try {
+            $type = uuid_type($uuid);
+        } catch (\ValueError $e) {
+            throw new \InvalidArgumentException(sprintf('Invalid UUID%s: "%s".', static::TYPE ? 'v'.static::TYPE : '', $uuid), 0, $e);
+        }
 
         if (false === $type || \UUID_TYPE_INVALID === $type || (static::TYPE ?: $type) !== $type) {
             throw new \InvalidArgumentException(sprintf('Invalid UUID%s: "%s".', static::TYPE ? 'v'.static::TYPE : '', $uuid));
@@ -55,7 +59,13 @@ class Uuid extends AbstractUid
             return new static($uuid);
         }
 
-        switch (uuid_type($uuid)) {
+        try {
+            $type = uuid_type($uuid);
+        } catch (\ValueError $e) {
+            throw new \InvalidArgumentException(sprintf('Invalid UUID%s: "%s".', static::TYPE ? 'v'.static::TYPE : '', $uuid), 0, $e);
+        }
+
+        switch ($type) {
             case UuidV1::TYPE: return new UuidV1($uuid);
             case UuidV3::TYPE: return new UuidV3($uuid);
             case UuidV4::TYPE: return new UuidV4($uuid);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Follows symfony/polyfill#318.

On PHP 8, the UUID extension triggers `ValueErrors` if we pass an invalid UUID to one of the `uuid_*` functions. This PR handles those errors so that the component behaves the same on PHP 7 and 8.