### PR TITLE
[Serializer] Stringable normalizer

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add the ability to provide (de)normalization context using metadata (e.g. `@Symfony\Component\Serializer\Annotation\Context`)
  * deprecated `ArrayDenormalizer::setSerializer()`, call `setDenormalizer()` instead.
  * added normalization formats to `UidNormalizer`
+ * added `StringNormalizer`
 
 5.2.0
 -----

--- a/src/Symfony/Component/Serializer/Normalizer/StringableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/StringableNormalizer.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\LogicException;
+
+/**
+ * A normalizer that uses an objects own Stringable implementation.
+ *
+ * @author Craig Morris <craig.michael.morris@gmail.com>
+ */
+class StringableNormalizer extends AbstractNormalizer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, string $format = null, array $context = [])
+    {
+        if ($this->isCircularReference($object, $context)) {
+            return $this->handleCircularReference($object);
+        }
+
+        if (!$object instanceof \JsonSerializable) {
+            throw new InvalidArgumentException(sprintf('The object must implement "%s".', \JsonSerializable::class));
+        }
+
+        if (!$this->serializer instanceof NormalizerInterface) {
+            throw new LogicException('Cannot normalize object because injected serializer is not a normalizer.');
+        }
+
+        return $this->serializer->normalize($object->jsonSerialize(), $format, $context);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, string $format = null)
+    {
+        return $data instanceof \JsonSerializable;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, string $type, string $format = null)
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, string $type, string $format = null, array $context = [])
+    {
+        throw new LogicException(sprintf('Cannot denormalize with "%s".', \Stringable::class));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return __CLASS__ === static::class;
+    }
+}

--- a/src/Symfony/Component/Serializer/Normalizer/StringableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/StringableNormalizer.php
@@ -42,7 +42,7 @@ class StringableNormalizer extends AbstractNormalizer
      */
     public function supportsNormalization($data, string $format = null)
     {
-        return $data instanceof \Stringable;
+        return $data instanceof \Stringable || method_exists($data, '__toString');
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/StringableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/StringableNormalizer.php
@@ -30,15 +30,11 @@ class StringableNormalizer extends AbstractNormalizer
             return $this->handleCircularReference($object);
         }
 
