### PR TITLE
[Notifier] Check for MercureBundle in MercureTransportFactory

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -25,7 +25,6 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader;
 use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
 use Symfony\Bundle\FullStack;
-use Symfony\Bundle\MercureBundle\MercureBundle;
 use Symfony\Component\Asset\PackageInterface;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\Cache\Adapter\AdapterInterface;

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/MercureTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/MercureTransportFactory.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Mercure;
 
+use Symfony\Bundle\MercureBundle\MercureBundle;
 use Symfony\Component\Mercure\PublisherInterface;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
@@ -47,6 +48,10 @@ final class MercureTransportFactory extends AbstractTransportFactory
 
         $publisherId = $dsn->getHost();
         if (!$this->publisherLocator->has($publisherId)) {
+            if (!class_exists(MercureBundle::class) && !$this->publisherLocator->getProvidedServices()) {
+                throw new LogicException('No publishers found. Did you forget to install the MercureBundle? Try running "composer require symfony/mercure-bundle".');
+            }
+
             throw new LogicException(sprintf('"%s" not found. Did you mean one of: %s?', $publisherId, implode(', ', array_keys($this->publisherLocator->getProvidedServices()))));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

https://github.com/symfony/symfony/pull/39903 has removed the check for `MercureBundle` from the `FrameworkExtension`.
The following PR is re-adding that check but in the `MercureTransportFactory` class.
