### PR TITLE
[Yaml] Implement `$blockChompingIndicator` for `TaggedValue` multi-line literal blocks

### DIFF
--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -77,25 +77,8 @@ class Dumper
                 }
 
                 if (Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK & $flags && \is_string($value) && str_contains($value, "\n") && !str_contains($value, "\r")) {
-                    $blockIndentationIndicator = $this->getBlockIndentationIndicator($value);
-
-                    if (isset($value[-2]) && "\n" === $value[-2] && "\n" === $value[-1]) {
-                        $blockChompingIndicator = '+';
-                    } elseif ("\n" === $value[-1]) {
-                        $blockChompingIndicator = '';
-                    } else {
-                        $blockChompingIndicator = '-';
-                    }
-
-                    $output .= \sprintf('%s%s%s |%s%s', $prefix, $dumpAsMap ? Inline::dump($key, $flags).':' : '-', '', $blockIndentationIndicator, $blockChompingIndicator);
-
-                    foreach (explode("\n", $value) as $row) {
-                        if ('' === $row) {
-                            $output .= "\n";
-                        } else {
-                            $output .= \sprintf("\n%s%s%s", $prefix, str_repeat(' ', $this->indentation), $row);
-                        }
-                    }
+                    $output .= \sprintf('%s%s%s |%s%s', $prefix, $dumpAsMap ? Inline::dump($key, $flags).':' : '-', '', $this->getBlockIndentationIndicator($value), $this->getBlockChompingIndicator($value));
+                    $output .= $this->dumpBlockScalarLines($value, $prefix);
 
                     continue;
                 }
