### PR TITLE
[FrameworkBundle][Security] Make CSRF tokens expirable

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -164,10 +164,19 @@ class Configuration implements ConfigurationInterface
                     ->treatFalseLike(['enabled' => false])
                     ->treatTrueLike(['enabled' => true])
                     ->treatNullLike(['enabled' => true])
+                    ->beforeNormalization()
+                        ->ifArray()
+                        ->then(function ($v) {
+                            $v['enabled'] = $v['enabled'] ?? true;
+
+                            return $v;
+                        })
+                    ->end()
                     ->addDefaultsIfNotSet()
                     ->children()
                         // defaults to framework.session.enabled && !class_exists(FullStack::class) && interface_exists(CsrfTokenManagerInterface::class)
                         ->booleanNode('enabled')->defaultNull()->end()
+                        ->integerNode('token_lifetime')->defaultNull()->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1553,6 +1553,7 @@ class FrameworkExtension extends Extension
         if (!class_exists(CsrfExtension::class)) {
             $container->removeDefinition('twig.extension.security_csrf');
         }
+        $container->setParameter('security.csrf.ttl', $config['token_lifetime']);
     }
 
     private function registerSerializerConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -63,6 +63,7 @@
 
     <xsd:complexType name="csrf_protection">
         <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="token_lifetime" type="xsd:integer" />
     </xsd:complexType>
 
     <xsd:complexType name="esi">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/security_csrf.php
@@ -37,6 +37,7 @@ return static function (ContainerConfigurator $container) {
                 service('security.csrf.token_generator'),
                 service('security.csrf.token_storage'),
                 service('request_stack')->ignoreOnInvalid(),
+                param('security.csrf.ttl'),
             ])
             ->tag('container.private', ['package' => 'symfony/framework-bundle', 'version' => '5.2'])
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -374,7 +374,8 @@ class ConfigurationTest extends TestCase
                 'x-forwarded-proto',
             ],
             'csrf_protection' => [
-                'enabled' => false,
+                'enabled' => null,
+                'token_lifetime' => null,
             ],
             'form' => [
                 'enabled' => !class_exists(FullStack::class),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -3,7 +3,9 @@
 $container->loadFromExtension('framework', [
     'secret' => 's3cr3t',
     'default_locale' => 'fr',
-    'csrf_protection' => true,
+    'csrf_protection' => [
+        'token_lifetime' => 60,
+    ],
     'form' => [
         'csrf_protection' => [
             'field_name' => '_csrf',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -7,7 +7,7 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config secret="s3cr3t" ide="file%%link%%format" default-locale="fr" http-method-override="false">
-        <framework:csrf-protection />
+        <framework:csrf-protection token_lifetime="60"/>
         <framework:form legacy-error-messages="false">
             <framework:csrf-protection field-name="_csrf"/>
         </framework:form>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -1,7 +1,8 @@
 framework:
     secret: s3cr3t
     default_locale: fr
-    csrf_protection: true
+    csrf_protection:
+        token_lifetime: 60
     form:
         csrf_protection:
             field_name: _csrf

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -83,6 +83,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertTrue($container->getParameter('form.type_extension.csrf.enabled'));
         $this->assertEquals('%form.type_extension.csrf.enabled%', $def->getArgument(1));
         $this->assertEquals('_csrf', $container->getParameter('form.type_extension.csrf.field_name'));
+        $this->assertEquals(60, $container->getParameter('security.csrf.ttl'));
         $this->assertEquals('%form.type_extension.csrf.field_name%', $def->getArgument(2));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TODO

This PR adds an opt-in mechanism to make CSRF tokens expirable (with a different value than session) mitigating replay attacks.