### PR TITLE
Speed up psalm by copy the cache

### DIFF
--- a/.github/psalm/cache/.gitignore
+++ b/.github/psalm/cache/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -68,9 +68,9 @@ jobs:
           cd base
           ./psalm.phar --set-baseline=.github/psalm/psalm.baseline.xml --no-progress
 
-      - name: Copy baseline
+      - name: Copy baseline and cache
         run: |
-          cp base/.github/psalm/psalm.baseline.xml pr/.github/psalm/psalm.baseline.xml
+          cp -R base/.github/psalm pr/.github/psalm
 
       - name: Install dependencies for PR
         run: |
@@ -82,13 +82,6 @@ jobs:
             echo "::group::composer update"
             composer update --no-progress --ansi
             echo "::endgroup::"
-
-      - name: Cache Psalm
-        uses: actions/cache@v2
-        with:
-          path: pr/.github/psalm/cache/
-          key: psalm-${{ github.base_ref }}
-          restore-keys: psalm-
 
       - name: Psalm
         run: |

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -68,9 +68,8 @@ jobs:
           cd base
           ./psalm.phar --set-baseline=.github/psalm/psalm.baseline.xml --no-progress
 
-      - name: Copy baseline and cache
-        run: |
-          cp -R base/.github/psalm pr/.github/psalm
+      - name: Copy baseline
+        run: cp base/.github/psalm/psalm.baseline.xml pr/.github/psalm/psalm.baseline.xml
 
       - name: Install dependencies for PR
         run: |

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -71,9 +71,15 @@ jobs:
       - name: Copy baseline
         run: cp base/.github/psalm/psalm.baseline.xml pr/.github/psalm/psalm.baseline.xml
 
+      # Move the "pr" project to "base" to make use of the psalm cache
+      - name: Move directories
+        run: |
+          rm -rf base
+          mv pr base
+
       - name: Install dependencies for PR
         run: |
-            cd pr
+            cd base
             echo "::group::modify composer.json"
             composer remove symfony/phpunit-bridge --no-interaction --no-update
             composer require --no-update phpunit/phpunit php-http/discovery psr/event-dispatcher
@@ -84,6 +90,6 @@ jobs:
 
       - name: Psalm
         run: |
-          cd pr
+          cd base
           ./psalm.phar --version
           ./psalm.phar --output-format=github --no-progress

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,7 +5,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    cacheDirectory="./.github/psalm/cache/"
     errorBaseline=".github/psalm/psalm.baseline.xml"
 >
     <projectFiles>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Psalm is not using cache when generating a baseline. When a new baseline is generated, it will not use the "old" cache. 

This PR copies the cache from the "generate baseline run". 