### PR TITLE
[Form] Ignoring invalid forms from delete_empty behavior in CollectionType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -132,6 +132,10 @@ class ResizeFormListener implements EventSubscriberInterface
             $previousData = $form->getData();
             /** @var FormInterface $child */
             foreach ($form as $name => $child) {
+                if (!$child->isValid() || !$child->isSynchronized()) {
+                    continue;
+                }
+
                 $isNew = !isset($previousData[$name]);
                 $isEmpty = \is_callable($this->deleteEmpty) ? ($this->deleteEmpty)($child->getData()) : $child->isEmpty();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -255,7 +255,7 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [0 => 'first', 1 => ''];
         foreach ($data as $child => $dat) {
-            $this->form->get($child)->setData($dat);
+            $this->form->get($child)->submit($dat);
         }
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', [], false, true, true);
@@ -282,11 +282,11 @@ class ResizeFormListenerTest extends TestCase
 
         $data = ['0' => ['name' => 'John'], '1' => ['name' => '']];
         foreach ($data as $child => $dat) {
-            $this->form->get($child)->setData($dat);
+            $this->form->get($child)->submit($dat);
         }
         $event = new FormEvent($this->form, $data);
         $callback = function ($data) {
-            return '' === $data['name'];
+            return null === $data['name'];
         };
         $listener = new ResizeFormListener('text', [], false, true, $callback);
         $listener->onSubmit($event);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\Tests\Fixtures\Author;
 use Symfony\Component\Form\Tests\Fixtures\AuthorType;
@@ -209,6 +210,28 @@ class CollectionTypeTest extends BaseTypeTest
         $this->assertFalse($form->has('1'));
         $this->assertEquals(new Author('s_first', 's_last'), $form[0]->getData());
         $this->assertEquals([new Author('s_first', 's_last')], $form->getData());
+    }
+
+    public function testNotDeleteEmptyIfInvalid()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'entry_type' => ChoiceType::class,
+            'entry_options' => [
+                'choices' => ['a', 'b'],
+            ],
+            'allow_add' => true,
+            'allow_delete' => true,
+            'delete_empty' => true,
+        ]);
+
+        $form->submit(['a', 'x', '']);
+
+        $this->assertSame(['a'], $form->getData());
+        $this->assertCount(2, $form);
+        $this->assertTrue($form->has('1'));
+        $this->assertFalse($form[1]->isValid());
+        $this->assertNull($form[1]->getData());
+        $this->assertSame('x', $form[1]->getViewData());
     }
 
     public function testNotResizedIfSubmittedWithExtraData()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37660
| License       | MIT
| Doc PR        | -

As expained on linked issue, empty forms cannot be removed if they are invalid upon submitting (e.g. transformation failures). Thus, form errors can be displayed properly to the end user.