### PR TITLE
[DependencyInjection][Security] Backport psr/container 1.1/2.0 compatibility

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -146,7 +146,7 @@ class AutowirePass extends AbstractRecursivePass
         $this->decoratedClass = null;
         $this->getPreviousValue = null;
 
-        if ($isRoot && ($definition = $this->container->getDefinition($this->currentId)) && $this->container->has($this->decoratedId = $definition->innerServiceId)) {
+        if ($isRoot && ($definition = $this->container->getDefinition($this->currentId)) && null !== ($this->decoratedId = $definition->innerServiceId) && $this->container->has($this->decoratedId)) {
             $this->decoratedClass = $this->container->findDefinition($this->decoratedId)->getClass();
         }
 

--- a/src/Symfony/Component/Security/Core/composer.json
+++ b/src/Symfony/Component/Security/Core/composer.json
@@ -21,7 +21,7 @@
         "symfony/service-contracts": "^1.1.6|^2"
     },
     "require-dev": {
-        "psr/container": "^1.0",
+        "psr/container": "^1.0|^2.0",
         "symfony/event-dispatcher": "^4.3",
         "symfony/expression-language": "^3.4|^4.0|^5.0",
         "symfony/http-foundation": "^3.4|^4.0|^5.0",

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -30,7 +30,7 @@
         "symfony/security-http": "self.version"
     },
     "require-dev": {
-        "psr/container": "^1.0",
+        "psr/container": "^1.0|^2.0",
         "symfony/finder": "^3.4|^4.0|^5.0",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-intl-icu": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/pull/40384/files#r588494278
| License       | MIT
| Doc PR        | N/A

This PR backports a fix that I had to apply to the 5.x branch in order to make it compatible with the `psr/container` 1.1 interfaces.

It also updates various composer.json files:
* Security Core only consumes a PSR `ContainerInterface` without providing its own implementation. I should be compatible with version 2 of the PSR package already.
* ~~DependencyInjection breaks on PHP 7.2 and 7.3 if `psr/container` 1.1.0 is installed. A version 1.1.1 has already been release that fixes the issue. I've added a conflict rule to document the incompatibility.~~