### PR TITLE
[HttpKernel] Handle multi-attribute controller arguments

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -44,6 +44,8 @@ HttpFoundation
 HttpKernel
 ----------
 
+ * Deprecate `ArgumentInterface`
+ * Deprecate `ArgumentMetadata::getAttribute()`, use `getAttributes()` instead
  * Marked the class `Symfony\Component\HttpKernel\EventListener\DebugHandlersListener` as internal
 
 Messenger

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -92,6 +92,8 @@ HttpFoundation
 HttpKernel
 ----------
 
+ * Remove `ArgumentInterface`
+ * Remove `ArgumentMetadata::getAttribute()`, use `getAttributes()` instead
  * Made `WarmableInterface::warmUp()` return a list of classes or files to preload on PHP 7.4+
  * Removed support for `service:action` syntax to reference controllers. Use `serviceOrFqcn::method` instead.
 

--- a/src/Symfony/Component/HttpKernel/Attribute/ArgumentInterface.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/ArgumentInterface.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Component\HttpKernel\Attribute;
 
+trigger_deprecation('symfony/http-kernel', '5.3', 'The "%s" interface is deprecated.', ArgumentInterface::class);
+
 /**
  * Marker interface for controller argument attributes.
+ *
+ * @deprecated since Symfony 5.3
  */
 interface ArgumentInterface
 {

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 5.3
 ---
 
+ * Deprecate `ArgumentInterface`
+ * Add `ArgumentMetadata::getAttributes()`
+ * Deprecate `ArgumentMetadata::getAttribute()`, use `getAttributes()` instead
  * marked the class `Symfony\Component\HttpKernel\EventListener\DebugHandlersListener` as internal
 
 5.2.0

--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadata.php
@@ -20,15 +20,20 @@ use Symfony\Component\HttpKernel\Attribute\ArgumentInterface;
  */
 class ArgumentMetadata
 {
+    public const IS_INSTANCEOF = 2;
+
     private $name;
     private $type;
     private $isVariadic;
     private $hasDefaultValue;
     private $defaultValue;
     private $isNullable;
-    private $attribute;
+    private $attributes;
 
-    public function __construct(string $name, ?string $type, bool $isVariadic, bool $hasDefaultValue, $defaultValue, bool $isNullable = false, ?ArgumentInterface $attribute = null)
+    /**
+     * @param object[] $attributes
+     */
+    public function __construct(string $name, ?string $type, bool $isVariadic, bool $hasDefaultValue, $defaultValue, bool $isNullable = false, $attributes = [])
     {
         $this->name = $name;
         $this->type = $type;
@@ -36,7 +41,13 @@ class ArgumentMetadata
         $this->hasDefaultValue = $hasDefaultValue;
         $this->defaultValue = $defaultValue;
         $this->isNullable = $isNullable || null === $type || ($hasDefaultValue && null === $defaultValue);
-        $this->attribute = $attribute;
+
+        if (null === $attributes || $attributes instanceof ArgumentInterface) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'The "%s" constructor expects an array of PHP attributes as last argument, %s given.', __CLASS__, get_debug_type($attributes));
+            $attributes = $attributes ? [$attributes] : [];
+        }
+
+        $this->attributes = $attributes;
     }
 
     /**
@@ -114,6 +125,39 @@ class ArgumentMetadata
      */
     public function getAttribute(): ?ArgumentInterface
     {
-        return $this->attribute;
+        trigger_deprecation('symfony/http-kernel', '5.3', 'Method "%s()" is deprecated, use "getAttributes()" instead.', __METHOD__);
+
+        if (!$this->attributes) {
+            return null;
+        }
+
+        return $this->attributes[0] instanceof ArgumentInterface ? $this->attributes[0] : null;
+    }
+
+    /**
+     * @return object[]
+     */
+    public function getAttributes(string $name = null, int $flags = 0): array
+    {
+        if (!$name) {
+            return $this->attributes;
+        }
+
+        $attributes = [];
+        if ($flags & self::IS_INSTANCEOF) {
+            foreach ($this->attributes as $attribute) {
+                if ($attribute instanceof $name) {
+                    $attributes[] = $attribute;
+                }
+            }
+        } else {
+            foreach ($this->attributes as $attribute) {
+                if (\get_class($attribute) === $name) {
+                    $attributes[] = $attribute;
+                }
+            }
+        }
+
+        return $attributes;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
@@ -15,7 +15,6 @@ use Fake\ImportedAndFake;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactory;
-use Symfony\Component\HttpKernel\Exception\InvalidMetadataException;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Foo;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\AttributeController;
 use Symfony\Component\HttpKernel\Tests\Fixtures\Controller\BasicTypesController;
@@ -128,18 +127,17 @@ class ArgumentMetadataFactoryTest extends TestCase
         $arguments = $this->factory->createArgumentMetadata([new AttributeController(), 'action']);
 
         $this->assertEquals([
-            new ArgumentMetadata('baz', 'string', false, false, null, false, new Foo('bar')),
+            new ArgumentMetadata('baz', 'string', false, false, null, false, [new Foo('bar')]),
         ], $arguments);
     }
 
     /**
      * @requires PHP 8
      */
