### PR TITLE
[Messenger] fix redis messenger options with dsn

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -85,6 +85,19 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testFromDsnWithMixDsnQueryOptions()
+    {
+        $this->assertEquals(
+            Connection::fromDsn('redis://localhost/queue/group1?serializer=2', ['consumer' => 'specific-consumer']),
+            Connection::fromDsn('redis://localhost/queue/group1/specific-consumer?serializer=2')
+        );
+
+        $this->assertEquals(
+            Connection::fromDsn('redis://localhost/queue/group1/consumer1', ['consumer' => 'specific-consumer']),
+            Connection::fromDsn('redis://localhost/queue/group1/consumer1')
+        );
+    }
+
     public function testKeepGettingPendingMessages()
     {
         $redis = $this->getMockBuilder(\Redis::class)->disableOriginalConstructor()->getMock();

--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -101,7 +101,8 @@ class Connection
         ];
 
         if (isset($parsedUrl['query'])) {
-            parse_str($parsedUrl['query'], $redisOptions);
+            parse_str($parsedUrl['query'], $dsnOptions);
+            $redisOptions = array_merge($redisOptions, $dsnOptions);
         }
 
         $autoSetup = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39834
| License       | MIT

This will fix the fact that you can use framework.messenger.transports.*.options to complete/default your redis configuration