### PR TITLE
[Cache] Support a custom serializer in the ApcuAdapter class

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/ApcuAdapter.php
@@ -13,16 +13,19 @@ namespace Symfony\Component\Cache\Adapter;
 
 use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Cache\Exception\CacheException;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
 class ApcuAdapter extends AbstractAdapter
 {
+    private $marshaller;
+
     /**
      * @throws CacheException if APCu is not enabled
      */
-    public function __construct(string $namespace = '', int $defaultLifetime = 0, string $version = null)
+    public function __construct(string $namespace = '', int $defaultLifetime = 0, string $version = null, ?MarshallerInterface $marshaller = null)
     {
         if (!static::isSupported()) {
             throw new CacheException('APCu is not enabled.');
@@ -40,6 +43,8 @@ class ApcuAdapter extends AbstractAdapter
                 apcu_add($version.'@'.$namespace, null);
             }
         }
+
+        $this->marshaller = $marshaller;
     }
 
     public static function isSupported()
@@ -57,7 +62,7 @@ class ApcuAdapter extends AbstractAdapter
             $values = [];
             foreach (apcu_fetch($ids, $ok) ?: [] as $k => $v) {
                 if (null !== $v || $ok) {
-                    $values[$k] = $v;
+                    $values[$k] = null !== $this->marshaller ? $this->marshaller->unmarshall($v) : $v;
                 }
             }
 
@@ -104,6 +109,10 @@ class ApcuAdapter extends AbstractAdapter
      */
     protected function doSave(array $values, int $lifetime)
     {
+        if (null !== $this->marshaller && (!$values = $this->marshaller->marshall($values, $failed))) {
+            return $failed;
+        }
+
         try {
             if (false === $failures = apcu_store($values, null, $lifetime)) {
                 $failures = $values;

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * added support for connecting to Redis Sentinel clusters when using the Redis PHP extension
+ * add support for a custom serializer to the `ApcuAdapter` class
 
 5.2.0
 -----


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #40523
| License       | MIT
| Doc PR        | n/a

Unlike some other cache adapters like the one for Redis, the APCu adapter does not support a custom serializer. Even though most things can be stored as-is in this cache, some others like resources cannot