### PR TITLE
[Intl] Add `DateIntervalFormatter`

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/IntlExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/IntlExtension.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Extension;
+
+use Symfony\Component\Intl\DateIntervalFormatter\DateIntervalFormatter;
+use Symfony\Component\Intl\DateIntervalFormatter\DateIntervalFormatterInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class IntlExtension extends AbstractExtension
+{
+    private $dateIntervalFormatter;
+
+    public function __construct(DateIntervalFormatterInterface $dateIntervalFormatter = null)
+    {
+        $this->dateIntervalFormatter = $dateIntervalFormatter ?? new DateIntervalFormatter();
+    }
+
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('date_interval', [$this->dateIntervalFormatter, 'formatInterval']),
+            new TwigFilter('date_relative', [$this->dateIntervalFormatter, 'formatRelative']),
+        ];
+    }
+}

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -31,7 +31,7 @@
         "symfony/form": "^5.3|^6.0",
         "symfony/http-foundation": "^5.3|^6.0",
         "symfony/http-kernel": "^4.4|^5.0|^6.0",
-        "symfony/intl": "^4.4|^5.0|^6.0",
+        "symfony/intl": "^5.4|^6.0",
         "symfony/mime": "^5.2|^6.0",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/property-info": "^4.4|^5.1|^6.0",

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -79,6 +79,7 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Intl\DateIntervalFormatter\DateIntervalFormatterInterface;
 use Symfony\Component\Lock\Lock;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
@@ -574,6 +575,10 @@ class FrameworkExtension extends Extension
             'kernel.locale_aware',
             'kernel.reset',
         ]);
