### PR TITLE
Allow psr/cache v3 but on symfony/cache

### DIFF
--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -41,7 +41,7 @@
         "symfony/templating": "^3.4|^4.0|^5.0",
         "symfony/translation": "^4.2|^5.0",
         "symfony/translation-contracts": "^1.1|^2",
-        "psr/cache": "^1.0|^2.0",
+        "psr/cache": "^1.0|^2.0|^3.0",
         "twig/twig": "^1.43|^2.13|^3.0.4"
     },
     "provide": {

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -23,7 +23,7 @@
     "require-dev": {
         "doctrine/dbal": "^2.6|^3.0",
         "doctrine/persistence": "^1.3|^2",
-        "psr/cache": "^1.0|^2.0",
+        "psr/cache": "^1.0|^2.0|^3.0",
         "symfony/console": "^3.4|^4.0|^5.0",
         "symfony/dependency-injection": "^3.4.19|^4.1.8|^5.0",
         "symfony/event-dispatcher": "^4.3|^5.0",

--- a/src/Symfony/Contracts/Cache/composer.json
+++ b/src/Symfony/Contracts/Cache/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "psr/cache": "^1.0|^2.0"
+        "psr/cache": "^1.0|^2.0|^3.0"
     },
     "suggest": {
         "symfony/cache-implementation": ""

--- a/src/Symfony/Contracts/composer.json
+++ b/src/Symfony/Contracts/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.1.3",
-        "psr/cache": "^1.0|^2.0",
+        "psr/cache": "^1.0|^2.0|^3.0",
         "psr/container": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Consumers of PSR-6 are compatible with v1|2|3.

Implementations aren't until they add explicit return types, which is not possible without a BC break.
