### PR TITLE
[DependencyInjection] Support PHP 8 builtin types in CheckTypeDeclarationsPass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -280,15 +280,26 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
             return;
         }
 
+        if ('mixed' === $type) {
+            return;
+        }
+
         if (is_a($class, $type, true)) {
             return;
         }
 
-        $checkFunction = sprintf('is_%s', $type);
-
-        if (!$reflectionType->isBuiltin() || !$checkFunction($value)) {
-            throw new InvalidParameterTypeException($this->currentId, \is_object($value) ? $class : \gettype($value), $parameter);
+        if ('false' === $type) {
+            if (false === $value) {
+                return;
+            }
+        } elseif ($reflectionType->isBuiltin()) {
+            $checkFunction = sprintf('is_%s', $type);
+            if ($checkFunction($value)) {
+                return;
+            }
         }
+
+        throw new InvalidParameterTypeException($this->currentId, \is_object($value) ? $class : \gettype($value), $parameter);
     }
 
     private function getExpressionLanguage(): ExpressionLanguage

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckTypeDeclarationsPassTest.php
@@ -839,6 +839,22 @@ class CheckTypeDeclarationsPassTest extends TestCase
     /**
      * @requires PHP 8
      */
+    public function testUnionTypePassesWithFalse()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('union', UnionConstructor::class)
+            ->setFactory([UnionConstructor::class, 'create'])
+            ->setArguments([false]);
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @requires PHP 8
+     */
     public function testUnionTypeFailsWithReference()
     {
         $container = new ContainerBuilder();
@@ -851,8 +867,6 @@ class CheckTypeDeclarationsPassTest extends TestCase
         $this->expectExceptionMessage('Invalid definition for service "union": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\UnionConstructor::__construct()" accepts "Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\Foo|int", "Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\Waldo" passed.');
 
         (new CheckTypeDeclarationsPass(true))->process($container);
-
-        $this->addToAssertionCount(1);
     }
 
     /**
@@ -867,6 +881,57 @@ class CheckTypeDeclarationsPassTest extends TestCase
 
         $this->expectException(\Symfony\Component\DependencyInjection\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid definition for service "union": argument 1 of "Symfony\\Component\\DependencyInjection\\Tests\\Fixtures\\CheckTypeDeclarationsPass\\UnionConstructor::__construct()" accepts "Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\Foo|int", "array" passed.');
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testUnionTypeWithFalseFailsWithReference()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('waldo', Waldo::class);
+        $container->register('union', UnionConstructor::class)
+            ->setFactory([UnionConstructor::class, 'create'])
+            ->setArguments([new Reference('waldo')]);
+
+        $this->expectException(\Symfony\Component\DependencyInjection\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "union": argument 1 of "Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\UnionConstructor::create()" accepts "array|false", "Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\Waldo" passed.');
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testUnionTypeWithFalseFailsWithTrue()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('waldo', Waldo::class);
+        $container->register('union', UnionConstructor::class)
+            ->setFactory([UnionConstructor::class, 'create'])
+            ->setArguments([true]);
+
+        $this->expectException(\Symfony\Component\DependencyInjection\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid definition for service "union": argument 1 of "Symfony\Component\DependencyInjection\Tests\Fixtures\CheckTypeDeclarationsPass\UnionConstructor::create()" accepts "array|false", "boolean" passed.');
+
+        (new CheckTypeDeclarationsPass(true))->process($container);
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testReferencePassesMixed()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('waldo', Waldo::class);
+        $container->register('union', UnionConstructor::class)
+            ->setFactory([UnionConstructor::class, 'make'])
+            ->setArguments([new Reference('waldo')]);
 
         (new CheckTypeDeclarationsPass(true))->process($container);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/UnionConstructor.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/CheckTypeDeclarationsPass/UnionConstructor.php
@@ -7,4 +7,14 @@ class UnionConstructor
     public function __construct(Foo|int $arg)
     {
     }
+
+    public static function create(array|false $arg): static
+    {
+        return new static(0);
+    }
+
+    public static function make(mixed $arg): static
+    {
+        return new static(0);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`CheckTypeDeclarationsPass` currently explodes if it encounters one of following the new builtin types of PHP 8:

* `false` (can only appear as part of a union)
* `mixed` (we don't need to check anything)

In either case, the pass will try to call a function `is_false()`/`is_mixed()` and fail.

This PR should fix both cases.