### PR TITLE
[Security] Replace Request by RequestContext in createLoginLink

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/LoginLink/FirewallAwareLoginLinkHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/LoginLink/FirewallAwareLoginLinkHandler.php
@@ -15,6 +15,7 @@ use Psr\Container\ContainerInterface;
 use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\LoginLink\LoginLinkDetails;
 use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
@@ -37,9 +38,9 @@ class FirewallAwareLoginLinkHandler implements LoginLinkHandlerInterface
         $this->requestStack = $requestStack;
     }
 
-    public function createLoginLink(UserInterface $user, Request $request = null): LoginLinkDetails
+    public function createLoginLink(UserInterface $user, RequestContext $requestContext = null): LoginLinkDetails
     {
-        return $this->getLoginLinkHandler()->createLoginLink($user, $request);
+        return $this->getLoginLinkHandler()->createLoginLink($user, $requestContext);
     }
 
     public function consumeLoginLink(Request $request): UserInterface

--- a/src/Symfony/Bundle/SecurityBundle/Tests/LoginLink/FirewallAwareLoginLinkHandlerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/LoginLink/FirewallAwareLoginLinkHandlerTest.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
 use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\LoginLink\LoginLinkDetails;
 use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
@@ -29,12 +30,13 @@ class FirewallAwareLoginLinkHandlerTest extends TestCase
         $user = $this->createMock(UserInterface::class);
         $linkDetails = new LoginLinkDetails('http://example.com', new \DateTimeImmutable());
         $request = Request::create('http://example.com/verify');
+        $requestContext = (new RequestContext())->fromRequest($request);
 
         $firewallMap = $this->createFirewallMap('main_firewall');
         $loginLinkHandler = $this->createMock(LoginLinkHandlerInterface::class);
         $loginLinkHandler->expects($this->once())
             ->method('createLoginLink')
-            ->with($user, $request)
+            ->with($user, $requestContext)
             ->willReturn($linkDetails);
         $loginLinkHandler->expects($this->once())
             ->method('consumeLoginLink')
@@ -47,7 +49,7 @@ class FirewallAwareLoginLinkHandlerTest extends TestCase
         $requestStack->push($request);
 
         $linker = new FirewallAwareLoginLinkHandler($firewallMap, $locator, $requestStack);
-        $actualLinkDetails = $linker->createLoginLink($user, $request);
+        $actualLinkDetails = $linker->createLoginLink($user, $requestContext);
         $this->assertSame($linkDetails, $actualLinkDetails);
 
         $actualUser = $linker->consumeLoginLink($request);

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -50,7 +50,7 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
         $this->expiredStorage = $expiredStorage;
     }
 
-    public function createLoginLink(UserInterface $user, Request $request = null): LoginLinkDetails
+    public function createLoginLink(UserInterface $user, RequestContext $requestContext = null): LoginLinkDetails
     {
         $expiresAt = new \DateTimeImmutable(sprintf('+%d seconds', $this->options['lifetime']));
 
@@ -62,9 +62,9 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
             'hash' => $this->computeSignatureHash($user, $expires),
         ];
 
-        if ($request) {
+        if ($requestContext) {
             $currentRequestContext = $this->urlGenerator->getContext();
-            $this->urlGenerator->setContext((new RequestContext())->fromRequest($request));
+            $this->urlGenerator->setContext($requestContext);
         }
 
         try {
@@ -74,7 +74,7 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
                 UrlGeneratorInterface::ABSOLUTE_URL
             );
         } finally {
-            if ($request) {
+            if ($requestContext) {
                 $this->urlGenerator->setContext($currentRequestContext);
             }
         }

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\LoginLink;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
@@ -25,7 +26,7 @@ interface LoginLinkHandlerInterface
     /**
      * Generate a link that can be used to authenticate as the given user.
      */
-    public function createLoginLink(UserInterface $user, Request $request = null): LoginLinkDetails;
+    public function createLoginLink(UserInterface $user, RequestContext $requestContext = null): LoginLinkDetails;
 
     /**
      * Validates if this request contains a login link and returns the associated User.

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -49,7 +49,7 @@ class LoginLinkHandlerTest extends TestCase
      * @dataProvider provideCreateLoginLinkData
      * @group time-sensitive
      */
-    public function testCreateLoginLink($user, array $extraProperties, Request $request = null)
+    public function testCreateLoginLink($user, array $extraProperties, RequestContext $requestContext = null)
     {
         $this->router->expects($this->once())
             ->method('generate')
@@ -66,13 +66,13 @@ class LoginLinkHandlerTest extends TestCase
             )
             ->willReturn('https://example.com/login/verify?user=weaverryan&hash=abchash&expires=1601235000');
 
-        if ($request) {
+        if ($requestContext) {
             $this->router->expects($this->once())
                 ->method('getContext')
                 ->willReturn(new RequestContext());
         }
 
-        $loginLink = $this->createLinker([], array_keys($extraProperties))->createLoginLink($user, $request);
+        $loginLink = $this->createLinker([], array_keys($extraProperties))->createLoginLink($user, $requestContext);
         $this->assertSame('https://example.com/login/verify?user=weaverryan&hash=abchash&expires=1601235000', $loginLink->getUrl());
     }
 
@@ -81,7 +81,7 @@ class LoginLinkHandlerTest extends TestCase
         yield [
             new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash'),
             ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'],
-            Request::create('https://example.com'),
+            (new RequestContext())->fromRequest(Request::create('https://example.com')),
         ];
 
         yield [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#15163

While writing the documentation for PR#40153 I noticed that the RequestContext :: fromRequest method does not add the '_locale' parameter. This new pull request to pass a RequestContext rather than a Request.
