### PR TITLE
Fix `ConstraintViolation#getMessageTemplate()` to always return `string`

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -100,7 +100,7 @@ class ConstraintViolation implements ConstraintViolationInterface
      */
     public function getMessageTemplate()
     {
-        return $this->messageTemplate;
+        return (string) $this->messageTemplate;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationTest.php
@@ -171,4 +171,19 @@ EOF;
             ))->getPropertyPath()
         );
     }
+
+    public function testRetrievedMessageTemplateIsAStringEvenIfNotSet()
+    {
+        self::assertSame(
+            '',
+            (new ConstraintViolation(
+                'irrelevant',
+                null,
+                [],
+                'irrelevant',
+                'irrelevant',
+                null
+            ))->getMessageTemplate()
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

`ConstraintViolation#getMessageTemplate()`'s inherited signature states that `string` is
to be returned by it at all times, yet the implementation returns `null` when no message
template had been provided at instantiation.

This patch obviates it, returning an empty string when the
message template is `null`.

Ref: https://github.com/symfony/symfony/pull/40415#issuecomment-792839512
