### PR TITLE
[WebLink] Removed unused property

### DIFF
--- a/src/Symfony/Component/WebLink/Link.php
+++ b/src/Symfony/Component/WebLink/Link.php
@@ -99,7 +99,6 @@ class Link implements EvolvableLinkInterface
     {
         $that = clone $this;
         $that->href = $href;
-        $that->templated = $this->hrefIsTemplated($href);
 
         return $that;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

In `Link::withHref()`, a property `templated` is written, that is never declared or accessed anywhere else. I assume that this is dead code.