### PR TITLE
[Notifier] Added ability to initialize sms options

### DIFF
--- a/src/Symfony/Component/Notifier/Message/SmsMessage.php
+++ b/src/Symfony/Component/Notifier/Message/SmsMessage.php
@@ -23,8 +23,9 @@ final class SmsMessage implements MessageInterface
     private $transport;
     private $subject;
     private $phone;
+    private $options;
 
-    public function __construct(string $phone, string $subject)
+    public function __construct(string $phone, string $subject, MessageOptionsInterface $options = null)
     {
         if ('' === $phone) {
             throw new InvalidArgumentException(sprintf('"%s" needs a phone number, it cannot be empty.', static::class));
@@ -32,6 +33,7 @@ final class SmsMessage implements MessageInterface
 
         $this->subject = $subject;
         $this->phone = $phone;
+        $this->options = $options;
     }
 
     public static function fromNotification(Notification $notification, SmsRecipientInterface $recipient): self
@@ -93,8 +95,18 @@ final class SmsMessage implements MessageInterface
         return $this->transport;
     }
 
+    /**
+     * @return $this
+     */
+    public function options(MessageOptionsInterface $options): self
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
     public function getOptions(): ?MessageOptionsInterface
     {
-        return null;
+        return $this->options;
     }
 }

--- a/src/Symfony/Component/Notifier/Tests/Message/SmsMessageTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Message/SmsMessageTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Notifier\Tests\Message;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 
 /**
@@ -56,5 +57,31 @@ class SmsMessageTest extends TestCase
         $this->assertSame('+3312345678', $message->getPhone());
 
         $message->phone('');
+    }
+
+    public function testOptionsDefaultsToNull()
+    {
+        $message = new SmsMessage('+3715673920', 'subject');
+
+        $this->assertNull($message->getOptions());
+    }
+
+    public function testSetOptions()
+    {
+        $options = new class() implements MessageOptionsInterface {
+            public function toArray(): array
+            {
+                return [];
+            }
+
+            public function getRecipientId(): ?string
+            {
+                return 'id';
+            }
+        };
+
+        $message = new SmsMessage('+3715673920', 'subject', $options);
+
+        $this->assertInstanceOf(MessageOptionsInterface::class, $message->getOptions());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x for features 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| License       | MIT

During implementing notifier transport were found SmsMessage::getOptions method always returns null and there is no ability to set sms options.
In the pr added ability to initialize sms options through the constructor.