### PR TITLE
Fix `ConstraintViolation#getPropertyPath()` to always return `string`

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -140,7 +140,7 @@ class ConstraintViolation implements ConstraintViolationInterface
      */
     public function getPropertyPath()
     {
-        return $this->propertyPath;
+        return (string) $this->propertyPath;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
@@ -156,4 +156,19 @@ EOF;
             null
         );
     }
+
+    public function testRetrievedPropertyPathIsAStringEvenIfNotSet()
+    {
+        self::assertSame(
+            '',
+            (new ConstraintViolation(
+                'irrelevant',
+                '',
+                [],
+                'irrelevant',
+                null,
+                null
+            ))->getPropertyPath()
+        );
+    }
 }


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |
    
`ConstraintViolation#getPropertyPath()`'s inherited signature states that `string` is
to be returned by it at all times, yet the implementation returns `null` when no property
path had been provided at instantiation.

This patch obviates it, returning an empty string when the
property path is `null`.
