### PR TITLE
[HttpFoundation] Change JsonResponse default encoding options

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -29,7 +29,7 @@ class JsonResponse extends Response
 
     public const DEFAULT_ENCODING_OPTIONS = 0;
 
-    protected $encodingOptions = 0;
+    protected $encodingOptions = self::DEFAULT_ENCODING_OPTIONS;
 
     /**
      * @param mixed $data    The response data

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -27,11 +27,9 @@ class JsonResponse extends Response
     protected $data;
     protected $callback;
 
-    // Encode <, >, ', &, and " characters in the JSON, making it also safe to be embedded into HTML.
-    // 15 === JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT
-    public const DEFAULT_ENCODING_OPTIONS = 15;
+    public const DEFAULT_ENCODING_OPTIONS = 0;
 
-    protected $encodingOptions = self::DEFAULT_ENCODING_OPTIONS;
+    protected $encodingOptions = 0;
 
     /**
      * @param mixed $data    The response data

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -202,18 +202,11 @@ class JsonResponseTest extends TestCase
         $this->assertEquals('text/javascript', $response->headers->get('Content-Type'));
     }
 
-    public function testJsonEncodeFlags()
-    {
-        $response = new JsonResponse('<>\'&"');
-
-        $this->assertEquals('"\u003C\u003E\u0027\u0026\u0022"', $response->getContent());
-    }
-
     public function testGetEncodingOptions()
     {
         $response = new JsonResponse();
 
-        $this->assertEquals(\JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_AMP | \JSON_HEX_QUOT, $response->getEncodingOptions());
+        $this->assertEquals(0, $response->getEncodingOptions());
     }
 
     public function testSetEncodingOptions()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes? I'm not sure about that
| License       | MIT

The use of `JSON_HEX_TAG`, `JSON_HEX_APOS`, `JSON_HEX_AMP` and `JSON_HEX_QUOT` flags in the `json_encode` function does not convert <, >, ', &, and " characters into HTML entities but encode them into Unicode characters, which does absolutely not make the JSON safer to be embedded into HTML, but makes it unreadable for a browser.
Example in an HTML page: `&amp;` (HTML entity of "&") outputs `&` but `\u0026` (Unicode translation of "&") outputs `\u0026`.

Also, by using JavaScript to get the data from an API endpoint, the JSON data is parsed and all Unicode characters are automatically converted to normal characters. RFC 7159 allows any character in a JSON string to be escaped, so the JSON parser knows that any character could have been escaped or converted to Unicode.

In this case, these flags are absolutely unnecessary and make the JSON response bigger to load due to the unnecessary added characters.

**If you really want to write JSON data directly to HTML, you can use the `htmlspecialchars` function to make it safe to be embedded.**

These flags have been originally added here to write JSON data directly to JavaScript (and not directly to HTML), which is a bad practice.
Example:
```php
<script>
    var data = <?= json_encode(['data' => 'insecure data']) ?>
</script>
```
This is very insecure as it could be a potential SQL injection vulnerability. So we need to add flags to escape special characters.
```php
<script>
    var data = <?= json_encode(['data' => 'insecure data'], JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT) ?>
</script>
```
But this is still a bad practice and should be replaced by one of these solutions:
- Use AJAX to get the data you need from the server.
- Echo the data into the page somewhere, and use JavaScript to get the information from the DOM.

**If you really want to keep this bad practice with Symfony, you can manually set the flags by calling the `setEncodingOptions` method of JsonResponse, or by changing the `DEFAULT_ENCODING_OPTIONS` constant.**