### PR TITLE
[Mailer][Mime] Fix case-sensitive handling of header names

### DIFF
--- a/src/Symfony/Component/Mailer/EventListener/MessageListener.php
+++ b/src/Symfony/Component/Mailer/EventListener/MessageListener.php
@@ -58,7 +58,7 @@ class MessageListener implements EventSubscriberInterface
             throw new InvalidArgumentException(sprintf('The "%d" rule is not supported.', $rule));
         }
 
-        $this->headerRules[$headerName] = $rule;
+        $this->headerRules[strtolower($headerName)] = $rule;
     }
 
     public function onMessage(MessageEvent $event): void

--- a/src/Symfony/Component/Mailer/Tests/EventListener/MessageListenerTest.php
+++ b/src/Symfony/Component/Mailer/Tests/EventListener/MessageListenerTest.php
@@ -101,5 +101,17 @@ class MessageListenerTest extends TestCase
             ->add(new MailboxListHeader('bcc', [new Address('bcc-initial@example.com'), new Address('bcc-default@example.com'), new Address('bcc-default-1@example.com')]))
         ;
         yield 'bcc, add another bcc (unique header)' => [$initialHeaders, $defaultHeaders, $expectedHeaders];
+
+        $initialHeaders = (new Headers())
+            ->add(new UnstructuredHeader('foo', 'initial'))
+        ;
+        $defaultHeaders = (new Headers())
+            ->add(new UnstructuredHeader('foo', 'bar'))
+            ->add(new UnstructuredHeader('bar', 'foo'))
+        ;
+        $rules = [
+            'Foo' => MessageListener::HEADER_REPLACE,
+        ];
+        yield 'Capitalized header rule (case-insensitive), replace if set' => [$initialHeaders, $defaultHeaders, $defaultHeaders, $rules];
     }
 }

--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -143,7 +143,7 @@ final class Headers
      */
     public function addHeader(string $name, $argument, array $more = []): self
     {
-        $parts = explode('\\', self::HEADER_CLASS_MAP[$name] ?? UnstructuredHeader::class);
+        $parts = explode('\\', self::HEADER_CLASS_MAP[strtolower($name)] ?? UnstructuredHeader::class);
         $method = 'add'.ucfirst(array_pop($parts));
         if ('addUnstructuredHeader' === $method) {
             $method = 'addTextHeader';
@@ -217,7 +217,7 @@ final class Headers
 
     public static function isUniqueHeader(string $name): bool
     {
-        return \in_array($name, self::UNIQUE_HEADERS, true);
+        return \in_array(strtolower($name), self::UNIQUE_HEADERS, true);
     }
 
     /**

--- a/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
@@ -239,6 +239,20 @@ class HeadersTest extends TestCase
         $this->assertFalse($headers->has('Message-ID'));
     }
 
+    public function testAddHeaderIsNotCaseSensitive()
+    {
+        $headers = new Headers();
+        $headers->addHeader('From', ['from@example.com']);
+
+        $this->assertInstanceOf(MailboxListHeader::class, $headers->get('from'));
+        $this->assertEquals([new Address('from@example.com')], $headers->get('from')->getBody());
+    }
+
+    public function testIsUniqueHeaderIsNotCaseSensitive()
+    {
+        $this->assertTrue(Headers::isUniqueHeader('From'));
+    }
+
     public function testToStringJoinsHeadersTogether()
     {
         $headers = new Headers();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39953
| License       | MIT
| Doc PR        | -

Fixes case-sensitive handling of header names in "Mime" and "Mailer" component, more in the [ticket](https://github.com/symfony/symfony/issues/39953).
