### PR TITLE
[Workflow] Re-add InvalidTokenConfigurationException for BC

### DIFF
--- a/src/Symfony/Component/Workflow/Exception/InvalidTokenConfigurationException.php
+++ b/src/Symfony/Component/Workflow/Exception/InvalidTokenConfigurationException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Workflow\Exception;
+
+/**
+ * Thrown by GuardListener when there is no token set, but guards are placed on a transition.
+ *
+ * @author Matt Johnson <matj1985@gmail.com>
+ */
+class InvalidTokenConfigurationException extends LogicException
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Reverts the BC breaking part of #39671