### PR TITLE
Dont allow unserializing classes with a destructor - 5.1

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -109,6 +109,16 @@ final class AmpResponse implements ResponseInterface
         return null !== $type ? $this->info[$type] ?? null : $this->info;
     }
 
+    public function __sleep()
+    {
+        throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
+    }
+
+    public function __wakeup()
+    {
+        throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+    }
+
     public function __destruct()
     {
         try {

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -63,6 +63,16 @@ class Connection
         $this->client = $client ?? new SqsClient([]);
     }
 
+    public function __sleep()
+    {
+        throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
+    }
+
+    public function __wakeup()
+    {
+        throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+    }
+
     public function __destruct()
     {
         $this->reset();

--- a/src/Symfony/Component/String/UnicodeString.php
+++ b/src/Symfony/Component/String/UnicodeString.php
@@ -359,6 +359,10 @@ class UnicodeString extends AbstractUnicodeString
 
     public function __wakeup()
     {
+        if (!\is_string($this->string)) {
+            throw new \BadMethodCallException('Cannot unserialize '.__CLASS__);
+        }
+
         normalizer_is_normalized($this->string) ?: $this->string = normalizer_normalize($this->string);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Prevent destructors with side-effects from being unserialized