### PR TITLE
[Console] Fix console logger according to PSR-3

### DIFF
--- a/src/Symfony/Component/Console/EventListener/ErrorListener.php
+++ b/src/Symfony/Component/Console/EventListener/ErrorListener.php
@@ -40,12 +40,12 @@ class ErrorListener implements EventSubscriberInterface
         $error = $event->getError();
 
         if (!$inputString = $this->getInputString($event)) {
-            $this->logger->error('An error occurred while using the console. Message: "{message}"', ['exception' => $error, 'message' => $error->getMessage()]);
+            $this->logger->critical('An error occurred while using the console. Message: "{message}"', ['exception' => $error, 'message' => $error->getMessage()]);
 
             return;
         }
 
-        $this->logger->error('Error thrown while running command "{command}". Message: "{message}"', ['exception' => $error, 'command' => $inputString, 'message' => $error->getMessage()]);
+        $this->logger->critical('Error thrown while running command "{command}". Message: "{message}"', ['exception' => $error, 'command' => $inputString, 'message' => $error->getMessage()]);
     }
 
     public function onConsoleTerminate(ConsoleTerminateEvent $event)

--- a/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
@@ -33,7 +33,7 @@ class ErrorListenerTest extends TestCase
         $logger = $this->getLogger();
         $logger
             ->expects($this->once())
-            ->method('error')
+            ->method('critical')
             ->with('Error thrown while running command "{command}". Message: "{message}"', ['exception' => $error, 'command' => 'test:run --foo=baz buzz', 'message' => 'An error occurred'])
         ;
 
@@ -48,7 +48,7 @@ class ErrorListenerTest extends TestCase
         $logger = $this->getLogger();
         $logger
             ->expects($this->once())
-            ->method('error')
+            ->method('critical')
             ->with('An error occurred while using the console. Message: "{message}"', ['exception' => $error, 'message' => 'An error occurred'])
         ;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39050, #29138
| License       | MIT

`Symfony\Component\HttpKernel\EventListener\ErrorListener` logs non-HTTP exceptions at `LogLevel::CRITICAL`.
`Symfony\Component\Messenger\Worker` logs unrecoverable exceptions at `LogLevel::CRITICAL`.
`Symfony\Component\Console\EventListener\ErrorListener` logs exceptions at `LogLevel::ERROR`.

As per PSR-3, unexpected and unrecoverable exceptions should be logged at `LogLevel::CRITICAL`.
