### PR TITLE
MockResponse total_time should not be simulated when provided

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -211,8 +211,8 @@ class MockResponse implements ResponseInterface
             $response->info['size_upload'] = 0.0;
         }
 
-        // simulate "total_time" if it is set
-        if (isset($response->info['total_time'])) {
+        // simulate "total_time" if it is not set
+        if (!isset($response->info['total_time'])) {
             $response->info['total_time'] = microtime(true) - $response->info['start_time'];
         }
 
@@ -260,7 +260,7 @@ class MockResponse implements ResponseInterface
             'http_code' => $response->info['http_code'],
         ] + $info + $response->info;
 
-        if (isset($response->info['total_time'])) {
+        if (!isset($response->info['total_time'])) {
             $response->info['total_time'] = microtime(true) - $response->info['start_time'];
         }
 
@@ -287,7 +287,7 @@ class MockResponse implements ResponseInterface
             $offset = \strlen($body);
         }
 
-        if (isset($response->info['total_time'])) {
+        if (!isset($response->info['total_time'])) {
             $response->info['total_time'] = microtime(true) - $response->info['start_time'];
         }
 

--- a/src/Symfony/Component/HttpClient/Tests/Response/MockResponseTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/Response/MockResponseTest.php
@@ -11,6 +11,24 @@ use Symfony\Component\HttpClient\Response\MockResponse;
  */
 class MockResponseTest extends TestCase
 {
+    public function testTotalTimeShouldBeSimulatedWhenNotProvided()
+    {
+        $response = new MockResponse('body');
+        $response = MockResponse::fromRequest('GET', 'https://example.com/file.txt', [], $response);
+
+        $this->assertNotNull($response->getInfo('total_time'));
+        $this->assertGreaterThan(0.0, $response->getInfo('total_time'));
+    }
+
+    public function testTotalTimeShouldNotBeSimulatedWhenProvided()
+    {
+        $totalTime = 4.2;
+        $response = new MockResponse('body', ['total_time' => $totalTime]);
+        $response = MockResponse::fromRequest('GET', 'https://example.com/file.txt', [], $response);
+
+        $this->assertEquals($totalTime, $response->getInfo('total_time'));
+    }
+
     public function testToArray()
     {
         $data = ['color' => 'orange', 'size' => 42];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When you provide a `total_time` to a MockResponse, it is overriden. It should be simulated only when it is not provided I guess.
Ex: `new MockResponse('{"foo":"bar"}', ['total_time' => 0.4])`