### PR TITLE
Use symfony/deprecation-contracts instead of trigger_error

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -214,7 +214,7 @@ class Configuration implements ConfigurationInterface
                             ->validate()
                                 ->ifTrue()
                                 ->then(function ($v) {
-                                    @trigger_error('Since symfony/framework-bundle 5.2: Setting the "framework.form.legacy_error_messages" option to "true" is deprecated. It will have no effect as of Symfony 6.0.', \E_USER_DEPRECATED);
+                                    trigger_deprecation('symfony/framework-bundle', '5.2', 'Setting the "framework.form.legacy_error_messages" option to "true" is deprecated. It will have no effect as of Symfony 6.0.');
 
                                     return $v;
                                 })

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -137,7 +137,7 @@ class MailgunApiTransport extends AbstractApiTransport
             } else {
                 // fallback to prefix with "h:" to not break BC
                 $headerName = 'h:'.$name;
-                @trigger_error(sprintf('Not prefixing the Mailgun header name with "h:" is deprecated since Symfony  5.1. Use header name "%s" instead.', $headerName), \E_USER_DEPRECATED);
+                trigger_deprecation('symfony/mailer', '5.1', 'Not prefixing the Mailgun header name with "h:" is deprecated. Use header name "%s" instead.', $headerName);
             }
 
             $payload[$headerName] = $header->getBodyAsString();

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/mailer": "^5.2.6"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

As `symfony/deprecation-contracts` added to requirements with PR #40468, we can update `trigger_error` call in favor reusing deprecation abstractions
