### PR TITLE
[PasswordHasher] Fix: Run 'php-cs-fixer fix'

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Command/UserPasswordHashCommand.php
+++ b/src/Symfony/Component/PasswordHasher/Command/UserPasswordHashCommand.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\PasswordHasher\Command;
 
-
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\RuntimeException;
@@ -36,7 +35,7 @@ use Symfony\Component\PasswordHasher\LegacyPasswordHasherInterface;
 class UserPasswordHashCommand extends Command
 {
     protected static $defaultName = 'security:hash-password';
-    protected static $defaultDescription = "Hashes a user password";
+    protected static $defaultDescription = 'Hashes a user password';
 
     private $hasherFactory;
     private $userClasses;

--- a/src/Symfony/Component/PasswordHasher/Exception/InvalidPasswordException.php
+++ b/src/Symfony/Component/PasswordHasher/Exception/InvalidPasswordException.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\PasswordHasher\Exception;
 
 /**
  * @author Robin Chalas <robin.chalas@gmail.com>
-*/
+ */
 class InvalidPasswordException extends \RuntimeException implements ExceptionInterface
 {
     public function __construct(string $message = 'Invalid password.', int $code = 0, ?\Throwable $previous = null)

--- a/src/Symfony/Component/PasswordHasher/Exception/LogicException.php
+++ b/src/Symfony/Component/PasswordHasher/Exception/LogicException.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\PasswordHasher\Exception;
 
 /**
  * @author Robin Chalas <robin.chalas@gmail.com>
-*/
+ */
 class LogicException extends \LogicException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/PasswordHasher/Hasher/MigratingPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/MigratingPasswordHasher.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\PasswordHasher\Hasher;
 
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
-use Symfony\Component\PasswordHasher\LegacyPasswordHasherInterface;
 
 /**
  * Hashes passwords using the best available hasher.

--- a/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactoryInterface.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactoryInterface.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\PasswordHasher\Hasher;
 
-use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * PasswordHasherFactoryInterface to support different password hashers for different user accounts.

--- a/src/Symfony/Component/PasswordHasher/Hasher/SodiumPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/SodiumPasswordHasher.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\PasswordHasher\Hasher;
 
-use Symfony\Component\PasswordHasher\Exception\LogicException;
 use Symfony\Component\PasswordHasher\Exception\InvalidPasswordException;
+use Symfony\Component\PasswordHasher\Exception\LogicException;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
 /**

--- a/src/Symfony/Component/PasswordHasher/Tests/Command/UserPasswordHashCommandTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Command/UserPasswordHashCommandTest.php
@@ -12,15 +12,14 @@
 namespace Symfony\Component\PasswordHasher\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\SecurityBundle\Command\UserPasswordHasherCommand;
 use Symfony\Component\Console\Tester\CommandTester;
-use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\PasswordHasher\Command\UserPasswordHashCommand;
+use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
-use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
 use Symfony\Component\PasswordHasher\Hasher\Pbkdf2PasswordHasher;
 use Symfony\Component\PasswordHasher\Hasher\SodiumPasswordHasher;
+use Symfony\Component\Security\Core\User\User;
 
 class UserPasswordHashCommandTest extends TestCase
 {
@@ -240,7 +239,7 @@ class UserPasswordHashCommandTest extends TestCase
 
     public function testEncodePasswordNoConfigForGivenUserClass()
     {
-        $this->expectException('\RuntimeException');
+        $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('No password hasher has been configured for account "Foo\Bar\User".');
 
         $this->passwordHasherCommandTester->execute([
@@ -277,7 +276,7 @@ EOTXT
 
     public function testThrowsExceptionOnNoConfiguredHashers()
     {
-        $this->expectException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('There are no configured password hashers for the "security" extension.');
 
         $tester = new CommandTester(new UserPasswordHashCommand($this->getMockBuilder(PasswordHasherFactoryInterface::class)->getMock(), []));

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/MessageDigestPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/MessageDigestPasswordHasherTest.php
@@ -38,7 +38,7 @@ class MessageDigestPasswordHasherTest extends TestCase
 
     public function testHashAlgorithmDoesNotExist()
     {
-        $this->expectException('LogicException');
+        $this->expectException(\LogicException::class);
         $hasher = new MessageDigestPasswordHasher('foobar');
         $hasher->hash('password', '');
     }

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/PasswordHasherFactoryTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/PasswordHasherFactoryTest.php
@@ -12,11 +12,11 @@
 namespace Symfony\Component\PasswordHasher\Tests\Hasher;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\PasswordHasher\Hasher\PasswordHasherAwareInterface;
-use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
 use Symfony\Component\PasswordHasher\Hasher\MessageDigestPasswordHasher;
 use Symfony\Component\PasswordHasher\Hasher\MigratingPasswordHasher;
 use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherAwareInterface;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
 use Symfony\Component\PasswordHasher\Hasher\SodiumPasswordHasher;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -112,7 +112,7 @@ class PasswordHasherFactoryTest extends TestCase
 
     public function testGetInvalidNamedHasherForHasherAware()
     {
-        $this->expectException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
         $factory = new PasswordHasherFactory([
             HasherAwareUser::class => new MessageDigestPasswordHasher('sha1'),
             'hasher_name' => new MessageDigestPasswordHasher('sha256'),

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/Pbkdf2PasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/Pbkdf2PasswordHasherTest.php
@@ -38,7 +38,7 @@ class Pbkdf2PasswordHasherTest extends TestCase
 
     public function testHashAlgorithmDoesNotExist()
     {
-        $this->expectException('LogicException');
+        $this->expectException(\LogicException::class);
         $hasher = new Pbkdf2PasswordHasher('foobar');
         $hasher->hash('password', '');
     }

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/UserPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/UserPasswordHasherTest.php
@@ -12,12 +12,12 @@
 namespace Symfony\Component\PasswordHasher\Tests\Hasher;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
-use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
+use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 class UserPasswordHasherTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.5
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This pull request

* [x] runs `php-cs-fixer fix` in `src/Symfony/Component/PasswordHasher`

💁‍♂️ I do not know who or what enforces coding standard issues in this repository, but after opening a few pull requests in this repository, I noticed that `fabbot.io` repeatedly reports coding standard violations that are unrelated to the proposed changes. As an experiment I ran 

```
$ php-cs-fixer fix
```

on the entire repository and found a lot of issues. Not sure, would you not prefer to have these fixed?

Since the `PasswordHasher` component was only recently extracted, I assume it is safe to propose to run `php-cs-fixer fix` at least on this newly introduced component.