### PR TITLE
[FrameworkBundle] Exclude unreadable files when executing About command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -116,7 +116,9 @@ EOT
         } else {
             $size = 0;
             foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS | \RecursiveDirectoryIterator::FOLLOW_SYMLINKS)) as $file) {
-                $size += $file->getSize();
+                if ($file->isReadable()) {
+                    $size += $file->getSize();
+                }
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/AboutCommand/AboutCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/AboutCommand/AboutCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command\AboutCommand;
+
+use Symfony\Bundle\FrameworkBundle\Command\AboutCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Tests\Command\AboutCommand\Fixture\TestAppKernel;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+
+class AboutCommandTest extends TestCase
+{
+    /** @var Filesystem */
+    private $fs;
+
+    protected function setUp(): void
+    {
+        $this->fs = new Filesystem();
+    }
+
+    public function testAboutWithReadableFiles()
+    {
+        $kernel = new TestAppKernel('test', true);
+        $this->fs->mkdir($kernel->getProjectDir());
+
+        $this->fs->dumpFile($kernel->getCacheDir().'/readable_file', 'The file content.');
+        $this->fs->chmod($kernel->getCacheDir().'/readable_file', 0777);
+
+        $tester = $this->createCommandTester($kernel);
+        $ret = $tester->execute([]);
+
+        $this->assertSame(0, $ret);
+        $this->assertStringContainsString('Cache directory', $tester->getDisplay());
+        $this->assertStringContainsString('Log directory', $tester->getDisplay());
+
+        $this->fs->chmod($kernel->getCacheDir().'/readable_file', 0777);
+
+        try {
+            $this->fs->remove($kernel->getProjectDir());
+        } catch (IOException $e) {
+        }
+    }
+
+    public function testAboutWithUnreadableFiles()
+    {
+        $kernel = new TestAppKernel('test', true);
+        $this->fs->mkdir($kernel->getProjectDir());
+
+        // skip test on Windows; PHP can't easily set file as unreadable on Windows
+        if ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->markTestSkipped('This test cannot run on Windows.');
+        }
+
+        $this->fs->dumpFile($kernel->getCacheDir().'/unreadable_file', 'The file content.');
+        $this->fs->chmod($kernel->getCacheDir().'/unreadable_file', 0222);
+
+        $tester = $this->createCommandTester($kernel);
+        $ret = $tester->execute([]);
+
+        $this->assertSame(0, $ret);
+        $this->assertStringContainsString('Cache directory', $tester->getDisplay());
+        $this->assertStringContainsString('Log directory', $tester->getDisplay());
+
+        $this->fs->chmod($kernel->getCacheDir().'/unreadable_file', 0777);
+
+        try {
+            $this->fs->remove($kernel->getProjectDir());
+        } catch (IOException $e) {
+        }
+    }
+
+    private function createCommandTester(TestAppKernel $kernel): CommandTester
+    {
+        $application = new Application($kernel);
+        $application->add(new AboutCommand());
+
+        return new CommandTester($application->find('about'));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/AboutCommand/Fixture/TestAppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/AboutCommand/Fixture/TestAppKernel.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command\AboutCommand\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
+
+class TestAppKernel extends Kernel
+{
+    public function registerBundles(): iterable
+    {
+        return [
+            new FrameworkBundle(),
+        ];
+    }
+
+    public function getProjectDir(): string
+    {
+        return __DIR__.'/test';
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+    }
+
+    protected function build(ContainerBuilder $container)
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/39916
| License       | MIT
| Doc PR        | ~

Fix as explained in: https://github.com/symfony/symfony/issues/39916.

Tests failed looks like not releated to my changes.