### PR TITLE
LoginLink create get Request Locale

### DIFF
--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -64,7 +64,11 @@ final class LoginLinkHandler implements LoginLinkHandlerInterface
 
         if ($request) {
             $currentRequestContext = $this->urlGenerator->getContext();
-            $this->urlGenerator->setContext((new RequestContext())->fromRequest($request));
+            $this->urlGenerator->setContext(
+                (new RequestContext())
+                    ->fromRequest($request)
+                    ->setParameter('_locale', $request->getLocale())
+            );
         }
 
         try {

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -69,7 +69,11 @@ class LoginLinkHandlerTest extends TestCase
         if ($request) {
             $this->router->expects($this->once())
                 ->method('getContext')
-                ->willReturn(new RequestContext());
+                ->willReturn($currentRequestContext = new RequestContext());
+
+            $this->router->expects($this->exactly(2))
+                ->method('setContext')
+                ->withConsecutive([$this->equalTo((new RequestContext())->fromRequest($request)->setParameter('_locale', $request->getLocale()))], [$currentRequestContext]);
         }
 
         $loginLink = $this->createLinker([], array_keys($extraProperties))->createLoginLink($user, $request);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#15163

While writing the documentation for PR#40153 I noticed that the RequestContext :: fromRequest method does not add the '_locale' parameter automaticaly. This new pull request to set _locale parameter to the RequestContext.
