### PR TITLE
[RateLimiter] Fix sliding_window misbehaving with stale records 

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
@@ -63,8 +63,12 @@ final class SlidingWindow implements LimiterStateInterface
     public static function createFromPreviousWindow(self $window, int $intervalInSeconds): self
     {
         $new = new self($window->id, $intervalInSeconds);
-        $new->hitCountForLastWindow = $window->hitCount;
-        $new->windowEndAt = $window->windowEndAt + $intervalInSeconds;
+        $windowEndAt = $window->windowEndAt + $intervalInSeconds;
+
+        if (time() < $windowEndAt) {
+            $new->hitCountForLastWindow = $window->hitCount;
+            $new->windowEndAt = $windowEndAt;
+        }
 
         return $new;
     }
@@ -112,7 +116,7 @@ final class SlidingWindow implements LimiterStateInterface
     public function getHitCount(): int
     {
         $startOfWindow = $this->windowEndAt - $this->intervalInSeconds;
-        $percentOfCurrentTimeFrame = (time() - $startOfWindow) / $this->intervalInSeconds;
+        $percentOfCurrentTimeFrame = min((time() - $startOfWindow) / $this->intervalInSeconds, 1);
 
         return (int) floor($this->hitCountForLastWindow * (1 - $percentOfCurrentTimeFrame) + $this->hitCount);
     }

--- a/src/Symfony/Component/RateLimiter/Tests/Strategy/SlidingWindowTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Strategy/SlidingWindowTest.php
@@ -12,9 +12,13 @@
 namespace Symfony\Component\RateLimiter\Tests\Policy;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\RateLimiter\Exception\InvalidIntervalException;
 use Symfony\Component\RateLimiter\Policy\SlidingWindow;
 
+/**
+ * @group time-sensitive
+ */
 class SlidingWindowTest extends TestCase
 {
     public function testGetExpirationTime()
@@ -35,5 +39,37 @@ class SlidingWindowTest extends TestCase
     {
         $this->expectException(InvalidIntervalException::class);
         new SlidingWindow('foo', 0);
+    }
+
+    public function testLongInterval()
+    {
+        ClockMock::register(SlidingWindow::class);
+        $window = new SlidingWindow('foo', 60);
+        $this->assertSame(0, $window->getHitCount());
+        $window->add(20);
+        $this->assertSame(20, $window->getHitCount());
+
+        sleep(60);
+        $new = SlidingWindow::createFromPreviousWindow($window, 60);
+        $this->assertSame(20, $new->getHitCount());
+
+        sleep(30);
+        $this->assertSame(10, $new->getHitCount());
+
+        sleep(30);
+        $this->assertSame(0, $new->getHitCount());
+
+        sleep(30);
+        $this->assertSame(0, $new->getHitCount());
+    }
+
+    public function testLongIntervalCreate()
+    {
+        ClockMock::register(SlidingWindow::class);
+        $window = new SlidingWindow('foo', 60);
+
+        sleep(300);
+        $new = SlidingWindow::createFromPreviousWindow($window, 60);
+        $this->assertFalse($new->isExpired());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently the SlidingWindow RateLimiter returns a negative value for getHitCount if the previous SlidingWindow was too long ago. This results in a really high value from `SlidingWindowLimiter::getAvailableTokens()` which is higher than the configured limit.

This limits the value of percentOfCurrentTimeframe in `SlidingWindow::getHitCount()` to 1 so it can't result in a negative hitcount.

The 2nd fix fixes the SlidingWindow instance (essentially) not storing hits if the previous instance is way in the past, as the next instance will still be "in the past". This causes RateLimit to behave as if it were disabled until it has caught up again, which could take a long time when it is configured with a small window size. 