-    public function testAttributeSignatureError()
+    public function testMultipleAttributes()
     {
-        $this->expectException(InvalidMetadataException::class);
-
-        $this->factory->createArgumentMetadata([new AttributeController(), 'invalidAction']);
+        $this->factory->createArgumentMetadata([new AttributeController(), 'multiAttributeArg']);
+        $this->assertCount(1, $this->factory->createArgumentMetadata([new AttributeController(), 'multiAttributeArg'])[0]->getAttributes());
     }
 
     private function signature1(self $foo, array $bar, callable $baz)

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataTest.php
@@ -12,10 +12,15 @@
 namespace Symfony\Component\HttpKernel\Tests\ControllerMetadata;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\HttpKernel\Attribute\ArgumentInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Tests\Fixtures\Attribute\Foo;
 
 class ArgumentMetadataTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testWithBcLayerWithDefault()
     {
         $argument = new ArgumentMetadata('foo', 'string', false, true, 'default value');
@@ -40,5 +45,28 @@ class ArgumentMetadataTest extends TestCase
         $this->assertFalse($argument->isNullable());
         $this->assertFalse($argument->hasDefaultValue());
         $argument->getDefaultValue();
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyAttribute()
+    {
+        $attribute = $this->createMock(ArgumentInterface::class);
+
+        $this->expectDeprecation('Since symfony/http-kernel 5.3: The "Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata" constructor expects an array of PHP attributes as last argument, %s given.');
+        $this->expectDeprecation('Since symfony/http-kernel 5.3: Method "Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata::getAttribute()" is deprecated, use "getAttributes()" instead.');
+
+        $argument = new ArgumentMetadata('foo', 'string', false, true, 'default value', true, $attribute);
+        $this->assertSame($attribute, $argument->getAttribute());
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testGetAttributes()
+    {
+        $argument = new ArgumentMetadata('foo', 'string', false, true, 'default value', true, [new Foo('bar')]);
+        $this->assertEquals([new Foo('bar')], $argument->getAttributes());
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Attribute/Foo.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Attribute/Foo.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\HttpKernel\Tests\Fixtures\Attribute;
 use Symfony\Component\HttpKernel\Attribute\ArgumentInterface;
 
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
-class Foo implements ArgumentInterface
+class Foo
 {
     private $foo;
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/AttributeController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/AttributeController.php
@@ -18,6 +18,6 @@ class AttributeController
     public function action(#[Foo('bar')] string $baz) {
     }
 
-    public function invalidAction(#[Foo('bar'), Foo('bar')] string $baz) {
+    public function multiAttributeArg(#[Foo('bar'), Undefined('bar')] string $baz) {
     }
 }

--- a/src/Symfony/Component/Security/Http/Attribute/CurrentUser.php
+++ b/src/Symfony/Component/Security/Http/Attribute/CurrentUser.php
@@ -11,12 +11,10 @@
 
 namespace Symfony\Component\Security\Http\Attribute;
 
-use Symfony\Component\HttpKernel\Attribute\ArgumentInterface;
-
 /**
  * Indicates that a controller argument should receive the current logged user.
  */
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
-class CurrentUser implements ArgumentInterface
+class CurrentUser
 {
 }

--- a/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php
+++ b/src/Symfony/Component/Security/Http/Controller/UserValueResolver.php
@@ -37,7 +37,7 @@ final class UserValueResolver implements ArgumentValueResolverInterface
     {
         // with the attribute, the type can be any UserInterface implementation
         // otherwise, the type must be UserInterface
-        if (UserInterface::class !== $argument->getType() && !$argument->getAttribute() instanceof CurrentUser) {
+        if (UserInterface::class !== $argument->getType() && !$argument->getAttributes(CurrentUser::class, ArgumentMetadata::IS_INSTANCEOF)) {
             return false;
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Controller/UserValueResolverTest.php
@@ -77,7 +77,8 @@ class UserValueResolverTest extends TestCase
         $tokenStorage->setToken($token);
 
         $resolver = new UserValueResolver($tokenStorage);
-        $metadata = new ArgumentMetadata('foo', null, false, false, null, false, new CurrentUser());
+        $metadata = $this->createMock(ArgumentMetadata::class);
+        $metadata = new ArgumentMetadata('foo', null, false, false, null, false, [new CurrentUser()]);
 
         $this->assertTrue($resolver->supports(Request::create('/'), $metadata));
         $this->assertSame([$user], iterator_to_array($resolver->resolve(Request::create('/'), $metadata)));
@@ -89,7 +90,7 @@ class UserValueResolverTest extends TestCase
         $tokenStorage->setToken(new UsernamePasswordToken('username', 'password', 'provider'));
 
         $resolver = new UserValueResolver($tokenStorage);
-        $metadata = new ArgumentMetadata('foo', null, false, false, null, false, new CurrentUser());
+        $metadata = new ArgumentMetadata('foo', null, false, false, null, false, [new CurrentUser()]);
 
         $this->assertFalse($resolver->supports(Request::create('/'), $metadata));
     }

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -20,7 +20,7 @@
         "symfony/deprecation-contracts": "^2.1",
         "symfony/security-core": "^5.3",
         "symfony/http-foundation": "^5.2",
-        "symfony/http-kernel": "^5.2",
+        "symfony/http-kernel": "^5.3",
         "symfony/polyfill-php80": "^1.15",
         "symfony/property-access": "^4.4|^5.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | todo

Currently, the `ArgumentMetadata` class used for controller argument value resolution can only hold one attribute per controller argument, while a method argument can take multiple attributes.

This allows accessing all attributes for a given argument, and deprecates the `ArgumentInterface` because it is not needed.
Spotted by @nicolas-grekas. 