### PR TITLE
[HttpFoundation] Fix consistency in sessions not found exceptions

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.3
 ---
 
+ * Calling `Request::getSession()` when there is no available session throws a `SessionNotFoundException`
  * Add the `RequestStack::getSession` method
  * Deprecate the `NamespacedAttributeBag` class
  * added `ResponseFormatSame` PHPUnit constraint

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpFoundation;
 
 use Symfony\Component\HttpFoundation\Exception\ConflictingHeadersException;
 use Symfony\Component\HttpFoundation\Exception\JsonException;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\Exception\SuspiciousOperationException;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -735,7 +736,7 @@ class Request
         }
 
         if (null === $session) {
-            throw new \BadMethodCallException('Session has not been set.');
+            throw new SessionNotFoundException('Session has not been set.');
         }
 
         return $session;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40112
| License       | MIT
| Doc PR        | -

Make `Request::getSession` thrown a `SessionNotFoundException` and make `SessionNotFoundException` extends `\BadMethodCallException` for backward compatibility and