### PR TITLE
[Messenger] Support metadata credentials in SQS transport connection

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -143,6 +143,12 @@ class Connection
         }
         unset($query['region']);
 
+        // if accessKeyId and accessKeySecret are both null assume we are using metadata credentials so don't pass the keys in
+        if ($clientConfiguration['accessKeyId'] === null && $clientConfiguration['accessKeySecret'] === null) {
+            unset($clientConfiguration['accessKeyId']);
+            unset($clientConfiguration['accessKeySecret']);
+        }
+
         if ('default' !== ($parsedUrl['host'] ?? 'default')) {
             $clientConfiguration['endpoint'] = sprintf('%s://%s%s', ($query['sslmode'] ?? null) === 'disable' ? 'http' : 'https', $parsedUrl['host'], ($parsedUrl['port'] ?? null) ? ':'.$parsedUrl['port'] : '');
             if (preg_match(';^sqs\.([^\.]++)\.amazonaws\.com$;', $parsedUrl['host'], $matches)) {

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -144,7 +144,7 @@ class Connection
         unset($query['region']);
 
         // if accessKeyId and accessKeySecret are both null assume we are using metadata credentials so don't pass the keys in
-        if ($clientConfiguration['accessKeyId'] === null && $clientConfiguration['accessKeySecret'] === null) {
+        if (null === $clientConfiguration['accessKeyId'] && null === $clientConfiguration['accessKeySecret']) {
             unset($clientConfiguration['accessKeyId']);
             unset($clientConfiguration['accessKeySecret']);
         }


### PR DESCRIPTION
AsyncAws requires that no credential keys are passed into the initialiser in order to fallback to metadata (EC2 instance for example) credentials.

| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT

Now sure how we want to handle this so I thought I would have a first pass. The other option is to pass something like the string 'metadata' to both the key and secret and then we know to remove the credentials keys before passing to the initialiser. However passing null as the key and secret wouldn't work even if you weren't using metadata credentials so this is why I did it this way.