### PR TITLE
[Runtime] Add support for PSR-7, PSR-15 and PSR-17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -135,11 +135,13 @@
         "masterminds/html5": "^2.6",
         "monolog/monolog": "^1.25.1|^2",
         "nyholm/psr7": "^1.0",
+        "nyholm/psr7-server": "^1.0",
         "paragonie/sodium_compat": "^1.8",
         "pda/pheanstalk": "^4.0",
         "php-http/httplug": "^1.0|^2.0",
         "predis/predis": "~1.1",
         "psr/http-client": "^1.0",
+        "psr/http-server-handler": "^1.0",
         "psr/simple-cache": "^1.0",
         "egulias/email-validator": "^2.1.10|^3.1",
         "symfony/mercure-bundle": "^0.2",
@@ -148,7 +150,8 @@
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "twig/cssinliner-extra": "^2.12|^3",
         "twig/inky-extra": "^2.12|^3",
-        "twig/markdown-extra": "^2.12|^3"
+        "twig/markdown-extra": "^2.12|^3",
+        "laminas/laminas-httphandlerrunner": "^1.3"
     },
     "conflict": {
         "async-aws/core": "<1.5",

--- a/composer.json
+++ b/composer.json
@@ -151,7 +151,7 @@
         "twig/cssinliner-extra": "^2.12|^3",
         "twig/inky-extra": "^2.12|^3",
         "twig/markdown-extra": "^2.12|^3",
-        "laminas/laminas-httphandlerrunner": "^1.3"
+        "laminas/laminas-httphandlerrunner": "^1.2"
     },
     "conflict": {
         "async-aws/core": "<1.5",

--- a/src/Symfony/Component/Runtime/PsrRuntime.php
+++ b/src/Symfony/Component/Runtime/PsrRuntime.php
@@ -55,11 +55,11 @@ class PsrRuntime extends GenericRuntime
     public function getRunner(?object $application): RunnerInterface
     {
         if ($application instanceof RequestHandlerInterface) {
-            return LaminasEmitter::createForRequestHandler($application, $this->createRequest(), ['emitter'=>$this->options['laminas_emitter'] ?? null]);
+            return LaminasEmitter::createForRequestHandler($application, $this->createRequest(), ['emitter' => $this->options['laminas_emitter'] ?? null]);
         }
 
         if ($application instanceof ResponseInterface) {
-            return LaminasEmitter::createForResponse($application, ['emitter'=>$this->options['laminas_emitter'] ?? null]);
+            return LaminasEmitter::createForResponse($application, ['emitter' => $this->options['laminas_emitter'] ?? null]);
         }
 
         return parent::getRunner($application);

--- a/src/Symfony/Component/Runtime/PsrRuntime.php
+++ b/src/Symfony/Component/Runtime/PsrRuntime.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Runtime;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7Server\ServerRequestCreator;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Symfony\Component\Runtime\Runner\Psr\LaminasEmitter;
+
+/**
+ * A runtime that supports PSR-7, PSR-15 and PSR-17.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * @experimental in 5.3
+ */
+class PsrRuntime extends GenericRuntime
+{
+    /**
+     * @var ServerRequestCreator|null
+     */
+    private $requestCreator;
+
+    private $options = [];
+
+    /**
+     * @param array {
+     *   debug?: ?bool,
+     *   server_request_creator?: ?string,
+     *   psr17_server_request_factory?: ?string,
+     *   psr17_uri_factory?: ?string,
+     *   psr17_uploaded_file_factory?: ?string,
+     *   psr17_stream_factory?: ?string,
+     *   laminas_emitter?: ?string,
+     * } $options
+     */
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+
+        parent::__construct($options);
+    }
+
+    public function getRunner(?object $application): RunnerInterface
+    {
+        if ($application instanceof RequestHandlerInterface) {
+            return LaminasEmitter::createForRequestHandler($application, $this->createRequest(), ['emitter'=>$this->options['laminas_emitter'] ?? null]);
+        }
+
+        if ($application instanceof ResponseInterface) {
+            return LaminasEmitter::createForResponse($application, ['emitter'=>$this->options['laminas_emitter'] ?? null]);
+        }
+
+        return parent::getRunner($application);
+    }
+
+    /**
+     * @return mixed
+     */
+    protected function getArgument(\ReflectionParameter $parameter, ?string $type)
+    {
+        if (ServerRequestInterface::class === $type) {
+            return $this->createRequest();
+        }
+
+        return parent::getArgument($parameter, $type);
+    }
+
+    /**
+     * @return ServerRequestInterface
+     */
+    private function createRequest()
+    {
+        if (null === $this->requestCreator) {
+            if (!class_exists(ServerRequestCreator::class)) {
+                throw new \LogicException(sprintf('The "%s" class requires "nyholm/psr7-server". Try running "composer require nyholm/psr7-server".', self::class));
+            }
+
+            $creatorClass = $this->options['server_request_creator'] ?? ServerRequestCreator::class;
+            if (isset($this->options['psr17_server_request_factory'], $this->options['psr17_uri_factory'], $this->options['psr17_uploaded_file_factory'], $this->options['psr17_stream_factory'])) {
+                $this->requestCreator = new $creatorClass(
+                    new $this->options['psr17_server_request_factory'](),
+                    new $this->options['psr17_uri_factory'](),
+                    new $this->options['psr17_uploaded_file_factory'](),
+                    new $this->options['psr17_stream_factory']()
+                );
+            } elseif (class_exists(Psr17Factory::class)) {
+                $psr17Factory = new Psr17Factory();
+                $this->requestCreator = new $creatorClass($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory);
+            } else {
+                throw new \LogicException(sprintf('The "%s" class requires PSR-17 factories. Try running "composer require nyholm/psr7" or provide class names to the "%s"::__construct().', self::class, self::class));
+            }
+        }
+
+        return $this->requestCreator->fromGlobals();
+    }
+}

--- a/src/Symfony/Component/Runtime/Runner/Psr/LaminasEmitter.php
+++ b/src/Symfony/Component/Runtime/Runner/Psr/LaminasEmitter.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Runtime\Runner\Psr;
+
+use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Symfony\Component\Runtime\RunnerInterface;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * @experimental in 5.3
+ */
+class LaminasEmitter implements RunnerInterface
+{
+    private $requestHandler;
+    private $response;
+    private $request;
+    private $emitter;
+
+    private function __construct(array $options)
+    {
+        $class = $options['emitter'] ?? SapiEmitter::class;
+        if (!class_exists(SapiEmitter::class)) {
+            throw new \LogicException(sprintf('The "%s" class requires "laminas/laminas-httphandlerrunner". Try running "composer require laminas/laminas-httphandlerrunner".', self::class));
+        }
+
+        if (!class_exists($class)) {
+            throw new \LogicException(sprintf('The class "%s" cannot be found.', $class));
+        }
+
+        $this->emitter = new $class();
+    }
+
+    /**
+     * @param array{emitter?: ?string} $options
+     */
+    public static function createForResponse(ResponseInterface $response, array $options): self
+    {
+        $emitter = new self($options);
+        $emitter->response = $response;
+
+        return $emitter;
+    }
+
+    /**
+     * @param array{emitter?: ?string} $options
+     */
+    public static function createForRequestHandler(RequestHandlerInterface $handler, ServerRequestInterface $request, array $options): self
+    {
+        $emitter = new self($options);
+        $emitter->requestHandler = $handler;
+        $emitter->request = $request;
+
+        return $emitter;
+    }
+
+    public function run(): int
+    {
+        if (null === $this->response) {
+            $this->response = $this->requestHandler->handle($this->request);
+        }
+
+        $this->emitter->emit($this->response);
+
+        return 0;
+    }
+}

--- a/src/Symfony/Component/Runtime/Tests/phpt/autoload.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/autoload.php
@@ -12,7 +12,8 @@ if (file_exists(dirname(__DIR__, 2).'/vendor/autoload.php')) {
     }
 
     $app = require $_SERVER['SCRIPT_FILENAME'];
-    $runtime = new SymfonyRuntime($_SERVER['APP_RUNTIME_OPTIONS']);
+    $runtimeClass = $_SERVER['APP_RUNTIME'] ?? SymfonyRuntime::class;
+    $runtime = new $runtimeClass($_SERVER['APP_RUNTIME_OPTIONS']);
     [$app, $args] = $runtime->getResolver($app)->resolve();
     exit($runtime->getRunner($app(...$args))->run());
 }

