### PR TITLE
Add Psalm baseline and update it automatically

### DIFF
--- a/.github/workflows/psalm-baseline.yml
+++ b/.github/workflows/psalm-baseline.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 6 1 * *'
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   psalm:
     name: Psalm baselne
@@ -33,32 +37,17 @@ jobs:
             ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
             echo "COMPOSER_ROOT_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*').x-dev" >> $GITHUB_ENV
 
-      - name: Determine composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache composer dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: composer-${{ github.base_ref }}
-          restore-keys: composer-
-
       - name: Install dependencies
         run: |
             echo "::group::modify composer.json"
-            cp composer.json composer.json.backup
-            composer remove symfony/phpunit-bridge --no-interaction --no-update
-            composer require psalm/phar --no-update
-            composer require --no-update phpunit/phpunit php-http/discovery psr/event-dispatcher
+            composer remove --no-interaction --no-update symfony/phpunit-bridge
+            composer require psalm/phar phpunit/phpunit php-http/discovery psr/event-dispatcher --no-update
             echo "::endgroup::"
             echo "::group::composer update"
             composer update --no-progress --ansi
+            git checkout composer.json
             echo "::endgroup::"
-            echo "::group::restore composer.json"
-            rm composer.json
-            cp composer.json.backup composer.json
-            echo "::endgroup::"
+            ./vendor/bin/psalm.phar --version
 
       - name: Generate Psalm baseline
         run: /vendor/bin/psalm.phar --set-baseline=.github/psalm/psalm.baseline.xml --no-progress

--- a/.github/workflows/psalm-baseline.yml
+++ b/.github/workflows/psalm-baseline.yml
@@ -1,0 +1,88 @@
+name: Update psalm baseline
+
+on:
+  schedule:
+    - cron: '0 6 1 * *'
+
+jobs:
+  psalm:
+    name: Psalm baselne
+    runs-on: Ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ['4.4', '5.x']
+
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          extensions: "json,memcached,mongodb,redis,xsl,ldap,dom"
+          ini-values: "memory_limit=-1"
+          coverage: none
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Configure composer
+        run: |
+            COMPOSER_HOME="$(composer config home)"
+            ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
+            echo "COMPOSER_ROOT_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*').x-dev" >> $GITHUB_ENV
+
+      - name: Determine composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ github.base_ref }}
+          restore-keys: composer-
+
+      - name: Install dependencies
+        run: |
+            echo "::group::modify composer.json"
+            cp composer.json composer.json.backup
+            composer remove symfony/phpunit-bridge --no-interaction --no-update
+            composer require psalm/phar --no-update
+            composer require --no-update phpunit/phpunit php-http/discovery psr/event-dispatcher
+            echo "::endgroup::"
+            echo "::group::composer update"
+            composer update --no-progress --ansi
+            echo "::endgroup::"
+            echo "::group::restore composer.json"
+            rm composer.json
+            cp composer.json.backup composer.json
+            echo "::endgroup::"
+
+      - name: Generate Psalm baseline
+        run: /vendor/bin/psalm.phar --set-baseline=.github/psalm/psalm.baseline.xml --no-progress
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.CARSONBOT_GITHUB_TOKEN }}
+          push-to-fork: carsonbot/symfony
+          author: carsonbot <noreply@github.com>
+          committer: carsonbot <noreply@github.com>
+          commit-message: Update psalm baseline
+          title: Update psalm baseline - ${{ matrix.branch }}
+          body: |
+            | Q             | A
+            | ------------- | ---
+            | Branch?       | ${{ matrix.branch }}
+            | Bug fix?      | no
+            | New feature?  | no
+            | Deprecations? | no
+            | Tickets       |
+            | License       | MIT
+            | Doc PR        |
+
+            The psalm baseline have changed for branch ${{ matrix.branch }}.
+          branch: psalm-baseline-${{ matrix.branch }}
+          base: ${{ matrix.branch }}

--- a/.github/workflows/psalm-baseline.yml
+++ b/.github/workflows/psalm-baseline.yml
@@ -72,6 +72,6 @@ jobs:
             | License       | MIT
             | Doc PR        |
 
-            The psalm baseline have changed for branch ${{ matrix.branch }}.
+            The psalm baseline has changed for branch ${{ matrix.branch }}.
           branch: psalm-baseline-${{ matrix.branch }}
           base: ${{ matrix.branch }}

--- a/.github/workflows/psalm-baseline.yml
+++ b/.github/workflows/psalm-baseline.yml
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   psalm:
-    name: Psalm baselne
+    name: Psalm baseline
     runs-on: Ubuntu-20.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | 
| New feature?  | 
| Deprecations? | 
| Tickets       | 
| License       | MIT
| Doc PR        | 

We added a Github action to make Psalm review PRs in #40291. This PR will do something more controversial, it moves towards adding "psalm compatibility". This really means that we want to make more types identifiable by static analysis tools which will make it easier to find bugs in Symfony and in code that uses Symfony components. The PR makes sure we have an updated baseline and that Psalm can be run locally. 

There are many opinions about this topic, I just have one opinion. Here is my suggestion.

## What we really don't want

We don't want to create PRs that add unnecessary comments or code just to please psalm.

## About the psalm errors

Some psalm errors is because we are missing an extension/dependency. Other are because we do strange things; sometimes for [performance](https://github.com/symfony/symfony/blob/a91ac7490644c25eae7deedf5a945c3da01054a7/src/Symfony/Component/Cache/Adapter/AbstractAdapter.php#L45-L49) and sometimes because [no apparent reason](https://github.com/symfony/symfony/blob/e2f1c467348952ab9dbe31b473dcf35015527f1b/src/Symfony/Component/EventDispatcher/EventDispatcher.php#L263-L274). But more importantly, we do have type inconstancies and minor bugs. 

We don't have to fix all psalm errors, we should only fix those that really help Symfony. We should agree on a list of rules of what and how to fix things. Here is a suggestion:

## Rules

Rule 1) Don't add `@psalm-` annotations. "Standard" annotations goes a long way. And when the next super cool static analyser comes around, all the `@psalm-` annotations are obsolete. 

Rule 2) Psalm does not understand complex code. Simple code is easier to maintain but we should never be discouraged to write complex code because of psalm complains. (There should, of course, be a reason to write complex code, ie performance)

Rule 3) No user should ever need to update the baseline and figure out merge conflicts. The baseline will be updated automatically with a PR. (See the GH Action)

Rule 4) Do add comments about enums. Say a function that only returns strings "foo" or "bar". Or another function that only returns integer 1, 2 or 3. This should be documented in the doc block. 

Rule 5) If possible, document array keys on arguments and returns. 

These rules might be incorrect or we might need to extend them. But I do think they are a good start. 