### PR TITLE
[Security] Fix event propagation for AuthenticationTokenCreatedEvent when globally registered

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPass.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Security\Core\AuthenticationEvents;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
+use Symfony\Component\Security\Http\Event\AuthenticationTokenCreatedEvent;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\Event\LoginFailureEvent;
@@ -40,6 +41,7 @@ class RegisterGlobalSecurityEventListenersPass implements CompilerPassInterface
         LoginFailureEvent::class,
         LoginSuccessEvent::class,
         LogoutEvent::class,
+        AuthenticationTokenCreatedEvent::class,
         AuthenticationSuccessEvent::class,
         InteractiveLoginEvent::class,
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterGlobalSecurityEventListenersPassTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\AuthenticationEvents;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
+use Symfony\Component\Security\Http\Event\AuthenticationTokenCreatedEvent;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\Event\LoginFailureEvent;
@@ -76,6 +77,7 @@ class RegisterGlobalSecurityEventListenersPassTest extends TestCase
             [LoginFailureEvent::class, LoginFailureEvent::class],
             [LoginSuccessEvent::class, LoginSuccessEvent::class],
             [LogoutEvent::class, LogoutEvent::class],
+            [AuthenticationTokenCreatedEvent::class, AuthenticationTokenCreatedEvent::class],
             [AuthenticationEvents::AUTHENTICATION_SUCCESS, AuthenticationEvents::AUTHENTICATION_SUCCESS],
             [SecurityEvents::INTERACTIVE_LOGIN, SecurityEvents::INTERACTIVE_LOGIN],
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

As promised, here's the follow-up to #39621, fixing `AuthenticationTokenCreatedEvent` to be propated from the global event dispatcher to firewall-specific event dispatchers.

The event was added in Symfony 5.2, therefore the separate PR targeting the 5.2 branch.