### PR TITLE
[DoctrineBridge] Param as connection in `*.event_subscriber/listener` tags

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
@@ -77,7 +77,9 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
         $managerDefs = [];
         foreach ($taggedServices as $taggedSubscriber) {
             [$tagName, $id, $tag] = $taggedSubscriber;
-            $connections = isset($tag['connection']) ? [$tag['connection']] : array_keys($this->connections);
+            $connections = isset($tag['connection'])
+                ? [$container->getParameterBag()->resolveValue($tag['connection'])]
+                : array_keys($this->connections);
             if ($listenerTag === $tagName && !isset($tag['event'])) {
                 throw new InvalidArgumentException(sprintf('Doctrine event listener "%s" must specify the "event" attribute.', $id));
             }

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
@@ -114,6 +114,8 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
     {
         $container = $this->createBuilder(true);
 
+        $container->setParameter('connection_param', 'second');
+
         $container
             ->register('a', 'stdClass')
             ->addTag('doctrine.event_listener', [
@@ -134,6 +136,14 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
             ->addTag('doctrine.event_listener', [
                 'event' => 'onFlush',
                 'connection' => 'second',
+            ])
+        ;
+
+        $container
+            ->register('d', 'stdClass')
+            ->addTag('doctrine.event_listener', [
+                'event' => 'onFlush',
+                'connection' => '%connection_param%',
             ])
         ;
 
@@ -167,6 +177,7 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
             [
                 [['onFlush'], 'a'],
                 [['onFlush'], 'c'],
+                [['onFlush'], 'd'],
             ],
             $secondEventManagerDef->getArgument(1)
         );
@@ -178,6 +189,7 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
             [
                 'a' => new ServiceClosureArgument(new Reference('a')),
                 'c' => new ServiceClosureArgument(new Reference('c')),
+                'd' => new ServiceClosureArgument(new Reference('d')),
             ],
             $serviceLocatorDef->getArgument(0)
         );
@@ -186,6 +198,8 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
     public function testProcessEventSubscribersWithMultipleConnections()
     {
         $container = $this->createBuilder(true);
+
+        $container->setParameter('connection_param', 'second');
 
         $container
             ->register('a', 'stdClass')
@@ -207,6 +221,14 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
             ->addTag('doctrine.event_subscriber', [
                 'event' => 'onFlush',
                 'connection' => 'second',
+            ])
+        ;
+
+        $container
+            ->register('d', 'stdClass')
+            ->addTag('doctrine.event_subscriber', [
+                'event' => 'onFlush',
+                'connection' => '%connection_param%',
             ])
         ;
 
@@ -240,6 +262,7 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
             [
                 'a',
                 'c',
+                'd',
             ],
             $eventManagerDef->getArgument(1)
         );
@@ -250,6 +273,7 @@ class RegisterEventListenersAndSubscribersPassTest extends TestCase
             [
                 'a' => new ServiceClosureArgument(new Reference('a')),
                 'c' => new ServiceClosureArgument(new Reference('c')),
+                'd' => new ServiceClosureArgument(new Reference('d')),
             ],
             $serviceLocatorDef->getArgument(0)
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #40260
| License       | MIT
| Doc PR        | -

It can be consider as bug, becouse using `%param%` is allowing in configuration, but can not be use in tag.
It can be consider as feaure becouse tag should be  provide by compiller pass.
