### PR TITLE
[Notifier] [OvhCloud] Add "sender"

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.3
 ---
 
+ * Add "sender" option to the DSN that allows configuring the sender
  * The bridge is not marked as `@experimental` anymore
 
 5.1.0

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 5.3
 ---
 
- * Add "sender" option to the DSN that allows configuring the sender
+ * Add `sender` option to the DSN that allows configuring the sender
  * The bridge is not marked as `@experimental` anymore
 
 5.1.0

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -31,19 +31,25 @@ final class OvhCloudTransport extends AbstractTransport
     private $applicationSecret;
     private $consumerKey;
     private $serviceName;
+    private $sender;
 
-    public function __construct(string $applicationKey, string $applicationSecret, string $consumerKey, string $serviceName, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $applicationKey, string $applicationSecret, string $consumerKey, string $serviceName, string $sender = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->applicationKey = $applicationKey;
         $this->applicationSecret = $applicationSecret;
         $this->consumerKey = $consumerKey;
         $this->serviceName = $serviceName;
+        $this->sender = $sender;
 
         parent::__construct($client, $dispatcher);
     }
 
     public function __toString(): string
     {
+        if (null !== $this->sender) {
+            return sprintf('ovhcloud://%s?consumer_key=%s&service_name=%s&sender=%s', $this->getEndpoint(), $this->consumerKey, $this->serviceName, $this->sender);
+        }
+
         return sprintf('ovhcloud://%s?consumer_key=%s&service_name=%s', $this->getEndpoint(), $this->consumerKey, $this->serviceName);
     }
 
@@ -68,8 +74,13 @@ final class OvhCloudTransport extends AbstractTransport
             'receivers' => [$message->getPhone()],
             'noStopClause' => false,
             'priority' => 'medium',
-            'senderForResponse' => true,
         ];
+
+        if ($this->sender) {
+            $content['sender'] = $this->sender;
+        } else {
+            $content['senderForResponse'] = true;
+        }
 
         $now = time() + $this->calculateTimeDelta();
         $headers['X-Ovh-Application'] = $this->applicationKey;

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransport.php
@@ -33,13 +33,12 @@ final class OvhCloudTransport extends AbstractTransport
     private $serviceName;
     private $sender;
 
-    public function __construct(string $applicationKey, string $applicationSecret, string $consumerKey, string $serviceName, string $sender = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(string $applicationKey, string $applicationSecret, string $consumerKey, string $serviceName, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->applicationKey = $applicationKey;
         $this->applicationSecret = $applicationSecret;
         $this->consumerKey = $consumerKey;
         $this->serviceName = $serviceName;
-        $this->sender = $sender;
 
         parent::__construct($client, $dispatcher);
     }
@@ -51,6 +50,13 @@ final class OvhCloudTransport extends AbstractTransport
         }
 
         return sprintf('ovhcloud://%s?consumer_key=%s&service_name=%s', $this->getEndpoint(), $this->consumerKey, $this->serviceName);
+    }
+
+    public function setSender(?string $sender): self
+    {
+        $this->sender = $sender;
+
+        return $this;
     }
 
     public function supports(MessageInterface $message): bool

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransportFactory.php
@@ -37,7 +37,7 @@ final class OvhCloudTransportFactory extends AbstractTransportFactory
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new OvhCloudTransport($applicationKey, $applicationSecret, $consumerKey, $serviceName, $sender, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new OvhCloudTransport($applicationKey, $applicationSecret, $consumerKey, $serviceName, $this->client, $this->dispatcher))->setHost($host)->setPort($port)->setSender($sender);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/OvhCloudTransportFactory.php
@@ -33,10 +33,11 @@ final class OvhCloudTransportFactory extends AbstractTransportFactory
         $applicationSecret = $this->getPassword($dsn);
         $consumerKey = $dsn->getRequiredOption('consumer_key');
         $serviceName = $dsn->getRequiredOption('service_name');
