### PR TITLE
[Notifier] Cleanup changelog (5.1)

### DIFF
--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -4,7 +4,6 @@ CHANGELOG
 5.1.0
 -----
 
- * Added the Mattermost notifier bridge
  * [BC BREAK] The `ChatMessage::fromNotification()` method's `$recipient` and `$transport`
    arguments were removed.
  * [BC BREAK] The `EmailMessage::fromNotification()` and `SmsMessage::fromNotification()`


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

New bridges are not mentioned in the changelog file of Notifier itself, but in the CHANGELOG of the bridge.
