### PR TITLE
[Security] #[CurrentUser] arguments should resolve to null for "anon."

### DIFF
--- a/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php
+++ b/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php
@@ -35,12 +35,9 @@ final class UserValueResolver implements ArgumentValueResolverInterface
 
     public function supports(Request $request, ArgumentMetadata $argument): bool
     {
-        if ($argument->getAttribute() instanceof CurrentUser) {
-            return true;
-        }
-
-        // only security user implementations are supported
-        if (UserInterface::class !== $argument->getType()) {
+        // with the attribute, the type can be any UserInterface implementation
+        // otherwise, the type must be UserInterface
+        if (UserInterface::class !== $argument->getType() && !$argument->getAttribute() instanceof CurrentUser) {
             return false;
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
@@ -83,6 +83,17 @@ class UserValueResolverTest extends TestCase
         $this->assertSame([$user], iterator_to_array($resolver->resolve(Request::create('/'), $metadata)));
     }
 
+    public function testResolveWithAttributeAndNoUser()
+    {
+        $tokenStorage = new TokenStorage();
+        $tokenStorage->setToken(new UsernamePasswordToken('username', 'password', 'provider'));
+
+        $resolver = new UserValueResolver($tokenStorage);
+        $metadata = new ArgumentMetadata('foo', null, false, false, null, false, new CurrentUser());
+
+        $this->assertFalse($resolver->supports(Request::create('/'), $metadata));
+    }
+
     public function testIntegration()
     {
         $user = $this->createMock(UserInterface::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The UserValueResolver should only resolve `UserInterface` (or subtype) typed arguments:
https://github.com/symfony/symfony/blob/bc9e946a56b3874b01d363772f396d8db879de8d/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php#L54-L55
When using the `#CurrentUser` attribute with an AnonymousToken in the storage, the resolved argument value is `anon.`. This PR fixes it. 

/cc @jvasseur 