### PR TITLE
[FrameworkBundle] Dont store cache misses on warmup

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -16,6 +16,7 @@ use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Cache\DoctrineProvider;
 
 /**
@@ -74,6 +75,14 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
         }
 
         return true;
+    }
+
+    protected function warmUpPhpArrayAdapter(PhpArrayAdapter $phpArrayAdapter, array $values)
+    {
+        // make sure we don't cache null values
+        $values = array_filter($values, function ($val) { return null !== $val; });
+
+        parent::warmUpPhpArrayAdapter($phpArrayAdapter, $values);
     }
 
     private function readAllComponents(Reader $reader, string $class)

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ValidatorCacheWarmer.php
@@ -80,7 +80,9 @@ class ValidatorCacheWarmer extends AbstractPhpFileCacheWarmer
     protected function warmUpPhpArrayAdapter(PhpArrayAdapter $phpArrayAdapter, array $values)
     {
         // make sure we don't cache null values
-        parent::warmUpPhpArrayAdapter($phpArrayAdapter, array_filter($values));
+        $values = array_filter($values, function ($val) { return null !== $val; });
+
+        parent::warmUpPhpArrayAdapter($phpArrayAdapter, $values);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Annotations\Reader;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 use Symfony\Component\Cache\DoctrineProvider;
@@ -118,6 +119,35 @@ class AnnotationsCacheWarmerTest extends TestCase
         $warmer->warmUp($this->cacheDir);
 
         spl_autoload_unregister($classLoader);
+    }
+
+    public function testWarmupRemoveCacheMisses()
+    {
+        $cacheFile = tempnam($this->cacheDir, __FUNCTION__);
+        $warmer = $this->getMockBuilder(AnnotationsCacheWarmer::class)
+            ->setConstructorArgs([new AnnotationReader(), $cacheFile])
+            ->setMethods(['doWarmUp'])
+            ->getMock();
+
+        $warmer->method('doWarmUp')->willReturnCallback(function ($cacheDir, ArrayAdapter $arrayAdapter) {
+            $arrayAdapter->getItem('foo_miss');
+
+            $item = $arrayAdapter->getItem('bar_hit');
+            $item->set('data');
+            $arrayAdapter->save($item);
+
+            $item = $arrayAdapter->getItem('baz_hit_null');
+            $item->set(null);
+            $arrayAdapter->save($item);
+
+            return true;
+        });
+
+        $warmer->warmUp($this->cacheDir);
+        $data = include $cacheFile;
+
+        $this->assertCount(1, $data[0]);
+        $this->assertTrue(isset($data[0]['bar_hit']));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38694
| License       | MIT
| Doc PR        | symfony/symfony-docs#15172

When we are warming the annotation cache, we are reading all annotation into an `ArrayAdapter`. When we are done we move the values to a `PhpArrayAdapter` to store them in a file. 

@Seldaek [found out](https://github.com/symfony/symfony/issues/38694#issuecomment-810501066) that when you are using a custom constraint with a `Symfony\Component\Validator\Constraints\Callback`, there is a strange error like: 

> Can use "yield from" only with arrays and Traversables

That is because the `Closure` in the `Symfony\Component\Validator\Constraints\Callback` cannot be serialised and saved to cache. But since the `ArrayAdapter` is also [storing misses as null](https://github.com/symfony/symfony/pull/35362), the null values are understood as real values. 

When all values are moved to the `PhpArrayAdapter` and we ask the cache for a value (via Doctrine's `CacheProvider`), it will return `null` as a value instead of `false` as a cache miss. And `null` is not something one could "yield from".

