### PR TITLE
[Form] error if the input string couldn't be parsed as a date

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -130,6 +130,10 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         } elseif ($timestamp > 253402214400) {
             // This timestamp represents UTC midnight of 9999-12-31 to prevent 5+ digit years
             throw new TransformationFailedException('Years beyond 9999 are not supported.');
+        } elseif (false === $timestamp) {
+            // the value couldn't be parsed but the Intl extension didn't report an error code, this
+            // could be the case when the Intl polyfill is used which always returns 0 as the error code
+            throw new TransformationFailedException(sprintf('"%s" could not be parsed as a date.', $value));
         }
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40597
| License       | MIT
| Doc PR        | 

When the Intl polyfill is used instead of the PHP intl extension, the
intl_get_error_code() function always returns 0 no matter if the input
string could be parsed.