### PR TITLE
[ErrorHandler] Fix error caused by `include` + open_basedir

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/HtmlErrorRenderer.php
@@ -352,7 +352,7 @@ class HtmlErrorRenderer implements ErrorRendererInterface
         extract($context, \EXTR_SKIP);
         ob_start();
 
-        include file_exists($name) ? $name : __DIR__.'/../Resources/'.$name;
+        include is_file(\dirname(__DIR__).'/Resources/'.$name) ? \dirname(__DIR__).'/Resources/'.$name : $name;
 
         return trim(ob_get_clean());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

https://github.com/symfony/symfony/pull/37492 introduced the option to specify your own error template using `HtmlErrorRenderer::setTemplate('...');`

However, the implementation using `file_exists(...)` in `include` can cause an error when not setting a custom template.
> php.WARNING: Warning: file_exists(): open_basedir restriction in effect. File(assets/css/error.css) is not within the allowed path(s): (...) {"exception":"[object] (ErrorException(code: 0): Warning: file_exists(): open_basedir restriction in effect. File(assets/css/error.css) is not within the allowed path(s): (...) at ...\\vendor\\symfony\\error-handler\\ErrorRenderer\\HtmlErrorRenderer.php:355)"} []

As you can see the error is caused by checking `file_exists(...)` using relative paths in environments with a restrictive `open_basedir` policy.

The proposed solution always uses absolute paths to include errors templates (and other files).