### PR TITLE
[Console] Add bright colors to console.

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add the `Command::$defaultDescription` static property and the `description` attribute
    on the `console.command` tag to allow the `list` command to instantiate commands lazily
  * Add option `--short` to the `list` command
+ * Add support for bright colors
 
 5.2.0
 -----

--- a/src/Symfony/Component/Console/Tests/ColorTest.php
+++ b/src/Symfony/Component/Console/Tests/ColorTest.php
@@ -24,6 +24,9 @@ class ColorTest extends TestCase
         $color = new Color('red', 'yellow');
         $this->assertSame("\033[31;43m \033[39;49m", $color->apply(' '));
 
+        $color = new Color('bright-red', 'bright-yellow');
+        $this->assertSame("\033[91;103m \033[39;49m", $color->apply(' '));
+
         $color = new Color('red', 'yellow', ['underscore']);
         $this->assertSame("\033[31;43;4m \033[39;49;24m", $color->apply(' '));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x <!-- see below -->
| Bug fix?      |no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #39869 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#14884 <!-- required for new features -->

Add the "bright" ANSI colours to symfony/console. This adds ANSI escape codes 90-97 and 100-107.
<!--
Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->
