### PR TITLE
[Runtime] Dont use "parent" as type hint

### DIFF
--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -177,7 +177,7 @@ class SymfonyRuntime extends GenericRuntime
         return parent::getArgument($parameter, $type);
     }
 
-    protected static function register(parent $runtime): parent
+    protected static function register(GenericRuntime $runtime): GenericRuntime
     {
         $self = new self($runtime->options + ['runtimes' => []]);
         $self->options['runtimes'] += [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no (minor)
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The type hint `parent` is weird and confusing. PHPStorm also warned be that it is not supported on PHP 7.2 and 7.3. 

I replace this will `GenericRuntime` instead. It will make it easier to extend `SymfonyRuntime`. 
