### PR TITLE
[DoctrineBridge] Take into account that indexBy="person_id" could be a db column name, for a referenced entity

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -122,7 +122,12 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
                             /** @var ClassMetadataInfo $subMetadata */
                             $indexProperty = $subMetadata->getSingleAssociationReferencedJoinColumnName($fieldName);
                             $subMetadata = $this->entityManager ? $this->entityManager->getClassMetadata($associationMapping['targetEntity']) : $this->classMetadataFactory->getMetadataFor($associationMapping['targetEntity']);
-                            $typeOfField = $subMetadata->getTypeOfField($indexProperty);
+
+                            //Not a property, maybe a column name?
+                            if (null === ($typeOfField = $subMetadata->getTypeOfField($indexProperty))) {
+                                $fieldName = $subMetadata->getFieldForColumn($indexProperty);
+                                $typeOfField = $subMetadata->getTypeOfField($fieldName);
+                            }
                         }
                     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -85,6 +85,7 @@ class DoctrineExtractorTest extends TestCase
             'indexedByDt',
             'indexedByCustomType',
             'indexedBuz',
+            'dummyGeneratedValueList',
         ]);
 
         $this->assertEquals(
@@ -245,6 +246,15 @@ class DoctrineExtractorTest extends TestCase
                 new Type(Type::BUILTIN_TYPE_STRING),
                 new Type(Type::BUILTIN_TYPE_OBJECT, false, DoctrineRelation::class)
             )]],
+            ['dummyGeneratedValueList', [new Type(
+                Type::BUILTIN_TYPE_OBJECT,
+                false,
+                'Doctrine\Common\Collections\Collection',
+                true,
+                new Type(Type::BUILTIN_TYPE_INT),
+                new Type(Type::BUILTIN_TYPE_OBJECT, false, DoctrineRelation::class)
+            )]],
+            ['json', null],
         ];
 
         if (class_exists(Types::class)) {

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineDummy.php
@@ -137,4 +137,9 @@ class DoctrineDummy
      * @OneToMany(targetEntity="DoctrineRelation", mappedBy="buzField", indexBy="buzField")
      */
     protected $indexedBuz;
+
+    /**
+     * @OneToMany(targetEntity="DoctrineRelation", mappedBy="dummyRelation", indexBy="gen_value_col_id", orphanRemoval=true)
+     */
+    protected $dummyGeneratedValueList;
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineGeneratedValue.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineGeneratedValue.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\OneToMany;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -34,4 +35,15 @@ class DoctrineGeneratedValue
      * @Column
      */
     public $foo;
+
+    /**
+     * @var int
+     * @Column(type="integer", name="gen_value_col_id")
+     */
+    public $valueId;
+
+    /**
+     * @OneToMany(targetEntity="DoctrineRelation", mappedBy="generatedValueRelation", indexBy="rguid_column", orphanRemoval=true)
+     */
+    protected $relationList;
 }

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineRelation.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/Fixtures/DoctrineRelation.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping\Column;
 use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\Id;
 use Doctrine\ORM\Mapping\ManyToOne;
+use Doctrine\ORM\Mapping\JoinColumn;
 
 /**
  * @Entity
@@ -60,4 +61,15 @@ class DoctrineRelation
      * @ManyToOne(targetEntity="DoctrineDummy", inversedBy="indexedBuz")
      */
     protected $buzField;
+
+    /**
+     * @ManyToOne(targetEntity="DoctrineDummy", inversedBy="dummyGeneratedValueList")
+     */
+    private $dummyRelation;
+
+    /**
+     * @ManyToOne(targetEntity="DoctrineGeneratedValue", inversedBy="relationList")
+     * @JoinColumn(name="gen_value_col_id", referencedColumnName="gen_value_col_id")
+     */
+    private $generatedValueRelation;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | bug-fix only

In Symfony 4.4.17 (I think), using ManyToMany in doctrine, along with indexBy="person_id" (in the related entity, which has a property of "id" (which in-turn uses the db column "person_id" worked as expected. When upgrading to Symfony 5.2.1, this stops working.

This change continues on from issue #37982 to fix a further edge case.