### PR TITLE
[ErrorHandler] Fix strpos error when trying to call a method without a name

### DIFF
--- a/src/Symfony/Component/Debug/FatalErrorHandler/UndefinedMethodFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/UndefinedMethodFatalErrorHandler.php
@@ -40,7 +40,7 @@ class UndefinedMethodFatalErrorHandler implements FatalErrorHandlerInterface
 
         $message = sprintf('Attempted to call an undefined method named "%s" of class "%s".', $methodName, $className);
 
-        if (!class_exists($className) || null === $methods = get_class_methods($className)) {
+        if ('' === $methodName || !class_exists($className) || null === $methods = get_class_methods($className)) {
             // failed to get the class or its methods on which an unknown method was called (for example on an anonymous class)
             return new UndefinedMethodException($message, $exception);
         }

--- a/src/Symfony/Component/Debug/Tests/FatalErrorHandler/UndefinedMethodFatalErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/FatalErrorHandler/UndefinedMethodFatalErrorHandlerTest.php
@@ -53,6 +53,15 @@ class UndefinedMethodFatalErrorHandlerTest extends TestCase
                     'type' => 1,
                     'line' => 12,
                     'file' => 'foo.php',
+                    'message' => 'Call to undefined method SplObjectStorage::()',
+                ],
+                'Attempted to call an undefined method named "" of class "SplObjectStorage".',
+            ],
+            [
+                [
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
                     'message' => 'Call to undefined method SplObjectStorage::walid()',
                 ],
                 "Attempted to call an undefined method named \"walid\" of class \"SplObjectStorage\".\nDid you mean to call \"valid\"?",

--- a/src/Symfony/Component/ErrorHandler/ErrorEnhancer/UndefinedMethodErrorEnhancer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorEnhancer/UndefinedMethodErrorEnhancer.php
@@ -39,7 +39,7 @@ class UndefinedMethodErrorEnhancer implements ErrorEnhancerInterface
 
         $message = sprintf('Attempted to call an undefined method named "%s" of class "%s".', $methodName, $className);
 
-        if (!class_exists($className) || null === $methods = get_class_methods($className)) {
+        if ('' === $methodName || !class_exists($className) || null === $methods = get_class_methods($className)) {
             // failed to get the class or its methods on which an unknown method was called (for example on an anonymous class)
             return new UndefinedMethodError($message, $error);
         }

--- a/src/Symfony/Component/ErrorHandler/Tests/ErrorEnhancer/UndefinedMethodErrorEnhancerTest.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/ErrorEnhancer/UndefinedMethodErrorEnhancerTest.php
@@ -41,6 +41,10 @@ class UndefinedMethodErrorEnhancerTest extends TestCase
                 'Attempted to call an undefined method named "what" of class "SplObjectStorage".',
             ],
             [
+                'Call to undefined method SplObjectStorage::()',
+                'Attempted to call an undefined method named "" of class "SplObjectStorage".',
+            ],
+            [
                 'Call to undefined method SplObjectStorage::walid()',
                 "Attempted to call an undefined method named \"walid\" of class \"SplObjectStorage\".\nDid you mean to call \"valid\"?",
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None (direct fix)
| License       | MIT
| Doc PR        | None
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
-->

When running the following code:

```php
class Foo
{
    // Some code here
}

$str = ''; // this should not happen, but for some reason, it did.
$foo->{$str}();
```

a fatal error occurs because the method name to execute is empty, but Symfony's error enhancer fails to parse it:

![Error screenshot](https://user-images.githubusercontent.com/7600265/106108704-ec019b80-6148-11eb-82bc-f7801e30fea4.png)

In this PR, I propose a fix with a more clear error to inform the developer about what happened.