### PR TITLE
Remove service session.storage.mock_file when user configure factory

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1050,6 +1050,7 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('session.storage.metadata_bag');
             $container->removeDefinition('session.storage.native');
             $container->removeDefinition('session.storage.php_bridge');
+            $container->removeDefinition('session.storage.mock_file');
             $container->removeAlias('session.storage.filesystem');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40282
| License       | MIT
| Doc PR        | -

When deprecating the session.storage services, and user configures a factory, the FrameworkExtension removes statefull services, but I forgot to also remove the `session.storage.mock_file` service.