### PR TITLE
[FrameworkBundle] Add renderForm() helper setting the appropriate HTTP status code

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.3
 ---
 
+ * Added `AbstractController::renderForm()` to render a form and set the appropriate HTTP status code
  * Added support for configuring PHP error level to log levels
  * Added the `dispatcher` option to `debug:event-dispatcher`
  * Added the `event_dispatcher.dispatcher` tag

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -17,6 +17,7 @@ use Psr\Link\LinkInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
@@ -285,6 +286,22 @@ abstract class AbstractController implements ServiceSubscriberInterface
         }
 
         $response->setCallback($callback);
+
+        return $response;
+    }
+
+    /**
+     * Renders a form.
+     *
+     * The FormView instance is passed to the template in a variable named "form".
+     * If the form is invalid, a 422 status code is returned.
+     */
+    public function renderForm(string $view, FormInterface $form, array $parameters = [], Response $response = null): Response
+    {
+        $response = $this->render($view, ['form' => $form->createView()] + $parameters, $response);
+        if ($form->isSubmitted() && !$form->isValid()) {
+            $response->setStatusCode(Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
 
         return $response;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

A 422 HTTP status code should be returned after the submission of an invalid form. Some libraries including [Turbo](https://github.com/hotwired/turbo/pull/39) rely on this behavior and will not display the updated form (containing errors) unless this status code is present.

Rails also [recently switched to this behavior ](https://github.com/rails/rails/pull/41026) by default for the same reason.

I propose to introduce a new helper method rendering the form and setting the appropriate status code. It makes the code cleaner:

```php
// src/Controller/TaskController.php

// ...
use Symfony\Component\HttpFoundation\Request;

class TaskController extends AbstractController
{
    public function new(Request $request): Response
    {
        $task = new Task();
        $form = $this->createForm(TaskType::class, $task);

        $form->handleRequest($request);
        if ($form->isSubmitted() && $form->isValid()) {
            $task = $form->getData();
            // ...

            return $this->redirectToRoute('task_success');
        }

        return $this->renderForm('task/new.html.twig', $form);
    }
}
```