### PR TITLE
Use lowest supported PHP version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
         strategy:
             matrix:
-                php: ['7.1', '7.4']
+                php: ['7.1.3', '7.4']
 
         services:
             ldap:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

I propose to use the lowest supported version, not the latest 7.1 version:
https://github.com/symfony/symfony/blob/d23b74ebcec187e02654dc21b5f099c362452569/composer.json#L19