### PR TITLE
[Uid] Get Uid shortened

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -163,4 +163,9 @@ abstract class AbstractUid implements \JsonSerializable
     {
         return $this->uid;
     }
+
+    public function shortened(): string
+    {
+        return $this->toBase32();
+    }
 }

--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add `AbstractUid::fromBinary()`, `AbstractUid::fromBase58()`, `AbstractUid::fromBase32()` and `AbstractUid::fromRfc4122()`
  * [BC BREAK] Replace `UuidV1::getTime()`, `UuidV6::getTime()` and `Ulid::getTime()` by `UuidV1::getDateTime()`, `UuidV6::getDateTime()` and `Ulid::getDateTime()`
  * Add `Uuid::NAMESPACE_*` constants from RFC4122
+ * Add `AbstractUid::shortened()`
 
 5.2.0
 -----

--- a/src/Symfony/Component/Uid/Tests/UlidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UlidTest.php
@@ -237,4 +237,12 @@ class UlidTest extends TestCase
     {
         $this->assertInstanceOf(CustomUlid::class, CustomUlid::fromString((new CustomUlid())->toBinary()));
     }
+
+    public function testShorten()
+    {
+        $ulid = Ulid::fromString('265507NNBY9QW9FTHVN65R0AH2');
+
+        $this->assertSame('265507NNBY9QW9FTHVN65R0AH2', $ulid->shortened());
+        $this->assertTrue($ulid->equals(Ulid::fromString('265507NNBY9QW9FTHVN65R0AH2')));
+    }
 }

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -318,4 +318,12 @@ class UuidTest extends TestCase
         $this->assertEquals(\DateTimeImmutable::createFromFormat('U.u', '-0.000001'), ((new UuidV1('13813ff6-1dd2-11b2-a456-426655440000'))->getDateTime()));
         $this->assertEquals(new \DateTimeImmutable('@-12219292800'), ((new UuidV1('00000000-0000-1000-a456-426655440000'))->getDateTime()));
     }
+
+    public function testShorten()
+    {
+        $uuid = Uuid::fromString('4629407a-d57e-4df8-97ea-3ba98b802a22');
+
+        $this->assertSame('265507NNBY9QW9FTHVN65R0AH2', $uuid->shortened());
+        $this->assertTrue($uuid->equals(Uuid::fromString('265507NNBY9QW9FTHVN65R0AH2')));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I was using the `AbstractUid::toBase32()` method as a shortened URL safe uid and thought that it might be great to have a proper method for this.

Not sure if that makes any sense to you guys.