+        $sender = $dsn->getOption('sender');
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 
-        return (new OvhCloudTransport($applicationKey, $applicationSecret, $consumerKey, $serviceName, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+        return (new OvhCloudTransport($applicationKey, $applicationSecret, $consumerKey, $serviceName, $sender, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
     }
 
     protected function getSupportedSchemes(): array

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/README.md
@@ -7,7 +7,7 @@ DSN example
 -----------
 
 ```
-OVHCLOUD_DSN=ovhcloud://APPLICATION_KEY:APPLICATION_SECRET@default?consumer_key=CONSUMER_KEY&service_name=SERVICE_NAME&SENDER=SENDER
+OVHCLOUD_DSN=ovhcloud://APPLICATION_KEY:APPLICATION_SECRET@default?consumer_key=CONSUMER_KEY&service_name=SERVICE_NAME&sender=SENDER
 ```
 
 where:

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/README.md
@@ -7,7 +7,7 @@ DSN example
 -----------
 
 ```
-OVHCLOUD_DSN=ovhcloud://APPLICATION_KEY:APPLICATION_SECRET@default?consumer_key=CONSUMER_KEY&service_name=SERVICE_NAME
+OVHCLOUD_DSN=ovhcloud://APPLICATION_KEY:APPLICATION_SECRET@default?consumer_key=CONSUMER_KEY&service_name=SERVICE_NAME&SENDER=SENDER
 ```
 
 where:
@@ -15,6 +15,7 @@ where:
 - `APPLICATION_SECRET` is your OvhCloud application secret
 - `CONSUMER_KEY` is your OvhCloud consumer key
 - `SERVICE_NAME` is your OvhCloud service name
+- `SENDER` is your sender (optional)
 
 Resources
 ---------

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportFactoryTest.php
@@ -31,12 +31,17 @@ final class OvhCloudTransportFactoryTest extends TransportFactoryTestCase
             'ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName',
             'ovhcloud://key:secret@host.test?consumer_key=consumerKey&service_name=serviceName',
         ];
+
+        yield [
+            'ovhcloud://host.test?consumer_key=consumerKey&service_name=serviceName&sender=sender',
+            'ovhcloud://key:secret@host.test?consumer_key=consumerKey&service_name=serviceName&sender=sender',
+        ];
     }
 
     public function supportsProvider(): iterable
     {
-        yield [true, 'ovhcloud://key:secret@default?consumer_key=consumerKey&service_name=serviceName'];
-        yield [false, 'somethingElse://key:secret@default?consumer_key=consumerKey&service_name=serviceName'];
+        yield [true, 'ovhcloud://key:secret@default?consumer_key=consumerKey&service_name=serviceName&sender=sender'];
+        yield [false, 'somethingElse://key:secret@default?consumer_key=consumerKey&service_name=serviceName&sender=sender'];
     }
 
     public function missingRequiredOptionProvider(): iterable
@@ -47,8 +52,9 @@ final class OvhCloudTransportFactoryTest extends TransportFactoryTestCase
 
     public function unsupportedSchemeProvider(): iterable
     {
-        yield ['somethingElse://key:secret@default?consumer_key=consumerKey&service_name=serviceName'];
+        yield ['somethingElse://key:secret@default?consumer_key=consumerKey&service_name=serviceName&sender=sender'];
         yield ['somethingElse://key:secret@default?service_name=serviceName'];
         yield ['somethingElse://key:secret@default?consumer_key=consumerKey'];
+        yield ['somethingElse://key:secret@default?sender=sender'];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
@@ -26,14 +26,15 @@ final class OvhCloudTransportTest extends TransportTestCase
     /**
      * @return OvhCloudTransport
      */
-    public function createTransport(?HttpClientInterface $client = null): TransportInterface
+    public function createTransport(?HttpClientInterface $client = null, string $sender = null): TransportInterface
     {
-        return new OvhCloudTransport('applicationKey', 'applicationSecret', 'consumerKey', 'serviceName', $client ?: $this->createMock(HttpClientInterface::class));
+        return new OvhCloudTransport('applicationKey', 'applicationSecret', 'consumerKey', 'serviceName', $sender, $client ?: $this->createMock(HttpClientInterface::class));
     }
 
     public function toStringProvider(): iterable
     {
         yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName', $this->createTransport()];
+        yield ['ovhcloud://eu.api.ovh.com?consumer_key=consumerKey&service_name=serviceName&sender=sender', $this->createTransport(null, 'sender')];
     }
 
     public function supportedMessagesProvider(): iterable

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
@@ -28,7 +28,7 @@ final class OvhCloudTransportTest extends TransportTestCase
      */
     public function createTransport(?HttpClientInterface $client = null, string $sender = null): TransportInterface
     {
-        return new OvhCloudTransport('applicationKey', 'applicationSecret', 'consumerKey', 'serviceName', $sender, $client ?: $this->createMock(HttpClientInterface::class));
+        return (new OvhCloudTransport('applicationKey', 'applicationSecret', 'consumerKey', 'serviceName', $client ?: $this->createMock(HttpClientInterface::class)))->setSender($sender);
     }
 
     public function toStringProvider(): iterable

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
@@ -26,7 +26,7 @@ final class OvhCloudTransportTest extends TransportTestCase
     /**
      * @return OvhCloudTransport
      */
-    public function createTransport(?HttpClientInterface $client = null, string $sender = null): TransportInterface
+    public function createTransport(?HttpClientInterface $client = null, ?string $sender = null): TransportInterface
     {
         return (new OvhCloudTransport('applicationKey', 'applicationSecret', 'consumerKey', 'serviceName', $client ?: $this->createMock(HttpClientInterface::class)))->setSender($sender);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features --> (I'm waiting to see if the feature is accepted )

Add "sender" option to the DSN that allows configuring the sender of the message.

OVHCloud manages two cases for sending sms according to the [doc](https://docs.ovh.com/fr/sms/envoyer_des_sms_avec_lapi_ovh_en_php/):

> The senderForResponse parameter will allow the use of a short number, which allows you to send SMS directly without having to create an alphanumeric sender (for example: your name).
> Short numbers also allow you to receive responses from the recipients of your SMS, which can be useful for a satisfaction survey, a voting application, a game, etc. 

![CleanShot 2021-03-05 at 13 26 33](https://user-images.githubusercontent.com/523981/110115554-84c5af80-7db6-11eb-815d-7e8bafa81e5d.png)

This PR introduces the management of these 2 cases with a new option `sender`:
* if `sender` is set, we use it
* if `sender` is not set, we use `senderForResponse` to get a short number (current behavior)

I took the logic implementedin the old official SDK : https://github.com/ovh/php-ovh-sms/blob/52d279e112a7da8f897745acab32a887321e03f1/src/Message.php#L161