### PR TITLE
Add `#[As-prefix]` to service attributes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -59,7 +59,7 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
-use Symfony\Component\EventDispatcher\Attribute\EventListener;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Finder\Finder;
@@ -555,7 +555,7 @@ class FrameworkExtension extends Extension
         $container->registerForAutoconfiguration(LoggerAwareInterface::class)
             ->addMethodCall('setLogger', [new Reference('logger')]);
 
-        $container->registerAttributeForAutoconfiguration(EventListener::class, static function (ChildDefinition $definition, EventListener $attribute): void {
+        $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute): void {
             $definition->addTag('kernel.event_listener', get_object_vars($attribute));
         });
 

--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -11,8 +11,11 @@
 
 namespace Symfony\Component\Console\Attribute;
 
+/**
+ * Service tag to autoconfigure commands.
+ */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class ConsoleCommand
+class AsCommand
 {
     public function __construct(
         public string $name,

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -10,7 +10,7 @@ CHANGELOG
    on the `console.command` tag to allow the `list` command to instantiate commands lazily
  * Add option `--short` to the `list` command
  * Add support for bright colors
- * Add `ConsoleCommand` attribute for declaring commands on PHP 8
+ * Add `#[AsCommand]` attribute for declaring commands on PHP 8
 
 5.2.0
 -----

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Console\Command;
 
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Attribute\ConsoleCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\LogicException;
@@ -67,7 +67,7 @@ class Command
     {
         $class = static::class;
 
-        if (\PHP_VERSION_ID >= 80000 && $attribute = (new \ReflectionClass($class))->getAttributes(ConsoleCommand::class)) {
+        if (\PHP_VERSION_ID >= 80000 && $attribute = (new \ReflectionClass($class))->getAttributes(AsCommand::class)) {
             return $attribute[0]->newInstance()->name;
         }
 
@@ -83,7 +83,7 @@ class Command
     {
         $class = static::class;
 
-        if (\PHP_VERSION_ID >= 80000 && $attribute = (new \ReflectionClass($class))->getAttributes(ConsoleCommand::class)) {
+        if (\PHP_VERSION_ID >= 80000 && $attribute = (new \ReflectionClass($class))->getAttributes(AsCommand::class)) {
             return $attribute[0]->newInstance()->description;
         }
 

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Console\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Attribute\ConsoleCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Helper\FormatterHelper;
@@ -409,7 +409,7 @@ class CommandTest extends TestCase
     /**
      * @requires PHP 8
      */
-    public function testConsoleCommandAttribute()
+    public function testCommandAttribute()
     {
         $this->assertSame('|foo|f', Php8Command::getDefaultName());
         $this->assertSame('desc', Php8Command::getDefaultDescription());
@@ -425,7 +425,7 @@ function createClosure()
     };
 }
 
-#[ConsoleCommand(name: 'foo', description: 'desc', hidden: true, aliases: ['f'])]
+#[AsCommand(name: 'foo', description: 'desc', hidden: true, aliases: ['f'])]
 class Php8Command extends Command
 {
 }

--- a/src/Symfony/Component/DependencyInjection/Attribute/AsTaggedItem.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/AsTaggedItem.php
@@ -17,7 +17,7 @@ namespace Symfony\Component\DependencyInjection\Attribute;
  * @author Nicolas Grekas <p@tchwork.com>
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class TaggedItem
+class AsTaggedItem
 {
     public function __construct(
         public ?string $index = null,

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * Add `ServicesConfigurator::remove()` in the PHP-DSL
  * Add `%env(not:...)%` processor to negate boolean values
  * Add support for loading autoconfiguration rules via the `#[Autoconfigure]` and `#[AutoconfigureTag]` attributes on PHP 8
- * Add `#[TaggedItem]` attribute for defining the index and priority of classes found in tagged iterators/locators
+ * Add `#[AsTaggedItem]` attribute for defining the index and priority of classes found in tagged iterators/locators
  * Add autoconfigurable attributes
  * Add support for per-env configuration in loaders
  * Add `ContainerBuilder::willBeAvailable()` to help with conditional configuration

--- a/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
-use Symfony\Component\DependencyInjection\Attribute\TaggedItem;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
@@ -126,7 +126,7 @@ class PriorityTaggedServiceUtil
         }
 
         if ($checkTaggedItem && !$r->hasMethod($defaultMethod)) {
-            foreach ($r->getAttributes(TaggedItem::class) as $attribute) {
+            foreach ($r->getAttributes(AsTaggedItem::class) as $attribute) {
                 return 'priority' === $indexAttribute ? $attribute->newInstance()->priority : $attribute->newInstance()->index;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/PriorityTaggedServiceTraitTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Compiler;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Argument\TaggedIteratorArgument;
-use Symfony\Component\DependencyInjection\Attribute\TaggedItem;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\Compiler\ResolveInstanceofConditionalsPass;
@@ -235,12 +235,12 @@ class PriorityTaggedServiceTraitImplementation
     }
 }
 
-#[TaggedItem(index: 'hello', priority: 1)]
+#[AsTaggedItem(index: 'hello', priority: 1)]
 class HelloNamedService extends \stdClass
 {
 }
 
-#[TaggedItem(priority: 2)]
+#[AsTaggedItem(priority: 2)]
 class HelloNamedService2
 {
 }

--- a/src/Symfony/Component/EventDispatcher/Attribute/AsEventListener.php
+++ b/src/Symfony/Component/EventDispatcher/Attribute/AsEventListener.php
@@ -17,7 +17,7 @@ namespace Symfony\Component\EventDispatcher\Attribute;
  * @author Alexander M. Turek <me@derrabus.de>
  */
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
-class EventListener
+class AsEventListener
 {
     public function __construct(
         public ?string $event = null,

--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 5.3
 ---
 
- * Add `EventListener` attribute for declaring listeners on PHP 8
+ * Add `#[AsEventListener]` attribute for declaring listeners on PHP 8
 
 5.1.0
 -----

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Compiler\ResolveInstanceofConditionals
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\EventDispatcher\Attribute\EventListener;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -248,7 +248,7 @@ class RegisterListenersPassTest extends TestCase
         }
 
         $container = new ContainerBuilder();
-        $container->registerAttributeForAutoconfiguration(EventListener::class, static function (ChildDefinition $definition, EventListener $attribute): void {
+        $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute): void {
             $definition->addTag('kernel.event_listener', get_object_vars($attribute));
         });
         $container->register('foo', TaggedInvokableListener::class)->setAutoconfigured(true);
@@ -282,7 +282,7 @@ class RegisterListenersPassTest extends TestCase
         }
 
         $container = new ContainerBuilder();
-        $container->registerAttributeForAutoconfiguration(EventListener::class, static function (ChildDefinition $definition, EventListener $attribute): void {
+        $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute): void {
             $definition->addTag('kernel.event_listener', get_object_vars($attribute));
         });
         $container->register('foo', TaggedMultiListener::class)->setAutoconfigured(true);

--- a/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedInvokableListener.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedInvokableListener.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\EventDispatcher\Tests\Fixtures;
 
-use Symfony\Component\EventDispatcher\Attribute\EventListener;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 
-#[EventListener]
+#[AsEventListener]
 final class TaggedInvokableListener
 {
     public function __invoke(CustomEvent $event): void

--- a/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedMultiListener.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/Fixtures/TaggedMultiListener.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\Component\EventDispatcher\Tests\Fixtures;
 
-use Symfony\Component\EventDispatcher\Attribute\EventListener;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 
-#[EventListener(event: CustomEvent::class, method: 'onCustomEvent')]
-#[EventListener(event: 'foo', priority: 42)]
-#[EventListener(event: 'bar', method: 'onBarEvent')]
+#[AsEventListener(event: CustomEvent::class, method: 'onCustomEvent')]
+#[AsEventListener(event: 'foo', priority: 42)]
+#[AsEventListener(event: 'bar', method: 'onBarEvent')]
 final class TaggedMultiListener
 {
     public function onCustomEvent(CustomEvent $event): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR renames all attributes that are related to autoconfiguration with the `As` prefix, as I proposed several times already.

This should help autocompletion, and it's required to not collide with existing class names (eg the `Command` class, but also the old `Controller` class, etc.)

I think this `As` prefix is a convention for the better.