### PR TITLE
[Security] Use concrete UserInterface and UserProviderInterface classes in the tests

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Fixtures/PasswordUpgraderProvider.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Fixtures/PasswordUpgraderProvider.php
@@ -11,9 +11,14 @@
 
 namespace Symfony\Component\Security\Http\Tests\Authenticator\Fixtures;
 
+use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Core\User\PasswordUpgraderInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
-abstract class PasswordUpgraderProvider implements UserProviderInterface, PasswordUpgraderInterface
+class PasswordUpgraderProvider extends InMemoryUserProvider implements PasswordUpgraderInterface
 {
+    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
+    {
+    }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -17,8 +17,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\Security;
-use Symfony\Component\Security\Core\User\User;
-use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\Authenticator\FormLoginAuthenticator;
@@ -37,8 +36,7 @@ class FormLoginAuthenticatorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->userProvider = $this->createMock(UserProviderInterface::class);
-        $this->userProvider->expects($this->any())->method('loadUserByUsername')->willReturn(new User('test', 's$cr$t'));
+        $this->userProvider = new InMemoryUserProvider(['test' => ['password' => 's$cr$t']]);
         $this->successHandler = $this->createMock(AuthenticationSuccessHandlerInterface::class);
         $this->failureHandler = $this->createMock(AuthenticationFailureHandlerInterface::class);
     }
@@ -149,8 +147,7 @@ class FormLoginAuthenticatorTest extends TestCase
         $request = Request::create('/login_check', 'POST', ['_username' => 'wouter', '_password' => 's$cr$t']);
         $request->setSession($this->createSession());
 
-        $this->userProvider = $this->createMock(PasswordUpgraderProvider::class);
-        $this->userProvider->expects($this->any())->method('loadUserByUsername')->willReturn(new User('test', 's$cr$t'));
+        $this->userProvider = new PasswordUpgraderProvider(['test' => ['password' => 's$cr$t']]);
 
         $this->setUpAuthenticator();
         $passport = $this->authenticator->authenticate($request);

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/X509AuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/X509AuthenticatorTest.php
@@ -14,8 +14,8 @@ namespace Symfony\Component\Security\Http\Tests\Authenticator;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Core\User\User;
-use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authenticator\X509Authenticator;
 
 class X509AuthenticatorTest extends TestCase
@@ -25,7 +25,7 @@ class X509AuthenticatorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->userProvider = $this->createMock(UserProviderInterface::class);
+        $this->userProvider = new InMemoryUserProvider();
         $this->authenticator = new X509Authenticator($this->userProvider, new TokenStorage(), 'main');
     }
 
@@ -45,10 +45,7 @@ class X509AuthenticatorTest extends TestCase
         $request = $this->createRequest($serverVars);
         $this->assertTrue($this->authenticator->supports($request));
 
-        $this->userProvider->expects($this->any())
-            ->method('loadUserByUsername')
-            ->with($username)
-            ->willReturn(new User($username, null));
+        $this->userProvider->createUser(new User($username, null));
 
         $passport = $this->authenticator->authenticate($request);
         $this->assertEquals($username, $passport->getUser()->getUsername());
@@ -69,10 +66,7 @@ class X509AuthenticatorTest extends TestCase
 
         $this->assertTrue($this->authenticator->supports($request));
 
-        $this->userProvider->expects($this->once())
-            ->method('loadUserByUsername')
-            ->with($emailAddress)
-            ->willReturn(new User($emailAddress, null));
+        $this->userProvider->createUser(new User($emailAddress, null));
 
         $passport = $this->authenticator->authenticate($request);
         $this->assertEquals($emailAddress, $passport->getUser()->getUsername());
@@ -105,10 +99,7 @@ class X509AuthenticatorTest extends TestCase
         ]);
         $this->assertTrue($authenticator->supports($request));
 
-        $this->userProvider->expects($this->once())
-            ->method('loadUserByUsername')
-            ->with('TheUser')
-            ->willReturn(new User('TheUser', null));
+        $this->userProvider->createUser(new User('TheUser', null));
 
         $passport = $this->authenticator->authenticate($request);
         $this->assertEquals('TheUser', $passport->getUser()->getUsername());
