### PR TITLE
[HttpClient] Add check for constant in Curl client

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -170,7 +170,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             $curlopts[\CURLOPT_DNS_USE_GLOBAL_CACHE] = false;
         }
 
-        if (\defined('CURLOPT_HEADEROPT')) {
+        if (\defined('CURLOPT_HEADEROPT') && \defined('CURLHEADER_SEPARATE')) {
             $curlopts[\CURLOPT_HEADEROPT] = \CURLHEADER_SEPARATE;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

After updating Curl on a server, I started receiving the following warning:

```
Warning: Use of undefined constant CURLHEADER_SEPARATE - assumed 'CURLHEADER_SEPARATE' 
```

This is a bit of a strange issue, so I'm not 100% sure if this fix is correct (or even if it needs fixing here or in PHP).

The `CURLOPT_HEADEROPT` and `CURLHEADER_SEPARATE` have been added in [Curl 7.37.0](https://curl.se/libcurl/c/CURLHEADER_SEPARATE.html). The update on the server installed Curl `7.29.0`.
So technically these constants should not exist, but in fact the `CURLOPT_HEADEROPT` constant is defined but not the `CURLHEADER_SEPARATE` constant.

This seems a bit weird since both constants have been introduced in the same version.

**PHP Version**: 7.4.14
**Curl Version**: 7.29.0
**CentOs Version**: CentOS Linux release 7.9.2009
**symfony/http-client Version**: 5.0.3

```bash
Psy Shell v0.10.6 (PHP 7.4.14 — cli) by Justin Hileman
>>> defined('CURLOPT_HEADEROPT')
=> true
>>> defined('CURLHEADER_SEPARATE')
=> false
>>> curl_version()
=> [
     "version_number" => 466176,
     "age" => 3,
     "features" => 558781,
     "ssl_version_number" => 0,
     "version" => "7.29.0",
     "host" => "x86_64-redhat-linux-gnu",
     "ssl_version" => "NSS/3.53.1",
     "libz_version" => "1.2.7",
     "protocols" => [
       "dict",
       "file",
       "ftp",
       "ftps",
       "gopher",
       "http",
       "https",
       "imap",
       "imaps",
       "ldap",
       "ldaps",
       "pop3",
       "pop3s",
       "rtsp",
       "scp",
       "sftp",
       "smtp",
       "smtps",
       "telnet",
       "tftp",
     ],
     "ares" => "",
     "ares_num" => 0,
     "libidn" => "1.28",
     "iconv_ver_num" => 0,
     "libssh_version" => "libssh2/1.8.0",
   ]
>>>
```

```bash
$ yum info libcurl

Installed Packages
Name        : curl
Arch        : x86_64
Version     : 7.29.0
Release     : 59.el7_9.1
Size        : 528 k
Repo        : installed
From repo   : updates
```

Curl PHP info:

```
cURL support => enabled
cURL Information => 7.29.0
Age => 3
Features
AsynchDNS => Yes
CharConv => No
Debug => No
GSS-Negotiate => Yes
IDN => Yes
IPv6 => Yes
krb4 => No
Largefile => Yes
libz => Yes
NTLM => Yes
NTLMWB => Yes
SPNEGO => No
SSL => Yes
SSPI => No
TLS-SRP => No
Protocols => dict, file, ftp, ftps, gopher, http, https, imap, imaps, ldap, ldaps, pop3, pop3s, rtsp, scp, sftp, smtp, smtps, telnet, tftp
Host => x86_64-redhat-linux-gnu
SSL Version => NSS/3.53.1
ZLib Version => 1.2.7
libSSH Version => libssh2/1.8.0
```