### PR TITLE
[FrameworkBundle] fix registering "annotations.cache" on the "container.hot_path"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -48,6 +48,7 @@
                     <argument type="service" id="cache.annotations" />
                 </service>
             </argument>
+            <tag name="container.hot_path" />
         </service>
 
         <service id="annotation_reader" alias="annotations.reader" />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Because `annotations.cache` is registered in a quite special way (see #25696), `ResolveHotPathPass` cannot propagate the `container.hot_path` tag to it.

Let's add the tag explicitly since this service is always on the hot path anyway.

Spotted with Blackfire.io as usual.