@@ -123,10 +114,7 @@ class X509AuthenticatorTest extends TestCase
         ]);
         $this->assertTrue($authenticator->supports($request));
 
-        $this->userProvider->expects($this->once())
-            ->method('loadUserByUsername')
-            ->with('cert@example.com')
-            ->willReturn(new User('cert@example.com', null));
+        $this->userProvider->createUser(new User('cert@example.com', null));
 
         $passport = $authenticator->authenticate($request);
         $this->assertEquals('cert@example.com', $passport->getUser()->getUsername());

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/UserProviderListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/UserProviderListenerTest.php
@@ -12,9 +12,9 @@
 namespace Symfony\Component\Security\Http\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
@@ -28,7 +28,7 @@ class UserProviderListenerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->userProvider = $this->createMock(UserProviderInterface::class);
+        $this->userProvider = new InMemoryUserProvider();
         $this->listener = new UserProviderListener($this->userProvider);
     }
 
@@ -42,8 +42,8 @@ class UserProviderListenerTest extends TestCase
         $this->assertEquals([$this->userProvider, 'loadUserByUsername'], $badge->getUserLoader());
 
         $user = new User('wouter', null);
-        $this->userProvider->expects($this->once())->method('loadUserByUsername')->with('wouter')->willReturn($user);
-        $this->assertSame($user, $passport->getUser());
+        $this->userProvider->createUser($user);
+        $this->assertTrue($user->isEqualTo($passport->getUser()));
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -25,7 +25,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundE
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Event\SwitchUserEvent;
 use Symfony\Component\Security\Http\Firewall\SwitchUserListener;
