### PR TITLE
[PasswordHasher] Use bcrypt as default hash algorithm for "native" and "auto"

### DIFF
--- a/src/Symfony/Component/PasswordHasher/CHANGELOG.md
+++ b/src/Symfony/Component/PasswordHasher/CHANGELOG.md
@@ -2,3 +2,4 @@
 ---
 
  * Add the component
+ * Use `bcrypt` as default algorithm in `NativePasswordHasher`

--- a/src/Symfony/Component/PasswordHasher/Hasher/NativePasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/NativePasswordHasher.php
@@ -29,7 +29,7 @@ final class NativePasswordHasher implements PasswordHasherInterface
     private $options;
 
     /**
-     * @param string|null $algo An algorithm supported by password_hash() or null to use the stronger available algorithm
+     * @param string|null $algo An algorithm supported by password_hash() or null to use the best available algorithm
      */
     public function __construct(int $opsLimit = null, int $memLimit = null, int $cost = null, ?string $algo = null)
     {
@@ -52,11 +52,11 @@ final class NativePasswordHasher implements PasswordHasherInterface
         $algos = [1 => \PASSWORD_BCRYPT, '2y' => \PASSWORD_BCRYPT];
 
         if (\defined('PASSWORD_ARGON2I')) {
-            $this->algo = $algos[2] = $algos['argon2i'] = (string) \PASSWORD_ARGON2I;
+            $algos[2] = $algos['argon2i'] = (string) \PASSWORD_ARGON2I;
         }
 
         if (\defined('PASSWORD_ARGON2ID')) {
-            $this->algo = $algos[3] = $algos['argon2id'] = (string) \PASSWORD_ARGON2ID;
+            $algos[3] = $algos['argon2id'] = (string) \PASSWORD_ARGON2ID;
         }
 
         if (null !== $algo) {

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/NativePasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/NativePasswordHasherTest.php
@@ -21,13 +21,13 @@ class NativePasswordHasherTest extends TestCase
 {
     public function testCostBelowRange()
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new NativePasswordHasher(null, null, 3);
     }
 
     public function testCostAboveRange()
     {
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         new NativePasswordHasher(null, null, 32);
     }
 
@@ -70,6 +70,14 @@ class NativePasswordHasherTest extends TestCase
         $hasher = new NativePasswordHasher(null, null, null, \PASSWORD_BCRYPT);
         $result = $hasher->hash('password', null);
         $this->assertTrue($hasher->verify($result, 'password', null));
+        $this->assertStringStartsWith('$2', $result);
+    }
+
+    public function testDefaultAlgorithm()
+    {
+        $hasher = new NativePasswordHasher();
+        $result = $hasher->hash('password');
+        $this->assertTrue($hasher->verify($result, 'password'));
         $this->assertStringStartsWith('$2', $result);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As suggested in https://github.com/symfony/symfony/pull/39802#issuecomment-776790017,  based on https://twitter.com/TerahashCorp/status/1155129705034653698
