### PR TITLE
[Mailer] Add supported auth modes to exception

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/EsmtpTransport.php
@@ -178,7 +178,7 @@ class EsmtpTransport extends SmtpTransport
         }
 
         if (!$authNames) {
-            throw new TransportException('Failed to find an authenticator supported by the SMTP server.');
+            throw new TransportException('Failed to find an authenticator supported by the SMTP server, which currently supports: '.implode(', ', $modes));
         }
 
         $message = sprintf('Failed to authenticate on SMTP server with username "%s" using the following authenticators: "%s".', $this->username, implode('", "', $authNames));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4+
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

If there is no match for the available authenticators the thrown exception now includes the supported auth methods as reported by the server.
