### PR TITLE
[HttpKernel] Add is_file() check before include

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -533,7 +533,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
                 if (!flock($lock, $wouldBlock ? \LOCK_SH : \LOCK_EX)) {
                     fclose($lock);
                     $lock = null;
-                } elseif (!\is_object($this->container = include $cachePath)) {
+                } elseif (!is_file($cachePath) || !\is_object($this->container = include $cachePath)) {
                     $this->container = null;
                 } elseif (!$oldContainer || \get_class($this->container) !== $oldContainer->name) {
                     flock($lock, \LOCK_UN);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes (?)
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I recently noticed that on every deployment I got warnings reported by sentry from the `cache:clear` command.

> Warning: include(/var/www/html/var/cache/pro_/App_KernelProdContainer.php): failed to open stream: No such file or directory

In `Symfony\Component\HttpKernel\Kernel` [line 469](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/HttpKernel/Kernel.php#L469)
 (on 4.4 it's on [line 536](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/HttpKernel/Kernel.php#L536))

This is because the code tries to include the `$cachePath` without checking if it exists/is a file first. It seems like something similar was fixed some time ago already (https://github.com/symfony/symfony/pull/27249) some lines above.

This PR fixes the mentioned warnings for me.

I'm running on Symfony 5.2.5 at the moment, but the docs said that bugfixes should target branch 4.4 and new features should target 5.x, and I guess this could rather be seen as a bugfix than a new feature, so I branched off of 4.4 and also set this as target for the PR, I hope that's correct.