### PR TITLE
[FrameworkBundle] Dump abstract arguments

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/JsonDescriptor.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Console\Descriptor;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\ArgumentInterface;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -391,6 +392,10 @@ class JsonDescriptor extends Descriptor
                 'type' => 'service',
                 'id' => (string) $value,
             ];
+        }
+
+        if ($value instanceof AbstractArgument) {
+            return ['type' => 'abstract', 'text' => $value->getText()];
         }
 
         if ($value instanceof ArgumentInterface) {

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Helper\Dumper;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
@@ -347,6 +348,8 @@ class TextDescriptor extends Descriptor
                     $argumentsInformation[] = sprintf('Service locator (%d element(s))', \count($argument->getValues()));
                 } elseif ($argument instanceof Definition) {
                     $argumentsInformation[] = 'Inlined Service';
+                } elseif ($argument instanceof AbstractArgument) {
+                    $argumentsInformation[] = sprintf('Abstract argument (%s)', $argument->getText());
                 } else {
                     $argumentsInformation[] = \is_array($argument) ? sprintf('Array (%d element(s))', \count($argument)) : $argument;
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/XmlDescriptor.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Console\Descriptor;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
@@ -409,6 +410,9 @@ class XmlDescriptor extends Descriptor
                 }
             } elseif ($argument instanceof Definition) {
                 $argumentXML->appendChild($dom->importNode($this->getContainerDefinitionDocument($argument, null, false, true)->childNodes->item(0), true));
+            } elseif ($argument instanceof AbstractArgument) {
+                $argumentXML->setAttribute('type', 'abstract');
+                $argumentXML->appendChild(new \DOMText($argument->getText()));
             } elseif (\is_array($argument)) {
                 $argumentXML->setAttribute('type', 'collection');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/ObjectsProvider.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Console\Descriptor;
 
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -144,6 +145,7 @@ class ObjectsProvider
                     new Reference('definition_1'),
                     new Reference('.definition_2'),
                 ]))
+                ->addArgument(new AbstractArgument('placeholder'))
                 ->setFactory(['Full\\Qualified\\FactoryClass', 'get']),
             '.definition_2' => $definition2
                 ->setPublic(false)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.json
@@ -60,7 +60,11 @@
                         "type": "service",
                         "id": ".definition_2"
                     }
-                ]
+                ],
+                {
+                    "type": "abstract",
+                    "text": "placeholder"
+                }
             ],
             "file": null,
             "factory_class": "Full\\Qualified\\FactoryClass",

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/builder_1_arguments.xml
@@ -22,6 +22,7 @@
       <argument type="service" id="definition_1"/>
       <argument type="service" id=".definition_2"/>
     </argument>
+    <argument type="abstract">placeholder</argument>
   </definition>
   <definition id="definition_without_class" class="" public="false" synthetic="false" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" file=""/>
   <definition id="service_container" class="Symfony\Component\DependencyInjection\ContainerInterface" public="true" synthetic="true" lazy="false" shared="true" abstract="false" autowired="false" autoconfigured="false" file="">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.json
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.json
@@ -58,7 +58,11 @@
                 "type": "service",
                 "id": ".definition_2"
             }
-        ]
+        ],
+        {
+            "type": "abstract",
+            "text": "placeholder"
+        }
     ],
     "file": null,
     "factory_class": "Full\\Qualified\\FactoryClass",

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.txt
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.txt
@@ -1,24 +1,25 @@
- ---------------- ----------------------------- 
- [32m Option         [39m [32m Value                       [39m 
- ---------------- ----------------------------- 
-  Service ID       -                            
-  Class            Full\Qualified\Class1        
-  Tags             -                            
-  Public           yes                          
-  Synthetic        no                           
-  Lazy             yes                          
-  Shared           yes                          
-  Abstract         yes                          
-  Autowired        no                           
-  Autoconfigured   no                           
-  Factory Class    Full\Qualified\FactoryClass  
-  Factory Method   get                          
-[39;49m  Arguments        Service(.definition_2)[39;49m[39;49m       [39;49m
-[39;49m                   [39;49m[39;49m%parameter%[39;49m[39;49m                  [39;49m
-[39;49m                   [39;49m[39;49mInlined Service[39;49m[39;49m              [39;49m
-[39;49m                   [39;49m[39;49mArray (3 element(s))[39;49m[39;49m         [39;49m
-[39;49m                   [39;49m[39;49mIterator (2 element(s))[39;49m[39;49m      [39;49m
-[39;49m                   [39;49m[39;49m- Service(definition_1)[39;49m[39;49m      [39;49m
-[39;49m                   [39;49m- Service(.definition_2)     
- ---------------- -----------------------------
+ ---------------- --------------------------------- 
+ [32m Option         [39m [32m Value                           [39m 
+ ---------------- --------------------------------- 
+  Service ID       -                                
+  Class            Full\Qualified\Class1            
+  Tags             -                                
+  Public           yes                              
+  Synthetic        no                               
+  Lazy             yes                              
+  Shared           yes                              
+  Abstract         yes                              
+  Autowired        no                               
+  Autoconfigured   no                               
+  Factory Class    Full\Qualified\FactoryClass      
+  Factory Method   get                              
+[39;49m  Arguments        Service(.definition_2)[39;49m[39;49m           [39;49m
+[39;49m                   [39;49m[39;49m%parameter%[39;49m[39;49m                      [39;49m
+[39;49m                   [39;49m[39;49mInlined Service[39;49m[39;49m                  [39;49m
+[39;49m                   [39;49m[39;49mArray (3 element(s))[39;49m[39;49m             [39;49m
+[39;49m                   [39;49m[39;49mIterator (2 element(s))[39;49m[39;49m          [39;49m
+[39;49m                   [39;49m[39;49m- Service(definition_1)[39;49m[39;49m          [39;49m
+[39;49m                   [39;49m[39;49m- Service(.definition_2)[39;49m[39;49m         [39;49m
+[39;49m                   [39;49mAbstract argument (placeholder)  
+ ---------------- ---------------------------------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Descriptor/definition_arguments_1.xml
@@ -20,4 +20,5 @@
     <argument type="service" id="definition_1"/>
     <argument type="service" id=".definition_2"/>
   </argument>
+  <argument type="abstract">placeholder</argument>
 </definition>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #24138
| License       | MIT
| Doc PR        | -

This PR fixes n exception thrown when dumping abstract arguments (ie. `./bin/console  debug:containter session.abstract_handler --show-arguments`)