### PR TITLE
Fixed parsing deprecated definitions without message key

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -416,7 +416,7 @@ class YamlFileLoader extends FileLoader
                         trigger_deprecation('symfony/dependency-injection', '5.1', 'Not setting the attribute "version" of the "deprecated" option in "%s" is deprecated.', $file);
                     }
 
-                    $alias->setDeprecated($deprecation['package'] ?? '', $deprecation['version'] ?? '', $deprecation['message']);
+                    $alias->setDeprecated($deprecation['package'] ?? '', $deprecation['version'] ?? '', $deprecation['message'] ?? '');
                 }
             }
 
@@ -485,7 +485,7 @@ class YamlFileLoader extends FileLoader
                 trigger_deprecation('symfony/dependency-injection', '5.1', 'Not setting the attribute "version" of the "deprecated" option in "%s" is deprecated.', $file);
             }
 
-            $definition->setDeprecated($deprecation['package'] ?? '', $deprecation['version'] ?? '', $deprecation['message']);
+            $definition->setDeprecated($deprecation['package'] ?? '', $deprecation['version'] ?? '', $deprecation['message'] ?? '');
         }
 
         if (isset($service['factory'])) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/deprecated_definition_without_message.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/deprecated_definition_without_message.yml
@@ -1,0 +1,12 @@
+services:
+    service_without_deprecation_message:
+        class: Foo
+        deprecated:
+            package: vendor/package
+            version: 1.1
+
+    alias_without_deprecation_message:
+        alias: foobar
+        deprecated:
+            package: vendor/package
+            version: 1.1

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -220,6 +220,27 @@ class YamlFileLoaderTest extends TestCase
         $this->assertSame(['$a' => 'a', 'App\Foo' => 'foo'], $services['bar_foo']->getArguments());
     }
 
+    public function testLoadDeprecatedDefinitionWithoutMessageKey()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('deprecated_definition_without_message.yml');
+
+        $this->assertTrue($container->getDefinition('service_without_deprecation_message')->isDeprecated());
+        $deprecation = $container->getDefinition('service_without_deprecation_message')->getDeprecation('service_without_deprecation_message');
+        $message = 'The "service_without_deprecation_message" service is deprecated. You should stop using it, as it will be removed in the future.';
+        $this->assertSame($message, $deprecation['message']);
+        $this->assertSame('vendor/package', $deprecation['package']);
+        $this->assertSame('1.1', $deprecation['version']);
+
+        $this->assertTrue($container->getAlias('alias_without_deprecation_message')->isDeprecated());
+        $deprecation = $container->getAlias('alias_without_deprecation_message')->getDeprecation('alias_without_deprecation_message');
+        $message = 'The "alias_without_deprecation_message" service alias is deprecated. You should stop using it, as it will be removed in the future.';
+        $this->assertSame($message, $deprecation['message']);
+        $this->assertSame('vendor/package', $deprecation['package']);
+        $this->assertSame('1.1', $deprecation['version']);
+    }
+
     public function testDeprecatedAliases()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

### Steps to reproduce

1. Create service/alias definition and mark it as deprecated without specifying message key as shown in https://symfony.com/doc/5.2/service_container/alias_private.html#deprecating-service-aliases. For example:

```yaml
services:
    service_without_deprecation_message:
        class: Foo
        deprecated:
            package: vendor/package
            version: 1.1

    alias_without_deprecation_message:
        alias: foobar
        deprecated:
            package: vendor/package
            version: 1.1
```

2. Clear cache by running `php bin/console cache:clear`

### Actual behaviour 

`Symfony\Component\Config\Exception\LoaderLoadException` exception is thrown with the following message: `Warning: Undefined array key "message" (...)` 

See https://gist.github.com/adamwojs/5bac85d4326d8fbe6f52a357fa6e57e6 for full stactrace.

### Excepted behaviour

Given definitions are loaded correctly. Default service/alias deprecation message is used as shown in linked documentation page.