### PR TITLE
[Messenger] Fix transporting non-UTF8 payloads by encoding them using base 64

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
@@ -76,6 +76,17 @@ class PhpSerializerTest extends TestCase
         $encoded = $serializer->encode($envelope);
         $this->assertStringNotContainsString('DummyPhpSerializerNonSendableStamp', $encoded['body']);
     }
+
+    public function testNonUtf8IsBase64Encoded()
+    {
+        $serializer = new PhpSerializer();
+
+        $envelope = new Envelope(new DummyMessage("\xE9"));
+
+        $encoded = $serializer->encode($envelope);
+        $this->assertTrue((bool) preg_match('//u', $encoded['body']), 'Encodes non-UTF8 payloads');
+        $this->assertEquals($envelope, $serializer->decode($encoded));
+    }
 }
 
 class DummyPhpSerializerNonSendableStamp implements NonSendableStampInterface

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -29,6 +29,10 @@ class PhpSerializer implements SerializerInterface
             throw new MessageDecodingFailedException('Encoded envelope should have at least a "body".');
         }
 
+        if (false === strpos($encodedEnvelope['body'], '}', -1)) {
+            $encodedEnvelope['body'] = base64_decode($encodedEnvelope['body']);
+        }
+
         $serializeEnvelope = stripslashes($encodedEnvelope['body']);
 
         return $this->safelyUnserialize($serializeEnvelope);
@@ -42,6 +46,10 @@ class PhpSerializer implements SerializerInterface
         $envelope = $envelope->withoutStampsOfType(NonSendableStampInterface::class);
 
         $body = addslashes(serialize($envelope));
+
+        if (!preg_match('//u', $body)) {
+            $body = base64_encode($body);
+        }
 
         return [
             'body' => $body,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #33913
| License       | MIT
| Doc PR        | -

Replaces #33920

When using the Doctrine transport, sending emails with binary attachments currently requires a custom Messenger serializer because the "body" column is created for UTF-8 only.

In #33920, it is proposed to change the TEXT type to a BLOB. It leaves at least one problem unhandled: the conversion of existing messenger tables.

This PR takes a more conservative approach, by encoding messages to base 64, only if they are non-UTF8.

Compatibility with the existing format is preserved.

The drawback of this approach is that the size of eg email attachments is going to increase by 33% because of the extra encoding. I think this drawback is acceptable for 4.4, and that this PR is the most pragmatic way to make attachments just work.