### PR TITLE
[Config] Switched to non-null defaults in exception constructors

### DIFF
--- a/src/Symfony/Component/Config/Exception/LoaderLoadException.php
+++ b/src/Symfony/Component/Config/Exception/LoaderLoadException.php
@@ -19,13 +19,13 @@ namespace Symfony\Component\Config\Exception;
 class LoaderLoadException extends \Exception
 {
     /**
-     * @param string     $resource       The resource that could not be imported
-     * @param string     $sourceResource The original resource importing the new resource
-     * @param int        $code           The error code
-     * @param \Throwable $previous       A previous exception
-     * @param string     $type           The type of resource
+     * @param string          $resource       The resource that could not be imported
+     * @param string|null     $sourceResource The original resource importing the new resource
+     * @param int|null        $code           The error code
+     * @param \Throwable|null $previous       A previous exception
+     * @param string|null     $type           The type of resource
      */
-    public function __construct(string $resource, string $sourceResource = null, int $code = null, \Throwable $previous = null, string $type = null)
+    public function __construct(string $resource, string $sourceResource = null, ?int $code = 0, \Throwable $previous = null, string $type = null)
     {
         $message = '';
         if ($previous) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Follow-up to #40271 on the 5.2 branch.