### PR TITLE
[Security] LoginLink with specific locale

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/LoginLink/FirewallAwareLoginLinkHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/LoginLink/FirewallAwareLoginLinkHandler.php
@@ -37,9 +37,9 @@ class FirewallAwareLoginLinkHandler implements LoginLinkHandlerInterface
         $this->requestStack = $requestStack;
     }
 
-    public function createLoginLink(UserInterface $user): LoginLinkDetails
+    public function createLoginLink(UserInterface $user, Request $request = null): LoginLinkDetails
     {
-        return $this->getLoginLinkHandler()->createLoginLink($user);
+        return $this->getLoginLinkHandler()->createLoginLink($user, $request);
     }
 
     public function consumeLoginLink(Request $request): UserInterface

--- a/src/Symfony/Bundle/SecurityBundle/Tests/LoginLink/FirewallAwareLoginLinkHandlerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/LoginLink/FirewallAwareLoginLinkHandlerTest.php
@@ -34,7 +34,7 @@ class FirewallAwareLoginLinkHandlerTest extends TestCase
         $loginLinkHandler = $this->createMock(LoginLinkHandlerInterface::class);
         $loginLinkHandler->expects($this->once())
             ->method('createLoginLink')
-            ->with($user)
+            ->with($user, $request)
             ->willReturn($linkDetails);
         $loginLinkHandler->expects($this->once())
             ->method('consumeLoginLink')
@@ -47,7 +47,7 @@ class FirewallAwareLoginLinkHandlerTest extends TestCase
         $requestStack->push($request);
 
         $linker = new FirewallAwareLoginLinkHandler($firewallMap, $locator, $requestStack);
-        $actualLinkDetails = $linker->createLoginLink($user);
+        $actualLinkDetails = $linker->createLoginLink($user, $request);
         $this->assertSame($linkDetails, $actualLinkDetails);
 
         $actualUser = $linker->consumeLoginLink($request);

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
@@ -25,7 +25,7 @@ interface LoginLinkHandlerInterface
     /**
      * Generate a link that can be used to authenticate as the given user.
      */
-    public function createLoginLink(UserInterface $user): LoginLinkDetails;
+    public function createLoginLink(UserInterface $user, Request $request = null): LoginLinkDetails;
 
     /**
      * Validates if this request contains a login link and returns the associated User.

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -48,7 +48,7 @@ class LoginLinkHandlerTest extends TestCase
      * @dataProvider provideCreateLoginLinkData
      * @group time-sensitive
      */
-    public function testCreateLoginLink($user, array $extraProperties)
+    public function testCreateLoginLink($user, array $extraProperties, Request $request = null)
     {
         $this->router->expects($this->once())
             ->method('generate')
@@ -65,12 +65,23 @@ class LoginLinkHandlerTest extends TestCase
             )
             ->willReturn('https://example.com/login/verify?user=weaverryan&hash=abchash&expires=1601235000');
 
-        $loginLink = $this->createLinker([], array_keys($extraProperties))->createLoginLink($user);
+        $loginLink = $this->createLinker([], array_keys($extraProperties))->createLoginLink($user, $request);
         $this->assertSame('https://example.com/login/verify?user=weaverryan&hash=abchash&expires=1601235000', $loginLink->getUrl());
     }
 
     public function provideCreateLoginLinkData()
     {
+        yield [
+            new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash'),
+            ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'],
+            Request::create('https://example.com'),
+        ];
+
+        yield [
+            new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash'),
+            ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'],
+        ];
+
         yield [
             new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash'),
             ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | 

I have added the possibility to create a login link for a specific locale. It's useful when we want generate a link for an other user who isn't in the same locale of us.