### PR TITLE
[Console] Fix type of InputOption::$default

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -394,11 +394,11 @@ class Command
     /**
      * Adds an option.
      *
-     * @param string                        $name        The option name
-     * @param string|array|null             $shortcut    The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
-     * @param int|null                      $mode        The option mode: One of the InputOption::VALUE_* constants
-     * @param string                        $description A description text
-     * @param string|string[]|int|bool|null $default     The default value (must be null for InputOption::VALUE_NONE)
+     * @param string                    $name        The option name
+     * @param string|array|null         $shortcut    The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
+     * @param int|null                  $mode        The option mode: One of the InputOption::VALUE_* constants
+     * @param string                    $description A description text
+     * @param string|string[]|bool|null $default     The default value (must be null for InputOption::VALUE_NONE)
      *
      * @throws InvalidArgumentException If option mode is invalid or incompatible
      *

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -33,11 +33,11 @@ class InputOption
     private $description;
 
     /**
-     * @param string                        $name        The option name
-     * @param string|array|null             $shortcut    The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
-     * @param int|null                      $mode        The option mode: One of the VALUE_* constants
-     * @param string                        $description A description text
-     * @param string|string[]|int|bool|null $default     The default value (must be null for self::VALUE_NONE)
+     * @param string                    $name        The option name
+     * @param string|array|null         $shortcut    The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
+     * @param int|null                  $mode        The option mode: One of the VALUE_* constants
+     * @param string                    $description A description text
+     * @param string|string[]|bool|null $default     The default value (must be null for self::VALUE_NONE)
      *
      * @throws InvalidArgumentException If option mode is invalid or incompatible
      */
@@ -149,7 +149,7 @@ class InputOption
     /**
      * Sets the default value.
      *
-     * @param string|string[]|int|bool|null $default The default value
+     * @param string|string[]|bool|null $default The default value
      *
      * @throws LogicException When incorrect default value is given
      */
@@ -173,7 +173,7 @@ class InputOption
     /**
      * Returns the default value.
      *
-     * @return string|string[]|int|bool|null The default value
+     * @return string|string[]|bool|null The default value
      */
     public function getDefault()
     {


### PR DESCRIPTION
Options can also be `int`s. So add this type to the PHPDoc parameter
type annotation of `InputInterface::setOption` and the return type
annotation of `InputInterface::getOption`.

| Q             | A
| ------------- | ---
| Branch?       | 4.4 or 5.2 for bug fixes
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40427
| License       | MIT
