### PR TITLE
Check if templating engine supports given view

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerTrait.php
@@ -207,7 +207,7 @@ trait ControllerTrait
      */
     protected function renderView(string $view, array $parameters = []): string
     {
-        if ($this->container->has('templating')) {
+        if ($this->container->has('templating') && $this->container->get('templating')->supports($view)) {
             @trigger_error('Using the "templating" service is deprecated since version 4.3 and will be removed in 5.0; use Twig instead.', \E_USER_DEPRECATED);
 
             return $this->container->get('templating')->render($view, $parameters);
@@ -227,7 +227,7 @@ trait ControllerTrait
      */
     protected function render(string $view, array $parameters = [], Response $response = null): Response
     {
-        if ($this->container->has('templating')) {
+        if ($this->container->has('templating') && $this->container->get('templating')->supports($view)) {
             @trigger_error('Using the "templating" service is deprecated since version 4.3 and will be removed in 5.0; use Twig instead.', \E_USER_DEPRECATED);
 
             $content = $this->container->get('templating')->render($view, $parameters);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
@@ -449,6 +449,7 @@ abstract class ControllerTraitTest extends TestCase
     {
         $templating = $this->createMock(EngineInterface::class);
         $templating->expects($this->once())->method('render')->willReturn('bar');
+        $templating->expects($this->once())->method('supports')->willReturn(true);
 
         $container = new Container();
         $container->set('templating', $templating);
@@ -466,6 +467,7 @@ abstract class ControllerTraitTest extends TestCase
     {
         $templating = $this->createMock(EngineInterface::class);
         $templating->expects($this->once())->method('render')->willReturn('bar');
+        $templating->expects($this->once())->method('supports')->willReturn(true);
 
         $container = new Container();
         $container->set('templating', $templating);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently the `ControllerTrait::render` and `ControllerTrait::renderView` methods assume that when the `templating` service is available it can always render the given view via that service.

However, that might not be the case. For example if `framework.templating` is not configured to support the `twig` engine for example but only some other custom engine, e.g.

```yaml
framework:
  templating:
    engines: 
      - foobar
```

it will fail when the given view references a Twig template for instance and the configured engine cannot render that.

The `Symfony\Component\Templating\EngineInterface` which `templating` implements defines a `support` method: 

https://github.com/symfony/symfony/blob/2536e178b183aeece7ac1e8e9195d6004025f25e/src/Symfony/Component/Templating/EngineInterface.php#L56-L63

which should be used here, in order to make sure that `templating` actually does support rendering the given view.
