### PR TITLE
[FrameworkBundle] [4.4]: Fix method name compare in ResolveControllerNameSubscriber

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/ResolveControllerNameSubscriber.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/ResolveControllerNameSubscriber.php
@@ -48,7 +48,7 @@ class ResolveControllerNameSubscriber implements EventSubscriberInterface
 
     public function __call(string $method, array $args)
     {
-        if ('onKernelRequest' !== $method && 'onKernelRequest' !== strtolower($method)) {
+        if ('onKernelRequest' !== $method && 'onkernelrequest' !== strtolower($method)) {
             throw new \Error(sprintf('Error: Call to undefined method "%s::%s()".', static::class, $method));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

The left side to `strtolower` was not actually lowercased, so it would be always `false`.

The bug was introduced in https://github.com/symfony/symfony/commit/6c109c71a9c181211932a058f2f6c7275144f593 (https://github.com/symfony/symfony/pull/31938)

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
