### PR TITLE
[PhpUnitBridge] Remove obsolete polyfills

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/PolyfillAssertTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/PolyfillAssertTrait.php
@@ -11,9 +11,7 @@
 
 namespace Symfony\Bridge\PhpUnit\Legacy;
 
-use PHPUnit\Framework\Constraint\IsEqual;
 use PHPUnit\Framework\Constraint\LogicalNot;
-use PHPUnit\Framework\Constraint\StringContains;
 use PHPUnit\Framework\Constraint\TraversableContains;
 
 /**
@@ -21,18 +19,6 @@ use PHPUnit\Framework\Constraint\TraversableContains;
  */
 trait PolyfillAssertTrait
 {
-    /**
-     * @param float  $delta
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertEqualsWithDelta($expected, $actual, $delta, $message = '')
-    {
-        $constraint = new IsEqual($expected, $delta);
-        static::assertThat($actual, $constraint, $message);
-    }
-
     /**
      * @param iterable $haystack
      * @param string   $message
@@ -58,225 +44,6 @@ trait PolyfillAssertTrait
     }
 
     /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertIsArray($actual, $message = '')
-    {
-        static::assertInternalType('array', $actual, $message);
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertIsBool($actual, $message = '')
-    {
-        static::assertInternalType('bool', $actual, $message);
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertIsFloat($actual, $message = '')
-    {
-        static::assertInternalType('float', $actual, $message);
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertIsInt($actual, $message = '')
-    {
-        static::assertInternalType('int', $actual, $message);
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertIsNumeric($actual, $message = '')
-    {
-        static::assertInternalType('numeric', $actual, $message);
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertIsObject($actual, $message = '')
-    {
-        static::assertInternalType('object', $actual, $message);
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertIsResource($actual, $message = '')
-    {
-        static::assertInternalType('resource', $actual, $message);
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertIsString($actual, $message = '')
-    {
-        static::assertInternalType('string', $actual, $message);
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertIsScalar($actual, $message = '')
-    {
-        static::assertInternalType('scalar', $actual, $message);
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertIsCallable($actual, $message = '')
-    {
-        static::assertInternalType('callable', $actual, $message);
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertIsIterable($actual, $message = '')
-    {
-        static::assertInternalType('iterable', $actual, $message);
-    }
-
-    /**
-     * @param string $needle
-     * @param string $haystack
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertStringContainsString($needle, $haystack, $message = '')
-    {
-        $constraint = new StringContains($needle, false);
-        static::assertThat($haystack, $constraint, $message);
-    }
-
-    /**
-     * @param string $needle
-     * @param string $haystack
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertStringContainsStringIgnoringCase($needle, $haystack, $message = '')
-    {
-        $constraint = new StringContains($needle, true);
-        static::assertThat($haystack, $constraint, $message);
-    }
-
-    /**
-     * @param string $needle
-     * @param string $haystack
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertStringNotContainsString($needle, $haystack, $message = '')
-    {
-        $constraint = new LogicalNot(new StringContains($needle, false));
-        static::assertThat($haystack, $constraint, $message);
-    }
-
-    /**
-     * @param string $needle
-     * @param string $haystack
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertStringNotContainsStringIgnoringCase($needle, $haystack, $message = '')
-    {
-        $constraint = new LogicalNot(new StringContains($needle, true));
-        static::assertThat($haystack, $constraint, $message);
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertFinite($actual, $message = '')
-    {
-        static::assertInternalType('float', $actual, $message);
-        static::assertTrue(is_finite($actual), $message ?: "Failed asserting that $actual is finite.");
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertInfinite($actual, $message = '')
-    {
-        static::assertInternalType('float', $actual, $message);
-        static::assertTrue(is_infinite($actual), $message ?: "Failed asserting that $actual is infinite.");
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertNan($actual, $message = '')
-    {
-        static::assertInternalType('float', $actual, $message);
-        static::assertTrue(is_nan($actual), $message ?: "Failed asserting that $actual is nan.");
-    }
-
-    /**
-     * @param string $filename
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertIsReadable($filename, $message = '')
-    {
-        static::assertInternalType('string', $filename, $message);
-        static::assertTrue(is_readable($filename), $message ?: "Failed asserting that $filename is readable.");
-    }
-
-    /**
-     * @param string $filename
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertNotIsReadable($filename, $message = '')
-    {
-        static::assertInternalType('string', $filename, $message);
-        static::assertFalse(is_readable($filename), $message ?: "Failed asserting that $filename is not readable.");
-    }
-
-    /**
      * @param string $filename
      * @param string $message
      *
@@ -285,30 +52,6 @@ trait PolyfillAssertTrait
     public static function assertIsNotReadable($filename, $message = '')
     {
         static::assertNotIsReadable($filename, $message);
-    }
-
-    /**
-     * @param string $filename
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertIsWritable($filename, $message = '')
-    {
-        static::assertInternalType('string', $filename, $message);
-        static::assertTrue(is_writable($filename), $message ?: "Failed asserting that $filename is writable.");
-    }
-
-    /**
-     * @param string $filename
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertNotIsWritable($filename, $message = '')
-    {
-        static::assertInternalType('string', $filename, $message);
-        static::assertFalse(is_writable($filename), $message ?: "Failed asserting that $filename is not writable.");
     }
 
     /**
@@ -328,57 +71,9 @@ trait PolyfillAssertTrait
      *
      * @return void
      */
-    public static function assertDirectoryExists($directory, $message = '')
-    {
-        static::assertInternalType('string', $directory, $message);
-        static::assertTrue(is_dir($directory), $message ?: "Failed asserting that $directory exists.");
-    }
-
-    /**
-     * @param string $directory
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertDirectoryNotExists($directory, $message = '')
-    {
-        static::assertInternalType('string', $directory, $message);
-        static::assertFalse(is_dir($directory), $message ?: "Failed asserting that $directory does not exist.");
-    }
-
-    /**
-     * @param string $directory
-     * @param string $message
-     *
-     * @return void
-     */
     public static function assertDirectoryDoesNotExist($directory, $message = '')
     {
         static::assertDirectoryNotExists($directory, $message);
-    }
-
-    /**
-     * @param string $directory
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertDirectoryIsReadable($directory, $message = '')
-    {
-        static::assertDirectoryExists($directory, $message);
-        static::assertIsReadable($directory, $message);
-    }
-
-    /**
-     * @param string $directory
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertDirectoryNotIsReadable($directory, $message = '')
-    {
-        static::assertDirectoryExists($directory, $message);
-        static::assertNotIsReadable($directory, $message);
     }
 
     /**
@@ -398,57 +93,9 @@ trait PolyfillAssertTrait
      *
      * @return void
      */
-    public static function assertDirectoryIsWritable($directory, $message = '')
-    {
-        static::assertDirectoryExists($directory, $message);
-        static::assertIsWritable($directory, $message);
-    }
-
-    /**
-     * @param string $directory
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertDirectoryNotIsWritable($directory, $message = '')
-    {
-        static::assertDirectoryExists($directory, $message);
-        static::assertNotIsWritable($directory, $message);
-    }
-
-    /**
-     * @param string $directory
-     * @param string $message
-     *
-     * @return void
-     */
     public static function assertDirectoryIsNotWritable($directory, $message = '')
     {
         static::assertDirectoryNotIsWritable($directory, $message);
-    }
-
-    /**
-     * @param string $filename
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertFileExists($filename, $message = '')
-    {
-        static::assertInternalType('string', $filename, $message);
-        static::assertTrue(file_exists($filename), $message ?: "Failed asserting that $filename exists.");
-    }
-
-    /**
-     * @param string $filename
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertFileNotExists($filename, $message = '')
-    {
-        static::assertInternalType('string', $filename, $message);
-        static::assertFalse(file_exists($filename), $message ?: "Failed asserting that $filename does not exist.");
     }
 
     /**
@@ -468,57 +115,9 @@ trait PolyfillAssertTrait
      *
      * @return void
      */
-    public static function assertFileIsReadable($filename, $message = '')
-    {
-        static::assertFileExists($filename, $message);
-        static::assertIsReadable($filename, $message);
-    }
-
-    /**
-     * @param string $filename
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertFileNotIsReadable($filename, $message = '')
-    {
-        static::assertFileExists($filename, $message);
-        static::assertNotIsReadable($filename, $message);
-    }
-
-    /**
-     * @param string $filename
-     * @param string $message
-     *
-     * @return void
-     */
     public static function assertFileIsNotReadable($filename, $message = '')
     {
         static::assertFileNotIsReadable($filename, $message);
-    }
-
-    /**
-     * @param string $filename
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertFileIsWritable($filename, $message = '')
-    {
-        static::assertFileExists($filename, $message);
-        static::assertIsWritable($filename, $message);
-    }
-
-    /**
-     * @param string $filename
-     * @param string $message
-     *
-     * @return void
-     */
-    public static function assertFileNotIsWritable($filename, $message = '')
-    {
-        static::assertFileExists($filename, $message);
-        static::assertNotIsWritable($filename, $message);
     }
 
     /**

--- a/src/Symfony/Bridge/PhpUnit/Legacy/PolyfillTestCaseTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/PolyfillTestCaseTrait.php
@@ -14,88 +14,12 @@ namespace Symfony\Bridge\PhpUnit\Legacy;
 use PHPUnit\Framework\Error\Error;
 use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\Error\Warning;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
 
 /**
  * This trait is @internal.
  */
 trait PolyfillTestCaseTrait
 {
-    /**
-     * @param string|string[] $originalClassName
-     *
-     * @return MockObject
-     */
-    protected function createMock($originalClassName)
-    {
-        $mock = $this->getMockBuilder($originalClassName)
-            ->disableOriginalConstructor()
-            ->disableOriginalClone()
-            ->disableArgumentCloning();
-
-        if (method_exists($mock, 'disallowMockingUnknownTypes')) {
-            $mock = $mock->disallowMockingUnknownTypes();
-        }
-
-        return $mock->getMock();
-    }
-
-    /**
-     * @param string|string[] $originalClassName
-     * @param string[]        $methods
-     *
-     * @return MockObject
-     */
-    protected function createPartialMock($originalClassName, array $methods)
-    {
-        $mock = $this->getMockBuilder($originalClassName)
-            ->disableOriginalConstructor()
-            ->disableOriginalClone()
-            ->disableArgumentCloning()
-            ->setMethods(empty($methods) ? null : $methods);
-
-        if (method_exists($mock, 'disallowMockingUnknownTypes')) {
-            $mock = $mock->disallowMockingUnknownTypes();
-        }
-
-        return $mock->getMock();
-    }
-
-    /**
-     * @param string $exception
-     *
-     * @return void
-     */
-    public function expectException($exception)
-    {
-        $this->doExpectException($exception);
-    }
-
-    /**
-     * @param int|string $code
-     *
-     * @return void
-     */
-    public function expectExceptionCode($code)
-    {
-        $property = new \ReflectionProperty(TestCase::class, 'expectedExceptionCode');
-        $property->setAccessible(true);
-        $property->setValue($this, $code);
-    }
-
-    /**
-     * @param string $message
-     *
-     * @return void
-     */
-    public function expectExceptionMessage($message)
-    {
-        $property = new \ReflectionProperty(TestCase::class, 'expectedExceptionMessage');
-        $property->setAccessible(true);
-        $property->setValue($this, $message);
-    }
-
     /**
      * @param string $messageRegExp
      *
@@ -107,23 +31,11 @@ trait PolyfillTestCaseTrait
     }
 
     /**
-     * @param string $messageRegExp
-     *
-     * @return void
-     */
-    public function expectExceptionMessageRegExp($messageRegExp)
-    {
-        $property = new \ReflectionProperty(TestCase::class, 'expectedExceptionMessageRegExp');
-        $property->setAccessible(true);
-        $property->setValue($this, $messageRegExp);
-    }
-
-    /**
      * @return void
      */
     public function expectNotice()
     {
-        $this->doExpectException(Notice::class);
+        $this->expectException(Notice::class);
     }
 
     /**
@@ -151,7 +63,7 @@ trait PolyfillTestCaseTrait
      */
     public function expectWarning()
     {
-        $this->doExpectException(Warning::class);
+        $this->expectException(Warning::class);
     }
 
     /**
@@ -179,7 +91,7 @@ trait PolyfillTestCaseTrait
      */
     public function expectError()
     {
-        $this->doExpectException(Error::class);
+        $this->expectException(Error::class);
     }
 
     /**
@@ -200,12 +112,5 @@ trait PolyfillTestCaseTrait
     public function expectErrorMessageMatches($regularExpression)
     {
         $this->expectExceptionMessageMatches($regularExpression);
-    }
-
-    private function doExpectException($exception)
-    {
-        $property = new \ReflectionProperty(TestCase::class, 'expectedException');
-        $property->setAccessible(true);
-        $property->setValue($this, $exception);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

PhpUnitBridge 5.3 requires PHPUnit 7.5 or later. This PR proposes to remove all polyfilled methods that already exist in PHPUnit 7.5 because they're essentially dead code.