### PR TITLE
[DependencyInjection] Fix "url" env var processor behavior when the url has no path

### DIFF
--- a/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
+++ b/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php
@@ -255,8 +255,10 @@ class EnvVarProcessor implements EnvVarProcessorInterface
                 'fragment' => null,
             ];
 
-            // remove the '/' separator
-            $parsedEnv['path'] = '/' === $parsedEnv['path'] ? null : substr($parsedEnv['path'], 1);
+            if (null !== $parsedEnv['path']) {
+                // remove the '/' separator
+                $parsedEnv['path'] = '/' === $parsedEnv['path'] ? null : substr($parsedEnv['path'], 1);
+            }
 
             return $parsedEnv;
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/EnvVarProcessorTest.php
@@ -610,4 +610,26 @@ CSV;
             return null;
         });
     }
+
+    /**
+     * @dataProvider provideGetEnvUrlPath
+     */
+    public function testGetEnvUrlPath(?string $expected, string $url)
+    {
+        $this->assertSame($expected, (new EnvVarProcessor(new Container()))->getEnv('url', 'foo', static function () use ($url): string {
+            return $url;
+        })['path']);
+    }
+
+    public function provideGetEnvUrlPath()
+    {
+        return [
+            [null, 'https://symfony.com'],
+            [null, 'https://symfony.com/'],
+            ['/', 'https://symfony.com//'],
+            ['blog', 'https://symfony.com/blog'],
+            ['blog/', 'https://symfony.com/blog/'],
+            ['blog//', 'https://symfony.com/blog//'],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Before:
```yaml
MY_URL_ENV_VAR=http://symfony.com
%env(key:path:url:MY_URL_ENV_VAR)% --> false
```

After:
```yaml
MY_URL_ENV_VAR=http://symfony.com
%env(key:path:url:MY_URL_ENV_VAR)% --> null
```

Returning `false` for the path prevents me from using the `default` env var processor that is triggered only for `''` and `null`.
(`%env(default:my_fallback_param:key:path:url:MY_URL_ENV_VAR)%`)

BTW, with PHP 8, it actually works because `substr(null, 1)` behavior changed (see https://3v4l.org/oHf6l).