@@ -103,13 +86,9 @@ class Dumper
                 if ($value instanceof TaggedValue) {
                     $output .= \sprintf('%s%s !%s', $prefix, $dumpAsMap ? Inline::dump($key, $flags).':' : '-', $value->getTag());
 
-                    if (Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK & $flags && \is_string($value->getValue()) && str_contains($value->getValue(), "\n") && !str_contains($value->getValue(), "\r\n")) {
-                        $blockIndentationIndicator = $this->getBlockIndentationIndicator($value->getValue());
-                        $output .= \sprintf(' |%s', $blockIndentationIndicator);
-
-                        foreach (explode("\n", $value->getValue()) as $row) {
-                            $output .= \sprintf("\n%s%s%s", $prefix, str_repeat(' ', $this->indentation), $row);
-                        }
+                    if (Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK & $flags && \is_string($value->getValue()) && str_contains($value->getValue(), "\n") && !str_contains($value->getValue(), "\r")) {
+                        $output .= \sprintf(' |%s%s', $this->getBlockIndentationIndicator($value->getValue()), $this->getBlockChompingIndicator($value->getValue()));
+                        $output .= $this->dumpBlockScalarLines($value->getValue(), $prefix);
 
                         continue;
                     }
@@ -148,13 +127,9 @@ class Dumper
     {
         $output = \sprintf('%s!%s', $prefix ? $prefix.' ' : '', $value->getTag());
 
-        if (Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK & $flags && \is_string($value->getValue()) && str_contains($value->getValue(), "\n") && !str_contains($value->getValue(), "\r\n")) {
-            $blockIndentationIndicator = $this->getBlockIndentationIndicator($value->getValue());
-            $output .= \sprintf(' |%s', $blockIndentationIndicator);
-
-            foreach (explode("\n", $value->getValue()) as $row) {
-                $output .= \sprintf("\n%s%s%s", $prefix, str_repeat(' ', $this->indentation), $row);
-            }
+        if (Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK & $flags && \is_string($value->getValue()) && str_contains($value->getValue(), "\n") && !str_contains($value->getValue(), "\r")) {
+            $output .= \sprintf(' |%s%s', $this->getBlockIndentationIndicator($value->getValue()), $this->getBlockChompingIndicator($value->getValue()));
+            $output .= $this->dumpBlockScalarLines($value->getValue(), $prefix);
 
             return $output;
         }
@@ -164,6 +139,34 @@ class Dumper
         }
 
         return $output."\n".$this->doDump($value->getValue(), $inline - 1, $indent, $flags, $nestingLevel + 1);
+    }
+
+    private function getBlockChompingIndicator(string $value): string
+    {
+        if (isset($value[-2]) && "\n" === $value[-2] && "\n" === $value[-1]) {
+            return '+';
+        }
+
+        if ("\n" === $value[-1]) {
+            return '';
+        }
+
+        return '-';
+    }
+
+    private function dumpBlockScalarLines(string $value, string $prefix): string
+    {
+        $output = '';
+
+        foreach (explode("\n", $value) as $row) {
+            if ('' === $row) {
+                $output .= "\n";
+            } else {
+                $output .= \sprintf("\n%s%s%s", $prefix, str_repeat(' ', $this->indentation), $row);
+            }
+        }
+
+        return $output;
     }
 
     private function getBlockIndentationIndicator(string $value): string

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -511,7 +511,7 @@ class DumperTest extends TestCase
     {
         $data = new TaggedValue('text', "a\nb\n");
 
-        $this->assertSame("!text |\n    a\n    b\n    ", $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
+        $this->assertSame("!text |\n    a\n    b\n", $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
     }
 
     public function testDumpingTaggedValueSpecialCharsInTag()
@@ -636,7 +636,7 @@ class DumperTest extends TestCase
         $data = [
             'foo' => new TaggedValue('bar', "foo\nline with trailing spaces:\n  \nbar\ninteger like line:\n123456789\nempty line:\n\nbaz"),
         ];
-        $expected = "foo: !bar |\n".
+        $expected = "foo: !bar |-\n".
             "    foo\n".
             "    line with trailing spaces:\n".
             "      \n".
@@ -644,7 +644,7 @@ class DumperTest extends TestCase
             "    integer like line:\n".
             "    123456789\n".
             "    empty line:\n".
-            "    \n".
+            "\n".
             '    baz';
 
         $this->assertSame($expected, $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
@@ -656,12 +656,12 @@ class DumperTest extends TestCase
         $data = [
             new TaggedValue('bar', "a\nb"),
         ];
-        $expected = "- !bar |\n    a\n    b";
+        $expected = "- !bar |-\n    a\n    b";
         $this->assertSame($expected, $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
 
         // @todo Fix the parser, eliminate these exceptions.
         $this->expectException(ParseException::class);
-        $this->expectExceptionMessage('Unable to parse at line 3 (near "!bar |").');
+        $this->expectExceptionMessage('Unable to parse at line 3 (near "!bar |-").');
 
         $this->parser->parse($expected, Yaml::PARSE_CUSTOM_TAGS);
     }
@@ -671,13 +671,13 @@ class DumperTest extends TestCase
         $data = [
             'foo' => new TaggedValue('bar', "a\nb\n\n\n"),
         ];
-        $expected = "foo: !bar |\n    a\n    b\n    \n    \n    ";
+        $expected = "foo: !bar |+\n    a\n    b\n\n\n";
         $this->assertSame($expected, $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
 
         // @todo Fix the parser, the result should be identical to $data.
         $this->assertSameData(
             [
-                'foo' => new TaggedValue('bar', "a\nb\n"),
+                'foo' => new TaggedValue('bar', "a\nb\n\n\n"),
             ],
             $this->parser->parse($expected, Yaml::PARSE_CUSTOM_TAGS));
     }
@@ -687,12 +687,12 @@ class DumperTest extends TestCase
         $data = [
             new TaggedValue('bar', "a\nb\n\n\n"),
         ];
-        $expected = "- !bar |\n    a\n    b\n    \n    \n    ";
+        $expected = "- !bar |+\n    a\n    b\n\n\n";
         $this->assertSame($expected, $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK));
 
         // @todo Fix the parser, eliminate these exceptions.
         $this->expectException(ParseException::class);
-        $this->expectExceptionMessage('Unable to parse at line 6 (near "!bar |").');
+        $this->expectExceptionMessage('Unable to parse at line 6 (near "!bar |+").');
 
         $this->parser->parse($expected, Yaml::PARSE_CUSTOM_TAGS);
     }
@@ -842,6 +842,69 @@ class DumperTest extends TestCase
         $yaml = $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
         $this->assertSame('"a\nb\n"', $yaml);
         $this->assertSame($data, $this->parser->parse($yaml));
+    }
+
+    #[DataProvider('getTopLevelTaggedMultiLineLiteralBlockData')]
+    public function testTopLevelTaggedMultiLineLiteralBlock(TaggedValue $data, string $expected)
+    {
+        $yaml = $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
+
+        $this->assertSame($expected, $yaml);
+    }
+
+    public static function getTopLevelTaggedMultiLineLiteralBlockData(): iterable
+    {
+        yield 'clip' => [
+            new TaggedValue('my-tag', "one\ntwo\n"),
+            "!my-tag |\n    one\n    two\n",
+        ];
+
+        yield 'keep' => [
+            new TaggedValue('my-tag', "one\ntwo\n\n"),
+            "!my-tag |+\n    one\n    two\n\n",
+        ];
+
+        yield 'keep with 3 trailing newlines' => [
+            new TaggedValue('my-tag', "one\ntwo\n\n\n"),
+            "!my-tag |+\n    one\n    two\n\n\n",
+        ];
+
+        yield 'strip' => [
+            new TaggedValue('my-tag', "one\ntwo"),
+            "!my-tag |-\n    one\n    two",
+        ];
+    }
+
+    public function testDumpTrailingNewlineInMultiLineLiteralBlocksForTaggedValues()
+    {
+        $data = [
+            'clip 1' => new TaggedValue('my-tag', "one\ntwo\n"),
+            'keep 1' => new TaggedValue('my-tag', "one\ntwo\n\n"),
+            'keep 2' => new TaggedValue('my-tag', "one\ntwo\n\n\n"),
+            'strip 1' => new TaggedValue('my-tag', "one\ntwo"),
+        ];
+        $yaml = $this->dumper->dump($data, 2, 0, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
+
+        $expected = <<<YAML
+            'clip 1': !my-tag |
+                one
+                two
+            'keep 1': !my-tag |+
+                one
+                two
+
+            'keep 2': !my-tag |+
+                one
+                two
+
+
+            'strip 1': !my-tag |-
+                one
+                two
+            YAML;
+
+        $this->assertSame($expected, $yaml);
+        $this->assertSameData($data, $this->parser->parse($yaml, Yaml::PARSE_CUSTOM_TAGS));
     }
 
     public function testDumpTrailingNewlineInMultiLineLiteralBlocks()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 8.1
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | - 
| License       | MIT

https://github.com/symfony/symfony/commit/4c513c24c7e671ac72dbd203e5809aaa3a17f9a0 introduced the notion of `$blockChompingIndicator` for multi-line literal blocks.

This PR implements the same logic for TaggedValue multi-line literal blocks.

The YAML dumper already correctly emits block chomping indicators (`|`, `|-`, `|+`) and handles empty lines when dumping **plain string** values with `DUMP_MULTI_LINE_LITERAL_BLOCK`. However, `TaggedValue` objects were missing this logic:

- Chomping indicator was always omitted (implying "clip"), causing data loss on round-trip for strings without a trailing newline (`|-` needed) or with multiple trailing newlines (`|+` needed).
- Empty lines within the content were indented with spaces, producing trailing whitespace.
- The `\r` guard checked `\r\n` specifically instead of any `\r`, unlike the plain-string path.

**Before:**
```yaml
# TaggedValue("text", "hello\nworld") — no trailing newline, needs strip
msg: !text |
    hello
    world
# Parses back as "hello\nworld\n" — trailing newline added!

# TaggedValue("text", "hello\nworld\n\n\n") — extra trailing newlines, needs keep
msg: !text |
    hello
    world
    ·
    ·
    ·
# Trailing newlines lost, trailing whitespace on empty lines
```

**After:**
```yaml
msg: !text |-
    hello
    world
# Round-trips correctly

msg: !text |+
    hello
    world


# Round-trips correctly, clean empty lines
```
