### PR TITLE
[Uid] Clarify the format returned by getTime()

### DIFF
--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -104,6 +104,9 @@ class Ulid extends AbstractUid
         return $this->uid;
     }
 
+    /**
+     * @return float Seconds since the Unix epoch 1970-01-01 00:00:00
+     */
     public function getTime(): float
     {
         $time = strtr(substr($this->uid, 0, 10), 'ABCDEFGHJKMNPQRSTVWXYZ', 'abcdefghijklmnopqrstuv');

--- a/src/Symfony/Component/Uid/UuidV1.php
+++ b/src/Symfony/Component/Uid/UuidV1.php
@@ -31,6 +31,9 @@ class UuidV1 extends Uuid
         }
     }
 
+    /**
+     * @return float Seconds since the Unix epoch 1970-01-01 00:00:00
+     */
     public function getTime(): float
     {
         $time = '0'.substr($this->uid, 15, 3).substr($this->uid, 9, 4).substr($this->uid, 0, 8);

--- a/src/Symfony/Component/Uid/UuidV6.php
+++ b/src/Symfony/Component/Uid/UuidV6.php
@@ -32,6 +32,9 @@ class UuidV6 extends Uuid
         }
     }
 
+    /**
+     * @return float Seconds since the Unix epoch 1970-01-01 00:00:00
+     */
     public function getTime(): float
     {
         $time = '0'.substr($this->uid, 0, 8).substr($this->uid, 9, 4).substr($this->uid, 15, 3);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I think adding a comment to explain the returned format is useful here, especially for uuid since their "normal" epoch is not the unix epoch.