### PR TITLE
[Mailer] Fix missing BCC recipients in SES bridge

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpTransportTest.php
@@ -60,6 +60,12 @@ class SesHttpTransportTest extends TestCase
             $this->assertStringContainsString('AWS3-HTTPS AWSAccessKeyId=ACCESS_KEY,Algorithm=HmacSHA256,Signature=', $options['headers'][0] ?? $options['request_headers'][0]);
 
             parse_str($options['body'], $body);
+
+            $this->assertArrayHasKey('Destinations_member_1', $body);
+            $this->assertSame('saif.gmati@symfony.com', $body['Destinations_member_1']);
+            $this->assertArrayHasKey('Destinations_member_2', $body);
+            $this->assertSame('jeremy@derusse.com', $body['Destinations_member_2']);
+
             $content = base64_decode($body['RawMessage_Data']);
 
             $this->assertStringContainsString('Hello!', $content);
@@ -83,6 +89,7 @@ class SesHttpTransportTest extends TestCase
         $mail = new Email();
         $mail->subject('Hello!')
             ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->bcc(new Address('jeremy@derusse.com', 'Jérémy Derussé'))
             ->from(new Address('fabpot@symfony.com', 'Fabien'))
             ->text('Hello There!');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36333
| License       | MIT
| Doc PR        | -

When using the `ses` (alias of `ses+https`) scheme, the bridge send the RawEmail to AWS.
But RawEmails does not contains the BCC recipients.

This PR adds the envelope's recipients to the list of Destinations in Amazon SES payload.