### PR TITLE
[Notifier] Fix typo in AllMySmsTransport namespace

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/AllMySmsTransport.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Notifier\Bridge\AllMySMs;
+namespace Symfony\Component\Notifier\Bridge\AllMySms;
 
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix code
| License       | MIT
| Doc PR        | .

Spotted when installing a new project with `symfony new` then making `composer require maker`: got a warning
Friendly ping @OskarStark @qdequippe 