### PR TITLE
[HttpKernel] [Kernel] Silence failed deprecations logs writes

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -598,8 +598,8 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             if ($collectDeprecations) {
                 restore_error_handler();
 
-                file_put_contents($cacheDir.'/'.$class.'Deprecations.log', serialize(array_values($collectedLogs)));
-                file_put_contents($cacheDir.'/'.$class.'Compiler.log', null !== $container ? implode("\n", $container->getCompiler()->getLog()) : '');
+                @file_put_contents($cacheDir.'/'.$class.'Deprecations.log', serialize(array_values($collectedLogs)));
+                @file_put_contents($cacheDir.'/'.$class.'Compiler.log', null !== $container ? implode("\n", $container->getCompiler()->getLog()) : '');
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When `->buildContainer()` throws because the cache directory cannot be created, we still try to write the deprecations logs inside the cache directory. In this case, the final exception is `Warning: file_put_contents(/app/var/cache/dev/App_KernelDevDebugContainerDeprecations.log): failed to open stream: No such file or directory` instead of `Unable to create the "cache" directory (/app/var/cache/dev).`.

Alternative:
```php
try {
    // ...
} catch (\RuntimeException $e)
} finally {
    if (isset($e)) {
        throw $e;
    }

    // ...
}
```