### PR TITLE
[Mime] SMimePart - Ignore closed generator when casting body to string or iterable.

### DIFF
--- a/src/Symfony/Component/Mime/Part/SMimePart.php
+++ b/src/Symfony/Component/Mime/Part/SMimePart.php
@@ -78,7 +78,7 @@ class SMimePart extends AbstractPart
         }
 
         if ($this->body instanceof \Generator && !$this->body->valid()) {
-            yield from [];
+            yield;
 
             return;
         }

--- a/src/Symfony/Component/Mime/Part/SMimePart.php
+++ b/src/Symfony/Component/Mime/Part/SMimePart.php
@@ -56,6 +56,10 @@ class SMimePart extends AbstractPart
             return $this->body;
         }
 
+        if ($this->body instanceof \Generator && !$this->body->valid()) {
+            return '';
+        }
+
         $body = '';
         foreach ($this->body as $chunk) {
             $body .= $chunk;
@@ -69,6 +73,12 @@ class SMimePart extends AbstractPart
     {
         if (\is_string($this->body)) {
             yield $this->body;
+
+            return;
+        }
+
+        if ($this->body instanceof \Generator && !$this->body->valid()) {
+            yield from [];
 
             return;
         }

--- a/src/Symfony/Component/Mime/Tests/Part/SMimePartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/SMimePartTest.php
@@ -46,7 +46,7 @@ class SMimePartTest extends TestCase
     {
         $iterable = $this->getIterable();
         // We using this method for close a generator which should throws: Exception : Cannot traverse an already closed generator
-        \iterator_to_array($iterable);
+        iterator_to_array($iterable);
 
         $p = new SMimePart($iterable, 'multipart', 'signed', []);
         $this->assertEquals('', $p->bodyToString());

--- a/src/Symfony/Component/Mime/Tests/Part/SMimePartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/SMimePartTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mime\Tests\Part;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Header\Headers;
+use Symfony\Component\Mime\Header\ParameterizedHeader;
+use Symfony\Component\Mime\Part\SMimePart;
+
+class SMimePartTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $p = new SMimePart('content', 'multipart', 'signed', []);
+        $this->assertEquals('content', $p->bodyToString());
+        $this->assertEquals('content', implode('', iterator_to_array($p->bodyToIterable())));
+        // bodyToIterable() can be called several times
+        $this->assertEquals('content', implode('', iterator_to_array($p->bodyToIterable())));
+        $this->assertEquals('multipart', $p->getMediaType());
+        $this->assertEquals('signed', $p->getMediaSubType());
+    }
+
+    public function testConstructorWithIterable()
+    {
+        $iterable = $this->getIterable();
+
+        $p = new SMimePart($iterable, 'multipart', 'signed', []);
+        $this->assertEquals('content', $p->bodyToString());
+        $this->assertEquals('content', implode('', iterator_to_array($p->bodyToIterable())));
+        // bodyToIterable() can be called several times
+        $this->assertEquals('content', implode('', iterator_to_array($p->bodyToIterable())));
+        $this->assertEquals('multipart', $p->getMediaType());
+        $this->assertEquals('signed', $p->getMediaSubType());
+    }
+
+    public function testConstructorWithInvalidIterable()
+    {
+        $iterable = $this->getIterable();
+        // We using this method for close a generator which should throws: Exception : Cannot traverse an already closed generator
+        \iterator_to_array($iterable);
+
+        $p = new SMimePart($iterable, 'multipart', 'signed', []);
+        $this->assertEquals('', $p->bodyToString());
+        $this->assertEquals('', implode('', iterator_to_array($p->bodyToIterable())));
+        // bodyToIterable() can be called several times
+        $this->assertEquals('', implode('', iterator_to_array($p->bodyToIterable())));
+        $this->assertEquals('multipart', $p->getMediaType());
+        $this->assertEquals('signed', $p->getMediaSubType());
+    }
+
+    public function testConstructorWithNonStringOrIterable()
+    {
+        $this->expectException(\TypeError::class);
+        new SMimePart(new \stdClass(), 'multipart', 'signed', []);
+    }
+
+    public function testHeaders()
+    {
+        $p = new SMimePart('content', 'multipart', 'signed', []);
+        $this->assertEquals(new Headers(
+            new ParameterizedHeader('Content-Type', 'multipart/signed', [])
+        ), $p->getPreparedHeaders());
+
+        $p = new SMimePart('content', 'multipart', 'signed', ['charset' => 'utf-8']);
+        $this->assertEquals(new Headers(
+            new ParameterizedHeader('Content-Type', 'multipart/signed', ['charset' => 'utf-8'])
+        ), $p->getPreparedHeaders());
+    }
+
+    private function getIterable(): iterable
+    {
+        $f = fopen('php://memory', 'r+', false);
+        fwrite($f, 'content');
+        rewind($f);
+
+        while (!feof($f)) {
+            yield fread($f, 2);
+        }
+
+        fclose($f);
+    }
+}

--- a/src/Symfony/Component/Mime/Tests/Part/SMimePartTest.php
+++ b/src/Symfony/Component/Mime/Tests/Part/SMimePartTest.php
@@ -78,14 +78,7 @@ class SMimePartTest extends TestCase
 
     private function getIterable(): iterable
     {
-        $f = fopen('php://memory', 'r+', false);
-        fwrite($f, 'content');
-        rewind($f);
-
-        while (!feof($f)) {
-            yield fread($f, 2);
-        }
-
-        fclose($f);
+        yield 'con';
+        yield 'tent';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/34674
| License       | MIT
| Doc PR        | ~

This is my proposal PR for a closed generator in `symfony/mime`.
Actually, there is no a "rewind" for closed generator - so we must check via `Generator::valid()` method if iterable body as `Generator` is valid and not closed.

This PR fix bug explained in https://github.com/symfony/symfony/issues/34674.
