### PR TITLE
[PropertyAccess] use bitwise flags to configure when the property accessor should throw

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -67,6 +67,11 @@ PhpunitBridge
 
  * Deprecated the `SetUpTearDownTrait` trait, use original methods with "void" return typehint
 
+PropertyAccess
+--------------
+
+* Deprecate passing a boolean as the second argument of `PropertyAccessor::__construct()`, pass a combination of bitwise flags instead.
+
 PropertyInfo
 ------------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -152,6 +152,7 @@ PhpUnitBridge
 PropertyAccess
 --------------
 
+ * Drop support for booleans as the second argument of `PropertyAccessor::__construct()`, pass a combination of bitwise flags instead.
  * Dropped support for booleans as the first argument of `PropertyAccessor::__construct()`.
    Pass a combination of bitwise flags instead.
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1573,13 +1573,16 @@ class FrameworkExtension extends Extension
         $magicMethods |= $config['magic_get'] ? PropertyAccessor::MAGIC_GET : 0;
         $magicMethods |= $config['magic_set'] ? PropertyAccessor::MAGIC_SET : 0;
 
+        $throw = PropertyAccessor::DO_NOT_THROW;
+        $throw |= $config['throw_exception_on_invalid_index'] ? PropertyAccessor::THROW_ON_INVALID_INDEX : 0;
+        $throw |= $config['throw_exception_on_invalid_property_path'] ? PropertyAccessor::THROW_ON_INVALID_PROPERTY_PATH : 0;
+
         $container
             ->getDefinition('property_accessor')
             ->replaceArgument(0, $magicMethods)
-            ->replaceArgument(1, $config['throw_exception_on_invalid_index'])
-            ->replaceArgument(3, $config['throw_exception_on_invalid_property_path'])
-            ->replaceArgument(4, new Reference(PropertyReadInfoExtractorInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE))
-            ->replaceArgument(5, new Reference(PropertyWriteInfoExtractorInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE))
+            ->replaceArgument(1, $throw)
+            ->replaceArgument(3, new Reference(PropertyReadInfoExtractorInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE))
+            ->replaceArgument(4, new Reference(PropertyWriteInfoExtractorInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE))
         ;
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_access.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/property_access.php
@@ -19,9 +19,8 @@ return static function (ContainerConfigurator $container) {
         ->set('property_accessor', PropertyAccessor::class)
             ->args([
                 abstract_arg('magic methods allowed, set by the extension'),
-                abstract_arg('throwExceptionOnInvalidIndex, set by the extension'),
+                abstract_arg('throw exceptions, set by the extension'),
                 service('cache.property_access')->ignoreOnInvalid(),
-                abstract_arg('throwExceptionOnInvalidPropertyPath, set by the extension'),
                 abstract_arg('propertyReadInfoExtractor, set by the extension'),
                 abstract_arg('propertyWriteInfoExtractor, set by the extension'),
             ])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -100,8 +100,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $def = $container->getDefinition('property_accessor');
         $this->assertSame(PropertyAccessor::MAGIC_SET | PropertyAccessor::MAGIC_GET, $def->getArgument(0));
-        $this->assertFalse($def->getArgument(1));
-        $this->assertTrue($def->getArgument(3));
+        $this->assertSame(PropertyAccessor::THROW_ON_INVALID_PROPERTY_PATH, $def->getArgument(1));
     }
 
     public function testPropertyAccessWithOverriddenValues()
@@ -109,8 +108,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('property_accessor');
         $def = $container->getDefinition('property_accessor');
         $this->assertSame(PropertyAccessor::MAGIC_GET | PropertyAccessor::MAGIC_CALL, $def->getArgument(0));
-        $this->assertTrue($def->getArgument(1));
-        $this->assertFalse($def->getArgument(3));
+        $this->assertSame(PropertyAccessor::THROW_ON_INVALID_INDEX, $def->getArgument(1));
     }
 
     public function testPropertyAccessCache()

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -84,7 +84,7 @@
         "symfony/messenger": "<4.4",
         "symfony/mime": "<4.4",
         "symfony/property-info": "<4.4",
-        "symfony/property-access": "<5.2",
+        "symfony/property-access": "<5.3",
         "symfony/serializer": "<5.2",
         "symfony/security-csrf": "<5.3",
         "symfony/security-core": "<5.3",

--- a/src/Symfony/Component/PropertyAccess/CHANGELOG.md
+++ b/src/Symfony/Component/PropertyAccess/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3.0
+-----
+
+ * deprecate passing a boolean as the second argument of `PropertyAccessor::__construct()`, expecting a combination of bitwise flags instead
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessorBuilder.php
@@ -283,6 +283,16 @@ class PropertyAccessorBuilder
      */
     public function getPropertyAccessor()
     {
-        return new PropertyAccessor($this->magicMethods, $this->throwExceptionOnInvalidIndex, $this->cacheItemPool, $this->throwExceptionOnInvalidPropertyPath, $this->readInfoExtractor, $this->writeInfoExtractor);
+        $throw = PropertyAccessor::DO_NOT_THROW;
+
+        if ($this->throwExceptionOnInvalidIndex) {
+            $throw |= PropertyAccessor::THROW_ON_INVALID_INDEX;
+        }
+
+        if ($this->throwExceptionOnInvalidPropertyPath) {
+            $throw |= PropertyAccessor::THROW_ON_INVALID_PROPERTY_PATH;
+        }
+
+        return new PropertyAccessor($this->magicMethods, $throw, $this->cacheItemPool, $this->readInfoExtractor, $this->writeInfoExtractor);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #31126
| License       | MIT
| Doc PR        | 
