### PR TITLE
[Console] Handle duplicate negatable options

### DIFF
--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -233,6 +233,9 @@ class InputDefinition
         if (isset($this->options[$option->getName()]) && !$option->equals($this->options[$option->getName()])) {
             throw new LogicException(sprintf('An option named "%s" already exists.', $option->getName()));
         }
+        if (isset($this->negations[$option->getName()])) {
+            throw new LogicException(sprintf('An option named "%s" already exists.', $option->getName()));
+        }
 
         if ($option->getShortcut()) {
             foreach (explode('|', $option->getShortcut()) as $shortcut) {

--- a/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
@@ -242,6 +242,26 @@ class InputDefinitionTest extends TestCase
         $definition->addOption($this->foo2);
     }
 
+    public function testAddDuplicateNetgatedOption()
+    {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('An option named "no-foo" already exists.');
+
+        $definition = new InputDefinition();
+        $definition->addOption(new InputOption('no-foo'));
+        $definition->addOption(new InputOption('foo', null, InputOption::VALUE_NEGATABLE));
+    }
+
+    public function testAddDuplicateNetgatedReverseOption()
+    {
+        $this->expectException('LogicException');
+        $this->expectExceptionMessage('An option named "no-foo" already exists.');
+
+        $definition = new InputDefinition();
+        $definition->addOption(new InputOption('foo', null, InputOption::VALUE_NEGATABLE));
+        $definition->addOption(new InputOption('no-foo'));
+    }
+
     public function testAddDuplicateShortcutOption()
     {
         $this->expectException('LogicException');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Throws an LogicException when adding a "standard" option "--no-foo" along side a negatable "--foo"