### PR TITLE
[Process] Add getter for process pipes to be able to work with them

### DIFF
--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3
+-----
+
+* Add `Process::getProcessPipes()` to be able to work with the pipes of a `Process`
+
 5.2.0
 -----
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1194,6 +1194,16 @@ class Process implements \IteratorAggregate
     }
 
     /**
+     * Gets the Process pipes.
+     *
+     * @return PipesInterface|null The Process pipes
+     */
+    public function getProcessPipes()
+    {
+        return $this->processPipes;
+    }
+
+    /**
      * Performs a check between the timeout definition and the time the process started.
      *
      * In case you run a background process (with the start method), you should


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no (Just a new getter function)
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This is my situation:

I have the following bash script and I want to execute it with the `Process` component within a PHP script:

```bash
#!/usr/bin/env bash

echo "Insert something:"
read INPUT

echo "-${INPUT}-"
```

In order for the PHP script to stop for the "read" and ask for the user input, I figured out that you have to pass PHP's STDIN to the Process like this:

```php
$process = new Process(['/path/to/my/script.sh'], null, [], \STDIN, null);

$process->start();

foreach ($process as $type => $buffer) {
    echo $buffer;
}

$process->wait();
```

With this the PHP script pauses when the bash script asks for user input. After submitting the input to the command line, the input is written to PHP's STDIN and because I passed \STDIN to the Process, my input is redirected to the bash script and then the bash script prints my input and finishes.

My problem was now to automatically write something to the "read" of the bash script without actually asking the user for the input.

The first important thing is to know when the bash script requires user input. My idea was to look for the text that was printed before the read and once it arrives, I can write something to the input. Something like this:

```php
$process = new Process(['/path/to/my/script.sh'], null, [], \STDIN, null);

$process->start();

foreach ($process as $type => $buffer) {
    $separator = "\r\n";
    $line = strtok($buffer, $separator);
    while ($line !== false) {
        if (mb_strpos($line, 'Insert something:') === 0) {
            // No echo here
            // Write a pre-defined value to the script's input so that the bash script continues and prints this value
        } else {
            echo $buffer;
        }
        $line = strtok($separator);
    }
}

$process->wait();
```

My first approach was to write something to \STDIN like this:

```php
fwrite(\STDIN, 'My pre-defined value' . PHP_EOL);
```

With this the input is printed to the command line, but it is not redirected to the bash script. The bash script does not receive the input and does not continue the execution. Only when I write something to the command line and hit enter, the script continues. But then my own input is printed, not the input the PHP script has written to \STDIN.

So this is where my PR comes in. I have added a getter function for the "processPipes" variable and I can use it like this now:

```php
fwrite($process->getProcessPipes()->pipes[0], 'My pre-defined value' . PHP_EOL);
```

With this my pre-defined value is submitted to the bash script and it directly continues and prints this value.

So this is my final PHP code then:

```php
$process = new Process(['/path/to/my/script.sh'], null, [], \STDIN, null);

$process->start();

foreach ($process as $type => $buffer) {
    $separator = "\r\n";
    $line = strtok($buffer, $separator);
    while ($line !== false) {
        if (mb_strpos($line, 'Insert something:') === 0) {
            // No echo here
            // Write a pre-defined value to the script's input so that the bash script continues and prints this value
            fwrite($process->getProcessPipes()->pipes[0], 'My pre-defined value' . PHP_EOL);
        } else {
            echo $buffer;
        }
        $line = strtok($separator);
    }
}

$process->wait();
```

I have not found any other way to achieve my requirement. That is why I wrote the PR. If there is already a way to do this that I haven't found, please let me know.

I have not written tests or added something to the docs, because it is a simple new getter function. I hope that is fine.

Here are issues that might be solved with it:

https://github.com/symfony/symfony/issues/39482
https://github.com/symfony/symfony/issues/40037 (I have created this a month ago for this use case)
