### PR TITLE
[twig-bridge] Allow NotificationEmail to be marked as public

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.3
+-----
+
+* Add a new `markAsPublic` method on `NotificationEmail` to change the `importance` context option to null after creation
+
 5.3.0
 -----
 

--- a/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/NotificationEmail.php
@@ -64,10 +64,17 @@ class NotificationEmail extends TemplatedEmail
     public static function asPublicEmail(Headers $headers = null, AbstractPart $body = null): self
     {
         $email = new static($headers, $body);
-        $email->context['importance'] = null;
-        $email->context['footer_text'] = null;
+        $email->markAsPublic();
 
         return $email;
+    }
+
+    public function markAsPublic(): self
+    {
+        $this->context['importance'] = null;
+        $this->context['footer_text'] = null;
+
+        return $this;
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Tests/Mime/NotificationEmailTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Mime/NotificationEmailTest.php
@@ -85,11 +85,34 @@ class NotificationEmailTest extends TestCase
             'a' => 'b',
             'footer_text' => null,
         ], $email->getContext());
+
+        $email = (new NotificationEmail())
+            ->markAsPublic()
+            ->markdown('Foo')
+            ->action('Bar', 'http://example.com/')
+            ->context(['a' => 'b'])
+        ;
+
+        $this->assertEquals([
+            'importance' => null,
+            'content' => 'Foo',
+            'exception' => false,
+            'action_text' => 'Bar',
+            'action_url' => 'http://example.com/',
+            'markdown' => true,
+            'raw' => false,
+            'a' => 'b',
+            'footer_text' => null,
+        ], $email->getContext());
     }
 
     public function testPublicMailSubject()
     {
         $email = NotificationEmail::asPublicEmail()->from('me@example.com')->subject('Foo');
+        $headers = $email->getPreparedHeaders();
+        $this->assertSame('Foo', $headers->get('Subject')->getValue());
+
+        $email = (new NotificationEmail())->markAsPublic()->from('me@example.com')->subject('Foo');
         $headers = $email->getPreparedHeaders();
         $this->assertSame('Foo', $headers->get('Subject')->getValue());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x for features
| Bug fix?      |no
| New feature?  | yes
| Deprecations? |no
| Tickets       | Fix #37879
| License       | MIT
| Doc PR        | -

Closes https://github.com/symfony/symfony/issues/37879

`NotificationEmail` can be created public from the `asPublicEmail` method in any context but with the Notifier component. In this case it is created by it as not public and therefore displays the importance in the subject of the email.
For end users, aka not admin, the importance in the subject's email is not necessary.
This PR will allow if needed to set a `NotificationEmail` as public even after being created, wherever it was created.

I am not sure how to handle the version in the changelog.
For the tests I don't know what's the policy so I just added a new case in each test case.


