### PR TITLE
[HttpKernel] Add `#[AsController]` attribute for declaring standalone controllers on PHP 8

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -74,6 +74,7 @@ use Symfony\Component\HttpClient\RetryableHttpClient;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
+use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
@@ -557,6 +558,9 @@ class FrameworkExtension extends Extension
 
         $container->registerAttributeForAutoconfiguration(EventListener::class, static function (ChildDefinition $definition, EventListener $attribute): void {
             $definition->addTag('kernel.event_listener', get_object_vars($attribute));
+        });
+        $container->registerAttributeForAutoconfiguration(AsController::class, static function (ChildDefinition $definition, AsController $attribute): void {
+            $definition->addTag('controller.service_arguments');
         });
 
         if (!$container->getParameter('kernel.debug')) {

--- a/src/Symfony/Component/HttpKernel/Attribute/AsController.php
+++ b/src/Symfony/Component/HttpKernel/Attribute/AsController.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Attribute;
+
+/**
+ * Service tag to autoconfigure controllers.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsController
+{
+    public function __construct()
+    {
+    }
+}

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Deprecate returning a `ContainerBuilder` from `KernelInterface::registerContainerConfiguration()`
  * Deprecate `HttpKernelInterface::MASTER_REQUEST` and add `HttpKernelInterface::MAIN_REQUEST` as replacement
  * Deprecate `KernelEvent::isMasterRequest()` and add `isMainRequest()` as replacement
+ * Add `#[AsController]` attribute for declaring standalone controllers on PHP 8
 
 5.2.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR adds an `#[AsController]` attribute to allow autoconfiguring controllers even when they don't extend `AbstractController`. This should allow removing the line about `controller.service_arguments` in `services.yaml` to cover this need (but that is noise to most.)
