### PR TITLE
[Validator] [Loader] Fix AutoMapping for entity inheritance

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/Factory/LazyLoadingMetadataFactory.php
@@ -97,6 +97,9 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
 
         $metadata = new ClassMetadata($class);
 
+        // Include constraints from the parent class
+        $this->mergeConstraints($metadata);
+
         if (null !== $this->loader) {
             $this->loader->loadClassMetadata($metadata);
         }
@@ -104,9 +107,6 @@ class LazyLoadingMetadataFactory implements MetadataFactoryInterface
         if (null !== $cacheItem) {
             $this->cache->save($cacheItem->set($metadata));
         }
-
-        // Include constraints from the parent class
-        $this->mergeConstraints($metadata);
 
         return $this->loadedClasses[$class] = $metadata;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40293
| License       | MIT
| Doc PR        | 

The Validator auto mapping functionnality do not handle class that extends an other one: see #40293.

This functionnality use to constrainst: `DisableAutoMapping` and `EnableAutoMapping`, and check the usage of other Constrainst on an Entity property to add or not some Constrainst automatically. But in a case of an entity that extends a MappedSuperClass, the annotations from the parent class aren't take in consideration.

In the LazyLoadingMetadataFactory, that call a `loadClassMetadata()` method, there is a method to merge constrainsts from parent in the child ClassMetadata. This PR just move the merge before the `loadClassMetadata()` to take all Constrainst in consideration for the AutoMapping functionnality.