### PR TITLE
[FrameworkBundle] Added resolve-env option to debug:config command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
  * Add `KernelTestCase::getContainer()` as the best way to get a container in tests
  * Rename the container parameter `profiler_listener.only_master_requests` to `profiler_listener.only_main_requests`
  * Add service `fragment.uri_generator` to generate the URI of a fragment
+ * Add `--resolve-env` option to `debug:config` command to resolve the value of environment variables in the command output
 
 5.2.0
 -----


### PR DESCRIPTION
This option replaces environment variables placeholders by their actual value in the command output

| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #40582
| License       | MIT
| Doc PR        | _see below_

I couldn't find any tests nor documentation about this command. If I missed it, I'd be more than pleased to complete this pull request!