### PR TITLE
[Mailer] AWS SES auth with SESSION_TOKEN support

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesTransportFactory.php
@@ -65,11 +65,16 @@ final class SesTransportFactory extends AbstractTransportFactory
                 case 'ses':
                 case 'ses+https':
                     $class = $class ?? SesHttpAsyncAwsTransport::class;
+
+                    $sessionToken = $dsn->getOption('sessionToken');
+
                     $options = [
                         'region' => $dsn->getOption('region') ?: 'eu-west-1',
                         'accessKeyId' => $dsn->getUser(),
                         'accessKeySecret' => $dsn->getPassword(),
                     ] + (
+                        $sessionToken ? ['sessionToken' => $sessionToken] : []
+                    ) + (
                         'default' === $dsn->getHost() ? [] : ['endpoint' => 'https://'.$dsn->getHost().($dsn->getPort() ? ':'.$dsn->getPort() : '')]
                     );
 

--- a/src/Symfony/Component/Mailer/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * added the `mailer` monolog channel and set it on all transport definitions
+ * Add support for `SESSION_TOKEN` for Async AWS Mailer transport
 
 5.2.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? |no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#14983

When we use AWS Lambda, we need not only `ACCESS_KEY` and `ACCESS_SECRET` in order to make requests to AWS SES, but also `SESSION TOKEN`. This PR introduces support for `SESSION_TOKEN`. For using it include it in DSN as query parameter named `sessionToken` e. g. `ses+https://%env(AWS_ACCESS_KEY_ID)%:%env(urlencode:AWS_SECRET_ACCESS_KEY)%@default?region=us-east-1&sessionToken=%env(urlencode:AWS_SESSION_TOKEN)%`.

Didn't add any tests as there wasn't any testing for this part of code.
