### PR TITLE
[FrameworkBundle][Messenger] Added RouterContextMiddleware

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -97,6 +97,7 @@ use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisTransportFactory;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\RouterContextMiddleware;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
@@ -944,8 +945,12 @@ class FrameworkExtension extends Extension
         if (!$this->isConfigEnabled($container, $config)) {
             $container->removeDefinition('console.command.router_debug');
             $container->removeDefinition('console.command.router_match');
+            $container->removeDefinition('messenger.middleware.router_context');
 
             return;
+        }
+        if (!class_exists(RouterContextMiddleware::class)) {
+            $container->removeDefinition('messenger.middleware.router_context');
         }
 
         $loader->load('routing.php');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -26,6 +26,7 @@ use Symfony\Component\Messenger\Middleware\DispatchAfterCurrentBusMiddleware;
 use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\RejectRedeliveredMessageMiddleware;
+use Symfony\Component\Messenger\Middleware\RouterContextMiddleware;
 use Symfony\Component\Messenger\Middleware\SendMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\TraceableMiddleware;
 use Symfony\Component\Messenger\Middleware\ValidationMiddleware;
@@ -98,6 +99,11 @@ return static function (ContainerConfigurator $container) {
             ->abstract()
             ->args([
                 service('debug.stopwatch'),
+            ])
+
+        ->set('messenger.middleware.router_context', RouterContextMiddleware::class)
+            ->args([
+                service('router'),
             ])
 
         // Discovery

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.3
 ---
 
+ * Add the `RouterContextMiddleware` to restore the original router context when handling a message
  * `InMemoryTransport` can perform message serialization through dsn `in-memory://?serialize=true`.
  * Added `queues` option to `Worker` to only fetch messages from a specific queue from a receiver implementing `QueueReceiverInterface`.
 

--- a/src/Symfony/Component/Messenger/Middleware/RouterContextMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/RouterContextMiddleware.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+use Symfony\Component\Messenger\Stamp\RouterContextStamp;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RequestContextAwareInterface;
+
+/**
+ * Restore the Router context when processing the message.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class RouterContextMiddleware implements MiddlewareInterface
+{
+    private $router;
+
+    public function __construct(RequestContextAwareInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    public function handle(Envelope $envelope, StackInterface $stack): Envelope
+    {
+        if (!$envelope->last(ConsumedByWorkerStamp::class) || !$contextStamp = $envelope->last(RouterContextStamp::class)) {
+            $context = $this->router->getContext();
+            $envelope = $envelope->with(new RouterContextStamp(
+                $context->getBaseUrl(),
+                $context->getMethod(),
+                $context->getHost(),
+                $context->getScheme(),
+                $context->getHttpPort(),
+                $context->getHttpsPort(),
+                $context->getPathInfo(),
+                $context->getQueryString()
+            ));
+
+            return $stack->next()->handle($envelope, $stack);
+        }
+
+        $currentContext = $this->router->getContext();
+
+        /* @var RouterContextStamp $contextStamp */
+        $this->router->setContext(new RequestContext(
+            $contextStamp->getBaseUrl(),
+            $contextStamp->getMethod(),
+            $contextStamp->getHost(),
+            $contextStamp->getScheme(),
+            $contextStamp->getHttpPort(),
+            $contextStamp->getHttpsPort(),
+            $contextStamp->getPathInfo(),
+            $contextStamp->getQueryString()
+        ));
+
+        try {
+            return $stack->next()->handle($envelope, $stack);
+        } finally {
+            $this->router->setContext($currentContext);
+        }
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/RouterContextStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/RouterContextStamp.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class RouterContextStamp implements StampInterface
+{
+    private $baseUrl;
+    private $method;
+    private $host;
+    private $scheme;
+    private $httpPort;
+    private $httpsPort;
+    private $pathInfo;
+    private $queryString;
+
+    public function __construct(string $baseUrl, string $method, string $host, string $scheme, int $httpPort, int $httpsPort, string $pathInfo, string $queryString)
+    {
+        $this->baseUrl = $baseUrl;
+        $this->method = $method;
+        $this->host = $host;
+        $this->scheme = $scheme;
+        $this->httpPort = $httpPort;
+        $this->httpsPort = $httpsPort;
+        $this->pathInfo = $pathInfo;
+        $this->queryString = $queryString;
+    }
+
+    public function getBaseUrl(): string
+    {
+        return $this->baseUrl;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    public function getHost(): string
+    {
+        return $this->host;
+    }
+
+    public function getScheme(): string
+    {
+        return $this->scheme;
+    }
+
+    public function getHttpPort(): int
+    {
+        return $this->httpPort;
+    }
+
+    public function getHttpsPort(): int
+    {
+        return $this->httpsPort;
+    }
+
+    public function getPathInfo(): string
+    {
+        return $this->pathInfo;
+    }
+
+    public function getQueryString(): string
+    {
+        return $this->queryString;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Middleware/RouterContextMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/RouterContextMiddlewareTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Middleware;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\RouterContextMiddleware;
+use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+use Symfony\Component\Messenger\Stamp\RouterContextStamp;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RequestContextAwareInterface;
+
+class RouterContextMiddlewareTest extends MiddlewareTestCase
+{
+    public function testMiddlewareStoreContext()
+    {
+        $context = new RequestContext('/', 'GET', 'symfony.com');
+
+        $router = $this->createMock(RequestContextAwareInterface::class);
+        $router
+            ->expects($this->once())
+            ->method('getContext')
+            ->willReturn($context);
+
+        $middleware = new RouterContextMiddleware($router);
+
+        $envelope = new Envelope(new \stdClass());
+        $envelope = $middleware->handle($envelope, $this->getStackMock());
+
+        $this->assertNotNull($stamp = $envelope->last(RouterContextStamp::class));
+        $this->assertSame('symfony.com', $stamp->getHost());
+    }
+
+    public function testMiddlewareRestoreContext()
+    {
+        $router = $this->createMock(RequestContextAwareInterface::class);
+        $originalContext = new RequestContext();
+
+        $router
+            ->expects($this->once())
+            ->method('getContext')
+            ->willReturn($originalContext);
+
+        $router
+            ->expects($this->exactly(2))
+            ->method('setContext')
+            ->withConsecutive(
+                [$this->callback(function ($context) {
+                    $this->assertSame('symfony.com', $context->getHost());
+
+                    return true;
+                })],
+                [$originalContext]
+            );
+
+        $middleware = new RouterContextMiddleware($router);
+        $envelope = new Envelope(new \stdClass(), [
+            new ConsumedByWorkerStamp(),
+            new RouterContextStamp('', 'GET', 'symfony.com', 'https', 80, 443, '/', ''),
+        ]);
+        $middleware->handle($envelope, $this->getStackMock());
+    }
+}

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -32,6 +32,7 @@
         "symfony/http-kernel": "^4.4|^5.0",
         "symfony/process": "^4.4|^5.0",
         "symfony/property-access": "^4.4|^5.0",
+        "symfony/routing": "^4.4|^5.0",
         "symfony/serializer": "^4.4|^5.0",
         "symfony/service-contracts": "^1.1|^2",
         "symfony/stopwatch": "^4.4|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TODO

When handling a message in async, we, sometimes need the Router Context to generate absolute URL. ie:
- sending an email when the message contains only the template
- generating a PDF

People can use the configuration `router.default_uri` to workaround and fix the issue, but this does not work when the web application servers several domains.

This PR provide a new middleware that store the current router context in a stamp, and restore the context when processing the message.