### PR TITLE
[SecurityBundle] Remove invalid service definition

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\SecurityBundle\CacheWarmer\ExpressionCacheWarmer;
-use Symfony\Bundle\SecurityBundle\EventListener\FirewallEventBubblingListener;
 use Symfony\Bundle\SecurityBundle\EventListener\FirewallListener;
 use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
 use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
@@ -126,10 +125,6 @@ return static function (ContainerConfigurator $container) {
         ->set('security.authentication_utils', AuthenticationUtils::class)
             ->args([service('request_stack')])
         ->alias(AuthenticationUtils::class, 'security.authentication_utils')
-
-        ->set('security.event_dispatcher.event_bubbling_listener', FirewallEventBubblingListener::class)
-            ->abstract()
-            ->args([service('event_dispatcher')])
 
         // Authorization related services
         ->set('security.access.decision_manager', AccessDecisionManager::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Removes an abstract service definition that points to an undefined class: `FirewallEventBubblingListener` was part of the new authenticator system at some point, but was removed before being released.

Targets 5.2, as 5.1 will be soon EOL.