### PR TITLE
[ErrorHandler] fix parsing return types in DebugClassLoader

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -16,9 +16,6 @@ if (!getenv('SYMFONY_PHPUNIT_VERSION')) {
         putenv('SYMFONY_PHPUNIT_VERSION=9.5');
     }
 }
-if (!getenv('SYMFONY_PATCH_TYPE_DECLARATIONS')) {
-    putenv('SYMFONY_PATCH_TYPE_DECLARATIONS=deprecations=1');
-}
 if (getcwd() === realpath(__DIR__.'/src/Symfony/Bridge/PhpUnit')) {
     putenv('SYMFONY_DEPRECATIONS_HELPER=disabled');
 }

--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -535,7 +535,7 @@ class DebugClassLoader
             if (null !== (self::INTERNAL_TYPES[$use] ?? null)) {
                 foreach (self::INTERNAL_TYPES[$use] as $method => $returnType) {
                     if ('void' !== $returnType) {
-                        self::$returnTypes[$class] += [$method => [$returnType, $returnType, $class, '']];
+                        self::$returnTypes[$class] += [$method => [$returnType, $returnType, $use, '']];
                     }
                 }
             }
@@ -612,7 +612,7 @@ class DebugClassLoader
                     $this->patchMethod($method, $returnType, $declaringFile, $normalizedType);
                 }
 
-                if (strncmp($ns, $declaringClass, $len)) {
+                if (false === strpos($doc, '@deprecated') && strncmp($ns, $declaringClass, $len)) {
                     if ($canAddReturnType && 'docblock' === $this->patchTypes['force'] && false === strpos($method->getFileName(), \DIRECTORY_SEPARATOR.'vendor'.\DIRECTORY_SEPARATOR)) {
                         $this->patchMethod($method, $returnType, $declaringFile, $normalizedType);
                     } elseif ('' !== $declaringClass && $this->patchTypes['deprecations']) {

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
@@ -320,12 +320,12 @@ class SerializableUser implements UserInterface, \Serializable
         return null;
     }
 
-    public function serialize()
+    public function serialize(): string
     {
         return serialize($this->name);
     }
 
-    public function unserialize($serialized)
+    public function unserialize($serialized): void
     {
         $this->name = unserialize($serialized);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In 5.3, we might want to make `SYMFONY_PATCH_TYPE_DECLARATIONS=deprecations=1` the default, so that ppl know when they're missing some return types when they inherit some classes from vendors. This would fix https://github.com/orgs/symfony/projects/1#card-30856423

On 4.4, we have to disable this mode of reporting until these PRs are merged:
- https://github.com/twigphp/Twig/pull/3481
- https://github.com/doctrine/collections/pull/269
- https://github.com/predis/predis/pull/678