### PR TITLE
[Config][FrameworkBundle] Hint to use PHP 8+ or to install Annotations for using attributes/annots

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1312,7 +1312,7 @@ class FrameworkExtension extends Extension
 
         if (\array_key_exists('enable_annotations', $config) && $config['enable_annotations']) {
             if (!$this->annotationsConfigEnabled && \PHP_VERSION_ID < 80000) {
-                throw new \LogicException('"enable_annotations" on the validator cannot be set as Doctrine Annotations support is disabled.');
+                throw new \LogicException('"enable_annotations" on the validator cannot be set as the PHP version is lower than 8 and Doctrine Annotations support is disabled. Consider upgrading PHP.');
             }
 
             $validatorBuilder->addMethodCall('enableAnnotationMapping', [true]);
@@ -1576,7 +1576,7 @@ class FrameworkExtension extends Extension
         $serializerLoaders = [];
         if (isset($config['enable_annotations']) && $config['enable_annotations']) {
             if (\PHP_VERSION_ID < 80000 && !$this->annotationsConfigEnabled) {
-                throw new \LogicException('"enable_annotations" on the serializer cannot be set as Annotations support is disabled.');
+                throw new \LogicException('"enable_annotations" on the serializer cannot be set as the PHP version is lower than 8 and Annotations support is disabled. Consider upgrading PHP.');
             }
 
             $annotationLoader = new Definition(

--- a/src/Symfony/Component/Config/Exception/LoaderLoadException.php
+++ b/src/Symfony/Component/Config/Exception/LoaderLoadException.php
@@ -64,7 +64,7 @@ class LoaderLoadException extends \Exception
         } elseif (null !== $type) {
             // maybe there is no loader for this specific type
             if ('annotation' === $type) {
-                $message .= ' Make sure annotations are installed and enabled.';
+                $message .= ' Make sure to use PHP 8+ or that annotations are installed and enabled.';
             } else {
                 $message .= sprintf(' Make sure there is a loader supporting the "%s" type.', $type);
             }

--- a/src/Symfony/Component/Config/Tests/Exception/LoaderLoadExceptionTest.php
+++ b/src/Symfony/Component/Config/Tests/Exception/LoaderLoadExceptionTest.php
@@ -31,7 +31,7 @@ class LoaderLoadExceptionTest extends TestCase
     public function testMessageCannotLoadResourceWithAnnotationType()
     {
         $exception = new LoaderLoadException('resource', null, 0, null, 'annotation');
-        $this->assertEquals('Cannot load resource "resource". Make sure annotations are installed and enabled.', $exception->getMessage());
+        $this->assertEquals('Cannot load resource "resource". Make sure to use PHP 8+ or that annotations are installed and enabled.', $exception->getMessage());
     }
 
     public function testMessageCannotImportResourceFromSource()

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -38,8 +38,7 @@
         "symfony/http-foundation": "For using a Symfony Request object",
         "symfony/config": "For using the all-in-one router or any loader",
         "symfony/yaml": "For using the YAML loader",
-        "symfony/expression-language": "For using expression matching",
-        "doctrine/annotations": "For using the annotation loader"
+        "symfony/expression-language": "For using expression matching"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Routing\\": "" },

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -55,8 +55,6 @@
         "symfony/config": "For using the XML mapping loader.",
         "symfony/property-access": "For using the ObjectNormalizer.",
         "symfony/mime": "For using a MIME type guesser within the DataUriNormalizer.",
-        "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
-        "doctrine/cache": "For using the default cached annotation reader and metadata cache.",
         "symfony/var-exporter": "For using the metadata compiler."
     },
     "autoload": {

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -56,8 +56,6 @@
     },
     "suggest": {
         "psr/cache-implementation": "For using the mapping cache.",
-        "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
-        "doctrine/cache": "For using the default cached annotation reader.",
         "symfony/http-foundation": "",
         "symfony/intl": "",
         "symfony/translation": "For translating validation errors.",


### PR DESCRIPTION
…s to use attributes/annots

| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | See https://github.com/symfony/recipes/pull/916
| License       | MIT
| Doc PR        | n/a

Improve the error message to hint that you can upgrade to PHP 8 instead of using `doctrine/annotations`.