### PR TITLE
[DependencyInjection] Implement psr/container 1.1

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/TestContainer.php
@@ -93,7 +93,7 @@ class TestContainer extends Container
     /**
      * {@inheritdoc}
      */
-    public function has($id): bool
+    public function has(string $id): bool
     {
         return $this->getPublicContainer()->has($id) || $this->getPrivateContainer()->has($id);
     }
@@ -101,7 +101,7 @@ class TestContainer extends Container
     /**
      * {@inheritdoc}
      */
-    public function get($id, int $invalidBehavior = /* self::EXCEPTION_ON_INVALID_REFERENCE */ 1): ?object
+    public function get(string $id, int $invalidBehavior = /* self::EXCEPTION_ON_INVALID_REFERENCE */ 1): ?object
     {
         return $this->getPrivateContainer()->has($id) ? $this->getPrivateContainer()->get($id) : $this->getPublicContainer()->get($id, $invalidBehavior);
     }

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -192,7 +192,7 @@ class Container implements ContainerInterface, ResetInterface
      *
      * @return bool true if the service is defined, false otherwise
      */
-    public function has($id)
+    public function has(string $id)
     {
         if (isset($this->aliases[$id])) {
             $id = $this->aliases[$id];
@@ -221,7 +221,7 @@ class Container implements ContainerInterface, ResetInterface
      *
      * @see Reference
      */
-    public function get($id, int $invalidBehavior = /* self::EXCEPTION_ON_INVALID_REFERENCE */ 1)
+    public function get(string $id, int $invalidBehavior = /* self::EXCEPTION_ON_INVALID_REFERENCE */ 1)
     {
         return $this->services[$id]
             ?? $this->services[$id = $this->aliases[$id] ?? $id]

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -517,10 +517,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @return bool true if the service is defined, false otherwise
      */
-    public function has($id)
+    public function has(string $id)
     {
-        $id = (string) $id;
-
         return isset($this->definitions[$id]) || isset($this->aliasDefinitions[$id]) || parent::has($id);
     }
 
@@ -539,9 +537,9 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @see Reference
      */
-    public function get($id, int $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE)
+    public function get(string $id, int $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE)
     {
-        if ($this->isCompiled() && isset($this->removedIds[$id = (string) $id]) && ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE >= $invalidBehavior) {
+        if ($this->isCompiled() && isset($this->removedIds[$id]) && ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE >= $invalidBehavior) {
             return parent::get($id);
         }
 

--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -48,7 +48,7 @@ interface ContainerInterface extends PsrContainerInterface
      *
      * @see Reference
      */
-    public function get($id, int $invalidBehavior = self::EXCEPTION_ON_INVALID_REFERENCE);
+    public function get(string $id, int $invalidBehavior = self::EXCEPTION_ON_INVALID_REFERENCE);
 
     /**
      * Returns true if the given service is defined.
@@ -57,7 +57,7 @@ interface ContainerInterface extends PsrContainerInterface
      *
      * @return bool true if the service is defined, false otherwise
      */
-    public function has($id);
+    public function has(string $id);
 
     /**
      * Check for whether or not a service has been initialized.

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "psr/container": "^1.0",
+        "psr/container": "^1.1.1",
         "symfony/deprecation-contracts": "^2.1",
         "symfony/polyfill-php80": "^1.15",
         "symfony/service-contracts": "^1.1.6|^2"

--- a/src/Symfony/Contracts/Service/ServiceLocatorTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceLocatorTrait.php
@@ -43,7 +43,7 @@ trait ServiceLocatorTrait
      *
      * @return bool
      */
-    public function has($id)
+    public function has(string $id)
     {
         return isset($this->factories[$id]);
     }
@@ -53,7 +53,7 @@ trait ServiceLocatorTrait
      *
      * @return mixed
      */
-    public function get($id)
+    public function get(string $id)
     {
         if (!isset($this->factories[$id])) {
             throw $this->createNotFoundException($id);

--- a/src/Symfony/Contracts/Service/composer.json
+++ b/src/Symfony/Contracts/Service/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "psr/container": "^1.0"
+        "psr/container": "^1.1"
     },
     "suggest": {
         "symfony/service-implementation": ""

--- a/src/Symfony/Contracts/composer.json
+++ b/src/Symfony/Contracts/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "psr/cache": "^1.0|^2.0|^3.0",
-        "psr/container": "^1.0",
+        "psr/container": "^1.1",
         "psr/event-dispatcher": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The `psr/container` interfaces have been updated with type declarations. The lack of those is what kept us from adding property type declarations to the `get()` and `has()` methods of our own `ContainerInterface`.

A small BC break is that we have never prevented calling code from passing `null` as the service ID. Even without strict types, this will cause a `TypeError` after my changes. I already had to update `AutowirePass` because of that.

On the other hand, it was neither documented that we allow `null` here nor did the container do anything useful (`has(null)` always resulted in `false` and `get(null)` always returned `null`).