### PR TITLE
[Intl] Add `Currencies::getCashFractionDigits()` and `Currencies::getCashRoundingIncrement()`

### DIFF
--- a/src/Symfony/Component/Intl/CHANGELOG.md
+++ b/src/Symfony/Component/Intl/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3
+---
+
+ * Add `Currencies::getCashFractionDigits()` and `Currencies::getCashRoundingIncrement()`
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/Intl/Currencies.php
+++ b/src/Symfony/Component/Intl/Currencies.php
@@ -25,6 +25,8 @@ final class Currencies extends ResourceBundle
     private const INDEX_NAME = 1;
     private const INDEX_FRACTION_DIGITS = 0;
     private const INDEX_ROUNDING_INCREMENT = 1;
+    private const INDEX_CASH_FRACTION_DIGITS = 2;
+    private const INDEX_CASH_ROUNDING_INCREMENT = 3;
 
     /**
      * @return string[]
@@ -94,15 +96,30 @@ final class Currencies extends ResourceBundle
         }
     }
 
-    /**
-     * @return float|int
-     */
-    public static function getRoundingIncrement(string $currency)
+    public static function getRoundingIncrement(string $currency): int
     {
         try {
             return self::readEntry(['Meta', $currency, self::INDEX_ROUNDING_INCREMENT], 'meta');
         } catch (MissingResourceException $e) {
             return self::readEntry(['Meta', 'DEFAULT', self::INDEX_ROUNDING_INCREMENT], 'meta');
+        }
+    }
+
+    public static function getCashFractionDigits(string $currency): int
+    {
+        try {
+            return self::readEntry(['Meta', $currency, self::INDEX_CASH_FRACTION_DIGITS], 'meta');
+        } catch (MissingResourceException $e) {
+            return self::readEntry(['Meta', 'DEFAULT', self::INDEX_CASH_FRACTION_DIGITS], 'meta');
+        }
+    }
+
+    public static function getCashRoundingIncrement(string $currency): int
+    {
+        try {
+            return self::readEntry(['Meta', $currency, self::INDEX_CASH_ROUNDING_INCREMENT], 'meta');
+        } catch (MissingResourceException $e) {
+            return self::readEntry(['Meta', 'DEFAULT', self::INDEX_CASH_ROUNDING_INCREMENT], 'meta');
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #21247
| License       | MIT
| Doc PR        | -