### PR TITLE
Use lowest supported PHP version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
         strategy:
             matrix:
-                php: ['7.2', '7.4']
+                php: ['7.2.5', '7.4']
 
         services:
             ldap:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

Same like #39818 but for `5.1` branch

I propose to use the lowest supported version, not the latest 7.2 version:
https://github.com/symfony/symfony/blob/db8ef3042a02383a9a2a3b6f81613994b3f648ea/composer.json#L19