### PR TITLE
[FrameworkBundle][HttpKernel][TwigBridge] Add an helper to generate fragments URL

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
 * Add a new `markAsPublic` method on `NotificationEmail` to change the `importance` context option to null after creation
+* Add a new `fragment_uri()` helper to generate the URI of a fragment
 
 5.3.0
 -----

--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
@@ -30,6 +30,7 @@ final class HttpKernelExtension extends AbstractExtension
         return [
             new TwigFunction('render', [HttpKernelRuntime::class, 'renderFragment'], ['is_safe' => ['html']]),
             new TwigFunction('render_*', [HttpKernelRuntime::class, 'renderFragmentStrategy'], ['is_safe' => ['html']]),
+            new TwigFunction('fragment_uri', [HttpKernelRuntime::class, 'generateFragmentUri']),
             new TwigFunction('controller', static::class.'::controller'),
         ];
     }

--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelRuntime.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelRuntime.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Twig\Extension;
 
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Symfony\Component\HttpKernel\Fragment\FragmentUriGeneratorInterface;
 
 /**
  * Provides integration with the HttpKernel component.
@@ -22,10 +23,12 @@ use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 final class HttpKernelRuntime
 {
     private $handler;
+    private $fragmentUriGenerator;
 
-    public function __construct(FragmentHandler $handler)
+    public function __construct(FragmentHandler $handler, FragmentUriGeneratorInterface $fragmentUriGenerator = null)
     {
         $this->handler = $handler;
+        $this->fragmentUriGenerator = $fragmentUriGenerator;
     }
 
     /**
@@ -53,5 +56,14 @@ final class HttpKernelRuntime
     public function renderFragmentStrategy(string $strategy, $uri, array $options = []): string
     {
         return $this->handler->render($uri, $strategy, $options);
+    }
+
+    public function generateFragmentUri(ControllerReference $controller, bool $absolute = false, bool $strict = true, bool $sign = true): string
+    {
+        if (null === $this->fragmentUriGenerator) {
+            throw new \LogicException(sprintf('An instance of "%s" must be provided to use "%s()".', FragmentUriGeneratorInterface::class, __METHOD__));
+        }
+
+        return $this->fragmentUriGenerator->generate($controller, null, $absolute, $strict, $sign);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
  * Deprecate all other values than "none", "php_array" and "file" for `framework.annotation.cache`
  * Add `KernelTestCase::getContainer()` as the best way to get a container in tests
  * Rename the container parameter `profiler_listener.only_master_requests` to `profiler_listener.only_main_requests`
+ * Add service `fragment.uri_generator` to generate the URI of a fragment
 
 5.2.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\HttpKernel\DependencyInjection\LazyLoadingFragmentHandler;
 use Symfony\Component\HttpKernel\Fragment\EsiFragmentRenderer;
+use Symfony\Component\HttpKernel\Fragment\FragmentUriGenerator;
+use Symfony\Component\HttpKernel\Fragment\FragmentUriGeneratorInterface;
 use Symfony\Component\HttpKernel\Fragment\HIncludeFragmentRenderer;
 use Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer;
 use Symfony\Component\HttpKernel\Fragment\SsiFragmentRenderer;
@@ -30,6 +32,10 @@ return static function (ContainerConfigurator $container) {
                 service('request_stack'),
                 param('kernel.debug'),
             ])
+
+        ->set('fragment.uri_generator', FragmentUriGenerator::class)
+            ->args([param('fragment.path'), service('uri_signer')])
+        ->alias(FragmentUriGeneratorInterface::class, 'fragment.uri_generator')
 
         ->set('fragment.renderer.inline', InlineFragmentRenderer::class)
             ->args([service('http_kernel'), service('event_dispatcher')])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -49,6 +49,7 @@ use Symfony\Component\HttpClient\RetryableHttpClient;
 use Symfony\Component\HttpClient\ScopingHttpClient;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\LoggerPass;
+use Symfony\Component\HttpKernel\Fragment\FragmentUriGeneratorInterface;
 use Symfony\Component\Messenger\Transport\TransportFactory;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Security\Core\Security;
@@ -181,6 +182,8 @@ abstract class FrameworkExtensionTest extends TestCase
     public function testFragmentsAndHinclude()
     {
         $container = $this->createContainerFromFile('fragments_and_hinclude');
+        $this->assertTrue($container->has('fragment.uri_generator'));
+        $this->assertTrue($container->hasAlias(FragmentUriGeneratorInterface::class));
         $this->assertTrue($container->hasParameter('fragment.renderer.hinclude.global_template'));
         $this->assertEquals('global_hinclude_template', $container->getParameter('fragment.renderer.hinclude.global_template'));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/FragmentController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/FragmentController.php
@@ -15,6 +15,8 @@ use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\Fragment\FragmentUriGeneratorInterface;
 use Twig\Environment;
 
 class FragmentController implements ContainerAwareInterface
@@ -44,6 +46,11 @@ class FragmentController implements ContainerAwareInterface
     public function forwardLocaleAction(Request $request)
     {
         return new Response($request->getLocale());
+    }
+
+    public function fragmentUriAction(Request $request, FragmentUriGeneratorInterface $fragmentUriGenerator)
+    {
+        return new Response($fragmentUriGenerator->generate(new ControllerReference(self::class.'::indexAction'), $request));
     }
 }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
@@ -57,6 +57,10 @@ fragment_inlined:
     path:     /fragment_inlined
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\FragmentController::inlinedAction }
 
+fragment_uri:
+    path:     /fragment_uri
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\FragmentController::fragmentUriAction }
+
 array_controller:
     path:     /array_controller
     defaults: { _controller: [ArrayController, someAction] }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/FragmentTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/FragmentTest.php
@@ -44,4 +44,12 @@ TXT
             [true],
         ];
     }
+
+    public function testGenerateFragmentUri()
+    {
+        $client = self::createClient(['test_case' => 'Fragment', 'root_config' => 'config.yml', 'debug' => true]);
+        $client->request('GET', '/fragment_uri');
+
+        $this->assertSame('/_fragment?_hash=CCRGN2D%2FoAJbeGz%2F%2FdoH3bNSPwLCrmwC1zAYCGIKJ0E%3D&_path=_format%3Dhtml%26_locale%3Den%26_controller%3DSymfony%255CBundle%255CFrameworkBundle%255CTests%255CFunctional%255CBundle%255CTestBundle%255CController%255CFragmentController%253A%253AindexAction', $client->getResponse()->getContent());
+    }
 }

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.php
@@ -123,7 +123,7 @@ return static function (ContainerConfigurator $container) {
         ->set('twig.extension.httpkernel', HttpKernelExtension::class)
 
         ->set('twig.runtime.httpkernel', HttpKernelRuntime::class)
-            ->args([service('fragment.handler')])
+            ->args([service('fragment.handler'), service('fragment.uri_generator')->ignoreOnInvalid()])
 
         ->set('twig.extension.httpfoundation', HttpFoundationExtension::class)
             ->args([service('url_helper')])

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Deprecate `HttpKernelInterface::MASTER_REQUEST` and add `HttpKernelInterface::MAIN_REQUEST` as replacement
  * Deprecate `KernelEvent::isMasterRequest()` and add `isMainRequest()` as replacement
  * Add `#[AsController]` attribute for declaring standalone controllers on PHP 8
+ * Add `FragmentUriGeneratorInterface` and `FragmentUriGenerator` to generate the URI of a fragment
 
 5.2.0
 -----

--- a/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/AbstractSurrogateFragmentRenderer.php
@@ -83,14 +83,7 @@ abstract class AbstractSurrogateFragmentRenderer extends RoutableFragmentRendere
 
     private function generateSignedFragmentUri(ControllerReference $uri, Request $request): string
     {
-        if (null === $this->signer) {
-            throw new \LogicException('You must use a URI when using the ESI rendering strategy or set a URL signer.');
-        }
-
-        // we need to sign the absolute URI, but want to return the path only.
-        $fragmentUri = $this->signer->sign($this->generateFragmentUri($uri, $request, true));
-
-        return substr($fragmentUri, \strlen($request->getSchemeAndHttpHost()));
+        return (new FragmentUriGenerator($this->fragmentPath, $this->signer))->generate($uri, $request);
     }
 
     private function containsNonScalars(array $values): bool

--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentUriGenerator.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentUriGenerator.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Fragment;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\UriSigner;
+
+/**
+ * Generates a fragment URI.
+ *
+ * @author Kévin Dunglas <kevin@dunglas.fr>
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+final class FragmentUriGenerator implements FragmentUriGeneratorInterface
+{
+    private $fragmentPath;
+    private $signer;
+    private $requestStack;
+
+    public function __construct(string $fragmentPath, UriSigner $signer = null, RequestStack $requestStack = null)
+    {
+        $this->fragmentPath = $fragmentPath;
+        $this->signer = $signer;
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function generate(ControllerReference $controller, Request $request = null, bool $absolute = false, bool $strict = true, bool $sign = true): string
+    {
+        if (null === $request && (null === $this->requestStack || null === $request = $this->requestStack->getCurrentRequest())) {
+            throw new \LogicException('Generating a fragment URL can only be done when handling a Request.');
+        }
+
+        if ($sign && null === $this->signer) {
+            throw new \LogicException('You must use a URI when using the ESI rendering strategy or set a URL signer.');
+        }
+
+        if ($strict) {
+            $this->checkNonScalar($controller->attributes);
+        }
+
+        // We need to forward the current _format and _locale values as we don't have
+        // a proper routing pattern to do the job for us.
+        // This makes things inconsistent if you switch from rendering a controller
+        // to rendering a route if the route pattern does not contain the special
+        // _format and _locale placeholders.
+        if (!isset($controller->attributes['_format'])) {
+            $controller->attributes['_format'] = $request->getRequestFormat();
+        }
+        if (!isset($controller->attributes['_locale'])) {
+            $controller->attributes['_locale'] = $request->getLocale();
+        }
+
+        $controller->attributes['_controller'] = $controller->controller;
+        $controller->query['_path'] = http_build_query($controller->attributes, '', '&');
+        $path = $this->fragmentPath.'?'.http_build_query($controller->query, '', '&');
+
+        // we need to sign the absolute URI, but want to return the path only.
+        $fragmentUri = $sign || $absolute ? $request->getUriForPath($path) : $request->getBaseUrl().$path;
+
+        if (!$sign) {
+            return $fragmentUri;
+        }
+
+        $fragmentUri = $this->signer->sign($fragmentUri);
+
+        return $absolute ? $fragmentUri : substr($fragmentUri, \strlen($request->getSchemeAndHttpHost()));
+    }
+
+    private function checkNonScalar(array $values): void
+    {
+        foreach ($values as $key => $value) {
+            if (\is_array($value)) {
+                $this->checkNonScalar($value);
+            } elseif (!is_scalar($value) && null !== $value) {
+                throw new \LogicException(sprintf('Controller attributes cannot contain non-scalar/non-null values (value for key "%s" is not a scalar or null).', $key));
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentUriGeneratorInterface.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentUriGeneratorInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Fragment;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+/**
+ * Interface implemented by rendering strategies able to generate an URL for a fragment.
+ *
+ * @author Kévin Dunglas <kevin@dunglas.fr>
+ */
+interface FragmentUriGeneratorInterface
+{
+    /**
+     * Generates a fragment URI for a given controller.
+     *
+     * @param bool $absolute Whether to generate an absolute URL or not
+     * @param bool $strict   Whether to allow non-scalar attributes or not
+     * @param bool $sign     Whether to sign the URL or not
+     *
+     * @return string A fragment URI
+     */
+    public function generate(ControllerReference $controller, Request $request = null, bool $absolute = false, bool $strict = true, bool $sign = true): string;
+}

