### PR TITLE
[Messenger] Messenger/Doctrine: Use DateTimeImmutable instead of DateTime

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -121,8 +121,8 @@ class Connection implements ResetInterface
      */
     public function send(string $body, array $headers, int $delay = 0): string
     {
-        $now = new \DateTime();
-        $availableAt = (clone $now)->modify(sprintf('+%d seconds', $delay / 1000));
+        $now = new \DateTimeImmutable();
+        $availableAt = $now->modify(sprintf('+%d seconds', $delay / 1000));
 
         $queryBuilder = $this->driverConnection->createQueryBuilder()
             ->insert($this->configuration['table_name'])
@@ -144,8 +144,8 @@ class Connection implements ResetInterface
             null,
             null,
             null,
-            Types::DATETIME_MUTABLE,
-            Types::DATETIME_MUTABLE,
+            Types::DATETIME_IMMUTABLE,
+            Types::DATETIME_IMMUTABLE,
         ]);
 
         return $this->driverConnection->lastInsertId();
@@ -198,12 +198,12 @@ class Connection implements ResetInterface
                 ->update($this->configuration['table_name'])
                 ->set('delivered_at', '?')
                 ->where('id = ?');
-            $now = new \DateTime();
+            $now = new \DateTimeImmutable();
             $this->executeStatement($queryBuilder->getSQL(), [
                 $now,
                 $doctrineEnvelope['id'],
             ], [
-                Types::DATETIME_MUTABLE,
+                Types::DATETIME_IMMUTABLE,
             ]);
 
             $this->driverConnection->commit();
@@ -313,8 +313,8 @@ class Connection implements ResetInterface
 
     private function createAvailableMessagesQueryBuilder(): QueryBuilder
     {
-        $now = new \DateTime();
-        $redeliverLimit = (clone $now)->modify(sprintf('-%d seconds', $this->configuration['redeliver_timeout']));
+        $now = new \DateTimeImmutable();
+        $redeliverLimit = $now->modify(sprintf('-%d seconds', $this->configuration['redeliver_timeout']));
 
         return $this->createQueryBuilder()
             ->where('m.delivered_at is null OR m.delivered_at < ?')
@@ -325,8 +325,8 @@ class Connection implements ResetInterface
                 $now,
                 $this->configuration['queue_name'],
             ], [
-                Types::DATETIME_MUTABLE,
-                Types::DATETIME_MUTABLE,
+                Types::DATETIME_IMMUTABLE,
+                Types::DATETIME_IMMUTABLE,
             ]);
     }
 
@@ -406,11 +406,11 @@ class Connection implements ResetInterface
         $table->addColumn('queue_name', Types::STRING)
             ->setLength(190) // MySQL 5.6 only supports 191 characters on an indexed column in utf8mb4 mode
             ->setNotnull(true);
-        $table->addColumn('created_at', Types::DATETIME_MUTABLE)
+        $table->addColumn('created_at', Types::DATETIME_IMMUTABLE)
             ->setNotnull(true);
-        $table->addColumn('available_at', Types::DATETIME_MUTABLE)
+        $table->addColumn('available_at', Types::DATETIME_IMMUTABLE)
             ->setNotnull(true);
-        $table->addColumn('delivered_at', Types::DATETIME_MUTABLE)
+        $table->addColumn('delivered_at', Types::DATETIME_IMMUTABLE)
             ->setNotnull(false);
         $table->setPrimaryKey(['id']);
         $table->addIndex(['queue_name']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no - but maybe should be treated as such?
| Deprecations? | no - I don't think I'm breaking any BC
| License       | MIT / Do whatever you want with it
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I know that Derick thinks that DateTime should have been immutable from the start. After having experienced some nasty bugs myself I decided to no longer use DateTime and only use DateTimeImmutable in my projects.

To accomplish this, I configured Doctrine as follows:
```yaml
doctrine:
    dbal:
        types:
            date: Doctrine\DBAL\Types\DateImmutableType
            datetime: Doctrine\DBAL\Types\DateTimeImmutableType
            datetimetz: Doctrine\DBAL\Types\DateTimeTzImmutableType
            time: Doctrine\DBAL\Types\TimeImmutableType
```

This lead to an error when using doctrine-messenger because it defaults to DateTime instead of DateTimeImmutable. I'm not sure if this is an MR you could/would merge,  let alone in a minor release branch, but one can always try :)

If this looks like something you would be willing to consider, I suppose I'd at least need to fix a test that asserts this change. Any other guidance is appreciated.