### PR TITLE
[FrameworkBundle] Make the TestBrowserToken interchangeable with other tokens

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -120,7 +120,7 @@ class KernelBrowser extends HttpKernelBrowser
             throw new \LogicException(sprintf('The first argument of "%s" must be instance of "%s", "%s" provided.', __METHOD__, UserInterface::class, \is_object($user) ? \get_class($user) : \gettype($user)));
         }
 
-        $token = new TestBrowserToken($user->getRoles(), $user);
+        $token = new TestBrowserToken($user->getRoles(), $user, $firewallContext);
         $token->setAuthenticated(true);
         $session = $this->getContainer()->get('session');
         $session->set('_security_'.$firewallContext, serialize($token));

--- a/src/Symfony/Bundle/FrameworkBundle/Test/TestBrowserToken.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/TestBrowserToken.php
@@ -21,13 +21,22 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 class TestBrowserToken extends AbstractToken
 {
-    public function __construct(array $roles = [], UserInterface $user = null)
+    private $firewallName;
+
+    public function __construct(array $roles = [], UserInterface $user = null, string $firewallName = 'main')
     {
         parent::__construct($roles);
 
         if (null !== $user) {
             $this->setUser($user);
         }
+
+        $this->firewallName = $firewallName;
+    }
+
+    public function getFirewallName(): string
+    {
+        return $this->firewallName;
     }
 
     public function getCredentials()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

For some reason most tokens implement getFirewallName (and the deprecated getProviderKey), but not all. This adds it to TestBrowserToken because it caused issues in my tests when upgrading to Symfony 5's `Client::loginUser()`. 

I am also happy to add this to AnonymousToken but I am more worried about BC impacts there, so I left it alone for now. All other token classes implement it, so I am not sure why this isn't in TokenInterface to begin with.