### PR TITLE
fix: Duplicate id in DOM for file field (bootstrap 4)

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -125,7 +125,7 @@
         {%- set label_attr = label_attr|merge({ class: (label_attr.class|default('') ~ ' custom-file-label')|trim }) -%}
         {%- set input_lang = 'en' -%}
         {% if app is defined and app.request is defined %}{%- set input_lang = app.request.locale -%}{%- endif -%}
-        <label for="{{ form.vars.id }}" lang="{{ input_lang }}" {% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}>
+        <label for="{{ form.vars.id }}" lang="{{ input_lang }}" {% with { attr: label_attr|merge({id: label_attr.id~'_file_label'}) } %}{{ block('attributes') }}{% endwith %}>
             {%- if attr.placeholder is defined and attr.placeholder is not none -%}
                 {{- translation_domain is same as(false) ? attr.placeholder : attr.placeholder|trans({}, translation_domain) -}}
             {%- endif -%}


### PR DESCRIPTION
fixing duplicate ID in the DOM as the label_attr.id has been already used within the file_label block.

| Q             | A
| ------------- | ---
| Branch?       | 5.x for features / 4.4 or 5.2 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40562
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This is casing an accessibility (WCAG) issue as specified here: https://www.w3.org/TR/WCAG20-TECHS/H93.html
