### PR TITLE
[Runtime] make GenericRuntime ... generic

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -38,6 +38,8 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\UriSigner;
+use Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner;
+use Symfony\Component\Runtime\Runner\Symfony\ResponseRunner;
 use Symfony\Component\Runtime\SymfonyRuntime;
 use Symfony\Component\String\LazyString;
 use Symfony\Component\String\Slugger\AsciiSlugger;
@@ -79,6 +81,8 @@ return static function (ContainerConfigurator $container) {
                 service('argument_resolver'),
             ])
             ->tag('container.hot_path')
+            ->tag('container.preload', ['class' => HttpKernelRunner::class])
+            ->tag('container.preload', ['class' => ResponseRunner::class])
             ->tag('container.preload', ['class' => SymfonyRuntime::class])
         ->alias(HttpKernelInterface::class, 'http_kernel')
 

--- a/src/Symfony/Component/Runtime/Internal/BasicErrorHandler.php
+++ b/src/Symfony/Component/Runtime/Internal/BasicErrorHandler.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Runtime\Internal;
  */
 class BasicErrorHandler
 {
-    public function __construct(bool $debug)
+    public static function register(bool $debug): void
     {
         error_reporting(-1);
 
@@ -32,10 +32,11 @@ class BasicErrorHandler
         if (0 <= ini_get('zend.assertions')) {
             ini_set('zend.assertions', 1);
             ini_set('assert.active', $debug);
-            ini_set('assert.bail', 0);
             ini_set('assert.warning', 0);
             ini_set('assert.exception', 1);
         }
+
+        set_error_handler(new self());
     }
 
     public function __invoke(int $type, string $message, string $file, int $line): bool

--- a/src/Symfony/Component/Runtime/Internal/ComposerPlugin.php
+++ b/src/Symfony/Component/Runtime/Internal/ComposerPlugin.php
@@ -102,14 +102,12 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
             throw new \InvalidArgumentException(sprintf('Class "%s" listed under "extra.runtime.class" in your composer.json file '.(class_exists($runtimeClass) ? 'should implement "%s".' : 'not found.'), $runtimeClass, RuntimeInterface::class));
         }
 
-        if (!\is_array($runtimeOptions = $extra['options'] ?? [])) {
-            throw new \InvalidArgumentException('The "extra.runtime.options" entry in your composer.json file must be an array.');
-        }
+        unset($extra['class'], $extra['autoload_template']);
 
         $code = strtr(file_get_contents($autoloadTemplate), [
             '%project_dir%' => $projectDir,
             '%runtime_class%' => var_export($runtimeClass, true),
-            '%runtime_options%' => '['.substr(var_export($runtimeOptions, true), 7, -1)."  'project_dir' => {$projectDir},\n]",
+            '%runtime_options%' => '['.substr(var_export($extra, true), 7, -1)."  'project_dir' => {$projectDir},\n]",
         ]);
 
         file_put_contents(substr_replace($autoloadFile, '_runtime', -4, 0), $code);

--- a/src/Symfony/Component/Runtime/Internal/Console/ApplicationRuntime.php
+++ b/src/Symfony/Component/Runtime/Internal/Console/ApplicationRuntime.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Runtime\Symfony\Component\Console;
+
+use Symfony\Component\Runtime\SymfonyRuntime;
+
+/**
+ * @internal
+ */
+class ApplicationRuntime extends SymfonyRuntime
+{
+}

--- a/src/Symfony/Component/Runtime/Internal/Console/Command/CommandRuntime.php
+++ b/src/Symfony/Component/Runtime/Internal/Console/Command/CommandRuntime.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Runtime\Symfony\Component\Console\Command;
+
+use Symfony\Component\Runtime\SymfonyRuntime;
+
+/**
+ * @internal
+ */
+class CommandRuntime extends SymfonyRuntime
+{
+}

--- a/src/Symfony/Component/Runtime/Internal/Console/Input/InputInterfaceRuntime.php
+++ b/src/Symfony/Component/Runtime/Internal/Console/Input/InputInterfaceRuntime.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Runtime\Symfony\Component\Console\Input;
+
+use Symfony\Component\Runtime\SymfonyRuntime;
+
+/**
+ * @internal
+ */
+class InputInterfaceRuntime extends SymfonyRuntime
+{
+}

--- a/src/Symfony/Component/Runtime/Internal/Console/Output/OutputInterfaceRuntime.php
+++ b/src/Symfony/Component/Runtime/Internal/Console/Output/OutputInterfaceRuntime.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Runtime\Symfony\Component\Console\Output;
+
+use Symfony\Component\Runtime\SymfonyRuntime;
+
+/**
+ * @internal
+ */
+class OutputInterfaceRuntime extends SymfonyRuntime
+{
+}

--- a/src/Symfony/Component/Runtime/Internal/HttpFoundation/RequestRuntime.php
+++ b/src/Symfony/Component/Runtime/Internal/HttpFoundation/RequestRuntime.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Runtime\Symfony\Component\HttpFoundation;
+
+use Symfony\Component\Runtime\SymfonyRuntime;
+
+/**
+ * @internal
+ */
+class RequestRuntime extends SymfonyRuntime
+{
+}

--- a/src/Symfony/Component/Runtime/Internal/HttpFoundation/ResponseRuntime.php
+++ b/src/Symfony/Component/Runtime/Internal/HttpFoundation/ResponseRuntime.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Runtime\Symfony\Component\HttpFoundation;
+
+use Symfony\Component\Runtime\SymfonyRuntime;
+
+/**
+ * @internal
+ */
+class ResponseRuntime extends SymfonyRuntime
+{
+}

