### PR TITLE
Always autoload string functions on symfony/symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -154,6 +154,9 @@
             "Symfony\\Bundle\\": "src/Symfony/Bundle/",
             "Symfony\\Component\\": "src/Symfony/Component/"
         },
+        "files": [
+            "src/Symfony/Component/String/Resources/functions.php"
+        ],
         "classmap": [
             "src/Symfony/Component/Intl/Resources/stubs"
         ],
@@ -163,7 +166,6 @@
     },
     "autoload-dev": {
         "files": [
-            "src/Symfony/Component/String/Resources/functions.php",
             "src/Symfony/Component/VarDumper/Resources/functions/dump.php"
         ]
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Autoloading these functions only in dev make them undefined for projects still using symfony/symfony, which causes troubles when upgrading to 5.2 (e.g. easyadmin uses `u()`).