### PR TITLE
[Console] Add CommandDefinition to make `list` lazy

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -12,6 +12,8 @@
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\CommandDescription;
+use Symfony\Component\Console\Command\DescribableCommandInterface;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -33,10 +35,8 @@ use Symfony\Component\HttpKernel\RebootableInterface;
  *
  * @final
  */
-class CacheClearCommand extends Command
+class CacheClearCommand extends Command implements DescribableCommandInterface
 {
-    protected static $defaultName = 'cache:clear';
-
     private $cacheClearer;
     private $filesystem;
 
@@ -46,6 +46,14 @@ class CacheClearCommand extends Command
 
         $this->cacheClearer = $cacheClearer;
         $this->filesystem = $filesystem ?: new Filesystem();
+    }
+
+    public static function describe(): CommandDescription
+    {
+        return new CommandDescription(
+            'cache:clear',
+            'Clears the cache'
+        );
     }
 
     /**
@@ -58,7 +66,6 @@ class CacheClearCommand extends Command
                 new InputOption('no-warmup', '', InputOption::VALUE_NONE, 'Do not warm up the cache'),
                 new InputOption('no-optional-warmers', '', InputOption::VALUE_NONE, 'Skip optional cache warmers (faster)'),
             ])
-            ->setDescription('Clears the cache')
             ->setHelp(<<<'EOF'
 The <info>%command.name%</info> command clears the application cache for a given environment
 and debug mode:

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Console;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\HelpCommand;
+use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\Command\ListCommand;
 use Symfony\Component\Console\Command\SignalableCommandInterface;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
@@ -489,8 +490,10 @@ class Application implements ResetInterface
             return null;
         }
 
-        // Will throw if the command is not correctly initialized.
-        $command->getDefinition();
+        if (!$command instanceof LazyCommand) {
+            // Will throw if the command is not correctly initialized.
+            $command->getDefinition();
+        }
 
         if (!$command->getName()) {
             throw new LogicException(sprintf('The command defined in "%s" cannot have an empty name.', get_debug_type($command)));

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -45,6 +45,7 @@ class Command
     private $aliases = [];
     private $definition;
     private $hidden = false;
+    private $enabled = true;
     private $help = '';
     private $description = '';
     private $fullDefinition;
@@ -73,8 +74,15 @@ class Command
     public function __construct(string $name = null)
     {
         $this->definition = new InputDefinition();
+        if ($this instanceof DescribableCommandInterface) {
+            $description = static::describe();
+            $this->setName($description->getName())
+                ->setAliases($description->getAliases())
+                ->setHidden($description->isHidden())
+                ->setDescription($description->getDescription());
 
-        if (null !== $name || null !== $name = static::getDefaultName()) {
+            $this->enabled = $description->isEnabled();
+        } elseif (null !== $name || null !== $name = static::getDefaultName()) {
             $this->setName($name);
         }
 
@@ -138,7 +146,7 @@ class Command
      */
     public function isEnabled()
     {
-        return true;
+        return $this->enabled;
     }
 
     /**

--- a/src/Symfony/Component/Console/Command/CommandDescription.php
+++ b/src/Symfony/Component/Console/Command/CommandDescription.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Command;
+
+/**
+ * Interface for command reacting to signal.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+final class CommandDescription
+{
+    private $name;
+    private $aliases;
+    private $description;
+    private $hidden;
+    private $enabled;
+
+    public function __construct(string $name, string $description = '', array $aliases = [], bool $hidden = false, bool $enabled = true)
+    {
+        $this->name = $name;
+        $this->aliases = $aliases;
+        $this->description = $description;
+        $this->hidden = $hidden;
+        $this->enabled = $enabled;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getAliases(): array
+    {
+        return $this->aliases;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function isHidden(): bool
+    {
+        return $this->hidden;
+    }
+}

--- a/src/Symfony/Component/Console/Command/DescribableCommandInterface.php
+++ b/src/Symfony/Component/Console/Command/DescribableCommandInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Command;
+
+/**
+ * Interface for command reacting to signal.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+interface DescribableCommandInterface
+{
+    public static function describe(): CommandDescription;
+}

--- a/src/Symfony/Component/Console/Command/LazyCommand.php
+++ b/src/Symfony/Component/Console/Command/LazyCommand.php
@@ -1,0 +1,211 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Command;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+final class LazyCommand extends Command
+{
+    private $command;
+    private $enabled;
+
+    public function __construct(CommandDescription $description, \Closure $commandFactory)
+    {
+        $this->setName($description->getName())
+            ->setAliases($description->getAliases())
+            ->setHidden($description->isHidden())
+            ->setDescription($description->getDescription());
+        $this->enabled = $description->isEnabled();
+
+        $this->command = $commandFactory;
+    }
+
+    public function ignoreValidationErrors(): void
+    {
+        $this->getCommand()->ignoreValidationErrors();
+    }
+
+    public function setApplication(Application $application = null): void
+    {
+        if ($this->command instanceof parent) {
+            $this->command->setApplication($application);
+        }
+
+        parent::setApplication($application);
+    }
+
+    public function setHelperSet(HelperSet $helperSet): void
+    {
+        if ($this->command instanceof parent) {
+            $this->command->setHelperSet($helperSet);
+        }
+
+        parent::setHelperSet($helperSet);
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function run(InputInterface $input, OutputInterface $output): int
+    {
+        return $this->getCommand()->run($input, $output);
+    }
+
+    /**
+     * @return $this
+     */
+    public function setCode(callable $code): self
+    {
+        $this->getCommand()->setCode($code);
+
+        return $this;
+    }
+
+    /**
+     * @internal
+     */
+    public function mergeApplicationDefinition(bool $mergeArgs = true): void
+    {
+        $this->getCommand()->mergeApplicationDefinition($mergeArgs);
+    }
+
+    /**
+     * @return $this
+     */
+    public function setDefinition($definition): self
+    {
+        $this->getCommand()->setDefinition($definition);
+
+        return $this;
+    }
+
+    public function getDefinition(): InputDefinition
+    {
+        return $this->getCommand()->getDefinition();
+    }
+
+    public function getNativeDefinition(): InputDefinition
+    {
+        return $this->getCommand()->getNativeDefinition();
+    }
+
+    /**
+     * @return $this
+     */
+    public function addArgument(string $name, int $mode = null, string $description = '', $default = null): self
+    {
+        $this->getCommand()->addArgument($name, $mode, $description, $default);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function addOption(string $name, $shortcut = null, int $mode = null, string $description = '', $default = null): self
+    {
+        $this->getCommand()->addOption($name, $shortcut, $mode, $description, $default);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setProcessTitle(string $title): self
+    {
+        $this->getCommand()->setProcessTitle($title);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setHelp(string $help): self
+    {
+        $this->getCommand()->setHelp($help);
+
+        return $this;
+    }
+
+    public function getHelp(): string
+    {
+        return $this->getCommand()->getHelp();
+    }
+
+    public function getProcessedHelp(): string
+    {
+        return $this->getCommand()->getProcessedHelp();
+    }
+
+    public function getSynopsis(bool $short = false): string
+    {
+        return $this->getCommand()->getSynopsis($short);
+    }
+
+    /**
+     * @return $this
+     */
+    public function addUsage(string $usage): self
+    {
+        $this->getCommand()->addUsage($usage);
+
+        return $this;
+    }
+
+    public function getUsages(): array
+    {
+        return $this->getCommand()->getUsages();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getHelper(string $name)
+    {
+        return $this->getCommand()->getHelper($name);
+    }
+
+    public function getCommand(): parent
+    {
+        if (!$this->command instanceof \Closure) {
+            return $this->command;
+        }
+
+        $command = $this->command = ($this->command)();
+        $command->setApplication($this->getApplication());
+
+        if (null !== $this->getHelperSet()) {
+            $command->setHelperSet($this->getHelperSet());
+        }
+
+        $command->setName($this->getName())
+            ->setAliases($this->getAliases())
+            ->setHidden($this->isHidden())
+            ->setDescription($this->getDescription());
+
+        // Will throw if the command is not correctly initialized.
+        $command->getDefinition();
+
+        return $command;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1757,7 +1757,7 @@ EOF;
 
                     $code = sprintf('return %s;', $code);
 
-                    return sprintf("function ()%s {\n            %s\n        }", $returnedType, $code);
+                    return sprintf("function () use (\$container) %s {\n            %s\n        }", $returnedType, $code);
                 }
 
                 if ($value instanceof IteratorArgument) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #33804
| License       | MIT
| Doc PR        | -

This is an alternative to #39851, that use an `CommandDescription` to expose the command's metadata.

This PR is WIP to get your point of view before moving spending too much time on it.

TODO:
* [ ] add tests
* [ ] trigger exception when command implement the interface **and** override the methods `isEnabled`, `isHidden`, ... meaning
* [ ] add changelog
* [ ] migrate commands (with dependencies) to this interface 