### PR TITLE
[HttpKernel] Show full URI when route not found

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -127,7 +127,7 @@ class RouterListener implements EventSubscriberInterface
             unset($parameters['_route'], $parameters['_controller']);
             $request->attributes->set('_route_params', $parameters);
         } catch (ResourceNotFoundException $e) {
-            $message = sprintf('No route found for "%s %s"', $request->getMethod(), $request->getPathInfo());
+            $message = sprintf('No route found for "%s %s"', $request->getMethod(), $request->getUriForPath($request->getPathInfo()));
 
             if ($referer = $request->headers->get('referer')) {
                 $message .= sprintf(' (from "%s")', $referer);
@@ -135,7 +135,7 @@ class RouterListener implements EventSubscriberInterface
 
             throw new NotFoundHttpException($message, $e);
         } catch (MethodNotAllowedException $e) {
-            $message = sprintf('No route found for "%s %s": Method Not Allowed (Allow: %s)', $request->getMethod(), $request->getPathInfo(), implode(', ', $e->getAllowedMethods()));
+            $message = sprintf('No route found for "%s %s": Method Not Allowed (Allow: %s)', $request->getMethod(), $request->getUriForPath($request->getPathInfo()), implode(', ', $e->getAllowedMethods()));
 
             throw new MethodNotAllowedHttpException($e->getAllowedMethods(), $message, $e);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      |no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

When accessing a route that does not exist, Symfony throws a `NotFoundHttpException` that says `No route found for "POST /path"`.

On some projects this might be good enough to find the root cause, but on projects that have lots of routes on different hosts, it becomes hard to understand how the request was initiated. Was it done over HTTP or HTTPS? What was the hostname? Did the user specify a port?

To make this easier, we now show the full URI of the path, like this: `No route found for "POST https://www.symfony.com/path"`.
