### PR TITLE
[FrameworkBundle] Allow x-forwarded-prefix trusted header in config

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -97,7 +97,7 @@ class Configuration implements ConfigurationInterface
                     ->enumPrototype()
                         ->values([
                             'forwarded',
-                            'x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-forwarded-port',
+                            'x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-forwarded-port', 'x-forwarded-prefix',
                         ])
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2305,6 +2305,7 @@ class FrameworkExtension extends Extension
                 case 'x-forwarded-host': $trustedHeaders |= Request::HEADER_X_FORWARDED_HOST; break;
                 case 'x-forwarded-proto': $trustedHeaders |= Request::HEADER_X_FORWARDED_PROTO; break;
                 case 'x-forwarded-port': $trustedHeaders |= Request::HEADER_X_FORWARDED_PORT; break;
+                case 'x-forwarded-prefix': $trustedHeaders |= Request::HEADER_X_FORWARDED_PREFIX; break;
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2 (as requested by @nicolas-grekas)
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Support for `X_FORWARDED_PREFIX` has been added in PR https://github.com/symfony/symfony/pull/37734.

However, it is impossible to use it because the configuration doesn't allow the `x-forwarded-prefix` value in `framework.yaml`.
