### PR TITLE
[Doctrine] Restore priority for EventSubscribers

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -164,11 +164,22 @@ class ContainerAwareEventManager extends EventManager
     private function initializeSubscribers()
     {
         $this->initializedSubscribers = true;
+
+        $eventListeners = $this->listeners;
+        // reset eventListener to respect priority: EventSubscribers have a higher priority
+        $this->listeners = [];
         foreach ($this->subscribers as $id => $subscriber) {
             if (\is_string($subscriber)) {
                 parent::addEventSubscriber($this->subscribers[$id] = $this->container->get($subscriber));
             }
         }
+        foreach ($eventListeners as $event => $listeners) {
+            if (!isset($this->listeners[$event])) {
+                $this->listeners[$event] = [];
+            }
+            $this->listeners[$event] += $listeners;
+        }
+        $this->subscribers = [];
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/ContainerAwareEventManagerTest.php
@@ -146,11 +146,14 @@ class ContainerAwareEventManagerTest extends TestCase
 
     public function testGetListenersForEvent()
     {
+        $this->evm = new ContainerAwareEventManager($this->container, ['lazy2']);
+
         $this->container->set('lazy', $listener1 = new MyListener());
+        $this->container->set('lazy2', $subscriber1 = new MySubscriber(['foo']));
         $this->evm->addEventListener('foo', 'lazy');
         $this->evm->addEventListener('foo', $listener2 = new MyListener());
 
-        $this->assertSame([$listener1, $listener2], array_values($this->evm->getListeners('foo')));
+        $this->assertSame([$subscriber1, $listener1, $listener2], array_values($this->evm->getListeners('foo')));
     }
 
     public function testGetListeners()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | fix #40031
| License       | MIT
| Doc PR        | -

Since #39990, lazy subscribers are called AFTER listeners (which is the opposite of previous implementation).
This PR restore the previous behavior.

Note: ordered subscribers is implemented in #39978 but is considered as a new feature.