### PR TITLE
[Cache] use the clock mock to make test more resilient

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Messenger/EarlyExpirationHandlerTest.php
+++ b/src/Symfony/Component/Cache/Tests/Messenger/EarlyExpirationHandlerTest.php
@@ -31,6 +31,9 @@ class EarlyExpirationHandlerTest extends TestCase
         (new Filesystem())->remove(sys_get_temp_dir().'/symfony-cache');
     }
 
+    /**
+     * @group time-sensitive
+     */
     public function testHandle()
     {
         $pool = new FilesystemAdapter();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

see for example https://ci.appveyor.com/project/fabpot/symfony/builds/37097868#L1534