### PR TITLE
[DependencyInjection] Don't trigger notice for deprecated aliases pointing to deprecated definitions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
@@ -62,7 +62,10 @@ class ResolveReferencesToAliasesPass extends AbstractRecursivePass
         $alias = $container->getAlias($id);
 
         if ($alias->isDeprecated()) {
-            @trigger_error(sprintf('%s. It is being referenced by the "%s" %s.', rtrim($alias->getDeprecationMessage($id), '. '), $this->currentId, $container->hasDefinition($this->currentId) ? 'service' : 'alias'), \E_USER_DEPRECATED);
+            $referencingDefinition = $container->hasDefinition($this->currentId) ? $container->getDefinition($this->currentId) : $container->getAlias($this->currentId);
+            if (!$referencingDefinition->isDeprecated()) {
+                @trigger_error(sprintf('%s. It is being referenced by the "%s" %s.', rtrim($alias->getDeprecationMessage($id), '. '), $this->currentId, $container->hasDefinition($this->currentId) ? 'service' : 'alias'), \E_USER_DEPRECATED);
+            }
         }
 
         $seen = [];

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveReferencesToAliasesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveReferencesToAliasesPassTest.php
@@ -123,6 +123,44 @@ class ResolveReferencesToAliasesPassTest extends TestCase
         $this->process($container);
     }
 
+    public function testNoDeprecationNoticeWhenReferencedByDeprecatedAlias()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', 'stdClass');
+
+        $aliasDeprecated = new Alias('foo');
+        $aliasDeprecated->setDeprecated(true);
+        $container->setAlias('deprecated_foo_alias', $aliasDeprecated);
+
+        $alias = new Alias('deprecated_foo_alias');
+        $alias->setDeprecated(true);
+        $container->setAlias('alias', $alias);
+
+        $this->process($container);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testNoDeprecationNoticeWhenReferencedByDeprecatedDefinition()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('foo', 'stdClass');
+
+        $aliasDeprecated = new Alias('foo');
+        $aliasDeprecated->setDeprecated(true);
+        $container->setAlias('foo_aliased', $aliasDeprecated);
+
+        $container
+            ->register('definition')
+            ->setDeprecated(true)
+            ->setArguments([new Reference('foo_aliased')])
+        ;
+
+        $this->process($container);
+        $this->addToAssertionCount(1);
+    }
+
     protected function process(ContainerBuilder $container)
     {
         $pass = new ResolveReferencesToAliasesPass();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Defining an alias that points to a deprecated definition should trigger a deprecation notice, but when the alias itself is deprecated, it should not trigger.