### PR TITLE
[RateLimiter] Policy rate

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/Rate.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Rate.php
@@ -68,9 +68,9 @@ final class Rate
      */
     public function calculateTimeForTokens(int $tokens): int
     {
-        $cyclesRequired = ceil($tokens / $this->refillAmount);
+        $cyclesRequired = $tokens / $this->refillAmount;
 
-        return TimeUtil::dateIntervalToSeconds($this->refillTime) * $cyclesRequired;
+        return ceil(TimeUtil::dateIntervalToSeconds($this->refillTime) * $cyclesRequired);
     }
 
     /**

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/RateTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/RateTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\RateLimiter\Tests\Policy;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\RateLimiter\Policy\Rate;
+
+class RateTest extends TestCase
+{
+    public function testCalculateTimeForTokens()
+    {
+        $rate = Rate::perMinute(1);
+        $this->assertEquals(60, $rate->calculateTimeForTokens(1));
+
+        // Following rates must all result in a rate of 1 token per second
+        $rate = Rate::perSecond(1);
+        $this->assertEquals(1, $rate->calculateTimeForTokens(1));
+
+        $rate = Rate::perMinute(60);
+        $this->assertEquals(1, $rate->calculateTimeForTokens(1));
+
+        $rate = new Rate(new \DateInterval('PT2M'), 120);
+        $this->assertEquals(1, $rate->calculateTimeForTokens(1));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT
| Doc PR        | no doc

Define a rate of 1 token per seconds should be the same as defining a rate of 60 tokens per minute, instead the last one results in a rate of 1 token per minute:

```
$factory = new RateLimiterFactory([
    'id' => 'login',
    'policy' => 'token_bucket',
    'limit' => 2,
    // this gives a rate of 1 token per second
    'rate' => ['interval' => '1 second'],
    // this gives a rate of 1 token per minute
    'rate' => ['interval' => '1 minute', 'amount' => 60],
], new InMemoryStorage());
```
