### PR TITLE
[Notifier] [OvhCloud] “Invalid signature” for message with slashes

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -75,14 +75,16 @@ final class OvhCloudTransport extends AbstractTransport
         $now = time() + $this->calculateTimeDelta();
         $headers['X-Ovh-Application'] = $this->applicationKey;
         $headers['X-Ovh-Timestamp'] = $now;
+        $headers['Content-Type'] = 'application/json';
 
-        $toSign = $this->applicationSecret.'+'.$this->consumerKey.'+POST+'.$endpoint.'+'.json_encode($content, \JSON_UNESCAPED_SLASHES).'+'.$now;
+        $body = json_encode($content, \JSON_UNESCAPED_SLASHES);
+        $toSign = $this->applicationSecret.'+'.$this->consumerKey.'+POST+'.$endpoint.'+'.$body.'+'.$now;
         $headers['X-Ovh-Consumer'] = $this->consumerKey;
         $headers['X-Ovh-Signature'] = '$1$'.sha1($toSign);
 
         $response = $this->client->request('POST', $endpoint, [
             'headers' => $headers,
-            'json' => $content,
+            'body' => $body,
         ]);
 
         if (200 !== $response->getStatusCode()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #39836 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

Test to show issue of invalid signature when message contains slash.
