### PR TITLE
[Cache] Don't invoke initializer on RedisProxy::isConnected()

### DIFF
--- a/src/Symfony/Component/Cache/Traits/RedisProxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisProxy.php
@@ -35,6 +35,11 @@ class RedisProxy
         return $this->redis->{$method}(...$args);
     }
 
+    public function isConnected()
+    {
+        return $this->redis->isConnected();
+    }
+
     public function hscan($strKey, &$iIterator, $strPattern = null, $iCount = null)
     {
         $this->ready ?: $this->ready = $this->initializer->__invoke($this->redis);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x for features / 4.4, 5.1 or 5.2 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

Being lazy connection we want to check if the connection is active but due to magic __call() that triggers a real connection to Redis by invoking initializer, we always get `true` here, which is probably not what we want
