### PR TITLE
[Security] Depreccate usage of User in InMemoryUserProvider

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -178,6 +178,7 @@ Security
    `DefaultAuthenticationSuccessHandler`.
  * Removed the `AbstractRememberMeServices::$providerKey` property in favor of `AbstractRememberMeServices::$firewallName`
  * `AccessDecisionManager` now throw an exception when a voter does not return a valid decision.
+ * Remove usages of the `User` class in `InMemoryUserProvider`, use `InMemoryUser` instead.
 
 Serializer
 ----------

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SecurityTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SecurityTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
-use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 
 class SecurityTest extends AbstractWebTestCase
 {
@@ -20,7 +20,7 @@ class SecurityTest extends AbstractWebTestCase
      */
     public function testLoginUser(string $username, array $roles, ?string $firewallContext)
     {
-        $user = new User($username, 'the-password', $roles);
+        $user = new InMemoryUser($username, 'the-password', $roles);
         $client = $this->createClient(['test_case' => 'Security', 'root_config' => 'config.yml']);
 
         if (null === $firewallContext) {
@@ -45,7 +45,7 @@ class SecurityTest extends AbstractWebTestCase
 
     public function testLoginUserMultipleRequests()
     {
-        $user = new User('the-username', 'the-password', ['ROLE_FOO']);
+        $user = new InMemoryUser('the-username', 'the-password', ['ROLE_FOO']);
         $client = $this->createClient(['test_case' => 'Security', 'root_config' => 'config.yml']);
         $client->loginUser($user);
 
@@ -58,7 +58,7 @@ class SecurityTest extends AbstractWebTestCase
 
     public function testLoginInBetweenRequests()
     {
-        $user = new User('the-username', 'the-password', ['ROLE_FOO']);
+        $user = new InMemoryUser('the-username', 'the-password', ['ROLE_FOO']);
         $client = $this->createClient(['test_case' => 'Security', 'root_config' => 'config.yml']);
 
         $client->request('GET', '/main/user_profile');

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecate using `SessionTokenStorage` outside a request context, it will throw a `SessionNotFoundException` in Symfony 6.0
  * Randomize CSRF tokens to harden BREACH attacks
  * Deprecated voters that do not return a valid decision when calling the `vote` method.
+ * Deprecate usages of the `User` class in `InMemoryUserProvider`, use `InMemoryUser` instead.
 
 5.2.0
 -----

--- a/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserProviderTest.php
@@ -13,8 +13,8 @@ namespace Symfony\Component\Security\Core\Tests\User;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
-use Symfony\Component\Security\Core\User\User;
 
 class InMemoryUserProviderTest extends TestCase
 {
@@ -25,20 +25,17 @@ class InMemoryUserProviderTest extends TestCase
         $user = $provider->loadUserByUsername('fabien');
         $this->assertEquals('foo', $user->getPassword());
         $this->assertEquals(['ROLE_USER'], $user->getRoles());
-        $this->assertFalse($user->isEnabled());
     }
 
     public function testRefresh()
     {
-        $user = new User('fabien', 'bar');
+        $user = new InMemoryUser('fabien', 'bar');
 
         $provider = $this->createProvider();
 
         $refreshedUser = $provider->refreshUser($user);
         $this->assertEquals('foo', $refreshedUser->getPassword());
         $this->assertEquals(['ROLE_USER'], $refreshedUser->getRoles());
-        $this->assertFalse($refreshedUser->isEnabled());
-        $this->assertFalse($refreshedUser->isCredentialsNonExpired());
     }
 
     protected function createProvider(): InMemoryUserProvider
@@ -46,7 +43,6 @@ class InMemoryUserProviderTest extends TestCase
         return new InMemoryUserProvider([
             'fabien' => [
                 'password' => 'foo',
-                'enabled' => false,
                 'roles' => ['ROLE_USER'],
             ],
         ]);
@@ -55,7 +51,7 @@ class InMemoryUserProviderTest extends TestCase
     public function testCreateUser()
     {
         $provider = new InMemoryUserProvider();
-        $provider->createUser(new User('fabien', 'foo'));
+        $provider->createUser(new InMemoryUser('fabien', 'foo'));
 
         $user = $provider->loadUserByUsername('fabien');
         $this->assertEquals('foo', $user->getPassword());
@@ -65,8 +61,8 @@ class InMemoryUserProviderTest extends TestCase
     {
         $this->expectException(\LogicException::class);
         $provider = new InMemoryUserProvider();
-        $provider->createUser(new User('fabien', 'foo'));
-        $provider->createUser(new User('fabien', 'foo'));
+        $provider->createUser(new InMemoryUser('fabien', 'foo'));
+        $provider->createUser(new InMemoryUser('fabien', 'foo'));
     }
 
     public function testLoadUserByUsernameDoesNotExist()

--- a/src/Symfony/Component/Security/Core/User/InMemoryUser.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUser.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\User;
+
+class InMemoryUser implements UserInterface, EquatableInterface
+{
+    private $username;
+    private $password;
+    private $roles;
+    private $extraFields;
+
+    public function __construct(?string $username, ?string $password, array $roles = [], array $extraFields = [])
+    {
+        if ('' === $username || null === $username) {
+            throw new \InvalidArgumentException('The username cannot be empty.');
+        }
+
+        $this->username = $username;
+        $this->password = $password;
+        $this->roles = $roles;
+        $this->extraFields = $extraFields;
+    }
+
+    public function __toString(): string
+    {
+        return $this->getUsername();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPassword(): ?string
+    {
+        return $this->password;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSalt(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function eraseCredentials()
+    {
+    }
+
+    public function getExtraFields(): array
+    {
+        return $this->extraFields;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEqualTo(UserInterface $user): bool
+    {
+        if (!$user instanceof self) {
+            return false;
+        }
+
+        if ($this->getPassword() !== $user->getPassword()) {
+            return false;
+        }
+
+        if ($this->getSalt() !== $user->getSalt()) {
+            return false;
+        }
+
+        $currentRoles = array_map('strval', (array) $this->getRoles());
+        $newRoles = array_map('strval', (array) $user->getRoles());
+        $rolesChanged = \count($currentRoles) !== \count($newRoles) || \count($currentRoles) !== \count(array_intersect($currentRoles, $newRoles));
+        if ($rolesChanged) {
+            return false;
+        }
+
+        if ($this->getUsername() !== $user->getUsername()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function setPassword(string $password)
+    {
+        $this->password = $password;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no (but adds `InMemoryUser`)
| Deprecations? | yes
| Tickets       | Fix part of #26348
| License       | MIT
| Doc PR        |-

Should implement the next step mentioned in https://github.com/symfony/symfony/issues/26348: _Create an InMemoryUser, exclusively used by the InMemoryUserProvider._