### PR TITLE
[Uid] Use the Uuid constructor when reconstructing an Ulid from its RFC-4122 version

### DIFF
--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -59,7 +59,7 @@ class Ulid extends AbstractUid
     public static function fromString(string $ulid): parent
     {
         if (36 === \strlen($ulid) && Uuid::isValid($ulid)) {
-            $ulid = Uuid::fromString($ulid)->toBinary();
+            $ulid = (new Uuid($ulid))->toBinary();
         } elseif (22 === \strlen($ulid) && 22 === strspn($ulid, BinaryUtil::BASE58[''])) {
             $ulid = BinaryUtil::fromBase($ulid, BinaryUtil::BASE58);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Ref https://github.com/symfony/polyfill/issues/323

In my scenario, I'm doing `Ulid::fromString('0164129e-c96f-eb1a-f011-57cf56e0c559')`. When we reach the modified line, we already know the provided `$ulid` string is an rfc-4122 valid uuid so we don't need to call `fromString` (I guess) + we don't care of the version, we just want the binary content. That fixes the referenced issue in my case because the missing constant is consequently not loaded.