### PR TITLE
[Mime] Escape commas in address names

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
@@ -62,8 +62,8 @@ class SesApiTransportTest extends TestCase
             parse_str($options['body'], $content);
 
             $this->assertSame('Hello!', $content['Message_Subject_Data']);
-            $this->assertSame('Saif Eddin <saif.gmati@symfony.com>', $content['Destination_ToAddresses_member'][0]);
-            $this->assertSame('Fabien <fabpot@symfony.com>', $content['Source']);
+            $this->assertSame('"Saif Eddin" <saif.gmati@symfony.com>', $content['Destination_ToAddresses_member'][0]);
+            $this->assertSame('"Fabien" <fabpot@symfony.com>', $content['Source']);
             $this->assertSame('Hello There!', $content['Message_Body_Text_Data']);
 
             $xml = '<SendEmailResponse xmlns="https://email.amazonaws.com/doc/2010-03-31/">

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -82,8 +82,8 @@ class MailgunApiTransportTest extends TestCase
             }
 
             $this->assertStringContainsString('Hello!', $content);
-            $this->assertStringContainsString('Saif Eddin <saif.gmati@symfony.com>', $content);
-            $this->assertStringContainsString('Fabien <fabpot@symfony.com>', $content);
+            $this->assertStringContainsString('"Saif Eddin" <saif.gmati@symfony.com>', $content);
+            $this->assertStringContainsString('"Fabien" <fabpot@symfony.com>', $content);
             $this->assertStringContainsString('Hello There!', $content);
 
             return new MockResponse(json_encode(['id' => 'foobar']), [

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
@@ -74,8 +74,8 @@ class PostmarkApiTransportTest extends TestCase
             $this->assertStringContainsStringIgnoringCase('X-Postmark-Server-Token: KEY', $options['headers'][1] ?? $options['request_headers'][1]);
 
             $body = json_decode($options['body'], true);
-            $this->assertSame('Fabien <fabpot@symfony.com>', $body['From']);
-            $this->assertSame('Saif Eddin <saif.gmati@symfony.com>', $body['To']);
+            $this->assertSame('"Fabien" <fabpot@symfony.com>', $body['From']);
+            $this->assertSame('"Saif Eddin" <saif.gmati@symfony.com>', $body['To']);
             $this->assertSame('Hello!', $body['Subject']);
             $this->assertSame('Hello There!', $body['TextBody']);
 

--- a/src/Symfony/Component/Mime/Address.php
+++ b/src/Symfony/Component/Mime/Address.php
@@ -77,7 +77,16 @@ final class Address
 
     public function toString(): string
     {
-        return ($n = $this->getName()) ? $n.' <'.$this->getEncodedAddress().'>' : $this->getEncodedAddress();
+        return ($n = $this->getEncodedName()) ? $n.' <'.$this->getEncodedAddress().'>' : $this->getEncodedAddress();
+    }
+
+    public function getEncodedName(): string
+    {
+        if ('' === $this->getName()) {
+            return '';
+        }
+
+        return sprintf('"%s"', preg_replace('/"/u', '\"', $this->getName()));
     }
 
     /**

--- a/src/Symfony/Component/Mime/Tests/AddressTest.php
+++ b/src/Symfony/Component/Mime/Tests/AddressTest.php
@@ -27,7 +27,7 @@ class AddressTest extends TestCase
         $a = new Address('fabien@symfonï.com', 'Fabien');
         $this->assertEquals('Fabien', $a->getName());
         $this->assertEquals('fabien@symfonï.com', $a->getAddress());
-        $this->assertEquals('Fabien <fabien@xn--symfon-nwa.com>', $a->toString());
+        $this->assertEquals('"Fabien" <fabien@xn--symfon-nwa.com>', $a->toString());
         $this->assertEquals('fabien@xn--symfon-nwa.com', $a->getEncodedAddress());
     }
 
@@ -152,5 +152,11 @@ class AddressTest extends TestCase
                 'example@example.com',
             ],
         ];
+    }
+
+    public function testEncodeNameIfNameContainsCommas()
+    {
+        $address = new Address('fabien@symfony.com', 'Fabien, "Potencier');
+        $this->assertSame('"Fabien, \"Potencier" <fabien@symfony.com>', $address->toString());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39416
| License       | MIT
| Doc PR        | --
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

Before:
```php
$address = new Address('fabien@symfony.com', 'Fabien, Potencier');
$address->toString(); // Fabien, Potencier <fabien@symfony.com> -> Interpreted like two emails
```

After:
```php
$address = new Address('fabien@symfony.com', 'Fabien, Potencier');
$address->toString(); // "Fabien, Potencier" <fabien@symfony.com>
```