### PR TITLE
[PhpUnitBridge] Allow relative path to composer cache

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -157,6 +157,18 @@ $COMPOSER = file_exists($COMPOSER = $oldPwd.'/composer.phar')
     ? ('#!/usr/bin/env php' === file_get_contents($COMPOSER, false, null, 0, 18) ? $PHP : '').' '.escapeshellarg($COMPOSER) // detect shell wrappers by looking at the shebang
     : 'composer';
 
+$prevCacheDir = getenv('COMPOSER_CACHE_DIR');
+if ($prevCacheDir) {
+    if (false === $absoluteCacheDir = realpath($prevCacheDir)) {
+        @mkdir($prevCacheDir, 0777, true);
+        $absoluteCacheDir = realpath($prevCacheDir);
+    }
+    if ($absoluteCacheDir) {
+        putenv("COMPOSER_CACHE_DIR=$absoluteCacheDir");
+    } else {
+        $prevCacheDir = false;
+    }
+}
 $SYMFONY_PHPUNIT_REMOVE = $getEnvVar('SYMFONY_PHPUNIT_REMOVE', 'phpspec/prophecy'.($PHPUNIT_VERSION < 6.0 ? ' symfony/yaml' : ''));
 $configurationHash = md5(implode(\PHP_EOL, [md5_file(__FILE__), $SYMFONY_PHPUNIT_REMOVE, (int) $PHPUNIT_REMOVE_RETURN_TYPEHINT]));
 $PHPUNIT_VERSION_DIR = sprintf('phpunit-%s-%d', $PHPUNIT_VERSION, $PHPUNIT_REMOVE_RETURN_TYPEHINT);
@@ -239,6 +251,9 @@ if (!file_exists("$PHPUNIT_DIR/$PHPUNIT_VERSION_DIR/phpunit") || $configurationH
     // --no-suggest is not in the list to keep compat with composer 1.0, which is shipped with Ubuntu 16.04LTS
     $exit = proc_close(proc_open("$q$COMPOSER install --no-dev --prefer-dist --no-progress $q", [], $p, getcwd()));
     putenv('COMPOSER_ROOT_VERSION'.(false !== $prevRoot ? '='.$prevRoot : ''));
+    if ($prevCacheDir) {
+        putenv("COMPOSER_CACHE_DIR=$prevCacheDir");
+    }
     if ($exit) {
         exit($exit);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | fix #37652
| License       | MIT
| Doc PR        | -

When users defines a relative path in the `COMPOSER_CACHE_DIR` env variable, 
The `simple-phpunit` code, by changing the directory (with `chdir`), give to composer a different context. At the end, composer stores its cache inside the `vendor/bin/.phpunit` folder, and inside the `vendor/bin/.phpunit/phpunit-X.Y.Z` folder. 

This PR convert the relative path provided by the user into Absolute path.