### PR TITLE
[DependencyInjection] Add env() and EnvConfigurator in the PHP-DSL

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add support for per-env configuration in loaders
  * Add `ContainerBuilder::willBeAvailable()` to help with conditional configuration
  * Add support an integer return value for default_index_method
+ * Add `env()` and `EnvConfigurator` in the PHP-DSL
 
 5.2.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
@@ -83,6 +83,10 @@ abstract class AbstractConfigurator
             return $def;
         }
 
+        if ($value instanceof EnvConfigurator) {
+            return (string) $value;
+        }
+
         if ($value instanceof self) {
             throw new InvalidArgumentException(sprintf('"%s()" can be used only at the root of service configuration files.', $value::FACTORY));
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ContainerConfigurator.php
@@ -201,3 +201,11 @@ function abstract_arg(string $description): AbstractArgument
 {
     return new AbstractArgument($description);
 }
+
+/**
+ * Creates an environment variable reference.
+ */
+function env(string $name): EnvConfigurator
+{
+    return new EnvConfigurator($name);
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/EnvConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/EnvConfigurator.php
@@ -1,0 +1,213 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+class EnvConfigurator
+{
+    /**
+     * @var string[]
+     */
+    private $stack;
+
+    public function __construct(string $name)
+    {
+        $this->stack = explode(':', $name);
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return '%env('.implode(':', $this->stack).')%';
+    }
+
+    /**
+     * @return $this
+     */
+    public function custom(string $processor, ...$args): self
+    {
+        array_unshift($this->stack, $processor, ...$args);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function base64(): self
+    {
+        array_unshift($this->stack, 'base64');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function bool(): self
+    {
+        array_unshift($this->stack, 'bool');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function not(): self
+    {
+        array_unshift($this->stack, 'not');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function const(): self
+    {
+        array_unshift($this->stack, 'const');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function csv(): self
+    {
+        array_unshift($this->stack, 'csv');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function file(): self
+    {
+        array_unshift($this->stack, 'file');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function float(): self
+    {
+        array_unshift($this->stack, 'float');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function int(): self
+    {
+        array_unshift($this->stack, 'int');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function json(): self
+    {
+        array_unshift($this->stack, 'json');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function key(string $key): self
+    {
+        array_unshift($this->stack, 'key', $key);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function url(): self
+    {
+        array_unshift($this->stack, 'url');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function queryString(): self
+    {
+        array_unshift($this->stack, 'query_string');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function resolve(): self
+    {
+        array_unshift($this->stack, 'resolve');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function default(string $fallbackParam): self
+    {
+        array_unshift($this->stack, 'default', $fallbackParam);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function string(): self
+    {
+        array_unshift($this->stack, 'string');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function trim(): self
+    {
+        array_unshift($this->stack, 'trim');
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function require(): self
+    {
+        array_unshift($this->stack, 'require');
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/env_configurator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/env_configurator.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $configurator): void {
+    $services = $configurator->services();
+
+    $services
+        ->set('foo', \stdClass::class)
+        ->public()
+        ->args([
+            env('CCC')->int()
+        ]);
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/Configurator/EnvConfiguratorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/Configurator/EnvConfiguratorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Loader\Configurator;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Loader\Configurator\EnvConfigurator;
+
+final class EnvConfiguratorTest extends TestCase
+{
+    /**
+     * @dataProvider provide
+     */
+    public function test(string $expected, EnvConfigurator $envConfigurator)
+    {
+        $this->assertSame($expected, (string) $envConfigurator);
+    }
+
+    public function provide()
+    {
+        yield ['%env(FOO)%', new EnvConfigurator('FOO')];
+        yield ['%env(string:FOO)%', new EnvConfigurator('string:FOO')];
+        yield ['%env(string:FOO)%', (new EnvConfigurator('FOO'))->string()];
+        yield ['%env(key:path:url:FOO)%', (new EnvConfigurator('FOO'))->url()->key('path')];
+        yield ['%env(default:fallback:bar:arg1:FOO)%', (new EnvConfigurator('FOO'))->custom('bar', 'arg1')->default('fallback')];
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -147,6 +147,15 @@ class PhpFileLoaderTest extends TestCase
         $this->assertSame(['foo' => 234, 'bar' => 345], $container->getParameterBag()->all());
     }
 
+    public function testEnvConfigurator()
+    {
+        $container = new ContainerBuilder();
+        $loader = new PhpFileLoader($container, new FileLocator(realpath(__DIR__.'/../Fixtures').'/config'), 'some-env');
+        $loader->load('env_configurator.php');
+
+        $this->assertSame('%env(int:CCC)%', $container->getDefinition('foo')->getArgument(0));
+    }
+
     /**
      * @group legacy
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Recently, I have been using env var processors a lot. This is a proposition to improve the DX a bit when you use the PHP-DSL to configure services.

Firstly, I am "annoyed" by the fact that I can do `param('my_param')` but not `env('MY_ENV')`.

Secondly, long chains of env var processors (eg: `%env(default:my_param:key:path:url:MY_ENV_VAR)` have two issues:
- you must construct and read them in "reverse"
- some env var processor are actually composed of 2 parts (key:path), you don't distinguish them easily from the rest

Before:
```php
->arg('$myArg', '%env(default:my_param:key:path:url:MY_ENV_VAR)%')
```

After:
```php
->arg(
    '$myArg',
    env('MY_ENV_VAR')
        ->url()
        ->key('path')
        ->default('my_param')
)
```

Custom env var processor would be callable with `->custom('my_custom_env_var_processor')` or you could extend the configurator and add your own methods.

WDYT?