### PR TITLE
[Security] Extract password hashing from security-core - with proper wording

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -69,7 +69,18 @@ PropertyInfo
 Security
 --------
 
+ * Deprecate all classes in the `Core\Encoder\`  sub-namespace, use the `PasswordHasher` component instead
  * Deprecated voters that do not return a valid decision when calling the `vote` method
+
+SecurityBundle
+--------------
+
+ * Deprecate `UserPasswordEncoderCommand` class and the corresponding `user:encode-password` command,
+   use `UserPasswordHashCommand` and `user:hash-password` instead
+ * Deprecate the `security.encoder_factory.generic` service, the `security.encoder_factory` and `Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface` aliases,
+   use `security.password_hasher_factory` and `Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface` instead
+ * Deprecate the `security.user_password_encoder.generic` service, the `security.password_encoder` and the `Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface` aliases,
+   use `security.user_password_hasher`, `security.password_hasher` and `Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface` instead
 
 Serializer
 ----------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -166,6 +166,7 @@ Routing
 Security
 --------
 
+ * Drop all classes in the `Core\Encoder\`  sub-namespace, use the `PasswordHasher` component instead
  * Drop support for `SessionInterface $session` as constructor argument of `SessionTokenStorage`, inject a `\Symfony\Component\HttpFoundation\RequestStack $requestStack` instead
  * Drop support for `session` provided by the ServiceLocator injected in `UsageTrackingTokenStorage`, provide a `request_stack` service instead
  * Make `SessionTokenStorage` throw a `SessionNotFoundException` when called outside a request context
@@ -178,6 +179,16 @@ Security
    `DefaultAuthenticationSuccessHandler`.
  * Removed the `AbstractRememberMeServices::$providerKey` property in favor of `AbstractRememberMeServices::$firewallName`
  * `AccessDecisionManager` now throw an exception when a voter does not return a valid decision.
+
+SecurityBundle
+--------------
+
+ * Remove the `UserPasswordEncoderCommand` class and the corresponding `user:encode-password` command,
+   use `UserPasswordHashCommand` and `user:hash-password` instead
+ * Remove the `security.encoder_factory.generic` service, the `security.encoder_factory` and `Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface` aliases,
+   use `security.password_hasher_factory` and `Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface` instead
+ * Remove the `security.user_password_encoder.generic` service, the `security.password_encoder` and the `Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface` aliases,
+   use `security.user_password_hasher`, `security.password_hasher` and `Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface` instead
 
 Serializer
 ----------

--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,7 @@
         "symfony/monolog-bridge": "self.version",
         "symfony/notifier": "self.version",
         "symfony/options-resolver": "self.version",
+        "symfony/password-hasher": "self.version",
         "symfony/process": "self.version",
         "symfony/property-access": "self.version",
         "symfony/property-info": "self.version",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -51,7 +51,7 @@
         "symfony/messenger": "^5.2",
         "symfony/mime": "^4.4|^5.0",
         "symfony/process": "^4.4|^5.0",
-        "symfony/security-bundle": "^5.2",
+        "symfony/security-bundle": "^5.3",
         "symfony/serializer": "^5.2",
         "symfony/stopwatch": "^4.4|^5.0",
         "symfony/string": "^5.0",

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,16 @@
 CHANGELOG
 =========
 
+5.3
+---
+
+ * Deprecate `UserPasswordEncoderCommand` class and the corresponding `user:encode-password` command,
+   use `UserPasswordHashCommand` and `user:hash-password` instead
+ * Deprecate the `security.encoder_factory.generic` service, the `security.encoder_factory` and `Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface` aliases,
+   use `security.password_hasher_factory` and `Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface` instead
+ * Deprecate the `security.user_password_encoder.generic` service, the `security.password_encoder` and the `Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface` aliases,
+   use `security.user_password_hasher`, `security.password_hasher` and `Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface` instead
+
 5.2.0
 -----
 

--- a/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/UserPasswordEncoderCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PasswordHasher\Command\UserPasswordHashCommand;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Encoder\SelfSaltingEncoderInterface;
 
@@ -30,6 +31,8 @@ use Symfony\Component\Security\Core\Encoder\SelfSaltingEncoderInterface;
  * @author Sarah Khalil <mkhalil.sarah@gmail.com>
  *
  * @final
+ *
+ * @deprecated since Symfony 5.3, use {@link UserPasswordHashCommand} instead
  */
 class UserPasswordEncoderCommand extends Command
 {
@@ -106,6 +109,8 @@ EOF
     {
         $io = new SymfonyStyle($input, $output);
         $errorIo = $output instanceof ConsoleOutputInterface ? new SymfonyStyle($input, $output->getErrorOutput()) : $io;
+
+        $errorIo->caution('The use of the "security:encode-password" command is deprecated since version 5.3 and will be removed in 6.0. Use "security:hash-password" instead.');
 
         $input->isInteractive() ? $errorIo->title('Symfony Password Encoder Utility') : $errorIo->newLine();
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/console.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\SecurityBundle\Command\UserPasswordEncoderCommand;
+use Symfony\Component\PasswordHasher\Command\UserPasswordHashCommand;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -20,6 +21,16 @@ return static function (ContainerConfigurator $container) {
                 service('security.encoder_factory'),
                 abstract_arg('encoders user classes'),
             ])
-            ->tag('console.command')
+            ->tag('console.command', ['command' => 'security:encode-password'])
+            ->deprecate('symfony/security-bundle', '5.3', 'The "%service_id%" service is deprecated, use "security.command.user_password_hash" instead.')
+    ;
+
+    $container->services()
+        ->set('security.command.user_password_hash', UserPasswordHashCommand::class)
+        ->args([
+            service('security.password_hasher_factory'),
+            abstract_arg('list of user classes'),
+        ])
+        ->tag('console.command')
     ;
 };

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.php
@@ -34,7 +34,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('User Provider'),
                 abstract_arg('Provider-shared Key'),
                 abstract_arg('User Checker'),
-                service('security.password_encoder'),
+                service('security.password_hasher'),
             ])
 
         ->set('security.authentication.listener.guard', GuardAuthenticationListener::class)

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/password_hasher.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/password_hasher.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('security.password_hasher_factory', PasswordHasherFactory::class)
+            ->args([[]])
+        ->alias(PasswordHasherFactoryInterface::class, 'security.password_hasher_factory')
+
+        ->set('security.user_password_hasher', UserPasswordHasher::class)
+            ->args([service('security.password_hasher_factory')])
+        ->alias('security.password_hasher', 'security.user_password_hasher')
+        ->alias(UserPasswordHasherInterface::class, 'security.password_hasher')
+    ;
+};

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
@@ -11,6 +11,8 @@
             <xsd:element name="access-decision-manager" type="access_decision_manager" minOccurs="0" maxOccurs="1" />
             <xsd:element name="encoders" type="encoders" minOccurs="0" maxOccurs="1" />
             <xsd:element name="encoder" type="encoder" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="password_hashers" type="password_hashers" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="password_hasher" type="password_hasher" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="providers" type="providers" minOccurs="0" maxOccurs="1" />
             <xsd:element name="provider" type="provider" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="firewalls" type="firewalls" minOccurs="0" maxOccurs="1" />
@@ -28,6 +30,12 @@
     <xsd:complexType name="encoders">
         <xsd:sequence>
             <xsd:element name="encoder" type="encoder" minOccurs="1" maxOccurs="unbounded" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="password_hashers">
+        <xsd:sequence>
+            <xsd:element name="password_hasher" type="password_hasher" minOccurs="1" maxOccurs="unbounded" />
         </xsd:sequence>
     </xsd:complexType>
 
@@ -68,6 +76,23 @@
     </xsd:simpleType>
 
     <xsd:complexType name="encoder">
+        <xsd:sequence>
+            <xsd:element name="migrate-from" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+        <xsd:attribute name="class" type="xsd:string" use="required" />
+        <xsd:attribute name="algorithm" type="xsd:string" />
+        <xsd:attribute name="hash-algorithm" type="xsd:string" />
+        <xsd:attribute name="key-length" type="xsd:string" />
+        <xsd:attribute name="ignore-case" type="xsd:boolean" />
+        <xsd:attribute name="encode-as-base64" type="xsd:boolean" />
+        <xsd:attribute name="iterations" type="xsd:string" />
+        <xsd:attribute name="cost" type="xsd:integer" />
+        <xsd:attribute name="memory-cost" type="xsd:string" />
+        <xsd:attribute name="time-cost" type="xsd:string" />
+        <xsd:attribute name="id" type="xsd:string" />
+    </xsd:complexType>
+
+    <xsd:complexType name="password_hasher">
         <xsd:sequence>
             <xsd:element name="migrate-from" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -18,6 +18,8 @@ use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
 use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Bundle\SecurityBundle\Security\LazyFirewallContext;
 use Symfony\Component\Ldap\Security\LdapUserProvider;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -109,13 +111,20 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 [],
             ])
+            ->deprecate('symfony/security-bundle', '5.3', 'The "%service_id%" service is deprecated, use "security.password_hasher_factory" instead.')
         ->alias('security.encoder_factory', 'security.encoder_factory.generic')
+            ->deprecate('symfony/security-bundle', '5.3', 'The "%alias_id%" service is deprecated, use "security.password_hasher_factory" instead.')
         ->alias(EncoderFactoryInterface::class, 'security.encoder_factory')
+            ->deprecate('symfony/security-bundle', '5.3', 'The "%alias_id%" service is deprecated, use "'.PasswordHasherFactoryInterface::class.'" instead.')
 
         ->set('security.user_password_encoder.generic', UserPasswordEncoder::class)
             ->args([service('security.encoder_factory')])
-        ->alias('security.password_encoder', 'security.user_password_encoder.generic')->public()
+            ->deprecate('symfony/security-bundle', '5.3', 'The "%service_id%" service is deprecated, use "security.user_password_hasher" instead.')
+        ->alias('security.password_encoder', 'security.user_password_encoder.generic')
+            ->public()
+            ->deprecate('symfony/security-bundle', '5.3', 'The "%alias_id%" service is deprecated, use "security.password_hasher"" instead.')
         ->alias(UserPasswordEncoderInterface::class, 'security.password_encoder')
+            ->deprecate('symfony/security-bundle', '5.3', 'The "%alias_id%" service is deprecated, use "'.UserPasswordHasherInterface::class.'" instead.')
 
         ->set('security.user_checker', UserChecker::class)
 
@@ -260,7 +269,7 @@ return static function (ContainerConfigurator $container) {
         ->set('security.validator.user_password', UserPasswordValidator::class)
             ->args([
                 service('security.token_storage'),
-                service('security.encoder_factory'),
+                service('security.password_hasher_factory'),
             ])
             ->tag('validator.constraint_validator', ['alias' => 'security.validator.user_password'])
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
@@ -72,7 +72,7 @@ return static function (ContainerConfigurator $container) {
         // Listeners
         ->set('security.listener.check_authenticator_credentials', CheckCredentialsListener::class)
             ->args([
-               service('security.encoder_factory'),
+               service('security.password_hasher_factory'),
             ])
             ->tag('kernel.event_subscriber')
 
@@ -90,7 +90,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('security.listener.password_migrating', PasswordMigratingListener::class)
             ->args([
-                service('security.encoder_factory'),
+                service('security.password_hasher_factory'),
             ])
             ->tag('kernel.event_subscriber')
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.php
@@ -221,7 +221,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('User Provider'),
                 abstract_arg('User Checker'),
                 abstract_arg('Provider-shared Key'),
-                service('security.encoder_factory'),
+                service('security.password_hasher_factory'),
                 param('security.authentication.hide_user_not_found'),
             ])
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/argon2i_encoder.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/argon2i_encoder.php
@@ -1,6 +1,6 @@
 <?php
 
-$this->load('container1.php');
+$this->load('legacy_encoders.php');
 
 $container->loadFromExtension('security', [
     'encoders' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/argon2i_hasher.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/argon2i_hasher.php
@@ -1,0 +1,13 @@
+<?php
+
+$this->load('container1.php');
+
+$container->loadFromExtension('security', [
+    'password_hashers' => [
+        'JMS\FooBundle\Entity\User7' => [
+            'algorithm' => 'argon2i',
+            'memory_cost' => 256,
+            'time_cost' => 1,
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/bcrypt_encoder.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/bcrypt_encoder.php
@@ -1,6 +1,6 @@
 <?php
 
-$this->load('container1.php');
+$this->load('legacy_encoders.php');
 
 $container->loadFromExtension('security', [
     'encoders' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/bcrypt_hasher.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/bcrypt_hasher.php
@@ -1,0 +1,12 @@
+<?php
+
+$this->load('container1.php');
+
+$container->loadFromExtension('security', [
+    'password_hashers' => [
+        'JMS\FooBundle\Entity\User7' => [
+            'algorithm' => 'bcrypt',
+            'cost' => 15,
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -1,7 +1,7 @@
 <?php
 
 $container->loadFromExtension('security', [
-    'encoders' => [
+    'password_hashers' => [
         'JMS\FooBundle\Entity\User1' => 'plaintext',
         'JMS\FooBundle\Entity\User2' => [
             'algorithm' => 'sha1',
@@ -12,7 +12,7 @@ $container->loadFromExtension('security', [
             'algorithm' => 'md5',
         ],
         'JMS\FooBundle\Entity\User4' => [
-            'id' => 'security.encoder.foo',
+            'id' => 'security.hasher.foo',
         ],
         'JMS\FooBundle\Entity\User5' => [
             'algorithm' => 'pbkdf2',

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/legacy_encoders.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/legacy_encoders.php
@@ -1,0 +1,108 @@
+<?php
+
+$container->loadFromExtension('security', [
+    'encoders' => [
+        'JMS\FooBundle\Entity\User1' => 'plaintext',
+        'JMS\FooBundle\Entity\User2' => [
+            'algorithm' => 'sha1',
+            'encode_as_base64' => false,
+            'iterations' => 5,
+        ],
+        'JMS\FooBundle\Entity\User3' => [
+            'algorithm' => 'md5',
+        ],
+        'JMS\FooBundle\Entity\User4' => [
+            'id' => 'security.encoder.foo',
+        ],
+        'JMS\FooBundle\Entity\User5' => [
+            'algorithm' => 'pbkdf2',
+            'hash_algorithm' => 'sha1',
+            'encode_as_base64' => false,
+            'iterations' => 5,
+            'key_length' => 30,
+        ],
+        'JMS\FooBundle\Entity\User6' => [
+            'algorithm' => 'native',
+            'time_cost' => 8,
+            'memory_cost' => 100,
+            'cost' => 15,
+        ],
+        'JMS\FooBundle\Entity\User7' => [
+            'algorithm' => 'auto',
+        ],
+    ],
+    'providers' => [
+        'default' => [
+            'memory' => [
+                'users' => [
+                    'foo' => ['password' => 'foo', 'roles' => 'ROLE_USER'],
+                ],
+            ],
+        ],
+        'digest' => [
+            'memory' => [
+                'users' => [
+                    'foo' => ['password' => 'foo', 'roles' => 'ROLE_USER, ROLE_ADMIN'],
+                ],
+            ],
+        ],
+        'basic' => [
+            'memory' => [
+                'users' => [
+                    'foo' => ['password' => '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33', 'roles' => 'ROLE_SUPER_ADMIN'],
+                    'bar' => ['password' => '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33', 'roles' => ['ROLE_USER', 'ROLE_ADMIN']],
+                ],
+            ],
+        ],
+        'service' => [
+            'id' => 'user.manager',
+        ],
+        'chain' => [
+            'chain' => [
+                'providers' => ['service', 'basic'],
+            ],
+        ],
+    ],
+
+    'firewalls' => [
+        'simple' => ['provider' => 'default', 'pattern' => '/login', 'security' => false],
+        'secure' => ['stateless' => true,
+            'provider' => 'default',
+            'http_basic' => true,
+            'form_login' => true,
+            'anonymous' => true,
+            'switch_user' => true,
+            'x509' => true,
+            'remote_user' => true,
+            'logout' => true,
+            'remember_me' => ['secret' => 'TheSecret'],
+            'user_checker' => null,
+        ],
+        'host' => [
+            'provider' => 'default',
+            'pattern' => '/test',
+            'host' => 'foo\\.example\\.org',
+            'methods' => ['GET', 'POST'],
+            'anonymous' => true,
+            'http_basic' => true,
+        ],
+        'with_user_checker' => [
+            'provider' => 'default',
+            'user_checker' => 'app.user_checker',
+            'anonymous' => true,
+            'http_basic' => true,
+        ],
+    ],
+
+    'access_control' => [
+        ['path' => '/blog/524', 'role' => 'ROLE_USER', 'requires_channel' => 'https', 'methods' => ['get', 'POST'], 'port' => 8000],
+        ['path' => '/blog/.*', 'role' => 'IS_AUTHENTICATED_ANONYMOUSLY'],
+        ['path' => '/blog/524', 'role' => 'IS_AUTHENTICATED_ANONYMOUSLY', 'allow_if' => "token.getUsername() matches '/^admin/'"],
+    ],
+
+    'role_hierarchy' => [
+        'ROLE_ADMIN' => 'ROLE_USER',
+        'ROLE_SUPER_ADMIN' => ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'],
+        'ROLE_REMOTE' => 'ROLE_USER,ROLE_ADMIN',
+    ],
+]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/migrating_encoder.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/migrating_encoder.php
@@ -1,6 +1,6 @@
 <?php
 
-$this->load('container1.php');
+$this->load('legacy_encoders.php');
 
 $container->loadFromExtension('security', [
     'encoders' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/migrating_hasher.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/migrating_hasher.php
@@ -1,0 +1,14 @@
+<?php
+
+$this->load('container1.php');
+
+$container->loadFromExtension('security', [
+    'password_hashers' => [
+        'JMS\FooBundle\Entity\User7' => [
+            'algorithm' => 'argon2i',
+            'memory_cost' => 256,
+            'time_cost' => 1,
+            'migrate_from' => 'bcrypt',
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/sodium_encoder.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/sodium_encoder.php
@@ -1,6 +1,6 @@
 <?php
 
-$this->load('container1.php');
+$this->load('legacy_encoders.php');
 
 $container->loadFromExtension('security', [
     'encoders' => [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/sodium_hasher.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/sodium_hasher.php
@@ -1,0 +1,13 @@
+<?php
+
+$this->load('container1.php');
+
+$container->loadFromExtension('security', [
+    'password_hashers' => [
+        'JMS\FooBundle\Entity\User7' => [
+            'algorithm' => 'sodium',
+            'time_cost' => 8,
+            'memory_cost' => 128 * 1024,
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/argon2i_encoder.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/argon2i_encoder.xml
@@ -9,7 +9,7 @@
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
     <imports>
-        <import resource="container1.xml"/>
+        <import resource="legacy_encoders.xml"/>
     </imports>
 
     <sec:config>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/argon2i_hasher.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/argon2i_hasher.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:sec="http://symfony.com/schema/dic/security"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/security
+        https://symfony.com/schema/dic/security/security-1.0.xsd">
+
+    <imports>
+        <import resource="container1.xml"/>
+    </imports>
+
+    <sec:config>
+        <sec:password_hasher class="JMS\FooBundle\Entity\User7" algorithm="argon2i" memory-cost="256" time-cost="1" />
+    </sec:config>
+
+</container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/bcrypt_encoder.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/bcrypt_encoder.xml
@@ -9,7 +9,7 @@
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
     <imports>
-        <import resource="container1.xml"/>
+        <import resource="legacy_encoders.xml"/>
     </imports>
 
     <sec:config>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/bcrypt_hasher.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/bcrypt_hasher.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:sec="http://symfony.com/schema/dic/security"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/security
+        https://symfony.com/schema/dic/security/security-1.0.xsd">
+
+    <imports>
+        <import resource="container1.xml"/>
+    </imports>
+
+    <sec:config>
+        <sec:password_hasher class="JMS\FooBundle\Entity\User7" algorithm="bcrypt" cost="15" />
+    </sec:config>
+
+</container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -9,19 +9,19 @@
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
     <config>
-        <encoder class="JMS\FooBundle\Entity\User1" algorithm="plaintext" />
+        <password_hasher class="JMS\FooBundle\Entity\User1" algorithm="plaintext" />
 
-        <encoder class="JMS\FooBundle\Entity\User2" algorithm="sha1" encode-as-base64="false" iterations="5" />
+        <password_hasher class="JMS\FooBundle\Entity\User2" algorithm="sha1" encode-as-base64="false" iterations="5" />
 
-        <encoder class="JMS\FooBundle\Entity\User3" algorithm="md5" />
+        <password_hasher class="JMS\FooBundle\Entity\User3" algorithm="md5" />
 
-        <encoder class="JMS\FooBundle\Entity\User4" id="security.encoder.foo" />
+        <password_hasher class="JMS\FooBundle\Entity\User4" id="security.hasher.foo" />
 
-        <encoder class="JMS\FooBundle\Entity\User5" algorithm="pbkdf2" hash-algorithm="sha1" encode-as-base64="false" iterations="5" key-length="30" />
+        <password_hasher class="JMS\FooBundle\Entity\User5" algorithm="pbkdf2" hash-algorithm="sha1" encode-as-base64="false" iterations="5" key-length="30" />
 
-        <encoder class="JMS\FooBundle\Entity\User6" algorithm="native" time-cost="8" memory-cost="100" cost="15" />
+        <password_hasher class="JMS\FooBundle\Entity\User6" algorithm="native" time-cost="8" memory-cost="100" cost="15" />
 
-        <encoder class="JMS\FooBundle\Entity\User7" algorithm="auto" />
+        <password_hasher class="JMS\FooBundle\Entity\User7" algorithm="auto" />
 
         <provider name="default">
             <memory>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/legacy_encoders.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/legacy_encoders.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<srv:container xmlns="http://symfony.com/schema/dic/security"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/security
+        https://symfony.com/schema/dic/security/security-1.0.xsd">
+
+    <config>
+        <encoder class="JMS\FooBundle\Entity\User1" algorithm="plaintext" />
+
+        <encoder class="JMS\FooBundle\Entity\User2" algorithm="sha1" encode-as-base64="false" iterations="5" />
+
+        <encoder class="JMS\FooBundle\Entity\User3" algorithm="md5" />
+
+        <encoder class="JMS\FooBundle\Entity\User4" id="security.encoder.foo" />
+
+        <encoder class="JMS\FooBundle\Entity\User5" algorithm="pbkdf2" hash-algorithm="sha1" encode-as-base64="false" iterations="5" key-length="30" />
+
+        <encoder class="JMS\FooBundle\Entity\User6" algorithm="native" time-cost="8" memory-cost="100" cost="15" />
+
+        <encoder class="JMS\FooBundle\Entity\User7" algorithm="auto" />
+
+        <provider name="default">
+            <memory>
+                <user name="foo" password="foo" roles="ROLE_USER" />
+            </memory>
+        </provider>
+
+        <provider name="digest">
+            <memory>
+                <user name="foo" password="foo" roles="ROLE_USER, ROLE_ADMIN" />
+            </memory>
+        </provider>
+
+        <provider name="basic">
+            <memory>
+                <user name="foo" password="0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" roles="ROLE_SUPER_ADMIN" />
+                <user name="bar" password="0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" roles="ROLE_USER, ROLE_ADMIN" />
+            </memory>
+        </provider>
+
+        <provider name="service" id="user.manager" />
+
+        <provider name="chain">
+            <chain providers="service, basic" />
+        </provider>
+
+        <firewall name="simple" pattern="/login" security="false" provider="default" />
+
+        <firewall name="secure" stateless="true" provider="default">
+            <http-basic />
+            <form-login />
+            <anonymous />
+            <switch-user />
+            <x509 />
+            <remote-user />
+            <logout />
+            <remember-me secret="TheSecret"/>
+        </firewall>
+
+        <firewall name="host" pattern="/test" host="foo\.example\.org" methods="GET,POST" provider="default">
+            <anonymous />
+            <http-basic />
+        </firewall>
+
+        <firewall name="with_user_checker" provider="default">
+            <anonymous />
+            <http-basic />
+            <user-checker>app.user_checker</user-checker>
+        </firewall>
+
+        <role id="ROLE_ADMIN">ROLE_USER</role>
+        <role id="ROLE_SUPER_ADMIN">ROLE_USER,ROLE_ADMIN,ROLE_ALLOWED_TO_SWITCH</role>
+        <role id="ROLE_REMOTE">ROLE_USER,ROLE_ADMIN</role>
+
+        <rule path="/blog/524" role="ROLE_USER" requires-channel="https" methods="get,POST" port="8000" />
+        <rule role='IS_AUTHENTICATED_ANONYMOUSLY' path="/blog/.*" />
+        <rule role='IS_AUTHENTICATED_ANONYMOUSLY' allow-if="token.getUsername() matches '/^admin/'" path="/blog/524" />
+    </config>
+</srv:container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/migrating_encoder.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/migrating_encoder.xml
@@ -9,7 +9,7 @@
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
     <imports>
-        <import resource="container1.xml"/>
+        <import resource="legacy_encoders.xml"/>
     </imports>
 
     <sec:config>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/migrating_hasher.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/migrating_hasher.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:sec="http://symfony.com/schema/dic/security"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/security
+        https://symfony.com/schema/dic/security/security-1.0.xsd">
+
+    <imports>
+        <import resource="container1.xml"/>
+    </imports>
+
+    <sec:config>
+        <sec:password_hasher class="JMS\FooBundle\Entity\User7" algorithm="argon2i" memory-cost="256" time-cost="1">
+            <sec:migrate-from>bcrypt</sec:migrate-from>
+        </sec:password_hasher>
+    </sec:config>
+
+</container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/sodium_encoder.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/sodium_encoder.xml
@@ -9,7 +9,7 @@
         https://symfony.com/schema/dic/security/security-1.0.xsd">
 
     <imports>
-        <import resource="container1.xml"/>
+        <import resource="legacy_encoders.xml"/>
     </imports>
 
     <sec:config>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/sodium_hasher.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/sodium_hasher.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:sec="http://symfony.com/schema/dic/security"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/security
+        https://symfony.com/schema/dic/security/security-1.0.xsd">
+
+    <imports>
+        <import resource="container1.xml"/>
+    </imports>
+
+    <sec:config>
+        <sec:password_hasher class="JMS\FooBundle\Entity\User7" algorithm="sodium" time-cost="8" memory-cost="131072" />
+    </sec:config>
+
+</container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/argon2i_encoder.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/argon2i_encoder.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: container1.yml }
+    - { resource: legacy_encoders.yml }
 
 security:
     encoders:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/argon2i_hasher.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/argon2i_hasher.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: container1.yml }
+
+security:
+    password_hashers:
+        JMS\FooBundle\Entity\User7:
+            algorithm: argon2i
+            memory_cost: 256
+            time_cost: 1

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/bcrypt_encoder.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/bcrypt_encoder.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: container1.yml }
+    - { resource: legacy_encoders.yml }
 
 security:
     encoders:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/bcrypt_hasher.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/bcrypt_hasher.yml
@@ -1,0 +1,8 @@
+imports:
+    - { resource: container1.yml }
+
+security:
+    password_hashers:
+        JMS\FooBundle\Entity\User7:
+            algorithm: bcrypt
+            cost: 15

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -1,5 +1,5 @@
 security:
-    encoders:
+    password_hashers:
         JMS\FooBundle\Entity\User1: plaintext
         JMS\FooBundle\Entity\User2:
             algorithm: sha1
@@ -8,7 +8,7 @@ security:
         JMS\FooBundle\Entity\User3:
             algorithm: md5
         JMS\FooBundle\Entity\User4:
-            id: security.encoder.foo
+            id: security.hasher.foo
         JMS\FooBundle\Entity\User5:
             algorithm: pbkdf2
             hash_algorithm: sha1

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/legacy_encoders.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/legacy_encoders.yml
@@ -1,0 +1,87 @@
+security:
+    encoders:
+        JMS\FooBundle\Entity\User1: plaintext
+        JMS\FooBundle\Entity\User2:
+            algorithm: sha1
+            encode_as_base64: false
+            iterations: 5
+        JMS\FooBundle\Entity\User3:
+            algorithm: md5
+        JMS\FooBundle\Entity\User4:
+            id: security.encoder.foo
+        JMS\FooBundle\Entity\User5:
+            algorithm: pbkdf2
+            hash_algorithm: sha1
+            encode_as_base64: false
+            iterations: 5
+            key_length: 30
+        JMS\FooBundle\Entity\User6:
+            algorithm: native
+            time_cost: 8
+            memory_cost: 100
+            cost: 15
+        JMS\FooBundle\Entity\User7:
+            algorithm: auto
+
+    providers:
+        default:
+            memory:
+                users:
+                    foo: { password: foo, roles: ROLE_USER }
+        digest:
+            memory:
+                users:
+                    foo: { password: foo, roles: 'ROLE_USER, ROLE_ADMIN' }
+        basic:
+            memory:
+                users:
+                    foo: { password: 0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33, roles: ROLE_SUPER_ADMIN }
+                    bar: { password: 0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33, roles: [ROLE_USER, ROLE_ADMIN] }
+        service:
+            id: user.manager
+        chain:
+            chain:
+                providers: [service, basic]
+
+
+    firewalls:
+        simple: { pattern: /login, security: false }
+        secure:
+            provider: default
+            stateless: true
+            http_basic: true
+            form_login: true
+            anonymous: true
+            switch_user:
+            x509: true
+            remote_user: true
+            logout: true
+            remember_me:
+                secret: TheSecret
+            user_checker: ~
+
+        host:
+            provider: default
+            pattern: /test
+            host: foo\.example\.org
+            methods: [GET,POST]
+            anonymous: true
+            http_basic: true
+
+        with_user_checker:
+            provider: default
+            anonymous: ~
+            http_basic: ~
+            user_checker: app.user_checker
+
+    role_hierarchy:
+        ROLE_ADMIN:       ROLE_USER
+        ROLE_SUPER_ADMIN: [ROLE_USER, ROLE_ADMIN, ROLE_ALLOWED_TO_SWITCH]
+        ROLE_REMOTE:      ROLE_USER,ROLE_ADMIN
+
+    access_control:
+        - { path: /blog/524, role: ROLE_USER, requires_channel: https, methods: [get, POST], port: 8000}
+        -
+            path: /blog/.*
+            role: IS_AUTHENTICATED_ANONYMOUSLY
+        - { path: /blog/524, role: IS_AUTHENTICATED_ANONYMOUSLY, allow_if: "token.getUsername() matches '/^admin/'" }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/migrating_encoder.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/migrating_encoder.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: container1.yml }
+    - { resource: legacy_encoders.yml }
 
 security:
     encoders:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/migrating_hasher.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/migrating_hasher.yml
@@ -1,0 +1,10 @@
+imports:
+    - { resource: container1.yml }
+
+security:
+    password_hashers:
+        JMS\FooBundle\Entity\User7:
+            algorithm: argon2i
+            memory_cost: 256
+            time_cost: 1
+            migrate_from: bcrypt

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/sodium_encoder.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/sodium_encoder.yml
@@ -1,5 +1,5 @@
 imports:
-    - { resource: container1.yml }
+    - { resource: legacy_encoders.yml }
 
 security:
     encoders:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/sodium_hasher.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/sodium_hasher.yml
@@ -1,0 +1,9 @@
+imports:
+    - { resource: container1.yml }
+
+security:
+    password_hashers:
+        JMS\FooBundle\Entity\User7:
+            algorithm: sodium
+            time_cost: 8
+            memory_cost: 131072

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/UserPasswordEncoderCommandTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Core\Encoder\SodiumPasswordEncoder;
  * Tests UserPasswordEncoderCommand.
  *
  * @author Sarah Khalil <mkhalil.sarah@gmail.com>
+ * @group legacy
  */
 class UserPasswordEncoderCommandTest extends AbstractWebTestCase
 {
@@ -40,7 +41,7 @@ class UserPasswordEncoderCommandTest extends AbstractWebTestCase
         ], ['decorated' => false]);
         $expected = str_replace("\n", \PHP_EOL, file_get_contents(__DIR__.'/app/PasswordEncode/emptysalt.txt'));
 
-        $this->assertEquals($expected, $this->passwordEncoderCommandTester->getDisplay());
+        $this->assertStringContainsString($expected, $this->passwordEncoderCommandTester->getDisplay());
     }
 
     public function testEncodeNoPasswordNoInteraction()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AbstractTokenCompareRoles/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AbstractTokenCompareRoles/config.yml
@@ -9,7 +9,7 @@ services:
 
 security:
 
-  encoders:
+  password_hashers:
     \Symfony\Component\Security\Core\User\UserInterface: plaintext
 
   providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/security.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/security.yml
@@ -1,7 +1,7 @@
 security:
     enable_authenticator_manager: true
 
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/ClearRememberMe/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/ClearRememberMe/config.yml
@@ -2,7 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/base_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/base_config.yml
@@ -15,7 +15,7 @@ services:
             - { name: container.service_subscriber }
 
 security:
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
@@ -28,5 +28,5 @@ security:
             memory:
                 users:
                     john: { password: doe, roles: [ROLE_SECURE] }
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Guarded/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Guarded/config.yml
@@ -14,7 +14,7 @@ services:
         tags: [controller.service_arguments]
 
 security:
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/config.yml
@@ -5,7 +5,7 @@ framework:
     serializer: ~
 
 security:
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/custom_handlers.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/JsonLogin/custom_handlers.yml
@@ -2,7 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_access.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_access.yml
@@ -2,7 +2,7 @@ imports:
 - { resource: ./../config/framework.yml }
 
 security:
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_cookie_clearing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Logout/config_cookie_clearing.yml
@@ -2,7 +2,7 @@ imports:
 - { resource: ./../config/framework.yml }
 
 security:
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/LogoutWithoutSessionInvalidation/config.yml
@@ -2,7 +2,7 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeLogout/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeLogout/config.yml
@@ -7,7 +7,7 @@ framework:
         cookie_samesite: lax
 
 security:
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/config.yml
@@ -6,7 +6,7 @@ parameters:
     env(APP_IPS): '127.0.0.1, ::1'
 
 security:
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/invalid_ip_access_control.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/invalid_ip_access_control.yml
@@ -2,7 +2,7 @@ imports:
     - { resource: ./../config/default.yml }
 
 security:
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_form_failure_handler.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_form_failure_handler.yml
@@ -2,7 +2,7 @@ imports:
     - { resource: ./../config/default.yml }
 
 security:
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_routes.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/localized_routes.yml
@@ -2,7 +2,7 @@ imports:
     - { resource: ./../config/default.yml }
 
 security:
-    encoders:
+    password_hashers:
         Symfony\Component\Security\Core\User\User: plaintext
 
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -23,11 +23,12 @@
         "symfony/deprecation-contracts": "^2.1",
         "symfony/event-dispatcher": "^5.1",
         "symfony/http-kernel": "^5.0",
+        "symfony/password-hasher": "^5.3",
         "symfony/polyfill-php80": "^1.15",
         "symfony/security-core": "^5.3",
         "symfony/security-csrf": "^4.4|^5.0",
-        "symfony/security-guard": "^5.2",
-        "symfony/security-http": "^5.2"
+        "symfony/security-guard": "^5.3",
+        "symfony/security-http": "^5.3"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.0",

--- a/src/Symfony/Component/PasswordHasher/.gitattributes
+++ b/src/Symfony/Component/PasswordHasher/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/PasswordHasher/.gitignore
+++ b/src/Symfony/Component/PasswordHasher/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/PasswordHasher/CHANGELOG.md
+++ b/src/Symfony/Component/PasswordHasher/CHANGELOG.md
@@ -1,0 +1,4 @@
+5.3
+---
+
+ * Add the component

--- a/src/Symfony/Component/PasswordHasher/Command/UserPasswordHashCommand.php
+++ b/src/Symfony/Component/PasswordHasher/Command/UserPasswordHashCommand.php
@@ -1,0 +1,213 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Command;
+
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\PasswordHasher\LegacyPasswordHasherInterface;
+
+/**
+ * Hashes a user's password.
+ *
+ * @author Sarah Khalil <mkhalil.sarah@gmail.com>
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ *
+ * @final
+ */
+class UserPasswordHashCommand extends Command
+{
+    protected static $defaultName = 'security:hash-password';
+    protected static $defaultDescription = "Hashes a user password";
+
+    private $hasherFactory;
+    private $userClasses;
+
+    public function __construct(PasswordHasherFactoryInterface $hasherFactory, array $userClasses = [])
+    {
+        $this->hasherFactory = $hasherFactory;
+        $this->userClasses = $userClasses;
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setDescription(self::$defaultDescription)
+            ->addArgument('password', InputArgument::OPTIONAL, 'The plain password to hash.')
+            ->addArgument('user-class', InputArgument::OPTIONAL, 'The User entity class path associated with the hasher used to hash the password.')
+            ->addOption('empty-salt', null, InputOption::VALUE_NONE, 'Do not generate a salt or let the hasher generate one.')
+            ->setHelp(<<<EOF
+
+The <info>%command.name%</info> command hashs passwords according to your
+security configuration. This command is mainly used to generate passwords for
+the <comment>in_memory</comment> user provider type and for changing passwords
+in the database while developing the application.
+
+Suppose that you have the following security configuration in your application:
+
+<comment>
+# app/config/security.yml
+security:
+    password_hashers:
+        Symfony\Component\Security\Core\User\User: plaintext
+        App\Entity\User: auto
+</comment>
+
+If you execute the command non-interactively, the first available configured
+user class under the <comment>security.password_hashers</comment> key is used and a random salt is
+generated to hash the password:
+
+  <info>php %command.full_name% --no-interaction [password]</info>
+
+Pass the full user class path as the second argument to hash passwords for
+your own entities:
+
+  <info>php %command.full_name% --no-interaction [password] 'App\Entity\User'</info>
+
+Executing the command interactively allows you to generate a random salt for
+hashing the password:
+
+  <info>php %command.full_name% [password] 'App\Entity\User'</info>
+
+In case your hasher doesn't require a salt, add the <comment>empty-salt</comment> option:
+
+  <info>php %command.full_name% --empty-salt [password] 'App\Entity\User'</info>
+
+EOF
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $errorIo = $output instanceof ConsoleOutputInterface ? new SymfonyStyle($input, $output->getErrorOutput()) : $io;
+
+        $input->isInteractive() ? $errorIo->title('Symfony Password Hash Utility') : $errorIo->newLine();
+
+        $password = $input->getArgument('password');
+        $userClass = $this->getUserClass($input, $io);
+        $emptySalt = $input->getOption('empty-salt');
+
+        $hasher = $this->hasherFactory->getPasswordHasher($userClass);
+        $saltlessWithoutEmptySalt = !$emptySalt && !$hasher instanceof LegacyPasswordHasherInterface;
+
+        if ($saltlessWithoutEmptySalt) {
+            $emptySalt = true;
+        }
+
+        if (!$password) {
+            if (!$input->isInteractive()) {
+                $errorIo->error('The password must not be empty.');
+
+                return 1;
+            }
+            $passwordQuestion = $this->createPasswordQuestion();
+            $password = $errorIo->askQuestion($passwordQuestion);
+        }
+
+        $salt = null;
+
+        if ($input->isInteractive() && !$emptySalt) {
+            $emptySalt = true;
+
+            $errorIo->note('The command will take care of generating a salt for you. Be aware that some hashers advise to let them generate their own salt. If you\'re using one of those hashers, please answer \'no\' to the question below. '.\PHP_EOL.'Provide the \'empty-salt\' option in order to let the hasher handle the generation itself.');
+
+            if ($errorIo->confirm('Confirm salt generation ?')) {
+                $salt = $this->generateSalt();
+                $emptySalt = false;
+            }
+        } elseif (!$emptySalt) {
+            $salt = $this->generateSalt();
+        }
+
+        $hashedPassword = $hasher->hash($password, $salt);
+
+        $rows = [
+            ['Hasher used', \get_class($hasher)],
+            ['Password hash', $hashedPassword],
+        ];
+        if (!$emptySalt) {
+            $rows[] = ['Generated salt', $salt];
+        }
+        $io->table(['Key', 'Value'], $rows);
+
+        if (!$emptySalt) {
+            $errorIo->note(sprintf('Make sure that your salt storage field fits the salt length: %s chars', \strlen($salt)));
+        } elseif ($saltlessWithoutEmptySalt) {
+            $errorIo->note('Self-salting hasher used: the hasher generated its own built-in salt.');
+        }
+
+        $errorIo->success('Password hashing succeeded');
+
+        return 0;
+    }
+
+    /**
+     * Create the password question to ask the user for the password to be hashed.
+     */
+    private function createPasswordQuestion(): Question
+    {
+        $passwordQuestion = new Question('Type in your password to be hashed');
+
+        return $passwordQuestion->setValidator(function ($value) {
+            if ('' === trim($value)) {
+                throw new InvalidArgumentException('The password must not be empty.');
+            }
+
+            return $value;
+        })->setHidden(true)->setMaxAttempts(20);
+    }
+
+    private function generateSalt(): string
+    {
+        return base64_encode(random_bytes(30));
+    }
+
+    private function getUserClass(InputInterface $input, SymfonyStyle $io): string
+    {
+        if (null !== $userClass = $input->getArgument('user-class')) {
+            return $userClass;
+        }
+
+        if (!$this->userClasses) {
+            throw new RuntimeException('There are no configured password hashers for the "security" extension.');
+        }
+
+        if (!$input->isInteractive() || 1 === \count($this->userClasses)) {
+            return reset($this->userClasses);
+        }
+
+        $userClasses = $this->userClasses;
+        natcasesort($userClasses);
+        $userClasses = array_values($userClasses);
+
+        return $io->choice('For which user class would you like to hash a password?', $userClasses, reset($userClasses));
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/PasswordHasher/Exception/ExceptionInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Exception;
+
+/**
+ * Interface for exceptions thrown by the password-hasher component.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/Symfony/Component/PasswordHasher/Exception/InvalidPasswordException.php
+++ b/src/Symfony/Component/PasswordHasher/Exception/InvalidPasswordException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Exception;
+
+/**
+ * @author Robin Chalas <robin.chalas@gmail.com>
+*/
+class InvalidPasswordException extends \RuntimeException implements ExceptionInterface
+{
+    public function __construct(string $message = 'Invalid password.', int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Exception/LogicException.php
+++ b/src/Symfony/Component/PasswordHasher/Exception/LogicException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Exception;
+
+/**
+ * @author Robin Chalas <robin.chalas@gmail.com>
+*/
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/PasswordHasher/Hasher/CheckPasswordLengthTrait.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/CheckPasswordLengthTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Hasher;
+
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
+
+/**
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+trait CheckPasswordLengthTrait
+{
+    private function isPasswordTooLong(string $password): bool
+    {
+        return PasswordHasherInterface::MAX_PASSWORD_LENGTH < \strlen($password);
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Hasher/MessageDigestPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/MessageDigestPasswordHasher.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Hasher;
+
+use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
+use Symfony\Component\PasswordHasher\Exception\LogicException;
+use Symfony\Component\PasswordHasher\LegacyPasswordHasherInterface;
+
+/**
+ * MessageDigestPasswordHasher uses a message digest algorithm.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class MessageDigestPasswordHasher implements LegacyPasswordHasherInterface
+{
+    use CheckPasswordLengthTrait;
+
+    private $algorithm;
+    private $encodeHashAsBase64;
+    private $iterations = 1;
+    private $hashLength = -1;
+
+    /**
+     * @param string $algorithm          The digest algorithm to use
+     * @param bool   $encodeHashAsBase64 Whether to base64 encode the password hash
+     * @param int    $iterations         The number of iterations to use to stretch the password hash
+     */
+    public function __construct(string $algorithm = 'sha512', bool $encodeHashAsBase64 = true, int $iterations = 5000)
+    {
+        $this->algorithm = $algorithm;
+        $this->encodeHashAsBase64 = $encodeHashAsBase64;
+
+        try {
+            $this->hashLength = \strlen($this->hash('', 'salt'));
+        } catch (\LogicException $e) {
+            // ignore algorithm not supported
+        }
+
+        $this->iterations = $iterations;
+    }
+
+    public function hash(string $plainPassword, ?string $salt = null): string
+    {
+        if ($this->isPasswordTooLong($plainPassword)) {
+            throw new InvalidPasswordException();
+        }
+
+        if (!\in_array($this->algorithm, hash_algos(), true)) {
+            throw new LogicException(sprintf('The algorithm "%s" is not supported.', $this->algorithm));
+        }
+
+        $salted = $this->mergePasswordAndSalt($plainPassword, $salt);
+        $digest = hash($this->algorithm, $salted, true);
+
+        // "stretch" hash
+        for ($i = 1; $i < $this->iterations; ++$i) {
+            $digest = hash($this->algorithm, $digest.$salted, true);
+        }
+
+        return $this->encodeHashAsBase64 ? base64_encode($digest) : bin2hex($digest);
+    }
+
+    public function verify(string $hashedPassword, string $plainPassword, ?string $salt = null): bool
+    {
+        if (\strlen($hashedPassword) !== $this->hashLength || false !== strpos($hashedPassword, '$')) {
+            return false;
+        }
+
+        return !$this->isPasswordTooLong($plainPassword) && hash_equals($hashedPassword, $this->hash($plainPassword, $salt));
+    }
+
+    public function needsRehash(string $hashedPassword): bool
+    {
+        return false;
+    }
+
+    private function mergePasswordAndSalt(string $password, ?string $salt): string
+    {
+        if (!$salt) {
+            return $password;
+        }
+
+        if (false !== strrpos($salt, '{') || false !== strrpos($salt, '}')) {
+            throw new \InvalidArgumentException('Cannot use { or } in salt.');
+        }
+
+        return $password.'{'.$salt.'}';
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Hasher/MigratingPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/MigratingPasswordHasher.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Hasher;
+
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
+use Symfony\Component\PasswordHasher\LegacyPasswordHasherInterface;
+
+/**
+ * Hashes passwords using the best available hasher.
+ * Verifies them using a chain of hashers.
+ *
+ * /!\ Don't put a PlaintextPasswordHasher in the list as that'd mean a leaked hash
+ * could be used to authenticate successfully without knowing the cleartext password.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class MigratingPasswordHasher implements PasswordHasherInterface
+{
+    private $bestHasher;
+    private $extraHashers;
+
+    public function __construct(PasswordHasherInterface $bestHasher, PasswordHasherInterface ...$extraHashers)
+    {
+        $this->bestHasher = $bestHasher;
+        $this->extraHashers = $extraHashers;
+    }
+
+    public function hash(string $plainPassword, ?string $salt = null): string
+    {
+        return $this->bestHasher->hash($plainPassword, $salt);
+    }
+
+    public function verify(string $hashedPassword, string $plainPassword, ?string $salt = null): bool
+    {
+        if ($this->bestHasher->verify($hashedPassword, $plainPassword, $salt)) {
+            return true;
+        }
+
+        if (!$this->bestHasher->needsRehash($hashedPassword)) {
+            return false;
+        }
+
+        foreach ($this->extraHashers as $hasher) {
+            if ($hasher->verify($hashedPassword, $plainPassword, $salt)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function needsRehash(string $hashedPassword): bool
+    {
+        return $this->bestHasher->needsRehash($hashedPassword);
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Hasher/NativePasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/NativePasswordHasher.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Hasher;
+
+use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
+
+/**
+ * Hashes passwords using password_hash().
+ *
+ * @author Elnur Abdurrakhimov <elnur@elnur.pro>
+ * @author Terje Bråten <terje@braten.be>
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class NativePasswordHasher implements PasswordHasherInterface
+{
+    use CheckPasswordLengthTrait;
+
+    private $algo = \PASSWORD_BCRYPT;
+    private $options;
+
+    /**
+     * @param string|null $algo An algorithm supported by password_hash() or null to use the stronger available algorithm
+     */
+    public function __construct(int $opsLimit = null, int $memLimit = null, int $cost = null, ?string $algo = null)
+    {
+        $cost = $cost ?? 13;
+        $opsLimit = $opsLimit ?? max(4, \defined('SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE') ? \SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE : 4);
+        $memLimit = $memLimit ?? max(64 * 1024 * 1024, \defined('SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE') ? \SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE : 64 * 1024 * 1024);
+
+        if (3 > $opsLimit) {
+            throw new \InvalidArgumentException('$opsLimit must be 3 or greater.');
+        }
+
+        if (10 * 1024 > $memLimit) {
+            throw new \InvalidArgumentException('$memLimit must be 10k or greater.');
+        }
+
+        if ($cost < 4 || 31 < $cost) {
+            throw new \InvalidArgumentException('$cost must be in the range of 4-31.');
+        }
+
+        $algos = [1 => \PASSWORD_BCRYPT, '2y' => \PASSWORD_BCRYPT];
+
+        if (\defined('PASSWORD_ARGON2I')) {
+            $this->algo = $algos[2] = $algos['argon2i'] = (string) \PASSWORD_ARGON2I;
+        }
+
+        if (\defined('PASSWORD_ARGON2ID')) {
+            $this->algo = $algos[3] = $algos['argon2id'] = (string) \PASSWORD_ARGON2ID;
+        }
+
+        if (null !== $algo) {
+            $this->algo = $algos[$algo] ?? $algo;
+        }
+
+        $this->options = [
+            'cost' => $cost,
+            'time_cost' => $opsLimit,
+            'memory_cost' => $memLimit >> 10,
+            'threads' => 1,
+        ];
+    }
+
+    public function hash(string $plainPassword): string
+    {
+        if ($this->isPasswordTooLong($plainPassword) || ((string) \PASSWORD_BCRYPT === $this->algo && 72 < \strlen($plainPassword))) {
+            throw new InvalidPasswordException();
+        }
+
+        return password_hash($plainPassword, $this->algo, $this->options);
+    }
+
+    public function verify(string $hashedPassword, string $plainPassword): bool
+    {
+        if ('' === $plainPassword || $this->isPasswordTooLong($plainPassword)) {
+            return false;
+        }
+
+        if (0 !== strpos($hashedPassword, '$argon')) {
+            // BCrypt encodes only the first 72 chars
+            return (72 >= \strlen($plainPassword) || 0 !== strpos($hashedPassword, '$2')) && password_verify($plainPassword, $hashedPassword);
+        }
+
+        if (\extension_loaded('sodium') && version_compare(\SODIUM_LIBRARY_VERSION, '1.0.14', '>=')) {
+            return sodium_crypto_pwhash_str_verify($hashedPassword, $plainPassword);
+        }
+
+        if (\extension_loaded('libsodium') && version_compare(phpversion('libsodium'), '1.0.14', '>=')) {
+            return \Sodium\crypto_pwhash_str_verify($hashedPassword, $plainPassword);
+        }
+
+        return password_verify($plainPassword, $hashedPassword);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function needsRehash(string $hashedPassword): bool
+    {
+        return password_needs_rehash($hashedPassword, $this->algo, $this->options);
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherAwareInterface.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherAwareInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Hasher;
+
+/**
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+interface PasswordHasherAwareInterface
+{
+    /**
+     * Gets the name of the password hasher used to hash the password.
+     *
+     * If the method returns null, the standard way to retrieve the password hasher
+     * will be used instead.
+     */
+    public function getPasswordHasherName(): ?string;
+}

--- a/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
@@ -1,0 +1,216 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Hasher;
+
+use Symfony\Component\Security\Core\Encoder\EncoderAwareInterface;
+use Symfony\Component\PasswordHasher\Exception\LogicException;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
+
+/**
+ * A generic hasher factory implementation.
+ *
+ * @author Nicolas Grekas <p@tchwork.com>
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+class PasswordHasherFactory implements PasswordHasherFactoryInterface
+{
+    private $passwordHashers;
+
+    public function __construct(array $passwordHashers)
+    {
+        $this->passwordHashers = $passwordHashers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPasswordHasher($user): PasswordHasherInterface
+    {
+        $hasherKey = null;
+
+        if (($user instanceof PasswordHasherAwareInterface && null !== $hasherName = $user->getPasswordHasherName()) || ($user instanceof EncoderAwareInterface && null !== $hasherName = $user->getEncoderName())) {
+            if (!\array_key_exists($hasherName, $this->passwordHashers)) {
+                throw new \RuntimeException(sprintf('The password hasher "%s" was not configured.', $hasherName));
+            }
+
+            $hasherKey = $hasherName;
+        } else {
+            foreach ($this->passwordHashers as $class => $hasher) {
+                if ((\is_object($user) && $user instanceof $class) || (!\is_object($user) && (is_subclass_of($user, $class) || $user == $class))) {
+                    $hasherKey = $class;
+                    break;
+                }
+            }
+        }
+
+        if (null === $hasherKey) {
+            throw new \RuntimeException(sprintf('No password hasher has been configured for account "%s".', \is_object($user) ? get_debug_type($user) : $user));
+        }
+
+        if (!$this->passwordHashers[$hasherKey] instanceof PasswordHasherInterface) {
+            $this->passwordHashers[$hasherKey] = $this->createHasher($this->passwordHashers[$hasherKey]);
+        }
+
+        return $this->passwordHashers[$hasherKey];
+    }
+
+    /**
+     * Creates the actual hasher instance.
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function createHasher(array $config, bool $isExtra = false): PasswordHasherInterface
+    {
+        if (isset($config['algorithm'])) {
+            $rawConfig = $config;
+            $config = $this->getHasherConfigFromAlgorithm($config);
+        }
+        if (!isset($config['class'])) {
+            throw new \InvalidArgumentException('"class" must be set in '.json_encode($config));
+        }
+        if (!isset($config['arguments'])) {
+            throw new \InvalidArgumentException('"arguments" must be set in '.json_encode($config));
+        }
+
+        $hasher = new $config['class'](...$config['arguments']);
+
+        if ($isExtra || !\in_array($config['class'], [NativePasswordHasher::class, SodiumPasswordHasher::class], true)) {
+            return $hasher;
+        }
+
+        if ($rawConfig ?? null) {
+            $extrapasswordHashers = array_map(function (string $algo) use ($rawConfig): PasswordHasherInterface {
+                $rawConfig['algorithm'] = $algo;
+
+                return $this->createHasher($rawConfig);
+            }, ['pbkdf2', $rawConfig['hash_algorithm'] ?? 'sha512']);
+        } else {
+            $extrapasswordHashers = [new Pbkdf2PasswordHasher(), new MessageDigestPasswordHasher()];
+        }
+
+        return new MigratingPasswordHasher($hasher, ...$extrapasswordHashers);
+    }
+
+    private function getHasherConfigFromAlgorithm(array $config): array
+    {
+        if ('auto' === $config['algorithm']) {
+            $hasherChain = [];
+            // "plaintext" is not listed as any leaked hashes could then be used to authenticate directly
+            foreach ([SodiumPasswordHasher::isSupported() ? 'sodium' : 'native', 'pbkdf2', $config['hash_algorithm']] as $algo) {
+                $config['algorithm'] = $algo;
+                $hasherChain[] = $this->createHasher($config, true);
+            }
+
+            return [
+                'class' => MigratingPasswordHasher::class,
+                'arguments' => $hasherChain,
+            ];
+        }
+
+        if ($frompasswordHashers = ($config['migrate_from'] ?? false)) {
+            unset($config['migrate_from']);
+            $hasherChain = [$this->createHasher($config, true)];
+
+            foreach ($frompasswordHashers as $name) {
+                if ($hasher = $this->passwordHashers[$name] ?? false) {
+                    $hasher = $hasher instanceof PasswordHasherInterface ? $hasher : $this->createHasher($hasher, true);
+                } else {
+                    $hasher = $this->createHasher(['algorithm' => $name], true);
+                }
+
+                $hasherChain[] = $hasher;
+            }
+
+            return [
+                'class' => MigratingPasswordHasher::class,
+                'arguments' => $hasherChain,
+            ];
+        }
+
+        switch ($config['algorithm']) {
+            case 'plaintext':
+                return [
+                    'class' => PlaintextPasswordHasher::class,
+                    'arguments' => [$config['ignore_case'] ?? false],
+                ];
+
+            case 'pbkdf2':
+                return [
+                    'class' => Pbkdf2PasswordHasher::class,
+                    'arguments' => [
+                        $config['hash_algorithm'] ?? 'sha512',
+                        $config['encode_as_base64'] ?? true,
+                        $config['iterations'] ?? 1000,
+                        $config['key_length'] ?? 40,
+                    ],
+                ];
+
+            case 'bcrypt':
+                $config['algorithm'] = 'native';
+                $config['native_algorithm'] = \PASSWORD_BCRYPT;
+
+                return $this->getHasherConfigFromAlgorithm($config);
+
+            case 'native':
+                return [
+                    'class' => NativePasswordHasher::class,
+                    'arguments' => [
+                        $config['time_cost'] ?? null,
+                        (($config['memory_cost'] ?? 0) << 10) ?: null,
+                        $config['cost'] ?? null,
+                    ] + (isset($config['native_algorithm']) ? [3 => $config['native_algorithm']] : []),
+                ];
+
+            case 'sodium':
+                return [
+                    'class' => SodiumPasswordHasher::class,
+                    'arguments' => [
+                        $config['time_cost'] ?? null,
+                        (($config['memory_cost'] ?? 0) << 10) ?: null,
+                    ],
+                ];
+
+            case 'argon2i':
+                if (SodiumPasswordHasher::isSupported() && !\defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) {
+                    $config['algorithm'] = 'sodium';
+                } elseif (\defined('PASSWORD_ARGON2I')) {
+                    $config['algorithm'] = 'native';
+                    $config['native_algorithm'] = \PASSWORD_ARGON2I;
+                } else {
+                    throw new LogicException(sprintf('Algorithm "argon2i" is not available. Either use %s"auto" or upgrade to PHP 7.2+ instead.', \defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13') ? '"argon2id", ' : ''));
+                }
+
+                return $this->getHasherConfigFromAlgorithm($config);
+
+            case 'argon2id':
+                if (($hasSodium = SodiumPasswordHasher::isSupported()) && \defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) {
+                    $config['algorithm'] = 'sodium';
+                } elseif (\defined('PASSWORD_ARGON2ID')) {
+                    $config['algorithm'] = 'native';
+                    $config['native_algorithm'] = \PASSWORD_ARGON2ID;
+                } else {
+                    throw new LogicException(sprintf('Algorithm "argon2id" is not available. Either use %s"auto", upgrade to PHP 7.3+ or use libsodium 1.0.15+ instead.', \defined('PASSWORD_ARGON2I') || $hasSodium ? '"argon2i", ' : ''));
+                }
+
+                return $this->getHasherConfigFromAlgorithm($config);
+        }
+
+        return [
+            'class' => MessageDigestPasswordHasher::class,
+            'arguments' => [
+                $config['algorithm'],
+                $config['encode_as_base64'] ?? true,
+                $config['iterations'] ?? 5000,
+            ],
+        ];
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactoryInterface.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactoryInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Hasher;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
+
+/**
+ * PasswordHasherFactoryInterface to support different password hashers for different user accounts.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+interface PasswordHasherFactoryInterface
+{
+    /**
+     * Returns the password hasher to use for the given user.
+     *
+     * @param UserInterface|string $user A UserInterface instance or a class name
+     *
+     * @throws \RuntimeException When no password hasher could be found for the user
+     */
+    public function getPasswordHasher($user): PasswordHasherInterface;
+}

--- a/src/Symfony/Component/PasswordHasher/Hasher/Pbkdf2PasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/Pbkdf2PasswordHasher.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Hasher;
+
+use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
+use Symfony\Component\PasswordHasher\Exception\LogicException;
+use Symfony\Component\PasswordHasher\LegacyPasswordHasherInterface;
+
+/**
+ * Pbkdf2PasswordHasher uses the PBKDF2 (Password-Based Key Derivation Function 2).
+ *
+ * Providing a high level of Cryptographic security,
+ *  PBKDF2 is recommended by the National Institute of Standards and Technology (NIST).
+ *
+ * But also warrants a warning, using PBKDF2 (with a high number of iterations) slows down the process.
+ * PBKDF2 should be used with caution and care.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ * @author Andrew Johnson
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+final class Pbkdf2PasswordHasher implements LegacyPasswordHasherInterface
+{
+    use CheckPasswordLengthTrait;
+
+    private $algorithm;
+    private $encodeHashAsBase64;
+    private $iterations = 1;
+    private $length;
+    private $encodedLength = -1;
+
+    /**
+     * @param string $algorithm          The digest algorithm to use
+     * @param bool   $encodeHashAsBase64 Whether to base64 encode the password hash
+     * @param int    $iterations         The number of iterations to use to stretch the password hash
+     * @param int    $length             Length of derived key to create
+     */
+    public function __construct(string $algorithm = 'sha512', bool $encodeHashAsBase64 = true, int $iterations = 1000, int $length = 40)
+    {
+        $this->algorithm = $algorithm;
+        $this->encodeHashAsBase64 = $encodeHashAsBase64;
+        $this->length = $length;
+
+        try {
+            $this->encodedLength = \strlen($this->hash('', 'salt'));
+        } catch (\LogicException $e) {
+            // ignore unsupported algorithm
+        }
+
+        $this->iterations = $iterations;
+    }
+
+    public function hash(string $plainPassword, ?string $salt = null): string
+    {
+        if ($this->isPasswordTooLong($plainPassword)) {
+            throw new InvalidPasswordException();
+        }
+
+        if (!\in_array($this->algorithm, hash_algos(), true)) {
+            throw new LogicException(sprintf('The algorithm "%s" is not supported.', $this->algorithm));
+        }
+
+        $digest = hash_pbkdf2($this->algorithm, $plainPassword, $salt, $this->iterations, $this->length, true);
+
+        return $this->encodeHashAsBase64 ? base64_encode($digest) : bin2hex($digest);
+    }
+
+    public function verify(string $hashedPassword, string $plainPassword, ?string $salt = null): bool
+    {
+        if (\strlen($hashedPassword) !== $this->encodedLength || false !== strpos($hashedPassword, '$')) {
+            return false;
+        }
+
+        return !$this->isPasswordTooLong($plainPassword) && hash_equals($hashedPassword, $this->hash($plainPassword, $salt));
+    }
+
+    public function needsRehash(string $hashedPassword): bool
+    {
+        return false;
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Hasher/PlaintextPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PlaintextPasswordHasher.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Hasher;
+
+use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
+use Symfony\Component\PasswordHasher\LegacyPasswordHasherInterface;
+
+/**
+ * PlaintextPasswordHasher does not do any hashing but is useful in testing environments.
+ *
+ * As this hasher is not cryptographically secure, usage of it in production environments is discouraged.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class PlaintextPasswordHasher implements LegacyPasswordHasherInterface
+{
+    use CheckPasswordLengthTrait;
+
+    private $ignorePasswordCase;
+
+    /**
+     * @param bool $ignorePasswordCase Compare password case-insensitive
+     */
+    public function __construct(bool $ignorePasswordCase = false)
+    {
+        $this->ignorePasswordCase = $ignorePasswordCase;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hash(string $plainPassword, ?string $salt = null): string
+    {
+        if ($this->isPasswordTooLong($plainPassword)) {
+            throw new InvalidPasswordException();
+        }
+
+        return $this->mergePasswordAndSalt($plainPassword, $salt);
+    }
+
+    public function verify(string $hashedPassword, string $plainPassword, ?string $salt = null): bool
+    {
+        if ($this->isPasswordTooLong($plainPassword)) {
+            return false;
+        }
+
+        $pass2 = $this->mergePasswordAndSalt($plainPassword, $salt);
+
+        if (!$this->ignorePasswordCase) {
+            return hash_equals($hashedPassword, $pass2);
+        }
+
+        return hash_equals(strtolower($hashedPassword), strtolower($pass2));
+    }
+
+    public function needsRehash(string $hashedPassword): bool
+    {
+        return false;
+    }
+
+    private function mergePasswordAndSalt(string $password, ?string $salt): string
+    {
+        if (empty($salt)) {
+            return $password;
+        }
+
+        if (false !== strrpos($salt, '{') || false !== strrpos($salt, '}')) {
+            throw new \InvalidArgumentException('Cannot use { or } in salt.');
+        }
+
+        return $password.'{'.$salt.'}';
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Hasher/SodiumPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/SodiumPasswordHasher.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Hasher;
+
+use Symfony\Component\PasswordHasher\Exception\LogicException;
+use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
+
+/**
+ * Hashes passwords using libsodium.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ * @author Zan Baldwin <hello@zanbaldwin.com>
+ * @author Dominik Müller <dominik.mueller@jkweb.ch>
+ */
+final class SodiumPasswordHasher implements PasswordHasherInterface
+{
+    use CheckPasswordLengthTrait;
+
+    private $opsLimit;
+    private $memLimit;
+
+    public function __construct(int $opsLimit = null, int $memLimit = null)
+    {
+        if (!self::isSupported()) {
+            throw new LogicException('Libsodium is not available. You should either install the sodium extension or use a different password hasher.');
+        }
+
+        $this->opsLimit = $opsLimit ?? max(4, \defined('SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE') ? \SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE : 4);
+        $this->memLimit = $memLimit ?? max(64 * 1024 * 1024, \defined('SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE') ? \SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE : 64 * 1024 * 1024);
+
+        if (3 > $this->opsLimit) {
+            throw new \InvalidArgumentException('$opsLimit must be 3 or greater.');
+        }
+
+        if (10 * 1024 > $this->memLimit) {
+            throw new \InvalidArgumentException('$memLimit must be 10k or greater.');
+        }
+    }
+
+    public static function isSupported(): bool
+    {
+        return version_compare(\extension_loaded('sodium') ? \SODIUM_LIBRARY_VERSION : phpversion('libsodium'), '1.0.14', '>=');
+    }
+
+    public function hash(string $plainPassword): string
+    {
+        if ($this->isPasswordTooLong($plainPassword)) {
+            throw new InvalidPasswordException();
+        }
+
+        if (\function_exists('sodium_crypto_pwhash_str')) {
+            return sodium_crypto_pwhash_str($plainPassword, $this->opsLimit, $this->memLimit);
+        }
+
+        if (\extension_loaded('libsodium')) {
+            return \Sodium\crypto_pwhash_str($plainPassword, $this->opsLimit, $this->memLimit);
+        }
+
+        throw new LogicException('Libsodium is not available. You should either install the sodium extension or use a different password hasher.');
+    }
+
+    public function verify(string $hashedPassword, string $plainPassword): bool
+    {
+        if ('' === $plainPassword) {
+            return false;
+        }
+
+        if ($this->isPasswordTooLong($plainPassword)) {
+            return false;
+        }
+
+        if (0 !== strpos($hashedPassword, '$argon')) {
+            // Accept validating non-argon passwords for seamless migrations
+            return (72 >= \strlen($plainPassword) || 0 !== strpos($hashedPassword, '$2')) && password_verify($plainPassword, $hashedPassword);
+        }
+
+        if (\function_exists('sodium_crypto_pwhash_str_verify')) {
+            return sodium_crypto_pwhash_str_verify($hashedPassword, $plainPassword);
+        }
+
+        if (\extension_loaded('libsodium')) {
+            return \Sodium\crypto_pwhash_str_verify($hashedPassword, $plainPassword);
+        }
+
+        return false;
+    }
+
+    public function needsRehash(string $hashedPassword): bool
+    {
+        if (\function_exists('sodium_crypto_pwhash_str_needs_rehash')) {
+            return sodium_crypto_pwhash_str_needs_rehash($hashedPassword, $this->opsLimit, $this->memLimit);
+        }
+
+        if (\extension_loaded('libsodium')) {
+            return \Sodium\crypto_pwhash_str_needs_rehash($hashedPassword, $this->opsLimit, $this->memLimit);
+        }
+
+        throw new LogicException('Libsodium is not available. You should either install the sodium extension or use a different password hasher.');
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasher.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Hasher;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Hashes passwords based on the user and the PasswordHasherFactory.
+ *
+ * @author Ariel Ferrandini <arielferrandini@gmail.com>
+ */
+class UserPasswordHasher implements UserPasswordHasherInterface
+{
+    private $hasherFactory;
+
+    public function __construct(PasswordHasherFactoryInterface $hasherFactory)
+    {
+        $this->hasherFactory = $hasherFactory;
+    }
+
+    public function hashPassword(UserInterface $user, string $plainPassword): string
+    {
+        $hasher = $this->hasherFactory->getPasswordHasher($user);
+
+        return $hasher->hash($plainPassword, $user->getSalt());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPasswordValid(UserInterface $user, string $plainPassword): bool
+    {
+        if (null === $user->getPassword()) {
+            return false;
+        }
+
+        $hasher = $this->hasherFactory->getPasswordHasher($user);
+
+        return $hasher->verify($user->getPassword(), $plainPassword, $user->getSalt());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function needsRehash(UserInterface $user): bool
+    {
+        if (null === $user->getPassword()) {
+            return false;
+        }
+
+        $hasher = $this->hasherFactory->getPasswordHasher($user);
+
+        return $hasher->needsRehash($user->getPassword());
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasherInterface.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasherInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Hasher;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Interface for the user password hasher service.
+ *
+ * @author Ariel Ferrandini <arielferrandini@gmail.com>
+ */
+interface UserPasswordHasherInterface
+{
+    /**
+     * Hashes the plain password for the given user.
+     */
+    public function hashPassword(UserInterface $user, string $plainPassword): string;
+
+    /**
+     * Checks if the plaintext password matches the user's password.
+     */
+    public function isPasswordValid(UserInterface $user, string $plainPassword): bool;
+
+    /**
+     * Checks if a password hash would benefit from rehashing.
+     */
+    public function needsRehash(UserInterface $user): bool;
+}

--- a/src/Symfony/Component/PasswordHasher/LICENSE
+++ b/src/Symfony/Component/PasswordHasher/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2004-2021 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/PasswordHasher/LegacyPasswordHasherInterface.php
+++ b/src/Symfony/Component/PasswordHasher/LegacyPasswordHasherInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher;
+
+use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
+
+/**
+ * Provides password hashing and verification capabilities for "legacy" hashers that require external salts.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Nicolas Grekas <p@tchwork.com>
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ */
+interface LegacyPasswordHasherInterface extends PasswordHasherInterface
+{
+    /**
+     * Hashes a plain password.
+     *
+     * @return string The hashed password
+     *
+     * @throws InvalidPasswordException If the plain password is invalid, e.g. excessively long
+     */
+    public function hash(string $plainPassword, ?string $salt = null): string;
+
+    /**
+     * Checks that a plain password and a salt match a password hash.
+     */
+    public function verify(string $hashedPassword, string $plainPassword, ?string $salt = null): bool;
+}

--- a/src/Symfony/Component/PasswordHasher/PasswordHasherInterface.php
+++ b/src/Symfony/Component/PasswordHasher/PasswordHasherInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher;
+
+use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
+
+/**
+ * Provides password hashing capabilities.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface PasswordHasherInterface
+{
+    public const MAX_PASSWORD_LENGTH = 4096;
+
+    /**
+     * Hashes a plain password.
+     *
+     * @throws InvalidPasswordException When the plain password is invalid, e.g. excessively long
+     */
+    public function hash(string $plainPassword): string;
+
+    /**
+     * Verifies a plain password against a hash.
+     */
+    public function verify(string $hashedPassword, string $plainPassword): bool;
+
+    /**
+     * Checks if a password hash would benefit from rehashing.
+     */
+    public function needsRehash(string $hashedPassword): bool;
+}

--- a/src/Symfony/Component/PasswordHasher/README.md
+++ b/src/Symfony/Component/PasswordHasher/README.md
@@ -1,0 +1,40 @@
+PasswordHasher Component
+========================
+
+The PasswordHasher component provides secure password hashing utilities.
+
+Getting Started
+---------------
+
+```
+$ composer require symfony/password-hasher
+```
+
+```php
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
+
+// Configure different password hashers via the factory
+$factory = new PasswordHasherFactory([
+    'common' => ['algorithm' => 'bcrypt'],
+    'memory-hard' => ['algorithm' => 'sodium'],
+]);
+
+// Retrieve the right password hasher by its name
+$passwordHasher = $factory->getPasswordHasher('common');
+
+// Hash a plain password
+$hash = $passwordHasher->hash('plain'); // returns a bcrypt hash
+
+// Verify that a given plain password matches the hash
+$passwordHasher->verify($hash, 'wrong'); // returns false
+$passwordHasher->verify($hash, 'plain'); // returns true (valid)
+```
+
+Resources
+---------
+
+  * [Documentation](https://symfony.com/doc/current/password-hasher.html)
+  * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+  * [Report issues](https://github.com/symfony/symfony/issues) and
+    [send Pull Requests](https://github.com/symfony/symfony/pulls)
+    in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/PasswordHasher/Tests/Command/UserPasswordHashCommandTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Command/UserPasswordHashCommandTest.php
@@ -1,0 +1,362 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Command\UserPasswordHasherCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\PasswordHasher\Command\UserPasswordHashCommand;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\Pbkdf2PasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\SodiumPasswordHasher;
+
+class UserPasswordHashCommandTest extends TestCase
+{
+    /** @var CommandTester */
+    private $passwordHasherCommandTester;
+
+    public function testEncodePasswordEmptySalt()
+    {
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'password',
+            'user-class' => 'Symfony\Component\Security\Core\User\User',
+            '--empty-salt' => true,
+        ], ['decorated' => false]);
+
+        $this->assertStringContainsString(' Password hash   password', $this->passwordHasherCommandTester->getDisplay());
+    }
+
+    public function testEncodeNoPasswordNoInteraction()
+    {
+        $statusCode = $this->passwordHasherCommandTester->execute([
+        ], ['interactive' => false]);
+
+        $this->assertStringContainsString('[ERROR] The password must not be empty.', $this->passwordHasherCommandTester->getDisplay());
+        $this->assertEquals(1, $statusCode);
+    }
+
+    public function testEncodePasswordBcrypt()
+    {
+        $this->setupBcrypt();
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'password',
+            'user-class' => 'Custom\Class\Bcrypt\User',
+        ], ['interactive' => false]);
+
+        $output = $this->passwordHasherCommandTester->getDisplay();
+        $this->assertStringContainsString('Password hashing succeeded', $output);
+
+        $hasher = new NativePasswordHasher(null, null, 17, \PASSWORD_BCRYPT);
+        preg_match('# Password hash\s{1,}([\w+\/$.]+={0,2})\s+#', $output, $matches);
+        $hash = $matches[1];
+        $this->assertTrue($hasher->verify($hash, 'password', null));
+    }
+
+    public function testEncodePasswordArgon2i()
+    {
+        if (!($sodium = SodiumPasswordHasher::isSupported() && !\defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) && !\defined('PASSWORD_ARGON2I')) {
+            $this->markTestSkipped('Argon2i algorithm not available.');
+        }
+        $this->setupArgon2i();
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'password',
+            'user-class' => 'Custom\Class\Argon2i\User',
+        ], ['interactive' => false]);
+
+        $output = $this->passwordHasherCommandTester->getDisplay();
+        $this->assertStringContainsString('Password hashing succeeded', $output);
+
+        $hasher = $sodium ? new SodiumPasswordHasher() : new NativePasswordHasher(null, null, null, \PASSWORD_ARGON2I);
+        preg_match('#  Password hash\s+(\$argon2i?\$[\w,=\$+\/]+={0,2})\s+#', $output, $matches);
+        $hash = $matches[1];
+        $this->assertTrue($hasher->verify($hash, 'password', null));
+    }
+
+    public function testEncodePasswordArgon2id()
+    {
+        if (!($sodium = (SodiumPasswordHasher::isSupported() && \defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13'))) && !\defined('PASSWORD_ARGON2ID')) {
+            $this->markTestSkipped('Argon2id algorithm not available.');
+        }
+        $this->setupArgon2id();
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'password',
+            'user-class' => 'Custom\Class\Argon2id\User',
+        ], ['interactive' => false]);
+
+        $output = $this->passwordHasherCommandTester->getDisplay();
+        $this->assertStringContainsString('Password hashing succeeded', $output);
+
+        $hasher = $sodium ? new SodiumPasswordHasher() : new NativePasswordHasher(null, null, null, \PASSWORD_ARGON2ID);
+        preg_match('#  Password hash\s+(\$argon2id?\$[\w,=\$+\/]+={0,2})\s+#', $output, $matches);
+        $hash = $matches[1];
+        $this->assertTrue($hasher->verify($hash, 'password', null));
+    }
+
+    public function testEncodePasswordNative()
+    {
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'password',
+            'user-class' => 'Custom\Class\Native\User',
+        ], ['interactive' => false]);
+
+        $output = $this->passwordHasherCommandTester->getDisplay();
+        $this->assertStringContainsString('Password hashing succeeded', $output);
+
+        $hasher = new NativePasswordHasher();
+        preg_match('# Password hash\s{1,}([\w+\/$.,=]+={0,2})\s+#', $output, $matches);
+        $hash = $matches[1];
+        $this->assertTrue($hasher->verify($hash, 'password', null));
+    }
+
+    public function testEncodePasswordSodium()
+    {
+        if (!SodiumPasswordHasher::isSupported()) {
+            $this->markTestSkipped('Libsodium is not available.');
+        }
+        $this->setupSodium();
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'password',
+            'user-class' => 'Custom\Class\Sodium\User',
+        ], ['interactive' => false]);
+
+        $output = $this->passwordHasherCommandTester->getDisplay();
+        $this->assertStringContainsString('Password hashing succeeded', $output);
+
+        preg_match('#  Password hash\s+(\$?\$[\w,=\$+\/]+={0,2})\s+#', $output, $matches);
+        $hash = $matches[1];
+        $this->assertTrue((new SodiumPasswordHasher())->verify($hash, 'password', null));
+    }
+
+    public function testEncodePasswordPbkdf2()
+    {
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'password',
+            'user-class' => 'Custom\Class\Pbkdf2\User',
+        ], ['interactive' => false]);
+
+        $output = $this->passwordHasherCommandTester->getDisplay();
+        $this->assertStringContainsString('Password hashing succeeded', $output);
+
+        $hasher = new Pbkdf2PasswordHasher('sha512', true, 1000);
+        preg_match('# Password hash\s{1,}([\w+\/]+={0,2})\s+#', $output, $matches);
+        $hash = $matches[1];
+        preg_match('# Generated salt\s{1,}([\w+\/]+={0,2})\s+#', $output, $matches);
+        $salt = $matches[1];
+        $this->assertTrue($hasher->verify($hash, 'password', $salt));
+    }
+
+    public function testEncodePasswordOutput()
+    {
+        $this->passwordHasherCommandTester->execute(
+            [
+                'password' => 'p@ssw0rd',
+            ], ['interactive' => false]
+        );
+
+        $this->assertStringContainsString('Password hashing succeeded', $this->passwordHasherCommandTester->getDisplay());
+        $this->assertStringContainsString(' Password hash    p@ssw0rd', $this->passwordHasherCommandTester->getDisplay());
+        $this->assertStringContainsString(' Generated salt ', $this->passwordHasherCommandTester->getDisplay());
+    }
+
+    public function testEncodePasswordEmptySaltOutput()
+    {
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'p@ssw0rd',
+            'user-class' => 'Symfony\Component\Security\Core\User\User',
+            '--empty-salt' => true,
+        ]);
+
+        $this->assertStringContainsString('Password hashing succeeded', $this->passwordHasherCommandTester->getDisplay());
+        $this->assertStringContainsString(' Password hash   p@ssw0rd', $this->passwordHasherCommandTester->getDisplay());
+        $this->assertStringNotContainsString(' Generated salt ', $this->passwordHasherCommandTester->getDisplay());
+    }
+
+    public function testEncodePasswordNativeOutput()
+    {
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'p@ssw0rd',
+            'user-class' => 'Custom\Class\Native\User',
+        ], ['interactive' => false]);
+
+        $this->assertStringNotContainsString(' Generated salt ', $this->passwordHasherCommandTester->getDisplay());
+    }
+
+    public function testEncodePasswordArgon2iOutput()
+    {
+        if (!(SodiumPasswordHasher::isSupported() && !\defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) && !\defined('PASSWORD_ARGON2I')) {
+            $this->markTestSkipped('Argon2i algorithm not available.');
+        }
+
+        $this->setupArgon2i();
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'p@ssw0rd',
+            'user-class' => 'Custom\Class\Argon2i\User',
+        ], ['interactive' => false]);
+
+        $this->assertStringNotContainsString(' Generated salt ', $this->passwordHasherCommandTester->getDisplay());
+    }
+
+    public function testEncodePasswordArgon2idOutput()
+    {
+        if (!(SodiumPasswordHasher::isSupported() && \defined('SODIUM_CRYPTO_PWHASH_ALG_ARGON2ID13')) && !\defined('PASSWORD_ARGON2ID')) {
+            $this->markTestSkipped('Argon2id algorithm not available.');
+        }
+
+        $this->setupArgon2id();
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'p@ssw0rd',
+            'user-class' => 'Custom\Class\Argon2id\User',
+        ], ['interactive' => false]);
+
+        $this->assertStringNotContainsString(' Generated salt ', $this->passwordHasherCommandTester->getDisplay());
+    }
+
+    public function testEncodePasswordSodiumOutput()
+    {
+        if (!SodiumPasswordHasher::isSupported()) {
+            $this->markTestSkipped('Libsodium is not available.');
+        }
+
+        $this->setupSodium();
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'p@ssw0rd',
+            'user-class' => 'Custom\Class\Sodium\User',
+        ], ['interactive' => false]);
+
+        $this->assertStringNotContainsString(' Generated salt ', $this->passwordHasherCommandTester->getDisplay());
+    }
+
+    public function testEncodePasswordNoConfigForGivenUserClass()
+    {
+        $this->expectException('\RuntimeException');
+        $this->expectExceptionMessage('No password hasher has been configured for account "Foo\Bar\User".');
+
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'password',
+            'user-class' => 'Foo\Bar\User',
+        ], ['interactive' => false]);
+    }
+
+    public function testEncodePasswordAsksNonProvidedUserClass()
+    {
+        $this->passwordHasherCommandTester->setInputs(['Custom\Class\Pbkdf2\User', "\n"]);
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'password',
+        ], ['decorated' => false]);
+
+        $this->assertStringContainsString(<<<EOTXT
+ For which user class would you like to hash a password? [Custom\Class\Native\User]:
+  [0] Custom\Class\Native\User
+  [1] Custom\Class\Pbkdf2\User
+  [2] Custom\Class\Test\User
+  [3] Symfony\Component\Security\Core\User\User
+EOTXT
+        , $this->passwordHasherCommandTester->getDisplay(true));
+    }
+
+    public function testNonInteractiveEncodePasswordUsesFirstUserClass()
+    {
+        $this->passwordHasherCommandTester->execute([
+            'password' => 'password',
+        ], ['interactive' => false]);
+
+        $this->assertStringContainsString('Hasher used      Symfony\Component\PasswordHasher\Hasher\PlaintextPasswordHasher', $this->passwordHasherCommandTester->getDisplay());
+    }
+
+    public function testThrowsExceptionOnNoConfiguredHashers()
+    {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('There are no configured password hashers for the "security" extension.');
+
+        $tester = new CommandTester(new UserPasswordHashCommand($this->getMockBuilder(PasswordHasherFactoryInterface::class)->getMock(), []));
+        $tester->execute([
+            'password' => 'password',
+        ], ['interactive' => false]);
+    }
+
+    protected function setUp(): void
+    {
+        putenv('COLUMNS='.(119 + \strlen(\PHP_EOL)));
+        $hasherFactory = new PasswordHasherFactory([
+            User::class => ['algorithm' => 'plaintext'],
+            'Custom\Class\Native\User' => ['algorithm' => 'native', 'cost' => 10],
+            'Custom\Class\Pbkdf2\User' => ['algorithm' => 'pbkdf2', 'hash_algorithm' => 'sha512', 'iterations' => 1000, 'encode_as_base64' => true],
+            'Custom\Class\Test\User' => ['algorithm' => 'test'],
+        ]);
+
+        $this->passwordHasherCommandTester = new CommandTester(new UserPasswordHashCommand(
+            $hasherFactory,
+            [User::class, 'Custom\Class\Native\User', 'Custom\Class\Pbkdf2\User', 'Custom\Class\Test\User']
+        ));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->passwordHasherCommandTester = null;
+    }
+
+    private function setupArgon2i()
+    {
+        putenv('COLUMNS='.(119 + \strlen(\PHP_EOL)));
+
+        $hasherFactory = new PasswordHasherFactory([
+            'Custom\Class\Argon2i\User' => ['algorithm' => 'argon2i'],
+        ]);
+
+        $this->passwordHasherCommandTester = new CommandTester(
+            new UserPasswordHashCommand($hasherFactory, ['Custom\Class\Argon2i\User'])
+        );
+    }
+
+    private function setupArgon2id()
+    {
+        putenv('COLUMNS='.(119 + \strlen(\PHP_EOL)));
+
+        $hasherFactory = new PasswordHasherFactory([
+            'Custom\Class\Argon2id\User' => ['algorithm' => 'argon2id'],
+        ]);
+
+        $this->passwordHasherCommandTester = new CommandTester(
+            new UserPasswordHashCommand($hasherFactory, ['Custom\Class\Argon2id\User'])
+        );
+    }
+
+    private function setupBcrypt()
+    {
+        putenv('COLUMNS='.(119 + \strlen(\PHP_EOL)));
+
+        $hasherFactory = new PasswordHasherFactory([
+            'Custom\Class\Bcrypt\User' => ['algorithm' => 'bcrypt'],
+        ]);
+
+        $this->passwordHasherCommandTester = new CommandTester(new UserPasswordHashCommand(
+            $hasherFactory,
+            [User::class, 'Custom\Class\Pbkdf2\User', 'Custom\Class\Test\User']
+        ));
+    }
+
+    private function setupSodium()
+    {
+        putenv('COLUMNS='.(119 + \strlen(\PHP_EOL)));
+
+        $hasherFactory = new PasswordHasherFactory([
+            'Custom\Class\Sodium\User' => ['algorithm' => 'sodium'],
+        ]);
+
+        $this->passwordHasherCommandTester = new CommandTester(
+            new UserPasswordHashCommand($hasherFactory, ['Custom\Class\Sodium\User'])
+        );
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/MessageDigestPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/MessageDigestPasswordHasherTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Tests\Hasher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
+use Symfony\Component\PasswordHasher\Hasher\MessageDigestPasswordHasher;
+
+class MessageDigestPasswordHasherTest extends TestCase
+{
+    public function testVerify()
+    {
+        $hasher = new MessageDigestPasswordHasher('sha256', false, 1);
+
+        $this->assertTrue($hasher->verify(hash('sha256', 'password'), 'password', ''));
+    }
+
+    public function testHash()
+    {
+        $hasher = new MessageDigestPasswordHasher('sha256', false, 1);
+        $this->assertSame(hash('sha256', 'password'), $hasher->hash('password', ''));
+
+        $hasher = new MessageDigestPasswordHasher('sha256', true, 1);
+        $this->assertSame(base64_encode(hash('sha256', 'password', true)), $hasher->hash('password', ''));
+
+        $hasher = new MessageDigestPasswordHasher('sha256', false, 2);
+        $this->assertSame(hash('sha256', hash('sha256', 'password', true).'password'), $hasher->hash('password', ''));
+    }
+
+    public function testHashAlgorithmDoesNotExist()
+    {
+        $this->expectException('LogicException');
+        $hasher = new MessageDigestPasswordHasher('foobar');
+        $hasher->hash('password', '');
+    }
+
+    public function testHashLength()
+    {
+        $this->expectException(InvalidPasswordException::class);
+        $hasher = new MessageDigestPasswordHasher();
+
+        $hasher->hash(str_repeat('a', 5000), 'salt');
+    }
+
+    public function testCheckPasswordLength()
+    {
+        $hasher = new MessageDigestPasswordHasher();
+
+        $this->assertFalse($hasher->verify('encoded', str_repeat('a', 5000), 'salt'));
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/MigratingPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/MigratingPasswordHasherTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Tests\Hasher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PasswordHasher\Hasher\MigratingPasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
+
+class MigratingPasswordHasherTest extends TestCase
+{
+    public function testValidation()
+    {
+        $bestHasher = new NativePasswordHasher(4, 12000, 4);
+
+        $extraHasher = $this->createMock(PasswordHasherInterface::class);
+        $extraHasher->expects($this->never())->method('hash');
+        $extraHasher->expects($this->never())->method('verify');
+        $extraHasher->expects($this->never())->method('needsRehash');
+
+        $hasher = new MigratingPasswordHasher($bestHasher, $extraHasher);
+
+        $this->assertTrue($hasher->needsRehash('foo'));
+
+        $hash = $hasher->hash('foo', 'salt');
+        $this->assertFalse($hasher->needsRehash($hash));
+
+        $this->assertTrue($hasher->verify($hash, 'foo', 'salt'));
+        $this->assertFalse($hasher->verify($hash, 'bar', 'salt'));
+    }
+
+    public function testFallback()
+    {
+        $bestHasher = new NativePasswordHasher(4, 12000, 4);
+
+        $extraHasher1 = $this->createMock(PasswordHasherInterface::class);
+        $extraHasher1->expects($this->any())
+            ->method('verify')
+            ->with('abc', 'foo', 'salt')
+            ->willReturn(true);
+
+        $hasher = new MigratingPasswordHasher($bestHasher, $extraHasher1);
+
+        $this->assertTrue($hasher->verify('abc', 'foo', 'salt'));
+
+        $extraHasher2 = $this->createMock(PasswordHasherInterface::class);
+        $extraHasher2->expects($this->any())
+            ->method('verify')
+            ->willReturn(false);
+
+        $hasher = new MigratingPasswordHasher($bestHasher, $extraHasher2);
+
+        $this->assertFalse($hasher->verify('abc', 'foo', 'salt'));
+
+        $hasher = new MigratingPasswordHasher($bestHasher, $extraHasher2, $extraHasher1);
+
+        $this->assertTrue($hasher->verify('abc', 'foo', 'salt'));
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/NativePasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/NativePasswordHasherTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Tests\Hasher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
+
+/**
+ * @author Elnur Abdurrakhimov <elnur@elnur.pro>
+ */
+class NativePasswordHasherTest extends TestCase
+{
+    public function testCostBelowRange()
+    {
+        $this->expectException('InvalidArgumentException');
+        new NativePasswordHasher(null, null, 3);
+    }
+
+    public function testCostAboveRange()
+    {
+        $this->expectException('InvalidArgumentException');
+        new NativePasswordHasher(null, null, 32);
+    }
+
+    /**
+     * @dataProvider validRangeData
+     */
+    public function testCostInRange($cost)
+    {
+        $this->assertInstanceOf(NativePasswordHasher::class, new NativePasswordHasher(null, null, $cost));
+    }
+
+    public function validRangeData()
+    {
+        $costs = range(4, 31);
+        array_walk($costs, function (&$cost) { $cost = [$cost]; });
+
+        return $costs;
+    }
+
+    public function testValidation()
+    {
+        $hasher = new NativePasswordHasher();
+        $result = $hasher->hash('password', null);
+        $this->assertTrue($hasher->verify($result, 'password', null));
+        $this->assertFalse($hasher->verify($result, 'anotherPassword', null));
+        $this->assertFalse($hasher->verify($result, '', null));
+    }
+
+    public function testNonArgonValidation()
+    {
+        $hasher = new NativePasswordHasher();
+        $this->assertTrue($hasher->verify('$5$abcdefgh$ZLdkj8mkc2XVSrPVjskDAgZPGjtj1VGVaa1aUkrMTU/', 'password', null));
+        $this->assertFalse($hasher->verify('$5$abcdefgh$ZLdkj8mkc2XVSrPVjskDAgZPGjtj1VGVaa1aUkrMTU/', 'anotherPassword', null));
+        $this->assertTrue($hasher->verify('$6$abcdefgh$yVfUwsw5T.JApa8POvClA1pQ5peiq97DUNyXCZN5IrF.BMSkiaLQ5kvpuEm/VQ1Tvh/KV2TcaWh8qinoW5dhA1', 'password', null));
+        $this->assertFalse($hasher->verify('$6$abcdefgh$yVfUwsw5T.JApa8POvClA1pQ5peiq97DUNyXCZN5IrF.BMSkiaLQ5kvpuEm/VQ1Tvh/KV2TcaWh8qinoW5dhA1', 'anotherPassword', null));
+    }
+
+    public function testConfiguredAlgorithm()
+    {
+        $hasher = new NativePasswordHasher(null, null, null, \PASSWORD_BCRYPT);
+        $result = $hasher->hash('password', null);
+        $this->assertTrue($hasher->verify($result, 'password', null));
+        $this->assertStringStartsWith('$2', $result);
+    }
+
+    public function testConfiguredAlgorithmWithLegacyConstValue()
+    {
+        $hasher = new NativePasswordHasher(null, null, null, '1');
+        $result = $hasher->hash('password', null);
+        $this->assertTrue($hasher->verify($result, 'password', null));
+        $this->assertStringStartsWith('$2', $result);
+    }
+
+    public function testCheckPasswordLength()
+    {
+        $hasher = new NativePasswordHasher(null, null, 4);
+        $result = password_hash(str_repeat('a', 72), \PASSWORD_BCRYPT, ['cost' => 4]);
+
+        $this->assertFalse($hasher->verify($result, str_repeat('a', 73), 'salt'));
+        $this->assertTrue($hasher->verify($result, str_repeat('a', 72), 'salt'));
+    }
+
+    public function testNeedsRehash()
+    {
+        $hasher = new NativePasswordHasher(4, 11000, 4);
+
+        $this->assertTrue($hasher->needsRehash('dummyhash'));
+
+        $hash = $hasher->hash('foo', 'salt');
+        $this->assertFalse($hasher->needsRehash($hash));
+
+        $hasher = new NativePasswordHasher(5, 11000, 5);
+        $this->assertTrue($hasher->needsRehash($hash));
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/PasswordHasherFactoryTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/PasswordHasherFactoryTest.php
@@ -1,0 +1,216 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Tests\Hasher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherAwareInterface;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
+use Symfony\Component\PasswordHasher\Hasher\MessageDigestPasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\MigratingPasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\SodiumPasswordHasher;
+use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class PasswordHasherFactoryTest extends TestCase
+{
+    public function testGetHasherWithMessageDigestHasher()
+    {
+        $factory = new PasswordHasherFactory([UserInterface::class => [
+            'class' => MessageDigestPasswordHasher::class,
+            'arguments' => ['sha512', true, 5],
+        ]]);
+
+        $hasher = $factory->getPasswordHasher($this->createMock(UserInterface::class));
+        $expectedHasher = new MessageDigestPasswordHasher('sha512', true, 5);
+
+        $this->assertEquals($expectedHasher->hash('foo', 'moo'), $hasher->hash('foo', 'moo'));
+    }
+
+    public function testGetHasherWithService()
+    {
+        $factory = new PasswordHasherFactory([
+            UserInterface::class => new MessageDigestPasswordHasher('sha1'),
+        ]);
+
+        $hasher = $factory->getPasswordHasher($this->createMock(UserInterface::class));
+        $expectedHasher = new MessageDigestPasswordHasher('sha1');
+        $this->assertEquals($expectedHasher->hash('foo', ''), $hasher->hash('foo', ''));
+
+        $hasher = $factory->getPasswordHasher(new User('user', 'pass'));
+        $expectedHasher = new MessageDigestPasswordHasher('sha1');
+        $this->assertEquals($expectedHasher->hash('foo', ''), $hasher->hash('foo', ''));
+    }
+
+    public function testGetHasherWithClassName()
+    {
+        $factory = new PasswordHasherFactory([
+            UserInterface::class => new MessageDigestPasswordHasher('sha1'),
+        ]);
+
+        $hasher = $factory->getPasswordHasher(SomeChildUser::class);
+        $expectedHasher = new MessageDigestPasswordHasher('sha1');
+        $this->assertEquals($expectedHasher->hash('foo', ''), $hasher->hash('foo', ''));
+    }
+
+    public function testGetHasherConfiguredForConcreteClassWithService()
+    {
+        $factory = new PasswordHasherFactory([
+            'Symfony\Component\Security\Core\User\User' => new MessageDigestPasswordHasher('sha1'),
+        ]);
+
+        $hasher = $factory->getPasswordHasher(new User('user', 'pass'));
+        $expectedHasher = new MessageDigestPasswordHasher('sha1');
+        $this->assertEquals($expectedHasher->hash('foo', ''), $hasher->hash('foo', ''));
+    }
+
+    public function testGetHasherConfiguredForConcreteClassWithClassName()
+    {
+        $factory = new PasswordHasherFactory([
+            'Symfony\Component\PasswordHasher\Tests\Hasher\SomeUser' => new MessageDigestPasswordHasher('sha1'),
+        ]);
+
+        $hasher = $factory->getPasswordHasher(SomeChildUser::class);
+        $expectedHasher = new MessageDigestPasswordHasher('sha1');
+        $this->assertEquals($expectedHasher->hash('foo', ''), $hasher->hash('foo', ''));
+    }
+
+    public function testGetNamedHasherForHasherAware()
+    {
+        $factory = new PasswordHasherFactory([
+            HasherAwareUser::class => new MessageDigestPasswordHasher('sha256'),
+            'hasher_name' => new MessageDigestPasswordHasher('sha1'),
+        ]);
+
+        $hasher = $factory->getPasswordHasher(new HasherAwareUser('user', 'pass'));
+        $expectedHasher = new MessageDigestPasswordHasher('sha1');
+        $this->assertEquals($expectedHasher->hash('foo', ''), $hasher->hash('foo', ''));
+    }
+
+    public function testGetNullNamedHasherForHasherAware()
+    {
+        $factory = new PasswordHasherFactory([
+            HasherAwareUser::class => new MessageDigestPasswordHasher('sha1'),
+            'hasher_name' => new MessageDigestPasswordHasher('sha256'),
+        ]);
+
+        $user = new HasherAwareUser('mathilde', 'krogulec');
+        $user->hasherName = null;
+        $hasher = $factory->getPasswordHasher($user);
+        $expectedHasher = new MessageDigestPasswordHasher('sha1');
+        $this->assertEquals($expectedHasher->hash('foo', ''), $hasher->hash('foo', ''));
+    }
+
+    public function testGetInvalidNamedHasherForHasherAware()
+    {
+        $this->expectException('RuntimeException');
+        $factory = new PasswordHasherFactory([
+            HasherAwareUser::class => new MessageDigestPasswordHasher('sha1'),
+            'hasher_name' => new MessageDigestPasswordHasher('sha256'),
+        ]);
+
+        $user = new HasherAwareUser('user', 'pass');
+        $user->hasherName = 'invalid_hasher_name';
+        $factory->getPasswordHasher($user);
+    }
+
+    public function testGetHasherForHasherAwareWithClassName()
+    {
+        $factory = new PasswordHasherFactory([
+            HasherAwareUser::class => new MessageDigestPasswordHasher('sha1'),
+            'hasher_name' => new MessageDigestPasswordHasher('sha256'),
+        ]);
+
+        $hasher = $factory->getPasswordHasher(HasherAwareUser::class);
+        $expectedHasher = new MessageDigestPasswordHasher('sha1');
+        $this->assertEquals($expectedHasher->hash('foo', ''), $hasher->hash('foo', ''));
+    }
+
+    public function testMigrateFrom()
+    {
+        if (!SodiumPasswordHasher::isSupported()) {
+            $this->markTestSkipped('Sodium is not available');
+        }
+
+        $factory = new PasswordHasherFactory([
+            'digest_hasher' => $digest = new MessageDigestPasswordHasher('sha256'),
+            SomeUser::class => ['algorithm' => 'sodium', 'migrate_from' => ['bcrypt', 'digest_hasher']],
+        ]);
+
+        $hasher = $factory->getPasswordHasher(SomeUser::class);
+        $this->assertInstanceOf(MigratingPasswordHasher::class, $hasher);
+
+        $this->assertTrue($hasher->verify((new SodiumPasswordHasher())->hash('foo', null), 'foo', null));
+        $this->assertTrue($hasher->verify((new NativePasswordHasher(null, null, null, \PASSWORD_BCRYPT))->hash('foo', null), 'foo', null));
+        $this->assertTrue($hasher->verify($digest->hash('foo', null), 'foo', null));
+        $this->assertStringStartsWith(\SODIUM_CRYPTO_PWHASH_STRPREFIX, $hasher->hash('foo', null));
+    }
+
+    public function testDefaultMigratingHashers()
+    {
+        $this->assertInstanceOf(
+            MigratingPasswordHasher::class,
+            (new PasswordHasherFactory([SomeUser::class => ['class' => NativePasswordHasher::class, 'arguments' => []]]))->getPasswordHasher(SomeUser::class)
+        );
+
+        $this->assertInstanceOf(
+            MigratingPasswordHasher::class,
+            (new PasswordHasherFactory([SomeUser::class => ['algorithm' => 'bcrypt', 'cost' => 11]]))->getPasswordHasher(SomeUser::class)
+        );
+
+        if (!SodiumPasswordHasher::isSupported()) {
+            return;
+        }
+
+        $this->assertInstanceOf(
+            MigratingPasswordHasher::class,
+            (new PasswordHasherFactory([SomeUser::class => ['class' => SodiumPasswordHasher::class, 'arguments' => []]]))->getPasswordHasher(SomeUser::class)
+        );
+    }
+}
+
+class SomeUser implements UserInterface
+{
+    public function getRoles(): array
+    {
+    }
+
+    public function getPassword(): ?string
+    {
+    }
+
+    public function getSalt(): ?string
+    {
+    }
+
+    public function getUsername(): string
+    {
+    }
+
+    public function eraseCredentials()
+    {
+    }
+}
+
+class SomeChildUser extends SomeUser
+{
+}
+
+class HasherAwareUser extends SomeUser implements PasswordHasherAwareInterface
+{
+    public $hasherName = 'hasher_name';
+
+    public function getPasswordHasherName(): ?string
+    {
+        return $this->hasherName;
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/Pbkdf2PasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/Pbkdf2PasswordHasherTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Tests\Hasher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
+use Symfony\Component\PasswordHasher\Hasher\Pbkdf2PasswordHasher;
+
+class Pbkdf2PasswordHasherTest extends TestCase
+{
+    public function testVerify()
+    {
+        $hasher = new Pbkdf2PasswordHasher('sha256', false, 1, 40);
+
+        $this->assertTrue($hasher->verify('c1232f10f62715fda06ae7c0a2037ca19b33cf103b727ba56d870c11f290a2ab106974c75607c8a3', 'password', ''));
+    }
+
+    public function testHash()
+    {
+        $hasher = new Pbkdf2PasswordHasher('sha256', false, 1, 40);
+        $this->assertSame('c1232f10f62715fda06ae7c0a2037ca19b33cf103b727ba56d870c11f290a2ab106974c75607c8a3', $hasher->hash('password', ''));
+
+        $hasher = new Pbkdf2PasswordHasher('sha256', true, 1, 40);
+        $this->assertSame('wSMvEPYnFf2gaufAogN8oZszzxA7cnulbYcMEfKQoqsQaXTHVgfIow==', $hasher->hash('password', ''));
+
+        $hasher = new Pbkdf2PasswordHasher('sha256', false, 2, 40);
+        $this->assertSame('8bc2f9167a81cdcfad1235cd9047f1136271c1f978fcfcb35e22dbeafa4634f6fd2214218ed63ebb', $hasher->hash('password', ''));
+    }
+
+    public function testHashAlgorithmDoesNotExist()
+    {
+        $this->expectException('LogicException');
+        $hasher = new Pbkdf2PasswordHasher('foobar');
+        $hasher->hash('password', '');
+    }
+
+    public function testHashLength()
+    {
+        $this->expectException(InvalidPasswordException::class);
+        $hasher = new Pbkdf2PasswordHasher('foobar');
+
+        $hasher->hash(str_repeat('a', 5000), 'salt');
+    }
+
+    public function testCheckPasswordLength()
+    {
+        $hasher = new Pbkdf2PasswordHasher('foobar');
+
+        $this->assertFalse($hasher->verify('encoded', str_repeat('a', 5000), 'salt'));
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/PlaintextPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/PlaintextPasswordHasherTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Tests\Hasher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
+use Symfony\Component\PasswordHasher\Hasher\PlaintextPasswordHasher;
+
+class PlaintextPasswordHasherTest extends TestCase
+{
+    public function testVerify()
+    {
+        $hasher = new PlaintextPasswordHasher();
+
+        $this->assertTrue($hasher->verify('foo', 'foo', ''));
+        $this->assertFalse($hasher->verify('bar', 'foo', ''));
+        $this->assertFalse($hasher->verify('FOO', 'foo', ''));
+
+        $hasher = new PlaintextPasswordHasher(true);
+
+        $this->assertTrue($hasher->verify('foo', 'foo', ''));
+        $this->assertFalse($hasher->verify('bar', 'foo', ''));
+        $this->assertTrue($hasher->verify('FOO', 'foo', ''));
+    }
+
+    public function testHash()
+    {
+        $hasher = new PlaintextPasswordHasher();
+
+        $this->assertSame('foo', $hasher->hash('foo', ''));
+    }
+
+    public function testHashLength()
+    {
+        $this->expectException(InvalidPasswordException::class);
+        $hasher = new PlaintextPasswordHasher();
+
+        $hasher->hash(str_repeat('a', 5000), 'salt');
+    }
+
+    public function testCheckPasswordLength()
+    {
+        $hasher = new PlaintextPasswordHasher();
+
+        $this->assertFalse($hasher->verify('encoded', str_repeat('a', 5000), 'salt'));
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/SodiumPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/SodiumPasswordHasherTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Tests\Hasher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
+use Symfony\Component\PasswordHasher\Hasher\SodiumPasswordHasher;
+
+class SodiumPasswordHasherTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!SodiumPasswordHasher::isSupported()) {
+            $this->markTestSkipped('Libsodium is not available.');
+        }
+    }
+
+    public function testValidation()
+    {
+        $hasher = new SodiumPasswordHasher();
+        $result = $hasher->hash('password', null);
+        $this->assertTrue($hasher->verify($result, 'password', null));
+        $this->assertFalse($hasher->verify($result, 'anotherPassword', null));
+        $this->assertFalse($hasher->verify($result, '', null));
+    }
+
+    public function testBCryptValidation()
+    {
+        $hasher = new SodiumPasswordHasher();
+        $this->assertTrue($hasher->verify('$2y$04$M8GDODMoGQLQRpkYCdoJh.lbiZPee3SZI32RcYK49XYTolDGwoRMm', 'abc', null));
+    }
+
+    public function testNonArgonValidation()
+    {
+        $hasher = new SodiumPasswordHasher();
+        $this->assertTrue($hasher->verify('$5$abcdefgh$ZLdkj8mkc2XVSrPVjskDAgZPGjtj1VGVaa1aUkrMTU/', 'password', null));
+        $this->assertFalse($hasher->verify('$5$abcdefgh$ZLdkj8mkc2XVSrPVjskDAgZPGjtj1VGVaa1aUkrMTU/', 'anotherPassword', null));
+        $this->assertTrue($hasher->verify('$6$abcdefgh$yVfUwsw5T.JApa8POvClA1pQ5peiq97DUNyXCZN5IrF.BMSkiaLQ5kvpuEm/VQ1Tvh/KV2TcaWh8qinoW5dhA1', 'password', null));
+        $this->assertFalse($hasher->verify('$6$abcdefgh$yVfUwsw5T.JApa8POvClA1pQ5peiq97DUNyXCZN5IrF.BMSkiaLQ5kvpuEm/VQ1Tvh/KV2TcaWh8qinoW5dhA1', 'anotherPassword', null));
+    }
+
+    public function testHashLength()
+    {
+        $this->expectException(InvalidPasswordException::class);
+        $hasher = new SodiumPasswordHasher();
+        $hasher->hash(str_repeat('a', 4097), 'salt');
+    }
+
+    public function testCheckPasswordLength()
+    {
+        $hasher = new SodiumPasswordHasher();
+        $result = $hasher->hash(str_repeat('a', 4096), null);
+        $this->assertFalse($hasher->verify($result, str_repeat('a', 4097), null));
+        $this->assertTrue($hasher->verify($result, str_repeat('a', 4096), null));
+    }
+
+    public function testUserProvidedSaltIsNotUsed()
+    {
+        $hasher = new SodiumPasswordHasher();
+        $result = $hasher->hash('password', 'salt');
+        $this->assertTrue($hasher->verify($result, 'password', 'anotherSalt'));
+    }
+
+    public function testNeedsRehash()
+    {
+        $hasher = new SodiumPasswordHasher(4, 11000);
+
+        $this->assertTrue($hasher->needsRehash('dummyhash'));
+
+        $hash = $hasher->hash('foo', 'salt');
+        $this->assertFalse($hasher->needsRehash($hash));
+
+        $hasher = new SodiumPasswordHasher(5, 11000);
+        $this->assertTrue($hasher->needsRehash($hash));
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/UserPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/UserPasswordHasherTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PasswordHasher\Tests\Hasher;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
+use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
+
+class UserPasswordHasherTest extends TestCase
+{
+    public function testHash()
+    {
+        $userMock = $this->createMock('Symfony\Component\Security\Core\User\UserInterface');
+        $userMock->expects($this->any())
+            ->method('getSalt')
+            ->willReturn('userSalt');
+
+        $mockHasher = $this->createMock(PasswordHasherInterface::class);
+        $mockHasher->expects($this->any())
+            ->method('hash')
+            ->with($this->equalTo('plainPassword'), $this->equalTo('userSalt'))
+            ->willReturn('hash');
+
+        $mockPasswordHasherFactory = $this->createMock(PasswordHasherFactoryInterface::class);
+        $mockPasswordHasherFactory->expects($this->any())
+            ->method('getPasswordHasher')
+            ->with($this->equalTo($userMock))
+            ->willReturn($mockHasher);
+
+        $passwordHasher = new UserPasswordHasher($mockPasswordHasherFactory);
+
+        $encoded = $passwordHasher->hashPassword($userMock, 'plainPassword');
+        $this->assertEquals('hash', $encoded);
+    }
+
+    public function testVerify()
+    {
+        $userMock = $this->createMock(UserInterface::class);
+        $userMock->expects($this->any())
+            ->method('getSalt')
+            ->willReturn('userSalt');
+        $userMock->expects($this->any())
+            ->method('getPassword')
+            ->willReturn('hash');
+
+        $mockHasher = $this->createMock(PasswordHasherInterface::class);
+        $mockHasher->expects($this->any())
+            ->method('verify')
+            ->with($this->equalTo('hash'), $this->equalTo('plainPassword'), $this->equalTo('userSalt'))
+            ->willReturn(true);
+
+        $mockPasswordHasherFactory = $this->createMock(PasswordHasherFactoryInterface::class);
+        $mockPasswordHasherFactory->expects($this->any())
+            ->method('getPasswordHasher')
+            ->with($this->equalTo($userMock))
+            ->willReturn($mockHasher);
+
+        $passwordHasher = new UserPasswordHasher($mockPasswordHasherFactory);
+
+        $isValid = $passwordHasher->isPasswordValid($userMock, 'plainPassword');
+        $this->assertTrue($isValid);
+    }
+
+    public function testNeedsRehash()
+    {
+        $user = new User('username', null);
+        $hasher = new NativePasswordHasher(4, 20000, 4);
+
+        $mockPasswordHasherFactory = $this->createMock(PasswordHasherFactoryInterface::class);
+        $mockPasswordHasherFactory->expects($this->any())
+            ->method('getPasswordHasher')
+            ->with($user)
+            ->will($this->onConsecutiveCalls($hasher, $hasher, new NativePasswordHasher(5, 20000, 5), $hasher));
+
+        $passwordHasher = new UserPasswordHasher($mockPasswordHasherFactory);
+
+        $user->setPassword($passwordHasher->hashPassword($user, 'foo', 'salt'));
+        $this->assertFalse($passwordHasher->needsRehash($user));
+        $this->assertTrue($passwordHasher->needsRehash($user));
+        $this->assertFalse($passwordHasher->needsRehash($user));
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/composer.json
+++ b/src/Symfony/Component/PasswordHasher/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "symfony/password-hasher",
+    "type": "library",
+    "description": "Provides password hashing utilities",
+    "keywords": ["password", "hashing"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Robin Chalas",
+            "email": "robin.chalas@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=7.2.5",
+        "symfony/polyfill-php80": "^1.15"
+    },
+    "require-dev": {
+        "symfony/security-core": "^5.3",
+        "symfony/console": "^5"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\PasswordHasher\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/PasswordHasher/phpunit.xml.dist
+++ b/src/Symfony/Component/PasswordHasher/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Security Password Component Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.3
 ---
 
+ * Deprecate all classes in the `Core\Encoder\`  sub-namespace, use the `PasswordHasher` component instead
  * Deprecate the `SessionInterface $session` constructor argument of `SessionTokenStorage`, inject a `\Symfony\Component\HttpFoundation\RequestStack $requestStack` instead
  * Deprecate the `session` service provided by the ServiceLocator injected in `UsageTrackingTokenStorage`, provide a `request_stack` service instead
  * Deprecate using `SessionTokenStorage` outside a request context, it will throw a `SessionNotFoundException` in Symfony 6.0

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Authentication;
 
+use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\AuthenticationEvents;
@@ -18,6 +19,7 @@ use Symfony\Component\Security\Core\Event\AuthenticationFailureEvent;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
 use Symfony\Component\Security\Core\Exception\AccountStatusException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Exception\ProviderNotFoundException;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -89,6 +91,8 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
                 break;
             } catch (AuthenticationException $e) {
                 $lastException = $e;
+            } catch (InvalidPasswordException $e) {
+                $lastException = new BadCredentialsException('Bad credentials.', 0, $e);
             }
         }
 

--- a/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
@@ -11,10 +11,16 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', BasePasswordEncoder::class, CheckPasswordLengthTrait::class));
+
+use Symfony\Component\PasswordHasher\Hasher\CheckPasswordLengthTrait;
+
 /**
  * BasePasswordEncoder is the base class for all password encoders.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 5.3, use CheckPasswordLengthTrait instead
  */
 abstract class BasePasswordEncoder implements PasswordEncoderInterface
 {

--- a/src/Symfony/Component/Security/Core/Encoder/EncoderAwareInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/EncoderAwareInterface.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherAwareInterface;
+
 /**
  * @author Christophe Coevoet <stof@notk.org>
+ *
+ * @deprecated since Symfony 5.3, use {@link PasswordHasherAwareInterface} instead.
  */
 interface EncoderAwareInterface
 {

--- a/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
+++ b/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
@@ -11,12 +11,18 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', EncoderFactory::class, PasswordHasherFactory::class));
+
 use Symfony\Component\Security\Core\Exception\LogicException;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherAwareInterface;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
 
 /**
  * A generic encoder factory implementation.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated since Symfony 5.3, use {@link PasswordHasherFactory} instead
  */
 class EncoderFactory implements EncoderFactoryInterface
 {
@@ -34,7 +40,7 @@ class EncoderFactory implements EncoderFactoryInterface
     {
         $encoderKey = null;
 
-        if ($user instanceof EncoderAwareInterface && (null !== $encoderName = $user->getEncoderName())) {
+        if (($user instanceof PasswordHasherAwareInterface && null !== $encoderName = $user->getPasswordHasherName()) || ($user instanceof EncoderAwareInterface && null !== $encoderName = $user->getEncoderName())) {
             if (!\array_key_exists($encoderName, $this->encoders)) {
                 throw new \RuntimeException(sprintf('The encoder "%s" was not configured.', $encoderName));
             }

--- a/src/Symfony/Component/Security/Core/Encoder/EncoderFactoryInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/EncoderFactoryInterface.php
@@ -11,12 +11,17 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', EncoderFactoryInterface::class, PasswordHasherFactoryInterface::class));
+
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 
 /**
  * EncoderFactoryInterface to support different encoders for different accounts.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated since Symfony 5.3, use {@link PasswordHasherFactoryInterface} instead
  */
 interface EncoderFactoryInterface
 {

--- a/src/Symfony/Component/Security/Core/Encoder/LegacyEncoderTrait.php
+++ b/src/Symfony/Component/Security/Core/Encoder/LegacyEncoderTrait.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Encoder;
+
+use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
+use Symfony\Component\PasswordHasher\LegacyPasswordHasherInterface;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+
+/**
+ * @internal
+ */
+trait LegacyEncoderTrait
+{
+    /**
+     * @var PasswordHasherInterface|LegacyPasswordHasherInterface
+     */
+    private $hasher;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encodePassword(string $raw, ?string $salt): string
+    {
+        try {
+            return $this->hasher->hash($raw, $salt);
+        } catch (InvalidPasswordException $e) {
+            throw new BadCredentialsException('Bad credentials.');
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPasswordValid(string $encoded, string $raw, ?string $salt): bool
+    {
+        return $this->hasher->verify($encoded, $raw, $salt);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function needsRehash(string $encoded): bool
+    {
+        return $this->hasher->needsRehash($encoded);
+    }
+}

--- a/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php
@@ -11,19 +11,20 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', MessageDigestPasswordEncoder::class, MessageDigestPasswordHasher::class));
+
+use Symfony\Component\PasswordHasher\Hasher\MessageDigestPasswordHasher;
 
 /**
  * MessageDigestPasswordEncoder uses a message digest algorithm.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 5.3, use {@link MessageDigestPasswordHasher} instead
  */
 class MessageDigestPasswordEncoder extends BasePasswordEncoder
 {
-    private $algorithm;
-    private $encodeHashAsBase64;
-    private $iterations = 1;
-    private $encodedLength = -1;
+    use LegacyEncoderTrait;
 
     /**
      * @param string $algorithm          The digest algorithm to use
@@ -32,51 +33,6 @@ class MessageDigestPasswordEncoder extends BasePasswordEncoder
      */
     public function __construct(string $algorithm = 'sha512', bool $encodeHashAsBase64 = true, int $iterations = 5000)
     {
-        $this->algorithm = $algorithm;
-        $this->encodeHashAsBase64 = $encodeHashAsBase64;
-
-        try {
-            $this->encodedLength = \strlen($this->encodePassword('', 'salt'));
-        } catch (\LogicException $e) {
-            // ignore algorithm not supported
-        }
-
-        $this->iterations = $iterations;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function encodePassword(string $raw, ?string $salt)
-    {
-        if ($this->isPasswordTooLong($raw)) {
-            throw new BadCredentialsException('Invalid password.');
-        }
-
-        if (!\in_array($this->algorithm, hash_algos(), true)) {
-            throw new \LogicException(sprintf('The algorithm "%s" is not supported.', $this->algorithm));
-        }
-
-        $salted = $this->mergePasswordAndSalt($raw, $salt);
-        $digest = hash($this->algorithm, $salted, true);
-
-        // "stretch" hash
-        for ($i = 1; $i < $this->iterations; ++$i) {
-            $digest = hash($this->algorithm, $digest.$salted, true);
-        }
-
-        return $this->encodeHashAsBase64 ? base64_encode($digest) : bin2hex($digest);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isPasswordValid(string $encoded, string $raw, ?string $salt)
-    {
-        if (\strlen($encoded) !== $this->encodedLength || false !== strpos($encoded, '$')) {
-            return false;
-        }
-
-        return !$this->isPasswordTooLong($raw) && $this->comparePasswords($encoded, $this->encodePassword($raw, $salt));
+        $this->hasher = new MessageDigestPasswordHasher($algorithm, $encodeHashAsBase64, $iterations);
     }
 }

--- a/src/Symfony/Component/Security/Core/Encoder/MigratingPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/MigratingPasswordEncoder.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', MigratingPasswordEncoder::class, MigratingPasswordHasher::class));
+
+use Symfony\Component\PasswordHasher\Hasher\MigratingPasswordHasher;
+
 /**
  * Hashes passwords using the best available encoder.
  * Validates them using a chain of encoders.
@@ -19,12 +23,11 @@ namespace Symfony\Component\Security\Core\Encoder;
  * could be used to authenticate successfully without knowing the cleartext password.
  *
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @deprecated since Symfony 5.3, use {@link MigratingPasswordHasher} instead
  */
 final class MigratingPasswordEncoder extends BasePasswordEncoder implements SelfSaltingEncoderInterface
 {
-    private $bestEncoder;
-    private $extraEncoders;
-
     public function __construct(PasswordEncoderInterface $bestEncoder, PasswordEncoderInterface ...$extraEncoders)
     {
         $this->bestEncoder = $bestEncoder;

--- a/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
@@ -11,7 +11,10 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', NativePasswordEncoder::class, NativePasswordHasher::class));
+
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
 
 /**
  * Hashes passwords using password_hash().
@@ -19,105 +22,18 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
  * @author Elnur Abdurrakhimov <elnur@elnur.pro>
  * @author Terje Bråten <terje@braten.be>
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @deprecated since Symfony 5.3, use {@link NativePasswordHasher} instead
  */
 final class NativePasswordEncoder implements PasswordEncoderInterface, SelfSaltingEncoderInterface
 {
-    private const MAX_PASSWORD_LENGTH = 4096;
-
-    private $algo = \PASSWORD_BCRYPT;
-    private $options;
+    use LegacyEncoderTrait;
 
     /**
      * @param string|null $algo An algorithm supported by password_hash() or null to use the stronger available algorithm
      */
     public function __construct(int $opsLimit = null, int $memLimit = null, int $cost = null, string $algo = null)
     {
-        $cost = $cost ?? 13;
-        $opsLimit = $opsLimit ?? max(4, \defined('SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE') ? \SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE : 4);
-        $memLimit = $memLimit ?? max(64 * 1024 * 1024, \defined('SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE') ? \SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE : 64 * 1024 * 1024);
-
-        if (3 > $opsLimit) {
-            throw new \InvalidArgumentException('$opsLimit must be 3 or greater.');
-        }
-
-        if (10 * 1024 > $memLimit) {
-            throw new \InvalidArgumentException('$memLimit must be 10k or greater.');
-        }
-
-        if ($cost < 4 || 31 < $cost) {
-            throw new \InvalidArgumentException('$cost must be in the range of 4-31.');
-        }
-
-        $algos = [1 => \PASSWORD_BCRYPT, '2y' => \PASSWORD_BCRYPT];
-
-        if (\defined('PASSWORD_ARGON2I')) {
-            $this->algo = $algos[2] = $algos['argon2i'] = (string) \PASSWORD_ARGON2I;
-        }
-
-        if (\defined('PASSWORD_ARGON2ID')) {
-            $this->algo = $algos[3] = $algos['argon2id'] = (string) \PASSWORD_ARGON2ID;
-        }
-
-        if (null !== $algo) {
-            $this->algo = $algos[$algo] ?? $algo;
-        }
-
-        $this->options = [
-            'cost' => $cost,
-            'time_cost' => $opsLimit,
-            'memory_cost' => $memLimit >> 10,
-            'threads' => 1,
-        ];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function encodePassword(string $raw, ?string $salt): string
-    {
-        if (\strlen($raw) > self::MAX_PASSWORD_LENGTH || ((string) \PASSWORD_BCRYPT === $this->algo && 72 < \strlen($raw))) {
-            throw new BadCredentialsException('Invalid password.');
-        }
-
-        // Ignore $salt, the auto-generated one is always the best
-
-        return password_hash($raw, $this->algo, $this->options);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isPasswordValid(string $encoded, string $raw, ?string $salt): bool
-    {
-        if ('' === $raw) {
-            return false;
-        }
-
-        if (\strlen($raw) > self::MAX_PASSWORD_LENGTH) {
-            return false;
-        }
-
-        if (0 !== strpos($encoded, '$argon')) {
-            // BCrypt encodes only the first 72 chars
-            return (72 >= \strlen($raw) || 0 !== strpos($encoded, '$2')) && password_verify($raw, $encoded);
-        }
-
-        if (\extension_loaded('sodium') && version_compare(\SODIUM_LIBRARY_VERSION, '1.0.14', '>=')) {
-            return sodium_crypto_pwhash_str_verify($encoded, $raw);
-        }
-
-        if (\extension_loaded('libsodium') && version_compare(phpversion('libsodium'), '1.0.14', '>=')) {
-            return \Sodium\crypto_pwhash_str_verify($encoded, $raw);
-        }
-
-        return password_verify($raw, $encoded);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function needsRehash(string $encoded): bool
-    {
-        return password_needs_rehash($encoded, $this->algo, $this->options);
+        $this->hasher = new NativePasswordHasher($opsLimit, $memLimit, $cost, $algo);
     }
 }

--- a/src/Symfony/Component/Security/Core/Encoder/PasswordEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PasswordEncoderInterface.php
@@ -11,12 +11,17 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', PasswordEncoderInterface::class, PasswordHasherInterface::class));
+
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
 /**
  * PasswordEncoderInterface is the interface for all encoders.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 5.3, use {@link PasswordHasherInterface} instead
  */
 interface PasswordEncoderInterface
 {

--- a/src/Symfony/Component/Security/Core/Encoder/Pbkdf2PasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/Pbkdf2PasswordEncoder.php
@@ -11,7 +11,10 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', Pbkdf2PasswordEncoder::class, Pbkdf2PasswordHasher::class));
+
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\PasswordHasher\Hasher\Pbkdf2PasswordHasher;
 
 /**
  * Pbkdf2PasswordEncoder uses the PBKDF2 (Password-Based Key Derivation Function 2).
@@ -25,14 +28,12 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
  * @author Andrew Johnson
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 5.3, use {@link Pbkdf2PasswordHasher} instead
  */
 class Pbkdf2PasswordEncoder extends BasePasswordEncoder
 {
-    private $algorithm;
-    private $encodeHashAsBase64;
-    private $iterations = 1;
-    private $length;
-    private $encodedLength = -1;
+    use LegacyEncoderTrait;
 
     /**
      * @param string $algorithm          The digest algorithm to use
@@ -42,48 +43,6 @@ class Pbkdf2PasswordEncoder extends BasePasswordEncoder
      */
     public function __construct(string $algorithm = 'sha512', bool $encodeHashAsBase64 = true, int $iterations = 1000, int $length = 40)
     {
-        $this->algorithm = $algorithm;
-        $this->encodeHashAsBase64 = $encodeHashAsBase64;
-        $this->length = $length;
-
-        try {
-            $this->encodedLength = \strlen($this->encodePassword('', 'salt'));
-        } catch (\LogicException $e) {
-            // ignore algorithm not supported
-        }
-
-        $this->iterations = $iterations;
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws \LogicException when the algorithm is not supported
-     */
-    public function encodePassword(string $raw, ?string $salt)
-    {
-        if ($this->isPasswordTooLong($raw)) {
-            throw new BadCredentialsException('Invalid password.');
-        }
-
-        if (!\in_array($this->algorithm, hash_algos(), true)) {
-            throw new \LogicException(sprintf('The algorithm "%s" is not supported.', $this->algorithm));
-        }
-
-        $digest = hash_pbkdf2($this->algorithm, $raw, $salt, $this->iterations, $this->length, true);
-
-        return $this->encodeHashAsBase64 ? base64_encode($digest) : bin2hex($digest);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isPasswordValid(string $encoded, string $raw, ?string $salt)
-    {
-        if (\strlen($encoded) !== $this->encodedLength || false !== strpos($encoded, '$')) {
-            return false;
-        }
-
-        return !$this->isPasswordTooLong($raw) && $this->comparePasswords($encoded, $this->encodePassword($raw, $salt));
+        $this->hasher = new Pbkdf2PasswordHasher($algorithm, $encodeHashAsBase64, $iterations, $length);
     }
 }

--- a/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', PlaintextPasswordEncoder::class, PlaintextPasswordHasher::class));
+
+use Symfony\Component\PasswordHasher\Hasher\PlaintextPasswordHasher;
 
 /**
  * PlaintextPasswordEncoder does not do any encoding but is useful in testing environments.
@@ -19,46 +21,18 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
  * As this encoder is not cryptographically secure, usage of it in production environments is discouraged.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 5.3, use {@link PlaintextPasswordHasher} instead
  */
 class PlaintextPasswordEncoder extends BasePasswordEncoder
 {
-    private $ignorePasswordCase;
+    use LegacyEncoderTrait;
 
     /**
      * @param bool $ignorePasswordCase Compare password case-insensitive
      */
     public function __construct(bool $ignorePasswordCase = false)
     {
-        $this->ignorePasswordCase = $ignorePasswordCase;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function encodePassword(string $raw, ?string $salt)
-    {
-        if ($this->isPasswordTooLong($raw)) {
-            throw new BadCredentialsException('Invalid password.');
-        }
-
-        return $this->mergePasswordAndSalt($raw, $salt);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isPasswordValid(string $encoded, string $raw, ?string $salt)
-    {
-        if ($this->isPasswordTooLong($raw)) {
-            return false;
-        }
-
-        $pass2 = $this->mergePasswordAndSalt($raw, $salt);
-
-        if (!$this->ignorePasswordCase) {
-            return $this->comparePasswords($encoded, $pass2);
-        }
-
-        return $this->comparePasswords(strtolower($encoded), strtolower($pass2));
+        $this->hasher = new PlaintextPasswordHasher($ignorePasswordCase);
     }
 }

--- a/src/Symfony/Component/Security/Core/Encoder/SelfSaltingEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/SelfSaltingEncoderInterface.php
@@ -11,11 +11,17 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" interface is deprecated, use "%s" on hasher implementations that deal with salts instead.', SelfSaltingEncoderInterface::class, LegacyPasswordHasherInterface::class));
+
+use Symfony\Component\PasswordHasher\LegacyPasswordHasherInterface;
+
 /**
  * SelfSaltingEncoderInterface is a marker interface for encoders that do not
  * require a user-generated salt.
  *
  * @author Zan Baldwin <hello@zanbaldwin.com>
+ *
+ * @deprecated since Symfony 5.3, use {@link LegacyPasswordHasherInterface} instead
  */
 interface SelfSaltingEncoderInterface
 {

--- a/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
@@ -11,8 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-use Symfony\Component\Security\Core\Exception\BadCredentialsException;
-use Symfony\Component\Security\Core\Exception\LogicException;
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', SodiumPasswordEncoder::class, SodiumPasswordHasher::class));
+
+use Symfony\Component\PasswordHasher\Hasher\SodiumPasswordHasher;
 
 /**
  * Hashes passwords using libsodium.
@@ -20,99 +21,20 @@ use Symfony\Component\Security\Core\Exception\LogicException;
  * @author Robin Chalas <robin.chalas@gmail.com>
  * @author Zan Baldwin <hello@zanbaldwin.com>
  * @author Dominik Müller <dominik.mueller@jkweb.ch>
+ *
+ * @deprecated since Symfony 5.3, use {@link SodiumPasswordHasher} instead
  */
 final class SodiumPasswordEncoder implements PasswordEncoderInterface, SelfSaltingEncoderInterface
 {
-    private const MAX_PASSWORD_LENGTH = 4096;
-
-    private $opsLimit;
-    private $memLimit;
+    use LegacyEncoderTrait;
 
     public function __construct(int $opsLimit = null, int $memLimit = null)
     {
-        if (!self::isSupported()) {
-            throw new LogicException('Libsodium is not available. You should either install the sodium extension, upgrade to PHP 7.2+ or use a different encoder.');
-        }
-
-        $this->opsLimit = $opsLimit ?? max(4, \defined('SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE') ? \SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE : 4);
-        $this->memLimit = $memLimit ?? max(64 * 1024 * 1024, \defined('SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE') ? \SODIUM_CRYPTO_PWHASH_MEMLIMIT_INTERACTIVE : 64 * 1024 * 1024);
-
-        if (3 > $this->opsLimit) {
-            throw new \InvalidArgumentException('$opsLimit must be 3 or greater.');
-        }
-
-        if (10 * 1024 > $this->memLimit) {
-            throw new \InvalidArgumentException('$memLimit must be 10k or greater.');
-        }
+        $this->hasher = new SodiumPasswordHasher($opsLimit, $memLimit);
     }
 
     public static function isSupported(): bool
     {
-        return version_compare(\extension_loaded('sodium') ? \SODIUM_LIBRARY_VERSION : phpversion('libsodium'), '1.0.14', '>=');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function encodePassword(string $raw, ?string $salt): string
-    {
-        if (\strlen($raw) > self::MAX_PASSWORD_LENGTH) {
-            throw new BadCredentialsException('Invalid password.');
-        }
-
-        if (\function_exists('sodium_crypto_pwhash_str')) {
-            return sodium_crypto_pwhash_str($raw, $this->opsLimit, $this->memLimit);
-        }
-
-        if (\extension_loaded('libsodium')) {
-            return \Sodium\crypto_pwhash_str($raw, $this->opsLimit, $this->memLimit);
-        }
-
-        throw new LogicException('Libsodium is not available. You should either install the sodium extension, upgrade to PHP 7.2+ or use a different encoder.');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isPasswordValid(string $encoded, string $raw, ?string $salt): bool
-    {
-        if ('' === $raw) {
-            return false;
-        }
-
-        if (\strlen($raw) > self::MAX_PASSWORD_LENGTH) {
-            return false;
-        }
-
-        if (0 !== strpos($encoded, '$argon')) {
-            // Accept validating non-argon passwords for seamless migrations
-            return (72 >= \strlen($raw) || 0 !== strpos($encoded, '$2')) && password_verify($raw, $encoded);
-        }
-
-        if (\function_exists('sodium_crypto_pwhash_str_verify')) {
-            return sodium_crypto_pwhash_str_verify($encoded, $raw);
-        }
-
-        if (\extension_loaded('libsodium')) {
-            return \Sodium\crypto_pwhash_str_verify($encoded, $raw);
-        }
-
-        return false;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function needsRehash(string $encoded): bool
-    {
-        if (\function_exists('sodium_crypto_pwhash_str_needs_rehash')) {
-            return sodium_crypto_pwhash_str_needs_rehash($encoded, $this->opsLimit, $this->memLimit);
-        }
-
-        if (\extension_loaded('libsodium')) {
-            return \Sodium\crypto_pwhash_str_needs_rehash($encoded, $this->opsLimit, $this->memLimit);
-        }
-
-        throw new LogicException('Libsodium is not available. You should either install the sodium extension, upgrade to PHP 7.2+ or use a different encoder.');
+        return SodiumPasswordHasher::isSupported();
     }
 }

--- a/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoder.php
@@ -11,12 +11,17 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', UserPasswordEncoder::class, UserPasswordHasher::class));
+
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
 
 /**
  * A generic password encoder.
  *
  * @author Ariel Ferrandini <arielferrandini@gmail.com>
+ *
+ * @deprecated since Symfony 5.3, use {@link UserPasswordHasher} instead
  */
 class UserPasswordEncoder implements UserPasswordEncoderInterface
 {

--- a/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoderInterface.php
@@ -11,12 +11,17 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" interface is deprecated, use "%s" on hasher implementations that deal with salts instead.', UserPasswordEncoderInterface::class, UserPasswordHasherInterface::class));
+
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
  * UserPasswordEncoderInterface is the interface for the password encoder service.
  *
  * @author Ariel Ferrandini <arielferrandini@gmail.com>
+ *
+ * @deprecated since Symfony 5.3, use {@link UserPasswordHasherInterface} instead
  */
 interface UserPasswordEncoderInterface
 {

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/EncoderFactoryTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/EncoderFactoryTest.php
@@ -20,7 +20,13 @@ use Symfony\Component\Security\Core\Encoder\NativePasswordEncoder;
 use Symfony\Component\Security\Core\Encoder\SodiumPasswordEncoder;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherAwareInterface;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
+use Symfony\Component\PasswordHasher\Hasher\MessageDigestPasswordHasher;
 
+/**
+ * @group legacy
+ */
 class EncoderFactoryTest extends TestCase
 {
     public function testGetEncoderWithMessageDigestEncoder()
@@ -176,6 +182,17 @@ class EncoderFactoryTest extends TestCase
             (new EncoderFactory([SomeUser::class => ['class' => SodiumPasswordEncoder::class, 'arguments' => []]]))->getEncoder(SomeUser::class)
         );
     }
+
+    public function testHasherAwareCompat()
+    {
+        $factory = new PasswordHasherFactory([
+            'encoder_name' => new MessageDigestPasswordHasher('sha1'),
+        ]);
+
+        $encoder = $factory->getPasswordHasher(new HasherAwareUser('user', 'pass'));
+        $expectedEncoder = new MessageDigestPasswordHasher('sha1');
+        $this->assertEquals($expectedEncoder->hash('foo', ''), $encoder->hash('foo', ''));
+    }
 }
 
 class SomeUser implements UserInterface
@@ -212,5 +229,16 @@ class EncAwareUser extends SomeUser implements EncoderAwareInterface
     public function getEncoderName(): ?string
     {
         return $this->encoderName;
+    }
+}
+
+
+class HasherAwareUser extends SomeUser implements PasswordHasherAwareInterface
+{
+    public $hasherName = 'encoder_name';
+
+    public function getPasswordHasherName(): ?string
+    {
+        return $this->hasherName;
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/MessageDigestPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/MessageDigestPasswordEncoderTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Encoder\MessageDigestPasswordEncoder;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
+/**
+ * @group legacy
+ */
 class MessageDigestPasswordEncoderTest extends TestCase
 {
     public function testIsPasswordValid()

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/MigratingPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/MigratingPasswordEncoderTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Encoder\MigratingPasswordEncoder;
 use Symfony\Component\Security\Core\Encoder\NativePasswordEncoder;
 
+/**
+ * @group legacy
+ */
 class MigratingPasswordEncoderTest extends TestCase
 {
     public function testValidation()

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/NativePasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/NativePasswordEncoderTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Security\Core\Encoder\NativePasswordEncoder;
 
 /**
  * @author Elnur Abdurrakhimov <elnur@elnur.pro>
+ * @group legacy
  */
 class NativePasswordEncoderTest extends TestCase
 {

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/Pbkdf2PasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/Pbkdf2PasswordEncoderTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Encoder\Pbkdf2PasswordEncoder;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
+/**
+ * @group legacy
+ */
 class Pbkdf2PasswordEncoderTest extends TestCase
 {
     public function testIsPasswordValid()

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/PlaintextPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/PlaintextPasswordEncoderTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
+/**
+ * @group legacy
+ */
 class PlaintextPasswordEncoderTest extends TestCase
 {
     public function testIsPasswordValid()

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/SodiumPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/SodiumPasswordEncoderTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Encoder\SodiumPasswordEncoder;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
+/**
+ * @group legacy
+ */
 class SodiumPasswordEncoderTest extends TestCase
 {
     protected function setUp(): void

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/TestPasswordEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/TestPasswordEncoderInterface.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Security\Core\Tests\Encoder;
 
 use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 
+/**
+ * @group legacy
+ */
 interface TestPasswordEncoderInterface extends PasswordEncoderInterface
 {
     public function needsRehash(string $encoded): bool;

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/UserPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/UserPasswordEncoderTest.php
@@ -19,6 +19,9 @@ use Symfony\Component\Security\Core\Encoder\UserPasswordEncoder;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserInterface;
 
+/**
+ * @group legacy
+ */
 class UserPasswordEncoderTest extends TestCase
 {
     public function testEncodePassword()

--- a/src/Symfony/Component/Security/Core/User/PasswordUpgraderInterface.php
+++ b/src/Symfony/Component/Security/Core/User/PasswordUpgraderInterface.php
@@ -17,11 +17,11 @@ namespace Symfony\Component\Security\Core\User;
 interface PasswordUpgraderInterface
 {
     /**
-     * Upgrades the encoded password of a user, typically for using a better hash algorithm.
+     * Upgrades the hashed password of a user, typically for using a better hash algorithm.
      *
      * This method should persist the new password in the user storage and update the $user object accordingly.
      * Because you don't want your users not being able to log in, this method should be opportunistic:
      * it's fine if it does nothing or if it fails without throwing any exception.
      */
-    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void;
+    public function upgradePassword(UserInterface $user, string $newHashedPassword): void;
 }

--- a/src/Symfony/Component/Security/Core/User/UserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserInterface.php
@@ -15,7 +15,7 @@ namespace Symfony\Component\Security\Core\User;
  * Represents the interface that all user classes must implement.
  *
  * This interface is useful because the authentication layer can deal with
- * the object through its lifecycle, using the object to get the encoded
+ * the object through its lifecycle, using the object to get the hashed
  * password (for checking against a submitted password), assigning roles
  * and so on.
  *
@@ -49,17 +49,17 @@ interface UserInterface
     /**
      * Returns the password used to authenticate the user.
      *
-     * This should be the encoded password. On authentication, a plain-text
-     * password will be salted, encoded, and then compared to this value.
+     * This should be the hashed password. On authentication, a plain-text
+     * password will be hashed, and then compared to this value.
      *
-     * @return string|null The encoded password if any
+     * @return string|null The hashed password if any
      */
     public function getPassword();
 
     /**
-     * Returns the salt that was originally used to encode the password.
+     * Returns the salt that was originally used to hash the password.
      *
-     * This can return null if the password was not encoded using a salt.
+     * This can return null if the password was not hashed using a salt.
      *
      * @return string|null The salt
      */

--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
@@ -13,7 +13,9 @@ namespace Symfony\Component\Security\Core\Validator\Constraints;
 
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
@@ -22,12 +24,19 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class UserPasswordValidator extends ConstraintValidator
 {
     private $tokenStorage;
-    private $encoderFactory;
+    private $hasherFactory;
 
-    public function __construct(TokenStorageInterface $tokenStorage, EncoderFactoryInterface $encoderFactory)
+    /**
+     * @param PasswordHasherFactoryInterface $hasherFactory
+     */
+    public function __construct(TokenStorageInterface $tokenStorage, $hasherFactory)
     {
+        if ($hasherFactory instanceof EncoderFactoryInterface) {
+           trigger_deprecation('symfony/security-core', '5.3', 'Passing a "%s" instance to the "%s" constructor is deprecated, use "%s" instead.', EncoderFactoryInterface::class, __CLASS__, PasswordHasherFactoryInterface::class);
+        }
+
         $this->tokenStorage = $tokenStorage;
-        $this->encoderFactory = $encoderFactory;
+        $this->hasherFactory = $hasherFactory;
     }
 
     /**
@@ -51,9 +60,9 @@ class UserPasswordValidator extends ConstraintValidator
             throw new ConstraintDefinitionException('The User object must implement the UserInterface interface.');
         }
 
-        $encoder = $this->encoderFactory->getEncoder($user);
+        $hasher = $this->hasherFactory instanceof EncoderFactoryInterface ? $this->hasherFactory->getEncoder($user) : $this->hasherFactory->getPasswordHasher($user);
 
-        if (null === $user->getPassword() || !$encoder->isPasswordValid($user->getPassword(), $password, $user->getSalt())) {
+        if (null === $user->getPassword() || !($hasher instanceof PasswordEncoderInterface ? $hasher->isPasswordValid($user->getPassword(), $password, $user->getSalt()) : $hasher->verify($user->getPassword(), $password, $user->getSalt()))) {
             $this->context->addViolation($constraint->message);
         }
     }

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -20,7 +20,8 @@
         "symfony/event-dispatcher-contracts": "^1.1|^2",
         "symfony/polyfill-php80": "^1.15",
         "symfony/service-contracts": "^1.1.6|^2",
-        "symfony/deprecation-contracts": "^2.1"
+        "symfony/deprecation-contracts": "^2.1",
+        "symfony/password-hasher": "^5.3"
     },
     "require-dev": {
         "psr/container": "^1.0",

--- a/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Guard\Provider;
 
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\AuthenticationExpiredException;
@@ -26,6 +27,7 @@ use Symfony\Component\Security\Guard\AuthenticatorInterface;
 use Symfony\Component\Security\Guard\PasswordAuthenticatedInterface;
 use Symfony\Component\Security\Guard\Token\GuardTokenInterface;
 use Symfony\Component\Security\Guard\Token\PreAuthenticationGuardToken;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 /**
  * Responsible for accepting the PreAuthenticationGuardToken and calling
@@ -42,19 +44,24 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
     private $userProvider;
     private $providerKey;
     private $userChecker;
-    private $passwordEncoder;
+    private $passwordHasher;
 
     /**
      * @param iterable|AuthenticatorInterface[] $guardAuthenticators The authenticators, with keys that match what's passed to GuardAuthenticationListener
      * @param string                            $providerKey         The provider (i.e. firewall) key
+     * @param UserPasswordHasherInterface       $passwordHasher
      */
-    public function __construct(iterable $guardAuthenticators, UserProviderInterface $userProvider, string $providerKey, UserCheckerInterface $userChecker, UserPasswordEncoderInterface $passwordEncoder = null)
+    public function __construct(iterable $guardAuthenticators, UserProviderInterface $userProvider, string $providerKey, UserCheckerInterface $userChecker, $passwordHasher = null)
     {
         $this->guardAuthenticators = $guardAuthenticators;
         $this->userProvider = $userProvider;
         $this->providerKey = $providerKey;
         $this->userChecker = $userChecker;
-        $this->passwordEncoder = $passwordEncoder;
+        $this->passwordHasher = $passwordHasher;
+
+        if ($passwordHasher instanceof UserPasswordEncoderInterface) {
+            trigger_deprecation('symfony/security-core', '5.3', sprintf('Passing a "%s" instance to the "%s" constructor is deprecated, use "%s" instead.', UserPasswordEncoderInterface::class, __CLASS__, UserPasswordHasherInterface::class));
+        }
     }
 
     /**
@@ -123,8 +130,13 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
 
             throw new BadCredentialsException(sprintf('Authentication failed because "%s::checkCredentials()" did not return true.', get_debug_type($guardAuthenticator)));
         }
-        if ($this->userProvider instanceof PasswordUpgraderInterface && $guardAuthenticator instanceof PasswordAuthenticatedInterface && null !== $this->passwordEncoder && (null !== $password = $guardAuthenticator->getPassword($token->getCredentials())) && method_exists($this->passwordEncoder, 'needsRehash') && $this->passwordEncoder->needsRehash($user)) {
-            $this->userProvider->upgradePassword($user, $this->passwordEncoder->encodePassword($user, $password));
+        if ($this->userProvider instanceof PasswordUpgraderInterface && $guardAuthenticator instanceof PasswordAuthenticatedInterface && null !== $this->passwordHasher && (null !== $password = $guardAuthenticator->getPassword($token->getCredentials())) && method_exists($this->passwordHasher, 'needsRehash') && $this->passwordHasher->needsRehash($user)) {
+            if ($this->passwordHasher instanceof PasswordEncoderInterface) {
+                // @deprecated since Symfony 5.3
+                $this->userProvider->upgradePassword($user, $this->passwordHasher->encodePassword($user, $password));
+            } else {
+                $this->userProvider->upgradePassword($user, $this->passwordHasher->hashPassword($user, $password));
+            }
         }
         $this->userChecker->checkPostAuth($user);
 

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/HttpBasicAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/HttpBasicAuthenticatorTest.php
@@ -4,31 +4,31 @@ namespace Symfony\Component\Security\Http\Tests\Authenticator;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
-use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authenticator\HttpBasicAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PasswordUpgradeBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
 use Symfony\Component\Security\Http\Tests\Authenticator\Fixtures\PasswordUpgraderProvider;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
 class HttpBasicAuthenticatorTest extends TestCase
 {
     private $userProvider;
-    private $encoderFactory;
-    private $encoder;
+    private $hasherFactory;
+    private $hasher;
     private $authenticator;
 
     protected function setUp(): void
     {
         $this->userProvider = $this->createMock(UserProviderInterface::class);
-        $this->encoderFactory = $this->createMock(EncoderFactoryInterface::class);
-        $this->encoder = $this->createMock(PasswordEncoderInterface::class);
-        $this->encoderFactory
+        $this->hasherFactory = $this->createMock(PasswordHasherFactoryInterface::class);
+        $this->hasher = $this->createMock(PasswordHasherInterface::class);
+        $this->hasherFactory
             ->expects($this->any())
-            ->method('getEncoder')
-            ->willReturn($this->encoder);
+            ->method('getPasswordHasher')
+            ->willReturn($this->hasher);
 
         $this->authenticator = new HttpBasicAuthenticator('test', $this->userProvider);
     }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/CheckCredentialsListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/CheckCredentialsListenerTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Security\Http\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
-use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
@@ -25,18 +24,20 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\EventListener\CheckCredentialsListener;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
 class CheckCredentialsListenerTest extends TestCase
 {
-    private $encoderFactory;
+    private $hasherFactory;
     private $listener;
     private $user;
 
     protected function setUp(): void
     {
-        $this->encoderFactory = $this->createMock(EncoderFactoryInterface::class);
-        $this->listener = new CheckCredentialsListener($this->encoderFactory);
-        $this->user = new User('wouter', 'encoded-password');
+        $this->hasherFactory = $this->createMock(PasswordHasherFactoryInterface::class);
+        $this->listener = new CheckCredentialsListener($this->hasherFactory);
+        $this->user = new User('wouter', 'password-hash');
     }
 
     /**
@@ -44,10 +45,10 @@ class CheckCredentialsListenerTest extends TestCase
      */
     public function testPasswordAuthenticated($password, $passwordValid, $result)
     {
-        $encoder = $this->createMock(PasswordEncoderInterface::class);
-        $encoder->expects($this->any())->method('isPasswordValid')->with('encoded-password', $password)->willReturn($passwordValid);
+        $hasher = $this->createMock(PasswordHasherInterface::class);
+        $hasher->expects($this->any())->method('verify')->with('password-hash', $password)->willReturn($passwordValid);
 
-        $this->encoderFactory->expects($this->any())->method('getEncoder')->with($this->identicalTo($this->user))->willReturn($encoder);
+        $this->hasherFactory->expects($this->any())->method('getPasswordHasher')->with($this->identicalTo($this->user))->willReturn($hasher);
 
         if (false === $result) {
             $this->expectException(BadCredentialsException::class);
@@ -73,7 +74,7 @@ class CheckCredentialsListenerTest extends TestCase
         $this->expectException(BadCredentialsException::class);
         $this->expectExceptionMessage('The presented password cannot be empty.');
 
-        $this->encoderFactory->expects($this->never())->method('getEncoder');
+        $this->hasherFactory->expects($this->never())->method('getPasswordHasher');
 
         $event = $this->createEvent(new Passport(new UserBadge('wouter', function () { return $this->user; }), new PasswordCredentials('')));
         $this->listener->checkPassport($event);
@@ -84,7 +85,7 @@ class CheckCredentialsListenerTest extends TestCase
      */
     public function testCustomAuthenticated($result)
     {
-        $this->encoderFactory->expects($this->never())->method('getEncoder');
+        $this->hasherFactory->expects($this->never())->method('getPasswordHasher');
 
         if (false === $result) {
             $this->expectException(BadCredentialsException::class);
@@ -108,7 +109,7 @@ class CheckCredentialsListenerTest extends TestCase
 
     public function testNoCredentialsBadgeProvided()
     {
-        $this->encoderFactory->expects($this->never())->method('getEncoder');
+        $this->hasherFactory->expects($this->never())->method('getPasswordHasher');
 
         $event = $this->createEvent(new SelfValidatingPassport(new UserBadge('wouter', function () { return $this->user; })));
         $this->listener->checkPassport($event);
@@ -116,10 +117,10 @@ class CheckCredentialsListenerTest extends TestCase
 
     public function testAddsPasswordUpgradeBadge()
     {
-        $encoder = $this->createMock(PasswordEncoderInterface::class);
-        $encoder->expects($this->any())->method('isPasswordValid')->with('encoded-password', 'ThePa$$word')->willReturn(true);
+        $hasher = $this->createMock(PasswordHasherInterface::class);
+        $hasher->expects($this->any())->method('verify')->with('password-hash', 'ThePa$$word')->willReturn(true);
 
-        $this->encoderFactory->expects($this->any())->method('getEncoder')->with($this->identicalTo($this->user))->willReturn($encoder);
+        $this->hasherFactory->expects($this->any())->method('getPasswordHasher')->with($this->identicalTo($this->user))->willReturn($hasher);
 
         $passport = new Passport(new UserBadge('wouter', function () { return $this->user; }), new PasswordCredentials('ThePa$$word'));
         $this->listener->checkPassport($this->createEvent($passport));
@@ -130,10 +131,10 @@ class CheckCredentialsListenerTest extends TestCase
 
     public function testAddsNoPasswordUpgradeBadgeIfItAlreadyExists()
     {
-        $encoder = $this->createMock(PasswordEncoderInterface::class);
-        $encoder->expects($this->any())->method('isPasswordValid')->with('encoded-password', 'ThePa$$word')->willReturn(true);
+        $hasher = $this->createMock(PasswordHasherInterface::class);
+        $hasher->expects($this->any())->method('verify')->with('password-hash', 'ThePa$$word')->willReturn(true);
 
-        $this->encoderFactory->expects($this->any())->method('getEncoder')->with($this->identicalTo($this->user))->willReturn($encoder);
+        $this->hasherFactory->expects($this->any())->method('getPasswordHasher')->with($this->identicalTo($this->user))->willReturn($hasher);
 
         $passport = $this->getMockBuilder(Passport::class)
             ->setMethods(['addBadge'])
@@ -147,10 +148,10 @@ class CheckCredentialsListenerTest extends TestCase
 
     public function testAddsNoPasswordUpgradeBadgeIfPasswordIsInvalid()
     {
-        $encoder = $this->createMock(PasswordEncoderInterface::class);
-        $encoder->expects($this->any())->method('isPasswordValid')->with('encoded-password', 'ThePa$$word')->willReturn(false);
+        $hasher = $this->createMock(PasswordHasherInterface::class);
+        $hasher->expects($this->any())->method('verify')->with('password-hash', 'ThePa$$word')->willReturn(false);
 
-        $this->encoderFactory->expects($this->any())->method('getEncoder')->with($this->identicalTo($this->user))->willReturn($encoder);
+        $this->hasherFactory->expects($this->any())->method('getPasswordHasher')->with($this->identicalTo($this->user))->willReturn($hasher);
 
         $passport = $this->getMockBuilder(Passport::class)
             ->setMethods(['addBadge'])

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/deprecation-contracts": "^2.1",
-        "symfony/security-core": "^5.2",
+        "symfony/security-core": "^5.3",
         "symfony/http-foundation": "^5.2",
         "symfony/http-kernel": "^5.2",
         "symfony/polyfill-php80": "^1.15",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fixes #39698
| License       | MIT
| Doc PR        | todo

This PR renames password "encoders" to password _hashers_ (naming widely used, see e.g. django or laravel).
This also takes the opportunity to extract the logic related to password hashing from security-core, moving it to a new password-hasher component.
Nowadays, many modern web apps and APIs don't deal with passwords at all, that's why splitting makes sense as a step towards making security-core not tied to the password concept.

For upgrading, applications will have to use `passwords_hashers` instead of `encoders` in their security configuration,  and type-hint against `PasswordHasherInterface` (and related) instead of `PasswordEncoderInterface`.

The proposed API is not much different from the encoder one regarding behavior and signatures, and it is slightly more close to the PHP built-in password hashing API:

```php
namespace Symfony\Component\PasswordHasher;

interface PasswordHasherInterface
{
    public function hash(string $plainPassword): string;

    public function verify(string $hashedPassword, string $plainPassword): bool;

    public function needsRehash(string $hashedPassword): bool;
}
```