### PR TITLE
[Security] Rename 'login throttling' to 'login limiting'

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -69,6 +69,7 @@ PropertyInfo
 Security
 --------
 
+ * [BC break] Renamed the `LoginThrottlingListener` class and `login_throttling` option to `LoginLimitingListener` and `login_limiting`
  * Deprecated voters that do not return a valid decision when calling the `vote` method
 
 Serializer

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3
+---
+
+ * [BC break] Renamed `login_throttling` to `login_limiting`
+
 5.2.0
 -----
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
@@ -25,7 +25,7 @@ use Symfony\Component\Security\Http\Authenticator\RemoteUserAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\X509Authenticator;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\EventListener\CheckCredentialsListener;
-use Symfony\Component\Security\Http\EventListener\LoginThrottlingListener;
+use Symfony\Component\Security\Http\EventListener\LoginLimitingListener;
 use Symfony\Component\Security\Http\EventListener\PasswordMigratingListener;
 use Symfony\Component\Security\Http\EventListener\RememberMeListener;
 use Symfony\Component\Security\Http\EventListener\SessionStrategyListener;
@@ -114,7 +114,7 @@ return static function (ContainerConfigurator $container) {
             ])
             ->tag('monolog.logger', ['channel' => 'security'])
 
-        ->set('security.listener.login_throttling', LoginThrottlingListener::class)
+        ->set('security.listener.login_limiting', LoginLimitingListener::class)
             ->abstract()
             ->args([
                 service('request_stack'),

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -29,8 +29,8 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\HttpBasic
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\HttpBasicLdapFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\JsonLoginFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\JsonLoginLdapFactory;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\LoginLimitingFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\LoginLinkFactory;
-use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\LoginThrottlingFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\RememberMeFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\RemoteUserFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\X509Factory;
@@ -67,7 +67,7 @@ class SecurityBundle extends Bundle
         $extension->addSecurityListenerFactory(new GuardAuthenticationFactory());
         $extension->addSecurityListenerFactory(new AnonymousFactory());
         $extension->addSecurityListenerFactory(new CustomAuthenticatorFactory());
-        $extension->addSecurityListenerFactory(new LoginThrottlingFactory());
+        $extension->addSecurityListenerFactory(new LoginLimitingFactory());
         $extension->addSecurityListenerFactory(new LoginLinkFactory());
 
         $extension->addUserProviderFactory(new InMemoryFactory());

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/FormLoginTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
 
-use Symfony\Component\Security\Http\EventListener\LoginThrottlingListener;
+use Symfony\Component\Security\Http\EventListener\LoginLimitingListener;
 
 class FormLoginTest extends AbstractWebTestCase
 {
@@ -112,13 +112,13 @@ class FormLoginTest extends AbstractWebTestCase
      * @dataProvider provideInvalidCredentials
      * @group time-sensitive
      */
-    public function testLoginThrottling($username, $password)
+    public function testLoginLimiting($username, $password)
     {
-        if (!class_exists(LoginThrottlingListener::class)) {
-            $this->markTestSkipped('Login throttling requires symfony/security-http:^5.2');
+        if (!class_exists(LoginLimitingListener::class)) {
+            $this->markTestSkipped('Login limiting requires symfony/security-http:^5.3');
         }
 
-        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'login_throttling.yml', 'enable_authenticator_manager' => true]);
+        $client = $this->createClient(['test_case' => 'StandardFormLogin', 'root_config' => 'login_limiting.yml', 'enable_authenticator_manager' => true]);
 
         $form = $client->request('GET', '/login')->selectButton('login')->form();
         $form['_username'] = $username;

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/login_limiting.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/login_limiting.yml
@@ -8,5 +8,5 @@ framework:
 security:
     firewalls:
         default:
-            login_throttling:
+            login_limiting:
                 max_attempts: 1

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,11 +4,12 @@ CHANGELOG
 5.3
 ---
 
+ * [BC break] Renamed `LoginThrottlingListener` to `LoginLimitingListener`
  * Deprecate the `SessionInterface $session` constructor argument of `SessionTokenStorage`, inject a `\Symfony\Component\HttpFoundation\RequestStack $requestStack` instead
  * Deprecate the `session` service provided by the ServiceLocator injected in `UsageTrackingTokenStorage`, provide a `request_stack` service instead
  * Deprecate using `SessionTokenStorage` outside a request context, it will throw a `SessionNotFoundException` in Symfony 6.0
  * Randomize CSRF tokens to harden BREACH attacks
- * Deprecated voters that do not return a valid decision when calling the `vote` method.
+ * Deprecated voters that do not return a valid decision when calling the `vote` method
 
 5.2.0
 -----

--- a/src/Symfony/Component/Security/Http/EventListener/LoginLimitingListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/LoginLimitingListener.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Http\Event\CheckPassportEvent;
  *
  * @experimental in 5.3
  */
-final class LoginThrottlingListener implements EventSubscriberInterface
+final class LoginLimitingListener implements EventSubscriberInterface
 {
     private $requestStack;
     private $limiter;

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/LoginLimitingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/LoginLimitingListenerTest.php
@@ -23,10 +23,10 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
-use Symfony\Component\Security\Http\EventListener\LoginThrottlingListener;
+use Symfony\Component\Security\Http\EventListener\LoginLimitingListener;
 use Symfony\Component\Security\Http\RateLimiter\DefaultLoginRateLimiter;
 
-class LoginThrottlingListenerTest extends TestCase
+class LoginLimitingListenerTest extends TestCase
 {
     private $requestStack;
     private $listener;
@@ -49,7 +49,7 @@ class LoginThrottlingListenerTest extends TestCase
         ], new InMemoryStorage());
         $limiter = new DefaultLoginRateLimiter($globalLimiter, $localLimiter);
 
-        $this->listener = new LoginThrottlingListener($this->requestStack, $limiter);
+        $this->listener = new LoginLimitingListener($this->requestStack, $limiter);
     }
 
     public function testPreventsLoginWhenOverLocalThreshold()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I'm just opening this PR to see if there is any support for such a change. **There is no need to leave bike-shedding comments, please stick to using GitHub's :+1: or :-1: PR reactions instead.**

Throttle as a verb refers to quite a violent activity:

> throttle
> *verb*
> 
> 1. attack or kill (someone) by choking or strangling them.
>    *"she was sorely tempted to throttle him"*
> 2. control (an engine or vehicle) with a throttle.
>    *"it has two engines that can be throttled"*

This has been brought up during the launch of this feature on symfony.com. As we're in experimental phase, I feel like we are in a position to change the name - if we want.

While looking online, WordPress' most popular plugin of this functionality is called "WP Limit Login Attempts". As such, this term is quite common in blog posts about WordPress development. Many other development blogs talk about "login rate limiting", "login limiting" or "login throttling".
Personally, I always explain this feature as "limiting failed login attempts" instead of "throttling failed login attempts". So I feel like "login limiting" might also be more self-explanatory. That's why I decided to throw this PR up in the open to see if other people agree - with no hard feelings if this gets closed.