### PR TITLE
[Serializer] Fix tests wrongly marked as incomplete

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/IgnoredAttributesTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/IgnoredAttributesTestTrait.php
@@ -38,8 +38,6 @@ trait IgnoredAttributesTestTrait
             $normalizer->normalize($objectOuter, null, $context)
         );
 
-        $this->markTestIncomplete('AbstractObjectNormalizer::getAttributes caches attributes by class instead of by class+context, reusing the normalizer with different config therefore fails. This is being fixed in https://github.com/symfony/symfony/pull/30907');
-
         $context = ['ignored_attributes' => ['foo', 'inner']];
         $this->assertEquals(
             [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

https://github.com/symfony/symfony/pull/30907 has been merged meanwhile.