### PR TITLE
[Notifier] Move abstract test cases to  namespace

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/Tests/AllMySmsTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/Tests/AllMySmsTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\AllMySms\Tests;
 
 use Symfony\Component\Notifier\Bridge\AllMySms\AllMySmsTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class AllMySmsTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/AllMySms/Tests/AllMySmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/AllMySms/Tests/AllMySmsTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\AllMySms\AllMySmsTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/Tests/ClickatellTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/Tests/ClickatellTransportFactoryTest.php
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Notifier\Bridge\Clickatell\Tests;
 
 use Symfony\Component\Notifier\Bridge\Clickatell\ClickatellTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 class ClickatellTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Discord\Tests;
 
 use Symfony\Component\Notifier\Bridge\Discord\DiscordTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class DiscordTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Discord/Tests/DiscordTransportTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Esendex\Tests;
 
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class EsendexTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Firebase\Tests;
 
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 /**

--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\FreeMobile\Tests;
 
 use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class FreeMobileTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FreeMobile/Tests/FreeMobileTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/Tests/GatewayApiTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/Tests/GatewayApiTransportFactoryTest.php
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Notifier\Bridge\GatewayApi\Tests;
 
 use Symfony\Component\Notifier\Bridge\GatewayApi\GatewayApiTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 /**

--- a/src/Symfony/Component/Notifier/Bridge/GatewayApi/Tests/GatewayApiTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GatewayApi/Tests/GatewayApiTransportTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;

--- a/src/Symfony/Component/Notifier/Bridge/Gitter/Tests/GitterTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Gitter/Tests/GitterTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Gitter\Tests;
 
 use Symfony\Component\Notifier\Bridge\Gitter\GitterTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 /**

--- a/src/Symfony/Component/Notifier/Bridge/Gitter/Tests/GitterTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Gitter/Tests/GitterTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\Gitter\GitterTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\GoogleChat\Tests;
 
 use Symfony\Component\Notifier\Bridge\GoogleChat\GoogleChatTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class GoogleChatTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Notification\Notification;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/Tests/InfobipTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/Tests/InfobipTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Infobip\Tests;
 
 use Symfony\Component\Notifier\Bridge\Infobip\InfobipTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class InfobipTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/Infobip/Tests/InfobipTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Infobip/Tests/InfobipTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\Infobip\InfobipTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/Tests/IqsmsTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/Tests/IqsmsTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Iqsms\Tests;
 
 use Symfony\Component\Notifier\Bridge\Iqsms\IqsmsTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class IqsmsTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/Iqsms/Tests/IqsmsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Iqsms/Tests/IqsmsTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\Iqsms\IqsmsTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportFactoryTest.php
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Notifier\Bridge\LinkedIn\Tests;
 
 use Symfony\Component\Notifier\Bridge\LinkedIn\LinkedInTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class LinkedInTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/Tests/LinkedInTransportTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Notification\Notification;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Mattermost\Tests;
 
 use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 /**

--- a/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mattermost/Tests/MattermostTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/MercureTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/MercureTransportFactoryTest.php
@@ -16,7 +16,7 @@ use Symfony\Bridge\PhpUnit\ClassExistsMock;
 use Symfony\Bundle\MercureBundle\MercureBundle;
 use Symfony\Component\Mercure\PublisherInterface;
 use Symfony\Component\Notifier\Bridge\Mercure\MercureTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\Dsn;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 use Symfony\Contracts\Service\ServiceProviderInterface;

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/MercureTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/Tests/MercureTransportTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/Tests/MobytTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/Tests/MobytTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Mobyt\Tests;
 
 use Symfony\Component\Notifier\Bridge\Mobyt\MobytTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 /**

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/Tests/MobytTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/Tests/MobytTransportTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Notifier\Bridge\Mobyt\MobytTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/Tests/NexmoTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/Tests/NexmoTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Nexmo\Tests;
 
 use Symfony\Component\Notifier\Bridge\Nexmo\NexmoTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class NexmoTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/Nexmo/Tests/NexmoTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Nexmo/Tests/NexmoTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\Nexmo\NexmoTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/Tests/OctopushTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/Tests/OctopushTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Octopush\Tests;
 
 use Symfony\Component\Notifier\Bridge\Octopush\OctopushTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class OctopushTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/Octopush/Tests/OctopushTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Octopush/Tests/OctopushTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\Octopush\OctopushTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\OvhCloud\Tests;
 
 use Symfony\Component\Notifier\Bridge\OvhCloud\OvhCloudTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class OvhCloudTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/OvhCloud/Tests/OvhCloudTransportTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Notifier\Bridge\OvhCloud\OvhCloudTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\RocketChat\Tests;
 
 use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 /**

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/Tests/RocketChatTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Sendinblue\Tests;
 
 use Symfony\Component\Notifier\Bridge\Sendinblue\SendinblueTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class SendinblueTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sendinblue/Tests/SendinblueTransportTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/Tests/SinchTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/Tests/SinchTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Sinch\Tests;
 
 use Symfony\Component\Notifier\Bridge\Sinch\SinchTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class SinchTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/Sinch/Tests/SinchTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sinch/Tests/SinchTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\Sinch\SinchTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportFactoryTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Slack\Tests;
 
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\Dsn;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Notification\Notification;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Smsapi\Tests;
 
 use Symfony\Component\Notifier\Bridge\Smsapi\SmsapiTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class SmsapiTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\Smsapi\SmsapiTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/Tests/SpotHitTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/Tests/SpotHitTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\SpotHit\Tests;
 
 use Symfony\Component\Notifier\Bridge\SpotHit\SpotHitTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class SpotHitTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/SpotHit/Tests/SpotHitTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/SpotHit/Tests/SpotHitTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\SpotHit\SpotHitTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Telegram\Tests;
 
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class TelegramTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Tests/TelegramTransportTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Twilio\Tests;
 
 use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class TwilioTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/Tests/ZulipTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/Tests/ZulipTransportFactoryTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Bridge\Zulip\Tests;
 
 use Symfony\Component\Notifier\Bridge\Zulip\ZulipTransportFactory;
-use Symfony\Component\Notifier\Tests\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
 use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
 
 final class ZulipTransportFactoryTest extends TransportFactoryTestCase

--- a/src/Symfony/Component/Notifier/Bridge/Zulip/Tests/ZulipTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Zulip/Tests/ZulipTransportTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\Zulip\ZulipTransport;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Tests\TransportTestCase;
+use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 

--- a/src/Symfony/Component/Notifier/Test/TransportFactoryTestCase.php
+++ b/src/Symfony/Component/Notifier/Test/TransportFactoryTestCase.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Notifier\Tests;
+namespace Symfony\Component\Notifier\Test;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Exception\IncompleteDsnException;

--- a/src/Symfony/Component/Notifier/Test/TransportTestCase.php
+++ b/src/Symfony/Component/Notifier/Test/TransportTestCase.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Notifier\Tests;
+namespace Symfony\Component\Notifier\Test;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no (only fixes builds)
| New feature?  | yes (not sure about a changeling entry)
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | no

This enables BC promise for the abstract test classes, like for other ones.

As we ignore current `/Tests` directory in `.gitattributes`, builds will fail if `symfony/notifier` is installed as dist.