### PR TITLE
[Messenger] Pass sender details to SendMessageToTransportsEvent

### DIFF
--- a/src/Symfony/Component/Messenger/Event/SendMessageToTransportsEvent.php
+++ b/src/Symfony/Component/Messenger/Event/SendMessageToTransportsEvent.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Event;
 
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 
 /**
  * Event is dispatched before a message is sent to the transport.
@@ -28,9 +29,12 @@ final class SendMessageToTransportsEvent
 {
     private Envelope $envelope;
 
-    public function __construct(Envelope $envelope)
+    private array $senders;
+
+    public function __construct(Envelope $envelope, array $senders)
     {
         $this->envelope = $envelope;
+        $this->senders = $senders;
     }
 
     public function getEnvelope(): Envelope
@@ -41,5 +45,13 @@ final class SendMessageToTransportsEvent
     public function setEnvelope(Envelope $envelope)
     {
         $this->envelope = $envelope;
+    }
+
+    /**
+     * @return array<string, SenderInterface>
+     */
+    public function getSenders(): array
+    {
+        return $this->senders;
     }
 }

--- a/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/SendMessageMiddleware.php
@@ -55,9 +55,11 @@ class SendMessageMiddleware implements MiddlewareInterface
             $this->logger->info('Received message {class}', $context);
         } else {
             $shouldDispatchEvent = true;
-            foreach ($this->sendersLocator->getSenders($envelope) as $alias => $sender) {
+            $senders = $this->sendersLocator->getSenders($envelope);
+            $senders = \is_array($senders) ? $senders : iterator_to_array($senders);
+            foreach ($senders as $alias => $sender) {
                 if (null !== $this->eventDispatcher && $shouldDispatchEvent) {
-                    $event = new SendMessageToTransportsEvent($envelope);
+                    $event = new SendMessageToTransportsEvent($envelope, $senders);
                     $this->eventDispatcher->dispatch($event);
                     $envelope = $event->getEnvelope();
                     $shouldDispatchEvent = false;

--- a/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/SendMessageMiddlewareTest.php
@@ -168,13 +168,13 @@ class SendMessageMiddlewareTest extends MiddlewareTestCase
     {
         $envelope = new Envelope(new DummyMessage('original envelope'));
 
+        $sender1 = $this->createMock(SenderInterface::class);
+        $sender2 = $this->createMock(SenderInterface::class);
+
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $dispatcher->expects($this->once())
             ->method('dispatch')
-            ->with(new SendMessageToTransportsEvent($envelope));
-
-        $sender1 = $this->createMock(SenderInterface::class);
-        $sender2 = $this->createMock(SenderInterface::class);
+            ->with(new SendMessageToTransportsEvent($envelope, ['foo' => $sender1, 'bar' => $sender2]));
 
         $sendersLocator = $this->createSendersLocator([DummyMessage::class => ['foo', 'bar']], ['foo' => $sender1, 'bar' => $sender2]);
         $middleware = new SendMessageMiddleware($sendersLocator, $dispatcher);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

This is a feature suggestion that will allow listeners for `SendMessageToTransportsEvent` to be able to read the sender and sender alias from a sent message.

Use case: To create metrics for messages that go through the system (and especially where to and from). Listener(s) can be created to measure this. They would listen to `WorkerMessageHandledEvent`, `WorkerMessageFailedEvent` and `SendMessageToTransportsEvent`. The first two receive envelopes that contain a `ReceivedStamp`, to determine where the message came from. However, the received envelopes for sent messages do not contain a stamp to read the sender. It would be great if this was possible to do with listener (instead of having to add middleware to each bus). 

Approach in this PR: stamp the envelope with `SentStamp` before dispatching `SendMessageToTransportsEvent`. 

Alternative approach: pass the info to the event directly: `new SendMessageToTransportsEvent($envelope, get_class($sender), $alias)`.  And keep the stamping afterwards.

**Edit**: I just noticed that one event is dispatched regardless of the number of senders. In that case the event could be dispatched after all the senders have been called (and thus all the stamps set). 