### PR TITLE
[TwigBridge] LintCommand supports Github Actions annotations

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+* Add `github` format & autodetection to render errors as annotations when
+  running the Twig linter command in a Github Actions environment.
+
 5.3
 ---
 

--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Twig\Command;
 
+use Symfony\Component\Console\CI\GithubActionReporter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\RuntimeException;
@@ -39,6 +40,11 @@ class LintCommand extends Command
 
     private $twig;
 
+    /**
+     * @var string|null
+     */
+    private $format;
+
     public function __construct(Environment $twig)
     {
         parent::__construct();
@@ -50,7 +56,7 @@ class LintCommand extends Command
     {
         $this
             ->setDescription(self::$defaultDescription)
-            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format', 'txt')
+            ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format')
             ->addOption('show-deprecations', null, InputOption::VALUE_NONE, 'Show deprecations as errors')
             ->addArgument('filename', InputArgument::IS_ARRAY, 'A file, a directory or "-" for reading from STDIN')
             ->setHelp(<<<'EOF'
@@ -80,6 +86,11 @@ EOF
         $io = new SymfonyStyle($input, $output);
         $filenames = $input->getArgument('filename');
         $showDeprecations = $input->getOption('show-deprecations');
+        $this->format = $input->getOption('format');
+
+        if (null === $this->format) {
+            $this->format = GithubActionReporter::isGithubActionEnvironment() ? 'github' : 'txt';
+        }
 
         if (['-'] === $filenames) {
             return $this->display($input, $output, $io, [$this->validate(file_get_contents('php://stdin'), uniqid('sf_', true))]);
@@ -169,26 +180,29 @@ EOF
 
     private function display(InputInterface $input, OutputInterface $output, SymfonyStyle $io, array $files)
     {
-        switch ($input->getOption('format')) {
+        switch ($this->format) {
             case 'txt':
                 return $this->displayTxt($output, $io, $files);
             case 'json':
                 return $this->displayJson($output, $files);
+            case 'github':
+                return $this->displayTxt($output, $io, $files, true);
             default:
                 throw new InvalidArgumentException(sprintf('The format "%s" is not supported.', $input->getOption('format')));
         }
     }
 
-    private function displayTxt(OutputInterface $output, SymfonyStyle $io, array $filesInfo)
+    private function displayTxt(OutputInterface $output, SymfonyStyle $io, array $filesInfo, bool $errorAsGithubAnnotations = false)
     {
         $errors = 0;
+        $githubReporter = $errorAsGithubAnnotations ? new GithubActionReporter($output) : null;
 
         foreach ($filesInfo as $info) {
             if ($info['valid'] && $output->isVerbose()) {
                 $io->comment('<info>OK</info>'.($info['file'] ? sprintf(' in %s', $info['file']) : ''));
             } elseif (!$info['valid']) {
                 ++$errors;
-                $this->renderException($io, $info['template'], $info['exception'], $info['file']);
+                $this->renderException($io, $info['template'], $info['exception'], $info['file'], $githubReporter);
             }
         }
 
@@ -220,9 +234,13 @@ EOF
         return min($errors, 1);
     }
 
-    private function renderException(SymfonyStyle $output, string $template, Error $exception, string $file = null)
+    private function renderException(SymfonyStyle $output, string $template, Error $exception, string $file = null, ?GithubActionReporter $githubReporter = null)
     {
         $line = $exception->getTemplateLine();
+
+        if ($githubReporter) {
+            $githubReporter->error($exception->getRawMessage(), $file, $line <= 0 ? null : $line);
+        }
 
         if ($file) {
             $output->text(sprintf('<error> ERROR </error> in %s (line %s)', $file, $line));

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -44,7 +44,7 @@
         "symfony/security-http": "^4.4|^5.0|^6.0",
         "symfony/serializer": "^5.2|^6.0",
         "symfony/stopwatch": "^4.4|^5.0|^6.0",
-        "symfony/console": "^4.4|^5.0|^6.0",
+        "symfony/console": "^5.3|^6.0",
         "symfony/expression-language": "^4.4|^5.0|^6.0",
         "symfony/web-link": "^4.4|^5.0|^6.0",
         "symfony/workflow": "^5.2|^6.0",
@@ -55,7 +55,7 @@
     "conflict": {
         "phpdocumentor/reflection-docblock": "<3.2.2",
         "phpdocumentor/type-resolver": "<1.4.0",
-        "symfony/console": "<4.4",
+        "symfony/console": "<5.3",
         "symfony/form": "<5.3",
         "symfony/http-foundation": "<5.3",
         "symfony/http-kernel": "<4.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #39122 (for `lint:twig`)
| License       | MIT
| Doc PR        | TODO
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

Adds a format to the Twig linter command to print Github Actions annotations when an error occurred ([documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-error-message)). There is a new format: `github` and the command will detect automatically the format to use in comparison with the environment.

> See a workflow example: https://github.com/YaFou/symfony-39826/actions/runs/485093369

---

TODO:
- [x] Changelog
- [x] Test with a real project