### PR TITLE
[HttpClient] Remove unnecessary "?" in url query

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -422,6 +422,10 @@ trait HttpClientTrait
             $url['path'] = '/';
         }
 
+        if ('?' === ($url['query'] ?? '')) {
+            $url['query'] = null;
+        }
+
         return $url;
     }
 

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTraitTest.php
@@ -44,6 +44,9 @@ class HttpClientTraitTest extends TestCase
         yield ['http://example.com/?a=2&b=b', '.?a=2'];
         yield ['http://example.com/?a=3&b=b', '.', ['a' => 3]];
         yield ['http://example.com/?a=3&b=b', '.?a=0', ['a' => 3]];
+        yield ['http://example.com/', 'http://example.com/', ['a' => null]];
+        yield ['http://example.com/?b=', 'http://example.com/', ['b' => '']];
+        yield ['http://example.com/?b=', 'http://example.com/', ['a' => null, 'b' => '']];
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When creating the Request with passing nullable values as query parameters `HttpClientTrait::resolveUrl` method keeps at the end of URL "?" (IMO unnecessary) character.

Before: 
```
        $client = HttpClient::create();
        $response = $client->request('GET', 'http://example.com/', ['query' => ['a' => null]]);
        
        $url = $response->getInfo('url'); // http://example.com/?
```

After:

```
        $client = HttpClient::create();
        $response = $client->request('GET', 'http://example.com/', ['query' => ['a' => null]]);
        
        $url = $response->getInfo('url'); // http://example.com/
```
