### PR TITLE
[FrameworkBundle] Deprecate session.storage service

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -31,6 +31,8 @@ Form
 FrameworkBundle
 ---------------
 
+ * Deprecate the `session.storage` alias and `session.storage.*` services, use the `session.storage.factory` alias and `session.storage.factory.*` services instead
+ * Deprecate the `framework.session.storage_id` configuration option, use the `framework.session.storage_factory_id` configuration option instead
  * Deprecate the `session` service and the `SessionInterface` alias, use the `\Symfony\Component\HttpFoundation\Request::getSession()` or the new `\Symfony\Component\HttpFoundation\RequestStack::getSession()` methods instead
 
 HttpFoundation

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -69,6 +69,8 @@ Form
 FrameworkBundle
 ---------------
 
+ * Remove the `session.storage` alias and `session.storage.*` services, use the `session.storage.factory` alias and `session.storage.factory.*` services instead
+ * Remove `framework.session.storage_id` configuration option, use the `framework.session.storage_factory_id` configuration option instead
  * Remove the `session` service and the `SessionInterface` alias, use the `\Symfony\Component\HttpFoundation\Request::getSession()` or the new `\Symfony\Component\HttpFoundation\RequestStack::getSession()` methods instead
  * `MicroKernelTrait::configureRoutes()` is now always called with a `RoutingConfigurator`
  * The "framework.router.utf8" configuration option defaults to `true`

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 5.3
 ---
 
