### PR TITLE
[Validator] Avoid triggering the autoloader for user-input values

### DIFF
--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -656,8 +656,10 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
             return;
         }
 
-        // If the value is a scalar, pass it anyway, because we want
-        // a NoSuchMetadataException to be thrown in that case
+        if (!\is_object($value)) {
+            throw new NoSuchMetadataException(sprintf('Cannot create metadata for non-objects. Got: "%s".', \gettype($value)));
+        }
+
         $this->validateObject(
             $value,
             $propertyPath,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

Following-up to https://twitter.com/seldaek/status/1372450636361502721 - mostly to see if the build passes or if this breaks some undocumented/unclear-to-me assumptions.

Essentially using the `Valid` constraint should only validate objects if they exist as objects. If a user sends a string and that gets assigned to a property, `Valid` should not attempt autoloading that user-given string. 

As far as I can tell, this is used in two places:

- https://github.com/symfony/symfony/blob/acb32dd396e95967990f004953e5a480cd507e51/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php#L364-L365 where non-objects are anyway ignored, so this change is harmless there.
- https://github.com/symfony/symfony/blob/acb32dd396e95967990f004953e5a480cd507e51/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php#L652-L660 where it's explicitly passing anything in there to get the proper exception, so my change makes sure that exception is thrown *before* autoloading attempts. I am just not 100% sure if there are cases where validateGenericNode will receive a class name as a string to validate in $value. I can't imagine why it would but that doesn't mean it's true.