### PR TITLE
[PropertyInfo] Fix breaking change with has*(arguments...) methods

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -239,7 +239,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         foreach ($this->accessorPrefixes as $prefix) {
             $methodName = $prefix.$camelProp;
 
-            if ($reflClass->hasMethod($methodName) && ($reflClass->getMethod($methodName)->getModifiers() & $this->methodReflectionFlags)) {
+            if ($reflClass->hasMethod($methodName) && $reflClass->getMethod($methodName)->getModifiers() & $this->methodReflectionFlags && !$reflClass->getMethod($methodName)->getNumberOfRequiredParameters()) {
                 $method = $reflClass->getMethod($methodName);
 
                 return new PropertyReadInfo(PropertyReadInfo::TYPE_METHOD, $methodName, $this->getReadVisiblityForMethod($method), $method->isStatic(), false);

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -75,6 +75,7 @@ class ReflectionExtractorTest extends TestCase
                 'xTotals',
                 'YT',
                 'date',
+                'element',
                 'c',
                 'd',
                 'e',
@@ -291,6 +292,7 @@ class ReflectionExtractorTest extends TestCase
             ['id', true],
             ['Guid', true],
             ['guid', false],
+            ['element', false],
         ];
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php
@@ -130,6 +130,8 @@ class Dummy extends ParentDummy
      */
     public $nestedIterators;
 
+    private $elements;
+
     public static function getStatic()
     {
     }
@@ -216,6 +218,10 @@ class Dummy extends ParentDummy
     }
 
     public function addDate(\DateTime $date)
+    {
+    }
+
+    public function hasElement(string $element): bool
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.1
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39885
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

Until 5.0:
```php
class Dummy
{
    private $elements;

    public function hasElement($element): bool
    {
        // ...
    }
}

$extractor = new ReflectionExtractor();
$extractor->isReadable('Dummy', 'element'); // false
```

After 5.0:
```php
class Dummy
{
    private $elements;

    public function hasElement($element): bool
    {
        // ...
    }
}

$extractor = new ReflectionExtractor();
$extractor->isReadable('Dummy', 'element'); // true => BREAKING CHANGE
```