### PR TITLE
Contracts: Remove ellipsis

### DIFF
--- a/src/Symfony/Contracts/README.md
+++ b/src/Symfony/Contracts/README.md
@@ -11,7 +11,7 @@ Design Principles
 
  * contracts are split by domain, each into their own sub-namespaces;
  * contracts are small and consistent sets of PHP interfaces, traits, normative
-   docblocks and reference test suites when applicable, ...;
+   docblocks and reference test suites when applicable;
  * all contracts must have a proven implementation to enter this repository;
  * they must be backward compatible with existing Symfony components.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        

I don't understand what the ellipsis is implying. I think it's better to remove it, it makes the contract clearer.