### PR TITLE
[FrameworkBundle] [SodiumVault] [Secrets]  change include by eval function to retrieve secrets list

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
@@ -156,7 +156,7 @@ class SodiumVault extends AbstractVault implements EnvVarLoaderInterface
             return [];
         }
 
-        $secrets = include $file;
+        $secrets = eval('?>'.file_get_contents($file));
 
         if (!$reveal) {
             return $secrets;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Secrets/SodiumVaultTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Secrets/SodiumVaultTest.php
@@ -46,18 +46,26 @@ class SodiumVaultTest extends TestCase
         $vault = new SodiumVault($this->secretsDir);
         $vault->generateKeys();
 
-        $plain = "plain\ntext";
+        $plainFoo = "plain\ntext";
+        $plainBar = "plain\ntext";
 
-        $vault->seal('foo', $plain);
+        $vault->seal('foo', $plainFoo);
+        $vault->seal('bar', $plainBar);
 
         $decrypted = $vault->reveal('foo');
-        $this->assertSame($plain, $decrypted);
+        $this->assertSame($plainFoo, $decrypted);
 
-        $this->assertSame(['foo' => null], $vault->list());
-        $this->assertSame(['foo' => $plain], $vault->list(true));
+        $decrypted = $vault->reveal('bar');
+        $this->assertSame($plainBar, $decrypted);
+
+        $this->assertSame(['bar' => null, 'foo' => null], $vault->list());
+        $this->assertSame(['bar' => $plainFoo, 'foo' => $plainBar], $vault->list(true));
 
         $this->assertTrue($vault->remove('foo'));
         $this->assertFalse($vault->remove('foo'));
+
+        $this->assertTrue($vault->remove('bar'));
+        $this->assertFalse($vault->remove('bar'));
 
         $this->assertSame([], $vault->list());
     }


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Branch?       | 5.x bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | no <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

When you call several times the command `secrets:set` from a `controller`, the `include list` method does not return the updated array in the file `[env].list.php`. So there is only the last secret to save. The `eval` function corrects this problem
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
