### PR TITLE
Fix deprecation messages

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', BasePasswordEncoder::class, CheckPasswordLengthTrait::class));
-
 use Symfony\Component\PasswordHasher\Hasher\CheckPasswordLengthTrait;
+
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', BasePasswordEncoder::class, CheckPasswordLengthTrait::class));
 
 /**
  * BasePasswordEncoder is the base class for all password encoders.

--- a/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
+++ b/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', EncoderFactory::class, PasswordHasherFactory::class));
-
-use Symfony\Component\Security\Core\Exception\LogicException;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherAwareInterface;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
+use Symfony\Component\Security\Core\Exception\LogicException;
+
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', EncoderFactory::class, PasswordHasherFactory::class));
 
 /**
  * A generic encoder factory implementation.

--- a/src/Symfony/Component/Security/Core/Encoder/EncoderFactoryInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/EncoderFactoryInterface.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', EncoderFactoryInterface::class, PasswordHasherFactoryInterface::class));
-
-use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', EncoderFactoryInterface::class, PasswordHasherFactoryInterface::class));
 
 /**
  * EncoderFactoryInterface to support different encoders for different accounts.

--- a/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', MessageDigestPasswordEncoder::class, MessageDigestPasswordHasher::class));
-
 use Symfony\Component\PasswordHasher\Hasher\MessageDigestPasswordHasher;
+
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', MessageDigestPasswordEncoder::class, MessageDigestPasswordHasher::class));
 
 /**
  * MessageDigestPasswordEncoder uses a message digest algorithm.

--- a/src/Symfony/Component/Security/Core/Encoder/MigratingPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/MigratingPasswordEncoder.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', MigratingPasswordEncoder::class, MigratingPasswordHasher::class));
-
 use Symfony\Component\PasswordHasher\Hasher\MigratingPasswordHasher;
+
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', MigratingPasswordEncoder::class, MigratingPasswordHasher::class));
 
 /**
  * Hashes passwords using the best available encoder.

--- a/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/NativePasswordEncoder.php
@@ -11,10 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', NativePasswordEncoder::class, NativePasswordHasher::class));
-
-use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
+
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', NativePasswordEncoder::class, NativePasswordHasher::class));
 
 /**
  * Hashes passwords using password_hash().

--- a/src/Symfony/Component/Security/Core/Encoder/PasswordEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PasswordEncoderInterface.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', PasswordEncoderInterface::class, PasswordHasherInterface::class));
-
-use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', PasswordEncoderInterface::class, PasswordHasherInterface::class));
 
 /**
  * PasswordEncoderInterface is the interface for all encoders.

--- a/src/Symfony/Component/Security/Core/Encoder/Pbkdf2PasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/Pbkdf2PasswordEncoder.php
@@ -11,10 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', Pbkdf2PasswordEncoder::class, Pbkdf2PasswordHasher::class));
-
-use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\PasswordHasher\Hasher\Pbkdf2PasswordHasher;
+
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', Pbkdf2PasswordEncoder::class, Pbkdf2PasswordHasher::class));
 
 /**
  * Pbkdf2PasswordEncoder uses the PBKDF2 (Password-Based Key Derivation Function 2).

--- a/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', PlaintextPasswordEncoder::class, PlaintextPasswordHasher::class));
-
 use Symfony\Component\PasswordHasher\Hasher\PlaintextPasswordHasher;
+
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', PlaintextPasswordEncoder::class, PlaintextPasswordHasher::class));
 
 /**
  * PlaintextPasswordEncoder does not do any encoding but is useful in testing environments.

--- a/src/Symfony/Component/Security/Core/Encoder/SelfSaltingEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/SelfSaltingEncoderInterface.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" interface is deprecated, use "%s" on hasher implementations that deal with salts instead.', SelfSaltingEncoderInterface::class, LegacyPasswordHasherInterface::class));
-
 use Symfony\Component\PasswordHasher\LegacyPasswordHasherInterface;
+
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" interface is deprecated, use "%s" on hasher implementations that deal with salts instead.', SelfSaltingEncoderInterface::class, LegacyPasswordHasherInterface::class));
 
 /**
  * SelfSaltingEncoderInterface is a marker interface for encoders that do not

--- a/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/SodiumPasswordEncoder.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', SodiumPasswordEncoder::class, SodiumPasswordHasher::class));
-
 use Symfony\Component\PasswordHasher\Hasher\SodiumPasswordHasher;
+
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', SodiumPasswordEncoder::class, SodiumPasswordHasher::class));
 
 /**
  * Hashes passwords using libsodium.

--- a/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoder.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', UserPasswordEncoder::class, UserPasswordHasher::class));
-
-use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" class is deprecated, use "%s" instead.', UserPasswordEncoder::class, UserPasswordHasher::class));
 
 /**
  * A generic password encoder.

--- a/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoderInterface.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\Security\Core\Encoder;
 
-trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" interface is deprecated, use "%s" instead.', UserPasswordEncoderInterface::class, UserPasswordHasherInterface::class));
-
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+
+trigger_deprecation('symfony/security-core', '5.3', sprintf('The "%s" interface is deprecated, use "%s" instead.', UserPasswordEncoderInterface::class, UserPasswordHasherInterface::class));
 
 /**
  * UserPasswordEncoderInterface is the interface for the password encoder service.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

The wrong namespace is used in the deprecation messages
