### PR TITLE
[Mailer][Mime] Update inline part names with newly generated ContentId

### DIFF
--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -491,6 +491,7 @@ class Email extends Message
                 $attachment['inline'] = true;
                 $inlineParts[$name] = $part = $this->createDataPart($attachment);
                 $html = str_replace('cid:'.$name, 'cid:'.$part->getContentId(), $html);
+                $part->setName($part->getContentId());
                 continue 2;
             }
             $attachmentParts[] = $this->createDataPart($attachment);


### PR DESCRIPTION
Inline parts are identified by matching attachment names to cids found in the html part. In line 487 cids are regenerated and replaced in the html part, but the attachment names were not similarly replaced.

| Q             | A
| ------------- | ---
| Branch?       | 5.2 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| License       | MIT
