### PR TITLE
Provides a SessionFactoryInterface

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionFactory;
+use Symfony\Component\HttpFoundation\Session\SessionFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\AbstractSessionHandler;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\IdentityMarshaller;
@@ -32,6 +33,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorageFactory
 use Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorageFactory;
 use Symfony\Component\HttpFoundation\Session\Storage\ServiceSessionFactory;
+use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageFactoryInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
 use Symfony\Component\HttpKernel\EventListener\SessionListener;
 
@@ -47,6 +49,7 @@ return static function (ContainerConfigurator $container) {
                 service('session.storage.factory'),
                 [service('session_listener'), 'onSessionUsage'],
             ])
+        ->alias(SessionFactoryInterface::class, 'session.factory')
 
         ->set('session.storage.factory.native', NativeSessionStorageFactory::class)
             ->args([
@@ -84,6 +87,7 @@ return static function (ContainerConfigurator $container) {
                 service('session.storage'),
             ])
             ->deprecate('symfony/framework-bundle', '5.3', 'The "%service_id%" service is deprecated, use "session.storage.factory.native", "session.storage.factory.php_bridge" or "session.storage.factory.mock_file" instead.')
+        ->alias(SessionStorageFactoryInterface::class, 'session.storage.factory')
 
         ->set('.session.deprecated', SessionInterface::class) // to be removed in 6.0
             ->factory([inline_service(DeprecatedSessionFactory::class)->args([service('request_stack')]), 'getSession'])

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 5.3
 ---
 
- * Add the `SessionFactory`, `NativeSessionStorageFactory`, `PhpBridgeSessionStorageFactory` and `MockFileSessionStorageFactory` classes
+ * Add the `SessionFactoryInterface` and `SessionStorageFactoryInterface`, and add the `SessionFactory`, `NativeSessionStorageFactory`, `PhpBridgeSessionStorageFactory` and `MockFileSessionStorageFactory` classes that implements these interfaces
  * Calling `Request::getSession()` when there is no available session throws a `SessionNotFoundException`
  * Add the `RequestStack::getSession` method
  * Deprecate the `NamespacedAttributeBag` class

--- a/src/Symfony/Component/HttpFoundation/Session/SessionFactory.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionFactory.php
@@ -20,7 +20,7 @@ class_exists(Session::class);
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class SessionFactory
+class SessionFactory implements SessionFactoryInterface
 {
     private $requestStack;
     private $storageFactory;

--- a/src/Symfony/Component/HttpFoundation/Session/SessionFactoryInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionFactoryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+interface SessionFactoryInterface
+{
+    /**
+     * Creates a new instance of SessionInterface.
+     */
+    public function createSession(): SessionInterface;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | 

When working on the documentation for the deprecated `session.storage` service, I realized that (https://github.com/symfony/symfony-docs/pull/14981/files#diff-b16540b9555d18f5dcf58902701dc1aa291887390fe5e8401478a4d36f121df2) people may need to override the SessionFactory. 

This PR adds a interface to make things cleaner.