### PR TITLE
[Security] [Core] add return types to authentication exceptions

### DIFF
--- a/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
@@ -29,7 +29,7 @@ class AccessDeniedException extends RuntimeException
     /**
      * @return array
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->attributes;
     }

--- a/src/Symfony/Component/Security/Core/Exception/AccountExpiredException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountExpiredException.php
@@ -22,7 +22,7 @@ class AccountExpiredException extends AccountStatusException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Account has expired.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
@@ -26,15 +26,13 @@ abstract class AccountStatusException extends AuthenticationException
 
     /**
      * Get the user.
-     *
-     * @return UserInterface
      */
-    public function getUser()
+    public function getUser(): UserInterface
     {
         return $this->user;
     }
 
-    public function setUser(UserInterface $user)
+    public function setUser(UserInterface $user): void
     {
         $this->user = $user;
     }

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationCredentialsNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationCredentialsNotFoundException.php
@@ -23,7 +23,7 @@ class AuthenticationCredentialsNotFoundException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Authentication credentials could not be found.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
@@ -25,15 +25,13 @@ class AuthenticationException extends RuntimeException
 
     /**
      * Get the token.
-     *
-     * @return TokenInterface|null
      */
-    public function getToken()
+    public function getToken(): ?TokenInterface
     {
         return $this->token;
     }
 
-    public function setToken(TokenInterface $token)
+    public function setToken(TokenInterface $token): void
     {
         $this->token = $token;
     }
@@ -81,20 +79,16 @@ class AuthenticationException extends RuntimeException
 
     /**
      * Message key to be used by the translation component.
-     *
-     * @return string
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'An authentication exception occurred.';
     }
 
     /**
      * Message data to be used by the translation component.
-     *
-     * @return array
      */
-    public function getMessageData()
+    public function getMessageData(): array
     {
         return [];
     }

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationExpiredException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationExpiredException.php
@@ -24,7 +24,7 @@ class AuthenticationExpiredException extends AccountStatusException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Authentication expired because your account information has changed.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationServiceException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationServiceException.php
@@ -22,7 +22,7 @@ class AuthenticationServiceException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Authentication request could not be processed due to a system problem.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/BadCredentialsException.php
+++ b/src/Symfony/Component/Security/Core/Exception/BadCredentialsException.php
@@ -22,7 +22,7 @@ class BadCredentialsException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Invalid credentials.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/CookieTheftException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CookieTheftException.php
@@ -23,7 +23,7 @@ class CookieTheftException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Cookie has already been used by someone else.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/CredentialsExpiredException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CredentialsExpiredException.php
@@ -22,7 +22,7 @@ class CredentialsExpiredException extends AccountStatusException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Credentials have expired.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAccountStatusException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAccountStatusException.php
@@ -40,18 +40,18 @@ class CustomUserMessageAccountStatusException extends AccountStatusException
      * @param string $messageKey  The message or message key
      * @param array  $messageData Data to be passed into the translator
      */
-    public function setSafeMessage(string $messageKey, array $messageData = [])
+    public function setSafeMessage(string $messageKey, array $messageData = []): void
     {
         $this->messageKey = $messageKey;
         $this->messageData = $messageData;
     }
 
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return $this->messageKey;
     }
 
-    public function getMessageData()
+    public function getMessageData(): array
     {
         return $this->messageData;
     }

--- a/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
@@ -39,18 +39,18 @@ class CustomUserMessageAuthenticationException extends AuthenticationException
      * @param string $messageKey  The message or message key
      * @param array  $messageData Data to be passed into the translator
      */
-    public function setSafeMessage(string $messageKey, array $messageData = [])
+    public function setSafeMessage(string $messageKey, array $messageData = []): void
     {
         $this->messageKey = $messageKey;
         $this->messageData = $messageData;
     }
 
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return $this->messageKey;
     }
 
-    public function getMessageData()
+    public function getMessageData(): array
     {
         return $this->messageData;
     }

--- a/src/Symfony/Component/Security/Core/Exception/DisabledException.php
+++ b/src/Symfony/Component/Security/Core/Exception/DisabledException.php
@@ -22,7 +22,7 @@ class DisabledException extends AccountStatusException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Account is disabled.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/InsufficientAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/InsufficientAuthenticationException.php
@@ -24,7 +24,7 @@ class InsufficientAuthenticationException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Not privileged to request the resource.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/InvalidCsrfTokenException.php
+++ b/src/Symfony/Component/Security/Core/Exception/InvalidCsrfTokenException.php
@@ -22,7 +22,7 @@ class InvalidCsrfTokenException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Invalid CSRF token.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/LockedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/LockedException.php
@@ -22,7 +22,7 @@ class LockedException extends AccountStatusException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Account is locked.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/ProviderNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/ProviderNotFoundException.php
@@ -23,7 +23,7 @@ class ProviderNotFoundException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'No authentication provider found to support the authentication token.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/SessionUnavailableException.php
+++ b/src/Symfony/Component/Security/Core/Exception/SessionUnavailableException.php
@@ -28,7 +28,7 @@ class SessionUnavailableException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'No session available, it either timed out or cookies are not enabled.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/TokenNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/TokenNotFoundException.php
@@ -22,7 +22,7 @@ class TokenNotFoundException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'No token could be found.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/UserNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UserNotFoundException.php
@@ -24,7 +24,7 @@ class UserNotFoundException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Username could not be found.';
     }
@@ -38,11 +38,9 @@ class UserNotFoundException extends AuthenticationException
     }
 
     /**
-     * @return string
-     *
      * @deprecated
      */
-    public function getUsername()
+    public function getUsername(): string
     {
         trigger_deprecation('symfony/security-core', '5.3', 'Method "%s()" is deprecated, use getUserIdentifier() instead.', __METHOD__);
 
@@ -60,7 +58,7 @@ class UserNotFoundException extends AuthenticationException
     /**
      * @deprecated
      */
-    public function setUsername(string $username)
+    public function setUsername(string $username): void
     {
         trigger_deprecation('symfony/security-core', '5.3', 'Method "%s()" is deprecated, use getUserIdentifier() instead.', __METHOD__);
 
@@ -70,7 +68,7 @@ class UserNotFoundException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageData()
+    public function getMessageData(): array
     {
         return ['{{ username }}' => $this->identifier, '{{ user_identifier }}' => $this->identifier];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

declare return types where possible for authentication based exceptions.

I was not sure if we can do this w/o breaking BC in the `4.4` or one of the `5.*` branches. If there are other reasons why this couldn't / shouldn't be done, I'm all ears.