### PR TITLE
[FrameworkBundle] Remove author comments for configuration and extension

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -36,9 +36,6 @@ use Symfony\Component\WebLink\HttpHeaderSerializer;
 
 /**
  * FrameworkExtension configuration structure.
- *
- * @author Jeremy Mikola <jmikola@gmail.com>
- * @author Grégoire Pineau <lyrixx@lyrixx.info>
  */
 class Configuration implements ConfigurationInterface
 {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -135,12 +135,8 @@ use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 
 /**
- * FrameworkExtension.
- *
- * @author Fabien Potencier <fabien@symfony.com>
- * @author Jeremy Mikola <jmikola@gmail.com>
- * @author Kévin Dunglas <dunglas@gmail.com>
- * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ * Process the configuration and prepare the dependency injection container with
+ * parameters and services.
  */
 class FrameworkExtension extends Extension
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I really don't want to step on anyones toes. I'm also super grateful for all the time, effort and energy these contributors (and everybody else) have given to Symfony. 

The `@author` tags should represent "who knows the most about this class" or to give the original author some kind of credit (more visible than `git blame`). 

The FrameworkBundle's `Configuration` and `FrameworkExtension` classes are a bit special. Fist because they are well known by most recurring contributors. They are also thousands of lines long and many many users have added a line or two. The `FrameworkExtension` have over 50 people that currently authored more than 5 lines. The named authors combined have about that 12% and 25% in `Configuration` and `FrameworkExtension` respectively. 

I do like the `@author` tag, but for the reasons above, I don't think they make sense for these classes. 
