### PR TITLE
[Routing] fix conflict with param named class in attribute

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -97,12 +97,10 @@ class AnnotationFileLoader extends FileLoader
 
         $nsTokens = [\T_NS_SEPARATOR => true, \T_STRING => true];
         if (\defined('T_NAME_QUALIFIED')) {
-            $nsTokens[T_NAME_QUALIFIED] = true;
+            $nsTokens[\T_NAME_QUALIFIED] = true;
         }
-
         for ($i = 0; isset($tokens[$i]); ++$i) {
             $token = $tokens[$i];
-
             if (!isset($token[1])) {
                 continue;
             }
@@ -124,6 +122,9 @@ class AnnotationFileLoader extends FileLoader
                 $skipClassToken = false;
                 for ($j = $i - 1; $j > 0; --$j) {
                     if (!isset($tokens[$j][1])) {
+                        if ('(' === $tokens[$j] || ',' === $tokens[$j]) {
+                            $skipClassToken = true;
+                        }
                         break;
                     }
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/Attributes/FooAttributes.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/Attributes/FooAttributes.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\Attributes;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class FooAttributes
+{
+    public string $class;
+    public array $foo = [];
+
+    public function __construct(string $class, array $foo)
+    {
+        $this->class = $class;
+        $this->foo = $foo;
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamAfterCommaController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamAfterCommaController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributesFixtures;
+
+use Symfony\Component\Routing\Tests\Fixtures\Attributes\FooAttributes;
+use Symfony\Component\Security\Core\User\User;
+
+#[FooAttributes(
+    foo: [
+        'bar' => ['foo','bar'],
+        'foo'
+    ],
+    class: User::class
+)]
+class AttributesClassParamAfterCommaController
+{
+
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamAfterParenthesisController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamAfterParenthesisController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributesFixtures;
+
+use Symfony\Component\Routing\Tests\Fixtures\Attributes\FooAttributes;
+use Symfony\Component\Security\Core\User\User;
+
+#[FooAttributes(
+    class: User::class,
+    foo: [
+        'bar' => ['foo','bar'],
+        'foo'
+    ]
+)]
+class AttributesClassParamAfterParenthesisController
+{
+
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamInlineAfterCommaController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamInlineAfterCommaController.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributesFixtures;
+
+use Symfony\Component\Routing\Tests\Fixtures\Attributes\FooAttributes;
+use Symfony\Component\Security\Core\User\User;
+
+#[FooAttributes(foo: ['bar' => ['foo','bar'],'foo'],class: User::class)]
+class AttributesClassParamInlineAfterCommaController
+{
+
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamInlineAfterParenthesisController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamInlineAfterParenthesisController.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributesFixtures;
+
+use Symfony\Component\Routing\Tests\Fixtures\Attributes\FooAttributes;
+use Symfony\Component\Security\Core\User\User;
+
+#[FooAttributes(class: User::class,foo: ['bar' => ['foo','bar'],'foo'])]
+class AttributesClassParamInlineAfterParenthesisController
+{
+
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamInlineQuotedAfterCommaController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamInlineQuotedAfterCommaController.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributesFixtures;
+
+use Symfony\Component\Routing\Tests\Fixtures\Attributes\FooAttributes;
+use Symfony\Component\Security\Core\User\User;
+
+#[FooAttributes(foo: ['bar' => ['foo','bar'],'foo'],class: 'Symfony\Component\Security\Core\User\User')]
+class AttributesClassParamInlineQuotedAfterCommaController
+{
+
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamInlineQuotedAfterParenthesisController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamInlineQuotedAfterParenthesisController.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributesFixtures;
+
+use Symfony\Component\Routing\Tests\Fixtures\Attributes\FooAttributes;
+use Symfony\Component\Security\Core\User\User;
+
+#[FooAttributes(class: 'Symfony\Component\Security\Core\User\User',foo: ['bar' => ['foo','bar'],'foo'])]
+class AttributesClassParamInlineQuotedAfterParenthesisController
+{
+
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamQuotedAfterCommaController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamQuotedAfterCommaController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributesFixtures;
+
+use Symfony\Component\Routing\Tests\Fixtures\Attributes\FooAttributes;
+
+#[FooAttributes(
+    foo: [
+        'bar' => ['foo','bar'],
+        'foo'
+    ],
+    class: 'Symfony\Component\Security\Core\User\User'
+)]
+class AttributesClassParamQuotedAfterCommaController
+{
+
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamQuotedAfterParenthesisController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributesFixtures/AttributesClassParamQuotedAfterParenthesisController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributesFixtures;
+
+use Symfony\Component\Routing\Tests\Fixtures\Attributes\FooAttributes;
+
+#[FooAttributes(
+    class: 'Symfony\Component\Security\Core\User\User',
+    foo: [
+        'bar' => ['foo','bar'],
+        'foo'
+    ]
+)]
+class AttributesClassParamQuotedAfterParenthesisController
+{
+
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -85,4 +85,72 @@ class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
         $this->assertTrue($this->loader->supports($fixture, 'annotation'), '->supports() checks the resource type if specified');
         $this->assertFalse($this->loader->supports($fixture, 'foo'), '->supports() checks the resource type if specified');
     }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testLoadAttributesClassAfterComma()
+    {
+        $this->reader->expects($this->once())->method('getClassAnnotation');
+
+        $this->loader->load(__DIR__.'/../Fixtures/AttributesFixtures/AttributesClassParamAfterCommaController.php');
+    }
+
+    public function testLoadAttributesInlineClassAfterComma()
+    {
+        $this->reader->expects($this->once())->method('getClassAnnotation');
+
+        $this->loader->load(__DIR__.'/../Fixtures/AttributesFixtures/AttributesClassParamInlineAfterCommaController.php');
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testLoadAttributesQuotedClassAfterComma()
+    {
+        $this->reader->expects($this->once())->method('getClassAnnotation');
+
+        $this->loader->load(__DIR__.'/../Fixtures/AttributesFixtures/AttributesClassParamQuotedAfterCommaController.php');
+    }
+
+    public function testLoadAttributesInlineQuotedClassAfterComma()
+    {
+        $this->reader->expects($this->once())->method('getClassAnnotation');
+
+        $this->loader->load(__DIR__.'/../Fixtures/AttributesFixtures/AttributesClassParamInlineQuotedAfterCommaController.php');
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testLoadAttributesClassAfterParenthesis()
+    {
+        $this->reader->expects($this->once())->method('getClassAnnotation');
+
+        $this->loader->load(__DIR__.'/../Fixtures/AttributesFixtures/AttributesClassParamAfterParenthesisController.php');
+    }
+
+    public function testLoadAttributesInlineClassAfterParenthesis()
+    {
+        $this->reader->expects($this->once())->method('getClassAnnotation');
+
+        $this->loader->load(__DIR__.'/../Fixtures/AttributesFixtures/AttributesClassParamInlineAfterParenthesisController.php');
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testLoadAttributesQuotedClassAfterParenthesis()
+    {
+        $this->reader->expects($this->once())->method('getClassAnnotation');
+
+        $this->loader->load(__DIR__.'/../Fixtures/AttributesFixtures/AttributesClassParamQuotedAfterParenthesisController.php');
+    }
+
+    public function testLoadAttributesInlineQuotedClassAfterParenthesis()
+    {
+        $this->reader->expects($this->once())->method('getClassAnnotation');
+
+        $this->loader->load(__DIR__.'/../Fixtures/AttributesFixtures/AttributesClassParamInlineQuotedAfterParenthesisController.php');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 4.4 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #40225
| License       | MIT
| Doc PR        | -

Fix conflict with AnnotationFileLoader and class PHP8 Attribute with param named "class"
