### PR TITLE
[EventDispatcher] [4.4] Allow Contract Event since Component Event is deprecated

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -150,8 +150,8 @@ class TraceableEventDispatcher implements TraceableEventDispatcherInterface
             $event = $eventName ?? new Event();
             $eventName = $swap;
 
-            if (!$event instanceof Event) {
-                throw new \TypeError(sprintf('Argument 1 passed to "%s::dispatch()" must be an instance of "%s", "%s" given.', EventDispatcherInterface::class, Event::class, \is_object($event) ? \get_class($event) : \gettype($event)));
+            if (!$event instanceof Event && !$event instanceof ContractsEvent) {
+                throw new \TypeError(sprintf('Argument 1 passed to "%s::dispatch()" must be an instance of "%s" or "%s", "%s" given.', EventDispatcherInterface::class, Event::class, ContractsEvent::class, \is_object($event) ? \get_class($event) : \gettype($event)));
             }
         }
 


### PR DESCRIPTION
Class `Symfony\Component\EventDispatcher\Event` is deprecated since 4.3, yet it is required by the EventDispatcher. This fix will allow using the new `Symfony\Contracts\EventDispatcher\Event` class.

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | none
| License       | MIT
| Doc PR        | not needed
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
