### PR TITLE
[MonologBridge] Typo in consoleFormatterOptions property name

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ConsoleHandler.php
@@ -51,7 +51,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
         OutputInterface::VERBOSITY_VERY_VERBOSE => Logger::INFO,
         OutputInterface::VERBOSITY_DEBUG => Logger::DEBUG,
     ];
-    private $consoleFormaterOptions;
+    private $consoleFormatterOptions;
 
     /**
      * @param OutputInterface|null $output            The console output to use (the handler remains disabled when passing null
@@ -60,7 +60,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
      * @param array                $verbosityLevelMap Array that maps the OutputInterface verbosity to a minimum logging
      *                                                level (leave empty to use the default mapping)
      */
-    public function __construct(OutputInterface $output = null, bool $bubble = true, array $verbosityLevelMap = [], array $consoleFormaterOptions = [])
+    public function __construct(OutputInterface $output = null, bool $bubble = true, array $verbosityLevelMap = [], array $consoleFormatterOptions = [])
     {
         parent::__construct(Logger::DEBUG, $bubble);
         $this->output = $output;
@@ -69,7 +69,7 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
             $this->verbosityLevelMap = $verbosityLevelMap;
         }
 
-        $this->consoleFormaterOptions = $consoleFormaterOptions;
+        $this->consoleFormatterOptions = $consoleFormatterOptions;
     }
 
     /**
@@ -167,13 +167,13 @@ class ConsoleHandler extends AbstractProcessingHandler implements EventSubscribe
             return new LineFormatter();
         }
         if (!$this->output) {
-            return new ConsoleFormatter($this->consoleFormaterOptions);
+            return new ConsoleFormatter($this->consoleFormatterOptions);
         }
 
         return new ConsoleFormatter(array_replace([
             'colors' => $this->output->isDecorated(),
             'multiline' => OutputInterface::VERBOSITY_DEBUG <= $this->output->getVerbosity(),
-        ], $this->consoleFormaterOptions));
+        ], $this->consoleFormatterOptions));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fixes a typo in the property name, see also https://github.com/symfony/monolog-bundle/pull/384