### PR TITLE
[Validator] Format datetime values in comparison constraints with `dateFormat` option

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,20 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Add a `dateFormat` option to comparison constraints (`EqualTo`,
+   `GreaterThanOrEqual`, `GreaterThan`, `LessThanOrEqual`, `LessThan`,
+   `IndenticalTo`, `NotEqualTo` and `NotIdenticalTo`) to format datetimes in
+   placeholders:
+   ```php
+   /**
+    * @Assert\EqualTo(value="2020-01-01", dateFormat="Y-d-m")
+    */
+   ```
+   will output a message like: `This value should be equal to 2020-01-01.`.
+
 5.3
 ---
  * Add the `normalizer` option to the `Unique` constraint

--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -84,11 +84,11 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
      *
      * @return string The string representation of the passed value
      */
-    protected function formatValue($value, int $format = 0)
+    protected function formatValue($value, int $format = 0, ?string $dateFormat = null)
     {
         if (($format & self::PRETTY_DATE) && $value instanceof \DateTimeInterface) {
             if (class_exists(\IntlDateFormatter::class)) {
-                $formatter = new \IntlDateFormatter(\Locale::getDefault(), \IntlDateFormatter::MEDIUM, \IntlDateFormatter::SHORT, 'UTC');
+                $formatter = new \IntlDateFormatter(\Locale::getDefault(), \IntlDateFormatter::MEDIUM, \IntlDateFormatter::SHORT, 'UTC', null, $dateFormat);
 
                 return $formatter->format(new \DateTime(
                     $value->format('Y-m-d H:i:s.u'),
@@ -96,7 +96,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
                 ));
             }
 
-            return $value->format('Y-m-d H:i:s');
+            return $value->format($dateFormat ?? 'Y-m-d H:i:s');
         }
 
         if (\is_object($value)) {

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Validator\Constraints;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Validator\Exception\InvalidOptionsException;
 use Symfony\Component\Validator\Exception\LogicException;
 
 /**
@@ -27,6 +28,7 @@ abstract class AbstractComparison extends Constraint
     public $message;
     public $value;
     public $propertyPath;
+    public $dateFormat;
 
     /**
      * {@inheritdoc}
@@ -56,6 +58,12 @@ abstract class AbstractComparison extends Constraint
 
         if (null !== $this->propertyPath && !class_exists(PropertyAccess::class)) {
             throw new LogicException(sprintf('The "%s" constraint requires the Symfony PropertyAccess component to use the "propertyPath" option.', static::class));
+        }
+
+        $this->dateFormat = $options['dateFormat'] ?? null;
+
+        if (null !== $this->dateFormat && !\is_string($this->dateFormat)) {
+            throw new InvalidOptionsException('The "dateFormat" option must be null or a string.', $options);
         }
     }
 

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -78,8 +78,8 @@ abstract class AbstractComparisonValidator extends ConstraintValidator
 
         if (!$this->compareValues($value, $comparedValue)) {
             $violationBuilder = $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING | self::PRETTY_DATE))
-                ->setParameter('{{ compared_value }}', $this->formatValue($comparedValue, self::OBJECT_TO_STRING | self::PRETTY_DATE))
+                ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING | self::PRETTY_DATE, $constraint->dateFormat))
+                ->setParameter('{{ compared_value }}', $this->formatValue($comparedValue, self::OBJECT_TO_STRING | self::PRETTY_DATE, $constraint->dateFormat))
                 ->setParameter('{{ compared_value_type }}', $this->formatTypeOf($comparedValue))
                 ->setCode($this->getErrorCode());
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -179,7 +179,7 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
      * @param mixed  $comparedValueString
      * @param string $comparedValueType
      */
-    public function testInvalidComparisonToValue($dirtyValue, $dirtyValueAsString, $comparedValue, $comparedValueString, $comparedValueType)
+    public function testInvalidComparisonToValue($dirtyValue, $dirtyValueAsString, $comparedValue, $comparedValueString, $comparedValueType, $dateFormat = null)
     {
         // Conversion of dates to string differs between ICU versions
         // Make sure we have the correct version loaded
@@ -189,6 +189,7 @@ abstract class AbstractComparisonValidatorTestCase extends ConstraintValidatorTe
 
         $constraint = $this->createConstraint(['value' => $comparedValue]);
         $constraint->message = 'Constraint Message';
+        $constraint->dateFormat = $dateFormat;
 
         $this->validator->validate($dirtyValue, $constraint);
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
@@ -74,6 +74,7 @@ class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
             [new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', '2000-01-01', 'Jan 1, 2000, 12:00 AM', 'DateTime'],
             [new \DateTime('2001-01-01 UTC'), 'Jan 1, 2001, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'],
             [new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
+            [new \DateTime('2001-01-01'), '2001-01-01', new \DateTime('2000-01-01'), '2000-01-01', 'DateTime', 'Y-MM-dd'],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
@@ -77,6 +77,7 @@ class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCas
             [new \DateTime('2000/01/01'), 'Jan 1, 2000, 12:00 AM', '2005/01/01', 'Jan 1, 2005, 12:00 AM', 'DateTime'],
             [new \DateTime('2000/01/01 UTC'), 'Jan 1, 2000, 12:00 AM', '2005/01/01 UTC', 'Jan 1, 2005, 12:00 AM', 'DateTime'],
             ['b', '"b"', 'c', '"c"', 'string'],
+            [new \DateTime('2000/01/01'), '2000-01-01', new \DateTime('2005/01/01'), '2005-01-01', 'DateTime', 'Y-MM-dd'],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -79,6 +79,7 @@ class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
             [new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
             ['22', '"22"', '333', '"333"', 'string'],
             ['22', '"22"', '22', '"22"', 'string'],
+            [new \DateTime('2000/01/01'), '2000-01-01', new \DateTime('2005/01/01'), '2005-01-01', 'DateTime', 'Y-MM-dd'],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
@@ -92,6 +92,7 @@ class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
             [new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', 'DateTime'],
             [new \DateTime('2001-01-01'), 'Jan 1, 2001, 12:00 AM', new \DateTime('1999-01-01'), 'Jan 1, 1999, 12:00 AM', 'DateTime'],
             [new ComparisonTest_Class(4), '4', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
+            [new \DateTime('2001-01-01'), '2001-01-01', new \DateTime('2001-01-01'), '2001-01-01', 'DateTime', 'Y-MM-dd'],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
@@ -80,6 +80,7 @@ class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
             [new \DateTime('2010-01-01 UTC'), 'Jan 1, 2010, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'],
             [new ComparisonTest_Class(5), '5', new ComparisonTest_Class(4), '4', __NAMESPACE__.'\ComparisonTest_Class'],
             ['c', '"c"', 'b', '"b"', 'string'],
+            [new \DateTime('2010-01-01'), '2010-01-01', new \DateTime('2000-01-01'), '2000-01-01', 'DateTime', 'Y-MM-dd'],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
@@ -78,6 +78,7 @@ class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
             [new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
             [new ComparisonTest_Class(6), '6', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
             ['333', '"333"', '22', '"22"', 'string'],
+            [new \DateTime('2010-01-01'), '2010-01-01', new \DateTime('2000-01-01'), '2000-01-01', 'DateTime', 'Y-MM-dd'],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
@@ -74,6 +74,7 @@ class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
             [new \DateTime('2000-01-01'), 'Jan 1, 2000, 12:00 AM', '2000-01-01', 'Jan 1, 2000, 12:00 AM', 'DateTime'],
             [new \DateTime('2000-01-01 UTC'), 'Jan 1, 2000, 12:00 AM', '2000-01-01 UTC', 'Jan 1, 2000, 12:00 AM', 'DateTime'],
             [new ComparisonTest_Class(5), '5', new ComparisonTest_Class(5), '5', __NAMESPACE__.'\ComparisonTest_Class'],
+            [new \DateTime('2000-01-01'), '2000-01-01', new \DateTime('2000-01-01'), '2000-01-01', 'DateTime', 'Y-MM-dd'],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
@@ -90,6 +90,7 @@ class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
             ['a', '"a"', 'a', '"a"', 'string'],
             [$date, 'Jan 1, 2000, 12:00 AM', $date, 'Jan 1, 2000, 12:00 AM', 'DateTime'],
             [$object, '2', $object, '2', __NAMESPACE__.'\ComparisonTest_Class'],
+            [$date, '2000-01-01', $date, '2000-01-01', 'DateTime', 'Y-MM-dd'],
         ];
 
         return $comparisons;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #36784
| License       | MIT
| Doc PR        | TODO
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

I have introduced a new option for comparison constraints called `dateFormat`. This option gives the ability to use a different format for datetime values in the following placeholders: `{{ value }}` and `{{ compared_value }}`.

Before:
```php
/**
 * @Assert\GreaterThanOrEqual(value="2020-01-01")
 */
```
will output: `This value should be greater than Jan 1, 2020, 12:00 AM`.

After:
```php
/**
 * @Assert\GreaterThanOrEqual(value="2020-01-01", dateFormat="Y-m-d")
 */
```
will output: `This value should be greater than 2020-01-01.`