### PR TITLE
[ErrorHandler] Added missing type annotations to FlattenException

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
+++ b/src/Symfony/Component/ErrorHandler/Exception/FlattenException.php
@@ -26,17 +26,40 @@ use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
  */
 class FlattenException extends LegacyFlattenException
 {
+    /** @var string */
     private $message;
+
+    /** @var int|string */
     private $code;
+
+    /** @var self|null */
     private $previous;
+
+    /** @var array */
     private $trace;
+
+    /** @var string */
     private $traceAsString;
+
+    /** @var string */
     private $class;
+
+    /** @var int */
     private $statusCode;
+
+    /** @var string */
     private $statusText;
+
+    /** @var array */
     private $headers;
+
+    /** @var string */
     private $file;
+
+    /** @var int */
     private $line;
+
+    /** @var string|null */
     private $asString;
 
     public static function create(\Exception $exception, $statusCode = null, array $headers = []): self
@@ -104,6 +127,8 @@ class FlattenException extends LegacyFlattenException
     }
 
     /**
+     * @param int $code
+     *
      * @return $this
      */
     public function setStatusCode($code): self
@@ -134,6 +159,8 @@ class FlattenException extends LegacyFlattenException
     }
 
     /**
+     * @param string $class
+     *
      * @return $this
      */
     public function setClass($class): self
@@ -149,6 +176,8 @@ class FlattenException extends LegacyFlattenException
     }
 
     /**
+     * @param string $file
+     *
      * @return $this
      */
     public function setFile($file): self
@@ -164,6 +193,8 @@ class FlattenException extends LegacyFlattenException
     }
 
     /**
+     * @param int $line
+     *
      * @return $this
      */
     public function setLine($line): self
@@ -191,6 +222,8 @@ class FlattenException extends LegacyFlattenException
     }
 
     /**
+     * @param string $message
+     *
      * @return $this
      */
     public function setMessage($message): self
@@ -215,6 +248,8 @@ class FlattenException extends LegacyFlattenException
     }
 
     /**
+     * @param int|string $code
+     *
      * @return $this
      */
     public function setCode($code): self
@@ -282,6 +317,10 @@ class FlattenException extends LegacyFlattenException
     }
 
     /**
+     * @param array       $trace
+     * @param string|null $file
+     * @param int|null    $line
+     *
      * @return $this
      */
     public function setTrace($trace, $file, $line): self


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40385
| License       | MIT
| Doc PR        | N/A

This class has no constructor where the properties' types could be inferred from. If we want potential contributors (and our serializer, see #40385) to read that code, I think it's only fair that we document the property types via doc blocks.