### PR TITLE
[Serializer] zero parts can be omitted in date interval input

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DateIntervalNormalizer.php
@@ -105,7 +105,7 @@ class DateIntervalNormalizer implements NormalizerInterface, DenormalizerInterfa
                 $dateIntervalFormat = substr($dateIntervalFormat, 2);
                 break;
         }
-        $valuePattern = '/^'.$signPattern.preg_replace('/%([yYmMdDhHiIsSwW])(\w)/', '(?P<$1>\d+)$2', $dateIntervalFormat).'$/';
+        $valuePattern = '/^'.$signPattern.preg_replace('/%([yYmMdDhHiIsSwW])(\w)/', '(?:(?P<$1>\d+)$2)?', preg_replace('/(T.*)$/', '($1)?', $dateIntervalFormat)).'$/';
         if (!preg_match($valuePattern, $data)) {
             throw new UnexpectedValueException(sprintf('Value "%s" contains intervals not accepted by format "%s".', $data, $dateIntervalFormat));
         }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/DateIntervalNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/DateIntervalNormalizerTest.php
@@ -124,6 +124,14 @@ class DateIntervalNormalizerTest extends TestCase
         $this->doTestDenormalizeUsingFormatPassedInConstructor($format, $input, $output, true);
     }
 
+    public function testDenormalizeIntervalsWithOmittedPartsBeingZero()
+    {
+        $normalizer = new DateIntervalNormalizer();
+
+        $this->assertDateIntervalEquals($this->getInterval('P3Y2M4DT0H0M0S'), $normalizer->denormalize('P3Y2M4D', \DateInterval::class));
+        $this->assertDateIntervalEquals($this->getInterval('P0Y0M0DT12H34M0S'), $normalizer->denormalize('PT12H34M', \DateInterval::class));
+    }
+
     private function doTestDenormalizeUsingFormatPassedInConstructor($format, $input, $output, bool $legacy = false)
     {
         $normalizer = $legacy ? new DateIntervalNormalizer($format) : new DateIntervalNormalizer([DateIntervalNormalizer::FORMAT_KEY => $format]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #35820
| License       | MIT
| Doc PR        | 