### PR TITLE
[Security] RoleHierarchy returns an unique array of roles

### DIFF
--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchy.php
@@ -48,7 +48,7 @@ class RoleHierarchy implements RoleHierarchyInterface
             }
         }
 
-        return $reachableRoles;
+        return array_values(array_unique($reachableRoles));
     }
 
     protected function buildRoleMap()

--- a/src/Symfony/Component/Security/Core/Tests/Role/RoleHierarchyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Role/RoleHierarchyTest.php
@@ -28,5 +28,6 @@ class RoleHierarchyTest extends TestCase
         $this->assertEquals(['ROLE_ADMIN', 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_ADMIN']));
         $this->assertEquals(['ROLE_FOO', 'ROLE_ADMIN', 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_FOO', 'ROLE_ADMIN']));
         $this->assertEquals(['ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_FOO', 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_SUPER_ADMIN']));
+        $this->assertEquals(['ROLE_SUPER_ADMIN', 'ROLE_ADMIN', 'ROLE_FOO', 'ROLE_USER'], $role->getReachableRoleNames(['ROLE_SUPER_ADMIN', 'ROLE_SUPER_ADMIN']));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes: performance
| Deprecations? |
| Tickets       |
| License       | MIT
| Doc PR        |

Speedup: https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php#L48
BTW, why isn't an `in_array()` there?