### PR TITLE
[Security] improve login throttling rate limiter requirement message

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -64,7 +64,7 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface, SecurityF
         }
 
         if (!class_exists(RateLimiterFactory::class)) {
-            throw new \LogicException('Login throttling requires symfony/rate-limiter to be installed and enabled.');
+            throw new \LogicException('Login throttling requires the Rate Limiter component. Try running "composer require symfony/rate-limiter".');
         }
 
         if (!isset($config['limiter'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Provide the composer command to the user if the `rate-limiter` component is not installed when attempting to use login throttling.