### PR TITLE
[Yaml] Add --exclude and negatable --parse-tags option to lint:yaml command

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Add new `lint:yaml dirname --exclude=/dirname/foo.yaml --exclude=/dirname/bar.yaml`
+   option to exclude one or more specific files from multiple file list
+ * Allow negatable for the parse tags option with `--no-parse-tags`
+
 5.3
 ---
 

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -142,6 +142,17 @@ YAML;
         $this->assertSame(1, $ret, 'lint:yaml exits with code 1 in case of error');
     }
 
+    public function testLintWithExclude()
+    {
+        $tester = $this->createCommandTester();
+        $filename1 = $this->createFile('foo: bar');
+        $filename2 = $this->createFile('bar: baz');
+
+        $ret = $tester->execute(['filename' => [$filename1, $filename2], '--exclude' => [$filename1]], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false]);
+        $this->assertSame(0, $ret, 'lint:yaml exits with code 0 in case of success');
+        $this->assertStringContainsString('All 1 YAML files contain valid syntax.', trim($tester->getDisplay()));
+    }
+
     public function testLintFileNotReadable()
     {
         $this->expectException(\RuntimeException::class);

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -23,10 +23,10 @@
         "symfony/polyfill-php81": "^1.22"
     },
     "require-dev": {
-        "symfony/console": "^4.4|^5.0|^6.0"
+        "symfony/console": "^5.3|^6.0"
     },
     "conflict": {
-        "symfony/console": "<4.4"
+        "symfony/console": "<5.3"
     },
     "suggest": {
         "symfony/console": "For validating YAML files using the lint command"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | symfony/symfony-docs#14780

Added a new `--exclude` option to exclude one or more specific files from multiple file list:

```lint:yaml dirname --exclude=/dirname/foo.yml --exclude=/dirname/bar.yml``` 
 
Allow negatable for the parse tags option with `--no-parse-tags` and increase the `symfony/console` dependency to version 5.3