### PR TITLE
Adding a Github action to run Psalm

### DIFF
--- a/.github/psalm/cache/.gitignore
+++ b/.github/psalm/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/.github/psalm/psalm.baseline.xml
+++ b/.github/psalm/psalm.baseline.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.x-dev@">
+</files>

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,0 +1,97 @@
+name: Static analysis
+
+on:
+  pull_request: ~
+
+jobs:
+  psalm:
+    name: Psalm
+    runs-on: Ubuntu-20.04
+
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          extensions: "json,memcached,mongodb,redis,xsl,ldap,dom"
+          ini-values: "memory_limit=-1"
+          coverage: none
+
+      - name: Checkout PR
+        uses: actions/checkout@v2
+        with:
+          path: pr
+
+      - name: Checkout base
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.base_ref }}
+          path: base
+
+      - name: Configure composer
+        run: |
+            cd base
+            COMPOSER_HOME="$(composer config home)"
+            ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
+            echo "COMPOSER_ROOT_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*').x-dev" >> $GITHUB_ENV
+
+      - name: Determine composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ github.base_ref }}
+          restore-keys: composer-
+
+      - name: Install Psalm
+        run: |
+          composer require psalm/phar
+          cp ./vendor/bin/psalm.phar base/psalm.phar
+          cp ./vendor/bin/psalm.phar pr/psalm.phar
+
+      - name: Install dependencies for base
+        run: |
+            cd base
+            echo "::group::modify composer.json"
+            sed -i -re 's/"replace": \{/"replace": \{"symfony\/phpunit-bridge": "self.version",/' composer.json
+            composer require --no-update phpunit/phpunit php-http/discovery psr/event-dispatcher
+            echo "::endgroup::"
+            echo "::group::composer update"
+            composer update --no-progress --ansi
+            echo "::endgroup::"
+
+      - name: Generate Psalm baseline
+        run: |
+          cd base
+          ./psalm.phar --set-baseline=.github/psalm/psalm.baseline.xml --no-progress
+
+      - name: Copy baseline
+        run: |
+          cp base/.github/psalm/psalm.baseline.xml pr/.github/psalm/psalm.baseline.xml
+
+      - name: Install dependencies for PR
+        run: |
+            cd pr
+            echo "::group::modify composer.json"
+            sed -i -re 's/"replace": \{/"replace": \{"symfony\/phpunit-bridge": "self.version",/' composer.json
+            composer require --no-update phpunit/phpunit php-http/discovery psr/event-dispatcher
+            echo "::endgroup::"
+            echo "::group::composer update"
+            composer update --no-progress --ansi
+            echo "::endgroup::"
+
+      - name: Cache Psalm
+        uses: actions/cache@v2
+        with:
+          path: pr/.github/psalm/cache/
+          key: psalm-${{ github.base_ref }}
+          restore-keys: psalm-
+
+      - name: Psalm
+        run: |
+          cd pr
+          ./psalm.phar --version
+          ./psalm.phar --output-format=github --no-progress

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="5"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    cacheDirectory="./.github/psalm/cache/"
+    errorBaseline=".github/psalm/psalm.baseline.xml"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="src/Symfony/*/*/Tests" />
+            <directory name="src/Symfony/*/*/*/Tests" />
+            <directory name="src/Symfony/*/*/*/*/Tests" />
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/15024

I've seen sometimes that we've forgotten to add `\` before `Throwable` or that we refer to a class that does not exist. One could argue that the code is not properly tested, but somehow these PRs still get merged. (And quickly fixed in a follow up PR). 

I suggest to add psalm to check every PR for some errors that can be found with a static analyser. This is to help/automate the PR review process. All psalm errors found should be reviewed and discussed. The maintainers can decide to ignore some warnings if they want to. (Ie false positives)

This PR is about “Psalm PR review”. It does not try to fix “Psalm compatibility”. Psalm compatibility is a separate issue that should be discussed separate from the "Psalm PR review". 

I currently plan to follow up with the more controversial topic of "Should we make Symfony more compatible with Psalm or not". 
