### PR TITLE
[DependencyInjection] Add a remove() method to the PHP configurator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3
+---
+
+ * Add `ServicesConfigurator::remove()` in the PHP-DSL
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractServiceConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractServiceConfigurator.php
@@ -82,6 +82,16 @@ abstract class AbstractServiceConfigurator extends AbstractConfigurator
     }
 
     /**
+     * Removes an already defined service definition or alias.
+     */
+    final public function remove(string $id): ServicesConfigurator
+    {
+        $this->__destruct();
+
+        return $this->parent->remove($id);
+    }
+
+    /**
      * Registers a stack of decorator services.
      *
      * @param InlineServiceConfigurator[]|ReferenceConfigurator[] $services

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServiceConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServiceConfigurator.php
@@ -45,6 +45,7 @@ class ServiceConfigurator extends AbstractServiceConfigurator
     private $instanceof;
     private $allowParent;
     private $path;
+    private $destructed = false;
 
     public function __construct(ContainerBuilder $container, array $instanceof, bool $allowParent, ServicesConfigurator $parent, Definition $definition, $id, array $defaultTags, string $path = null)
     {
@@ -58,6 +59,11 @@ class ServiceConfigurator extends AbstractServiceConfigurator
 
     public function __destruct()
     {
+        if ($this->destructed) {
+            return;
+        }
+        $this->destructed = true;
+
         parent::__destruct();
 
         $this->container->removeBindings($this->id);

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ServicesConfigurator.php
@@ -97,6 +97,17 @@ class ServicesConfigurator extends AbstractConfigurator
     }
 
     /**
+     * Removes an already defined service definition or alias.
+     */
+    final public function remove(string $id): self
+    {
+        $this->container->removeDefinition($id);
+        $this->container->removeAlias($id);
+
+        return $this;
+    }
+
+    /**
      * Creates an alias.
      */
     final public function alias(string $id, string $referencedId): AliasConfigurator

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/remove.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/remove.expected.yml
@@ -1,0 +1,9 @@
+
+services:
+    service_container:
+        class: Symfony\Component\DependencyInjection\ContainerInterface
+        public: true
+        synthetic: true
+    baz:
+        class: Symfony\Component\DependencyInjection\Loader\Configurator\BazService
+        public: true

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/remove.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/remove.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return function (ContainerConfigurator $c) {
+    $services = $c->services()->defaults()->public();
+
+    $services
+        ->set('foo', FooService::class)
+        ->remove('foo')
+
+        ->set('baz', BazService::class)
+        ->alias('baz-alias', 'baz')
+        ->remove('baz-alias')
+
+        ->remove('bat'); // noop
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -80,6 +80,7 @@ class PhpFileLoaderTest extends TestCase
         yield ['php7'];
         yield ['anonymous'];
         yield ['lazy_fqcn'];
+        yield ['remove'];
     }
 
     public function testAutoConfigureAndChildDefinition()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT
| Doc PR        | todo

This especially useful in the `configureContainer()` method of the kernel. It allows to not use a compiler pass to remove some services (for instance, in test mode).