### PR TITLE
[OptionsResolver] Add prototype definition support for nested options

### DIFF
--- a/src/Symfony/Component/OptionsResolver/CHANGELOG.md
+++ b/src/Symfony/Component/OptionsResolver/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3
+---
+
+ * Add prototype definition for nested options
+
 5.1.0
 -----
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #34207
| License       | MIT
| Doc PR        | symfony/symfony-docs#...

This proposal adds a new method `setPrototype(true)` to the `OptionsResolver` component to mark options definition as array prototype:
```php
$this->resolver
    ->setDefault('connections', static function (OptionsResolver $resolver) { // nested option
        $resolver
            ->setPrototype(true) // <- the new method
            ->setRequired('table')
            ->setDefaults(['user' => 'root', 'password' => null]);
    })
;
```
This feature will allow passing options this way:
```php
$this->resolver->resolve([
    'connections' => [
        'default' => [ // <- the array index "default" is optional and validation free
            'table' => 'default',
        ],
        'custom' => [
            'user' => 'foo',
            'password' => 'pa$$',
            'table' => 'symfony',
        ],
    ],
])
```
You can add as many items as you want with the advantage of validating each item according to its prototype definition.

The result for this example would be:
```php
[
    'connections' => [
        'default' => [
            'user' => 'root',
            'password' => null,
            'table' => 'default',
        ],
        'custom' => [
            'user' => 'foo',
            'password' => 'pa$$',
            'table' => 'symfony',
        ],
    ],
]
```

This feature is feasible only for nested options so far and the nested option (e.g. "connections") must be of type array of array.

See the test cases for more details about this feature.

Cheers!