### PR TITLE
[Cache] Fix APCu adapter support checks on CLI context

### DIFF
--- a/src/Symfony/Component/Cache/Traits/ApcuTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ApcuTrait.php
@@ -23,7 +23,7 @@ trait ApcuTrait
 {
     public static function isSupported()
     {
-        return \function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), \FILTER_VALIDATE_BOOLEAN) && ('cli' !== \PHP_SAPI || filter_var(ini_get('apc.enable_cli');
+        return \function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), \FILTER_VALIDATE_BOOLEAN) && ('cli' !== \PHP_SAPI || filter_var(ini_get('apc.enable_cli'));
     }
 
     private function init(string $namespace, int $defaultLifetime, ?string $version)

--- a/src/Symfony/Component/Cache/Traits/ApcuTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ApcuTrait.php
@@ -23,7 +23,7 @@ trait ApcuTrait
 {
     public static function isSupported()
     {
-        return \function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), \FILTER_VALIDATE_BOOLEAN);
+        return \function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), \FILTER_VALIDATE_BOOLEAN) && ('cli' !== \PHP_SAPI || filter_var(ini_get('apc.enable_cli');
     }
 
     private function init(string $namespace, int $defaultLifetime, ?string $version)

--- a/src/Symfony/Component/Cache/Traits/ApcuTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ApcuTrait.php
@@ -23,7 +23,7 @@ trait ApcuTrait
 {
     public static function isSupported()
     {
-        return \function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), \FILTER_VALIDATE_BOOLEAN) && ('cli' !== \PHP_SAPI || filter_var(ini_get('apc.enable_cli'));
+        return \function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), \FILTER_VALIDATE_BOOLEAN) && ('cli' !== \PHP_SAPI || filter_var(ini_get('apc.enable_cli')));
     }
 
     private function init(string $namespace, int $defaultLifetime, ?string $version)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

On CLI context, APCu cache adapter should not be considered as supported unless `apc.enable_cli` is set to `true`.