### PR TITLE
[WebLink] Escape double quotes in attributes values

### DIFF
--- a/src/Symfony/Component/WebLink/HttpHeaderSerializer.php
+++ b/src/Symfony/Component/WebLink/HttpHeaderSerializer.php
@@ -39,14 +39,14 @@ final class HttpHeaderSerializer
             foreach ($link->getAttributes() as $key => $value) {
                 if (\is_array($value)) {
                     foreach ($value as $v) {
-                        $attributesParts[] = sprintf('%s="%s"', $key, $v);
+                        $attributesParts[] = sprintf('%s="%s"', $key, preg_replace('/(?<!\\\\)"/', '\"', $v));
                     }
 
                     continue;
                 }
 
                 if (!\is_bool($value)) {
-                    $attributesParts[] = sprintf('%s="%s"', $key, $value);
+                    $attributesParts[] = sprintf('%s="%s"', $key, preg_replace('/(?<!\\\\)"/', '\"', $value));
 
                     continue;
                 }

--- a/src/Symfony/Component/WebLink/Tests/HttpHeaderSerializerTest.php
+++ b/src/Symfony/Component/WebLink/Tests/HttpHeaderSerializerTest.php
@@ -44,4 +44,12 @@ class HttpHeaderSerializerTest extends TestCase
     {
         $this->assertNull($this->serializer->serialize([]));
     }
+
+    public function testSerializeDoubleQuotesInAttributeValue()
+    {
+        $this->assertSame('</foo>; rel="alternate"; title="\"escape me\" \"already escaped\" \"\"\""', $this->serializer->serialize([
+            (new Link('alternate', '/foo'))
+                ->withAttribute('title', '"escape me" \"already escaped\" ""\"'),
+        ]));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

If the attribute value contains a double quote, the serialized value is invalid: `</foo>; rel="alternate"; title="foo " bar"`. Ideally we would use `addcslashes` but we can't because users that already pass escaped values would then be impacted.