### PR TITLE
[HttpKernel] ConfigDataCollector to return known data without the need of a Kernel

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -59,12 +59,19 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
      */
     public function collect(Request $request, Response $response/*, \Throwable $exception = null*/)
     {
+        $eom = \DateTime::createFromFormat('d/m/Y', '01/'.Kernel::END_OF_MAINTENANCE);
+        $eol = \DateTime::createFromFormat('d/m/Y', '01/'.Kernel::END_OF_LIFE);
+
         $this->data = [
             'app_name' => $this->name,
             'app_version' => $this->version,
             'token' => $response->headers->get('X-Debug-Token'),
             'symfony_version' => Kernel::VERSION,
-            'symfony_state' => 'unknown',
+            'symfony_minor_version' => sprintf('%s.%s', Kernel::MAJOR_VERSION, Kernel::MINOR_VERSION),
+            'symfony_lts' => 4 === Kernel::MINOR_VERSION,
+            'symfony_state' => $this->determineSymfonyState(),
+            'symfony_eom' => $eom->format('F Y'),
+            'symfony_eol' => $eol->format('F Y'),
             'env' => isset($this->kernel) ? $this->kernel->getEnvironment() : 'n/a',
             'debug' => isset($this->kernel) ? $this->kernel->isDebug() : 'n/a',
             'php_version' => \PHP_VERSION,
@@ -82,14 +89,6 @@ class ConfigDataCollector extends DataCollector implements LateDataCollectorInte
             foreach ($this->kernel->getBundles() as $name => $bundle) {
                 $this->data['bundles'][$name] = new ClassStub(\get_class($bundle));
             }
-
-            $this->data['symfony_state'] = $this->determineSymfonyState();
-            $this->data['symfony_minor_version'] = sprintf('%s.%s', Kernel::MAJOR_VERSION, Kernel::MINOR_VERSION);
-            $this->data['symfony_lts'] = 4 === Kernel::MINOR_VERSION;
-            $eom = \DateTime::createFromFormat('d/m/Y', '01/'.Kernel::END_OF_MAINTENANCE);
-            $eol = \DateTime::createFromFormat('d/m/Y', '01/'.Kernel::END_OF_LIFE);
-            $this->data['symfony_eom'] = $eom->format('F Y');
-            $this->data['symfony_eol'] = $eol->format('F Y');
         }
 
         if (preg_match('~^(\d+(?:\.\d+)*)(.+)?$~', $this->data['php_version'], $matches) && isset($matches[2])) {

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -41,6 +41,13 @@ class ConfigDataCollectorTest extends TestCase
         $this->assertSame(\extension_loaded('xdebug'), $c->hasXDebug());
         $this->assertSame(\extension_loaded('Zend OPcache') && filter_var(ini_get('opcache.enable'), \FILTER_VALIDATE_BOOLEAN), $c->hasZendOpcache());
         $this->assertSame(\extension_loaded('apcu') && filter_var(ini_get('apc.enabled'), \FILTER_VALIDATE_BOOLEAN), $c->hasApcu());
+        $this->assertSame(sprintf('%s.%s', Kernel::MAJOR_VERSION, Kernel::MINOR_VERSION), $c->getSymfonyMinorVersion());
+        $this->assertContains($c->getSymfonyState(), ['eol', 'eom', 'dev', 'stable']);
+
+        $eom = \DateTime::createFromFormat('d/m/Y', '01/'.Kernel::END_OF_MAINTENANCE)->format('F Y');
+        $eol = \DateTime::createFromFormat('d/m/Y', '01/'.Kernel::END_OF_LIFE)->format('F Y');
+        $this->assertSame($eom, $c->getSymfonyEom());
+        $this->assertSame($eol, $c->getSymfonyEol());
     }
 
     /**
@@ -57,6 +64,34 @@ class ConfigDataCollectorTest extends TestCase
 
         $this->assertSame('name', $c->getApplicationName());
         $this->assertNull($c->getApplicationVersion());
+    }
+
+    public function testCollectWithoutKernel()
+    {
+        $c = new ConfigDataCollector();
+        $c->collect(new Request(), new Response());
+
+        $this->assertSame('n/a', $c->getEnv());
+        $this->assertSame('n/a', $c->isDebug());
+        $this->assertSame('config', $c->getName());
+        $this->assertMatchesRegularExpression('~^'.preg_quote($c->getPhpVersion(), '~').'~', \PHP_VERSION);
+        $this->assertMatchesRegularExpression('~'.preg_quote((string) $c->getPhpVersionExtra(), '~').'$~', \PHP_VERSION);
+        $this->assertSame(\PHP_INT_SIZE * 8, $c->getPhpArchitecture());
+        $this->assertSame(class_exists(\Locale::class, false) && \Locale::getDefault() ? \Locale::getDefault() : 'n/a', $c->getPhpIntlLocale());
+        $this->assertSame(date_default_timezone_get(), $c->getPhpTimezone());
+        $this->assertSame(Kernel::VERSION, $c->getSymfonyVersion());
+        $this->assertSame(4 === Kernel::MINOR_VERSION, $c->isSymfonyLts());
+        $this->assertNull($c->getToken());
+        $this->assertSame(\extension_loaded('xdebug'), $c->hasXDebug());
+        $this->assertSame(\extension_loaded('Zend OPcache') && filter_var(ini_get('opcache.enable'), \FILTER_VALIDATE_BOOLEAN), $c->hasZendOpcache());
+        $this->assertSame(\extension_loaded('apcu') && filter_var(ini_get('apc.enabled'), \FILTER_VALIDATE_BOOLEAN), $c->hasApcu());
+        $this->assertSame(sprintf('%s.%s', Kernel::MAJOR_VERSION, Kernel::MINOR_VERSION), $c->getSymfonyMinorVersion());
+        $this->assertContains($c->getSymfonyState(), ['eol', 'eom', 'dev', 'stable']);
+
+        $eom = \DateTime::createFromFormat('d/m/Y', '01/'.Kernel::END_OF_MAINTENANCE)->format('F Y');
+        $eol = \DateTime::createFromFormat('d/m/Y', '01/'.Kernel::END_OF_LIFE)->format('F Y');
+        $this->assertSame($eom, $c->getSymfonyEom());
+        $this->assertSame($eol, $c->getSymfonyEol());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40534
| License       | MIT
| Doc PR        | 

Sets `$this->data` with information that can be known without the need of a `Kernel`.