### PR TITLE
[Mailer] AWS SES transport Source ARN header support

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -70,6 +70,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
             $this->assertSame('<b>Hello There!</b>', $content['Content']['Simple']['Body']['Html']['Data']);
             $this->assertSame(['replyto-1@example.com', 'replyto-2@example.com'], $content['ReplyToAddresses']);
             $this->assertSame('aws-configuration-set-name', $content['ConfigurationSetName']);
+            $this->assertSame('aws-source-arn', $content['FromEmailAddressIdentityArn']);
             $this->assertSame('bounces@example.com', $content['FeedbackForwardingEmailAddress']);
 
             $json = '{"MessageId": "foobar"}';
@@ -91,6 +92,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
             ->returnPath(new Address('bounces@example.com'));
 
         $mail->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', 'aws-configuration-set-name');
+        $mail->getHeaders()->addTextHeader('X-SES-SOURCE-ARN', 'aws-source-arn');
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
@@ -69,6 +69,7 @@ class SesApiTransportTest extends TestCase
             $this->assertSame('Fabien <fabpot@symfony.com>', $content['Source']);
             $this->assertSame('Hello There!', $content['Message_Body_Text_Data']);
             $this->assertSame('aws-configuration-set-name', $content['ConfigurationSetName']);
+            $this->assertSame('aws-source-arn', $content['FromEmailAddressIdentityArn']);
 
             $xml = '<SendEmailResponse xmlns="https://email.amazonaws.com/doc/2010-03-31/">
   <SendEmailResult>
@@ -90,6 +91,7 @@ class SesApiTransportTest extends TestCase
             ->text('Hello There!');
 
         $mail->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', 'aws-configuration-set-name');
+        $mail->getHeaders()->addTextHeader('X-SES-SOURCE-ARN', 'aws-source-arn');
 
         $message = $transport->send($mail);
 
@@ -135,6 +137,7 @@ class SesApiTransportTest extends TestCase
              ->attach('attached data');
 
         $mail->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', 'aws-configuration-set-name');
+        $mail->getHeaders()->addTextHeader('X-SES-SOURCE-ARN', 'aws-source-arn');
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
@@ -69,6 +69,7 @@ class SesHttpAsyncAwsTransportTest extends TestCase
             $this->assertStringContainsString('Fabien <fabpot@symfony.com>', $content);
             $this->assertStringContainsString('Hello There!', $content);
             $this->assertSame('aws-configuration-set-name', $body['ConfigurationSetName']);
+            $this->assertSame('aws-source-arn', $body['FromEmailAddressIdentityArn']);
 
             $json = '{"MessageId": "foobar"}';
 
@@ -86,6 +87,7 @@ class SesHttpAsyncAwsTransportTest extends TestCase
             ->text('Hello There!');
 
         $mail->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', 'aws-configuration-set-name');
+        $mail->getHeaders()->addTextHeader('X-SES-SOURCE-ARN', 'aws-source-arn');
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpTransportTest.php
@@ -77,6 +77,7 @@ class SesHttpTransportTest extends TestCase
             $this->assertStringContainsString('Hello There!', $content);
 
             $this->assertSame('aws-configuration-set-name', $body['ConfigurationSetName']);
+            $this->assertSame('aws-source-arn', $body['FromEmailAddressIdentityArn']);
 
             $xml = '<SendEmailResponse xmlns="https://email.amazonaws.com/doc/2010-03-31/">
   <SendRawEmailResult>
@@ -99,6 +100,7 @@ class SesHttpTransportTest extends TestCase
             ->text('Hello There!');
 
         $mail->getHeaders()->addTextHeader('X-SES-CONFIGURATION-SET', 'aws-configuration-set-name');
+        $mail->getHeaders()->addTextHeader('X-SES-SOURCE-ARN', 'aws-source-arn');
 
         $message = $transport->send($mail);
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
@@ -92,6 +92,9 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
         if ($header = $email->getHeaders()->get('X-SES-CONFIGURATION-SET')) {
             $request['ConfigurationSetName'] = $header->getBodyAsString();
         }
+        if ($header = $email->getHeaders()->get('X-SES-SOURCE-ARN')) {
+            $request['FromEmailAddressIdentityArn'] = $header->getBodyAsString();
+        }
         if ($email->getReturnPath()) {
             $request['FeedbackForwardingEmailAddress'] = $email->getReturnPath()->toString();
         }

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiTransport.php
@@ -99,6 +99,10 @@ class SesApiTransport extends AbstractApiTransport
                 $payload['ConfigurationSetName'] = $header->getBodyAsString();
             }
 
+            if ($header = $email->getHeaders()->get('X-SES-SOURCE-ARN')) {
+                $payload['FromEmailAddressIdentityArn'] = $header->getBodyAsString();
+            }
+
             return $payload;
         }
 
@@ -126,6 +130,9 @@ class SesApiTransport extends AbstractApiTransport
         }
         if ($header = $email->getHeaders()->get('X-SES-CONFIGURATION-SET')) {
             $payload['ConfigurationSetName'] = $header->getBodyAsString();
+        }
+        if ($header = $email->getHeaders()->get('X-SES-SOURCE-ARN')) {
+            $payload['FromEmailAddressIdentityArn'] = $header->getBodyAsString();
         }
 
         return $payload;

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpAsyncAwsTransport.php
@@ -83,6 +83,10 @@ class SesHttpAsyncAwsTransport extends AbstractTransport
             && $configurationSetHeader = $message->getOriginalMessage()->getHeaders()->get('X-SES-CONFIGURATION-SET')) {
             $request['ConfigurationSetName'] = $configurationSetHeader->getBodyAsString();
         }
+        if (($message->getOriginalMessage() instanceof Message)
+            && $sourceArnHeader = $message->getOriginalMessage()->getHeaders()->get('X-SES-SOURCE-ARN')) {
+            $request['FromEmailAddressIdentityArn'] = $sourceArnHeader->getBodyAsString();
+        }
 
         return new SendEmailRequest($request);
     }

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesHttpTransport.php
@@ -77,6 +77,11 @@ class SesHttpTransport extends AbstractHttpTransport
             $request['body']['ConfigurationSetName'] = $configurationSetHeader->getBodyAsString();
         }
 
+        if ($message->getOriginalMessage() instanceof Message
+            && $sourceArnHeader = $message->getOriginalMessage()->getHeaders()->get('X-SES-SOURCE-ARN')) {
+            $request['body']['FromEmailAddressIdentityArn'] = $sourceArnHeader->getBodyAsString();
+        }
+
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint(), $request);
 
         $result = new \SimpleXMLElement($response->getContent(false));

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * added the `mailer` monolog channel and set it on all transport definitions
+ * Add support for `X-SES-SOURCE-ARN` in `symfony/amazon-mailer`
 
 5.2.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | need help (this part was never mentioned in docs)

AWS SES API has [FromEmailAddressIdentityArn](https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendEmail.html#SES-SendEmail-request-FromEmailAddressIdentityArn) field which is necessary for using identities verified by different AWS account.

With this PR I am adding ability to set this field via setting `X-SES-SOURCE-ARN` header.

I've added support for this API field in the same way as it was done before for `X-SES-CONFIGURATION-SET`. It was never documented, but you can use header `X-SES-CONFIGURATION-SET` to set `ConfigurationSetName` API param.
