### PR TITLE
[TwigBridge] Render email once

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php
+++ b/src/Symfony/Bridge/Twig/Mime/BodyRenderer.php
@@ -46,6 +46,14 @@ final class BodyRenderer implements BodyRendererInterface
         }
 
         $messageContext = $message->getContext();
+
+        $previousRenderingKey = $messageContext[__CLASS__] ?? null;
+        unset($messageContext[__CLASS__]);
+        $currentRenderingKey = md5(serialize([$messageContext, $message->getTextTemplate(), $message->getHtmlTemplate()]));
+        if ($previousRenderingKey === $currentRenderingKey) {
+            return;
+        }
+
         if (isset($messageContext['email'])) {
             throw new InvalidArgumentException(sprintf('A "%s" context cannot have an "email" entry as this is a reserved variable.', \get_class($message)));
         }
@@ -66,6 +74,7 @@ final class BodyRenderer implements BodyRendererInterface
         if (!$message->getTextBody() && null !== $html = $message->getHtmlBody()) {
             $message->text($this->convertHtmlToText(\is_resource($html) ? stream_get_contents($html) : $html));
         }
+        $message->context($message->getContext() + [__CLASS__ => $currentRenderingKey]);
     }
 
     private function convertHtmlToText(string $html): string

--- a/src/Symfony/Bridge/Twig/Tests/Mime/BodyRendererTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/BodyRendererTest.php
@@ -79,6 +79,27 @@ HTML;
         $this->prepareEmail('Text', '', ['email' => 'reserved!']);
     }
 
+    public function testRenderedOnce()
+    {
+        $twig = new Environment(new ArrayLoader([
+            'text' => 'Text',
+        ]));
+        $renderer = new BodyRenderer($twig);
+        $email = (new TemplatedEmail())
+            ->to('fabien@symfony.com')
+            ->from('helene@symfony.com')
+        ;
+        $email->textTemplate('text');
+
+        $renderer->render($email);
+        $this->assertEquals('Text', $email->getTextBody());
+
+        $email->text('reset');
+
+        $renderer->render($email);
+        $this->assertEquals('reset', $email->getTextBody());
+    }
+
     private function prepareEmail(?string $text, ?string $html, array $context = []): TemplatedEmail
     {
         $twig = new Environment(new ArrayLoader([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39718
| License       | MIT
| Doc PR        | -

When `\Symfony\Component\Mailer\Mailer` send an email via the Bus (async) it dispatches an `MessageEvent`, then the consumer call the `\Symfony\Component\Mailer\Transport\AbstractTransport::send` method which also dispatches an `MessageEvent`.

This event is listened by `\Symfony\Bridge\Twig\Mime\BodyRenderer::render` which rendered twice an email.

I'm not sure why the event is send twice, and if we could safely remove one of them (or maybe deprecating the `MessageEvent`, in favor of `SendMessageEvent` + `AsyncMessageEvent`)

This PR store a flag in the Message to avoid rendering it twice.