### PR TITLE
Stop using deprecated ArrayCache from Doctrine 

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Test/DoctrineTestHelper.php
+++ b/src/Symfony/Bridge/Doctrine/Test/DoctrineTestHelper.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bridge\Doctrine\Test;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
@@ -62,8 +61,6 @@ class DoctrineTestHelper
         $config->setProxyDir(sys_get_temp_dir());
         $config->setProxyNamespace('SymfonyTests\Doctrine');
         $config->setMetadataDriverImpl(new AnnotationDriver(new AnnotationReader()));
-        $config->setQueryCacheImpl(new ArrayCache());
-        $config->setMetadataCacheImpl(new ArrayCache());
 
         return $config;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1447,8 +1447,8 @@ class FrameworkExtension extends Extension
                 }
 
                 $container
-                    ->getDefinition('annotations.filesystem_cache')
-                    ->replaceArgument(0, $cacheDir)
+                    ->getDefinition('annotations.filesystem_cache_adapter')
+                    ->replaceArgument(2, $cacheDir)
                 ;
 
                 $cacheService = 'annotations.filesystem_cache';

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -24,13 +24,23 @@
         <service id="annotations.cached_reader" class="Doctrine\Common\Annotations\CachedReader">
             <argument type="service" id="annotations.reader" />
             <argument type="service">
-                <service class="Doctrine\Common\Cache\ArrayCache" />
+                <service class="Symfony\Component\Cache\DoctrineProvider">
+                    <argument type="service">
+                        <service class="Symfony\Component\Cache\Adapter\ArrayAdapter" />
+                    </argument>
+                </service>
             </argument>
             <argument /><!-- Debug-Flag -->
         </service>
 
-        <service id="annotations.filesystem_cache" class="Doctrine\Common\Cache\FilesystemCache">
+        <service id="annotations.filesystem_cache_adapter" class="Symfony\Component\Cache\Adapter\FilesystemAdapter">
+            <argument />
+            <argument>0</argument>
             <argument /><!-- Cache-Directory -->
+        </service>
+
+        <service id="annotations.filesystem_cache" class="Symfony\Component\Cache\DoctrineProvider">
+            <argument type="service" id="annotations.filesystem_cache_adapter" />
         </service>
 
         <service id="annotations.cache_warmer" class="Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -997,7 +997,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $container->addCompilerPass(new TestAnnotationsPass());
         $container->compile();
 
-        $this->assertEquals($container->getParameter('kernel.cache_dir').'/annotations', $container->getDefinition('annotations.filesystem_cache')->getArgument(0));
+        $this->assertEquals($container->getParameter('kernel.cache_dir').'/annotations', $container->getDefinition('annotations.filesystem_cache_adapter')->getArgument(2));
         $this->assertSame('annotations.filesystem_cache', (string) $container->getDefinition('annotation_reader')->getArgument(1));
     }
 

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -15,7 +15,10 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\CacheProvider;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\DoctrineProvider;
 use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContextFactory;
 use Symfony\Component\Validator\Exception\LogicException;
@@ -197,11 +200,15 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         }
 
         if (null === $annotationReader) {
-            if (!class_exists(AnnotationReader::class) || !class_exists(ArrayCache::class)) {
+            if (!class_exists(AnnotationReader::class) || !class_exists(CacheProvider::class)) {
                 throw new LogicException('Enabling annotation based constraint mapping requires the packages doctrine/annotations and doctrine/cache to be installed.');
             }
 
-            $annotationReader = new CachedReader(new AnnotationReader(), new ArrayCache());
+            if (class_exists(ArrayAdapter::class)) {
+                $annotationReader = new CachedReader(new AnnotationReader(), new DoctrineProvider(new ArrayAdapter()));
+            } else {
+                $annotationReader = new CachedReader(new AnnotationReader(), new ArrayCache());
+            }
         }
 
         $this->annotationReader = $annotationReader;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Follows https://github.com/doctrine/cache/pull/355