### PR TITLE
[Translation] Missing translations from traits

### DIFF
--- a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
@@ -60,6 +60,9 @@ class TranslatorPathsPass extends AbstractRecursivePass
             foreach ($this->paths as $class => $_) {
                 if (($r = $container->getReflectionClass($class)) && !$r->isInterface()) {
                     $paths[] = $r->getFileName();
+                    foreach ($r->getTraits() as $trait) {
+                        $paths[] = $trait->getFileName();
+                    }
                 }
             }
             if ($paths) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #40528 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

If you use ->trans() in traits, your translations will be cleaned with translation:update --clean command

Affected all Symfony versions

Please write some tests for me, I took me long time to debug and repair this :(

![image](https://user-images.githubusercontent.com/177340/111880657-159eac80-89ad-11eb-803b-7c63c67b27b9.png)
