### PR TITLE
[Security] Add concept of required passport badges

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.3
 ---
 
+ * Add `required_badges` firewall config option
  * [BC break] Add `login_throttling.lock_factory` setting defaulting to `null` (instead of `lock.factory`)
  * Add a `login_throttling.interval` (in `security.firewalls`) option to change the default throttling interval.
  * Add the `debug:firewall` command.

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -495,6 +495,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                 ->replaceArgument(0, $authenticators)
                 ->replaceArgument(2, new Reference($firewallEventDispatcherId))
                 ->replaceArgument(3, $id)
+                ->replaceArgument(6, $firewall['required_badges'] ?? [])
                 ->addTag('monolog.logger', ['channel' => 'security'])
             ;
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
@@ -172,6 +172,7 @@
             <xsd:element name="remember-me" type="remember_me" minOccurs="0" maxOccurs="1" />
             <xsd:element name="remote-user" type="remote_user" minOccurs="0" maxOccurs="1" />
             <xsd:element name="x509" type="x509" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="required-badge" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <!-- allow factories to use dynamic elements -->
             <xsd:any processContents="lax" minOccurs="0" maxOccurs="unbounded" />
         </xsd:choice>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_authenticator.php
@@ -46,6 +46,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('provider key'),
                 service('logger')->nullOnInvalid(),
                 param('security.authentication.manager.erase_credentials'),
+                abstract_arg('required badges'),
             ])
             ->tag('monolog.logger', ['channel' => 'security'])
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -26,6 +26,8 @@ use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Encoder\NativePasswordEncoder;
 use Symfony\Component\Security\Core\Encoder\SodiumPasswordEncoder;
 use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\RememberMeBadge;
 
 abstract class CompleteConfigurationTest extends TestCase
 {
@@ -37,7 +39,11 @@ abstract class CompleteConfigurationTest extends TestCase
     {
         $container = $this->getContainer('authenticator_manager');
 
-        $this->assertEquals(AuthenticatorManager::class, $container->getDefinition('security.authenticator.manager.main')->getClass());
+        $authenticatorManager = $container->getDefinition('security.authenticator.manager.main');
+        $this->assertEquals(AuthenticatorManager::class, $authenticatorManager->getClass());
+
+        // required badges
+        $this->assertEquals([CsrfTokenBadge::class, RememberMeBadge::class], $authenticatorManager->getArgument(6));
 
         // login link
         $expiredStorage = $container->getDefinition($expiredStorageId = 'security.authenticator.expired_login_link_storage.main');

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/authenticator_manager.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/authenticator_manager.php
@@ -1,9 +1,12 @@
 <?php
 
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge;
+
 $container->loadFromExtension('security', [
     'enable_authenticator_manager' => true,
     'firewalls' => [
         'main' => [
+            'required_badges' => [CsrfTokenBadge::class, 'RememberMeBadge'],
             'login_link' => [
                 'check_route' => 'login_check',
                 'check_post_only' => true,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/authenticator_manager.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/authenticator_manager.xml
@@ -9,6 +9,8 @@
 
     <config enable-authenticator-manager="true">
         <firewall name="main">
+            <required-badge>Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge</required-badge>
+            <required-badge>RememberMeBadge</required-badge>
             <login-link check-route="login_check"
                 check-post-only="true"
                 max-uses="1"

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/authenticator_manager.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/authenticator_manager.yml
@@ -2,6 +2,9 @@ security:
     enable_authenticator_manager: true
     firewalls:
         main:
+            required_badges:
+                - 'Symfony\Component\Security\Http\Authenticator\Passport\Badge\CsrfTokenBadge'
+                - RememberMeBadge
             login_link:
                 check_route: login_check
                 check_post_only: true


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | n
| Tickets       | Fix #39305
| License       | MIT
| Doc PR        | tbd

A badge on a passport is a critical security element, it determines which security checks are run during authentication. Using the `required_badges` setting, applications can make sure the expected security checks are run.