### PR TITLE
[Mime] Remove @internal from Headers methods

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -60,6 +60,11 @@ Messenger
  * Deprecated the `prefetch_count` parameter in the AMQP bridge, it has no effect and will be removed in Symfony 6.0
  * Deprecated the use of TLS option for Redis Bridge, use `rediss://127.0.0.1` instead of `redis://127.0.0.1?tls=1`
 
+Mime
+----
+
+ * Remove the internal annotation from the `getHeaderBody()` and `getHeaderParameter()` methods of the `Headers` class.
+
 Notifier
 --------
 

--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -254,9 +254,6 @@ final class Headers
         return $arr;
     }
 
-    /**
-     * @internal
-     */
     public function getHeaderBody($name)
     {
         return $this->has($name) ? $this->get($name)->getBody() : null;
@@ -274,9 +271,6 @@ final class Headers
         }
     }
 
-    /**
-     * @internal
-     */
     public function getHeaderParameter(string $name, string $parameter): ?string
     {
         if (!$this->has($name)) {

--- a/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
+++ b/src/Symfony/Component/Mime/Tests/Header/HeadersTest.php
@@ -279,4 +279,39 @@ class HeadersTest extends TestCase
             "Foo: =?utf-8?Q?aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa?=\r\n =?utf-8?Q?aaaa?=",
         ], $headers->toArray());
     }
+
+    public function testHeaderBody()
+    {
+        $headers = new Headers();
+        $this->assertNull($headers->getHeaderBody('Content-Type'));
+        $headers->setHeaderBody('Text', 'Content-Type', 'type');
+        $this->assertSame('type', $headers->getHeaderBody('Content-Type'));
+    }
+
+    public function testHeaderParameter()
+    {
+        $headers = new Headers();
+        $this->assertNull($headers->getHeaderParameter('Content-Disposition', 'name'));
+
+        $headers->addParameterizedHeader('Content-Disposition', 'name');
+        $headers->setHeaderParameter('Content-Disposition', 'name', 'foo');
+        $this->assertSame('foo', $headers->getHeaderParameter('Content-Disposition', 'name'));
+    }
+
+    public function testHeaderParameterNotDefined()
+    {
+        $headers = new Headers();
+
+        $this->expectException(\LogicException::class);
+        $headers->setHeaderParameter('Content-Disposition', 'name', 'foo');
+    }
+
+    public function testSetHeaderParameterNotParameterized()
+    {
+        $headers = new Headers();
+        $headers->addTextHeader('Content-Disposition', 'name');
+
+        $this->expectException(\LogicException::class);
+        $headers->setHeaderParameter('Content-Disposition', 'name', 'foo');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

I don't understand why the methods
- `Headers::getHeaderBody()`
- `Headers::setHeaderBody()`
- `Headers::getHeaderParameter()`
- `Headers::setHeaderParameter()`
are marked as internal.

They are already used by others libraries, like 
https://github.com/symfony/mailchimp-mailer/blob/a6c3fa9aeaf83ad79445c9e7c072e15288bea3c9/Transport/MandrillApiTransport.php#L92
https://github.com/symfony/mailchimp-mailer/blob/a6c3fa9aeaf83ad79445c9e7c072e15288bea3c9/Transport/MandrillApiTransport.php#L99

The implementation shouldn't change so they could be under the BC promise.
Plus they are useful, and I don't see any other way that reimplementing the method if we want to do something like
```
->getHeaderParameter('Content-Disposition', 'name')
```