### PR TITLE
[RateLimiter][Security] Add a `login_throttling.interval` (in `security.firewalls`) option to change the default throttling interval.

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * [BC break] Add `login_throttling.lock_factory` setting defaulting to `null` (instead of `lock.factory`)
+ * Add a `login_throttling.interval` (in `security.firewalls`) option to change the default throttling interval.
  * Add the `debug:firewall` command.
  * Deprecate `UserPasswordEncoderCommand` class and the corresponding `user:encode-password` command,
    use `UserPasswordHashCommand` and `user:hash-password` instead

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -54,6 +54,7 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface, SecurityF
             ->children()
                 ->scalarNode('limiter')->info(sprintf('A service id implementing "%s".', RequestRateLimiterInterface::class))->end()
                 ->integerNode('max_attempts')->defaultValue(5)->end()
+                ->scalarNode('interval')->defaultValue('1 minute')->end()
                 ->scalarNode('lock_factory')->info('The service ID of the lock factory used by the login rate limiter (or null to disable locking)')->defaultNull()->end()
             ->end();
     }
@@ -76,7 +77,7 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface, SecurityF
             $limiterOptions = [
                 'policy' => 'fixed_window',
                 'limit' => $config['max_attempts'],
-                'interval' => '1 minute',
+                'interval' => $config['interval'],
                 'lock_factory' => $config['lock_factory'],
             ];
             FrameworkExtension::registerRateLimiter($container, $localId = '_login_local_'.$firewallName, $limiterOptions);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/login_throttling.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/login_throttling.yml
@@ -10,3 +10,4 @@ security:
         default:
             login_throttling:
                 max_attempts: 1
+                interval: '8 minutes'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 5.x
| Bug fix      |  no
| New feature  | yes
| Deprecations | no
| License       | MIT
| Doc PR        | ⚠️  no doc

The only way to customize the default rate-limiter's options of the login_throttling (means fixed_window / 1 minute / 5 tokens) are through a custom limiter, which implies to declare a rate-limiter factory in the "framework.rate_limiter", a service which use this factory etc. It's really heavy just for changing an interval (moreover, 1 minute can be discutable).
 
In this PullRequest, I just propose to allow an `interval` option. 

Example : 
```yaml
security:
  firewalls:
    main:
       login_throttling:
           max_attempts: 5
           interval: '15 minutes'
```

See functional tests.


🤷🏻‍♂️  This pull-request is a copy of [this pull-request ](https://github.com/symfony/symfony/pull/39927) that I've created some weeks ago. On the original PR, I just needed to rebase on 5.x to pass the tests (fabbot etc.) but the rebase I've tried runs in a loop of conflicts and I'm stuck. I've never experienced this before... SORRY.