--- a/src/Symfony/Component/Runtime/Internal/HttpKernel/HttpKernelInterfaceRuntime.php
+++ b/src/Symfony/Component/Runtime/Internal/HttpKernel/HttpKernelInterfaceRuntime.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Runtime\Symfony\Component\HttKernel;
+
+use Symfony\Component\Runtime\SymfonyRuntime;
+
+/**
+ * @internal
+ */
+class HttpKernelInterfaceRuntime extends SymfonyRuntime
+{
+}

--- a/src/Symfony/Component/Runtime/Internal/SymfonyErrorHandler.php
+++ b/src/Symfony/Component/Runtime/Internal/SymfonyErrorHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Runtime\Internal;
+
+use Symfony\Component\ErrorHandler\BufferingLogger;
+use Symfony\Component\ErrorHandler\DebugClassLoader;
+use Symfony\Component\ErrorHandler\ErrorHandler;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @internal
+ */
+class SymfonyErrorHandler
+{
+    public static function register(bool $debug): void
+    {
+        BasicErrorHandler::register($debug);
+
+        if (class_exists(ErrorHandler::class)) {
+            DebugClassLoader::enable();
+            restore_error_handler();
+            ErrorHandler::register(new ErrorHandler(new BufferingLogger(), true));
+        }
+    }
+}

--- a/src/Symfony/Component/Runtime/RuntimeInterface.php
+++ b/src/Symfony/Component/Runtime/RuntimeInterface.php
@@ -25,7 +25,7 @@ interface RuntimeInterface
      *
      * The callable itself should return an object that represents the application to pass to the getRunner() method.
      */
-    public function getResolver(callable $callable): ResolverInterface;
+    public function getResolver(callable $callable, \ReflectionFunction $reflector = null): ResolverInterface;
 
     /**
      * Returns a callable that knows how to run the passed object and that returns its exit status as int.

--- a/src/Symfony/Component/Runtime/Tests/phpt/autoload.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/autoload.php
@@ -12,7 +12,8 @@ if (file_exists(dirname(__DIR__, 2).'/vendor/autoload.php')) {
     }
 
     $app = require $_SERVER['SCRIPT_FILENAME'];
-    $runtime = new SymfonyRuntime($_SERVER['APP_RUNTIME_OPTIONS']);
+    $runtime = $_SERVER['APP_RUNTIME'] ?? SymfonyRuntime::class;
+    $runtime = new $runtime($_SERVER['APP_RUNTIME_OPTIONS']);
     [$app, $args] = $runtime->getResolver($app)->resolve();
     exit($runtime->getRunner($app(...$args))->run());
 }

--- a/src/Symfony/Component/Runtime/Tests/phpt/generic-request.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/generic-request.php
@@ -1,0 +1,19 @@
+<?php
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Runtime\GenericRuntime;
+use Symfony\Runtime\Symfony\Component\HttpFoundation\RequestRuntime;
+use Symfony\Runtime\Symfony\Component\HttpFoundation\ResponseRuntime;
+
+$_SERVER['APP_RUNTIME'] = GenericRuntime::class;
+require __DIR__.'/autoload.php';
+
+return function (Request $request, array $context) {
+    echo class_exists(RequestRuntime::class, false) ? 'OK request runtime' : 'KO request runtime', "\n";
+
+    return new StreamedResponse(function () use ($context) {
+        echo 'OK Request '.$context['SOME_VAR'], "\n";
+        echo class_exists(ResponseRuntime::class, false) ? 'KO response runtime' : 'OK response runtime', "\n";
+    });
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/generic-request.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/generic-request.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test Request/Response
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/generic-request.php';
+
+?>
+--EXPECTF--
+OK request runtime
+OK Request foo_bar
+OK response runtime

--- a/src/Symfony/Component/Runtime/Tests/phpt/kernel-loop.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/kernel-loop.php
@@ -1,9 +1,9 @@
 <?php
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Runtime\SymfonyRuntime;
 use Symfony\Component\Runtime\Runner\ClosureRunner;
 use Symfony\Component\Runtime\RunnerInterface;
+use Symfony\Component\Runtime\SymfonyRuntime;
 
 require __DIR__.'/autoload.php';
 

--- a/src/Symfony/Component/Runtime/composer.json
+++ b/src/Symfony/Component/Runtime/composer.json
@@ -30,7 +30,10 @@
         "symfony/dotenv": "<5.1"
     },
     "autoload": {
-        "psr-4": { "Symfony\\Component\\Runtime\\": "" },
+        "psr-4": {
+            "Symfony\\Component\\Runtime\\": "",
+            "Symfony\\Runtime\\Symfony\\Component\\": "Internal/"
+        },
         "exclude-from-classmap": [
             "/Tests/"
         ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR will allow #40436 to move to https://github.com/symfony/psr-http-message-bridge 
For the record, it builds on a prototype I wrote almost one year ago at https://github.com/tchwork/bootstrapper.

This PR makes the `GenericRuntime` implementation able to auto-discover runtime implementations for specific types.

It uses the autoloader for the discovery: when a closure-app requires or returns a type `Vendor\Foo`, it will use a convention and check if the class `Symfony\Runtime\Vendor\FooRuntime` exists. If yes, it will use it to resolve the corresponding type. Such runtime classes have to extend `GenericRuntime` so that they can use the protected API it provides. This requirement is aligned with the fact that the very convention proposed here is an implementation detail that works when using a `GenericRuntime` as the main runtime (This behavior can be overridden by providing explicit entries in the new `runtimes` option when booting the `GenericRuntime`.)

`SymfonyRuntime` can be used as both the main runtime or a type-specific runtime:
- when used as the main runtime, it configures the typical global-state for Symfony and has a fast codepath for Symfony types, while still being generic.
- it can also be used in another runtime as a way to resolve Symfony types (would typically be useful to #40436 for running Console apps in a PSR-based web app.)