### PR TITLE
[DoctrineBridge] Add username to UserNameNotFoundException

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -62,7 +62,10 @@ class EntityUserProvider implements UserProviderInterface, PasswordUpgraderInter
         }
 
         if (null === $user) {
-            throw new UsernameNotFoundException(sprintf('User "%s" not found.', $username));
+            $e = new UsernameNotFoundException(sprintf('User "%s" not found.', $username));
+            $e->setUsername($username);
+
+            throw $e;
         }
 
         return $user;
@@ -92,7 +95,10 @@ class EntityUserProvider implements UserProviderInterface, PasswordUpgraderInter
 
             $refreshedUser = $repository->find($id);
             if (null === $refreshedUser) {
-                throw new UsernameNotFoundException('User with id '.json_encode($id).' not found.');
+                $e = new UsernameNotFoundException('User with id '.json_encode($id).' not found.');
+                $e->setUsername(json_encode($id));
+
+                throw $e;
             }
         }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/SecuredPageBundle/Security/Core/User/ArrayUserProvider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/SecuredPageBundle/Security/Core/User/ArrayUserProvider.php
@@ -34,7 +34,10 @@ class ArrayUserProvider implements UserProviderInterface
         $user = $this->getUser($username);
 
         if (null === $user) {
-            throw new UsernameNotFoundException(sprintf('User "%s" not found.', $username));
+            $e = new UsernameNotFoundException(sprintf('User "%s" not found.', $username));
+            $e->setUsername($username);
+
+            throw $e;
         }
 
         return $user;

--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -73,18 +73,27 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
             $query = str_replace('{username}', $username, $this->defaultSearch);
             $search = $this->ldap->query($this->baseDn, $query);
         } catch (ConnectionException $e) {
-            throw new UsernameNotFoundException(sprintf('User "%s" not found.', $username), 0, $e);
+            $e = new UsernameNotFoundException(sprintf('User "%s" not found.', $username), 0, $e);
+            $e->setUsername($username);
+
+            throw $e;
         }
 
         $entries = $search->execute();
         $count = \count($entries);
 
         if (!$count) {
-            throw new UsernameNotFoundException(sprintf('User "%s" not found.', $username));
+            $e = new UsernameNotFoundException(sprintf('User "%s" not found.', $username));
+            $e->setUsername($username);
+
+            throw $e;
         }
 
         if ($count > 1) {
-            throw new UsernameNotFoundException('More than one user found.');
+            $e = new UsernameNotFoundException('More than one user found.');
+            $e->setUsername($username);
+
+            throw $e;
         }
 
         $entry = $entries[0];

--- a/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
@@ -105,7 +105,10 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
         $user = $guardAuthenticator->getUser($token->getCredentials(), $this->userProvider);
 
         if (null === $user) {
-            throw new UsernameNotFoundException(sprintf('Null returned from "%s::getUser()".', \get_class($guardAuthenticator)));
+            $e = new UsernameNotFoundException(sprintf('Null returned from "%s::getUser()".', \get_class($guardAuthenticator)));
+            $e->setUsername($token->getUsername());
+
+            throw $e;
         }
 
         if (!$user instanceof UserInterface) {


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #39878  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

Adds username to UserNameNotFoundException when thrown from EntityUserProvider.

In other places there are no tests for this and I am not sure if the current setup even allows asserting if exceptions contain fields, besides the default ones.
