### PR TITLE
[Yaml] do not dump extra trailing newlines for multiline blocks

### DIFF
--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -64,14 +64,18 @@ class Dumper
             $dumpAsMap = Inline::isHash($input);
 
             foreach ($input as $key => $value) {
+                if ('' !== $output && "\n" !== $output[-1]) {
+                    $output .= "\n";
+                }
+
                 if ($inline >= 1 && Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK & $flags && \is_string($value) && false !== strpos($value, "\n") && false === strpos($value, "\r")) {
                     // If the first line starts with a space character, the spec requires a blockIndicationIndicator
                     // http://www.yaml.org/spec/1.2/spec.html#id2793979
                     $blockIndentationIndicator = (' ' === substr($value, 0, 1)) ? (string) $this->indentation : '';
-                    $output .= sprintf("%s%s%s |%s\n", $prefix, $dumpAsMap ? Inline::dump($key, $flags).':' : '-', '', $blockIndentationIndicator);
+                    $output .= sprintf('%s%s%s |%s-', $prefix, $dumpAsMap ? Inline::dump($key, $flags).':' : '-', '', $blockIndentationIndicator);
 
                     foreach (explode("\n", $value) as $row) {
-                        $output .= sprintf("%s%s%s\n", $prefix, str_repeat(' ', $this->indentation), $row);
+                        $output .= sprintf("\n%s%s%s", $prefix, str_repeat(' ', $this->indentation), $row);
                     }
 
                     continue;
@@ -84,10 +88,10 @@ class Dumper
                         // If the first line starts with a space character, the spec requires a blockIndicationIndicator
                         // http://www.yaml.org/spec/1.2/spec.html#id2793979
                         $blockIndentationIndicator = (' ' === substr($value->getValue(), 0, 1)) ? (string) $this->indentation : '';
-                        $output .= sprintf(" |%s\n", $blockIndentationIndicator);
+                        $output .= sprintf(' |%s', $blockIndentationIndicator);
 
                         foreach (explode("\n", $value->getValue()) as $row) {
-                            $output .= sprintf("%s%s%s\n", $prefix, str_repeat(' ', $this->indentation), $row);
+                            $output .= sprintf("\n%s%s%s", $prefix, str_repeat(' ', $this->indentation), $row);
                         }
 
                         continue;

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -493,19 +493,16 @@ YAML;
         $data = [
             'foo' => new TaggedValue('bar', "foo\nline with trailing spaces:\n  \nbar\ninteger like line:\n123456789\nempty line:\n\nbaz"),
         ];
-        $expected = <<<YAML
-foo: !bar |
-    foo
-    line with trailing spaces:
-      
-    bar
-    integer like line:
-    123456789
-    empty line:
-    
-    baz
-
-YAML;
+        $expected = "foo: !bar |\n".
+            "    foo\n".
+            "    line with trailing spaces:\n".
+            "      \n".
+            "    bar\n".
+            "    integer like line:\n".
+            "    123456789\n".
+            "    empty line:\n".
+            "    \n".
+            '    baz';
 
         $this->assertSame($expected, $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
     }
@@ -545,7 +542,9 @@ YAML;
             ],
         ];
 
-        $this->assertSame(file_get_contents(__DIR__.'/Fixtures/multiple_lines_as_literal_block_leading_space_in_first_line.yml'), $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
+        $expected = "data:\n    multi_line: |4-\n            the first line has leading spaces\n        The second line does not.";
+
+        $this->assertSame($expected, $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
     }
 
     public function testCarriageReturnFollowedByNewlineIsMaintainedWhenDumpingAsMultiLineLiteralBlock()
@@ -566,6 +565,18 @@ YAML;
                 'foo' => "bar\n\rbaz: qux",
             ],
         ], 4, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
+    }
+
+    public function testNoTrailingNewlineWhenDumpingAsMultiLineLiteralBlock()
+    {
+        $data = [
+            "a\nb",
+            "c\nd",
+        ];
+        $yaml = $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
+
+        $this->assertSame("- |-\n    a\n    b\n- |-\n    c\n    d", $yaml);
+        $this->assertSame($data, Yaml::parse($yaml));
     }
 
     public function testZeroIndentationThrowsException()

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/multiple_lines_as_literal_block.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/multiple_lines_as_literal_block.yml
@@ -1,6 +1,6 @@
 data:
     single_line: 'foo bar baz'
-    multi_line: |
+    multi_line: |-
         foo
         line with trailing spaces:
           

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/multiple_lines_as_literal_block_leading_space_in_first_line.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/multiple_lines_as_literal_block_leading_space_in_first_line.yml
@@ -1,4 +1,0 @@
-data:
-    multi_line: |4
-            the first line has leading spaces
-        The second line does not.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38310
| License       | MIT
| Doc PR        | 