### PR TITLE
[DependencyInjection] Negated (not:) env var processor

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `ServicesConfigurator::remove()` in the PHP-DSL
+ * added `%env(not:...)%` processor to negate boolean values
 
 5.2.0
 -----

--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -41,6 +41,7 @@ class EnvVarProcessor implements EnvVarProcessorInterface
         return [
             'base64' => 'string',
             'bool' => 'bool',
+            'not' => 'bool',
             'const' => 'bool|int|float|string|array',
             'csv' => 'array',
             'file' => 'string',
@@ -191,8 +192,10 @@ class EnvVarProcessor implements EnvVarProcessorInterface
             return (string) $env;
         }
 
-        if ('bool' === $prefix) {
-            return (bool) (filter_var($env, \FILTER_VALIDATE_BOOLEAN) ?: filter_var($env, \FILTER_VALIDATE_INT) ?: filter_var($env, \FILTER_VALIDATE_FLOAT));
+        if (in_array($prefix, ['bool', 'not'], true)) {
+            $env = (bool) (filter_var($env, \FILTER_VALIDATE_BOOLEAN) ?: filter_var($env, \FILTER_VALIDATE_INT) ?: filter_var($env, \FILTER_VALIDATE_FLOAT));
+
+            return 'not' === $prefix ? !$env : $env;
         }
 
         if ('int' === $prefix) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/RegisterEnvVarProcessorsPassTest.php
@@ -33,6 +33,7 @@ class RegisterEnvVarProcessorsPassTest extends TestCase
             'foo' => ['string'],
             'base64' => ['string'],
             'bool' => ['bool'],
+            'not' => ['bool'],
             'const' => ['bool', 'int', 'float', 'string', 'array'],
             'csv' => ['array'],
             'file' => ['string'],

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -64,6 +64,22 @@ class EnvVarProcessorTest extends TestCase
         $this->assertSame($processed, $result);
     }
 
+    /**
+     * @dataProvider validBools
+     */
+    public function testGetEnvNot($value, $processed)
+    {
+        $processor = new EnvVarProcessor(new Container());
+
+        $result = $processor->getEnv('not', 'foo', function ($name) use ($value) {
+            $this->assertSame('foo', $name);
+
+            return $value;
+        });
+
+        $this->assertSame(!$processed, $result);
+    }
+
     public function validBools()
     {
         return [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      |no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#14976

This little PR suggests a `not:` env var processor (in a perfect world, I would name it `!:` but only words are accepted as prefixes 🙃)
Goal is to _negate_ a boolean env variable.

Example usage:

```bash
FOO=yes
BAR=off
```

```yaml
# config/services.yaml
parameters:
    not_foo: '%env(not:FOO)%' # false
    not_bar: '%env(not:BAR)%' # true
```

I'm thinking of this for this kind of usages:
- `some_prod_related_stuff: '%env(not:APP_DEBUG)%'`
- `enabled: '%env(not:bool:key:disabled:query_string:SOME_DSN)%'`

~~Processor raises an exception when preceding resolved value is not a boolean.~~
This processor allows any truthy/falsy values, like `bool:`.

Thank you,
Ben