### PR TITLE
[BrowserKit] Add different header notations to tests

### DIFF
--- a/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
@@ -63,6 +63,18 @@ class HttpBrowserTest extends AbstractBrowserTest
             ['POST', 'http://example.com/', [], [], ['CONTENT_TYPE' => 'application/json'], '["content"]'],
             ['POST', 'http://example.com/', ['headers' => $defaultHeaders + ['content-type' => 'application/json'], 'body' => '["content"]', 'max_redirects' => 0]],
         ];
+        yield 'custom header with HTTP_ prefix' => [
+            ['PUT', 'http://example.com/', [], [], ['HTTP_CONTENT_TYPE' => 'application/json'], '["content"]'],
+            ['PUT', 'http://example.com/', ['headers' => $defaultHeaders + ['content-type' => 'application/json'], 'body' => '["content"]', 'max_redirects' => 0]],
+        ];
+        yield 'modify notation of custom header with HTTP_ prefix' => [
+            ['PUT', 'http://example.com/', [], [], ['HTTP_Content-Type' => 'application/json'], '["content"]'],
+            ['PUT', 'http://example.com/', ['headers' => $defaultHeaders + ['content-type' => 'application/json'], 'body' => '["content"]', 'max_redirects' => 0]],
+        ];
+        yield 'modify notation of custom header' => [
+            ['PUT', 'http://example.com/', [], [], ['Content-Type' => 'application/json'], '["content"]'],
+            ['PUT', 'http://example.com/', ['headers' => $defaultHeaders + ['content-type' => 'application/json'], 'body' => '["content"]', 'max_redirects' => 0]],
+        ];
     }
 
     public function testMultiPartRequestWithSingleFile()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #29736
| License       | MIT
| Doc PR        | -

In the past there was a issue #29736 that the header wasn't processed correctly. To reproduce and prevent this behaviour i extended the tests for this. At the end everything is fine, also in 5.x branch. See https://github.com/malteschlueter/symfony/commit/bf03d6889d84e3bfd4dcec85f47f6c1aa8c8bb49.
