### PR TITLE
[DomCrawler] improve failure messages of the CrawlerSelectorTextContains constraint

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/WebTestCaseTest.php
@@ -183,7 +183,7 @@ class WebTestCaseTest extends TestCase
     {
         $this->getCrawlerTester(new Crawler('<html><body><h1>Foo'))->assertSelectorTextNotContains('body > h1', 'Bar');
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('matches selector "body > h1" and does not have a node matching selector "body > h1" with content containing "Foo".');
+        $this->expectExceptionMessage('matches selector "body > h1" and the text "Foo" of the node matching selector "body > h1" does not contain "Foo".');
         $this->getCrawlerTester(new Crawler('<html><body><h1>Foo'))->assertSelectorTextNotContains('body > h1', 'Foo');
     }
 
@@ -199,7 +199,7 @@ class WebTestCaseTest extends TestCase
     {
         $this->getCrawlerTester(new Crawler('<html><head><title>Foobar'))->assertPageTitleContains('Foo');
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessage('matches selector "title" and has a node matching selector "title" with content containing "Bar".');
+        $this->expectExceptionMessage('matches selector "title" and the text "Foo" of the node matching selector "title" contains "Bar".');
         $this->getCrawlerTester(new Crawler('<html><head><title>Foo'))->assertPageTitleContains('Bar');
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -38,7 +38,7 @@
         "symfony/browser-kit": "^4.3|^5.0",
         "symfony/console": "^4.3.4|^5.0",
         "symfony/css-selector": "^3.4|^4.0|^5.0",
-        "symfony/dom-crawler": "^4.3|^5.0",
+        "symfony/dom-crawler": "^4.4.20|^5.2.4",
         "symfony/dotenv": "^4.3.6|^5.0",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/form": "^4.3.5|^5.0",

--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextContains.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorTextContains.php
@@ -18,6 +18,8 @@ final class CrawlerSelectorTextContains extends Constraint
 {
     private $selector;
     private $expectedText;
+    private $hasNode = false;
+    private $nodeText;
 
     public function __construct(string $selector, string $expectedText)
     {
@@ -30,7 +32,11 @@ final class CrawlerSelectorTextContains extends Constraint
      */
     public function toString(): string
     {
-        return sprintf('has a node matching selector "%s" with content containing "%s"', $this->selector, $this->expectedText);
+        if ($this->hasNode) {
+            return sprintf('the text "%s" of the node matching selector "%s" contains "%s"', $this->nodeText, $this->selector, $this->expectedText);
+        }
+
+        return sprintf('the Crawler has a node matching selector "%s"', $this->selector);
     }
 
     /**
@@ -42,10 +48,15 @@ final class CrawlerSelectorTextContains extends Constraint
     {
         $crawler = $crawler->filter($this->selector);
         if (!\count($crawler)) {
+            $this->hasNode = false;
+
             return false;
         }
 
-        return false !== mb_strpos($crawler->text(null, true), $this->expectedText);
+        $this->hasNode = true;
+        $this->nodeText = $crawler->text(null, true);
+
+        return false !== mb_strpos($this->nodeText, $this->expectedText);
     }
 
     /**
@@ -55,6 +66,6 @@ final class CrawlerSelectorTextContains extends Constraint
      */
     protected function failureDescription($crawler): string
     {
-        return 'the Crawler '.$this->toString();
+        return $this->toString();
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorTextContainsTest.php
@@ -24,15 +24,22 @@ class CrawlerSelectorTextContainsTest extends TestCase
         $constraint = new CrawlerSelectorTextContains('title', 'Foo');
         $this->assertTrue($constraint->evaluate(new Crawler('<html><head><title>Foobar'), '', true));
         $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
+        $this->assertFalse($constraint->evaluate(new Crawler('<html><head></head><body>Bar'), '', true));
 
         try {
             $constraint->evaluate(new Crawler('<html><head><title>Bar'));
-        } catch (ExpectationFailedException $e) {
-            $this->assertEquals("Failed asserting that the Crawler has a node matching selector \"title\" with content containing \"Foo\".\n", TestFailure::exceptionToString($e));
 
-            return;
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertEquals("Failed asserting that the text \"Bar\" of the node matching selector \"title\" contains \"Foo\".\n", TestFailure::exceptionToString($e));
         }
 
-        $this->fail();
+        try {
+            $constraint->evaluate(new Crawler('<html><head></head><body>Bar'));
+
+            $this->fail();
+        } catch (ExpectationFailedException $e) {
+            $this->assertEquals("Failed asserting that the Crawler has a node matching selector \"title\".\n", TestFailure::exceptionToString($e));
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33551, #37757
| License       | MIT
| Doc PR        | 