### PR TITLE
Deprecate configuring tag names and service ids in compiler passes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/TestServiceContainerWeakRefPass.php
@@ -26,6 +26,10 @@ class TestServiceContainerWeakRefPass implements CompilerPassInterface
 
     public function __construct(string $privateTagName = 'container.private')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/framework-bundle', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->privateTagName = $privateTagName;
     }
 

--- a/src/Symfony/Component/Cache/DependencyInjection/CacheCollectorPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CacheCollectorPass.php
@@ -32,6 +32,10 @@ class CacheCollectorPass implements CompilerPassInterface
 
     public function __construct(string $dataCollectorCacheId = 'data_collector.cache', string $cachePoolTag = 'cache.pool', string $cachePoolRecorderInnerSuffix = '.recorder_inner')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/cache', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->dataCollectorCacheId = $dataCollectorCacheId;
         $this->cachePoolTag = $cachePoolTag;
         $this->cachePoolRecorderInnerSuffix = $cachePoolRecorderInnerSuffix;

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolClearerPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolClearerPass.php
@@ -24,6 +24,10 @@ class CachePoolClearerPass implements CompilerPassInterface
 
     public function __construct(string $cachePoolClearerTag = 'cache.pool.clearer')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/cache', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->cachePoolClearerTag = $cachePoolClearerTag;
     }
 

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -40,6 +40,10 @@ class CachePoolPass implements CompilerPassInterface
 
     public function __construct(string $cachePoolTag = 'cache.pool', string $kernelResetTag = 'kernel.reset', string $cacheClearerId = 'cache.global_clearer', string $cachePoolClearerTag = 'cache.pool.clearer', string $cacheSystemClearerId = 'cache.system_clearer', string $cacheSystemClearerTag = 'kernel.cache_clearer', string $reverseContainerId = 'reverse_container', string $reversibleTag = 'container.reversible', string $messageHandlerId = 'cache.early_expiration_handler')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/cache', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->cachePoolTag = $cachePoolTag;
         $this->kernelResetTag = $kernelResetTag;
         $this->cacheClearerId = $cacheClearerId;

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPrunerPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPrunerPass.php
@@ -28,6 +28,10 @@ class CachePoolPrunerPass implements CompilerPassInterface
 
     public function __construct(string $cacheCommandServiceId = 'console.command.cache_pool_prune', string $cachePoolTag = 'cache.pool')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/cache', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->cacheCommandServiceId = $cacheCommandServiceId;
         $this->cachePoolTag = $cachePoolTag;
     }

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -25,6 +25,7 @@
         "psr/cache": "^1.0|^2.0",
         "psr/log": "^1.1",
         "symfony/cache-contracts": "^1.1.7|^2",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/polyfill-php80": "^1.15",
         "symfony/service-contracts": "^1.1|^2",
         "symfony/var-exporter": "^4.4|^5.0"

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -36,6 +36,10 @@ class AddConsoleCommandPass implements CompilerPassInterface
 
     public function __construct(string $commandLoaderServiceId = 'console.command_loader', string $commandTag = 'console.command', string $noPreloadTag = 'container.no_preload', string $privateTagName = 'container.private')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/console', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->commandLoaderServiceId = $commandLoaderServiceId;
         $this->commandTag = $commandTag;
         $this->noPreloadTag = $noPreloadTag;

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php73": "^1.8",
         "symfony/polyfill-php80": "^1.15",

--- a/src/Symfony/Component/DependencyInjection/Compiler/AliasDeprecatedPublicServicesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AliasDeprecatedPublicServicesPass.php
@@ -23,6 +23,10 @@ final class AliasDeprecatedPublicServicesPass extends AbstractRecursivePass
 
     public function __construct(string $tagName = 'container.private')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/dependency-injection', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->tagName = $tagName;
     }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
