### PR TITLE
[Messenger] Doctrine setup with migrations

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/PostgreSqlConnection.php
@@ -87,7 +87,7 @@ final class PostgreSqlConnection extends Connection
     {
         parent::setup();
 
-        $this->executeStatement('BEGIN;'.implode("\n", $this->getTriggerSql()).'COMMIT;');
+        $this->executeStatement(implode("\n", $this->getTriggerSql()));
     }
 
     /**
@@ -109,6 +109,7 @@ final class PostgreSqlConnection extends Connection
     private function getTriggerSql(): array
     {
         return [
+            'BEGIN;',
             sprintf('LOCK TABLE %s;', $this->configuration['table_name']),
             // create trigger function
             sprintf(<<<'SQL'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | 
| Deprecations? | no
| Tickets       | Fix #40130
| License       | MIT
| Doc PR        | 

This PR reverts parts of #40055.

When running these commands, You do need to be in a transaction: 
- `doctrine:schema:create`
- `messenger:setup-transports`
- `doctrine:migrations:diff` and `doctrine:migrations:migrate`

