### PR TITLE
[Serializer] Drop extra space

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -33,7 +33,7 @@ class AnnotationLoader implements LoaderInterface
     private const KNOWN_ANNOTATIONS = [
         DiscriminatorMap::class => true,
         Groups::class => true,
-        Ignore:: class => true,
+        Ignore::class => true,
         MaxDepth::class => true,
         SerializedName::class => true,
     ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | none

This extra space prevents phpab to prepare a static autoloader due to a parse error:
```
$ phpab src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
phpab %development% - Copyright (C) 2009 - 2021 by Arne Blankerts and Contributors

Scanning file src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
Could not process file '/home/taffit/Debian/symfony/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php' due to parse errors: Parse error while trying to process class definition (unexpected token "T_DOUBLE_ARROW" in name).
```