### PR TITLE
[TwigBridge] Install symfony/intl to run tests on Travis

### DIFF
--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -29,6 +29,7 @@
         "symfony/form": "^4.4.17",
         "symfony/http-foundation": "^4.3|^5.0",
         "symfony/http-kernel": "^4.4",
+        "symfony/intl": "^4.4|^5.0",
         "symfony/mime": "^4.3|^5.0",
         "symfony/polyfill-intl-icu": "~1.0",
         "symfony/routing": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | bi
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The hard dependency on `symfony/intl` was removed from the Form component in 5.3-dev (#40298). I suggest to add the explicit dev dependency on TwigBridge on 4.4 already.