### PR TITLE
[Translation] Fix update existing key with existing +int-icu domain

### DIFF
--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -167,7 +167,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
         }
         $intlDomain = $domain;
         $suffixLength = \strlen(self::INTL_DOMAIN_SUFFIX);
-        if (\strlen($domain) > $suffixLength && false !== strpos($domain, self::INTL_DOMAIN_SUFFIX, -$suffixLength)) {
+        if (\strlen($domain) < $suffixLength || false === strpos($domain, self::INTL_DOMAIN_SUFFIX, -$suffixLength)) {
             $intlDomain .= self::INTL_DOMAIN_SUFFIX;
         }
         foreach ($messages as $id => $message) {

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -129,6 +129,16 @@ class MessageCatalogueTest extends TestCase
         $this->assertEquals('bar', $catalogue->get('foo', 'domain88'));
     }
 
+    public function testAddIntICU()
+    {
+        $catalogue = new MessageCatalogue('en', ['domain1+intl-icu' => ['foo' => 'foo']]);
+        $catalogue->add(['foo1' => 'foo1'], 'domain1');
+        $catalogue->add(['foo' => 'bar'], 'domain1');
+
+        $this->assertEquals('bar', $catalogue->get('foo', 'domain1'));
+        $this->assertEquals('foo1', $catalogue->get('foo1', 'domain1'));
+    }
+
     public function testReplace()
     {
         $catalogue = new MessageCatalogue('en', ['domain1' => ['foo' => 'foo'], 'domain1+intl-icu' => ['bar' => 'bar']]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |  none
| License       | MIT
| Doc PR        | none

Using php-translation webui interface, I was trying to update an existing +int-icu domain but a regular domain was created and the existing key wasn't updated. Looks like in the method I modified, we should have been looking for a potential domain+intl-icu domain and try update it first
