### PR TITLE
Make EmailMessage & SmsMessage transport nullable

### DIFF
--- a/src/Symfony/Component/Notifier/Message/EmailMessage.php
+++ b/src/Symfony/Component/Notifier/Message/EmailMessage.php
@@ -97,10 +97,13 @@ final class EmailMessage implements MessageInterface
     /**
      * @return $this
      */
-    public function transport(string $transport): self
+    public function transport(?string $transport): self
     {
         if (!$this->message instanceof Email) {
             throw new LogicException('Cannot set a Transport on a RawMessage instance.');
+        }
+        if (null === $transport) {
+            return $this;
         }
 
         $this->message->getHeaders()->addTextHeader('X-Transport', $transport);

--- a/src/Symfony/Component/Notifier/Message/SmsMessage.php
+++ b/src/Symfony/Component/Notifier/Message/SmsMessage.php
@@ -81,7 +81,7 @@ final class SmsMessage implements MessageInterface
     /**
      * @return $this
      */
-    public function transport(string $transport): self
+    public function transport(?string $transport): self
     {
         $this->transport = $transport;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Ideally, this should have been done in #38361 as it's exactly the same problem: the `transport` method can be called with `null` with deserializing a message from json (for example).