### PR TITLE
[DomCrawler] deprecate parents() in favor of ancestors()

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -6,6 +6,11 @@ Asset
 
  * Deprecated `RemoteJsonManifestVersionStrategy`, use `JsonManifestVersionStrategy` instead.
 
+DomCrawler
+----------
+
+* Deprecated the `parents()` method, use `ancestors()` instead.
+
 Form
 ----
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -33,6 +33,11 @@ DependencyInjection
  * The `ref()` function from the PHP-DSL has been removed, use `service()` instead.
  * Removed `Definition::setPrivate()` and `Alias::setPrivate()`, use `setPublic()` instead
 
+DomCrawler
+----------
+
+ * Removed the `parents()` method, use `ancestors()` instead.
+
 Dotenv
 ------
 

--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.3.0
 -----
 
+ * The `parents()` method is deprecated. Use `ancestors()` instead.
  * Marked the `containsOption()`, `availableOptionValues()`, and `disableValidation()` methods of the
    `ChoiceFormField` class as internal
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -494,13 +494,27 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
-     * Returns the parents nodes of the current selection.
+     * Returns the parent nodes of the current selection.
      *
      * @return static
      *
      * @throws \InvalidArgumentException When current node is empty
      */
     public function parents()
+    {
+        @trigger_deprecation('symfony/dom-crawler', '5.3', sprintf('The %s() method is deprecated, use ancestors() instead.', __METHOD__));
+
+        return $this->ancestors();
+    }
+
+    /**
+     * Returns the ancestors of the current selection.
+     *
+     * @return static
+     *
+     * @throws \InvalidArgumentException When the current node is empty
+     */
+    public function ancestors()
     {
         if (!$this->nodes) {
             throw new \InvalidArgumentException('The current node list is empty.');

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php80": "^1.15"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #26432
| License       | MIT
| Doc PR        | 