### PR TITLE
[Validator] Add Validation::createIsValidCallable() that returns a boolean instead of exception

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3
+---
+
+ * Add `Validation::createIsValidCallable()` that returns true/false instead of throwing exceptions
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Validator/Tests/ValidationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidationTest.php
@@ -30,7 +30,29 @@ class ValidationTest extends TestCase
     public function testCreateCallableInvalid()
     {
         $validator = Validation::createCallable(new Email());
-        $this->expectException(ValidationFailedException::class);
-        $validator('test');
+        try {
+            $validator('test');
+            $this->fail('No ValidationFailedException thrown');
+        } catch (ValidationFailedException $e) {
+            $this->assertEquals('test', $e->getValue());
+
+            $violations = $e->getViolations();
+            $this->assertCount(1, $violations);
+            $this->assertEquals('This value is not a valid email address.', $violations->get(0)->getMessage());
+        }
+    }
+
+    public function testCreateIsValidCallableValid()
+    {
+        $validator = Validation::createIsValidCallable(new Email());
+        $this->assertTrue($validator('test@example.com'));
+    }
+
+    public function testCreateIsValidCallableInvalid()
+    {
+        $validator = Validation::createIsValidCallable(new Email());
+        $this->assertFalse($validator('test', $violations));
+        $this->assertCount(1, $violations);
+        $this->assertEquals('This value is not a valid email address.', $violations->get(0)->getMessage());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #36820
| License       | MIT
| Doc PR        | tbd

This adds a `Validator::createValidCallable()` (I'm very open for other name suggestions) that returns a boolean instead of exceptions. This allows usingit in places where booleans are expected, for instance in the referenced OptionsResolver case:

```php
$resolver->setAllowedValues('name', Validation::createValidCallable(
    new Assert\Length(['min' => 10 ])
));
```