### PR TITLE
[Intl] fix Locale::getFallback() throwing exception on long $locale

### DIFF
--- a/src/Symfony/Component/Intl/Locale.php
+++ b/src/Symfony/Component/Intl/Locale.php
@@ -68,7 +68,8 @@ final class Locale extends \Locale
     public static function getFallback(string $locale): ?string
     {
         if (\function_exists('locale_parse')) {
-            $localeSubTags = locale_parse($locale);
+            $localeSubTags = locale_parse($locale) ?? ['language' => $locale];
+
             if (1 === \count($localeSubTags)) {
                 if ('root' !== self::$defaultFallback && self::$defaultFallback === $localeSubTags['language']) {
                     return 'root';

--- a/src/Symfony/Component/Intl/Tests/LocaleTest.php
+++ b/src/Symfony/Component/Intl/Tests/LocaleTest.php
@@ -70,4 +70,16 @@ class LocaleTest extends TestCase
 
         Locale::setDefaultFallback($prev);
     }
+
+    /**
+     * @requires function locale_parse
+     */
+    public function testLongLocaleFallback()
+    {
+        $locale = 'LC_TYPE=fr_FR.UTF-8;LC_NUMERIC=C;LC_TIME=fr_FR.UTF-8;LC_COLLATE=fr_FR.UTF-8;'.
+            'LC_MONETARY=fr_FR.UTF-8;LC_MESSAGES=fr_FR.UTF-8;LC_PAPER=fr_FR.UTF-8;LC_NAME=fr_FR.UTF-8;'.
+            'LC_ADDRESS=fr_FR.UTF-8;LC_TELEPHONE=fr_FR.UTF-8;LC_MEASUREMENT=fr_FR.UTF-8;LC_IDENTIFICATION=fr_FR.UTF-8';
+
+        $this->assertNull(Locale::getFallback($locale));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39100 
| License       | MIT
| Doc PR        | 

`Locale::getFallback()` throws an exception when the `$locale` length is greater than `INTL_MAX_LOCALE_LEN` so I added a condition to check if locale_parse return null, the `Locale::getFallback()` don't call `\count` function and just return null instead.
