### PR TITLE
[PasswordHasher] Fix: Use algorithm instead of algo

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Hasher/NativePasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/NativePasswordHasher.php
@@ -25,13 +25,13 @@ final class NativePasswordHasher implements PasswordHasherInterface
 {
     use CheckPasswordLengthTrait;
 
-    private $algo = \PASSWORD_BCRYPT;
+    private $algorithm = \PASSWORD_BCRYPT;
     private $options;
 
     /**
-     * @param string|null $algo An algorithm supported by password_hash() or null to use the best available algorithm
+     * @param string|null $algorithm An algorithm supported by password_hash() or null to use the best available algorithm
      */
-    public function __construct(int $opsLimit = null, int $memLimit = null, int $cost = null, ?string $algo = null)
+    public function __construct(int $opsLimit = null, int $memLimit = null, int $cost = null, ?string $algorithm = null)
     {
         $cost = $cost ?? 13;
         $opsLimit = $opsLimit ?? max(4, \defined('SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE') ? \SODIUM_CRYPTO_PWHASH_OPSLIMIT_INTERACTIVE : 4);
@@ -49,18 +49,18 @@ final class NativePasswordHasher implements PasswordHasherInterface
             throw new \InvalidArgumentException('$cost must be in the range of 4-31.');
         }
 
-        $algos = [1 => \PASSWORD_BCRYPT, '2y' => \PASSWORD_BCRYPT];
+        $algorithms = [1 => \PASSWORD_BCRYPT, '2y' => \PASSWORD_BCRYPT];
 
         if (\defined('PASSWORD_ARGON2I')) {
-            $algos[2] = $algos['argon2i'] = (string) \PASSWORD_ARGON2I;
+            $algorithms[2] = $algorithms['argon2i'] = (string) \PASSWORD_ARGON2I;
         }
 
         if (\defined('PASSWORD_ARGON2ID')) {
-            $algos[3] = $algos['argon2id'] = (string) \PASSWORD_ARGON2ID;
+            $algorithms[3] = $algorithms['argon2id'] = (string) \PASSWORD_ARGON2ID;
         }
 
-        if (null !== $algo) {
-            $this->algo = $algos[$algo] ?? $algo;
+        if (null !== $algorithm) {
+            $this->algorithm = $algorithms[$algorithm] ?? $algorithm;
         }
 
         $this->options = [
@@ -73,11 +73,11 @@ final class NativePasswordHasher implements PasswordHasherInterface
 
     public function hash(string $plainPassword): string
     {
-        if ($this->isPasswordTooLong($plainPassword) || ((string) \PASSWORD_BCRYPT === $this->algo && 72 < \strlen($plainPassword))) {
+        if ($this->isPasswordTooLong($plainPassword) || ((string) \PASSWORD_BCRYPT === $this->algorithm && 72 < \strlen($plainPassword))) {
             throw new InvalidPasswordException();
         }
 
-        return password_hash($plainPassword, $this->algo, $this->options);
+        return password_hash($plainPassword, $this->algorithm, $this->options);
     }
 
     public function verify(string $hashedPassword, string $plainPassword): bool
@@ -107,6 +107,6 @@ final class NativePasswordHasher implements PasswordHasherInterface
      */
     public function needsRehash(string $hashedPassword): bool
     {
-        return password_needs_rehash($hashedPassword, $this->algo, $this->options);
+        return password_needs_rehash($hashedPassword, $this->algorithm, $this->options);
     }
 }

--- a/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
@@ -105,14 +105,14 @@ class PasswordHasherFactory implements PasswordHasherFactoryInterface
         if ('auto' === $config['algorithm']) {
             // "plaintext" is not listed as any leaked hashes could then be used to authenticate directly
             if (SodiumPasswordHasher::isSupported()) {
-                $algos = ['native', 'sodium', 'pbkdf2', $config['hash_algorithm']];
+                $algorithms = ['native', 'sodium', 'pbkdf2', $config['hash_algorithm']];
             } else {
-                $algos = ['native', 'pbkdf2', $config['hash_algorithm']];
+                $algorithms = ['native', 'pbkdf2', $config['hash_algorithm']];
             }
 
             $hasherChain = [];
-            foreach ($algos as $algo) {
-                $config['algorithm'] = $algo;
+            foreach ($algorithms as $algorithm) {
+                $config['algorithm'] = $algorithm;
                 $hasherChain[] = $this->createHasher($config, true);
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

This pull request

* [x] renames fields, variables, and parameters using `algos` or `algo` (which appear to be entirely made-up words) to `algorithms` and `algorithm` respectively