### PR TITLE
Deprecate passing null as $message or $code to exceptions

### DIFF
--- a/src/Symfony/Component/Config/Exception/FileLoaderImportCircularReferenceException.php
+++ b/src/Symfony/Component/Config/Exception/FileLoaderImportCircularReferenceException.php
@@ -20,6 +20,12 @@ class FileLoaderImportCircularReferenceException extends LoaderLoadException
 {
     public function __construct(array $resources, ?int $code = 0, \Throwable $previous = null)
     {
+        if (null === $code) {
+            trigger_deprecation('symfony/config', '5.3', 'Passing null as $code to "%s()" is deprecated, pass 0 instead.', __METHOD__);
+
+            $code = 0;
+        }
+
         $message = sprintf('Circular reference detected in "%s" ("%s" > "%s").', $this->varToString($resources[0]), implode('" > "', $resources), $resources[0]);
 
         \Exception::__construct($message, $code, $previous);

--- a/src/Symfony/Component/Config/Exception/LoaderLoadException.php
+++ b/src/Symfony/Component/Config/Exception/LoaderLoadException.php
@@ -27,6 +27,12 @@ class LoaderLoadException extends \Exception
      */
     public function __construct(string $resource, string $sourceResource = null, ?int $code = 0, \Throwable $previous = null, string $type = null)
     {
+        if (null === $code) {
+            trigger_deprecation('symfony/config', '5.3', 'Passing null as $code to "%s()" is deprecated, pass 0 instead.', __METHOD__);
+
+            $code = 0;
+        }
+
         $message = '';
         if ($previous) {
             // Include the previous exception, to help the user see what might be the underlying cause

--- a/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
@@ -24,6 +24,12 @@ class AccessDeniedHttpException extends HttpException
      */
     public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+
         parent::__construct(403, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/BadRequestHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/BadRequestHttpException.php
@@ -23,6 +23,12 @@ class BadRequestHttpException extends HttpException
      */
     public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+
         parent::__construct(400, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/ConflictHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ConflictHttpException.php
@@ -23,6 +23,12 @@ class ConflictHttpException extends HttpException
      */
     public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+
         parent::__construct(409, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/GoneHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/GoneHttpException.php
@@ -23,6 +23,12 @@ class GoneHttpException extends HttpException
      */
     public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+
         parent::__construct(410, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/HttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/HttpException.php
@@ -23,6 +23,17 @@ class HttpException extends \RuntimeException implements HttpExceptionInterface
 
     public function __construct(int $statusCode, ?string $message = '', \Throwable $previous = null, array $headers = [], ?int $code = 0)
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+        if (null === $code) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $code to "%s()" is deprecated, pass 0 instead.', __METHOD__);
+
+            $code = 0;
+        }
+
         $this->statusCode = $statusCode;
         $this->headers = $headers;
 

--- a/src/Symfony/Component/HttpKernel/Exception/LengthRequiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/LengthRequiredHttpException.php
@@ -23,6 +23,12 @@ class LengthRequiredHttpException extends HttpException
      */
     public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+
         parent::__construct(411, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php
@@ -24,6 +24,17 @@ class MethodNotAllowedHttpException extends HttpException
      */
     public function __construct(array $allow, ?string $message = '', \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+        if (null === $code) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $code to "%s()" is deprecated, pass 0 instead.', __METHOD__);
+
+            $code = 0;
+        }
+
         $headers['Allow'] = strtoupper(implode(', ', $allow));
 
         parent::__construct(405, $message, $previous, $headers, $code);

--- a/src/Symfony/Component/HttpKernel/Exception/NotAcceptableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/NotAcceptableHttpException.php
@@ -23,6 +23,12 @@ class NotAcceptableHttpException extends HttpException
      */
     public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+
         parent::__construct(406, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/NotFoundHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/NotFoundHttpException.php
@@ -23,6 +23,12 @@ class NotFoundHttpException extends HttpException
      */
     public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+
         parent::__construct(404, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/PreconditionFailedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PreconditionFailedHttpException.php
@@ -23,6 +23,12 @@ class PreconditionFailedHttpException extends HttpException
      */
     public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+
         parent::__construct(412, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/PreconditionRequiredHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/PreconditionRequiredHttpException.php
@@ -25,6 +25,12 @@ class PreconditionRequiredHttpException extends HttpException
      */
     public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+
         parent::__construct(428, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/ServiceUnavailableHttpException.php
@@ -24,6 +24,17 @@ class ServiceUnavailableHttpException extends HttpException
      */
     public function __construct($retryAfter = null, ?string $message = '', \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+        if (null === $code) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $code to "%s()" is deprecated, pass 0 instead.', __METHOD__);
+
+            $code = 0;
+        }
+
         if ($retryAfter) {
             $headers['Retry-After'] = $retryAfter;
         }

--- a/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/TooManyRequestsHttpException.php
@@ -26,6 +26,17 @@ class TooManyRequestsHttpException extends HttpException
      */
     public function __construct($retryAfter = null, ?string $message = '', \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+        if (null === $code) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $code to "%s()" is deprecated, pass 0 instead.', __METHOD__);
+
+            $code = 0;
+        }
+
         if ($retryAfter) {
             $headers['Retry-After'] = $retryAfter;
         }

--- a/src/Symfony/Component/HttpKernel/Exception/UnauthorizedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnauthorizedHttpException.php
@@ -24,6 +24,17 @@ class UnauthorizedHttpException extends HttpException
      */
     public function __construct(string $challenge, ?string $message = '', \Throwable $previous = null, ?int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+        if (null === $code) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $code to "%s()" is deprecated, pass 0 instead.', __METHOD__);
+
+            $code = 0;
+        }
+
         $headers['WWW-Authenticate'] = $challenge;
 
         parent::__construct(401, $message, $previous, $headers, $code);

--- a/src/Symfony/Component/HttpKernel/Exception/UnprocessableEntityHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnprocessableEntityHttpException.php
@@ -23,6 +23,12 @@ class UnprocessableEntityHttpException extends HttpException
      */
     public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+
         parent::__construct(422, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/UnsupportedMediaTypeHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/UnsupportedMediaTypeHttpException.php
@@ -23,6 +23,12 @@ class UnsupportedMediaTypeHttpException extends HttpException
      */
     public function __construct(?string $message = '', \Throwable $previous = null, int $code = 0, array $headers = [])
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+
         parent::__construct(415, $message, $previous, $headers, $code);
     }
 }

--- a/src/Symfony/Component/Mailer/Exception/HttpTransportException.php
+++ b/src/Symfony/Component/Mailer/Exception/HttpTransportException.php
@@ -22,6 +22,12 @@ class HttpTransportException extends TransportException
 
     public function __construct(?string $message, ResponseInterface $response, int $code = 0, \Throwable $previous = null)
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/mailer', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+
         parent::__construct($message, $code, $previous);
 
         $this->response = $response;

--- a/src/Symfony/Component/Routing/Exception/MethodNotAllowedException.php
+++ b/src/Symfony/Component/Routing/Exception/MethodNotAllowedException.php
@@ -27,6 +27,12 @@ class MethodNotAllowedException extends \RuntimeException implements ExceptionIn
      */
     public function __construct(array $allowedMethods, ?string $message = '', int $code = 0, \Throwable $previous = null)
     {
+        if (null === $message) {
+            trigger_deprecation('symfony/routing', '5.3', 'Passing null as $message to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            $message = '';
+        }
+
         $this->allowedMethods = array_map('strtoupper', $allowedMethods);
 
         parent::__construct($message, $code, $previous);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Follow-up to #40271.

Following the example of the PHP core, this PR introduces deprecation warnings that are triggered if a developer attempts to pass null as `$code` or `$message` to an exception constructor.