### PR TITLE
[Asset] Fix JsonManifest when there is no dependency on HttpClient

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/assets.php
@@ -77,7 +77,7 @@ return static function (ContainerConfigurator $container) {
             ->abstract()
             ->args([
                 abstract_arg('manifest path'),
-                service('http_client'),
+                service('http_client')->nullOnInvalid(),
             ])
 
         ->set('assets.remote_json_manifest_version_strategy', RemoteJsonManifestVersionStrategy::class)

--- a/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
+++ b/src/Symfony/Component/Asset/Tests/VersionStrategy/JsonManifestVersionStrategyTest.php
@@ -61,6 +61,14 @@ class JsonManifestVersionStrategyTest extends TestCase
         $strategy->getVersion('main.js');
     }
 
+    public function testRemoteManifestFileWithoutHttpClient()
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(sprintf('The "%s" class needs an HTTP client to use a remote manifest. Try running "composer require symfony/http-client".', JsonManifestVersionStrategy::class));
+
+        new JsonManifestVersionStrategy('https://cdn.example.com/manifest.json');
+    }
+
     public function provideValidStrategies()
     {
         yield from $this->provideStrategies('manifest-valid.json');

--- a/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
@@ -38,6 +38,10 @@ class JsonManifestVersionStrategy implements VersionStrategyInterface
     {
         $this->manifestPath = $manifestPath;
         $this->httpClient = $httpClient;
+
+        if (null === $this->httpClient && 0 === strpos(parse_url($this->manifestPath, \PHP_URL_SCHEME), 'http')) {
+            throw new \LogicException(sprintf('The "%s" class needs an HTTP client to use a remote manifest. Try running "composer require symfony/http-client".', self::class));
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  |no
| Deprecations? |no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Recently on my project, I don't have any more dependency on HttpClient and the tests on the 5.x I have this error :

<img width="678" alt="Capture d’écran 2021-01-17 à 14 26 16" src="https://user-images.githubusercontent.com/12966574/104844393-45a7d180-58d0-11eb-870b-ad4b7b78d092.png">

~~I think this should also be the case for the RemoteJsonManifestVersionStrategy but I don't have a use case to try it.~~

It's related to https://github.com/symfony/symfony/pull/39484
