### PR TITLE
[Security] Remove deprecated support for passing a UserInterface implementation to Passport

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -91,6 +91,7 @@ Security
    If you are using the `isAccountNonLocked()`, `isAccountNonExpired()` or `isCredentialsNonExpired()` method, consider re-implementing
    them in your own user class, as they are not part of the `InMemoryUser` API
  * Deprecate class `UserChecker`, use `InMemoryUserChecker` or your own implementation instead
+ * [BC break] Remove support for passing a `UserInterface` implementation to `Passport`, use the `UserBadge` instead.
  * Deprecate `UserInterface::getPassword()`
    If your `getPassword()` method does not return `null` (i.e. you are using password-based authentication),
    you should implement `PasswordAuthenticatedUserInterface`.

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate class `User`, use `InMemoryUser` instead
  * Deprecate class `UserChecker`, use `InMemoryUserChecker` or your own implementation instead
+ * [BC break] Remove support for passing a `UserInterface` implementation to `Passport`, use the `UserBadge` instead.
  * Add `PasswordAuthenticatedUserInterface` for user classes that use passwords
  * Add `LegacyPasswordAuthenticatedUserInterface` for user classes that use user-provided salts in addition to passwords
  * Deprecate all classes in the `Core\Encoder\`  sub-namespace, use the `PasswordHasher` component instead

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Passport.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Passport.php
@@ -32,23 +32,13 @@ class Passport implements UserPassportInterface
     private $attributes = [];
 
     /**
-     * @param UserBadge            $userBadge
      * @param CredentialsInterface $credentials the credentials to check for this authentication, use
      *                                          SelfValidatingPassport if no credentials should be checked
      * @param BadgeInterface[]     $badges
      */
-    public function __construct($userBadge, CredentialsInterface $credentials, array $badges = [])
+    public function __construct(UserBadge $userBadge, CredentialsInterface $credentials, array $badges = [])
     {
-        if ($userBadge instanceof UserInterface) {
-            trigger_deprecation('symfony/security-http', '5.2', 'The 1st argument of "%s" must be an instance of "%s", support for "%s" will be removed in symfony/security-http 5.3.', __CLASS__, UserBadge::class, UserInterface::class);
-
-            $this->user = $userBadge;
-        } elseif ($userBadge instanceof UserBadge) {
-            $this->addBadge($userBadge);
-        } else {
-            throw new \TypeError(sprintf('Argument 1 of "%s" must be an instance of "%s", "%s" given.', __METHOD__, UserBadge::class, get_debug_type($userBadge)));
-        }
-
+        $this->addBadge($userBadge);
         $this->addBadge($credentials);
         foreach ($badges as $badge) {
             $this->addBadge($badge);

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/SelfValidatingPassport.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/SelfValidatingPassport.php
@@ -26,21 +26,11 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 class SelfValidatingPassport extends Passport
 {
     /**
-     * @param UserBadge        $userBadge
      * @param BadgeInterface[] $badges
      */
-    public function __construct($userBadge, array $badges = [])
+    public function __construct(UserBadge $userBadge, array $badges = [])
     {
-        if ($userBadge instanceof UserInterface) {
-            trigger_deprecation('symfony/security-http', '5.2', 'The 1st argument of "%s" must be an instance of "%s", support for "%s" will be removed in symfony/security-http 5.3.', __CLASS__, UserBadge::class, UserInterface::class);
-
-            $this->user = $userBadge;
-        } elseif ($userBadge instanceof UserBadge) {
-            $this->addBadge($userBadge);
-        } else {
-            throw new \TypeError(sprintf('Argument 1 of "%s" must be an instance of "%s", "%s" given.', __METHOD__, UserBadge::class, get_debug_type($userBadge)));
-        }
-
+        $this->addBadge($userBadge);
         foreach ($badges as $badge) {
             $this->addBadge($badge);
         }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/UserProviderListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/UserProviderListenerTest.php
@@ -61,16 +61,4 @@ class UserProviderListenerTest extends TestCase
     {
         yield [new SelfValidatingPassport(new UserBadge('wouter', function () {}))];
     }
-
-    /**
-     * @group legacy
-     */
-    public function testLegacyUserPassport()
-    {
-        $passport = new SelfValidatingPassport($user = $this->createMock(UserInterface::class));
-        $this->listener->checkPassport(new CheckPassportEvent($this->createMock(AuthenticatorInterface::class), $passport));
-
-        $this->assertFalse($passport->hasBadge(UserBadge::class));
-        $this->assertSame($user, $passport->getUser());
-    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In https://github.com/symfony/symfony/pull/37846#pullrequestreview-473047140 , we agreed to have a deprecation path of only one minor release as the `Passport` feature is still experimental.