### PR TITLE
[DoctrineBridge] Fix eventListener initialization when eventSubscriber constructor dispatch an event

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -177,6 +177,7 @@ class ContainerAwareEventManager extends EventManager
             if (!isset($this->listeners[$event])) {
                 $this->listeners[$event] = [];
             }
+            unset($this->initialized[$event]);
             $this->listeners[$event] += $listeners;
         }
         $this->subscribers = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40365
| License       | MIT
| Doc PR        | -


The issue occurred, when an EventSubscriber (lazyLoaded) dispatch an event when constructed. In that case, the state of the `ContainerAwareEventManager` become inconsistent for the triggered event:
- the `listener` property contains both listener instance and `serviceId` meaning it's not fully initialized
- the `initialized` property contains `true` meaning the listeners are initialized

Sorry for this PR without test, But it's really to hard to reproduce the issue :(

@parijke @michanismus @fliespl @reypm could you please check if this patch fixes the issue for you?