### PR TITLE
[FrameworkBundle] Prevent deprecation notice when used with PropertyAccess 5.2+

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1475,9 +1475,15 @@ class FrameworkExtension extends Extension
 
         $loader->load('property_access.xml');
 
+        // Support constructor signature of PropertyAccess 5.2 and up.
+        $magicCall = $config['magic_call'];
+        if (\defined('Symfony\Component\PropertyAccess\PropertyAccessor::MAGIC_CALL')) {
+            $magicCall = ($magicCall ? PropertyAccessor::MAGIC_CALL : 0) | PropertyAccessor::MAGIC_GET | PropertyAccessor::MAGIC_SET;
+        }
+
         $container
             ->getDefinition('property_accessor')
-            ->replaceArgument(0, $config['magic_call'])
+            ->replaceArgument(0, $magicCall)
             ->replaceArgument(1, $config['throw_exception_on_invalid_index'])
             ->replaceArgument(3, $config['throw_exception_on_invalid_property_path'])
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -81,7 +81,11 @@ abstract class FrameworkExtensionTest extends TestCase
         $container = $this->createContainerFromFile('full');
 
         $def = $container->getDefinition('property_accessor');
-        $this->assertFalse($def->getArgument(0));
+        if (\defined('Symfony\Component\PropertyAccess\PropertyAccessor::MAGIC_CALL')) {
+            $this->assertEquals(PropertyAccessor::MAGIC_GET | PropertyAccessor::MAGIC_SET, $def->getArgument(0));
+        } else {
+            $this->assertFalse($def->getArgument(0));
+        }
         $this->assertFalse($def->getArgument(1));
         $this->assertTrue($def->getArgument(3));
     }
@@ -90,6 +94,11 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainerFromFile('property_accessor');
         $def = $container->getDefinition('property_accessor');
+        if (\defined('Symfony\Component\PropertyAccess\PropertyAccessor::MAGIC_CALL')) {
+            $this->assertEquals(PropertyAccessor::MAGIC_CALL | PropertyAccessor::MAGIC_GET | PropertyAccessor::MAGIC_SET, $def->getArgument(0));
+        } else {
+            $this->assertFalse($def->getArgument(0));
+        }
         $this->assertTrue($def->getArgument(0));
         $this->assertTrue($def->getArgument(1));
         $this->assertFalse($def->getArgument(3));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39830
| License       | MIT

PropertyAccess 5.2 changed the meaning of the first constructor parameter. To prevent a deprecation notice, the compatibility code is replicated in FrameworkExtension.

This change prevents a deprecation notice when used with PropertyAccess 5.2+. Users can't do anything about this notice except downgrading so I think a code change is in order to avoid it.