### PR TITLE
[DependencyInjection] Definition::removeMethodCall should remove all matching calls

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -392,7 +392,6 @@ class Definition
         foreach ($this->calls as $i => $call) {
             if ($call[0] === $method) {
                 unset($this->calls[$i]);
-                break;
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/DefinitionTest.php
@@ -425,4 +425,20 @@ class DefinitionTest extends TestCase
         $def->addError('Second error');
         $this->assertSame(['First error', 'Second error'], $def->getErrors());
     }
+
+    public function testMultipleMethodCalls()
+    {
+        $def = new Definition('stdClass');
+
+        $def->addMethodCall('configure', ['arg1']);
+        $this->assertTrue($def->hasMethodCall('configure'));
+        $this->assertCount(1, $def->getMethodCalls());
+
+        $def->addMethodCall('configure', ['arg2']);
+        $this->assertTrue($def->hasMethodCall('configure'));
+        $this->assertCount(2, $def->getMethodCalls());
+
+        $def->removeMethodCall('configure');
+        $this->assertFalse($def->hasMethodCall('configure'));
+    }
 }


### PR DESCRIPTION
It would only remove the first match, leaving the other method call(s) there to exist. This leads to unexpected situations.

| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | None
| License       | MIT
| Doc PR        | 

I found out that `Definition::removeMethodCall` only removes the first method call and stops. It should remove all method calls named `$method`.