@@ -19,13 +19,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 final class AttributeAutoconfigurationPass implements CompilerPassInterface
 {
-    private $ignoreAttributesTag;
-
-    public function __construct(string $ignoreAttributesTag = 'container.ignore_attributes')
-    {
-        $this->ignoreAttributesTag = $ignoreAttributesTag;
-    }
-
     public function process(ContainerBuilder $container): void
     {
         if (80000 > \PHP_VERSION_ID) {
@@ -37,7 +30,7 @@ final class AttributeAutoconfigurationPass implements CompilerPassInterface
         foreach ($container->getDefinitions() as $id => $definition) {
             if (!$definition->isAutoconfigured()
                 || $definition->isAbstract()
-                || $definition->hasTag($this->ignoreAttributesTag)
+                || $definition->hasTag('container.ignore_attributes')
                 || !($reflector = $container->getReflectionClass($definition->getClass(), false))
             ) {
                 continue;

--- a/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/DecoratorServicePass.php
@@ -30,6 +30,10 @@ class DecoratorServicePass extends AbstractRecursivePass
 
     public function __construct(?string $innerId = '.inner')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/dependency-injection', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->innerId = $innerId;
     }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterAutoconfigureAttributesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterAutoconfigureAttributesPass.php
@@ -24,16 +24,13 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
  */
 final class RegisterAutoconfigureAttributesPass implements CompilerPassInterface
 {
-    private $ignoreAttributesTag;
     private $registerForAutoconfiguration;
 
-    public function __construct(string $ignoreAttributesTag = 'container.ignore_attributes')
+    public function __construct()
     {
         if (80000 > \PHP_VERSION_ID) {
             return;
         }
-
-        $this->ignoreAttributesTag = $ignoreAttributesTag;
 
         $parseDefinitions = new \ReflectionMethod(YamlFileLoader::class, 'parseDefinitions');
         $parseDefinitions->setAccessible(true);
@@ -80,7 +77,7 @@ final class RegisterAutoconfigureAttributesPass implements CompilerPassInterface
 
     public function accept(Definition $definition): bool
     {
-        return 80000 <= \PHP_VERSION_ID && $definition->isAutoconfigured() && !$definition->hasTag($this->ignoreAttributesTag);
+        return 80000 <= \PHP_VERSION_ID && $definition->isAutoconfigured() && !$definition->hasTag('container.ignore_attributes');
     }
 
     public function processClass(ContainerBuilder $container, \ReflectionClass $class)

--- a/src/Symfony/Component/DependencyInjection/Compiler/RegisterReverseContainerPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RegisterReverseContainerPass.php
@@ -28,6 +28,10 @@ class RegisterReverseContainerPass implements CompilerPassInterface
 
     public function __construct(bool $beforeRemoving, string $serviceId = 'reverse_container', string $tagName = 'container.reversible')
     {
+        if (1 < \func_num_args()) {
+            trigger_deprecation('symfony/dependency-injection', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->beforeRemoving = $beforeRemoving;
         $this->serviceId = $serviceId;
         $this->tagName = $tagName;

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDecoratorStackPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDecoratorStackPass.php
@@ -28,6 +28,10 @@ class ResolveDecoratorStackPass implements CompilerPassInterface
 
     public function __construct(string $tag = 'container.stack')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/dependency-injection', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->tag = $tag;
     }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveHotPathPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveHotPathPass.php
@@ -28,6 +28,10 @@ class ResolveHotPathPass extends AbstractRecursivePass
 
     public function __construct(string $tagName = 'container.hot_path')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/dependency-injection', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->tagName = $tagName;
     }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveNoPreloadPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveNoPreloadPass.php
@@ -29,6 +29,10 @@ class ResolveNoPreloadPass extends AbstractRecursivePass
 
     public function __construct(string $tagName = 'container.no_preload')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/dependency-injection', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->tagName = $tagName;
     }
 

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/AddEventAliasesPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/AddEventAliasesPass.php
@@ -26,6 +26,10 @@ class AddEventAliasesPass implements CompilerPassInterface
 
     public function __construct(array $eventAliases, string $eventAliasesParameter = 'event_dispatcher.event_aliases')
     {
+        if (1 < \func_num_args()) {
+            trigger_deprecation('symfony/event-dispatcher', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->eventAliases = $eventAliases;
         $this->eventAliasesParameter = $eventAliasesParameter;
     }

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -37,6 +37,10 @@ class RegisterListenersPass implements CompilerPassInterface
 
     public function __construct(string $dispatcherService = 'event_dispatcher', string $listenerTag = 'kernel.event_listener', string $subscriberTag = 'kernel.event_subscriber', string $eventAliasesParameter = 'event_dispatcher.event_aliases')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/event-dispatcher', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->dispatcherService = $dispatcherService;
         $this->listenerTag = $listenerTag;
         $this->subscriberTag = $subscriberTag;

--- a/src/Symfony/Component/Form/DependencyInjection/FormPass.php
+++ b/src/Symfony/Component/Form/DependencyInjection/FormPass.php
@@ -38,6 +38,10 @@ class FormPass implements CompilerPassInterface
 
     public function __construct(string $formExtensionService = 'form.extension', string $formTypeTag = 'form.type', string $formTypeExtensionTag = 'form.type_extension', string $formTypeGuesserTag = 'form.type_guesser', string $formDebugCommandService = 'console.command.form_debug')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->formExtensionService = $formExtensionService;
         $this->formTypeTag = $formTypeTag;
         $this->formTypeExtensionTag = $formTypeExtensionTag;

--- a/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php
+++ b/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php
@@ -23,6 +23,10 @@ final class HttpClientPass implements CompilerPassInterface
 
     public function __construct(string $clientTag = 'http_client.client')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/http-client', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->clientTag = $clientTag;
     }
 

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -23,6 +23,7 @@
     "require": {
         "php": ">=7.2.5",
         "psr/log": "^1.0",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/http-client-contracts": "^2.4",
         "symfony/polyfill-php73": "^1.11",
         "symfony/polyfill-php80": "^1.15",

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ControllerArgumentValueResolverPass.php
@@ -34,6 +34,10 @@ class ControllerArgumentValueResolverPass implements CompilerPassInterface
 
     public function __construct(string $argumentResolverService = 'argument_resolver', string $argumentValueResolverTag = 'controller.argument_value_resolver', string $traceableResolverStopwatch = 'debug.stopwatch')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->argumentResolverService = $argumentResolverService;
         $this->argumentValueResolverTag = $argumentValueResolverTag;
         $this->traceableResolverStopwatch = $traceableResolverStopwatch;

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/FragmentRendererPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/FragmentRendererPass.php
@@ -30,6 +30,10 @@ class FragmentRendererPass implements CompilerPassInterface
 
     public function __construct(string $handlerService = 'fragment.handler', string $rendererTag = 'kernel.fragment_renderer')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->handlerService = $handlerService;
         $this->rendererTag = $rendererTag;
     }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterControllerArgumentLocatorsPass.php
@@ -39,6 +39,10 @@ class RegisterControllerArgumentLocatorsPass implements CompilerPassInterface
 
     public function __construct(string $resolverServiceId = 'argument_resolver.service', string $controllerTag = 'controller.service_arguments', string $controllerLocator = 'argument_resolver.controller_locator', string $notTaggedControllerResolverServiceId = 'argument_resolver.not_tagged_controller')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->resolverServiceId = $resolverServiceId;
         $this->controllerTag = $controllerTag;
         $this->controllerLocator = $controllerLocator;

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterLocaleAwareServicesPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RegisterLocaleAwareServicesPass.php
@@ -28,6 +28,10 @@ class RegisterLocaleAwareServicesPass implements CompilerPassInterface
 
     public function __construct(string $listenerServiceId = 'locale_aware_listener', string $localeAwareTag = 'kernel.locale_aware')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->listenerServiceId = $listenerServiceId;
         $this->localeAwareTag = $localeAwareTag;
     }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/RemoveEmptyControllerArgumentLocatorsPass.php
@@ -25,6 +25,10 @@ class RemoveEmptyControllerArgumentLocatorsPass implements CompilerPassInterface
 
     public function __construct(string $controllerLocator = 'argument_resolver.controller_locator')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->controllerLocator = $controllerLocator;
     }
 

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ResettableServicePass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ResettableServicePass.php
@@ -27,6 +27,10 @@ class ResettableServicePass implements CompilerPassInterface
 
     public function __construct(string $tagName = 'kernel.reset')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/http-kernel', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->tagName = $tagName;
     }
 

--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -36,6 +36,10 @@ class MessengerPass implements CompilerPassInterface
 
     public function __construct(string $handlerTag = 'messenger.message_handler', string $busTag = 'messenger.bus', string $receiverTag = 'messenger.receiver')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/messenger', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->handlerTag = $handlerTag;
         $this->busTag = $busTag;
         $this->receiverTag = $receiverTag;

--- a/src/Symfony/Component/Mime/DependencyInjection/AddMimeTypeGuesserPass.php
+++ b/src/Symfony/Component/Mime/DependencyInjection/AddMimeTypeGuesserPass.php
@@ -27,6 +27,10 @@ class AddMimeTypeGuesserPass implements CompilerPassInterface
 
     public function __construct(string $mimeTypesService = 'mime_types', string $mimeTypeGuesserTag = 'mime.mime_type_guesser')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/mime', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->mimeTypesService = $mimeTypesService;
         $this->mimeTypeGuesserTag = $mimeTypeGuesserTag;
     }

--- a/src/Symfony/Component/PropertyInfo/DependencyInjection/PropertyInfoConstructorPass.php
+++ b/src/Symfony/Component/PropertyInfo/DependencyInjection/PropertyInfoConstructorPass.php
@@ -30,6 +30,10 @@ final class PropertyInfoConstructorPass implements CompilerPassInterface
 
     public function __construct(string $service = 'property_info.constructor_extractor', string $tag = 'property_info.constructor_extractor')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/property-info', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->service = $service;
         $this->tag = $tag;
     }

--- a/src/Symfony/Component/PropertyInfo/DependencyInjection/PropertyInfoPass.php
+++ b/src/Symfony/Component/PropertyInfo/DependencyInjection/PropertyInfoPass.php
@@ -34,6 +34,10 @@ class PropertyInfoPass implements CompilerPassInterface
 
     public function __construct(string $propertyInfoService = 'property_info', string $listExtractorTag = 'property_info.list_extractor', string $typeExtractorTag = 'property_info.type_extractor', string $descriptionExtractorTag = 'property_info.description_extractor', string $accessExtractorTag = 'property_info.access_extractor', string $initializableExtractorTag = 'property_info.initializable_extractor')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/property-info', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->propertyInfoService = $propertyInfoService;
         $this->listExtractorTag = $listExtractorTag;
         $this->typeExtractorTag = $typeExtractorTag;

--- a/src/Symfony/Component/Routing/DependencyInjection/RoutingResolverPass.php
+++ b/src/Symfony/Component/Routing/DependencyInjection/RoutingResolverPass.php
@@ -30,6 +30,10 @@ class RoutingResolverPass implements CompilerPassInterface
 
     public function __construct(string $resolverServiceId = 'routing.resolver', string $loaderTag = 'routing.loader')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/routing', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->resolverServiceId = $resolverServiceId;
         $this->loaderTag = $loaderTag;
     }

--- a/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
+++ b/src/Symfony/Component/Serializer/DependencyInjection/SerializerPass.php
@@ -33,6 +33,10 @@ class SerializerPass implements CompilerPassInterface
 
     public function __construct(string $serializerService = 'serializer', string $normalizerTag = 'serializer.normalizer', string $encoderTag = 'serializer.encoder')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/serializer', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->serializerService = $serializerService;
         $this->normalizerTag = $normalizerTag;
         $this->encoderTag = $encoderTag;

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-php80": "^1.15"
     },