--- a/src/Symfony/Component/Runtime/Tests/phpt/psr15.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/psr15.php
@@ -1,0 +1,18 @@
+<?php
+
+use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+$_SERVER['APP_RUNTIME'] = \Symfony\Component\Runtime\PsrRuntime::class;
+
+require __DIR__.'/autoload.php';
+
+return function (array $context) {
+    return new class implements RequestHandlerInterface {
+        public function handle(ServerRequestInterface $request): ResponseInterface
+        {
+            return new \Nyholm\Psr7\Response(200, [], 'Hello PSR-15');
+        }
+    };
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/psr15.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/psr15.php
@@ -1,15 +1,15 @@
 <?php
 
-use Psr\Http\Server\RequestHandlerInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 
 $_SERVER['APP_RUNTIME'] = \Symfony\Component\Runtime\PsrRuntime::class;
 
 require __DIR__.'/autoload.php';
 
 return function (array $context) {
-    return new class implements RequestHandlerInterface {
+    return new class() implements RequestHandlerInterface {
         public function handle(ServerRequestInterface $request): ResponseInterface
         {
             return new \Nyholm\Psr7\Response(200, [], 'Hello PSR-15');

--- a/src/Symfony/Component/Runtime/Tests/phpt/psr15.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/psr15.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test PSR-15 Request/Response
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/psr15.php';
+
+?>
+--EXPECTF--
+Hello PSR-15

--- a/src/Symfony/Component/Runtime/Tests/phpt/psr7.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/psr7.php
@@ -1,12 +1,11 @@
 <?php
 
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Psr\Http\Message\ServerRequestInterface;
 
 $_SERVER['APP_RUNTIME'] = \Symfony\Component\Runtime\PsrRuntime::class;
 
 require __DIR__.'/autoload.php';
 
-return function (\Psr\Http\Message\ServerRequestInterface $request) {
+return function (ServerRequestInterface $request) {
     return new \Nyholm\Psr7\Response(200, [], 'Hello PSR-7');
 };

--- a/src/Symfony/Component/Runtime/Tests/phpt/psr7.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/psr7.php
@@ -1,0 +1,12 @@
+<?php
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+$_SERVER['APP_RUNTIME'] = \Symfony\Component\Runtime\PsrRuntime::class;
+
+require __DIR__.'/autoload.php';
+
+return function (\Psr\Http\Message\ServerRequestInterface $request) {
+    return new \Nyholm\Psr7\Response(200, [], 'Hello PSR-7');
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/psr7.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/psr7.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test PSR-7 Request/Response
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/psr7.php';
+
+?>
+--EXPECTF--
+Hello PSR-7

--- a/src/Symfony/Component/Runtime/composer.json
+++ b/src/Symfony/Component/Runtime/composer.json
@@ -26,6 +26,7 @@
         "symfony/http-foundation": "^4.4|^5",
         "symfony/http-kernel": "^4.4|^5",
         "psr/http-server-handler": "^1.0",
+        "nyholm/psr7": "^1.3",
         "nyholm/psr7-server": "^1.0",
         "laminas/laminas-httphandlerrunner": "^1.2"
     },

--- a/src/Symfony/Component/Runtime/composer.json
+++ b/src/Symfony/Component/Runtime/composer.json
@@ -27,7 +27,7 @@
         "symfony/http-kernel": "^4.4|^5",
         "psr/http-server-handler": "^1.0",
         "nyholm/psr7-server": "^1.0",
-        "laminas/laminas-httphandlerrunner": "^1.3"
+        "laminas/laminas-httphandlerrunner": "^1.2"
     },
     "conflict": {
         "symfony/dotenv": "<5.1"

--- a/src/Symfony/Component/Runtime/composer.json
+++ b/src/Symfony/Component/Runtime/composer.json
@@ -24,7 +24,10 @@
         "symfony/console": "^4.4|^5",
         "symfony/dotenv": "^5.1",
         "symfony/http-foundation": "^4.4|^5",
-        "symfony/http-kernel": "^4.4|^5"
+        "symfony/http-kernel": "^4.4|^5",
+        "psr/http-server-handler": "^1.0",
+        "nyholm/psr7-server": "^1.0",
+        "laminas/laminas-httphandlerrunner": "^1.3"
     },
     "conflict": {
         "symfony/dotenv": "<5.1"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This will add a PSR runtime. The issue with PSR-7 and PSR-17 is that there is nothing covering how to create a ServerRequest from globals nor how to emit/send the response. 

This PR is using two packages: nyholm/psr7-server and laminas/laminas-httphandlerrunner. Why these? The former is because it was the first one package that was trying to create a ServerRequest from globals. It might be more popular packages out now, I dont know. 

The latter is a super old package (previously form zend). It is stable and does the job well. 

### How to use

```php
require_once dirname(__DIR__).'/vendor/autoload_runtime.php';

return function (\Psr\Http\Message\ServerRequestInterface $request) {
    return new \Nyholm\Psr7\Response(200, [], 'PSR-7');
};
```

```php
use Psr\Http\Server\RequestHandlerInterface;
use Psr\Http\Message\ServerRequestInterface;
use Psr\Http\Message\ResponseInterface;

require_once dirname(__DIR__).'/vendor/autoload_runtime.php';

class Application implements RequestHandlerInterface {
    public function handle(ServerRequestInterface $request): ResponseInterface
    {
        return new \Nyholm\Psr7\Response(200, [], 'PSR-15');
    }
}

return function (array $context) {
    return new Application($context['APP_ENV'] ?? 'dev');
};
```

### TODO
- [x] Add tests
- [ ] Add docs
- [ ] Add changelog