### PR TITLE
[Form] disable error bubbling by default when inherit_data is configured

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -157,7 +157,7 @@ class FormType extends BaseType
         // For any form that is not represented by a single HTML control,
         // errors should bubble up by default
         $errorBubbling = function (Options $options) {
-            return $options['compound'];
+            return $options['compound'] && !$options['inherit_data'];
         };
 
         // If data is given, the form is locked to that data

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -512,6 +512,16 @@ class FormTypeTest extends BaseTypeTest
         $this->assertTrue($form->getConfig()->getErrorBubbling());
     }
 
+    public function testErrorBubblingForCompoundFieldsIsDisabledByDefaultIfInheritDataIsEnabled()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'compound' => true,
+            'inherit_data' => true,
+        ]);
+
+        $this->assertFalse($form->getConfig()->getErrorBubbling());
+    }
+
     public function testPropertyPath()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [
@@ -728,6 +738,28 @@ class FormTypeTest extends BaseTypeTest
             ->createView();
 
         $this->assertEquals(['%parent_param%' => 'parent_value', '%override_param%' => 'child_value'], $view['child']->vars['help_translation_parameters']);
+    }
+
+    public function testErrorBubblingDoesNotSkipCompoundFieldsWithInheritDataConfigured()
+    {
+        $form = $this->factory->createNamedBuilder('form', self::TESTED_TYPE)
+            ->add(
+                $this->factory->createNamedBuilder('inherit_data_type', self::TESTED_TYPE, null, [
+                    'inherit_data' => true,
+                ])
+                ->add('child', self::TESTED_TYPE, [
+                    'compound' => false,
+                    'error_bubbling' => true,
+                ])
+            )
+            ->getForm();
+        $error = new FormError('error message');
+        $form->get('inherit_data_type')->get('child')->addError($error);
+
+        $this->assertCount(0, $form->getErrors());
+        $this->assertCount(1, $form->get('inherit_data_type')->getErrors());
+        $this->assertSame($error, $form->get('inherit_data_type')->getErrors()[0]);
+        $this->assertCount(0, $form->get('inherit_data_type')->get('child')->getErrors());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #14441
| License       | MIT
| Doc PR        | 
