### PR TITLE
[Mailer] Add Bcc recipients to sendmail

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
@@ -17,6 +17,7 @@ use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\Smtp\SmtpTransport;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\AbstractStream;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\ProcessStream;
+use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\RawMessage;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -99,6 +100,18 @@ class SendmailTransport extends AbstractTransport
 
         $this->stream->setCommand($command);
         $this->stream->initialize();
+        if (false !== strpos($command, ' -t')) {
+            $email = $message->getOriginalMessage();
+            if ($email instanceof Email) {
+                foreach ($email->getBcc() as $recipient) {
+                    $this->stream->write('Bcc:'.$recipient->toString()."\n");
+                }
+            } else {
+                foreach ($message->getEnvelope()->getRecipients() as $recipient) {
+                    $this->stream->write('Bcc:'.$recipient->toString()."\n");
+                }
+            }
+        }
         foreach ($chunks as $chunk) {
             $this->stream->write($chunk);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36333 #40070
| License       | MIT
| Doc PR        | -


When sending an email via `sendmail` with flag `-t`, Symfony will send a raw email, and the `sendmail` binary will get the recipient list from the message headers. But the BCC header is not removed from the RawEmail on purpose.

This PR injects the removed BCC headers.