### PR TITLE
[Messenger] Fix Doctrine setup when using a migration

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -87,7 +87,7 @@ final class PostgreSqlConnection extends Connection
     {
         parent::setup();
 
-        $this->executeStatement(implode("\n", $this->getTriggerSql()));
+        $this->executeStatement('BEGIN;'.implode("\n", $this->getTriggerSql()).'COMMIT;');
     }
 
     /**
@@ -109,7 +109,6 @@ final class PostgreSqlConnection extends Connection
     private function getTriggerSql(): array
     {
         return [
-            'BEGIN;',
             sprintf('LOCK TABLE %s;', $this->configuration['table_name']),
             // create trigger function
             sprintf(<<<'SQL'
@@ -124,7 +123,6 @@ SQL
             // register trigger
             sprintf('DROP TRIGGER IF EXISTS notify_trigger ON %s;', $this->configuration['table_name']),
             sprintf('CREATE TRIGGER notify_trigger AFTER INSERT OR UPDATE ON %1$s FOR EACH ROW EXECUTE PROCEDURE notify_%1$s();', $this->configuration['table_name']),
-            'COMMIT;',
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #39928 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a

#38136 fixed running `messenger:setup-transports` (issue reported in #37179), but it breaks usage with `make:migration` (reported in #39928) as code is already executed in a transaction.

This PR fixes both use cases.
