### PR TITLE
[DebugBundle] Remove warning of ServerDumpPlaceholderCommand in console

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Command/ServerDumpPlaceholderCommand.php
+++ b/src/Symfony/Bundle/DebugBundle/Command/ServerDumpPlaceholderCommand.php
@@ -27,6 +27,9 @@ use Symfony\Component\VarDumper\Server\DumpServer;
  */
 class ServerDumpPlaceholderCommand extends Command
 {
+    protected static $defaultName = 'server:dump';
+    protected static $defaultDescription = 'Start a dump server that collects and displays dumps in a single place';
+
     private $replacedCommand;
 
     public function __construct(DumpServer $server = null, array $descriptors = [])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2.5
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40495
| License       | MIT
| Doc PR        | 

In 5.2.5 the console commands are lazy. (https://github.com/symfony/symfony/pull/39851)
With this change the ServerDumpCommand::$defaultName is used which isn't set in the placeholder command.
If no vardump-server in debug.dump_destination is defined, this will lead to a warning and not adding the command to the console list.