### PR TITLE
[WIP] [Messenger] Locate exactly one handler

### DIFF
--- a/src/Symfony/Component/Messenger/Exception/MultipleHandlersForMessageException.php
+++ b/src/Symfony/Component/Messenger/Exception/MultipleHandlersForMessageException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+class MultipleHandlersForMessageException extends LogicException
+{
+    public function __construct(string $messageType)
+    {
+        parent::__construct(sprintf('Multiple handlers for message "%s"', $messageType));
+    }
+}

--- a/src/Symfony/Component/Messenger/Handler/ExactlyOneHandlerLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/ExactlyOneHandlerLocator.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\MultipleHandlersForMessageException;
+use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
+
+final class ExactlyOneHandlerLocator implements HandlersLocatorInterface
+{
+    private $handlers;
+
+    public function __construct(array $handlers)
+    {
+        foreach ($handlers as $type => $h) {
+            if (\count($h) > 1) {
+                throw new MultipleHandlersForMessageException($type);
+            }
+        }
+
+        $this->handlers = $handlers;
+    }
+
+    public function getHandlers(Envelope $envelope): iterable
+    {
+        $type = \get_class($envelope->getMessage());
+        if (!isset($this->handlers[$type])) {
+            throw new NoHandlerForMessageException($type);
+        }
+
+        yield $this->handlers[$type][0];
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Handler/ExactlyOneHandlerLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/ExactlyOneHandlerLocatorTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Stamp\ReceivedStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Handler\HandlersLocatorInterface;
+use Symfony\Component\Messenger\Handler\ExactlyOneHandlerLocator;
+use Symfony\Component\Messenger\Exception\MultipleHandlersForMessageException;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\SecondMessage;
+use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
+
+class ExactlyOneHandlerLocatorTest extends TestCase
+{
+    public function testItIsAHandlerLocator(): void
+    {
+        $this->assertInstanceOf(HandlersLocatorInterface::class, new ExactlyOneHandlerLocator([]));
+    }
+
+    public function testItProvidesAHandler(): void
+    {
+        $handler1 = $this->createPartialMock(ExactlyOneHandlerLocatorTestCallable::class, ['__invoke']);
+        $handler2 = $this->createPartialMock(ExactlyOneHandlerLocatorTestCallable::class, ['__invoke']);
+
+        $locator = new ExactlyOneHandlerLocator([
+            DummyMessage::class => [$handler1],
+            SecondMessage::class => [$handler2],
+        ]);
+
+        $this->assertSame([$handler1], iterator_to_array($locator->getHandlers(
+            new Envelope(new DummyMessage('Body'), [new ReceivedStamp('transportName')])
+        )));
+    }
+
+    public function testItThrowsAnExceptionWhenMultipleHandlersMatchesMessage()
+    {
+        $this->expectException(MultipleHandlersForMessageException::class);
+
+        new ExactlyOneHandlerLocator([
+            DummyMessage::class => [
+                $this->createPartialMock(ExactlyOneHandlerLocatorTestCallable::class, ['__invoke']),
+                $this->createPartialMock(ExactlyOneHandlerLocatorTestCallable::class, ['__invoke']),
+            ],
+        ]);
+    }
+
+    public function testItThrowsExceptionWhenNoHandlerMatchesMessage(): void
+    {
+        $this->expectException(NoHandlerForMessageException::class);
+
+        $locator = new ExactlyOneHandlerLocator([]);
+        iterator_to_array($locator->getHandlers(
+            new Envelope(new DummyMessage('Body'), [new ReceivedStamp('transportName')])
+        ));
+    }
+}
+
+class ExactlyOneHandlerLocatorTestCallable
+{
+    public function __invoke()
+    {
+    }
+}


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/issues/36958

| Q             | A
| ------------- | ---
| Branch?       | 5.x for features
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #36958
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The main idea is to allow definition of a command bus which helps developper detect the following misconfigurations:
- No command handler has been defined for a given command
- Many command handlers has been defined for a given command

Today, only the first case can be detected (this is the default behaviour of the HandleMessageMiddleware), the second one is not (instead, all the command handlers will be called). 