### PR TITLE
[Cache] skip storing failure-to-save as misses in ArrayAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/ArrayAdapterTest.php
@@ -47,6 +47,10 @@ class ArrayAdapterTest extends AdapterTestCase
         // Miss (should be present as NULL in $values)
         $cache->getItem('bar');
 
+        // Fail (should be missing from $values)
+        $item = $cache->getItem('buz');
+        $cache->save($item->set(function() {}));
+
         $values = $cache->getValues();
 
         $this->assertCount(2, $values);

--- a/src/Symfony/Component/Cache/Traits/ArrayTrait.php
+++ b/src/Symfony/Component/Cache/Traits/ArrayTrait.php
@@ -145,6 +145,7 @@ trait ArrayTrait
             try {
                 $serialized = serialize($value);
             } catch (\Exception $e) {
+                unset($this->values[$key]);
                 $type = \is_object($value) ? \get_class($value) : \gettype($value);
                 $message = sprintf('Failed to save key "{key}" of type %s: ', $type).$e->getMessage();
                 CacheItem::log($this->logger, $message, ['key' => $key, 'exception' => $e]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38694
| License       | MIT
| Doc PR        | -

In addition to #40645