### PR TITLE
[Yaml] keep trailing newlines when dumping multi-line strings

### DIFF
--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -72,10 +72,23 @@ class Dumper
                     // If the first line starts with a space character, the spec requires a blockIndicationIndicator
                     // http://www.yaml.org/spec/1.2/spec.html#id2793979
                     $blockIndentationIndicator = (' ' === substr($value, 0, 1)) ? (string) $this->indentation : '';
-                    $output .= sprintf('%s%s%s |%s-', $prefix, $dumpAsMap ? Inline::dump($key, $flags).':' : '-', '', $blockIndentationIndicator);
+
+                    if (isset($value[-2]) && "\n" === $value[-2] && "\n" === $value[-1]) {
+                        $blockChompingIndicator = '+';
+                    } elseif ("\n" === $value[-1]) {
+                        $blockChompingIndicator = '';
+                    } else {
+                        $blockChompingIndicator = '-';
+                    }
+
+                    $output .= sprintf('%s%s%s |%s%s', $prefix, $dumpAsMap ? Inline::dump($key, $flags).':' : '-', '', $blockIndentationIndicator, $blockChompingIndicator);
 
                     foreach (explode("\n", $value) as $row) {
-                        $output .= sprintf("\n%s%s%s", $prefix, str_repeat(' ', $this->indentation), $row);
+                        if ('' === $row) {
+                            $output .= "\n";
+                        } else {
+                            $output .= sprintf("\n%s%s%s", $prefix, str_repeat(' ', $this->indentation), $row);
+                        }
                     }
 
                     continue;

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -567,7 +567,7 @@ YAML;
         ], 4, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
     }
 
-    public function testNoTrailingNewlineWhenDumpingAsMultiLineLiteralBlock()
+    public function testNoExtraTrailingNewlineWhenDumpingAsMultiLineLiteralBlock()
     {
         $data = [
             "a\nb",
@@ -576,6 +576,44 @@ YAML;
         $yaml = $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
 
         $this->assertSame("- |-\n    a\n    b\n- |-\n    c\n    d", $yaml);
+        $this->assertSame($data, Yaml::parse($yaml));
+    }
+
+    public function testDumpTrailingNewlineInMultiLineLiteralBlocks()
+    {
+        $data = [
+            'clip 1' => "one\ntwo\n",
+            'clip 2' => "one\ntwo\n",
+            'keep 1' => "one\ntwo\n",
+            'keep 2' => "one\ntwo\n\n",
+            'strip 1' => "one\ntwo",
+            'strip 2' => "one\ntwo",
+        ];
+        $yaml = $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
+
+        $expected = <<<YAML
+'clip 1': |
+    one
+    two
+'clip 2': |
+    one
+    two
+'keep 1': |
+    one
+    two
+'keep 2': |+
+    one
+    two
+
+'strip 1': |-
+    one
+    two
+'strip 2': |-
+    one
+    two
+YAML;
+
+        $this->assertSame($expected, $yaml);
         $this->assertSame($data, Yaml::parse($yaml));
     }
 

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/multiple_lines_as_literal_block.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/multiple_lines_as_literal_block.yml
@@ -8,7 +8,7 @@ data:
         integer like line:
         123456789
         empty line:
-        
+
         baz
     multi_line_with_carriage_return: "foo\nbar\r\nbaz"
     nested_inlined_multi_line_string: { inlined_multi_line: "foo\nbar\r\nempty line:\n\nbaz" }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/pull/39668#issuecomment-753484545
| License       | MIT
| Doc PR        | 