### PR TITLE
Re-enable triggering deprecations about return types

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -16,6 +16,9 @@ if (!getenv('SYMFONY_PHPUNIT_VERSION')) {
         putenv('SYMFONY_PHPUNIT_VERSION=9.5');
     }
 }
+if (!getenv('SYMFONY_PATCH_TYPE_DECLARATIONS') && \PHP_VERSION_ID >= 70200) {
+    putenv('SYMFONY_PATCH_TYPE_DECLARATIONS=deprecations=1');
+}
 if (getcwd() === realpath(__DIR__.'/src/Symfony/Bridge/PhpUnit')) {
     putenv('SYMFONY_DEPRECATIONS_HELPER=disabled');
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Now that the three PRs linked in #40066 are merged, we can re-enable this check.