### PR TITLE
fix code style

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -289,7 +289,7 @@ abstract class AbstractDescriptorTest extends TestCase
     }
 
     /** @dataProvider getDescribeContainerBuilderWithPriorityTagsTestData */
-    public function testDescribeContainerBuilderWithPriorityTags(ContainerBuilder $builder, $expectedDescription, array $options): void
+    public function testDescribeContainerBuilderWithPriorityTags(ContainerBuilder $builder, $expectedDescription, array $options)
     {
         $this->assertDescription($expectedDescription, $builder, $options);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/workflows.php
@@ -12,7 +12,7 @@ $container->loadFromExtension('framework', [
             'initial_marking' => ['draft'],
             'metadata' => [
                 'title' => 'article workflow',
-                'description' => 'workflow for articles'
+                'description' => 'workflow for articles',
             ],
             'places' => [
                 'draft',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1641,7 +1641,7 @@ abstract class FrameworkExtensionTest extends TestCase
     /**
      * @dataProvider provideMailer
      */
-    public function testMailer(string $configFile, array $expectedTransports): void
+    public function testMailer(string $configFile, array $expectedTransports)
     {
         $container = $this->createContainerFromFile($configFile);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ClassAliasExampleClass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/ClassAliasExampleClass.php
@@ -4,7 +4,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Fixtures;
 
 class_alias(
     ClassAliasTargetClass::class,
-    __NAMESPACE__ . '\ClassAliasExampleClass'
+    __NAMESPACE__.'\ClassAliasExampleClass'
 );
 
 if (false) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Validation/Category.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Validation/Category.php
@@ -6,7 +6,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class Category
 {
-    const NAME_PATTERN = '/\w+/';
+    public const NAME_PATTERN = '/\w+/';
 
     public $id;
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -345,7 +345,7 @@ class SecurityDataCollectorTest extends TestCase
      *
      * @dataProvider providerCollectDecisionLog
      */
-    public function testCollectDecisionLog(string $strategy, array $decisionLog, array $voters, array $expectedVoterClasses, array $expectedDecisionLog): void
+    public function testCollectDecisionLog(string $strategy, array $decisionLog, array $voters, array $expectedVoterClasses, array $expectedDecisionLog)
     {
         $accessDecisionManager = $this
             ->getMockBuilder(TraceableAccessDecisionManager::class)

--- a/src/Symfony/Component/DomCrawler/Tests/Html5ParserCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Html5ParserCrawlerTest.php
@@ -27,7 +27,7 @@ class Html5ParserCrawlerTest extends AbstractCrawlerTest
     }
 
     /** @dataProvider validHtml5Provider */
-    public function testHtml5ParserParseContentStartingWithValidHeading(string $content): void
+    public function testHtml5ParserParseContentStartingWithValidHeading(string $content)
     {
         $this->skipTestIfHTML5LibraryNotAvailable();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/StringToFloatTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/StringToFloatTransformerTest.php
@@ -30,7 +30,7 @@ class StringToFloatTransformerTest extends TestCase
     /**
      * @dataProvider provideTransformations
      */
-    public function testTransform($from, $to): void
+    public function testTransform($from, $to)
     {
         $transformer = new StringToFloatTransformer();
 

--- a/src/Symfony/Component/HttpClient/Tests/Exception/HttpExceptionTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Exception/HttpExceptionTraitTest.php
@@ -39,7 +39,7 @@ ERROR;
     /**
      * @dataProvider provideParseError
      */
-    public function testParseError(string $mimeType, string $json, string $expectedMessage): void
+    public function testParseError(string $mimeType, string $json, string $expectedMessage)
     {
         $response = $this->createMock(ResponseInterface::class);
         $response

--- a/src/Symfony/Component/Mailer/Test/TransportFactoryTestCase.php
+++ b/src/Symfony/Component/Mailer/Test/TransportFactoryTestCase.php
@@ -54,7 +54,7 @@ abstract class TransportFactoryTestCase extends TestCase
     /**
      * @dataProvider supportsProvider
      */
-    public function testSupports(Dsn $dsn, bool $supports): void
+    public function testSupports(Dsn $dsn, bool $supports)
     {
         $factory = $this->getFactory();
 

--- a/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
@@ -20,7 +20,7 @@ class DsnTest extends TestCase
     /**
      * @dataProvider fromStringProvider
      */
-    public function testFromString(string $string, Dsn $dsn): void
+    public function testFromString(string $string, Dsn $dsn)
     {
         $this->assertEquals($dsn, Dsn::fromString($string));
     }

--- a/src/Symfony/Component/Mailer/Tests/TransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/TransportTest.php
@@ -27,7 +27,7 @@ class TransportTest extends TestCase
     /**
      * @dataProvider fromStringProvider
      */
-    public function testFromString(string $dsn, TransportInterface $transport): void
+    public function testFromString(string $dsn, TransportInterface $transport)
     {
         $transportFactory = new Transport([new DummyTransportFactory()]);
 

--- a/src/Symfony/Component/Routing/Tests/Loader/ObjectLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ObjectLoaderTest.php
@@ -43,7 +43,7 @@ class ObjectLoaderTest extends TestCase
     /**
      * @dataProvider getBadResourceStrings
      */
-    public function testExceptionWithoutSyntax(string $resourceString): void
+    public function testExceptionWithoutSyntax(string $resourceString)
     {
         $this->expectException('InvalidArgumentException');
         $loader = new TestObjectLoader();

--- a/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ObjectRouteLoaderTest.php
@@ -71,7 +71,7 @@ class ObjectRouteLoaderTest extends TestCase
     /**
      * @dataProvider getBadResourceStrings
      */
-    public function testExceptionWithoutSyntax(string $resourceString): void
+    public function testExceptionWithoutSyntax(string $resourceString)
     {
         $this->expectException('InvalidArgumentException');
         $loader = new TestObjectRouteLoader();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I ran the CS fixer and checked all test methods to not make use of `void`.