### PR TITLE
[Validator] UniqueValidator: Add duplicate value as message parameter

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
@@ -43,6 +43,7 @@ class UniqueValidator extends ConstraintValidator
             if (\in_array($element, $collectionElements, true)) {
                 $this->context->buildViolation($constraint->message)
                     ->setParameter('{{ value }}', $this->formatValue($value))
+                    ->setParameter('{{ duplicate_value }}', $this->formatValue($element, self::OBJECT_TO_STRING))
                     ->setCode(Unique::IS_NOT_UNIQUE)
                     ->addViolation();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40305
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/15038/files

Add `duplicate_value` message parameter to the `UniqueValidator`, as the only parameter is for the entire collection.
I opted to base this against 4.4 as I consider it a bug and that's the PR that was opened for the docs, but I can change to 5 if needed.

Thank you!