### PR TITLE
[Filesystem] Try to rename directories before deleting them

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -170,6 +170,12 @@ class Filesystem
                     throw new IOException(sprintf('Failed to remove symlink "%s": ', $file).self::$lastError);
                 }
             } elseif (is_dir($file)) {
+                // Rename directory before removing it to mitigate the chance of
+                // another process writing to it during the operation.
+                // @see https://github.com/symfony/symfony/issues/27578
+                $orig_file = $file;
+                $file = '.symfony-tmp.' . substr(sha1(rand()), 0, 7);
+                $this->rename($orig_file, $file);
                 $this->remove(new \FilesystemIterator($file, \FilesystemIterator::CURRENT_AS_PATHNAME | \FilesystemIterator::SKIP_DOTS));
 
                 if (!self::box('rmdir', $file) && file_exists($file)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #27578
| License       | MIT

This is a proof of concept solution for #27578. The bug is so old that I'm no longer in a position where I see it regularly, but I'm confident that it is still a bug. This is totally untested but hopefully points people on the right track.
