### PR TITLE
Be explicit about anchor background color in profiler toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -100,6 +100,7 @@
 .sf-toolbar-block > a:hover {
     display: block;
     text-decoration: none;
+    background-color: transparent;
     color: inherit;
 }
 
@@ -238,6 +239,7 @@ div.sf-toolbar .sf-toolbar-block a:hover {
     padding: 0 10px;
 }
 .sf-toolbar-block-request .sf-toolbar-info-piece a {
+    background-color: transparent;
     text-decoration: none;
 }
 .sf-toolbar-block-request .sf-toolbar-info-piece a:hover {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Hello, 

we have a project where we work with background colors on links. When we define this in our stylesheet, the Web Profiler picks these styles up due to the cascade. We added two CSS statements to the Web Profiler stylesheet to be explicit about the transparent background.

![2021-03-15 16_10_08](https://user-images.githubusercontent.com/4400435/111176325-860e8d80-85a9-11eb-82c4-7954aa01245a.png)
![2021-03-15 16_10_30](https://user-images.githubusercontent.com/4400435/111176328-86a72400-85a9-11eb-9515-280c5593a288.png)
