### PR TITLE
[Translation] Fix return PHPDoc of TranslatorBagInterface

### DIFF
--- a/src/Symfony/Component/Translation/TranslatorBagInterface.php
+++ b/src/Symfony/Component/Translation/TranslatorBagInterface.php
@@ -25,7 +25,7 @@ interface TranslatorBagInterface
      *
      * @param string|null $locale The locale or null to use the default
      *
-     * @return MessageCatalogueInterface
+     * @return MessageCatalogueInterface|null
      *
      * @throws InvalidArgumentException If the locale contains invalid characters
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

Fixing return type for `TranslatorBagInterface::getCatalogue`, it could be null if no catalogue exists for the passed locale.
