### PR TITLE
[Uid] [GenerateUuidCommand] Compute a new \DateTimeImmutable every loop

### DIFF
--- a/src/Symfony/Component/Uid/Command/GenerateUuidCommand.php
+++ b/src/Symfony/Component/Uid/Command/GenerateUuidCommand.php
@@ -131,7 +131,7 @@ EOF
                 }
 
                 try {
-                    $time = new \DateTimeImmutable($time);
+                    new \DateTimeImmutable($time);
                 } catch (\Exception $e) {
                     $io->error(sprintf('Invalid timestamp "%s": %s', $time, str_replace('DateTimeImmutable::__construct(): ', '', $e->getMessage())));
 
@@ -139,7 +139,7 @@ EOF
                 }
 
                 $create = function () use ($node, $time): Uuid {
-                    return $this->factory->timeBased($node)->create($time);
+                    return $this->factory->timeBased($node)->create(new \DateTimeImmutable($time));
                 };
                 break;
 

--- a/src/Symfony/Component/Uid/Tests/Command/GenerateUlidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/GenerateUlidCommandTest.php
@@ -89,4 +89,15 @@ final class GenerateUlidCommandTest extends TestCase
 
         Ulid::fromRfc4122(trim($commandTester->getDisplay()));
     }
+
+    public function testTimestampIncrementWhenGeneratingSeveralTimeBasedUlids()
+    {
+        $commandTester = new CommandTester(new GenerateUlidCommand());
+
+        $this->assertSame(0, $commandTester->execute(['--time' => 'now', '--count' => '2']));
+
+        $ulids = explode("\n", trim($commandTester->getDisplay(true)));
+
+        $this->assertNotSame($ulids[0], $ulids[1]);
+    }
 }

--- a/src/Symfony/Component/Uid/Tests/Command/GenerateUuidCommandTest.php
+++ b/src/Symfony/Component/Uid/Tests/Command/GenerateUuidCommandTest.php
@@ -209,4 +209,15 @@ final class GenerateUuidCommandTest extends TestCase
 
         Uuid::fromBase32(trim($commandTester->getDisplay()));
     }
+
+    public function testTimestampIncrementWhenGeneratingSeveralTimeBasedUuids()
+    {
+        $commandTester = new CommandTester(new GenerateUuidCommand());
+
+        $this->assertSame(0, $commandTester->execute(['--time-based' => 'now', '--count' => '2']));
+
+        $uuids = explode("\n", trim($commandTester->getDisplay(true)));
+
+        $this->assertNotSame($uuids[0], $uuids[1]);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Before (the timestamp is never increased):
```
➜  uuid:generate --time-based=now --count=3
eb017d96-88cf-11eb-a80e-c3dd8d58cd10
eb017d96-88cf-11eb-a80e-c3dd8d58cd10
eb017d96-88cf-11eb-a80e-c3dd8d58cd10
```

After:
```
➜  uuid:generate --time-based=now --count=3
0ef9ed97-88d0-11eb-a80e-c3dd8d58cd10
0ef9ed98-88d0-11eb-a80e-c3dd8d58cd10
0ef9ed99-88d0-11eb-a80e-c3dd8d58cd10
```

It it useful if time based is not the default in the factory.