+ * Deprecate the `session.storage` alias and `session.storage.*` services, use the `session.storage.factory` alias and `session.storage.factory.*` services instead
+ * Deprecate the `framework.session.storage_id` configuration option, use the `framework.session.storage_factory_id` configuration option instead
  * Deprecate the `session` service and the `SessionInterface` alias, use the `Request::getSession()` or the new `RequestStack::getSession()` methods instead
  * Added `AbstractController::renderForm()` to render a form and set the appropriate HTTP status code
  * Added support for configuring PHP error level to log levels

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/SessionPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/SessionPass.php
@@ -22,7 +22,7 @@ class SessionPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!$container->has('session.storage')) {
+        if (!$container->has('session.factory')) {
             return;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -600,8 +600,15 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('session')
                     ->info('session configuration')
                     ->canBeEnabled()
+                    ->beforeNormalization()
+                        ->ifTrue(function ($v) {
+                            return \is_array($v) && isset($v['storage_id']) && isset($v['storage_factory_id']);
+                        })
+                        ->thenInvalid('You cannot use both "storage_id" and "storage_factory_id" at the same time under "framework.session"')
+                    ->end()
                     ->children()
                         ->scalarNode('storage_id')->defaultValue('session.storage.native')->end()
+                        ->scalarNode('storage_factory_id')->defaultNull()->end()
                         ->scalarNode('handler_id')->defaultValue('session.handler.native_file')->end()
                         ->scalarNode('name')
                             ->validate()

--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -18,7 +18,6 @@ use Symfony\Component\BrowserKit\History;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\Profiler\Profile as HttpProfile;
@@ -123,7 +122,7 @@ class KernelBrowser extends HttpKernelBrowser
 
         $token = new TestBrowserToken($user->getRoles(), $user);
         $token->setAuthenticated(true);
-        $session = new Session($this->getContainer()->get('test.service_container')->get('session.storage'));
+        $session = $this->getContainer()->get('test.service_container')->get('session.factory')->createSession();
         $session->set('_security_'.$firewallContext, serialize($token));
         $session->save();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -107,6 +107,7 @@
 
     <xsd:complexType name="session">
         <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="storage-factory-id" type="xsd:string" />
         <xsd:attribute name="storage-id" type="xsd:string" />
         <xsd:attribute name="handler-id" type="xsd:string" />
         <xsd:attribute name="name" type="xsd:string" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/SessionPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/SessionPassTest.php
@@ -22,7 +22,7 @@ class SessionPassTest extends TestCase
     {
         $container = new ContainerBuilder();
         $container
-            ->register('session.storage'); // marker service
+            ->register('session.factory'); // marker service
         $container
             ->register('.session.do-not-use');
 
@@ -41,7 +41,7 @@ class SessionPassTest extends TestCase
         ];
         $container = new ContainerBuilder();
         $container
-            ->register('session.storage'); // marker service
+            ->register('session.factory'); // marker service
         $container
             ->register('session')
             ->setArguments($arguments);
@@ -70,7 +70,7 @@ class SessionPassTest extends TestCase
         ];
         $container = new ContainerBuilder();
         $container
-            ->register('session.storage'); // marker service
+            ->register('session.factory'); // marker service
         $container
             ->register('trueSession')
             ->setArguments($arguments);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -463,6 +463,7 @@ class ConfigurationTest extends TestCase
             'session' => [
                 'enabled' => false,
                 'storage_id' => 'session.storage.native',
+                'storage_factory_id' => null,
                 'handler_id' => 'session.handler.native_file',
                 'cookie_httponly' => true,
                 'cookie_samesite' => null,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/csrf.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/csrf.php
@@ -6,6 +6,7 @@ $container->loadFromExtension('framework', [
         'legacy_error_messages' => false,
     ],
     'session' => [
+        'storage_factory_id' => 'session.storage.factory.native',
         'handler_id' => null,
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -27,7 +27,7 @@ $container->loadFromExtension('framework', [
         'utf8' => true,
     ],
     'session' => [
-        'storage_id' => 'session.storage.native',
+        'storage_factory_id' => 'session.storage.factory.native',
         'handler_id' => 'session.handler.native_file',
         'name' => '_SYMFONY',
         'cookie_lifetime' => 86400,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session_cookie_secure_auto.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session_cookie_secure_auto.php
@@ -2,6 +2,7 @@
 
 $container->loadFromExtension('framework', [
     'session' => [
+        'storage_factory_id' => 'session.storage.factory.native',
         'handler_id' => null,
         'cookie_secure' => 'auto',
     ],

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session_cookie_secure_auto_legacy.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session_cookie_secure_auto_legacy.php
@@ -1,8 +1,9 @@
 <?php
 
+// To be removed in Symfony 6.0
 $container->loadFromExtension('framework', [
     'session' => [
-        'storage_factory_id' => 'session.storage.factory.native',
         'handler_id' => null,
+        'cookie_secure' => 'auto',
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session_legacy.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session_legacy.php
@@ -1,8 +1,8 @@
 <?php
 
+// To be removed in Symfony 6.0
 $container->loadFromExtension('framework', [
     'session' => [
-        'storage_factory_id' => 'session.storage.factory.native',
         'handler_id' => null,
     ],
 ]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/csrf.xml
@@ -9,6 +9,6 @@
     <framework:config>
         <framework:csrf-protection />
         <framework:form legacy-error-messages="false" />
-        <framework:session />
+        <framework:session storage-factory-id="session.storage.factory.native" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_sets_field_name.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/form_csrf_sets_field_name.xml
@@ -8,7 +8,7 @@
 
     <framework:config>
         <framework:csrf-protection field-name="_custom" />
-        <framework:session />
+        <framework:session storage-factory-id="session.storage.factory.native" />
         <framework:form legacy-error-messages="false" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -15,7 +15,7 @@
         <framework:ssi enabled="true" />
         <framework:profiler only-exceptions="true" enabled="false" />
         <framework:router resource="%kernel.project_dir%/config/routing.xml" type="xml" utf8="true" />
-        <framework:session gc-maxlifetime="90000" gc-probability="1" gc-divisor="108" storage-id="session.storage.native" handler-id="session.handler.native_file" name="_SYMFONY" cookie-lifetime="86400" cookie-path="/" cookie-domain="example.com" cookie-secure="true" cookie-httponly="false" use-cookies="true" save-path="/path/to/sessions" sid-length="22" sid-bits-per-character="4" />
+        <framework:session gc-maxlifetime="90000" gc-probability="1" gc-divisor="108" storage-factory-id="session.storage.factory.native" handler-id="session.handler.native_file" name="_SYMFONY" cookie-lifetime="86400" cookie-path="/" cookie-domain="example.com" cookie-secure="true" cookie-httponly="false" use-cookies="true" save-path="/path/to/sessions" sid-length="22" sid-bits-per-character="4" />
         <framework:request>
             <framework:format name="csv">
                 <framework:mime-type>text/csv</framework:mime-type>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session.xml
@@ -7,6 +7,6 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config>
-        <framework:session handler-id="null"/>
+        <framework:session storage-factory-id="session.storage.factory.native" handler-id="null"/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session_cookie_secure_auto.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session_cookie_secure_auto.xml
@@ -7,6 +7,6 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config>
-        <framework:session handler-id="null" cookie-secure="auto" />
+        <framework:session storage-factory-id="session.storage.factory.native" handler-id="null" cookie-secure="auto" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session_cookie_secure_auto_legacy.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session_cookie_secure_auto_legacy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-
+<!-- To be removed in Symfony 6.0 -->
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:framework="http://symfony.com/schema/dic/symfony"
@@ -7,8 +7,6 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config>
-        <framework:csrf-protection field-name="_custom_form" />
-        <framework:form legacy-error-messages="false" />
-        <framework:session storage-factory-id="session.storage.factory.native" />
+        <framework:session handler-id="null" cookie-secure="auto" />
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session_legacy.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session_legacy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-
+<!-- To be removed in Symfony 6.0 -->
 <container xmlns="http://symfony.com/schema/dic/services"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:framework="http://symfony.com/schema/dic/symfony"
@@ -7,8 +7,6 @@
                         http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config>
-        <framework:csrf-protection field-name="_custom_form" />
-        <framework:form legacy-error-messages="false" />
-        <framework:session storage-factory-id="session.storage.factory.native" />
+        <framework:session handler-id="null"/>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/csrf.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/csrf.yml
@@ -3,4 +3,5 @@ framework:
     csrf_protection: ~
     form:
         legacy_error_messages: false
-    session: ~
+    session:
+        storage_factory_id: session.storage.factory.native

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -19,7 +19,7 @@ framework:
         type:         xml
         utf8:         true
     session:
-        storage_id:      session.storage.native
+        storage_factory_id: session.storage.factory.native
         handler_id:      session.handler.native_file
         name:            _SYMFONY
         cookie_lifetime:  86400

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session.yml
@@ -1,3 +1,4 @@
 framework:
     session:
+        storage_factory_id: session.storage.factory.native
         handler_id: null

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session_cookie_secure_auto_legacy.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session_cookie_secure_auto_legacy.yml
@@ -1,5 +1,5 @@
+# to be removed in Symfony 6.0
 framework:
     session:
-        storage_factory_id: session.storage.factory.native
         handler_id: ~
         cookie_secure: auto

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session_legacy.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session_legacy.yml
@@ -1,0 +1,4 @@
+# to be removed in Symfony 6.0
+framework:
+    session:
+        handler_id: null

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigDump/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ConfigDump/config.yml
@@ -5,6 +5,7 @@ framework:
     secret: '%secret%'
     default_locale: '%env(LOCALE)%'
     session:
+        storage_factory_id: session.storage.factory.native
         cookie_httponly: '%env(bool:COOKIE_HTTPONLY)%'
 
 parameters:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDump/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ContainerDump/config.yml
@@ -7,7 +7,8 @@ framework:
     fragments: true
     profiler: true
     router: true
-    session: true
+    session:
+        storage_factory_id: session.storage.factory.native
     request: true
     assets: true
     translator: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
@@ -9,7 +9,7 @@ framework:
     test: true
     default_locale: en
     session:
-        storage_id:     session.storage.mock_file
+        storage_factory_id: session.storage.factory.mock_file
 
 services:
     logger: { class: Psr\Log\NullLogger }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterTokenUsageTrackingPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/RegisterTokenUsageTrackingPass.php
@@ -41,7 +41,7 @@ class RegisterTokenUsageTrackingPass implements CompilerPassInterface
             TokenStorageInterface::class => new BoundArgument(new Reference('security.untracked_token_storage'), false),
         ]);
 
-        if (!$container->has('session.storage')) {
+        if (!$container->has('session.factory') && !$container->has('session.storage')) {
             $container->setAlias('security.token_storage', 'security.untracked_token_storage')->setPublic(true);
             $container->getDefinition('security.untracked_token_storage')->addTag('kernel.reset', ['method' => 'reset']);
         } elseif ($container->hasDefinition('security.context_listener')) {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterTokenUsageTrackingPassTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Compiler/RegisterTokenUsageTrackingPassTest.php
@@ -18,7 +18,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionFactory;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
+use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorageFactory;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage;
 use Symfony\Component\Security\Http\Firewall\ContextListener;
@@ -66,7 +68,7 @@ class RegisterTokenUsageTrackingPassTest extends TestCase
         $container = new ContainerBuilder();
 
         $container->setParameter('security.token_storage.class', UsageTrackingTokenStorage::class);
-        $container->register('session.storage', NativeSessionStorage::class);
+        $container->register('session.factory', SessionFactory::class);
         $container->register('security.context_listener', ContextListener::class)
             ->setArguments([
                 new Reference('security.untracked_token_storage'),

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -398,6 +398,7 @@ class SecurityExtensionTest extends TestCase
             ],
             [
                 [
+                    'storage_factory_id' => 'session.storage.factory.native',
                     'cookie_secure' => true,
                     'cookie_samesite' => 'lax',
                     'save_path' => null,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Anonymous/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Anonymous/config.yml
@@ -7,7 +7,7 @@ framework:
     test: ~
     default_locale: en
     session:
-        storage_id: session.storage.mock_file
+        storage_factory_id: session.storage.factory.mock_file
     profiler: { only_exceptions: false }
 
 services:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/config.yml
@@ -5,7 +5,7 @@ framework:
     default_locale: en
     profiler: false
     session:
-        storage_id: session.storage.mock_file
+        storage_factory_id: session.storage.factory.mock_file
 
 services:
     logger: { class: Psr\Log\NullLogger }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/FirewallEntryPoint/config.yml
@@ -9,7 +9,7 @@ framework:
     test: ~
     default_locale: en
     session:
-        storage_id:     session.storage.mock_file
+        storage_factory_id: session.storage.factory.mock_file
     profiler: { only_exceptions: false }
 
 services:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Guarded/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Guarded/config.yml
@@ -5,7 +5,7 @@ framework:
     default_locale: en
     profiler: false
     session:
-        storage_id: session.storage.mock_file
+        storage_factory_id: session.storage.factory.mock_file
 
 services:
     logger: { class: Psr\Log\NullLogger }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeLogout/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeLogout/config.yml
@@ -3,6 +3,7 @@ imports:
 
 framework:
     session:
+        storage_factory_id: session.storage.factory.mock_file
         cookie_secure: auto
         cookie_samesite: lax
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
@@ -10,7 +10,7 @@ framework:
     test: ~
     default_locale: en
     session:
-        storage_id: session.storage.mock_file
+        storage_factory_id: session.storage.factory.mock_file
     profiler: { only_exceptions: false }
 
 services:

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -39,7 +39,7 @@
         "symfony/dom-crawler": "^4.4|^5.0",
         "symfony/expression-language": "^4.4|^5.0",
         "symfony/form": "^4.4|^5.0",
-        "symfony/framework-bundle": "^5.2",
+        "symfony/framework-bundle": "^5.3",
         "symfony/process": "^4.4|^5.0",
         "symfony/rate-limiter": "^5.2",
         "symfony/serializer": "^4.4|^5.0",

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
@@ -43,7 +43,7 @@ class WebProfilerBundleKernel extends Kernel
         $containerBuilder->loadFromExtension('framework', [
             'secret' => 'foo-secret',
             'profiler' => ['only_exceptions' => false],
-            'session' => ['storage_id' => 'session.storage.mock_file'],
+            'session' => ['storage_factory_id' => 'session.storage.factory.mock_file'],
             'router' => ['utf8' => true],
         ]);
 

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/config": "^4.4|^5.0",
-        "symfony/framework-bundle": "^5.1",
+        "symfony/framework-bundle": "^5.3",
         "symfony/http-kernel": "^5.2",
         "symfony/routing": "^4.4|^5.0",
         "symfony/twig-bundle": "^4.4|^5.0",

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.3
 ---
 
+ * Add the `SessionFactory`, `NativeSessionStorageFactory`, `PhpBridgeSessionStorageFactory` and `MockFileSessionStorageFactory` classes
  * Calling `Request::getSession()` when there is no available session throws a `SessionNotFoundException`
  * Add the `RequestStack::getSession` method
  * Deprecate the `NamespacedAttributeBag` class

--- a/src/Symfony/Component/HttpFoundation/Session/SessionFactory.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageFactoryInterface;
+
+// Help opcache.preload discover always-needed symbols
+class_exists(Session::class);
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class SessionFactory
+{
+    private $requestStack;
+    private $storageFactory;
+    private $usageReporter;
+
+    public function __construct(RequestStack $requestStack, SessionStorageFactoryInterface $storageFactory, callable $usageReporter = null)
+    {
+        $this->requestStack = $requestStack;
+        $this->storageFactory = $storageFactory;
+        $this->usageReporter = $usageReporter;
+    }
+
+    public function createSession(): SessionInterface
+    {
+        return new Session($this->storageFactory->createStorage($this->requestStack->getMasterRequest()), null, null, $this->usageReporter);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorageFactory.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorageFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage;
+
+use Symfony\Component\HttpFoundation\Request;
+
+// Help opcache.preload discover always-needed symbols
+class_exists(MockFileSessionStorage::class);
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class MockFileSessionStorageFactory implements SessionStorageFactoryInterface
+{
+    private $savePath;
+    private $name;
+    private $metaBag;
+
+    /**
+     * @see MockFileSessionStorage constructor.
+     */
+    public function __construct(string $savePath = null, string $name = 'MOCKSESSID', MetadataBag $metaBag = null)
+    {
+        $this->savePath = $savePath;
+        $this->name = $name;
+        $this->metaBag = $metaBag;
+    }
+
+    public function createStorage(?Request $request): SessionStorageInterface
+    {
+        return new MockFileSessionStorage($this->savePath, $this->name, $this->metaBag);
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorageFactory.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorageFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage;
+
+use Symfony\Component\HttpFoundation\Request;
+
+// Help opcache.preload discover always-needed symbols
+class_exists(NativeSessionStorage::class);
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class NativeSessionStorageFactory implements SessionStorageFactoryInterface
+{
+    private $options;
+    private $handler;
+    private $metaBag;
+    private $secure;
+
+    /**
+     * @see NativeSessionStorage constructor.
+     */
+    public function __construct(array $options = [], $handler = null, MetadataBag $metaBag = null, bool $secure = false)
+    {
+        $this->options = $options;
+        $this->handler = $handler;
+        $this->metaBag = $metaBag;
+        $this->secure = $secure;
+    }
+
+    public function createStorage(?Request $request): SessionStorageInterface
+    {
+        $storage = new NativeSessionStorage($this->options, $this->handler, $this->metaBag);
+        if ($this->secure && $request && $request->isSecure()) {
+            $storage->setOptions(['cookie_secure' => true]);
+        }
+
+        return $storage;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorageFactory.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/PhpBridgeSessionStorageFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage;
+
+use Symfony\Component\HttpFoundation\Request;
+
+// Help opcache.preload discover always-needed symbols
+class_exists(PhpBridgeSessionStorage::class);
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class PhpBridgeSessionStorageFactory implements SessionStorageFactoryInterface
+{
+    private $handler;
+    private $metaBag;
+    private $secure;
+
+    /**
+     * @see PhpBridgeSessionStorage constructor.
+     */
+    public function __construct($handler = null, MetadataBag $metaBag = null, bool $secure = false)
+    {
+        $this->handler = $handler;
+        $this->metaBag = $metaBag;
+        $this->secure = $secure;
+    }
+
+    public function createStorage(?Request $request): SessionStorageInterface
+    {
+        $storage = new PhpBridgeSessionStorage($this->handler, $this->metaBag);
+        if ($this->secure && $request && $request->isSecure()) {
+            $storage->setOptions(['cookie_secure' => true]);
+        }
+
+        return $storage;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/ServiceSessionFactory.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/ServiceSessionFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal to be removed in Symfony 6
+ */
+final class ServiceSessionFactory implements SessionStorageFactoryInterface
+{
+    private $storage;
+
+    public function __construct(SessionStorageInterface $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    public function createStorage(?Request $request): SessionStorageInterface
+    {
+        if ($this->storage instanceof NativeSessionStorage && $request && $request->isSecure()) {
+            $this->storage->setOptions(['cookie_secure' => true]);
+        }
+
+        return $this->storage;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageFactoryInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageFactoryInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+interface SessionStorageFactoryInterface
+{
+    /**
+     * Creates a new instance of SessionStorageInterface
+     */
+    public function createStorage(?Request $request): SessionStorageInterface;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | TODO

Following the deprecation of `session` service, this PR deprecate other services that contains state: `session.storage`
- `session.storage`
- `session.storage.native`, `session.storage.php_bridge` and `session.storage.mock_file`
- `session.storage.metadata_bag`

Because people can inject / decorate override all these services, providing a migration path like I did with `session` would have been very hard. That's why, I added a new `opt-in` flag:

When people use `framework.session: true` or `framework.session.storage_id` the previous behavior is kept and deprecation are triggered when accessing the services.
But when people use the new `framework.session.storage_factory_id` configuration, the previous services (`session.storage.*`) are deleted (in case people would try to inject the legacy `session.storage*` services and would have expect to manipulate the same objects as the object injected in the session)