### PR TITLE
[Security] Remove unnecessary inherited doc annotation

### DIFF
--- a/src/Symfony/Component/Security/Core/User/User.php
+++ b/src/Symfony/Component/Security/Core/User/User.php
@@ -83,7 +83,14 @@ final class User implements UserInterface, EquatableInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Checks whether the user's account has expired.
+     *
+     * Internally, if this method returns false, the authentication system
+     * will throw an AccountExpiredException and prevent login.
+     *
+     * @return bool true if the user's account is non expired, false otherwise
+     *
+     * @see AccountExpiredException
      */
     public function isAccountNonExpired(): bool
     {
@@ -91,7 +98,14 @@ final class User implements UserInterface, EquatableInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Checks whether the user is locked.
+     *
+     * Internally, if this method returns false, the authentication system
+     * will throw a LockedException and prevent login.
+     *
+     * @return bool true if the user is not locked, false otherwise
+     *
+     * @see LockedException
      */
     public function isAccountNonLocked(): bool
     {
@@ -99,7 +113,14 @@ final class User implements UserInterface, EquatableInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Checks whether the user's credentials (password) has expired.
+     *
+     * Internally, if this method returns false, the authentication system
+     * will throw a CredentialsExpiredException and prevent login.
+     *
+     * @return bool true if the user's credentials are non expired, false otherwise
+     *
+     * @see CredentialsExpiredException
      */
     public function isCredentialsNonExpired(): bool
     {
@@ -107,7 +128,14 @@ final class User implements UserInterface, EquatableInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Checks whether the user is enabled.
+     *
+     * Internally, if this method returns false, the authentication system
+     * will throw a DisabledException and prevent login.
+     *
+     * @return bool true if the user is enabled, false otherwise
+     *
+     * @see DisabledException
      */
     public function isEnabled(): bool
     {


### PR DESCRIPTION
Removes unnecessary inherited doc annotation from php doc from the methods that are not inherited from any parent class/interface.
Adds Doc blocks from the relevant methods in the `AdvancedUserInterface` (Removed in 5.0).

| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