@@ -112,13 +111,13 @@ class SwitchUserListenerTest extends TestCase
 
     public function testExitUserDispatchesEventWithRefreshedUser()
     {
-        $originalUser = $this->createMock(UserInterface::class);
-        $refreshedUser = $this->createMock(UserInterface::class);
+        $originalUser = new User('username', null);
+        $refreshedUser = new User('username', null);
         $this
             ->userProvider
             ->expects($this->any())
             ->method('refreshUser')
-            ->with($originalUser)
+            ->with($this->identicalTo($originalUser))
             ->willReturn($refreshedUser);
         $originalToken = new UsernamePasswordToken($originalUser, '', 'key');
         $this->tokenStorage->setToken(new SwitchUserToken('username', '', 'key', ['ROLE_USER'], $originalToken));
@@ -399,13 +398,13 @@ class SwitchUserListenerTest extends TestCase
 
     public function testSwitchUserRefreshesOriginalToken()
     {
-        $originalUser = $this->createMock(UserInterface::class);
-        $refreshedOriginalUser = $this->createMock(UserInterface::class);
+        $originalUser = new User('username', null);
+        $refreshedOriginalUser = new User('username', null);
         $this
             ->userProvider
             ->expects($this->any())
             ->method('refreshUser')
-            ->with($originalUser)
+            ->with($this->identicalTo($originalUser))
             ->willReturn($refreshedOriginalUser);
         $originalToken = new UsernamePasswordToken($originalUser, '', 'key');
         $this->tokenStorage->setToken(new SwitchUserToken('username', '', 'key', ['ROLE_USER'], $originalToken));

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -29,7 +29,7 @@ class LoginLinkHandlerTest extends TestCase
 {
     /** @var MockObject|UrlGeneratorInterface */
     private $router;
-    /** @var MockObject|UserProviderInterface */
+    /** @var TestLoginLinkHandlerUserProvider */
     private $userProvider;
     /** @var PropertyAccessorInterface */
     private $propertyAccessor;
@@ -39,7 +39,7 @@ class LoginLinkHandlerTest extends TestCase
     protected function setUp(): void
     {
         $this->router = $this->createMock(UrlGeneratorInterface::class);
-        $this->userProvider = $this->createMock(UserProviderInterface::class);
+        $this->userProvider = new TestLoginLinkHandlerUserProvider();
         $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
         $this->expiredLinkStorage = $this->createMock(ExpiredLoginLinkStorage::class);
     }
@@ -94,10 +94,7 @@ class LoginLinkHandlerTest extends TestCase
         $request = Request::create(sprintf('/login/verify?user=weaverryan&hash=%s&expires=%d', $signature, $expires));
 
         $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
-        $this->userProvider->expects($this->once())
-            ->method('loadUserByUsername')
-            ->with('weaverryan')
-            ->willReturn($user);
+        $this->userProvider->createUser($user);
 
         $this->expiredLinkStorage->expects($this->once())
             ->method('incrementUsages')
@@ -105,7 +102,7 @@ class LoginLinkHandlerTest extends TestCase
 
         $linker = $this->createLinker(['max_uses' => 3]);
         $actualUser = $linker->consumeLoginLink($request);
-        $this->assertSame($user, $actualUser);
+        $this->assertEquals($user, $actualUser);
     }
 
     public function testConsumeLoginLinkWithExpired()
@@ -116,10 +113,7 @@ class LoginLinkHandlerTest extends TestCase
         $request = Request::create(sprintf('/login/verify?user=weaverryan&hash=%s&expires=%d', $signature, $expires));
 
         $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
-        $this->userProvider->expects($this->once())
-            ->method('loadUserByUsername')
-            ->with('weaverryan')
-            ->willReturn($user);
+        $this->userProvider->createUser($user);
 
         $linker = $this->createLinker(['max_uses' => 3]);
         $linker->consumeLoginLink($request);
@@ -129,11 +123,6 @@ class LoginLinkHandlerTest extends TestCase
     {
         $this->expectException(InvalidLoginLinkException::class);
         $request = Request::create('/login/verify?user=weaverryan&hash=thehash&expires=10000');
-
-        $this->userProvider->expects($this->once())
-            ->method('loadUserByUsername')
-            ->with('weaverryan')
-            ->willThrowException(new UsernameNotFoundException());
 
         $linker = $this->createLinker();
         $linker->consumeLoginLink($request);
@@ -145,10 +134,7 @@ class LoginLinkHandlerTest extends TestCase
         $request = Request::create(sprintf('/login/verify?user=weaverryan&hash=fake_hash&expires=%d', time() + 500));
 
         $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
-        $this->userProvider->expects($this->once())
-            ->method('loadUserByUsername')
-            ->with('weaverryan')
-            ->willReturn($user);
+        $this->userProvider->createUser($user);
 
         $linker = $this->createLinker();
         $linker->consumeLoginLink($request);
@@ -162,10 +148,7 @@ class LoginLinkHandlerTest extends TestCase
         $request = Request::create(sprintf('/login/verify?user=weaverryan&hash=%s&expires=%d', $signature, $expires));
 
         $user = new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash');
-        $this->userProvider->expects($this->once())
-            ->method('loadUserByUsername')
-            ->with('weaverryan')
-            ->willReturn($user);
+        $this->userProvider->createUser($user);
 
         $this->expiredLinkStorage->expects($this->once())
             ->method('countUsages')
@@ -195,6 +178,35 @@ class LoginLinkHandlerTest extends TestCase
         ], $options);
 
         return new LoginLinkHandler($this->router, $this->userProvider, $this->propertyAccessor, $extraProperties, 's3cret', $options, $this->expiredLinkStorage);
+    }
+}
+
+class TestLoginLinkHandlerUserProvider implements UserProviderInterface
+{
+    private $users = [];
+
+    public function createUser(TestLoginLinkHandlerUser $user): void
+    {
+        $this->users[$user->getUsername()] = $user;
+    }
+
+    public function loadUserByUsername(string $username): TestLoginLinkHandlerUser
+    {
+        if (!isset($this->users[$username])) {
+            throw new UsernameNotFoundException();
+        }
+
+        return clone $this->users[$username];
+    }
+
+    public function refreshUser(UserInterface $user)
+    {
+        return $this->users[$username];
+    }
+
+    public function supportsClass(string $class)
+    {
+        return TestLoginLinkHandlerUser::class === $class;
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | n/a

Fixes failing deps=high builds in #40403