### PR TITLE
[Routing] allow non-pattern paths to have exclusion rules

### DIFF
--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -88,6 +88,7 @@ abstract class FileLoader extends Loader
             }
 
             $ret = [];
+            $i = strcspn($resource, '*?{[');
             $isSubpath = 0 !== $i && false !== strpos(substr($resource, 0, $i), '/');
             foreach ($this->glob($resource, false, $_, $ignoreErrors || !$isSubpath, false, $excluded) as $path => $info) {
                 if (null !== $res = $this->doImport($path, 'glob' === $type ? null : $type, $ignoreErrors, $sourceResource)) {

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -78,7 +78,7 @@ abstract class FileLoader extends Loader
         }
         $exclude = \func_num_args() >= 5 ? func_get_arg(4) : null;
 
-        if (\is_string($resource) && \strlen($resource) !== ($i = strcspn($resource, '*?{[')) && false === strpos($resource, "\n")) {
+        if (\is_string($resource) && false === strpos($resource, "\n")) {
             $excluded = [];
             foreach ((array) $exclude as $pattern) {
                 foreach ($this->glob($pattern, true, $_, false, true) as $path => $info) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/39588
| License       | MIT

See https://github.com/symfony/symfony/issues/39588

I have no insight in the reasoning behind adding the character-check in the if-statement initially. Therefor I don't the all the implications that removing this part might have. For example, when applying the change in [my reproducer](https://github.com/Jeroeny/reproduce/tree/excl), this route also disappeared:

```
 ----------------------- -------- -------- ------ --------------------------
  Name                    Method   Scheme   Host   Path                     
 ----------------------- -------- -------- ------ --------------------------
  _preview_error          ANY      ANY      ANY    /_error/{code}.{_format}
```