### PR TITLE
[Serializer] Allow AbstractNormalizer to use null for non-optional nullable constructor parameters without default value

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -501,6 +501,8 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                     $params[] = $this->defaultContext[self::DEFAULT_CONSTRUCTOR_ARGUMENTS][$class][$key];
                 } elseif ($constructorParameter->isDefaultValueAvailable()) {
                     $params[] = $constructorParameter->getDefaultValue();
+                } elseif ($constructorParameter->hasType() && $constructorParameter->getType()->allowsNull()) {
+                    $params[] = null;
                 } else {
                     throw new MissingConstructorArgumentsException(sprintf('Cannot create an instance of "%s" from serialized data because its constructor requires parameter "%s" to be present.', $class, $constructorParameter->name));
                 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/NullableOptionalConstructorArgumentDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/NullableOptionalConstructorArgumentDummy.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class NullableOptionalConstructorArgumentDummy
+{
+    private $foo;
+
+    public function __construct(?\stdClass $foo)
+    {
+        $this->foo = $foo;
+    }
+
+    public function setFoo($foo)
+    {
+        $this->foo = 'this setter should not be called when using the constructor argument';
+    }
+
+    public function getFoo()
+    {
+        return $this->foo;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractNormalizerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Tests\Fixtures\AbstractNormalizerDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NullableConstructorArgumentDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\NullableOptionalConstructorArgumentDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\StaticConstructorDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\StaticConstructorNormalizer;
 use Symfony\Component\Serializer\Tests\Fixtures\VariadicConstructorTypedArgsDummy;
@@ -120,7 +121,31 @@ class AbstractNormalizerTest extends TestCase
     public function testObjectWithNullableConstructorArgument()
     {
         $normalizer = new ObjectNormalizer();
+        $dummy = $normalizer->denormalize(['foo' => null], NullableOptionalConstructorArgumentDummy::class);
+
+        $this->assertNull($dummy->getFoo());
+    }
+
+    public function testObjectWithNullableConstructorArgumentWithoutInput()
+    {
+        $normalizer = new ObjectNormalizer();
+        $dummy = $normalizer->denormalize([], NullableOptionalConstructorArgumentDummy::class);
+
+        $this->assertNull($dummy->getFoo());
+    }
+
+    public function testObjectWithNullableNonOptionalConstructorArgument()
+    {
+        $normalizer = new ObjectNormalizer();
         $dummy = $normalizer->denormalize(['foo' => null], NullableConstructorArgumentDummy::class);
+
+        $this->assertNull($dummy->getFoo());
+    }
+
+    public function testObjectWithNullableNonOptionalConstructorArgumentWithoutInput()
+    {
+        $normalizer = new ObjectNormalizer();
+        $dummy = $normalizer->denormalize([], NullableConstructorArgumentDummy::class);
 
         $this->assertNull($dummy->getFoo());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40511
| License       | MIT

Serializer component AbstractNormalizer attemps to guess constructor parameters, and falls back using default values when possible. Yet, it misses one use case: nullable non-optional parameter with value not being present in incoming input, case in which null is a valid value, not the default one, yet still valid.

This PR introduce a two-line fix that forcefully set null as value for missing from input non-optional nullable constructor parameters values.