### PR TITLE
[FrameworkBundle] AnnotationsCacheWarmer should support doctrine/annotations:^1.13

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
 
 use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\CachedReader;
+use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\DoctrineProvider;
@@ -52,7 +53,13 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
         }
 
         $annotatedClasses = include $annotatedClassPatterns;
-        $reader = new CachedReader($this->annotationReader, new DoctrineProvider($arrayAdapter), $this->debug);
+
+        if (class_exists(PsrCachedReader::class)) {
+            // doctrine/annotations:1.13 and above
+            $reader = new PsrCachedReader($this->annotationReader, $arrayAdapter, $this->debug);
+        } else {
+            $reader = new CachedReader($this->annotationReader, new DoctrineProvider($arrayAdapter), $this->debug);
+        }
 
         foreach ($annotatedClasses as $class) {
             if (null !== $this->excludeRegexp && preg_match($this->excludeRegexp, $class)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40353
| License       | MIT
| Doc PR        | 

The `AnnotationsCacheWarmer` is creating a cached a `new CachedReader` in the `doWarmUp()`. But this will fail if doctrine/cache is not installed. In #40338 I added the `kernel.cache_warmer` tag on `annotations.cache_warmer` service even though the doctrine/cache is not installed. 

This PR will make sure `AnnotationsCacheWarmer` is using the `PsrCacheReader` when available. 

This bug was not found in the tests because doctrine/cache is always installed. 

----------

Big golden star to @jrushlow because you test dev-master. 