### PR TITLE
Changing ZulipTransportFactory tag to prevent the exception UnsupportedSchemeException

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -89,7 +89,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set('notifier.transport_factory.zulip', ZulipTransportFactory::class)
             ->parent('notifier.transport_factory.abstract')
-            ->tag('texter.transport_factory')
+            ->tag('chatter.transport_factory')
 
         ->set('notifier.transport_factory.infobip', InfobipTransportFactory::class)
             ->parent('notifier.transport_factory.abstract')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #40374 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
Changing ZulipTransportFactory to 'chatter.transport_factory' to prevent the exception UnsupportedSchemeException "The "zulip" scheme is not supported."