### PR TITLE
[Inflector][String] Fixed pluralize "coupon"

### DIFF
--- a/src/Symfony/Component/Inflector/Inflector.php
+++ b/src/Symfony/Component/Inflector/Inflector.php
@@ -231,6 +231,9 @@ final class Inflector
         // bacteria (bacterium), criteria (criterion), phenomena (phenomenon)
         ['noi', 3, true, true, 'ions'],
 
+        // coupon (coupons)
+        ['nop', 3, true, true, 'pons'],
+
         // seasons (season), treasons (treason), poisons (poison), lessons (lesson)
         ['nos', 3, true, true, 'sons'],
 

--- a/src/Symfony/Component/Inflector/Tests/InflectorTest.php
+++ b/src/Symfony/Component/Inflector/Tests/InflectorTest.php
@@ -201,6 +201,7 @@ class InflectorTest extends TestCase
             ['crisis', 'crises'],
             ['criteria', 'criterion'],
             ['cup', 'cups'],
+            ['coupon', 'coupons'],
             ['data', 'data'],
             ['day', 'days'],
             ['disco', 'discos'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40467
| License       | MIT
| Doc PR        | 

The rule for "bacteria (bacterium), criteria (criterion), phenomena (phenomenon)" is producing this behaviour. I added an exception to the "criterion exception". 

"coupon" is an old French word, that is maybe why it does not follow the classic "on" rule... I dont know. The test passes and I dont think I've added any side-effects. 

This is also my first time working with the `EnglishInflector`. 
