### PR TITLE
[Security] Refresh original user in SwitchUserListener

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -217,6 +217,7 @@ class SwitchUserListener extends AbstractListener implements ListenerInterface
 
         if (null !== $this->dispatcher && $original->getUser() instanceof UserInterface) {
             $user = $this->provider->refreshUser($original->getUser());
+            $original->setUser($user);
             $switchEvent = new SwitchUserEvent($request, $user, $original);
             $this->dispatcher->dispatch($switchEvent, SecurityEvents::SWITCH_USER);
             $original = $switchEvent->getToken();

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -413,4 +413,34 @@ class SwitchUserListenerTest extends TestCase
         $this->assertInstanceOf(UsernamePasswordToken::class, $this->tokenStorage->getToken());
         $this->assertFalse($this->event->hasResponse());
     }
+
+    public function testSwitchUserRefreshesOriginalToken()
+    {
+        $originalUser = $this->createMock(UserInterface::class);
+        $refreshedOriginalUser = $this->createMock(UserInterface::class);
+        $this
+            ->userProvider
+            ->expects($this->any())
+            ->method('refreshUser')
+            ->with($originalUser)
+            ->willReturn($refreshedOriginalUser);
+        $originalToken = new UsernamePasswordToken($originalUser, '', 'key');
+        $this->tokenStorage->setToken(new SwitchUserToken('username', '', 'key', ['ROLE_USER'], $originalToken));
+        $this->request->query->set('_switch_user', SwitchUserListener::EXIT_VALUE);
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                $this->callback(function (SwitchUserEvent $event) use ($refreshedOriginalUser) {
+                    return $event->getToken()->getUser() === $refreshedOriginalUser;
+                }),
+                SecurityEvents::SWITCH_USER
+            )
+        ;
+
+        $listener = new SwitchUserListener($this->tokenStorage, $this->userProvider, $this->userChecker, 'provider123', $this->accessDecisionManager, null, '_switch_user', 'ROLE_ALLOWED_TO_SWITCH', $dispatcher);
+        $listener($this->event);
+    }
 }


### PR DESCRIPTION
Fixes #39991

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39991
| License       | MIT
| Doc PR        | NA

Fix SwitchUserListener to update original token with refreshed user. This prevents a non-refreshed user from causing problems elsewhere, such as in Voters.