### PR TITLE
Modernize func_get_args() calls to variadic parameters

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/ExpressionFunction.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionFunction.php
@@ -85,12 +85,12 @@ class ExpressionFunction
             throw new \InvalidArgumentException(sprintf('An expression function name must be defined when PHP function "%s" is namespaced.', $phpFunctionName));
         }
 
-        $compiler = function () use ($phpFunctionName) {
-            return sprintf('\%s(%s)', $phpFunctionName, implode(', ', \func_get_args()));
+        $compiler = function (...$args) use ($phpFunctionName) {
+            return sprintf('\%s(%s)', $phpFunctionName, implode(', ', $args));
         };
 
-        $evaluator = function () use ($phpFunctionName) {
-            return $phpFunctionName(...\array_slice(\func_get_args(), 1));
+        $evaluator = function ($p, ...$args) use ($phpFunctionName) {
+            return $phpFunctionName(...$args);
         };
 
         return new self($expressionFunctionName ?: end($parts), $compiler, $evaluator);

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -746,14 +746,16 @@ class Filesystem
     }
 
     /**
+     * @param mixed ...$args
+     *
      * @return mixed
      */
-    private static function box(callable $func)
+    private static function box(callable $func, ...$args)
     {
         self::$lastError = null;
         set_error_handler(__CLASS__.'::handleError');
         try {
-            $result = $func(...\array_slice(\func_get_args(), 1));
+            $result = $func(...$args);
             restore_error_handler();
 
             return $result;

--- a/src/Symfony/Component/Intl/Tests/Locale/AbstractLocaleTest.php
+++ b/src/Symfony/Component/Intl/Tests/Locale/AbstractLocaleTest.php
@@ -27,5 +27,10 @@ abstract class AbstractLocaleTest extends TestCase
         $this->assertSame('en_GB', $this->call('getDefault'));
     }
 
-    abstract protected function call($methodName);
+    /**
+     * @param mixed ...$args
+     *
+     * @return mixed
+     */
+    abstract protected function call(string $methodName, ...$args);
 }

--- a/src/Symfony/Component/Intl/Tests/Locale/LocaleTest.php
+++ b/src/Symfony/Component/Intl/Tests/Locale/LocaleTest.php
@@ -139,10 +139,8 @@ class LocaleTest extends AbstractLocaleTest
         $this->assertSame('en', $this->call('getDefault'));
     }
 
-    protected function call($methodName)
+    protected function call(string $methodName, ...$args)
     {
-        $args = \array_slice(\func_get_args(), 1);
-
         return Locale::{$methodName}(...$args);
     }
 }

--- a/src/Symfony/Component/Intl/Tests/Locale/Verification/LocaleTest.php
+++ b/src/Symfony/Component/Intl/Tests/Locale/Verification/LocaleTest.php
@@ -29,10 +29,8 @@ class LocaleTest extends AbstractLocaleTest
         parent::setUp();
     }
 
-    protected function call($methodName)
+    protected function call(string $methodName, ...$args)
     {
-        $args = \array_slice(\func_get_args(), 1);
-
         return \Locale::{$methodName}(...$args);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

While reviewing #40143, I stumbled across the `Filesystem::box()` method and I felt like we could make the code look a little less PHP5-ish.