### PR TITLE
[Yaml] a colon followed by spaces exclusively separates mapping keys and values

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -200,7 +200,7 @@ class Parser
                     array_pop($this->refsBeingParsed);
                 }
             } elseif (
-                self::preg_match('#^(?P<key>(?:![^\s]++\s++)?(?:'.Inline::REGEX_QUOTED_STRING.'|(?:!?!php/const:)?[^ \'"\[\{!].*?)) *\:(\s++(?P<value>.+))?$#u', rtrim($this->currentLine), $values)
+                self::preg_match('#^(?P<key>(?:![^\s]++\s++)?(?:'.Inline::REGEX_QUOTED_STRING.'|(?:!?!php/const:)?[^ \'"\[\{!].*?)) *\:( ++(?P<value>.+))?$#u', rtrim($this->currentLine), $values)
                 && (false === strpos($values['key'], ' #') || \in_array($values['key'][0], ['"', "'"]))
             ) {
                 if ($context && 'sequence' == $context) {

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -877,4 +877,21 @@ class InlineTest extends TestCase
             [['!'], '! ["!"]'],
         ];
     }
+
+    /**
+     * @dataProvider ideographicSpaceProvider
+     */
+    public function testParseIdeographicSpace(string $yaml, string $expected)
+    {
+        $this->assertSame($expected, Inline::parse($yaml));
+    }
+
+    public function ideographicSpaceProvider(): array
+    {
+        return [
+            ["\u{3000}", '　'],
+            ["'\u{3000}'", '　'],
+            ["'a　b'", 'a　b'],
+        ];
+    }
 }

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2733,6 +2733,22 @@ YAML;
         // (before, there was no \n after row2)
         $this->assertSame(['a' => ['b' => "row\nrow2\n"], 'c' => 'd'], $this->parser->parse($longDocument));
     }
+
+    public function testParseIdeographicSpaces()
+    {
+        $expected = <<<YAML
+unquoted: \u{3000}
+quoted: '\u{3000}'
+within_string: 'a　b'
+regular_space: 'a b'
+YAML;
+        $this->assertSame([
+            'unquoted' => '　',
+            'quoted' => '　',
+            'within_string' => 'a　b',
+            'regular_space' => 'a b',
+        ], $this->parser->parse($expected));
+    }
 }
 
 class B


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/pull/39769#issuecomment-757540072
| License       | MIT
| Doc PR        | 