### PR TITLE
[Filesystem] Fix dumpFile() method call

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1731,7 +1731,7 @@ class FilesystemTest extends FilesystemTestCase
         file_put_contents($filename, 'FOO BAR');
         chmod($filename, 0745);
 
-        $this->filesystem->dumpFile($filename, 'bar', null);
+        $this->filesystem->dumpFile($filename, 'bar');
 
         $this->assertFilePermissions(745, $filename);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | ?
| New feature?  | no
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | ---

The dumpFile() method in the Filesystem component takes two arguments (filename and content). I found a test with the third argument set to null.