### PR TITLE
[Uid] refer to AbstractUid instead of "parent"

### DIFF
--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -121,7 +121,7 @@ class Uuid extends AbstractUid
         return $this->uid;
     }
 
-    public function compare(parent $other): int
+    public function compare(AbstractUid $other): int
     {
         if (false !== $cmp = uuid_compare($this->uid, $other->uid)) {
             return $cmp;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Following @OskarStark's suggestion. 

Except for internal code and test code, we do this on one more place. That is `LazyResponseEvent`, but that class is final so there is no need to change it. 
