### PR TITLE
[Serializer] Nicer ExtraAttributesException message for single attribute

### DIFF
--- a/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
+++ b/src/Symfony/Component/Serializer/Exception/ExtraAttributesException.php
@@ -22,7 +22,11 @@ class ExtraAttributesException extends RuntimeException
 
     public function __construct(array $extraAttributes, \Throwable $previous = null)
     {
-        $msg = sprintf('Extra attributes are not allowed ("%s" are unknown).', implode('", "', $extraAttributes));
+        $msg = sprintf(
+            'Extra attributes are not allowed ("%s" %s unknown).',
+            implode('", "', $extraAttributes),
+            \count($extraAttributes) > 1 ? 'are' : 'is'
+        );
 
         $this->extraAttributes = $extraAttributes;
 

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -61,6 +61,20 @@ class AbstractObjectNormalizerTest extends TestCase
         $this->assertInstanceOf(Dummy::class, $normalizer->instantiateObject($data, $class, $context, new \ReflectionClass($class), []));
     }
 
+    public function testDenormalizeWithExtraAttribute()
+    {
+        $this->expectException(ExtraAttributesException::class);
+        $this->expectExceptionMessage('Extra attributes are not allowed ("fooFoo" is unknown).');
+        $factory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $normalizer = new AbstractObjectNormalizerDummy($factory);
+        $normalizer->denormalize(
+            ['fooFoo' => 'foo'],
+            Dummy::class,
+            'any',
+            ['allow_extra_attributes' => false]
+        );
+    }
+
     public function testDenormalizeWithExtraAttributes()
     {
         $this->expectException(ExtraAttributesException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | n/a

This PR changes wording of ExtraAttributesException message in case there is only one extra attribute:

Before
----
    Extra attributes are not allowed ("foo", "bar" are unknown).
    Extra attributes are not allowed ("foo" are unknown).

After:
----

    Extra attributes are not allowed ("foo", "bar" are unknown).
    Extra attributes are not allowed ("foo" is unknown).
