### PR TITLE
[TwigBridge] Remove full head content in HTML to text converter

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php
+++ b/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php
@@ -74,6 +74,6 @@ final class BodyRenderer implements BodyRendererInterface
             return $this->converter->convert($html);
         }
 
-        return strip_tags(preg_replace('{<(head|style)\b.*?</\1>}i', '', $html));
+        return strip_tags(preg_replace('{<(head|style)\b.*?</\1>}is', '', $html));
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Mime/BodyRendererTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/BodyRendererTest.php
@@ -37,6 +37,23 @@ class BodyRendererTest extends TestCase
         $this->assertEquals(str_replace('=', '=3D', $html), $body->getParts()[1]->bodyToString());
     }
 
+    public function testRenderMultiLineHtmlOnly()
+    {
+        $html = <<<HTML
+<head>
+<style type="text/css">
+css
+</style>
+</head>
+<b>HTML</b>
+HTML;
+        $email = $this->prepareEmail(null, $html);
+        $body = $email->getBody();
+        $this->assertInstanceOf(AlternativePart::class, $body);
+        $this->assertEquals('HTML', str_replace(["\r", "\n"], '', $body->getParts()[0]->bodyToString()));
+        $this->assertEquals(str_replace(['=', "\n"], ['=3D', "\r\n"], $html), $body->getParts()[1]->bodyToString());
+    }
+
     public function testRenderHtmlOnlyWithTextSet()
     {
         $email = $this->prepareEmail(null, '<b>HTML</b>');


### PR DESCRIPTION
When extracting text from HTML part all the content between opening and closing tag should be removed

| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

Without the `s` flag the preg_replace match only head (or style) tags on a single line