### PR TITLE
[FrameworkBundle] ensure TestBrowserToken::$firewallName is serialized

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/TestBrowserToken.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/TestBrowserToken.php
@@ -43,4 +43,16 @@ class TestBrowserToken extends AbstractToken
     {
         return null;
     }
+
+    public function __serialize(): array
+    {
+        return [$this->firewallName, parent::__serialize()];
+    }
+
+    public function __unserialize(array $data): void
+    {
+        [$this->firewallName, $parentData] = $data;
+
+        parent::__unserialize($parentData);
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Test/TestBrowserTokenTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Test/TestBrowserTokenTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Test;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Test\TestBrowserToken;
+
+final class TestBrowserTokenTest extends TestCase
+{
+    public function testCanBeSerializedAndUnserialized()
+    {
+        $token = unserialize(serialize(new TestBrowserToken()));
+
+        $this->assertSame('main', $token->getFirewallName());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Fixes a bug introduced in #40368. When `TestBrowserToken` in unserialized, `$firewallName` is `null` so trying to access it via `getFirewallName` throws a `TypeError`.
