### PR TITLE
[HttpKernel] Deprecate returning a `ContainerBuilder` from `KernelInterface::registerContainerConfiguration()`

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -46,7 +46,8 @@ HttpKernel
 
  * Deprecate `ArgumentInterface`
  * Deprecate `ArgumentMetadata::getAttribute()`, use `getAttributes()` instead
- * Marked the class `Symfony\Component\HttpKernel\EventListener\DebugHandlersListener` as internal
+ * Mark the class `Symfony\Component\HttpKernel\EventListener\DebugHandlersListener` as internal
+ * Deprecate returning a `ContainerBuilder` from `KernelInterface::registerContainerConfiguration()`
 
 Messenger
 ---------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -94,8 +94,9 @@ HttpKernel
 
  * Remove `ArgumentInterface`
  * Remove `ArgumentMetadata::getAttribute()`, use `getAttributes()` instead
- * Made `WarmableInterface::warmUp()` return a list of classes or files to preload on PHP 7.4+
- * Removed support for `service:action` syntax to reference controllers. Use `serviceOrFqcn::method` instead.
+ * Make `WarmableInterface::warmUp()` return a list of classes or files to preload on PHP 7.4+
+ * Remove support for `service:action` syntax to reference controllers. Use `serviceOrFqcn::method` instead.
+ * Remove support for returning a `ContainerBuilder` from `KernelInterface::registerContainerConfiguration()`
 
 Inflector
 ---------

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -7,7 +7,8 @@ CHANGELOG
  * Deprecate `ArgumentInterface`
  * Add `ArgumentMetadata::getAttributes()`
  * Deprecate `ArgumentMetadata::getAttribute()`, use `getAttributes()` instead
- * marked the class `Symfony\Component\HttpKernel\EventListener\DebugHandlersListener` as internal
+ * Mark the class `Symfony\Component\HttpKernel\EventListener\DebugHandlersListener` as internal
+ * Deprecate returning a `ContainerBuilder` from `KernelInterface::registerContainerConfiguration()`
 
 5.2.0
 -----

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -642,6 +642,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
         $this->prepareContainer($container);
 
         if (null !== $cont = $this->registerContainerConfiguration($this->getContainerLoader($container))) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Returning a ContainerBuilder from "%s::registerContainerConfiguration()" is deprecated.', get_debug_type($this));
             $container->merge($cont);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

This behavior was introduced in https://github.com/symfony/symfony/commit/38aef98694fc6724a09071bf45088259d4126677#diff-7753dd9020accbf6eb7c3dbb86a992340ce9dff4a0258458d7bbdd0a3d396939R261

But this is never used nor tested AFAIK, and the interface doesn't document it.