### PR TITLE
[HttpClient] fix using stream_copy_to_stream() with responses cast to php streams

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/StreamWrapper.php
+++ b/src/Symfony/Component/HttpClient/Response/StreamWrapper.php
@@ -281,7 +281,7 @@ class StreamWrapper
             'uid' => 0,
             'gid' => 0,
             'rdev' => 0,
-            'size' => (int) ($headers['content-length'][0] ?? 0),
+            'size' => (int) ($headers['content-length'][0] ?? -1),
             'atime' => 0,
             'mtime' => strtotime($headers['last-modified'][0] ?? '') ?: 0,
             'ctime' => 0,

--- a/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpClientTestCase.php
@@ -63,6 +63,19 @@ abstract class HttpClientTestCase extends BaseHttpClientTestCase
         $this->assertTrue(feof($stream));
     }
 
+    public function testStreamCopyToStream()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://localhost:8057');
+        $h = fopen('php://temp', 'w+');
+        stream_copy_to_stream($response->toStream(), $h);
+
+        $this->assertTrue(rewind($h));
+        $this->assertSame("{\n    \"SER", fread($h, 10));
+        $this->assertSame('VER_PROTOCOL', fread($h, 12));
+        $this->assertFalse(feof($h));
+    }
+
     public function testToStream404()
     {
         $client = $this->getHttpClient(__FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40574
| License       | MIT
| Doc PR        | -