### PR TITLE
[Security] Allow in memory user to have extra fields

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
    use `security.password_hasher_factory` and `Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface` instead
  * Deprecate the `security.user_password_encoder.generic` service, the `security.password_encoder` and the `Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface` aliases,
    use `security.user_password_hasher`, `security.password_hasher` and `Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface` instead
+ * Add `extra_fields` for `memory` provider to allow configuring extra fields for users
 
 5.2.0
 -----

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -319,7 +319,7 @@ class MainConfiguration implements ConfigurationInterface
                             'memory' => [
                                 'users' => [
                                     'foo' => ['password' => 'foo', 'roles' => 'ROLE_USER'],
-                                    'bar' => ['password' => 'bar', 'roles' => '[ROLE_USER, ROLE_ADMIN]'],
+                                    'bar' => ['password' => 'bar', 'roles' => ['ROLE_USER', 'ROLE_ADMIN'], 'extra_fields' => ['name' => 'John', 'age' => 77]],
                                 ],
                             ],
                         ],

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/InMemoryFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/InMemoryFactory.php
@@ -31,7 +31,7 @@ class InMemoryFactory implements UserProviderFactoryInterface
         $users = [];
 
         foreach ($config['users'] as $username => $user) {
-            $users[$username] = ['password' => null !== $user['password'] ? (string) $user['password'] : $defaultPassword, 'roles' => $user['roles']];
+            $users[$username] = ['password' => null !== $user['password'] ? (string) $user['password'] : $defaultPassword, 'roles' => $user['roles'], 'extra_fields' => $user['extra_fields']];
         }
 
         $definition->addArgument($users);
@@ -55,6 +55,9 @@ class InMemoryFactory implements UserProviderFactoryInterface
                             ->scalarNode('password')->defaultNull()->end()
                             ->arrayNode('roles')
                                 ->beforeNormalization()->ifString()->then(function ($v) { return preg_split('/\s*,\s*/', $v); })->end()
+                                ->prototype('scalar')->end()
+                            ->end()
+                            ->arrayNode('extra_fields')
                                 ->prototype('scalar')->end()
                             ->end()
                         ->end()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/MemoryUserExtraFieldsTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/MemoryUserExtraFieldsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class MemoryUserExtraFieldsTest extends AbstractWebTestCase
+{
+    public function testMemoryUserHasExtraFields()
+    {
+        $client = $this->createClient(['test_case' => 'MemoryUserExtraFields', 'root_config' => 'config.yml']);
+
+        $client->request('POST', '/login', [
+            '_username' => 'foo',
+            '_password' => 'bar',
+        ]);
+        $client->request('GET', '/memory-user-extra-fields');
+
+        $response = $client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('username:foo, age:77', $response->getContent());
+    }
+}
+
+class MemoryUserExtraFieldsController
+{
+    public function __invoke(UserInterface $user): Response
+    {
+        $username = $user->getUsername();
+
+        /** @var User $user */
+        $age = $user->getExtraFields()['age'] ?? '';
+
+        return new Response(
+            sprintf('username:%s, age:%s', $username, $age)
+        );
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MemoryUserExtraFields/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MemoryUserExtraFields/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+
+return [
+    new FrameworkBundle(),
+    new SecurityBundle(),
+];

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MemoryUserExtraFields/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MemoryUserExtraFields/config.yml
@@ -1,0 +1,20 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+security:
+    password_hashers:
+        Symfony\Component\Security\Core\User\User: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    foo: { password: bar, roles: [ROLE_USER], extra_fields: {'age': 77} }
+
+    firewalls:
+        default:
+            form_login:
+                check_path: login
+
+    access_control:
+        - { path: ^/memory-user-extra-fields, roles: ROLE_USER }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MemoryUserExtraFields/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/MemoryUserExtraFields/routing.yml
@@ -1,0 +1,7 @@
+login:
+    path: /login
+
+memory-user-extra-fields:
+    path: /memory-user-extra-fields
+    defaults:
+        _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\MemoryUserExtraFieldsController

--- a/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserProviderTest.php
@@ -25,6 +25,7 @@ class InMemoryUserProviderTest extends TestCase
         $user = $provider->loadUserByUsername('fabien');
         $this->assertEquals('foo', $user->getPassword());
         $this->assertEquals(['ROLE_USER'], $user->getRoles());
+        $this->assertEquals(['name' => 'John', 'age' => 77, 'salary' => 1234.56], $user->getExtraFields());
         $this->assertFalse($user->isEnabled());
     }
 
@@ -37,6 +38,7 @@ class InMemoryUserProviderTest extends TestCase
         $refreshedUser = $provider->refreshUser($user);
         $this->assertEquals('foo', $refreshedUser->getPassword());
         $this->assertEquals(['ROLE_USER'], $refreshedUser->getRoles());
+        $this->assertEquals(['name' => 'John', 'age' => 77, 'salary' => 1234.56], $refreshedUser->getExtraFields());
         $this->assertFalse($refreshedUser->isEnabled());
         $this->assertFalse($refreshedUser->isCredentialsNonExpired());
     }
