### PR TITLE
[FrameworkBundle][HttpKernel] use TestLogger in test env

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Deprecate `HttpKernelInterface::MASTER_REQUEST` and add `HttpKernelInterface::MAIN_REQUEST` as replacement
  * Deprecate `KernelEvent::isMasterRequest()` and add `isMainRequest()` as replacement
  * Add `#[AsController]` attribute for declaring standalone controllers on PHP 8
+ * When available, use `Symfony\Component\HttpKernel\Log\Logger` as logger in test environment.
 
 5.2.0
 -----

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/LoggerPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/LoggerPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\DependencyInjection;
 
 use Psr\Log\LoggerInterface;
+use Psr\Log\Test\TestLogger;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Log\Logger;

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/LoggerPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/LoggerPass.php
@@ -35,7 +35,12 @@ class LoggerPass implements CompilerPassInterface
             return;
         }
 
-        $container->register('logger', Logger::class)
+        $definition = $container->register('logger', Logger::class)
             ->setPublic(false);
+
+        if ('test' === $container->getParameter('kernel.environment') && class_exists(TestLogger::class)) {
+            $definition->setClass(TestLogger::class)
+                ->addTag('kernel.reset', ['method' => 'reset']);
+        }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LoggerPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LoggerPassTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Psr\Log\Test\TestLogger;
+use Symfony\Bridge\PhpUnit\ClassExistsMock;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\LoggerPass;
 use Symfony\Component\HttpKernel\Log\Logger;
@@ -46,8 +47,11 @@ class LoggerPassTest extends TestCase
     /**
      * @dataProvider providesEnvironments
      */
-    public function testRegisterLogger(string $environment, string $expectedClass)
+    public function testRegisterLogger(string $environment, string $expectedClass, bool $classExists = true)
     {
+        ClassExistsMock::register(LoggerPass::class);
+        ClassExistsMock::withMockedClasses([TestLogger::class => $classExists]);
+
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', false);
         $container->setParameter('kernel.environment', $environment);
@@ -63,5 +67,6 @@ class LoggerPassTest extends TestCase
     {
         yield 'Dev environment' => ['dev', Logger::class];
         yield 'Test environment' => ['test', TestLogger::class];
+        yield 'Test environment, no TestLogger' => ['test', Logger::class, false];
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LoggerPassTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/LoggerPassTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use Psr\Log\Test\TestLogger;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\LoggerPass;
 use Symfony\Component\HttpKernel\Log\Logger;
@@ -42,15 +43,25 @@ class LoggerPassTest extends TestCase
         $this->assertSame('Foo', $container->getDefinition('logger')->getClass());
     }
 
-    public function testRegisterLogger()
+    /**
+     * @dataProvider providesEnvironments
+     */
+    public function testRegisterLogger(string $environment, string $expectedClass)
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', false);
+        $container->setParameter('kernel.environment', $environment);
 
         (new LoggerPass())->process($container);
 
         $definition = $container->getDefinition('logger');
-        $this->assertSame(Logger::class, $definition->getClass());
+        $this->assertSame($expectedClass, $definition->getClass());
         $this->assertFalse($definition->isPublic());
+    }
+
+    public function providesEnvironments()
+    {
+        yield 'Dev environment' => ['dev', Logger::class];
+        yield 'Test environment' => ['test', TestLogger::class];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | TODO

In test env, use `TestLogger` when available. Allow to easily test if some informations have been logged:
```php
// Inside a WebTestCase:
$this->assertTrue(static::$container->get('logger')->hasWarningThatContains('Foo'));
```