### PR TITLE
[Uid] Inline UuidV*::TYPE constants

### DIFF
--- a/src/Symfony/Component/Uid/NilUuid.php
+++ b/src/Symfony/Component/Uid/NilUuid.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Uid;
  */
 class NilUuid extends Uuid
 {
-    protected const TYPE = \UUID_TYPE_NULL;
+    protected const TYPE = -1;
 
     public function __construct()
     {

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Uid;
  */
 class Uuid extends AbstractUid
 {
-    protected const TYPE = \UUID_TYPE_DEFAULT;
+    protected const TYPE = 0;
 
     public function __construct(string $uuid)
     {

--- a/src/Symfony/Component/Uid/UuidV1.php
+++ b/src/Symfony/Component/Uid/UuidV1.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\Uid;
  */
 class UuidV1 extends Uuid
 {
-    protected const TYPE = \UUID_TYPE_TIME;
+    protected const TYPE = 1;
 
     public function __construct(string $uuid = null)
     {

--- a/src/Symfony/Component/Uid/UuidV3.php
+++ b/src/Symfony/Component/Uid/UuidV3.php
@@ -22,5 +22,5 @@ namespace Symfony\Component\Uid;
  */
 class UuidV3 extends Uuid
 {
-    protected const TYPE = \UUID_TYPE_MD5;
+    protected const TYPE = 3;
 }

--- a/src/Symfony/Component/Uid/UuidV4.php
+++ b/src/Symfony/Component/Uid/UuidV4.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\Uid;
  */
 class UuidV4 extends Uuid
 {
-    protected const TYPE = \UUID_TYPE_RANDOM;
+    protected const TYPE = 4;
 
     public function __construct(string $uuid = null)
     {

--- a/src/Symfony/Component/Uid/UuidV5.php
+++ b/src/Symfony/Component/Uid/UuidV5.php
@@ -22,5 +22,5 @@ namespace Symfony\Component\Uid;
  */
 class UuidV5 extends Uuid
 {
-    protected const TYPE = \UUID_TYPE_SHA1;
+    protected const TYPE = 5;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Ref https://github.com/symfony/polyfill/issues/323

If we hardcode those values in the polyfill, we can surely hardcode them here? In my case, I have tested that `uuid_type` actually returns `3` even if the `\UUID_TYPE_MD5` constant is undefined :man_shrugging: 