-        if (!$object instanceof \JsonSerializable) {
-            throw new InvalidArgumentException(sprintf('The object must implement "%s".', \JsonSerializable::class));
+        if (!$object instanceof \Stringable && !method_exists($object, '__toString')) {
+            throw new InvalidArgumentException(sprintf('The object must implement "%s or __toString()".', \Stringable::class));
         }
 
-        if (!$this->serializer instanceof NormalizerInterface) {
-            throw new LogicException('Cannot normalize object because injected serializer is not a normalizer.');
-        }
-
-        return $this->serializer->normalize($object->jsonSerialize(), $format, $context);
+        return $object->__toString();
     }
 
     /**
@@ -46,7 +42,7 @@ class StringableNormalizer extends AbstractNormalizer
      */
     public function supportsNormalization($data, string $format = null)
     {
-        return $data instanceof \JsonSerializable;
+        return $data instanceof \Stringable;
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/StringableNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/StringableNormalizer.php
@@ -19,17 +19,13 @@ use Symfony\Component\Serializer\Exception\LogicException;
  *
  * @author Craig Morris <craig.michael.morris@gmail.com>
  */
-class StringableNormalizer extends AbstractNormalizer
+class StringableNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
     /**
      * {@inheritdoc}
      */
     public function normalize($object, string $format = null, array $context = [])
     {
-        if ($this->isCircularReference($object, $context)) {
-            return $this->handleCircularReference($object);
-        }
-
         if (!$object instanceof \Stringable && !method_exists($object, '__toString')) {
             throw new InvalidArgumentException(sprintf('The object must implement "%s or __toString()".', \Stringable::class));
         }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/StringableDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/StringableDummy.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class StringableDummy implements \Stringable
+{
+    public function __toString()
+    {
+        return 'hello worlds';
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/StringableLegacyDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/StringableLegacyDummy.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Serializer\Tests\Fixtures;
 
-class StringableDummy implements \Stringable
+class StringableLegacyDummy
 {
     public function __toString(): string
     {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
@@ -50,7 +50,3 @@ class StringableNormalizerTest extends TestCase
         $this->assertSame('hello worlds', $this->normalizer->normalize(new StringableLegacyDummy()));
     }
 }
-
-abstract class StringNormalizer implements SerializerInterface, NormalizerInterface
-{
-}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\StringableNormalizer;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
@@ -11,14 +11,16 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Serializer\Exception\CircularReferenceException;
-use Symfony\Component\Serializer\Exception\InvalidArgumentException;
-use Symfony\Component\Serializer\Normalizer\StringableNormalizer;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\StringableDummy;
+use Symfony\Component\Serializer\Normalizer\StringableNormalizer;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\CircularReferenceException;
 use Symfony\Component\Serializer\Tests\Fixtures\JsonSerializableDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\StringableLegacyDummy;
 
 /**
  * @author Craig Morris <craig.michael.morris@gmail.com>
@@ -37,14 +39,7 @@ class StringableNormalizerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->createNormalizer();
-    }
-
-    private function createNormalizer(array $defaultContext = [])
-    {
-        $this->serializer = $this->createMock(StringableNormalizer::class);
-        $this->normalizer = new StringableNormalizer(null, null, $defaultContext);
-        $this->normalizer->setSerializer($this->serializer);
+        $this->normalizer = new StringableNormalizer();
     }
 
     public function testSupportNormalization()
@@ -55,45 +50,15 @@ class StringableNormalizerTest extends TestCase
 
     public function testNormalize()
     {
-        $this->serializer
-            ->expects($this->once())
-            ->method('normalize')
-            ->willReturnCallback(function ($data) {
-                $this->assertSame(['foo' => 'a', 'bar' => 'b', 'baz' => 'c'], array_diff_key($data, ['qux' => '']));
-
-                return 'string_object';
-            })
-        ;
-
-        $this->assertEquals('string_object', $this->normalizer->normalize(new JsonSerializableDummy()));
+        $this->assertSame('hello worlds', $this->normalizer->normalize(new StringableDummy));
     }
 
-    public function testCircularNormalize()
+    public function testNormalizeLegacy()
     {
-        $this->expectException(CircularReferenceException::class);
-        $this->createNormalizer([JsonSerializableNormalizer::CIRCULAR_REFERENCE_LIMIT => 1]);
-
-        $this->serializer
-            ->expects($this->once())
-            ->method('normalize')
-            ->willReturnCallback(function ($data, $format, $context) {
-                $this->normalizer->normalize($data['qux'], $format, $context);
-
-                return 'string_object';
-            })
-        ;
-
-        $this->assertEquals('string_object', $this->normalizer->normalize(new JsonSerializableDummy()));
-    }
-
-    public function testInvalidDataThrowException()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The object must implement "JsonSerializable".');
-        $this->normalizer->normalize(new \stdClass());
+        $this->assertSame('hello worlds', $this->normalizer->normalize(new StringableLegacyDummy));
     }
 }
 
-abstract class JsonSerializerNormalizer implements SerializerInterface, NormalizerInterface
+abstract class StringNormalizer implements SerializerInterface, NormalizerInterface
 {
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
@@ -11,15 +11,12 @@
 
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\Serializer\SerializerInterface;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Symfony\Component\Serializer\Tests\Fixtures\StringableDummy;
 use Symfony\Component\Serializer\Normalizer\StringableNormalizer;
-use Symfony\Component\Serializer\Exception\InvalidArgumentException;
-use Symfony\Component\Serializer\Exception\CircularReferenceException;
-use Symfony\Component\Serializer\Tests\Fixtures\JsonSerializableDummy;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\StringableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\StringableLegacyDummy;
 
 /**
@@ -50,12 +47,12 @@ class StringableNormalizerTest extends TestCase
 
     public function testNormalize()
     {
-        $this->assertSame('hello worlds', $this->normalizer->normalize(new StringableDummy));
+        $this->assertSame('hello worlds', $this->normalizer->normalize(new StringableDummy()));
     }
 
     public function testNormalizeLegacy()
     {
-        $this->assertSame('hello worlds', $this->normalizer->normalize(new StringableLegacyDummy));
+        $this->assertSame('hello worlds', $this->normalizer->normalize(new StringableLegacyDummy()));
     }
 }
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Normalizer;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Exception\CircularReferenceException;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\StringableNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\JsonSerializableDummy;
+
+/**
+ * @author Craig Morris <craig.michael.morris@gmail.com>
+ */
+class StringableNormalizerTest extends TestCase
+{
+    /**
+     * @var StringableNormalizer
+     */
+    private $normalizer;
+
+    /**
+     * @var MockObject|SerializerInterface
+     */
+    private $serializer;
+
+    protected function setUp(): void
+    {
+        $this->createNormalizer();
+    }
+
+    private function createNormalizer(array $defaultContext = [])
+    {
+        $this->serializer = $this->createMock(StringableNormalizer::class);
+        $this->normalizer = new StringableNormalizer(null, null, $defaultContext);
+        $this->normalizer->setSerializer($this->serializer);
+    }
+
+    public function testSupportNormalization()
+    {
+        $this->assertTrue($this->normalizer->supportsNormalization(new StringableDummy()));
+        $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
+    }
+
+    public function testNormalize()
+    {
+        $this->serializer
+            ->expects($this->once())
+            ->method('normalize')
+            ->willReturnCallback(function ($data) {
+                $this->assertSame(['foo' => 'a', 'bar' => 'b', 'baz' => 'c'], array_diff_key($data, ['qux' => '']));
+
+                return 'string_object';
+            })
+        ;
+
+        $this->assertEquals('string_object', $this->normalizer->normalize(new JsonSerializableDummy()));
+    }
+
+    public function testCircularNormalize()
+    {
+        $this->expectException(CircularReferenceException::class);
+        $this->createNormalizer([JsonSerializableNormalizer::CIRCULAR_REFERENCE_LIMIT => 1]);
+
+        $this->serializer
+            ->expects($this->once())
+            ->method('normalize')
+            ->willReturnCallback(function ($data, $format, $context) {
+                $this->normalizer->normalize($data['qux'], $format, $context);
+
+                return 'string_object';
+            })
+        ;
+
+        $this->assertEquals('string_object', $this->normalizer->normalize(new JsonSerializableDummy()));
+    }
+
+    public function testInvalidDataThrowException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The object must implement "JsonSerializable".');
+        $this->normalizer->normalize(new \stdClass());
+    }
+}
+
+abstract class JsonSerializerNormalizer implements SerializerInterface, NormalizerInterface
+{
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
@@ -12,9 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\StringableNormalizer;
-use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\StringableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\StringableLegacyDummy;
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
@@ -29,11 +29,6 @@ class StringableNormalizerTest extends TestCase
      */
     private $normalizer;
 
-    /**
-     * @var MockObject|SerializerInterface
-     */
-    private $serializer;
-
     protected function setUp(): void
     {
         $this->normalizer = new StringableNormalizer();

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/StringableNormalizerTest.php
@@ -37,6 +37,7 @@ class StringableNormalizerTest extends TestCase
     public function testSupportNormalization()
     {
         $this->assertTrue($this->normalizer->supportsNormalization(new StringableDummy()));
+        $this->assertTrue($this->normalizer->supportsNormalization(new StringableLegacyDummy()));
         $this->assertFalse($this->normalizer->supportsNormalization(new \stdClass()));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x for features
| Bug fix?      | /no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#...

Since PHP8.0 introduces a `Stringable` interface to the already existing `__toString()` convention, it might be worth hooking into this when normalizing objects if they implement this method or interface.

The inverse to this would be a `ParsableDenormalizer` which would parse strings back into objects which I will submit another PR for. 