### PR TITLE
[Notifier] Cleanup changelog (5.2)

### DIFF
--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -5,7 +5,6 @@ CHANGELOG
 -----
 
  * [BC BREAK] The `TransportInterface::send()` and `AbstractTransport::doSend()` methods changed to return a `?SentMessage` instance instead of `void`.
- * Added the Zulip notifier bridge
  * The `EmailRecipientInterface` and `RecipientInterface` were introduced.
  * Added `email` and `phone` properties to `Recipient`.
  * [BC BREAK] Changed the type-hint of the `$recipient` argument in the `as*Message()` method


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

New bridges are not mentioned in the changelog file of Notifier itself, but in the CHANGELOG of the bridge.

Same as #39739 but for `5.2`