### PR TITLE
[Mailer] make async-ses required

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/composer.json
@@ -17,11 +17,11 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "async-aws/ses": "^1.0",
         "symfony/deprecation-contracts": "^2.1",
         "symfony/mailer": "^4.4.21|^5.2.6"
     },
     "require-dev": {
-        "async-aws/ses": "^1.0",
         "symfony/http-client": "^4.4|^5.0"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40480
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

AWS S3 signature is not supported anymore, which mean the old "raw HTTP" implementation does not work anymore, and only the implementation that use "async-aws" works.

This PR move "async-aws" to the "requires" section in order to fix that.