### PR TITLE
[HttpFoundation] Revert #38614 and add assert to avoid regressions

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1836,15 +1836,9 @@ class Request
         }
 
         $basename = basename($baseUrl);
-        if (empty($basename) || !strpos(rawurldecode($truncatedRequestUri).'/', '/'.$basename.'/')) {
-            // strip autoindex filename, for virtualhost based on URL path
-            $baseUrl = \dirname($baseUrl).'/';
-
-            $basename = basename($baseUrl);
-            if (empty($basename) || !strpos(rawurldecode($truncatedRequestUri).'/', '/'.$basename.'/')) {
-                // no match whatsoever; set it blank
-                return '';
-            }
+        if (empty($basename) || !strpos(rawurldecode($truncatedRequestUri), $basename)) {
+            // no match whatsoever; set it blank
+            return '';
         }
 
         // If using mod_rewrite or ISAPI_Rewrite strip the script filename

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1770,8 +1770,8 @@ class RequestTest extends TestCase
                     'SCRIPT_NAME' => '/foo/app.php',
                     'PHP_SELF' => '/foo/app.php',
                 ],
-                '/sub/foo',
-                '/bar',
+                '',
+                '/sub/foo/bar',
             ],
             [
                 '/sub/foo/app.php/bar',
@@ -1790,8 +1790,18 @@ class RequestTest extends TestCase
                     'SCRIPT_NAME' => '/foo/app2.phpx',
                     'PHP_SELF' => '/foo/app2.phpx',
                 ],
-                '/sub/foo',
-                '/bar/baz',
+                '',
+                '/sub/foo/bar/baz',
+            ],
+            [
+                '/foo/api/bar',
+                [
+                    'SCRIPT_FILENAME' => '/var/www/api/index.php',
+                    'SCRIPT_NAME' => '/api/index.php',
+                    'PHP_SELF' => '/api/index.php',
+                ],
+                '',
+                '/foo/api/bar',
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39882
| License       | MIT

#38614 introduced a BC, this PR revert the PR, update tests and add an assert to avoid regressions.

