### PR TITLE
[TwigBridge] Fix "Serialization of 'Closure'" error when rendering an TemplatedEmail

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Mime/BodyRendererTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/BodyRendererTest.php
@@ -100,6 +100,27 @@ HTML;
         $this->assertEquals('reset', $email->getTextBody());
     }
 
+    public function testRenderedOnceUnserializableContext()
+    {
+        $twig = new Environment(new ArrayLoader([
+            'text' => 'Text',
+        ]));
+        $renderer = new BodyRenderer($twig);
+        $email = (new TemplatedEmail())
+            ->to('fabien@symfony.com')
+            ->from('helene@symfony.com')
+        ;
+        $email->textTemplate('text');
+        $email->context([
+            'foo' => static function () {
+                return 'bar';
+            },
+        ]);
+
+        $renderer->render($email);
+        $this->assertEquals('Text', $email->getTextBody());
+    }
+
     private function prepareEmail(?string $text, ?string $html, array $context = []): TemplatedEmail
     {
         $twig = new Environment(new ArrayLoader([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40445
| License       | MIT
| Doc PR        | 


When context contains a closure, it can't be serialized. In that case, we now assume that fingerprint is always different, and in that case, email will always be re-rendered