### PR TITLE
[PropertyInfo]  use the right context for properties defined in traits

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -201,7 +201,17 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         }
 
         try {
-            return $this->docBlockFactory->create($reflectionProperty, $this->createFromReflector($reflectionProperty->getDeclaringClass()));
+            $reflector = $reflectionProperty->getDeclaringClass();
+
+            foreach ($reflector->getTraits() as $trait) {
+                if ($trait->hasProperty($property)) {
+                    $reflector = $trait;
+
+                    break;
+                }
+            }
+
+            return $this->docBlockFactory->create($reflectionProperty, $this->createFromReflector($reflector));
         } catch (\InvalidArgumentException $e) {
             return null;
         } catch (\RuntimeException $e) {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -16,6 +16,9 @@ use phpDocumentor\Reflection\DocBlock\Tags\InvalidTag;
 use phpDocumentor\Reflection\Types\Collection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsedInTrait;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsingTrait;
 use Symfony\Component\PropertyInfo\Type;
 
 /**
@@ -271,6 +274,23 @@ class PhpDocExtractorTest extends TestCase
     public function testDocBlockFallback($property, $types)
     {
         $this->assertEquals($types, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\DockBlockFallback', $property));
+    }
+
+    /**
+     * @dataProvider propertiesDefinedByTraitsProvider
+     */
+    public function testPropertiesDefinedByTraits(string $property, Type $type)
+    {
+        $this->assertEquals([$type], $this->extractor->getTypes(DummyUsingTrait::class, $property));
+    }
+
+    public function propertiesDefinedByTraitsProvider(): array
+    {
+        return [
+            ['propertyInTraitPrimitiveType', new Type(Type::BUILTIN_TYPE_STRING)],
+            ['propertyInTraitObjectSameNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyUsedInTrait::class)],
+            ['propertyInTraitObjectDifferentNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)],
+        ];
     }
 
     protected function isPhpDocumentorV5()

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/DummyTrait.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/DummyTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage;
+
+use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
+
+trait DummyTrait
+{
+    /**
+     * @var string
+     */
+    private $propertyInTraitPrimitiveType;
+
+    /**
+     * @var DummyUsedInTrait
+     */
+    private $propertyInTraitObjectSameNamespace;
+
+    /**
+     * @var Dummy
+     */
+    private $propertyInTraitObjectDifferentNamespace;
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/DummyUsedInTrait.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/DummyUsedInTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage;
+
+class DummyUsedInTrait
+{
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/DummyUsingTrait.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/DummyUsingTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage;
+
+class DummyUsingTrait
+{
+    use DummyTrait;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #28732, #34191
| License       | MIT
| Doc PR        | 