### PR TITLE
Fix Trying to clone an uncloneable object of class

### DIFF
--- a/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/StoreFactoryTest.php
@@ -40,7 +40,7 @@ class StoreFactoryTest extends TestCase
     public function validConnections()
     {
         if (class_exists(\Redis::class)) {
-            yield [$this->createMock(\Redis::class), RedisStore::class];
+            yield [new \Redis(), RedisStore::class];
         }
         if (class_exists(RedisProxy::class)) {
             yield [$this->createMock(RedisProxy::class), RedisStore::class];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


Since `ext-redis: 5.3..3`, the `\Redis` class is not cloneable anymore (https://github.com/phpredis/phpredis/commit/cd05a344).
PHPUnit 7.5 (used byt PHP 7.1) clones objects provided by the dataprovier, when they are cloneable.
To check if an object is cloneable, it use the `Reflexion::isCloneable` method and check if the `__clone` method is public.

The issue is, the Class generated by `createMock` is cloneable, which leads to an exception such as:
> Trying to clone an uncloneable object of class Mock_Redis_b2f171b3

This PR fake replaces the mock by a real instance of the class.