### PR TITLE
[Validator] Delete obsolete statement in Regex::getHtmlPattern() phpDoc

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -64,9 +64,6 @@ class Regex extends Constraint
      * Example: /^[a-z]+$/ would be converted to [a-z]+
      * However, if options are specified, it cannot be converted.
      *
-     * Pattern is also ignored if match=false since the pattern should
-     * then be reversed before application.
-     *
      * @see http://dev.w3.org/html5/spec/single-page.html#the-pattern-attribute
      *
      * @return string|null


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #12235
| License       | MIT
| Doc PR        | 

The original issue was #5307 (`match=false` not handled in `getHtmlPattern()`).
Then #5382 patched it to return null (rather than an incorrect result) and inserted a statement and a "todo" in the phpDoc.
Later (but still years ago) #12235 properly implemented pattern inversion, but only removed the "todo"; this PR removes the statement.