### PR TITLE
[Translator] Added $translator->addLoader() to README example

### DIFF
--- a/src/Symfony/Component/Translation/README.md
+++ b/src/Symfony/Component/Translation/README.md
@@ -12,8 +12,10 @@ $ composer require symfony/translation
 
 ```php
 use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\Loader\ArrayLoader;
 
 $translator = new Translator('fr_FR');
+$translator->addLoader('array', new ArrayLoader());
 $translator->addResource('array', [
     'Hello World!' => 'Bonjour !',
 ], 'fr_FR');


### PR DESCRIPTION
For the example to work it needs the line with $translator->addLoader().
Fixed it for request at https://github.com/symfony/symfony/issues/39854#issuecomment-762283989

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->
