### PR TITLE
[Console][SymfonyStyle] replace listing(array) with listing(iterable)

### DIFF
--- a/src/Symfony/Component/Console/Style/StyleInterface.php
+++ b/src/Symfony/Component/Console/Style/StyleInterface.php
@@ -31,7 +31,7 @@ interface StyleInterface
     /**
      * Formats a list.
      */
-    public function listing(array $elements);
+    public function listing(iterable $elements);
 
     /**
      * Formats informational text.

--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -97,14 +97,13 @@ class SymfonyStyle extends OutputStyle
     /**
      * {@inheritdoc}
      */
-    public function listing(array $elements)
+    public function listing(iterable $elements)
     {
         $this->autoPrependText();
-        $elements = array_map(function ($element) {
-            return sprintf(' * %s', $element);
-        }, $elements);
+        foreach ($elements as $element) {
+            $this->writeln(sprintf(' * %s', $element));
+        }
 
-        $this->writeln($elements);
         $this->newLine();
     }
 


### PR DESCRIPTION
This allows to use a generator function instead of arrays for time consuming operations.

    $list = function() {
        while(true) {
            yield "1 more second";
            sleep(1);
        }
    };
    $io->listing($list());

| Q             | A
| ------------- | ---
| Branch?       | 5.x for features / 4.4 or 5.2 for bug fixes <!-- see below -->
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
