### PR TITLE
[Validator] Exposing constraint error messages

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -77,6 +77,16 @@ abstract class Constraint
     }
 
     /**
+     * Returning entire list of available errors.
+     *
+     * @return array
+     */
+    public static function getErrorNames()
+    {
+        return static::$errorNames;
+    }
+
+    /**
      * Initializes the constraint with options.
      *
      * You should pass an associative array. The keys should be the names of

--- a/src/Symfony/Component/Validator/Tests/ConstraintTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintTest.php
@@ -216,6 +216,11 @@ class ConstraintTest extends TestCase
         Constraint::getErrorName(1);
     }
 
+    public function testGetErrorNames()
+    {
+        $this->assertIsArray(Constraint::getErrorNames());
+    }
+
     public function testOptionsAsDefaultOption()
     {
         $constraint = new ConstraintA($options = ['value1']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - 
| License       | MIT
| Doc PR        | -

While building dynamic forms and sending it via APIs. It is preventing us to send the constraints inside the form. Adding a getter will help us to retrieve all the available validation messages of the Constraint.