@@ -48,6 +50,7 @@ class InMemoryUserProviderTest extends TestCase
                 'password' => 'foo',
                 'enabled' => false,
                 'roles' => ['ROLE_USER'],
+                'extra_fields' => ['name' => 'John', 'age' => 77, 'salary' => 1234.56],
             ],
         ]);
     }

--- a/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
@@ -28,7 +28,7 @@ class InMemoryUserProvider implements UserProviderInterface
 
     /**
      * The user array is a hash where the keys are usernames and the values are
-     * an array of attributes: 'password', 'enabled', and 'roles'.
+     * an array of attributes: 'password', 'enabled', 'roles' and 'extra_fields'.
      *
      * @param array $users An array of users
      */
@@ -38,7 +38,8 @@ class InMemoryUserProvider implements UserProviderInterface
             $password = $attributes['password'] ?? null;
             $enabled = $attributes['enabled'] ?? true;
             $roles = $attributes['roles'] ?? [];
-            $user = new User($username, $password, $roles, $enabled, true, true, true);
+            $extraFields = $attributes['extra_fields'] ?? [];
+            $user = new User($username, $password, $roles, $enabled, true, true, true, $extraFields);
 
             $this->createUser($user);
         }
@@ -65,7 +66,7 @@ class InMemoryUserProvider implements UserProviderInterface
     {
         $user = $this->getUser($username);
 
-        return new User($user->getUsername(), $user->getPassword(), $user->getRoles(), $user->isEnabled(), $user->isAccountNonExpired(), $user->isCredentialsNonExpired(), $user->isAccountNonLocked());
+        return new User($user->getUsername(), $user->getPassword(), $user->getRoles(), $user->isEnabled(), $user->isAccountNonExpired(), $user->isCredentialsNonExpired(), $user->isAccountNonLocked(), $user->getExtraFields());
     }
 
     /**
@@ -79,7 +80,7 @@ class InMemoryUserProvider implements UserProviderInterface
 
         $storedUser = $this->getUser($user->getUsername());
 
-        return new User($storedUser->getUsername(), $storedUser->getPassword(), $storedUser->getRoles(), $storedUser->isEnabled(), $storedUser->isAccountNonExpired(), $storedUser->isCredentialsNonExpired() && $storedUser->getPassword() === $user->getPassword(), $storedUser->isAccountNonLocked());
+        return new User($storedUser->getUsername(), $storedUser->getPassword(), $storedUser->getRoles(), $storedUser->isEnabled(), $storedUser->isAccountNonExpired(), $storedUser->isCredentialsNonExpired() && $storedUser->getPassword() === $user->getPassword(), $storedUser->isAccountNonLocked(), $storedUser->getExtraFields());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #40091
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/14928

---

```yaml
# config/packages/security.yaml
security:
    providers:
        users_in_memory:
            memory:
                users:
                    aa: {password: 'aa', roles: 'ROLE_USER'}
                    bb: {password: 'bb', roles: ['ROLE_ADMIN', 'ROLE_USER'], extra_fields: {'name': 'John', 'age': 77}}
```

```php
// $user -> Symfony\Component\Security\Core\User\User
$user->getExtraFields()['age']; // 77
```