### PR TITLE
fix: fixing duplicate ID in the DOM as the label_attr.id has been alr…

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -123,7 +123,7 @@
         {%- set type = type|default('file') -%}
         {{- block('form_widget_simple') -}}
         {%- set label_attr = label_attr|merge({ class: (label_attr.class|default('') ~ ' custom-file-label')|trim }) -%}
-        <label for="{{ form.vars.id }}" {% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}>
+        <label for="{{ form.vars.id }}" {% with { attr: label_attr|merge({id: label_attr.id~'_file_label'}) } %}{{ block('attributes') }}{% endwith %}>
             {%- if attr.placeholder is defined -%}
                 {{- translation_domain is same as(false) ? attr.placeholder : attr.placeholder|trans({}, translation_domain) -}}
             {%- endif -%}


### PR DESCRIPTION
fixing duplicate ID in the DOM as the label_attr.id has been already used within the file_label block.

| Q             | A
| ------------- | ---
| Branch?       | 5.x for features / 4.4 or 5.2 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40562
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This is causing an accessibility (WCAG) issue as specified here: https://www.w3.org/TR/WCAG20-TECHS/H93.html
