### PR TITLE
[Mime] Fix case-sensitive handling of header names

### DIFF
--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -201,7 +201,7 @@ final class Headers
 
     public static function isUniqueHeader(string $name): bool
     {
-        return \in_array($name, self::UNIQUE_HEADERS, true);
+        return \in_array(strtolower($name), self::UNIQUE_HEADERS, true);
     }
 
     public function toString(): string

--- a/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
@@ -212,6 +212,11 @@ class HeadersTest extends TestCase
         $this->assertFalse($headers->has('Message-ID'));
     }
 
+    public function testIsUniqueHeaderIsNotCaseSensitive()
+    {
+        $this->assertTrue(Headers::isUniqueHeader('From'));
+    }
+
     public function testToStringJoinsHeadersTogether()
     {
         $headers = new Headers();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39953
| License       | MIT
| Doc PR        | -

Fixes case-sensitive handling of header names in "Mailer" component, more in the [ticket](https://github.com/symfony/symfony/issues/39953) and the [root PR](https://github.com/symfony/symfony/pull/39954).
