### PR TITLE
[DependencyInjection] Autoconfigurable attributes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -58,6 +58,7 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\EventDispatcher\Attribute\EventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Finder\Finder;
@@ -548,6 +549,10 @@ class FrameworkExtension extends Extension
             ->addTag('mime.mime_type_guesser');
         $container->registerForAutoconfiguration(LoggerAwareInterface::class)
             ->addMethodCall('setLogger', [new Reference('logger')]);
+
+        $container->registerAttributeForAutoconfiguration(EventListener::class, static function (ChildDefinition $definition, EventListener $attribute): void {
+            $definition->addTag('kernel.event_listener', get_object_vars($attribute));
+        });
 
         if (!$container->getParameter('kernel.debug')) {
             // remove tagged iterator argument for resource checkers

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `ServicesConfigurator::remove()` in the PHP-DSL
  * Add `%env(not:...)%` processor to negate boolean values
  * Add support for loading autoconfiguration rules via the `#[Autoconfigure]` and `#[AutoconfigureTag]` attributes on PHP 8
+ * Add autoconfigurable attributes
 
 5.2.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class AttributeAutoconfigurationPass implements CompilerPassInterface
+{
+    private $ignoreAttributesTag;
+
+    public function __construct(string $ignoreAttributesTag = 'container.ignore_attributes')
+    {
+        $this->ignoreAttributesTag = $ignoreAttributesTag;
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (80000 > \PHP_VERSION_ID) {
+            return;
+        }
+
+        $autoconfiguredAttributes = $container->getAutoconfiguredAttributes();
+
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (!$definition->isAutoconfigured()
+                || $definition->isAbstract()
+                || $definition->hasTag($this->ignoreAttributesTag)
+                || !($reflector = $container->getReflectionClass($definition->getClass(), false))
+            ) {
+                continue;
+            }
+
+            $instanceof = $definition->getInstanceofConditionals();
+            $conditionals = $instanceof[$reflector->getName()] ?? new ChildDefinition('');
+            foreach ($reflector->getAttributes() as $attribute) {
+                if ($configurator = $autoconfiguredAttributes[$attribute->getName()] ?? null) {
+                    $configurator($conditionals, $attribute->newInstance(), $reflector);
+                }
+            }
+            $instanceof[$reflector->getName()] = $conditionals;
+            $definition->setInstanceofConditionals($instanceof);
+        }
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -43,6 +43,7 @@ class PassConfig
             100 => [
                 new ResolveClassPass(),
                 new RegisterAutoconfigureAttributesPass(),
+                new AttributeAutoconfigurationPass(),
                 new ResolveInstanceofConditionalsPass(),
                 new RegisterEnvVarProcessorsPass(),
             ],

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Attribute/CustomAutoconfiguration.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Attribute/CustomAutoconfiguration.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final class CustomAutoconfiguration
+{
+    public function __construct(
+        public string $someAttribute,
+        public int $priority = 0,
+    ) {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedService1.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedService1.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomAutoconfiguration;
+
+#[CustomAutoconfiguration(someAttribute: 'one')]
+#[CustomAutoconfiguration(someAttribute: 'two')]
+final class TaggedService1
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedService2.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedService2.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomAutoconfiguration;
+
+#[CustomAutoconfiguration(someAttribute: 'prio 100', priority: 100)]
+final class TaggedService2
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedService3.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedService3.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Attribute\CustomAutoconfiguration;
+
+#[CustomAutoconfiguration(someAttribute: 'three')]
+final class TaggedService3
+{
+    public int $sum = 0;
+    public bool $hasBeenConfigured = false;
+
+    public function __construct(
+        public string $foo,
+    ) {
+    }
+
+    public function doSomething(int $a, int $b, int $c): void
+    {
+        $this->sum = $a + $b + $c;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedService3Configurator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TaggedService3Configurator.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+final class TaggedService3Configurator
+{
+    public function __invoke(TaggedService3 $service)
+    {
+        $service->hasBeenConfigured = true;
+    }
+}

--- a/src/Symfony/Component/EventDispatcher/Attribute/EventListener.php
+++ b/src/Symfony/Component/EventDispatcher/Attribute/EventListener.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Attribute;
+
+/**
+ * Service tag to autoconfigure event listeners.
+ *
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class EventListener
+{
+    public function __construct(
+        public ?string $event = null,
+        public ?string $method = null,
+        public int $priority = 0
+    ) {
+    }
+}

--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3
+---
+
+ * Add `EventListener` attribute for declaring listeners on PHP 8.
+
 5.1.0
 -----
 

--- a/src/Symfony/Component/EventDispatcher/Tests/Fixtures/CustomEvent.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Fixtures/CustomEvent.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Tests\Fixtures;
+
+final class CustomEvent
+{
+}

--- a/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedInvokableListener.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedInvokableListener.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Tests\Fixtures;
+
+use Symfony\Component\EventDispatcher\Attribute\EventListener;
+
+#[EventListener]
+final class TaggedInvokableListener
+{
+    public function __invoke(CustomEvent $event): void
+    {
+    }
+}

--- a/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedMultiListener.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedMultiListener.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Tests\Fixtures;
+
+use Symfony\Component\EventDispatcher\Attribute\EventListener;
+
+#[EventListener(event: CustomEvent::class, method: 'onCustomEvent')]
+#[EventListener(event: 'foo', priority: 42)]
+#[EventListener(event: 'bar', method: 'onBarEvent')]
+final class TaggedMultiListener
+{
+    public function onCustomEvent(CustomEvent $event): void
+    {
+    }
+
+    public function onFoo(): void
+    {
+    }
+
+    public function onBarEvent(): void
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | TODO

Alternative to #39776. Please have a look at that PR as well to see the full discussion.

With this PR, I propose to introduce a way to autoconfigure services by using PHP Attributes. The feature is enabled on all autoconfigured service definitions. The heart of this feature is a new way to register autoconfiguration rules:

```php
$container->registerAttributeForAutoconfiguration(
    MyAttribute::class,
    static function (ChildDefinition $definition, MyAttribute $attribute, \ReflectionClass $reflector): void {
        $definition->addTag('my_tag', ['some_property' => $attribute->someProperty]);
    }
);
```

An example for such an attribute is shipped with this PR with the `EventListener` attribute. This piece of code is a fully functional autoconfigurable event listener:

```php
use Symfony\Component\EventDispatcher\Attribute\EventListener;
use Symfony\Component\HttpKernel\Event\RequestEvent;

#[EventListener]
class MyListener
{
    public function __invoke(RequestEvent $event): void
    {
        // …
    }
}
```

What makes attributes interesting for this kind of configuration is that they can transport meta information that can be evaluated during autoconfiguration. For instance, if we wanted to change the priority of the listener, we can just pass it to the attribute.

```php
#[EventListener(priority: 42)]
```

The attribute itself is a dumb data container and is unaware of the DI component.

This PR provides applications and bundles with the necessary tools to build own attributes and autoconfiguration rules.