### PR TITLE
[FrameworkBundle] Command cache:pool:clear warns and fails when one of the pools fails to clear

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
@@ -89,14 +89,25 @@ EOF
             $clearer->clear($kernel->getContainer()->getParameter('kernel.cache_dir'));
         }
 
+        $failure = false;
         foreach ($pools as $id => $pool) {
             $io->comment(sprintf('Clearing cache pool: <info>%s</info>', $id));
 
             if ($pool instanceof CacheItemPoolInterface) {
-                $pool->clear();
+                if (!$pool->clear()) {
+                    $io->warning(sprintf('Cache pool "%s" could not be cleared.', $pool));
+                    $failure = true;
+                }
             } else {
-                $this->poolClearer->clearPool($id);
+                if (false === $this->poolClearer->clearPool($id)) {
+                    $io->warning(sprintf('Cache pool "%s" could not be cleared.', $pool));
+                    $failure = true;
+                }
             }
+        }
+
+        if ($failure) {
+            return 1;
         }
 
         $io->success('Cache was successfully cleared.');

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
@@ -13,7 +13,9 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Finder\SplFileInfo;
 
 /**
  * @group functional
@@ -71,6 +73,35 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
         $this->expectExceptionMessage('You have requested a non-existent service "unknown_pool"');
         $this->createCommandTester()
             ->execute(['pools' => ['unknown_pool']], ['decorated' => false]);
+    }
+
+    public function testClearFailed()
+    {
+        $tester = $this->createCommandTester();
+        /** @var FilesystemAdapter $pool */
+        $pool = static::$container->get('cache.public_pool');
+        $item = $pool->getItem('foo');
+        $item->set('baz');
+        $pool->save($item);
+        $r = new \ReflectionObject($pool);
+        $p = $r->getProperty('directory');
+        $p->setAccessible(true);
+        $poolDir = $p->getValue($pool);
+
+        /** @var SplFileInfo $entry */
+        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($poolDir)) as $entry) {
+            // converts files into dir to make adapter fail
+            if ($entry->isFile()) {
+                unlink($entry->getPathname());
+                mkdir($entry->getPathname());
+            }
+        }
+
+        $tester->execute(['pools' => ['cache.public_pool']]);
+
+        $this->assertSame(1, $tester->getStatusCode(), 'cache:pool:clear exits with 1 in case of error');
+        $this->assertStringNotContainsString('[OK] Cache was successfully cleared.', $tester->getDisplay());
+        $this->assertStringContainsString('[WARNING] Cache pool "cache.public_pool" could not be cleared.', $tester->getDisplay());
     }
 
     private function createCommandTester()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | fix #39890
| License       | MIT
| Doc PR        | -

Throw an exception when clear cache fails