+
+        if (class_exists(DateIntervalFormatterInterface::class)) {
+            $loader->load('intl.php');
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/intl.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/intl.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\Intl\DateIntervalFormatter\DateIntervalFormatter;
+use Symfony\Component\Intl\DateIntervalFormatter\DateIntervalFormatterInterface;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('intl.date_interval_formatter', DateIntervalFormatter::class)
+            ->alias(DateIntervalFormatterInterface::class, 'intl.date_interval_formatter')
+    ;
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\TranslationsCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
+use Symfony\Component\Intl\DateIntervalFormatter\DateIntervalFormatter;
+use Symfony\Component\Intl\DateIntervalFormatter\DateIntervalFormatterInterface;
 use Symfony\Component\Translation\Dumper\CsvFileDumper;
 use Symfony\Component\Translation\Dumper\IcuResFileDumper;
 use Symfony\Component\Translation\Dumper\IniFileDumper;
@@ -158,5 +160,8 @@ return static function (ContainerConfigurator $container) {
             ->args([service(ContainerInterface::class)])
             ->tag('container.service_subscriber', ['id' => 'translator'])
             ->tag('kernel.cache_warmer')
+
+        ->set('translation.formatter.date_interval', DateIntervalFormatter::class)
+            ->alias(DateIntervalFormatterInterface::class, 'translation.formatter.date_interval')
     ;
 };

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
@@ -21,6 +21,7 @@ use Symfony\Bridge\Twig\Extension\ExpressionExtension;
 use Symfony\Bridge\Twig\Extension\HttpFoundationExtension;
 use Symfony\Bridge\Twig\Extension\HttpKernelExtension;
 use Symfony\Bridge\Twig\Extension\HttpKernelRuntime;
+use Symfony\Bridge\Twig\Extension\IntlExtension;
 use Symfony\Bridge\Twig\Extension\ProfilerExtension;
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Bridge\Twig\Extension\SerializerExtension;
@@ -167,5 +168,9 @@ return static function (ContainerConfigurator $container) {
             ->args([service('serializer')])
 
         ->set('twig.extension.serializer', SerializerExtension::class)
+
+        ->set('twig.extension.intl', IntlExtension::class)
+            ->args([service('intl.date_interval_formatter')->nullOnInvalid()])
+            ->tag('twig.extension')
     ;
 };

--- a/src/Symfony/Component/Intl/CHANGELOG.md
+++ b/src/Symfony/Component/Intl/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+* Add `DateIntervalFormatter` to humanize a `DateInterval` or a difference between two `DateTimeInterface` objects
+
 5.3
 ---
 

--- a/src/Symfony/Component/Intl/DateIntervalFormatter/DateIntervalFormatter.php
+++ b/src/Symfony/Component/Intl/DateIntervalFormatter/DateIntervalFormatter.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Intl\DateIntervalFormatter;
+
+class DateIntervalFormatter implements DateIntervalFormatterInterface
+{
+    private const VALUE_NAMES = [
+        'y' => 'year',
+        'm' => 'month',
+        'd' => 'day',
+        'h' => 'hour',
+        'i' => 'minute',
+        's' => 'second',
+    ];
+
+    public function formatInterval($interval, int $precision = 0): string
+    {
+        if (!$interval instanceof \DateInterval) {
+            $interval = new \DateInterval($interval);
+        }
+
+        $elements = [];
+        $currentPrecision = 0;
+
+        foreach (self::VALUE_NAMES as $value => $name) {
+            if ($elements) {
+                ++$currentPrecision;
+            }
+
+            if ((!$precision || $currentPrecision < $precision) && $interval->{$value}) {
+                $elements[] = $this->format($interval->{$value}, $name);
+            }
+        }
+
+        $lastElement = array_pop($elements);
+
+        return null !== $lastElement ? ($elements ? implode(', ', $elements).' and '.$lastElement : $lastElement) : 'now';
+    }
+
+    /**
+     * @param \DateTimeInterface|string      $dateTime
+     * @param \DateTimeInterface|string|null $currentDateTime
+     */
+    public function formatRelative($dateTime, $currentDateTime = null, int $precision = 0): string
+    {
+        if (!$dateTime instanceof \DateTimeInterface) {
+            $dateTime = new \DateTimeImmutable($dateTime);
+        }
+
+        if (!$currentDateTime instanceof \DateTimeInterface) {
+            $currentDateTime = new \DateTimeImmutable($currentDateTime ?? 'now');
+        }
+
+        if ($dateTime > $currentDateTime) {
+            return 'in '.$this->formatInterval($currentDateTime->diff($dateTime));
+        }
+
+        if ($dateTime->getTimestamp() === $currentDateTime->getTimestamp()) {
+            return 'now';
+        }
+
+        return $this->formatInterval($currentDateTime->diff($dateTime), $precision).' ago';
+    }
+
+    private function format(int $number, string $singular): string
+    {
+        return $number > 1 ? "{$number} {$singular}s" : "{$number} {$singular}";
+    }
+}

--- a/src/Symfony/Component/Intl/DateIntervalFormatter/DateIntervalFormatterInterface.php
+++ b/src/Symfony/Component/Intl/DateIntervalFormatter/DateIntervalFormatterInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Intl\DateIntervalFormatter;
+
+interface DateIntervalFormatterInterface
+{
+    /**
+     * @param \DateInterval|string $interval
+     */
+    public function formatInterval($interval, int $precision = 0): string;
+
+    /**
+     * @param \DateTimeInterface|string      $dateTime
+     * @param \DateTimeInterface|string|null $currentDateTime
+     */
+    public function formatRelative($dateTime, $currentDateTime = null, int $precision = 0): string;
+}

--- a/src/Symfony/Component/Intl/Tests/DateIntervalFormatter/DateIntervalFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateIntervalFormatter/DateIntervalFormatterTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Intl\Tests\DateIntervalFormatter;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Intl\DateIntervalFormatter\DateIntervalFormatter;
+
+class DateIntervalFormatterTest extends TestCase
+{
+    /**
+     * @dataProvider provideIntervals
+     */
+    public function testFormatInterval($interval, string $expected, int $precision = 0)
+    {
+        $formatter = new DateIntervalFormatter();
+        $this->assertSame($expected, $formatter->formatInterval($interval, $precision));
+    }
+
+    public function provideIntervals(): \Generator
+    {
+        yield [new \DateInterval('PT0S'), 'now'];
+        yield [new \DateInterval('PT1S'), '1 second'];
+        yield [new \DateInterval('PT10S'), '10 seconds'];
+        yield [new \DateInterval('PT1M10S'), '1 minute and 10 seconds'];
+        yield [new \DateInterval('PT10M10S'), '10 minutes and 10 seconds'];
+        yield [new \DateInterval('PT1H10M10S'), '1 hour, 10 minutes and 10 seconds'];
+        yield [new \DateInterval('PT10H10M10S'), '10 hours, 10 minutes and 10 seconds'];
+        yield [new \DateInterval('P1DT10H10M10S'), '1 day, 10 hours, 10 minutes and 10 seconds'];
+        yield [new \DateInterval('P10DT10H10M10S'), '10 days, 10 hours, 10 minutes and 10 seconds'];
+        yield [new \DateInterval('P1M10DT10H10M10S'), '1 month, 10 days, 10 hours, 10 minutes and 10 seconds'];
+        yield [new \DateInterval('P10M10DT10H10M10S'), '10 months, 10 days, 10 hours, 10 minutes and 10 seconds'];
+        yield [new \DateInterval('P1Y10M10DT10H10M10S'), '1 year, 10 months, 10 days, 10 hours, 10 minutes and 10 seconds'];
+        yield [new \DateInterval('P10Y10M10DT10H10M10S'), '10 years, 10 months, 10 days, 10 hours, 10 minutes and 10 seconds'];
+        yield [new \DateInterval('P10Y10M10DT10H10M10S'), '10 years, 10 months and 10 days', 3];
+        yield [new \DateInterval('P1Y1DT1S'), '1 year and 1 day', 3];
+        yield ['PT1M10S', '1 minute and 10 seconds'];
+    }
+
+    /**
+     * @dataProvider provideDates
+     */
+    public function testFormatDates($dateTime, $currentDateTime, string $expected, int $precision = 0)
+    {
+        $formatter = new DateIntervalFormatter();
+        $this->assertSame($expected, $formatter->formatRelative($dateTime, $currentDateTime, $precision));
+    }
+
+    public function provideDates(): \Generator
+    {
+        yield [new \DateTime('2021-01-01'), new \DateTime('2020-01-01'), 'in 1 year'];
+        yield [new \DateTime('2020-01-01'), new \DateTime('2021-01-01'), '1 year ago'];
+        yield [new \DateTime('2021-01-01'), new \DateTime('2021-01-01'), 'now'];
+        yield [new \DateTime('2020-01-01'), new \DateTime('2021-02-02'), '1 year and 1 month ago', 2];
+        yield ['2021-01-01', new \DateTime('2020-01-01'), 'in 1 year'];
+        yield ['2021-01-01', '2020-01-01', 'in 1 year'];
+        yield ['-1 hour', null, '1 hour ago'];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #29929
| License       | MIT
| Doc PR        | TODO
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

```php
$formatter = new DateIntervalFormatter();
$formatter->formatInterval(new \DateInterval('P1DT5H2M')); // one day, 5 hours and 2 minutes
```

You can set a precision. The precision cuts the formatted content to a given number of elements:
```php
$formatter = new DateIntervalFormatter();
$formatter->formatInterval(new \DateInterval('P1DT20H2M'), 2); // one day and 20 hours
```