### PR TITLE
Provide implemented packages of replaced dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,22 @@
             "homepage": "https://symfony.com/contributors"
         }
     ],
+    "provide": {
+        "php-http/async-client-implementation": "*",
+        "php-http/client-implementation": "*",
+        "psr/cache-implementation": "1.0|2.0",
+        "psr/container-implementation": "1.0",
+        "psr/event-dispatcher-implementation": "1.0",
+        "psr/http-client-implementation": "1.0",
+        "psr/link-implementation": "1.0",
+        "psr/log-implementation": "1.0",
+        "psr/simple-cache-implementation": "1.0",
+        "symfony/cache-implementation": "1.0|2.0",
+        "symfony/event-dispatcher-implementation": "1.1",
+        "symfony/http-client-implementation": "1.1",
+        "symfony/service-implementation": "1.0",
+        "symfony/translation-implementation": "1.0"
+    },
     "require": {
         "php": ">=7.1.3",
         "ext-xml": "*",

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -18,7 +18,7 @@
     "provide": {
         "psr/cache-implementation": "1.0|2.0",
         "psr/simple-cache-implementation": "1.0",
-        "symfony/cache-implementation": "1.0"
+        "symfony/cache-implementation": "1.0|2.0"
     },
     "require": {
         "php": ">=7.1.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The meta package symfony/symfony does not provide the virtual packages of the dependencies it replaces.
Composer does not pick it as a candidate to replace those packages if the implement such a package/interface.

See https://github.com/composer/composer/issues/9643, https://github.com/composer/composer/issues/9666
