### PR TITLE
[Serializer] Rename normalize param

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ProblemNormalizer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Normalizer;
 
 use Symfony\Component\ErrorHandler\Exception\FlattenException;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
 /**
  * Normalizes errors according to the API Problem spec (RFC 7807).
@@ -40,20 +41,24 @@ class ProblemNormalizer implements NormalizerInterface, CacheableSupportsMethodI
      *
      * @return array
      */
-    public function normalize($exception, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = [])
     {
+        if (!$object instanceof FlattenException) {
+            throw new InvalidArgumentException(sprintf('The object must implement "%s".', FlattenException::class));
+        }
+
         $context += $this->defaultContext;
         $debug = $this->debug && ($context['debug'] ?? true);
 
         $data = [
             'type' => $context['type'],
             'title' => $context['title'],
-            'status' => $context['status'] ?? $exception->getStatusCode(),
-            'detail' => $debug ? $exception->getMessage() : $exception->getStatusText(),
+            'status' => $context['status'] ?? $object->getStatusCode(),
+            'detail' => $debug ? $object->getMessage() : $object->getStatusText(),
         ];
         if ($debug) {
-            $data['class'] = $exception->getClass();
-            $data['trace'] = $exception->getTrace();
+            $data['class'] = $object->getClass();
+            $data['trace'] = $object->getTrace();
         }
 
         return $data;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The ProblemNormalizer is the only one Normalizer which 
- Use a different param name `$exception` instead of the one in the interface `$object`.
- Doesn't type check the param.

The first point lead to an unfixable error with Psalm when extending the ProblemNormalizer
- If the variable is named `$object` it does not match with the parent
- If the variable is named `$exception` it does not match with the interface