--- a/src/Symfony/Component/Translation/DependencyInjection/TranslationDumperPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslationDumperPass.php
@@ -25,6 +25,10 @@ class TranslationDumperPass implements CompilerPassInterface
 
     public function __construct(string $writerServiceId = 'translation.writer', string $dumperTag = 'translation.dumper')
     {
+        if (1 < \func_num_args()) {
+            trigger_deprecation('symfony/translation', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->writerServiceId = $writerServiceId;
         $this->dumperTag = $dumperTag;
     }

--- a/src/Symfony/Component/Translation/DependencyInjection/TranslationExtractorPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslationExtractorPass.php
@@ -26,6 +26,10 @@ class TranslationExtractorPass implements CompilerPassInterface
 
     public function __construct(string $extractorServiceId = 'translation.extractor', string $extractorTag = 'translation.extractor')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/translation', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->extractorServiceId = $extractorServiceId;
         $this->extractorTag = $extractorTag;
     }

--- a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php
@@ -26,6 +26,10 @@ class TranslatorPass implements CompilerPassInterface
 
     public function __construct(string $translatorServiceId = 'translator.default', string $readerServiceId = 'translation.reader', string $loaderTag = 'translation.loader', string $debugCommandServiceId = 'console.command.translation_debug', string $updateCommandServiceId = 'console.command.translation_update')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/translation', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->translatorServiceId = $translatorServiceId;
         $this->readerServiceId = $readerServiceId;
         $this->loaderTag = $loaderTag;

--- a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
@@ -33,6 +33,10 @@ class TranslatorPathsPass extends AbstractRecursivePass
 
     public function __construct(string $translatorServiceId = 'translator', string $debugCommandServiceId = 'console.command.translation_debug', string $updateCommandServiceId = 'console.command.translation_update', string $resolverServiceId = 'argument_resolver.service')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/translation', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->translatorServiceId = $translatorServiceId;
         $this->debugCommandServiceId = $debugCommandServiceId;
         $this->updateCommandServiceId = $updateCommandServiceId;

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php80": "^1.15",
         "symfony/translation-contracts": "^2.3"

--- a/src/Symfony/Component/Validator/DependencyInjection/AddAutoMappingConfigurationPass.php
+++ b/src/Symfony/Component/Validator/DependencyInjection/AddAutoMappingConfigurationPass.php
@@ -27,6 +27,10 @@ class AddAutoMappingConfigurationPass implements CompilerPassInterface
 
     public function __construct(string $validatorBuilderService = 'validator.builder', string $tag = 'validator.auto_mapper')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/validator', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->validatorBuilderService = $validatorBuilderService;
         $this->tag = $tag;
     }

