### PR TITLE
[WebProfilerBundle] Disable CSP if dumper was used

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.php
@@ -24,6 +24,7 @@ return static function (ContainerConfigurator $container) {
                 service('router')->ignoreOnInvalid(),
                 abstract_arg('paths that should be excluded from the AJAX requests shown in the toolbar'),
                 service('web_profiler.csp.handler'),
+                service('data_collector.dump')->ignoreOnInvalid(),
             ])
             ->tag('kernel.event_subscriber')
     ;

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpKernel\DataCollector\DumpDataCollector;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 class WebProfilerExtensionTest extends TestCase
@@ -55,6 +56,7 @@ class WebProfilerExtensionTest extends TestCase
         $this->kernel = $this->createMock(KernelInterface::class);
 
         $this->container = new ContainerBuilder();
+        $this->container->register('data_collector.dump', DumpDataCollector::class)->setPublic(true);
         $this->container->register('error_handler.error_renderer.html', HtmlErrorRenderer::class)->setPublic(true);
         $this->container->register('event_dispatcher', EventDispatcher::class)->setPublic(true);
         $this->container->register('router', $this->getMockClass('Symfony\\Component\\Routing\\RouterInterface'))->setPublic(true);

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Functional/WebProfilerBundleKernel.php
@@ -10,6 +10,7 @@ use Symfony\Bundle\WebProfilerBundle\WebProfilerBundle;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DumpDataCollector;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
@@ -65,6 +66,7 @@ class WebProfilerBundleKernel extends Kernel
 
     protected function build(ContainerBuilder $container)
     {
+        $container->register('data_collector.dump', DumpDataCollector::class);
         $container->register('logger', NullLogger::class);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x for features
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #29084
| License       | MIT
| Doc PR        | -

Disables a configured Content Security Policy if the dumper was used to avoid breaking the toolbar. This is a less invasive alternative to #29155 which fixes #29084 (there is a project with a test case linked there).