### PR TITLE
[Messenger] Fix merging PrototypedArrayNode associative values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php72": "~1.5",
         "symfony/polyfill-php73": "^1.11",
-        "symfony/polyfill-php80": "^1.15"
+        "symfony/polyfill-php80": "^1.15",
+        "symfony/polyfill-php81": "^1.22"
     },
     "replace": {
         "symfony/asset": "self.version",

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -225,11 +225,11 @@ class PrototypedArrayNode extends ArrayNode
 
         $value = $this->remapXml($value);
 
-        $isAssoc = array_keys($value) !== range(0, \count($value) - 1);
+        $isList = array_is_list($value);
         $normalized = [];
         foreach ($value as $k => $v) {
             if (null !== $this->keyAttribute && \is_array($v)) {
-                if (!isset($v[$this->keyAttribute]) && \is_int($k) && !$isAssoc) {
+                if (!isset($v[$this->keyAttribute]) && \is_int($k) && $isList) {
                     $ex = new InvalidConfigurationException(sprintf('The attribute "%s" must be set for path "%s".', $this->keyAttribute, $this->getPath()));
                     $ex->setPath($this->getPath());
 
@@ -271,7 +271,7 @@ class PrototypedArrayNode extends ArrayNode
             }
 
             $prototype = $this->getPrototypeForChild($k);
-            if (null !== $this->keyAttribute || $isAssoc) {
+            if (null !== $this->keyAttribute || !$isList) {
                 $normalized[$k] = $prototype->normalize($v);
             } else {
                 $normalized[] = $prototype->normalize($v);
@@ -304,9 +304,10 @@ class PrototypedArrayNode extends ArrayNode
             return $rightSide;
         }
 
+        $isList = array_is_list($rightSide);
         foreach ($rightSide as $k => $v) {
-            // prototype, and key is irrelevant, append the element
-            if (null === $this->keyAttribute) {
+            // prototype, and key is irrelevant there are no named keys, append the element
+            if (null === $this->keyAttribute && $isList) {
                 $leftSide[] = $v;
                 continue;
             }

--- a/src/Symfony/Component/Config/Tests/Definition/PrototypedArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/PrototypedArrayNodeTest.php
@@ -338,4 +338,56 @@ class PrototypedArrayNodeTest extends TestCase
            ],
         ];
     }
+
+    /**
+     * @dataProvider getPrototypedArrayNodeDataToMerge
+     */
+    public function testPrototypedArrayNodeMerge($left, $right, $expected)
+    {
+        $node = new PrototypedArrayNode('options');
+        $node->setNormalizeKeys(false);
+        $node->setPrototype(new VariableNode('value'));
+        $node->setDefaultValue([]);
+
+        $result = $node->merge($left, $right);
+
+        self::assertSame($result, $expected);
+    }
+
+    public function getPrototypedArrayNodeDataToMerge()
+    {
+        return [
+            // data to merged is a plain array
+            [
+                ['foo', 'bar'],
+                ['foo', 'baz', 'qux'],
+                ['foo', 'bar', 'foo', 'baz', 'qux'],
+            ],
+            // data to be merged is an associative array
+            [
+                ['option1' => true, 'option2' => 'foo'],
+                [
+                    'option2' => 'bar',
+                    'option3' => 42,
+                    'option4' => [
+                        'option41' => 'baz',
+                        'option42' => [
+                            'option423' => 'qux',
+                        ],
+                    ],
+                ],
+                [
+                    'option1' => true,
+                    'option2' => 'bar',
+                    'option3' => 42,
+                    'option4' => [
+                        'option41' => 'baz',
+                        'option42' => [
+                            'option423' => 'qux',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
 }

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=7.1.3",
         "symfony/filesystem": "^3.4|^4.0|^5.0",
-        "symfony/polyfill-ctype": "~1.8"
+        "symfony/polyfill-ctype": "~1.8",
+        "symfony/polyfill-php81": "^1.22"
     },
     "require-dev": {
         "symfony/event-dispatcher": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
Now keys will not be considered as irrelevant.

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39846, fix #36874
| License       | MIT
| Doc PR        | 

The problem was because in ConfigTree `options` are defined as `arrayNode` and has a `prototype('variable')`. So for combining config together `PrototypedArrayNode::mergeValues()` was called. And there was a trouble - for that `PrototypedArrayNode` `$rightSide` values were added without keys:

`\Symfony\Component\Config\Definition\PrototypedArrayNode::mergeValues`
```php
foreach ($rightSide as $k => $v) {
    // prototype, and key is irrelevant, append the element
    if (null === $this->keyAttribute) {
        $leftSide[] = $v;
        continue;
    }
```