### PR TITLE
[PropertyInfo] fix extracting mixed type-hinted property types

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -162,8 +162,8 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
             try {
                 $reflectionProperty = new \ReflectionProperty($class, $property);
                 $type = $reflectionProperty->getType();
-                if (null !== $type) {
-                    return $this->extractFromReflectionType($type, $reflectionProperty->getDeclaringClass());
+                if (null !== $type && $types = $this->extractFromReflectionType($type, $reflectionProperty->getDeclaringClass())) {
+                    return $types;
                 }
             } catch (\ReflectionException $e) {
                 // noop

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -239,6 +239,7 @@ class ReflectionExtractorTest extends TestCase
             ['string', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Stringable'), new Type(Type::BUILTIN_TYPE_STRING)]],
             ['payload', null],
             ['data', null],
+            ['mixedProperty', null],
         ];
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php80Dummy.php
@@ -4,6 +4,8 @@ namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
 
 class Php80Dummy
 {
+    public mixed $mixedProperty;
+
     public function getFoo(): array|null
     {
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39947
| License       | MIT
| Doc PR        | 