### PR TITLE
[Messenger] Handle more attributes on SQS queue setup

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Added new `debug` option to log HTTP requests and responses.
  * Allowed for receiver & sender injection into AmazonSqsTransport
+ * Added configuration support on queue setup
 
 5.2.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This PR uses Amazon SQS transport options in the queue setup to configure its default values.

ATM, Amazon SQS bridge uses a bunch of transport options while retrieving messages from SQS (`visibility_timeout`, `wait_time`) but does not take advantages of these options when `auto_setup` is configured.

Setup method already have logic to handle fifo queues automatically. This PR goes a little further by using `visibility_timeout`, `wait_time` or the new `retention_period` options if available.