### PR TITLE
Switched to non-null defaults in exception constructors

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
@@ -77,7 +77,7 @@ class DelegatingLoader extends BaseDelegatingLoader
             // - this handles the case and prevents the second fatal error
             //   by triggering an exception beforehand.
 
-            throw new LoaderLoadException($resource, null, null, null, $type);
+            throw new LoaderLoadException($resource, null, 0, null, $type);
         }
         $this->loading = true;
 

--- a/src/Symfony/Component/Config/Exception/FileLoaderImportCircularReferenceException.php
+++ b/src/Symfony/Component/Config/Exception/FileLoaderImportCircularReferenceException.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Config\Exception;
  */
 class FileLoaderImportCircularReferenceException extends LoaderLoadException
 {
-    public function __construct(array $resources, int $code = null, \Throwable $previous = null)
+    public function __construct(array $resources, ?int $code = 0, \Throwable $previous = null)
     {
         $message = sprintf('Circular reference detected in "%s" ("%s" > "%s").', $this->varToString($resources[0]), implode('" > "', $resources), $resources[0]);
 

--- a/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
+++ b/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
@@ -21,13 +21,13 @@ namespace Symfony\Component\Config\Exception;
 class FileLoaderLoadException extends \Exception
 {
     /**
-     * @param string     $resource       The resource that could not be imported
-     * @param string     $sourceResource The original resource importing the new resource
-     * @param int        $code           The error code
-     * @param \Throwable $previous       A previous exception
-     * @param string     $type           The type of resource
+     * @param string          $resource       The resource that could not be imported
+     * @param string|null     $sourceResource The original resource importing the new resource
+     * @param int|null        $code           The error code
+     * @param \Throwable|null $previous       A previous exception
+     * @param string|null     $type           The type of resource
      */
-    public function __construct(string $resource, string $sourceResource = null, int $code = null, \Throwable $previous = null, string $type = null)
+    public function __construct(string $resource, string $sourceResource = null, ?int $code = 0, \Throwable $previous = null, string $type = null)
     {
         $message = '';
         if ($previous) {

--- a/src/Symfony/Component/Config/Loader/DelegatingLoader.php
+++ b/src/Symfony/Component/Config/Loader/DelegatingLoader.php
@@ -34,7 +34,7 @@ class DelegatingLoader extends Loader
     public function load($resource, $type = null)
     {
         if (false === $loader = $this->resolver->resolve($resource, $type)) {
-            throw new LoaderLoadException($resource, null, null, null, $type);
+            throw new LoaderLoadException($resource, null, 0, null, $type);
         }
 
         return $loader->load($resource, $type);

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -177,7 +177,7 @@ abstract class FileLoader extends Loader
                     throw $e;
                 }
 
-                throw new LoaderLoadException($resource, $sourceResource, null, $e, $type);
+                throw new LoaderLoadException($resource, $sourceResource, 0, $e, $type);
             }
         }
 

--- a/src/Symfony/Component/Config/Loader/Loader.php
+++ b/src/Symfony/Component/Config/Loader/Loader.php
@@ -70,7 +70,7 @@ abstract class Loader implements LoaderInterface
         $loader = null === $this->resolver ? false : $this->resolver->resolve($resource, $type);
 
         if (false === $loader) {
-            throw new LoaderLoadException($resource, null, null, null, $type);
+            throw new LoaderLoadException($resource, null, 0, null, $type);
         }
 
         return $loader;

--- a/src/Symfony/Component/Config/Tests/Exception/LoaderLoadExceptionTest.php
+++ b/src/Symfony/Component/Config/Tests/Exception/LoaderLoadExceptionTest.php
@@ -24,13 +24,13 @@ class LoaderLoadExceptionTest extends TestCase
 
     public function testMessageCannotLoadResourceWithType()
     {
-        $exception = new LoaderLoadException('resource', null, null, null, 'foobar');
+        $exception = new LoaderLoadException('resource', null, 0, null, 'foobar');
         $this->assertEquals('Cannot load resource "resource". Make sure there is a loader supporting the "foobar" type.', $exception->getMessage());
     }
 
     public function testMessageCannotLoadResourceWithAnnotationType()
     {
-        $exception = new LoaderLoadException('resource', null, null, null, 'annotation');
+        $exception = new LoaderLoadException('resource', null, 0, null, 'annotation');
         $this->assertEquals('Cannot load resource "resource". Make sure annotations are installed and enabled.', $exception->getMessage());
     }
 
@@ -56,7 +56,7 @@ class LoaderLoadExceptionTest extends TestCase
         $exception = new LoaderLoadException(
             'resource',
             null,
-            null,
+            0,
             new \Exception('There was a previous error with an ending dot.')
         );
         $this->assertEquals(
@@ -70,7 +70,7 @@ class LoaderLoadExceptionTest extends TestCase
         $exception = new LoaderLoadException(
             'resource',
             null,
-            null,
+            0,
             new \Exception('There was a previous error with no ending dot')
         );
         $this->assertEquals(
@@ -84,7 +84,7 @@ class LoaderLoadExceptionTest extends TestCase
         $exception = new LoaderLoadException(
             '@resource',
             null,
-            null,
+            0,
             new \Exception('There was a previous error with an ending dot.')
         );
         $this->assertEquals(

--- a/src/Symfony/Component/Console/Exception/CommandNotFoundException.php
+++ b/src/Symfony/Component/Console/Exception/CommandNotFoundException.php
@@ -21,10 +21,10 @@ class CommandNotFoundException extends \InvalidArgumentException implements Exce
     private $alternatives;
 
     /**
-     * @param string     $message      Exception message to throw
-     * @param array      $alternatives List of similar defined names
-     * @param int        $code         Exception code
-     * @param \Throwable $previous     Previous exception used for the exception chaining
+     * @param string          $message      Exception message to throw
+     * @param string[]        $alternatives List of similar defined names
+     * @param int             $code         Exception code
+     * @param \Throwable|null $previous     Previous exception used for the exception chaining
      */
     public function __construct(string $message, array $alternatives = [], int $code = 0, \Throwable $previous = null)
     {
@@ -34,7 +34,7 @@ class CommandNotFoundException extends \InvalidArgumentException implements Exce
     }
 
     /**
-     * @return array A list of similar defined names
+     * @return string[] A list of similar defined names
      */
     public function getAlternatives()
     {

--- a/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
@@ -18,11 +18,11 @@ namespace Symfony\Component\HttpKernel\Exception;
 class AccessDeniedHttpException extends HttpException
 {
     /**
-     * @param string     $message  The internal exception message
-     * @param \Throwable $previous The previous exception
-     * @param int        $code     The internal exception code
+     * @param string|null     $message  The internal exception message
+     * @param \Throwable|null $previous The previous exception
+     * @param int             $code     The internal exception code
      */
-    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(403, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/BadRequestHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/BadRequestHttpException.php
@@ -17,11 +17,11 @@ namespace Symfony\Component\HttpKernel\Exception;
 class BadRequestHttpException extends HttpException
 {
     /**
-     * @param string     $message  The internal exception message
-     * @param \Throwable $previous The previous exception
-     * @param int        $code     The internal exception code
+     * @param string|null     $message  The internal exception message
+     * @param \Throwable|null $previous The previous exception
+     * @param int             $code     The internal exception code
      */
-    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(400, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/ConflictHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ConflictHttpException.php
@@ -17,11 +17,11 @@ namespace Symfony\Component\HttpKernel\Exception;
 class ConflictHttpException extends HttpException
 {
     /**
-     * @param string     $message  The internal exception message
-     * @param \Throwable $previous The previous exception
-     * @param int        $code     The internal exception code
+     * @param string|null     $message  The internal exception message
+     * @param \Throwable|null $previous The previous exception
+     * @param int             $code     The internal exception code
      */
-    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(409, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/GoneHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/GoneHttpException.php
@@ -17,11 +17,11 @@ namespace Symfony\Component\HttpKernel\Exception;
 class GoneHttpException extends HttpException
 {
     /**
-     * @param string     $message  The internal exception message
-     * @param \Throwable $previous The previous exception
-     * @param int        $code     The internal exception code
+     * @param string|null     $message  The internal exception message
+     * @param \Throwable|null $previous The previous exception
+     * @param int             $code     The internal exception code
      */
-    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(410, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/HttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/HttpException.php
@@ -21,7 +21,7 @@ class HttpException extends \RuntimeException implements HttpExceptionInterface
     private $statusCode;
     private $headers;
 
-    public function __construct(int $statusCode, string $message = null, \Throwable $previous = null, array $headers = [], ?int $code = 0)
+    public function __construct(int $statusCode, ?string $message = '', \Throwable $previous = null, array $headers = [], ?int $code = 0)
     {
         $this->statusCode = $statusCode;
         $this->headers = $headers;

--- a/src/Symfony/Component/HttpKernel/Exception/LengthRequiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/LengthRequiredHttpException.php
@@ -17,11 +17,11 @@ namespace Symfony\Component\HttpKernel\Exception;
 class LengthRequiredHttpException extends HttpException
 {
     /**
-     * @param string     $message  The internal exception message
-     * @param \Throwable $previous The previous exception
-     * @param int        $code     The internal exception code
+     * @param string|null     $message  The internal exception message
+     * @param \Throwable|null $previous The previous exception
+     * @param int             $code     The internal exception code
      */
-    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(411, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php
@@ -17,12 +17,12 @@ namespace Symfony\Component\HttpKernel\Exception;
 class MethodNotAllowedHttpException extends HttpException
 {
     /**
-     * @param array      $allow    An array of allowed methods
-     * @param string     $message  The internal exception message
-     * @param \Throwable $previous The previous exception
-     * @param int        $code     The internal exception code
+     * @param string[]        $allow    An array of allowed methods
+     * @param string|null     $message  The internal exception message
+     * @param \Throwable|null $previous The previous exception
+     * @param int|null        $code     The internal exception code
      */
-    public function __construct(array $allow, string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    public function __construct(array $allow, ?string $message = '', \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
         $headers['Allow'] = strtoupper(implode(', ', $allow));
 

--- a/src/Symfony/Component/HttpKernel/Exception/NotAcceptableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/NotAcceptableHttpException.php
@@ -17,11 +17,11 @@ namespace Symfony\Component\HttpKernel\Exception;
 class NotAcceptableHttpException extends HttpException
 {
     /**
-     * @param string     $message  The internal exception message
-     * @param \Throwable $previous The previous exception
-     * @param int        $code     The internal exception code
+     * @param string|null     $message  The internal exception message
+     * @param \Throwable|null $previous The previous exception
+     * @param int             $code     The internal exception code
      */
-    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(406, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/NotFoundHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/NotFoundHttpException.php
@@ -17,11 +17,11 @@ namespace Symfony\Component\HttpKernel\Exception;
 class NotFoundHttpException extends HttpException
 {
     /**
-     * @param string     $message  The internal exception message
-     * @param \Throwable $previous The previous exception
-     * @param int        $code     The internal exception code
+     * @param string|null     $message  The internal exception message
+     * @param \Throwable|null $previous The previous exception
+     * @param int             $code     The internal exception code
      */
-    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(404, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/PreconditionFailedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PreconditionFailedHttpException.php
@@ -17,11 +17,11 @@ namespace Symfony\Component\HttpKernel\Exception;
 class PreconditionFailedHttpException extends HttpException
 {
     /**
-     * @param string     $message  The internal exception message
-     * @param \Throwable $previous The previous exception
-     * @param int        $code     The internal exception code
+     * @param string|null     $message  The internal exception message
+     * @param \Throwable|null $previous The previous exception
+     * @param int             $code     The internal exception code
      */
-    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(412, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/PreconditionRequiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PreconditionRequiredHttpException.php
@@ -19,11 +19,11 @@ namespace Symfony\Component\HttpKernel\Exception;
 class PreconditionRequiredHttpException extends HttpException
 {
     /**
-     * @param string     $message  The internal exception message
-     * @param \Throwable $previous The previous exception
-     * @param int        $code     The internal exception code
+     * @param string|null     $message  The internal exception message
+     * @param \Throwable|null $previous The previous exception
+     * @param int             $code     The internal exception code
      */
-    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(428, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
@@ -17,12 +17,12 @@ namespace Symfony\Component\HttpKernel\Exception;
 class ServiceUnavailableHttpException extends HttpException
 {
     /**
-     * @param int|string $retryAfter The number of seconds or HTTP-date after which the request may be retried
-     * @param string     $message    The internal exception message
-     * @param \Throwable $previous   The previous exception
-     * @param int        $code       The internal exception code
+     * @param int|string|null $retryAfter The number of seconds or HTTP-date after which the request may be retried
+     * @param string|null     $message    The internal exception message
+     * @param \Throwable|null $previous   The previous exception
+     * @param int|null        $code       The internal exception code
      */
-    public function __construct($retryAfter = null, string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    public function __construct($retryAfter = null, ?string $message = '', \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
         if ($retryAfter) {
             $headers['Retry-After'] = $retryAfter;

--- a/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
@@ -19,12 +19,12 @@ namespace Symfony\Component\HttpKernel\Exception;
 class TooManyRequestsHttpException extends HttpException
 {
     /**
-     * @param int|string $retryAfter The number of seconds or HTTP-date after which the request may be retried
-     * @param string     $message    The internal exception message
-     * @param \Throwable $previous   The previous exception
-     * @param int        $code       The internal exception code
+     * @param int|string|null $retryAfter The number of seconds or HTTP-date after which the request may be retried
+     * @param string|null     $message    The internal exception message
+     * @param \Throwable|null $previous   The previous exception
+     * @param int|null        $code       The internal exception code
      */
-    public function __construct($retryAfter = null, string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    public function __construct($retryAfter = null, ?string $message = '', \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
         if ($retryAfter) {
             $headers['Retry-After'] = $retryAfter;

--- a/src/Symfony/Component/HttpKernel/Exception/UnauthorizedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnauthorizedHttpException.php
@@ -17,12 +17,12 @@ namespace Symfony\Component\HttpKernel\Exception;
 class UnauthorizedHttpException extends HttpException
 {
     /**
-     * @param string     $challenge WWW-Authenticate challenge string
-     * @param string     $message   The internal exception message
-     * @param \Throwable $previous  The previous exception
-     * @param int        $code      The internal exception code
+     * @param string          $challenge WWW-Authenticate challenge string
+     * @param string|null     $message   The internal exception message
+     * @param \Throwable|null $previous  The previous exception
+     * @param int|null        $code      The internal exception code
      */
-    public function __construct(string $challenge, string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    public function __construct(string $challenge, ?string $message = '', \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
         $headers['WWW-Authenticate'] = $challenge;
 

--- a/src/Symfony/Component/HttpKernel/Exception/UnprocessableEntityHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnprocessableEntityHttpException.php
@@ -17,11 +17,11 @@ namespace Symfony\Component\HttpKernel\Exception;
 class UnprocessableEntityHttpException extends HttpException
 {
     /**
-     * @param string     $message  The internal exception message
-     * @param \Throwable $previous The previous exception
-     * @param int        $code     The internal exception code
+     * @param string|null     $message  The internal exception message
+     * @param \Throwable|null $previous The previous exception
+     * @param int             $code     The internal exception code
      */
-    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(422, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Exception/UnsupportedMediaTypeHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnsupportedMediaTypeHttpException.php
@@ -17,11 +17,11 @@ namespace Symfony\Component\HttpKernel\Exception;
 class UnsupportedMediaTypeHttpException extends HttpException
 {
     /**
-     * @param string     $message  The internal exception message
-     * @param \Throwable $previous The previous exception
-     * @param int        $code     The internal exception code
+     * @param string|null     $message  The internal exception message
+     * @param \Throwable|null $previous The previous exception
+     * @param int             $code     The internal exception code
      */
-    public function __construct(string $message = null, \Throwable $previous = null, int $code = 0, array $headers = [])
+    public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
         parent::__construct(415, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/AccessDeniedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/AccessDeniedHttpExceptionTest.php
@@ -3,10 +3,11 @@
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class AccessDeniedHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new AccessDeniedHttpException($message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/BadRequestHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/BadRequestHttpExceptionTest.php
@@ -3,10 +3,11 @@
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class BadRequestHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new BadRequestHttpException($message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/ConflictHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/ConflictHttpExceptionTest.php
@@ -3,10 +3,11 @@
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class ConflictHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new ConflictHttpException($message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/GoneHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/GoneHttpExceptionTest.php
@@ -3,10 +3,11 @@
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
 use Symfony\Component\HttpKernel\Exception\GoneHttpException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class GoneHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new GoneHttpException($message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/HttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/HttpExceptionTest.php
@@ -32,7 +32,7 @@ class HttpExceptionTest extends TestCase
      */
     public function testHeadersConstructor($headers)
     {
-        $exception = new HttpException(200, null, null, $headers);
+        $exception = new HttpException(200, '', null, $headers);
         $this->assertSame($headers, $exception->getHeaders());
     }
 
@@ -50,11 +50,11 @@ class HttpExceptionTest extends TestCase
     {
         $previous = new class('Error of PHP 7+') extends \Error {
         };
-        $exception = $this->createException(null, $previous);
+        $exception = $this->createException('', $previous);
         $this->assertSame($previous, $exception->getPrevious());
     }
 
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new HttpException(200, $message, $previous, $headers, $code);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/LengthRequiredHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/LengthRequiredHttpExceptionTest.php
@@ -2,11 +2,12 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\LengthRequiredHttpException;
 
 class LengthRequiredHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new LengthRequiredHttpException($message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/MethodNotAllowedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/MethodNotAllowedHttpExceptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
 class MethodNotAllowedHttpExceptionTest extends HttpExceptionTest
@@ -18,7 +19,7 @@ class MethodNotAllowedHttpExceptionTest extends HttpExceptionTest
             'Cache-Control' => 'public, s-maxage=1200',
         ];
 
-        $exception = new MethodNotAllowedHttpException(['get'], null, null, null, $headers);
+        $exception = new MethodNotAllowedHttpException(['get'], '', null, 0, $headers);
 
         $headers['Allow'] = 'GET';
 
@@ -35,7 +36,7 @@ class MethodNotAllowedHttpExceptionTest extends HttpExceptionTest
         $this->assertSame($headers, $exception->getHeaders());
     }
 
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new MethodNotAllowedHttpException(['get'], $message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/NotAcceptableHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/NotAcceptableHttpExceptionTest.php
@@ -2,11 +2,12 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
 
 class NotAcceptableHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new NotAcceptableHttpException($message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/NotFoundHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/NotFoundHttpExceptionTest.php
@@ -2,11 +2,12 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class NotFoundHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new NotFoundHttpException($message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionFailedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionFailedHttpExceptionTest.php
@@ -2,11 +2,12 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException;
 
 class PreconditionFailedHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new PreconditionFailedHttpException($message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionRequiredHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/PreconditionRequiredHttpExceptionTest.php
@@ -2,11 +2,12 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\PreconditionRequiredHttpException;
 
 class PreconditionRequiredHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new PreconditionRequiredHttpException($message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/ServiceUnavailableHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/ServiceUnavailableHttpExceptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 class ServiceUnavailableHttpExceptionTest extends HttpExceptionTest
@@ -18,7 +19,7 @@ class ServiceUnavailableHttpExceptionTest extends HttpExceptionTest
             'Cache-Control' => 'public, s-maxage=1337',
         ];
 
-        $exception = new ServiceUnavailableHttpException(1337, null, null, null, $headers);
+        $exception = new ServiceUnavailableHttpException(1337, '', null, 0, $headers);
 
         $headers['Retry-After'] = 1337;
 
@@ -35,7 +36,7 @@ class ServiceUnavailableHttpExceptionTest extends HttpExceptionTest
         $this->assertSame($headers, $exception->getHeaders());
     }
 
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new ServiceUnavailableHttpException(null, $message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/TooManyRequestsHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/TooManyRequestsHttpExceptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
 
 class TooManyRequestsHttpExceptionTest extends HttpExceptionTest
@@ -18,7 +19,7 @@ class TooManyRequestsHttpExceptionTest extends HttpExceptionTest
             'Cache-Control' => 'public, s-maxage=69',
         ];
 
-        $exception = new TooManyRequestsHttpException(69, null, null, null, $headers);
+        $exception = new TooManyRequestsHttpException(69, '', null, 0, $headers);
 
         $headers['Retry-After'] = 69;
 
@@ -35,7 +36,7 @@ class TooManyRequestsHttpExceptionTest extends HttpExceptionTest
         $this->assertSame($headers, $exception->getHeaders());
     }
 
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new TooManyRequestsHttpException(null, $message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/UnauthorizedHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/UnauthorizedHttpExceptionTest.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class UnauthorizedHttpExceptionTest extends HttpExceptionTest
@@ -18,7 +19,7 @@ class UnauthorizedHttpExceptionTest extends HttpExceptionTest
             'Cache-Control' => 'public, s-maxage=1200',
         ];
 
-        $exception = new UnauthorizedHttpException('Challenge', null, null, null, $headers);
+        $exception = new UnauthorizedHttpException('Challenge', '', null, 0, $headers);
 
         $headers['WWW-Authenticate'] = 'Challenge';
 
@@ -35,7 +36,7 @@ class UnauthorizedHttpExceptionTest extends HttpExceptionTest
         $this->assertSame($headers, $exception->getHeaders());
     }
 
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new UnauthorizedHttpException('Challenge', $message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/UnprocessableEntityHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/UnprocessableEntityHttpExceptionTest.php
@@ -2,11 +2,12 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 class UnprocessableEntityHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new UnprocessableEntityHttpException($message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/UnsupportedMediaTypeHttpExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/UnsupportedMediaTypeHttpExceptionTest.php
@@ -2,11 +2,12 @@
 
 namespace Symfony\Component\HttpKernel\Tests\Exception;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\UnsupportedMediaTypeHttpException;
 
 class UnsupportedMediaTypeHttpExceptionTest extends HttpExceptionTest
 {
-    protected function createException(string $message = null, \Throwable $previous = null, ?int $code = 0, array $headers = [])
+    protected function createException(string $message = '', \Throwable $previous = null, int $code = 0, array $headers = []): HttpException
     {
         return new UnsupportedMediaTypeHttpException($message, $previous, $code, $headers);
     }

--- a/src/Symfony/Component/Mailer/Exception/HttpTransportException.php
+++ b/src/Symfony/Component/Mailer/Exception/HttpTransportException.php
@@ -20,7 +20,7 @@ class HttpTransportException extends TransportException
 {
     private $response;
 
-    public function __construct(string $message = null, ResponseInterface $response, int $code = 0, \Throwable $previous = null)
+    public function __construct(?string $message, ResponseInterface $response, int $code = 0, \Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/src/Symfony/Component/Routing/Exception/MethodNotAllowedException.php
+++ b/src/Symfony/Component/Routing/Exception/MethodNotAllowedException.php
@@ -22,7 +22,10 @@ class MethodNotAllowedException extends \RuntimeException implements ExceptionIn
 {
     protected $allowedMethods = [];
 
-    public function __construct(array $allowedMethods, string $message = null, int $code = 0, \Throwable $previous = null)
+    /**
+     * @param string[] $allowedMethods
+     */
+    public function __construct(array $allowedMethods, ?string $message = '', int $code = 0, \Throwable $previous = null)
     {
         $this->allowedMethods = array_map('strtoupper', $allowedMethods);
 
@@ -32,7 +35,7 @@ class MethodNotAllowedException extends \RuntimeException implements ExceptionIn
     /**
      * Gets the allowed HTTP methods.
      *
-     * @return array
+     * @return string[]
      */
     public function getAllowedMethods()
     {

--- a/src/Symfony/Component/Routing/RouteCollectionBuilder.php
+++ b/src/Symfony/Component/Routing/RouteCollectionBuilder.php
@@ -362,11 +362,11 @@ class RouteCollectionBuilder
         }
 
         if (null === $resolver = $this->loader->getResolver()) {
-            throw new LoaderLoadException($resource, null, null, null, $type);
+            throw new LoaderLoadException($resource, null, 0, null, $type);
         }
 
         if (false === $loader = $resolver->resolve($resource, $type)) {
-            throw new LoaderLoadException($resource, null, null, null, $type);
+            throw new LoaderLoadException($resource, null, 0, null, $type);
         }
 
         $collections = $loader->load($resource, $type);

--- a/src/Symfony/Component/Yaml/Exception/ParseException.php
+++ b/src/Symfony/Component/Yaml/Exception/ParseException.php
@@ -28,7 +28,6 @@ class ParseException extends RuntimeException
      * @param int             $parsedLine The line where the error occurred
      * @param string|null     $snippet    The snippet of code near the problem
      * @param string|null     $parsedFile The file name where the error occurred
-     * @param \Exception|null $previous   The previous exception
      */
     public function __construct(string $message, int $parsedLine = -1, string $snippet = null, string $parsedFile = null, \Throwable $previous = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

PHP 8.1 will trigger a deprecation warning if we pass `null` as `$message` or `$code` to the constructor of `\Exception`. However, many of our own exception accept `null` for those parameters and even use them as default.

This is unfortunate because code like the following snippet would trigger that deprecation although the code itself is perfectly fine:

```php
throw new NotFoundHttpException();
```

With this PR, I'd like to change our defaults to `''` and `0` while still allowing to pass `null` for BC. In a follow-up PR for the 5.x branch, I'd like to deprecate passing `null`, matching the future behavior of PHP.

This PR also adjust various PHPDoc blocks with inaccurate types.