### PR TITLE
[Serializer] Parsable Denormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add the ability to provide (de)normalization context using metadata (e.g. `@Symfony\Component\Serializer\Annotation\Context`)
  * deprecated `ArrayDenormalizer::setSerializer()`, call `setDenormalizer()` instead.
  * added normalization formats to `UidNormalizer`
+ * added `ParsableDenormalizer`
 
 5.2.0
 -----

--- a/src/Symfony/Component/Serializer/Normalizer/ParsableDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ParsableDenormalizer.php
@@ -11,13 +11,6 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
-use Symfony\Component\Serializer\Exception\BadMethodCallException;
-use Symfony\Component\Serializer\Exception\InvalidArgumentException;
-use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
-use Symfony\Component\Serializer\Serializer;
-use Symfony\Component\Serializer\SerializerAwareInterface;
-use Symfony\Component\Serializer\SerializerInterface;
-
 /**
  * Denormalizes strings to objects through a parse method.
  *

--- a/src/Symfony/Component/Serializer/Normalizer/ParsableDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ParsableDenormalizer.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+use Symfony\Component\Serializer\Exception\BadMethodCallException;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\SerializerAwareInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Denormalizes strings to objects through a parse method.
+ *
+ * @author Craig Morris <craig.michael.morris@gmail.com>
+ *
+ * @final
+ */
+class ParsableDenormalizer implements DenormalizerInterface, CacheableSupportsMethodInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, string $type, string $format = null, array $context = [])
+    {
+        return $type::parse($data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
+    {
+        return method_exists($type, 'parse');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasCacheableSupportsMethod(): bool
+    {
+        return __CLASS__ === static::class;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ParsableDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ParsableDummy.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class ParsableDummy
+{
+    public $str;
+
+    public function __construct($str)
+    {
+        $this->str = $str;
+    }
+
+    public static function parse($str)
+    {
+        return new static($str);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ParsableDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ParsableDenormalizerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Normalizer;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\ErrorHandler\Exception\FlattenException;
+use Symfony\Component\Serializer\Normalizer\ParsableDenormalizer;
+use Symfony\Component\Serializer\Normalizer\ProblemNormalizer;
+use Symfony\Component\Serializer\Tests\Fixtures\ParsableDummy;
+
+class ParsableDenormalizerTest extends TestCase
+{
+    /**
+     * @var ParsableDenormalizer
+     */
+    private $normalizer;
+
+    protected function setUp(): void
+    {
+        $this->normalizer = new ParsableDenormalizer();
+    }
+
+    public function testSupportDenormalization()
+    {
+        $this->assertTrue($this->normalizer->supportsDenormalization('', ParsableDummy::class));
+        $this->assertFalse($this->normalizer->supportsDenormalization('', \stdClass::class));
+    }
+
+    public function testDenormalize()
+    {
+        $actual = $this->normalizer->denormalize('hello worlds', ParsableDummy::class);
+
+        $this->assertInstanceOf(ParsableDummy::class, $actual);
+        $this->assertSame('hello worlds', $actual->str);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ParsableDenormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ParsableDenormalizerTest.php
@@ -12,9 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Normalizer;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\ErrorHandler\Exception\FlattenException;
 use Symfony\Component\Serializer\Normalizer\ParsableDenormalizer;
-use Symfony\Component\Serializer\Normalizer\ProblemNormalizer;
 use Symfony\Component\Serializer\Tests\Fixtures\ParsableDummy;
 
 class ParsableDenormalizerTest extends TestCase


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#...

As the inverse of #40458, this denormalizer will attempt to parse a string into an object if that object supports it.

This is a common pattern seen in many objects such as Carbon and DateTime.