### PR TITLE
[Uid] Fix time to float conversion

### DIFF
--- a/src/Symfony/Component/Uid/BinaryUtil.php
+++ b/src/Symfony/Component/Uid/BinaryUtil.php
@@ -124,7 +124,7 @@ class BinaryUtil
         $time = self::add($time, self::TIME_OFFSET_COM2);
 
         if ($time >= self::TIME_OFFSET_COM2) {
-            $time = -1 * self::toBase($time ^ "\xff\xff\xff\xff\xff\xff\xff\xff", self::BASE10);
+            $time = -1 * (self::toBase($time ^ "\xff\xff\xff\xff\xff\xff\xff\xff", self::BASE10) + 1);
         } else {
             $time[0] = $time[0] & "\x7F";
             $time = self::toBase($time, self::BASE10);

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -199,4 +199,13 @@ class UuidTest extends TestCase
     {
         $this->assertInstanceOf(CustomUuid::class, CustomUuid::fromString(self::A_UUID_V4));
     }
+
+    public function testGetTime()
+    {
+        $this->assertSame(103072857660.6847, ((new UuidV1('ffffffff-ffff-1fff-a456-426655440000'))->getTime()));
+        $this->assertSame(0.0000001, ((new UuidV1('13814001-1dd2-11b2-a456-426655440000'))->getTime()));
+        $this->assertSame(0.0, (new UuidV1('13814000-1dd2-11b2-a456-426655440000'))->getTime());
+        $this->assertSame(-0.0000001, (new UuidV1('13813fff-1dd2-11b2-a456-426655440000'))->getTime());
+        $this->assertSame(-12219292800.0, ((new UuidV1('00000000-0000-1000-a456-426655440000'))->getTime()));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

On 32b systems, when the timestamp is before the UNIX epoch, the result is currently shifted by 1. Inverting all the bits is not enough, we need to add 1. I guess https://en.wikipedia.org/wiki/Two%27s_complement is relevant here?

Alternative:
```php
$time = -1 * self::toBase(self::add($time ^ "\xff\xff\xff\xff\xff\xff\xff\xff", "\x00\x00\x00\x00\x00\x00\x00\x01"), self::BASE10);
```