### PR TITLE
[Console] fix emojis messing up the line width

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -311,7 +311,7 @@ class QuestionHelper extends Helper
                         $remainingCharacters = substr($ret, \strlen(trim($this->mostRecentlyEnteredValue($fullChoice))));
                         $output->write($remainingCharacters);
                         $fullChoice .= $remainingCharacters;
-                        $i = self::strlen($fullChoice);
+                        $i = (false === $encoding = mb_detect_encoding($fullChoice, null, true)) ? \strlen($fullChoice) : mb_strlen($fullChoice, $encoding);
 
                         $matches = array_filter(
                             $autocomplete($ret),

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -501,8 +501,6 @@ class SymfonyStyle extends OutputStyle
             }
 
             $line = $prefix.$line;
-            $decorationLength = Helper::strlen($line) - Helper::strlenWithoutDecoration($this->getFormatter(), $line);
-            $messageLineLength = min($this->lineLength - $prefixLength - $indentLength + $decorationLength, $this->lineLength);
             $line .= str_repeat(' ', max($this->lineLength - Helper::strlenWithoutDecoration($this->getFormatter(), $line), 0));
 
             if ($style) {

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_21.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/command/command_21.php
@@ -1,0 +1,13 @@
+<?php
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+//Ensure texts with emojis don't make longer lines than expected
+return function (InputInterface $input, OutputInterface $output) {
+    $output = new SymfonyStyle($input, $output);
+    $output->success('Lorem ipsum dolor sit amet');
+    $output->success('Lorem ipsum dolor sit amet with one emoji 🎉');
+    $output->success('Lorem ipsum dolor sit amet with so many of them 👩‍🌾👩‍🌾👩‍🌾👩‍🌾👩‍🌾');
+};

--- a/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_21.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Style/SymfonyStyle/output/output_21.txt
@@ -1,0 +1,7 @@
+
+ [OK] Lorem ipsum dolor sit amet                                                                                        
+
+ [OK] Lorem ipsum dolor sit amet with one emoji 🎉                                                                      
+
+ [OK] Lorem ipsum dolor sit amet with so many of them 👩‍🌾👩‍🌾👩‍🌾👩‍🌾👩‍🌾                                              
+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/37904
| License       | MIT


Description
========

The emojis, because they take as much space as two characters, would cause the console to display too many spaces to complete a line, which made it uneven, as described in the issue.

The fix uses the `width` function instead of `strlen`. To answer @ogizanagi's comment, yes it does work with "composed" emojis.

Before : 

![image](https://user-images.githubusercontent.com/11477247/111832081-9d72b100-88f0-11eb-8eda-65ee480c898d.png)

After : 

![image](https://user-images.githubusercontent.com/11477247/111832103-a6638280-88f0-11eb-802e-838d97f61c81.png)

Other changes
==========

Removed two unused lines of code, the value of `$messageLineLength` was never used.

Note
====
I'd like to add some tests, but I don't know how since I think this depends on console client width ?

Thanks for your reviews :pray: 
