### PR TITLE
[FrameworkBundle] Rename parameter of magic method configureContainer

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -29,7 +29,7 @@ use Symfony\Component\Routing\RouteCollectionBuilder;
  * @author Fabien Potencier <fabien@symfony.com>
  *
  * @method void configureRoutes(RoutingConfigurator $routes)
- * @method void configureContainer(ContainerConfigurator $c)
+ * @method void configureContainer(ContainerConfigurator $container)
  */
 trait MicroKernelTrait
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Default application Kernel has `configureContainer` method defined with `$container` as first parameter. PhpStorm inspection said: 
```
Parameter's name changed during inheritance
Parameter's name changed from 'c' to 'container'
```