### PR TITLE
[DoctrineBridge] add missing `@experimental` annotation on Uid generators

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 -----
 
  * added support for symfony/uid as `UlidType` and `UuidType` as Doctrine types
- * added `UlidGenerator`, `UUidV1Generator`, `UuidV4Generator` and `UuidV6Generator`
+ * added `UlidGenerator`, `UuidV1Generator`, `UuidV4Generator` and `UuidV6Generator`
 
 5.0.0
 -----

--- a/src/Symfony/Bridge/Doctrine/IdGenerator/UlidGenerator.php
+++ b/src/Symfony/Bridge/Doctrine/IdGenerator/UlidGenerator.php
@@ -15,6 +15,9 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Id\AbstractIdGenerator;
 use Symfony\Component\Uid\Ulid;
 
+/**
+ * @experimental in 5.2
+ */
 final class UlidGenerator extends AbstractIdGenerator
 {
     public function generate(EntityManager $em, $entity): Ulid

--- a/src/Symfony/Bridge/Doctrine/IdGenerator/UuidV1Generator.php
+++ b/src/Symfony/Bridge/Doctrine/IdGenerator/UuidV1Generator.php
@@ -15,6 +15,9 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Id\AbstractIdGenerator;
 use Symfony\Component\Uid\UuidV1;
 
+/**
+ * @experimental in 5.2
+ */
 final class UuidV1Generator extends AbstractIdGenerator
 {
     public function generate(EntityManager $em, $entity): UuidV1

--- a/src/Symfony/Bridge/Doctrine/IdGenerator/UuidV4Generator.php
+++ b/src/Symfony/Bridge/Doctrine/IdGenerator/UuidV4Generator.php
@@ -15,6 +15,9 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Id\AbstractIdGenerator;
 use Symfony\Component\Uid\UuidV4;
 
+/**
+ * @experimental in 5.2
+ */
 final class UuidV4Generator extends AbstractIdGenerator
 {
     public function generate(EntityManager $em, $entity): UuidV4

--- a/src/Symfony/Bridge/Doctrine/IdGenerator/UuidV6Generator.php
+++ b/src/Symfony/Bridge/Doctrine/IdGenerator/UuidV6Generator.php
@@ -15,6 +15,9 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Id\AbstractIdGenerator;
 use Symfony\Component\Uid\UuidV6;
 
+/**
+ * @experimental in 5.2
+ */
 final class UuidV6Generator extends AbstractIdGenerator
 {
     public function generate(EntityManager $em, $entity): UuidV6


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Forgotten when we created the classes.

Needed since I plan to remove all the `UuidV*` generators. They're useless and a more flexible approach based on https://github.com/doctrine/DoctrineBundle/pull/1284 is coming.