### PR TITLE
[SecurityBundle] role_names variable instead of roles

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CacheWarmer/ExpressionCacheWarmer.php
+++ b/src/Symfony/Bundle/SecurityBundle/CacheWarmer/ExpressionCacheWarmer.php
@@ -37,7 +37,7 @@ class ExpressionCacheWarmer implements CacheWarmerInterface
     public function warmUp($cacheDir)
     {
         foreach ($this->expressions as $expression) {
-            $this->expressionLanguage->parse($expression, ['token', 'user', 'object', 'subject', 'roles', 'request', 'trust_resolver']);
+            $this->expressionLanguage->parse($expression, ['token', 'user', 'object', 'subject', 'roles', 'role_names', 'request', 'trust_resolver']);
         }
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/CacheWarmer/ExpressionCacheWarmerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/CacheWarmer/ExpressionCacheWarmerTest.php
@@ -26,8 +26,8 @@ class ExpressionCacheWarmerTest extends TestCase
         $expressionLang->expects($this->exactly(2))
             ->method('parse')
             ->withConsecutive(
-                [$expressions[0], ['token', 'user', 'object', 'subject', 'roles', 'request', 'trust_resolver']],
-                [$expressions[1], ['token', 'user', 'object', 'subject', 'roles', 'request', 'trust_resolver']]
+                [$expressions[0], ['token', 'user', 'object', 'subject', 'roles', 'role_names', 'request', 'trust_resolver']],
+                [$expressions[1], ['token', 'user', 'object', 'subject', 'roles', 'role_names', 'request', 'trust_resolver']]
             );
 
         (new ExpressionCacheWarmer($expressions, $expressionLang))->warmUp('');


### PR DESCRIPTION
replaced the roles variable with role_names in order to fix cache warming

introduced @ d64372df8c8d63e124d14de5c08fcbbb4674a12e

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40087
| License       | MIT
| Doc PR        | symfony/symfony-docs#14923
