### PR TITLE
[HttpFoundation][HttpKernel] Configure `session.cookie_secure` earlier

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -389,6 +389,9 @@ class NativeSessionStorage implements SessionStorageInterface
                     $this->emulateSameSite = $value;
                     continue;
                 }
+                if ('cookie_secure' === $key && 'auto' === $value) {
+                    continue;
+                }
                 ini_set('url_rewriter.tags' !== $key ? 'session.'.$key : $key, $value);
             }
         }

--- a/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpKernel\EventListener;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 /**
  * Sets the session in the request.
@@ -33,10 +34,12 @@ class SessionListener extends AbstractSessionListener
         $this->container = $container;
     }
 
-    protected function getSession(): ?SessionInterface
+    public function onKernelRequest(GetResponseEvent $event)
     {
-        if (!$this->container->has('session')) {
-            return null;
+        parent::onKernelRequest($event);
+
+        if (!$event->isMasterRequest() || !$this->container->has('session')) {
+            return;
         }
 
         if ($this->container->has('session_storage')
@@ -45,6 +48,13 @@ class SessionListener extends AbstractSessionListener
             && $masterRequest->isSecure()
         ) {
             $storage->setOptions(['cookie_secure' => true]);
+        }
+    }
+
+    protected function getSession(): ?SessionInterface
+    {
+        if (!$this->container->has('session')) {
+            return null;
         }
 
         return $this->container->get('session');

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/SessionListenerTest.php
@@ -59,7 +59,7 @@ class SessionListenerTest extends TestCase
         $listener = new SessionListener($container);
 
         $event = $this->createMock(RequestEvent::class);
-        $event->expects($this->once())->method('isMasterRequest')->willReturn(true);
+        $event->expects($this->exactly(2))->method('isMasterRequest')->willReturn(true);
         $event->expects($this->once())->method('getRequest')->willReturn($request);
 
         $listener->onKernelRequest($event);
@@ -203,12 +203,16 @@ class SessionListenerTest extends TestCase
         $listener = new SessionListener($container);
         $listener->onKernelRequest($event);
 
+        // storage->setOptions() should have been called already
+        $container->set('session_storage', null);
+        $sessionStorage = null;
+
         $subRequest = $masterRequest->duplicate();
         // at this point both master and subrequest have a closure to build the session
 
         $masterRequest->getSession();
 
-        // calling the factory on the subRequest should not trigger a second call to storage->sesOptions()
+        // calling the factory on the subRequest should not trigger a second call to storage->setOptions()
         $subRequest->getSession();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40221
| License       | MIT
| Doc PR        | N/A

This PR does what @stof had suggested in #40221, allow me to quote him directly:

> 1. avoid setting auto as a value for the ini setting in the NativeSessionStorage initialization
> 2. ensuring that SessionListener resolves the auto value by the time the SessionListener runs, and not by the time the getSession() method is called in the Request session factory callback
