### PR TITLE
[Console] Handle calls to mb_ functions with non string arguments

### DIFF
--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -47,6 +47,8 @@ abstract class Helper implements HelperInterface
      */
     public static function strlen($string)
     {
+        $string = (string) $string;
+
         if (false === $encoding = mb_detect_encoding($string, null, true)) {
             return \strlen($string);
         }
@@ -65,6 +67,8 @@ abstract class Helper implements HelperInterface
      */
     public static function substr($string, $from, $length = null)
     {
+        $string = (string) $string;
+
         if (false === $encoding = mb_detect_encoding($string, null, true)) {
             return substr($string, $from, $length);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40200
| License       | MIT
| Doc PR        | no

In PHP8.1, a number of functions who were accepting null arguments will only accept
string ones.
(see https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg)

In the polyfill, mb_* functions are already declared with a strict type checking of "string".

Therefore, it is necessary to get rid of the use of non string arguments when calling mb_* functions,
so that it won't break when either using the polyfill,or future php8 versions.

In every call where the argument may not be a string, this commit enforces the string type of the argument (with transtyping)

--- For reviewers
* I generally don't like transtyping, but found it was the more "secure" way (on a non-BC point of view) here.
Specially in Console/Helper/Table.php, where $cell can be an object (there are 2 "$cell instanceof ... tests)
However, where the argument can already be either null or string (and not anything else), there may a beter approach ?

* It's the first time I send a PR on symfony, so don't hesitate pointing me to thinks I've forgotten to done.
