### PR TITLE
Specify that we run CI on Ubuntu-20.04

### DIFF
--- a/.github/workflows/intl-data-tests.yml
+++ b/.github/workflows/intl-data-tests.yml
@@ -15,7 +15,7 @@ defaults:
 jobs:
   tests:
     name: Tests (intl-data)
-    runs-on: ubuntu-latest
+    runs-on: Ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/phpunit-bridge.yml
+++ b/.github/workflows/phpunit-bridge.yml
@@ -15,7 +15,7 @@ defaults:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: Ubuntu-20.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
   integration:
     name: Integration
-    runs-on: ubuntu-latest
+    runs-on: Ubuntu-20.04
 
     strategy:
       matrix:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This will remove the warning when we run the CI. This will also explicitly show what operating system we run the test on. Currently we just say: "Whatever Ubuntu Github decides"...