### PR TITLE
[Mailer] Fix SES test

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -100,15 +100,16 @@ class SesApiAsyncAwsTransportTest extends TestCase
     public function testSendThrowsForErrorResponse()
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
-            $xml = "<SendEmailResponse xmlns=\"https://email.amazonaws.com/doc/2010-03-31/\">
-                <Error>
-                    <Message>i'm a teapot</Message>
-                    <Code>418</Code>
-                </Error>
-            </SendEmailResponse>";
+            $json = json_encode([
+                'message' => 'i\'m a teapot',
+                'type' => 'sender',
+            ]);
 
-            return new MockResponse($xml, [
+            return new MockResponse($json, [
                 'http_code' => 418,
+                'response_headers' => [
+                    'x-amzn-errortype' => '418',
+                ],
             ]);
         });
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
@@ -95,15 +95,16 @@ class SesHttpAsyncAwsTransportTest extends TestCase
     public function testSendThrowsForErrorResponse()
     {
         $client = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
-            $xml = "<SendEmailResponse xmlns=\"https://email.amazonaws.com/doc/2010-03-31/\">
-                <Error>
-                    <Message>i'm a teapot</Message>
-                    <Code>418</Code>
-                </Error>
-            </SendEmailResponse>";
+            $json = json_encode([
+                'message' => 'i\'m a teapot',
+                'type' => 'sender',
+            ]);
 
-            return new MockResponse($xml, [
+            return new MockResponse($json, [
                 'http_code' => 418,
+                'response_headers' => [
+                    'x-amzn-errortype' => '418',
+                ],
             ]);
         });
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When using the native (deprecated) Transport, we used the `SES` AWS endoint, but the new version that rely on async-aws uses `SESV2`. The former uses XML, but the new one use JSON.
Since https://github.com/async-aws/aws/pull/933 `async-aws` is stricter on reponses parsing, and now is not able to parse an XML response when the endpoint expect JSON.

This PR fixes the tests to be compliant with AWS SESV2 protocol