### PR TITLE
[RateLimiter] Fix infinite values with NoLimiter

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/NoLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/NoLimiter.php
@@ -29,12 +29,12 @@ final class NoLimiter implements LimiterInterface
 {
     public function reserve(int $tokens = 1, ?float $maxTime = null): Reservation
     {
-        return new Reservation(time(), new RateLimit(\INF, new \DateTimeImmutable(), true, \INF));
+        return new Reservation(time(), new RateLimit(\PHP_INT_MAX, new \DateTimeImmutable(), true, \PHP_INT_MAX));
     }
 
     public function consume(int $tokens = 1): RateLimit
     {
-        return new RateLimit(\INF, new \DateTimeImmutable(), true, \INF);
+        return new RateLimit(\PHP_INT_MAX, new \DateTimeImmutable(), true, \PHP_INT_MAX);
     }
 
     public function reset(): void

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/NoLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/NoLimiterTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\RateLimiter\Tests\Policy;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\RateLimiter\Policy\NoLimiter;
+use Symfony\Component\RateLimiter\RateLimit;
+use Symfony\Component\RateLimiter\Reservation;
+
+class NoLimiterTest extends TestCase
+{
+    public function testConsume()
+    {
+        $limiter = new NoLimiter();
+        $this->assertInstanceOf(RateLimit::class, $limiter->consume());
+    }
+
+    public function testReserve()
+    {
+        $limiter = new NoLimiter();
+        $this->assertInstanceOf(Reservation::class, $limiter->reserve());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39899
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

See #39899. I don't find any solution to convert `\INF` constant (which is a float value) to an integer.