### PR TITLE
[Console] Fix typo in console.command description

### DIFF
--- a/src/Symfony/Component/Console/ConsoleEvents.php
+++ b/src/Symfony/Component/Console/ConsoleEvents.php
@@ -21,7 +21,7 @@ final class ConsoleEvents
     /**
      * The COMMAND event allows you to attach listeners before any command is
      * executed by the console. It also allows you to modify the command, input and output
-     * before they are handled to the command.
+     * before they are handed to the command.
      *
      * @Event("Symfony\Component\Console\Event\ConsoleCommandEvent")
      */


### PR DESCRIPTION
input and output can be handed to the command, handed off to the command, or can be handled by the command, but handled to the command doesn't work

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
