### PR TITLE
[Messenger] [AmazonSqs] Fix auto-setup for fifo queue

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -258,7 +258,9 @@ class Connection
         $parameters = ['QueueName' => $this->configuration['queue_name']];
 
         if (self::isFifoQueue($this->configuration['queue_name'])) {
-            $parameters['FifoQueue'] = true;
+            $parameters['Attributes'] = [
+                'FifoQueue' => 'true',
+            ];
         }
 
         $this->client->createQueue($parameters);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39837 
| License       | MIT

When you want the AmazonSqs transport to create the queue on the fly and you have a fifo queue, the parameters are wrong, and a regular queue is created. This PR fixes the parameters.