### PR TITLE
[HttpFoundation] deprecate the NamespacedAttributeBag class

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -23,6 +23,11 @@ Form
  * Deprecated passing an array as the second argument of the `RadioListMapper::mapDataToForms()` method, pass `\Traversable` instead.
  * Deprecated passing an array as the first argument of the `RadioListMapper::mapFormsToData()` method, pass `\Traversable` instead.
 
+HttpFoundation
+--------------
+
+ * Deprecate the `NamespacedAttributeBag` class
+
 HttpKernel
 ----------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -79,6 +79,7 @@ FrameworkBundle
 HttpFoundation
 --------------
 
+ * Remove the `NamespacedAttributeBag` class
  * Removed `Response::create()`, `JsonResponse::create()`,
    `RedirectResponse::create()`, `StreamedResponse::create()` and
    `BinaryFileResponse::create()` methods (use `__construct()` instead)

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.3
 ---
 
+ * Deprecate the `NamespacedAttributeBag` class
  * added `ResponseFormatSame` PHPUnit constraint
 
 5.2.0

--- a/src/Symfony/Component/HttpFoundation/Session/Attribute/NamespacedAttributeBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Attribute/NamespacedAttributeBag.php
@@ -11,11 +11,15 @@
 
 namespace Symfony\Component\HttpFoundation\Session\Attribute;
 
+trigger_deprecation('symfony/http-foundation', '5.3', sprintf('The "%s" class is deprecated.', NamespacedAttributeBag::class));
+
 /**
  * This class provides structured storage of session attributes using
  * a name spacing character in the key.
  *
  * @author Drak <drak@zikula.org>
+ *
+ * @deprecated since Symfony 5.3
  */
 class NamespacedAttributeBag extends AttributeBag
 {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/NamespacedAttributeBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Attribute/NamespacedAttributeBagTest.php
@@ -18,6 +18,8 @@ use Symfony\Component\HttpFoundation\Session\Attribute\NamespacedAttributeBag;
  * Tests NamespacedAttributeBag.
  *
  * @author Drak <drak@zikula.org>
+ *
+ * @group legacy
  */
 class NamespacedAttributeBagTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #32616
| License       | MIT
| Doc PR        | 