### PR TITLE
[Security] Handle properly 'auto' option for remember me cookie security

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -69,7 +69,12 @@ class RememberMeFactory implements SecurityFactoryInterface
         }
 
         // remember-me options
-        $rememberMeServices->replaceArgument(3, array_intersect_key($config, $this->options));
+        $mergedOptions = array_intersect_key($config, $this->options);
+        if ('auto' === $mergedOptions['secure']) {
+            $mergedOptions['secure'] = null;
+        }
+
+        $rememberMeServices->replaceArgument(3, $mergedOptions);
 
         // attach to remember-me aware listeners
         $userProviders = [];

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/RememberMeCookieTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/RememberMeCookieTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+
+class RememberMeCookieTest extends AbstractWebTestCase
+{
+    /** @dataProvider getSessionRememberMeSecureCookieFlagAutoHttpsMap */
+    public function testSessionRememberMeSecureCookieFlagAuto($https, $expectedSecureFlag)
+    {
+        $client = $this->createClient(['test_case' => 'RememberMeCookie', 'root_config' => 'config.yml']);
+
+        $client->request('POST', '/login', [
+            '_username' => 'test',
+            '_password' => 'test',
+        ], [], [
+             'HTTPS' => (int) $https,
+        ]);
+
+        $cookies = $client->getResponse()->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
+
+        $this->assertEquals($expectedSecureFlag, $cookies['']['/']['REMEMBERME']->isSecure());
+    }
+
+    public function getSessionRememberMeSecureCookieFlagAutoHttpsMap()
+    {
+        return [
+            [true, true],
+            [false, false],
+        ];
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/bundles.php
@@ -1,0 +1,9 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+
+return [
+    new FrameworkBundle(),
+    new SecurityBundle(),
+];

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/config.yml
@@ -1,0 +1,25 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+security:
+    encoders:
+        Symfony\Component\Security\Core\User\User: plaintext
+
+    providers:
+        in_memory:
+            memory:
+                users:
+                    test: { password: test, roles: [ROLE_USER] }
+
+    firewalls:
+        default:
+            form_login:
+                check_path: login
+                remember_me: true
+                require_previous_session: false
+            remember_me:
+                always_remember_me: true
+                secret: key
+                secure: auto
+            logout: ~
+            anonymous: ~

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/routing.yml
@@ -1,0 +1,2 @@
+login:
+    path: /login


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40471
| License       | MIT
| Doc PR        | n/a

Manually setting remember_me cookie secure as auto is still is being set as secure one even if used over http.

This PR fixes this behaviour by converting auto to null prior setting it up for service.