### PR TITLE
[Translation] XliffLintCommand supports Github Actions annotations

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+* Add `github` format & autodetection to render errors as annotations when
+  running the XLIFF linter command in a Github Actions environment.
+
 5.3
 ---
 

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -39,7 +39,8 @@
         "symfony/dependency-injection": "<5.0",
         "symfony/http-kernel": "<5.0",
         "symfony/twig-bundle": "<5.0",
-        "symfony/yaml": "<4.4"
+        "symfony/yaml": "<4.4",
+        "symfony/console": "<5.3"
     },
     "provide": {
         "symfony/translation-implementation": "2.3"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #39122 (for `lint:xliff`)
| License       | MIT
| Doc PR        | TODO
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

Adds a format to the XLIFF linter command to print Github Actions annotations when an error occurred ([documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-error-message)). There is a new format: `github` and the command will detect automatically the format to use in comparison with the environment.

> See a workflow example: https://github.com/YaFou/symfony-39828/actions/runs/485142330

---

TODO:
- [x] Test with a real project