### PR TITLE
[PropertyAccess] throw type error when incompatible types are passed

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -127,7 +127,7 @@ PhpUnitBridge
 PropertyAccess
 --------------
 
- * Dropped support of a boolean as the first argument of `PropertyAccessor::__construct()`.
+ * Dropped support for booleans as the first argument of `PropertyAccessor::__construct()`.
    Pass a combination of bitwise flags instead.
 
 PropertyInfo

--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -92,6 +92,8 @@ class PropertyAccessor implements PropertyAccessorInterface
             trigger_deprecation('symfony/property-access', '5.2', 'Passing a boolean as the first argument to "%s()" is deprecated. Pass a combination of bitwise flags instead (i.e an integer).', __METHOD__);
 
             $magicMethods = ($magicMethods ? self::MAGIC_CALL : 0) | self::MAGIC_GET | self::MAGIC_SET;
+        } elseif (!\is_int($magicMethods)) {
+            throw new \TypeError(sprintf('Argument 1 passed to "%s()" must be an integer, "%s" given.', __METHOD__, get_debug_type($readInfoExtractor)));
         }
 
         $this->magicMethodsFlags = $magicMethods;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 