### PR TITLE
[Messenger] fixed SQS recovery on connection get HTTP errors

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Added new `debug` option to log HTTP requests and responses.
  * Allowed for receiver & sender injection into AmazonSqsTransport
+ * Added support for AmazonSqsReceiver recovery on connection get HTTP errors
 
 5.2.0
 -----

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Exception/SqsConnectionException.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Exception/SqsConnectionException.php
@@ -1,9 +1,19 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Exception;
 
 use Symfony\Component\Messenger\Exception\RecoverableExceptionInterface;
 use Symfony\Component\Messenger\Exception\TransportException;
 
 class SqsConnectionException extends TransportException implements RecoverableExceptionInterface
-{}
+{
+}

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Exception/SqsConnectionException.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Exception/SqsConnectionException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\Messenger\Bridge\AmazonSqs\Exception;
+
+use Symfony\Component\Messenger\Exception\RecoverableExceptionInterface;
+use Symfony\Component\Messenger\Exception\TransportException;
+
+class SqsConnectionException extends TransportException implements RecoverableExceptionInterface
+{}

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/AmazonSqsReceiver.php
@@ -15,6 +15,7 @@ use AsyncAws\Core\Exception\Http\HttpException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
+use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
@@ -43,7 +44,7 @@ class AmazonSqsReceiver implements ReceiverInterface, MessageCountAwareInterface
         try {
             $sqsEnvelope = $this->connection->get();
         } catch (HttpException $e) {
-            throw new TransportException($e->getMessage(), 0, $e);
+            throw new RecoverableMessageHandlingException($e->getMessage(), 0, $e);
         }
         if (null === $sqsEnvelope) {
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #39784
| License       | MIT
| Doc PR        | symfony/symfony-docs#14829

e.g. when AWS HTTP 500 internal error leads to `ServerException`s, this is temporary and not specific to
the contents of a message (which won't have been received). So it should use the new `RecoverableExceptionInterface`
marker to indicate that we should always retry in this scenario.