### PR TITLE
[Form] IntegerType: Always use en for IntegerToLocalizedStringTransformer

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
@@ -24,19 +24,21 @@ class IntegerToLocalizedStringTransformer extends NumberToLocalizedStringTransfo
     /**
      * Constructs a transformer.
      *
-     * @param bool $grouping     Whether thousands should be grouped
-     * @param int  $roundingMode One of the ROUND_ constants in this class
+     * @param bool        $grouping     Whether thousands should be grouped
+     * @param int         $roundingMode One of the ROUND_ constants in this class
+     * @param string|null $locale       locale used for transforming
      */
-    public function __construct($grouping = false, $roundingMode = self::ROUND_DOWN)
+    public function __construct($grouping = false, $roundingMode = self::ROUND_DOWN, $locale = null)
     {
-        if (\is_int($grouping) || \is_bool($roundingMode) || 2 < \func_num_args()) {
+        if (\is_int($grouping) || \is_bool($roundingMode) || \is_int($locale)) {
             @trigger_error(sprintf('Passing a precision as the first value to %s::__construct() is deprecated since Symfony 4.2 and support for it will be dropped in 5.0.', __CLASS__), \E_USER_DEPRECATED);
 
             $grouping = $roundingMode;
-            $roundingMode = 2 < \func_num_args() ? func_get_arg(2) : self::ROUND_DOWN;
+            $roundingMode = null !== $locale ? $locale : self::ROUND_DOWN;
+            $locale = null;
         }
 
-        parent::__construct(0, $grouping, $roundingMode);
+        parent::__construct(0, $grouping, $roundingMode, $locale);
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/IntegerType.php
@@ -25,7 +25,7 @@ class IntegerType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addViewTransformer(new IntegerToLocalizedStringTransformer($options['grouping'], $options['rounding_mode']));
+        $builder->addViewTransformer(new IntegerToLocalizedStringTransformer($options['grouping'], $options['rounding_mode'], !$options['grouping'] ? 'en' : null));
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -17,11 +17,40 @@ class IntegerTypeTest extends BaseTypeTest
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\IntegerType';
 
+    private $previousLocale;
+
     protected function setUp(): void
     {
         IntlTestHelper::requireIntl($this, false);
-
+        $this->previousLocale = \Locale::getDefault();
         parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        \Locale::setDefault($this->previousLocale);
+    }
+
+    public function testArabicLocale()
+    {
+        \Locale::setDefault('ar');
+
+        $form = $this->factory->create(static::TESTED_TYPE);
+        $form->submit('123456');
+
+        $this->assertSame(123456, $form->getData());
+        $this->assertSame('123456', $form->getViewData());
+    }
+
+    public function testArabicLocaleNonHtml5()
+    {
+        \Locale::setDefault('ar');
+
+        $form = $this->factory->create(static::TESTED_TYPE, null, ['grouping' => true]);
+        $form->submit('123456');
+
+        $this->assertSame(123456, $form->getData());
+        $this->assertSame('١٢٣٬٤٥٦', $form->getViewData());
     }
 
     public function testSubmitRejectsFloats()


### PR DESCRIPTION
Fixes #40456

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40456
| License       | MIT