--- a/src/Symfony/Component/Validator/DependencyInjection/AddConstraintValidatorsPass.php
+++ b/src/Symfony/Component/Validator/DependencyInjection/AddConstraintValidatorsPass.php
@@ -27,6 +27,10 @@ class AddConstraintValidatorsPass implements CompilerPassInterface
 
     public function __construct(string $validatorFactoryServiceId = 'validator.validator_factory', string $constraintValidatorTag = 'validator.constraint_validator')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/validator', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->validatorFactoryServiceId = $validatorFactoryServiceId;
         $this->constraintValidatorTag = $constraintValidatorTag;
     }

--- a/src/Symfony/Component/Validator/DependencyInjection/AddValidatorInitializersPass.php
+++ b/src/Symfony/Component/Validator/DependencyInjection/AddValidatorInitializersPass.php
@@ -26,6 +26,10 @@ class AddValidatorInitializersPass implements CompilerPassInterface
 
     public function __construct(string $builderService = 'validator.builder', string $initializerTag = 'validator.initializer')
     {
+        if (0 < \func_num_args()) {
+            trigger_deprecation('symfony/validator', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
+        }
+
         $this->builderService = $builderService;
         $this->initializerTag = $initializerTag;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR is aimed at reducing the code complexity by hardcoding the name of tags and service ids that compiler passes have to deal with.

I think making these names configurable only adds boilerplate and maintenance overhead for no benefit:
- for the practice: the need to use a pass with a renamed tag/id should be extremely rare (do yo know any?)
- for the theory: a decorating pass could still rename before/after the processing, so this use case is still supported.

Side note: I skipped updating changelog+upgrade files. This would be just noise to me (nobody uses this possibility anyway ;) )