--- a/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
@@ -62,12 +62,7 @@ class HIncludeFragmentRenderer extends RoutableFragmentRenderer
     public function render($uri, Request $request, array $options = [])
     {
         if ($uri instanceof ControllerReference) {
-            if (null === $this->signer) {
-                throw new \LogicException('You must use a proper URI when using the Hinclude rendering strategy or set a URL signer.');
-            }
-
-            // we need to sign the absolute URI, but want to return the path only.
-            $uri = substr($this->signer->sign($this->generateFragmentUri($uri, $request, true)), \strlen($request->getSchemeAndHttpHost()));
+            $uri = (new FragmentUriGenerator($this->fragmentPath, $this->signer))->generate($uri, $request);
         }
 
         // We need to replace ampersands in the URI with the encoded form in order to return valid html/xml content.

--- a/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
@@ -22,7 +22,10 @@ use Symfony\Component\HttpKernel\EventListener\FragmentListener;
  */
 abstract class RoutableFragmentRenderer implements FragmentRendererInterface
 {
-    private $fragmentPath = '/_fragment';
+    /**
+     * @internal
+     */
+    protected $fragmentPath = '/_fragment';
 
     /**
      * Sets the fragment path that triggers the fragment listener.
@@ -44,43 +47,6 @@ abstract class RoutableFragmentRenderer implements FragmentRendererInterface
      */
     protected function generateFragmentUri(ControllerReference $reference, Request $request, bool $absolute = false, bool $strict = true)
     {
-        if ($strict) {
-            $this->checkNonScalar($reference->attributes);
-        }
-
-        // We need to forward the current _format and _locale values as we don't have
-        // a proper routing pattern to do the job for us.
-        // This makes things inconsistent if you switch from rendering a controller
-        // to rendering a route if the route pattern does not contain the special
-        // _format and _locale placeholders.
-        if (!isset($reference->attributes['_format'])) {
-            $reference->attributes['_format'] = $request->getRequestFormat();
-        }
-        if (!isset($reference->attributes['_locale'])) {
-            $reference->attributes['_locale'] = $request->getLocale();
-        }
-
-        $reference->attributes['_controller'] = $reference->controller;
-
-        $reference->query['_path'] = http_build_query($reference->attributes, '', '&');
-
-        $path = $this->fragmentPath.'?'.http_build_query($reference->query, '', '&');
-
-        if ($absolute) {
-            return $request->getUriForPath($path);
-        }
-
-        return $request->getBaseUrl().$path;
-    }
-
-    private function checkNonScalar(array $values)
-    {
-        foreach ($values as $key => $value) {
-            if (\is_array($value)) {
-                $this->checkNonScalar($value);
-            } elseif (!is_scalar($value) && null !== $value) {
-                throw new \LogicException(sprintf('Controller attributes cannot contain non-scalar/non-null values (value for key "%s" is not a scalar or null).', $key));
-            }
-        }
+        return (new FragmentUriGenerator($this->fragmentPath))->generate($reference, $request, $absolute, $strict, false);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix n/a
| License       | MIT
| Doc PR        | todo

This PR adds a new helper to generate raw fragment URL. Fragments will be useful to generate lazy frames with Symfony UX Turbo (https://github.com/symfony/ux/pull/64). This will also be convenient when using hinclude, ESI etc in case you want full control over the generated HTML.
This is also more in sync with the new best practices we apply in the form component (generate the HTML by yourself instead of using Twig helpers hiding the HTML elements).

Example:

```html
<turbo-frame id="set_aside_tray" src="{{ fragment_uri(controller('Symfony\Bundle\FrameworkBundle\Controller', {template: "foo.html.twig"})) }}">
  <img src="/icons/spinner.gif">
</turbo-frame>
```