### PR TITLE
[FrameworkBundle] Fix PropertyAccess definition when not in debug

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1983,7 +1983,7 @@ class FrameworkExtension extends Extension
 
             if (!$container->getParameter('kernel.debug')) {
                 $propertyAccessDefinition->setFactory([PropertyAccessor::class, 'createCache']);
-                $propertyAccessDefinition->setArguments([null, 0, $version, new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)]);
+                $propertyAccessDefinition->setArguments(['', 0, $version, new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)]);
                 $propertyAccessDefinition->addTag('cache.pool', ['clearer' => 'cache.system_clearer']);
                 $propertyAccessDefinition->addTag('monolog.logger', ['channel' => 'cache']);
             } else {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

The signature of the `PropertyAccessor::createCache()` method specifies that the first argument must be a string but in the `FrameworkBundle` configures its DIC with a first argument to `null`. Replacing `null` by `''` allows to respect the contact of `PropertyAccessor::createCache()` and removes the following error when the `symfony/framework-bundle` is blocked in `4.4` but the symfony/property-access goes up to `5.2`.

```
Argument 3 passed to Symfony\Component\PropertyAccess\PropertyAccessor::createCache() must be of the type string, null given, called in /usr/src/app/var/cache/prod/ContainerDX7KWI4/getCache_PropertyAccessService.php on line 12
```