### PR TITLE
[DependencyInjection] Support `psr/container:2`

### DIFF
--- a/src/Symfony/Contracts/Service/composer.json
+++ b/src/Symfony/Contracts/Service/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "psr/container": "^1.1"
+        "psr/container": "^1.1|^2.0"
     },
     "suggest": {
         "symfony/service-implementation": ""


### PR DESCRIPTION
Fixes:
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - symfony/service-contracts v2.2.0 requires psr/container ^1.0 -> found psr/container[1.0.0, 1.1.0, 1.1.1] but it conflicts with your root composer.json require (^2.0).
    - symfony/mailer v5.2.5 requires symfony/service-contracts ^1.1|^2 -> satisfiable by symfony/service-contracts[v2.2.0].
    - symfony/mailer is locked to version v5.2.5 and an update of this package was not requested.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.

| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | NaN
| License       | MIT
| Doc PR        | NaN
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
