### PR TITLE
[Form] clear unchecked choice radio boxes even if clear missing is set to false

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -141,6 +141,8 @@ class ChoiceType extends AbstractType
                             $knownValues[$child->getName()] = $value;
                             unset($unknownValues[$value]);
                             continue;
+                        } else {
+                            $knownValues[$child->getName()] = null;
                         }
                     }
                 } else {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -1287,6 +1287,20 @@ class ChoiceTypeTest extends BaseTypeTest
         $this->assertNull($form[4]->getViewData());
     }
 
+    public function testSubmitSingleExpandedClearMissingFalse()
+    {
+        $form = $this->factory->create(self::TESTED_TYPE, 'foo', [
+            'choices' => [
+                'foo label' => 'foo',
+                'bar label' => 'bar',
+            ],
+            'expanded' => true,
+        ]);
+        $form->submit('bar', false);
+
+        $this->assertSame('bar', $form->getData());
+    }
+
     public function testSubmitMultipleExpanded()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #16802
| License       | MIT
| Doc PR        | 