### PR TITLE
[Yaml] fixed parser incorrectly parses some yaml block sequences

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -559,9 +559,9 @@ class Parser
     /**
      * Returns the next embed block of YAML.
      *
-     * @param int|null $indentation The indent level at which the block is to be read, or null for default
-     * @param bool     $inSequence  True if the enclosing data structure is a sequence
-     * @param bool     $isInlineFirstChild
+     * @param int|null $indentation        The indent level at which the block is to be read, or null for default
+     * @param bool     $inSequence         True if the enclosing data structure is a sequence
+     * @param bool     $isInlineFirstChild True if the definition has an inline first element
      *
      * @return string A YAML string
      *

--- a/src/Symfony/Component/Yaml/Tests/Fixtures/YtsBasicTests.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/YtsBasicTests.yml
@@ -200,3 +200,41 @@ php: |
          'age' => 38
        ]
      ]
+---
+test: Block Sequence in Block Sequence 1
+brief: |
+  Block Sequence in Block Sequence 1
+yaml: |
+  - - s1_i1
+    - s1_i2
+  - s2
+php: |
+  [
+    [
+      "s1_i1",
+      "s1_i2"
+    ],
+    "s2"
+  ]
+---
+test: Block Sequence in Block Sequence 2
+brief: |
+  Block Sequence in Block Sequence 2
+yaml: |
+  - - s1_i1
+    - - s1_i1_1
+      - s1_i1_2
+    - s1_i2
+  - s2
+php: |
+  [
+    [
+      "s1_i1",
+      [
+        "s1_i1_1",
+        "s1_i1_2",
+      ],
+      "s1_i2"
+    ],
+      "s2"
+  ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #40438
| License       | MIT
| Doc PR        | 


