### PR TITLE
[Console] Add `ConsoleCommand` attribute for declaring commands on PHP 8

### DIFF
--- a/src/Symfony/Component/Console/Attribute/ConsoleCommand.php
+++ b/src/Symfony/Component/Console/Attribute/ConsoleCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class ConsoleCommand
+{
+    public function __construct(
+        public string $name,
+        public ?string $description = null,
+        array $aliases = [],
+        bool $hidden = false,
+    ) {
+        if (!$hidden && !$aliases) {
+            return;
+        }
+
+        $name = explode('|', $name);
+        $name = array_merge($name, $aliases);
+
+        if ($hidden && '' !== $name[0]) {
+            array_unshift($name, '');
+        }
+
+        $this->name = implode('|', $name);
+    }
+}

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
    on the `console.command` tag to allow the `list` command to instantiate commands lazily
  * Add option `--short` to the `list` command
  * Add support for bright colors
+ * Add `ConsoleCommand` attribute for declaring commands on PHP 8
 
 5.2.0
 -----

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Command;
 
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Attribute\ConsoleCommand;
 use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\LogicException;
@@ -65,6 +66,11 @@ class Command
     public static function getDefaultName()
     {
         $class = static::class;
+
+        if (\PHP_VERSION_ID >= 80000 && $attribute = (new \ReflectionClass($class))->getAttributes(ConsoleCommand::class)) {
+            return $attribute[0]->newInstance()->name;
+        }
+
         $r = new \ReflectionProperty($class, 'defaultName');
 
         return $class === $r->class ? static::$defaultName : null;
@@ -76,6 +82,11 @@ class Command
     public static function getDefaultDescription(): ?string
     {
         $class = static::class;
+
+        if (\PHP_VERSION_ID >= 80000 && $attribute = (new \ReflectionClass($class))->getAttributes(ConsoleCommand::class)) {
+            return $attribute[0]->newInstance()->description;
+        }
+
         $r = new \ReflectionProperty($class, 'defaultDescription');
 
         return $class === $r->class ? static::$defaultDescription : null;

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Console\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Attribute\ConsoleCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Helper\FormatterHelper;
@@ -404,6 +405,15 @@ class CommandTest extends TestCase
 
         $this->assertEquals('interact called'.\PHP_EOL.'not bound'.\PHP_EOL, $tester->getDisplay());
     }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testConsoleCommandAttribute()
+    {
+        $this->assertSame('|foo|f', Php8Command::getDefaultName());
+        $this->assertSame('desc', Php8Command::getDefaultDescription());
+    }
 }
 
 // In order to get an unbound closure, we should create it outside a class
@@ -413,4 +423,9 @@ function createClosure()
     return function (InputInterface $input, OutputInterface $output) {
         $output->writeln($this instanceof Command ? 'bound to the command' : 'not bound to the command');
     };
+}
+
+#[ConsoleCommand(name: 'foo', description: 'desc', hidden: true, aliases: ['f'])]
+class Php8Command extends Command
+{
 }

--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 5.3
 ---
 
- * Add `EventListener` attribute for declaring listeners on PHP 8.
+ * Add `EventListener` attribute for declaring listeners on PHP 8
 
 5.1.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Builds on #39851

On PHP8, this PR will allow using an attribute instead of the public static properties for the name and the description.

```php

#[ConsoleCommand(
	name: 'app:my-command',
	description: '🌈',
	hidden: true,
	aliases: ['🌈'],
)]
class MyCommand extends Command
{
}
```