### PR TITLE
[Notifier] [Firebase] Add data field to options

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Firebase/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * The bridge is not marked as `@experimental` anymore
+ * Add `data` field to options
 
 5.1.0
 -----

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseOptions.php
@@ -27,10 +27,13 @@ abstract class FirebaseOptions implements MessageOptionsInterface
      */
     protected $options;
 
-    public function __construct(string $to, array $options)
+    private $data;
+
+    public function __construct(string $to, array $options, array $data = [])
     {
         $this->to = $to;
         $this->options = $options;
+        $this->data = $data;
     }
 
     public function toArray(): array
@@ -38,6 +41,7 @@ abstract class FirebaseOptions implements MessageOptionsInterface
         return [
             'to' => $this->to,
             'notification' => $this->options,
+            'data' => $this->data,
         ];
     }
 
@@ -56,6 +60,13 @@ abstract class FirebaseOptions implements MessageOptionsInterface
     public function body(string $body): self
     {
         $this->options['body'] = $body;
+
+        return $this;
+    }
+
+    public function data(array $data): self
+    {
+        $this->data = $data;
 
         return $this;
     }

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
@@ -65,6 +65,9 @@ final class FirebaseTransport extends AbstractTransport
         }
         $options['notification'] = $options['notification'] ?? [];
         $options['notification']['body'] = $message->getSubject();
+
+        $options['data'] = $options['data'] ?? [];
+
         $response = $this->client->request('POST', $endpoint, [
             'headers' => [
                 'Authorization' => sprintf('key=%s', $this->token),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x  
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/40078
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The Firebase Notifier must comply to the specifications at https://firebase.google.com/docs/cloud-messaging/xmpp-server-ref.html#notification-payload-support .
The options are missing the `data` field which is a common field for all types of notifications: web, ios and android. 
