### PR TITLE
[HttpKernel] harden test to not depend on the actual time

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
@@ -190,26 +190,25 @@ class FileProfilerStorageTest extends TestCase
 
     public function testStoreTime()
     {
-        $dt = new \DateTime('now');
-        $start = $dt->getTimestamp();
+        $start = $now = time();
 
         for ($i = 0; $i < 3; ++$i) {
-            $dt->modify('+1 minute');
+            $now += 60;
             $profile = new Profile('time_'.$i);
             $profile->setIp('127.0.0.1');
             $profile->setUrl('http://foo.bar');
-            $profile->setTime($dt->getTimestamp());
+            $profile->setTime($now);
             $profile->setMethod('GET');
             $this->storage->write($profile);
         }
 
-        $records = $this->storage->find('', '', 3, 'GET', $start, time() + 3 * 60);
+        $records = $this->storage->find('', '', 3, 'GET', $start, $start + 3 * 60);
         $this->assertCount(3, $records, '->find() returns all previously added records');
         $this->assertEquals('time_2', $records[0]['token'], '->find() returns records ordered by time in descendant order');
         $this->assertEquals('time_1', $records[1]['token'], '->find() returns records ordered by time in descendant order');
         $this->assertEquals('time_0', $records[2]['token'], '->find() returns records ordered by time in descendant order');
 
-        $records = $this->storage->find('', '', 3, 'GET', $start, time() + 2 * 60);
+        $records = $this->storage->find('', '', 3, 'GET', $start, $start + 2 * 60);
         $this->assertCount(2, $records, '->find() should return only first two of the previously added records');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

From time to time this test fails (e.g. https://travis-ci.com/github/symfony/symfony/jobs/468014427#L7092). We can fix that by not depending on the system clock which is actually not needed in this test.