### PR TITLE
[Messenger] Support Redis Cluster

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Add `rediss://` DSN scheme support for TLS protocol
  * Deprecate TLS option, use `rediss://127.0.0.1` instead of `redis://127.0.0.1?tls=1`
+ * Add support for `\RedisCluster` instance in `Connection` constructor
+ * Add support for Redis Cluster in DSN
 
 5.2.0
 -----

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisClusterProxy.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisClusterProxy.php
@@ -12,20 +12,19 @@
 namespace Symfony\Component\Messenger\Bridge\Redis\Transport;
 
 /**
- * Allow to delay connection to Redis.
+ * Allow to delay connection to Redis Cluster.
  *
- * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- * @author Nicolas Grekas <p@tchwork.com>
+ * @author Johann Pardanaud <johann@pardanaud.com>
  *
  * @internal
  */
-class RedisProxy
+class RedisClusterProxy
 {
     private $redis;
     private $initializer;
     private $ready = false;
 
-    public function __construct(\Redis $redis, \Closure $initializer)
+    public function __construct(?\RedisCluster $redis, \Closure $initializer)
     {
         $this->redis = $redis;
         $this->initializer = $initializer;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #38264
| License       | MIT
| Doc PR        | symfony/symfony-docs#14956

This PR brings support for Redis Cluster in the Messenger component:

- The first commit _Support RedisCluster instance_ allows to pass a `RedisCluster` object when instanciating the `Connection` class, which brings support for Redis Cluster without any friction.
- The second commit _Support multiple hosts DSN for Redis Cluster_ is more opiniated and brings a DSN format to configure a Redis Cluster from `config/packages/messenger.yaml`.

Instanciating `Connection` with a `RedisCluster` object:

```php
$redis = new \RedisCluster(null, ['host-01:6379', 'host-02:6379', 'host-03:6379', 'host-04:6379']);
$connection = new Connection([], [], [], $redis);
```

Configuring a Redis Cluster from YAML:

```yaml
// config/packages/messenger.yaml

framework:
    messenger:
            metadata:
                default: 'redis://host-01:6379,redis://host-02:6379,redis://host-03:6379'
                lazy: 'redis://host-01:6379?lazy=1,redis://host-02:6379,redis://host-03:6379'

                # Configuration will be `lazy = true` and `auto_setup = true`
                multipleConfig: 'redis://host-01:6379?lazy=1&auto_setup=false,redis://host-02:6379,redis://host-03:6379?auto_setup=true'
```

This format allows to define multiple hosts for a Redis Cluster and still contains valid URLs. Custom configuration is still supported, it can be specified on only one of the URLs in the DSN (see `lazy` above). If the user provides multiple configurations on different URLs, they are simply merged with the following code and if an option is defined multiple times then the latest takes precedence (see `multipleConfig` above).

I understand the way the DSN is handled could not suit you. Please, if you close this PR only for the DSN part, just tell me and I will make a new PR with only the first commit.