### PR TITLE
[Filesystem] Add targetIterator for fs mirror

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -521,7 +521,7 @@ class Filesystem
 
         // Iterate in destination folder to remove obsolete entries
         if ($this->exists($targetDir) && isset($options['delete']) && $options['delete']) {
-            $deleteIterator = func_num_args() === 5 ? func_get_arg(4) : $iterator;
+            $deleteIterator = 5 === \func_num_args() ? func_get_arg(4) : $iterator;
             if (null === $deleteIterator) {
                 $flags = \FilesystemIterator::SKIP_DOTS;
                 $deleteIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, $flags), \RecursiveIteratorIterator::CHILD_FIRST);

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -497,14 +497,14 @@ class Filesystem
      *  - existing files in the target directory will be overwritten, except if they are newer (see the `override` option)
      *  - files in the target directory that do not exist in the source directory will not be deleted (see the `delete` option)
      *
-     * @param string            $originDir The origin directory
-     * @param string            $targetDir The target directory
+     * @param string            $originDir      The origin directory
+     * @param string            $targetDir      The target directory
      * @param \Traversable|null $originIterator Iterator that filters which files and directories to copy, if null a recursive iterator is created
-     * @param array             $options   An array of boolean options
-     *                                     Valid options are:
-     *                                     - $options['override'] If true, target files newer than origin files are overwritten (see copy(), defaults to false)
-     *                                     - $options['copy_on_windows'] Whether to copy files instead of links on Windows (see symlink(), defaults to false)
-     *                                     - $options['delete'] Whether to delete files that are not in the source directory (defaults to false)
+     * @param array             $options        An array of boolean options
+     *                                          Valid options are:
+     *                                          - $options['override'] If true, target files newer than origin files are overwritten (see copy(), defaults to false)
+     *                                          - $options['copy_on_windows'] Whether to copy files instead of links on Windows (see symlink(), defaults to false)
+     *                                          - $options['delete'] Whether to delete files that are not in the source directory (defaults to false)
      * @param \Traversable|null $targetIterator Iterator that filters which files and directory in target directory to delete if not in source directory (if $options['delete'] is true)
      *
      * @throws IOException When file type is unknown

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -497,16 +497,19 @@ class Filesystem
      *  - existing files in the target directory will be overwritten, except if they are newer (see the `override` option)
      *  - files in the target directory that do not exist in the source directory will not be deleted (see the `delete` option)
      *
-     * @param \Traversable|null $iterator Iterator that filters which files and directories to copy, if null a recursive iterator is created
-     * @param array             $options  An array of boolean options
-     *                                    Valid options are:
-     *                                    - $options['override'] If true, target files newer than origin files are overwritten (see copy(), defaults to false)
-     *                                    - $options['copy_on_windows'] Whether to copy files instead of links on Windows (see symlink(), defaults to false)
-     *                                    - $options['delete'] Whether to delete files that are not in the source directory (defaults to false)
+     * @param string            $originDir The origin directory
+     * @param string            $targetDir The target directory
+     * @param \Traversable|null $originIterator Iterator that filters which files and directories to copy, if null a recursive iterator is created
+     * @param array             $options   An array of boolean options
+     *                                     Valid options are:
+     *                                     - $options['override'] If true, target files newer than origin files are overwritten (see copy(), defaults to false)
+     *                                     - $options['copy_on_windows'] Whether to copy files instead of links on Windows (see symlink(), defaults to false)
+     *                                     - $options['delete'] Whether to delete files that are not in the source directory (defaults to false)
+     * @param \Traversable|null $targetIterator Iterator that filters which files and directory in target directory to delete if not in source directory (if $options['delete'] is true)
      *
      * @throws IOException When file type is unknown
      */
-    public function mirror(string $originDir, string $targetDir, \Traversable $iterator = null, array $options = [])
+    public function mirror(string $originDir, string $targetDir, \Traversable $originIterator = null, array $options = [], \Traversable $targetIterator = null)
     {
         $targetDir = rtrim($targetDir, '/\\');
         $originDir = rtrim($originDir, '/\\');
@@ -518,7 +521,7 @@ class Filesystem
 
         // Iterate in destination folder to remove obsolete entries
         if ($this->exists($targetDir) && isset($options['delete']) && $options['delete']) {
-            $deleteIterator = $iterator;
+            $deleteIterator = $targetIterator;
             if (null === $deleteIterator) {
                 $flags = \FilesystemIterator::SKIP_DOTS;
                 $deleteIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, $flags), \RecursiveIteratorIterator::CHILD_FIRST);
@@ -534,15 +537,15 @@ class Filesystem
 
         $copyOnWindows = $options['copy_on_windows'] ?? false;
 
-        if (null === $iterator) {
+        if (null === $originIterator) {
             $flags = $copyOnWindows ? \FilesystemIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS : \FilesystemIterator::SKIP_DOTS;
-            $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($originDir, $flags), \RecursiveIteratorIterator::SELF_FIRST);
+            $originIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($originDir, $flags), \RecursiveIteratorIterator::SELF_FIRST);
         }
 
         $this->mkdir($targetDir);
         $filesCreatedWhileMirroring = [];
 
-        foreach ($iterator as $file) {
+        foreach ($originIterator as $file) {
             if ($file->getPathname() === $targetDir || $file->getRealPath() === $targetDir || isset($filesCreatedWhileMirroring[$file->getRealPath()])) {
                 continue;
             }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -497,8 +497,6 @@ class Filesystem
      *  - existing files in the target directory will be overwritten, except if they are newer (see the `override` option)
      *  - files in the target directory that do not exist in the source directory will not be deleted (see the `delete` option)
      *
-     * @param string            $originDir      The origin directory
-     * @param string            $targetDir      The target directory
      * @param \Traversable|null $iterator       Iterator that filters which files and directories to copy, if null a recursive iterator is created
      * @param array             $options        An array of boolean options
      *                                          Valid options are:

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -519,7 +519,7 @@ class Filesystem
 
         // Iterate in destination folder to remove obsolete entries
         if ($this->exists($targetDir) && isset($options['delete']) && $options['delete']) {
-            $deleteIterator = 4 < \func_num_args() ? func_get_arg(4) : $iterator;
+            $deleteIterator = (4 < \func_num_args() ? func_get_arg(4) : null) ?? $iterator;
             if (null === $deleteIterator) {
                 $flags = \FilesystemIterator::SKIP_DOTS;
                 $deleteIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, $flags), \RecursiveIteratorIterator::CHILD_FIRST);

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -521,7 +521,7 @@ class Filesystem
 
         // Iterate in destination folder to remove obsolete entries
         if ($this->exists($targetDir) && isset($options['delete']) && $options['delete']) {
-            $deleteIterator = 5 === \func_num_args() ? func_get_arg(4) : $iterator;
+            $deleteIterator = 4 < \func_num_args() ? func_get_arg(4) : $iterator;
             if (null === $deleteIterator) {
                 $flags = \FilesystemIterator::SKIP_DOTS;
                 $deleteIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, $flags), \RecursiveIteratorIterator::CHILD_FIRST);

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -377,7 +377,7 @@ class FilesystemTest extends FilesystemTestCase
 
         // create symlink to nonexistent dir
         rmdir($basePath.'dir');
-        $this->assertFalse(is_dir($basePath.'dir-link'));
+        $this->assertDirectoryNotExists($basePath.'dir-link');
 
         $this->filesystem->remove($basePath);
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -377,7 +377,7 @@ class FilesystemTest extends FilesystemTestCase
 
         // create symlink to nonexistent dir
         rmdir($basePath.'dir');
-        $this->assertDirectoryNotExists($basePath.'dir-link');
+        $this->assertDirectoryDoesNotExist($basePath.'dir-link');
 
         $this->filesystem->remove($basePath);
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1209,7 +1209,7 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertSame('../../../', $this->filesystem->makePathRelative('var/lib/symfony/', '/var/lib/symfony/src/Symfony/Component'));
     }
 
-    public function testMirrorOriginIterator(): void
+    public function testMirrorOriginIterator()
     {
         $sourcePath = $this->workspace.\DIRECTORY_SEPARATOR.'source'.\DIRECTORY_SEPARATOR;
         $targetPath = $this->workspace.\DIRECTORY_SEPARATOR.'target'.\DIRECTORY_SEPARATOR;
@@ -1231,7 +1231,7 @@ class FilesystemTest extends FilesystemTestCase
         self::assertFileDoesNotExist($targetFile2);
     }
 
-    public function testMirrorTargetIterator(): void
+    public function testMirrorTargetIterator()
     {
         $sourcePath = $this->workspace.\DIRECTORY_SEPARATOR.'source'.\DIRECTORY_SEPARATOR;
         $targetPath = $this->workspace.\DIRECTORY_SEPARATOR.'target'.\DIRECTORY_SEPARATOR;
@@ -1246,7 +1246,7 @@ class FilesystemTest extends FilesystemTestCase
         $targetIterator = Finder::create();
         $targetIterator->files()->in($targetPath)->name('file2');
 
-        $this->filesystem->mirror($sourcePath, $targetPath, NULL, ['delete' => true], $targetIterator);
+        $this->filesystem->mirror($sourcePath, $targetPath, null, ['delete' => true], $targetIterator);
 
         self::assertFileExists($targetFile1);
         self::assertFileDoesNotExist($targetFile2);

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1252,6 +1252,33 @@ class FilesystemTest extends FilesystemTestCase
         self::assertFileDoesNotExist($targetFile2);
     }
 
+    public function testMirrorOriginAndTargetIterator()
+    {
+        $sourcePath = $this->workspace.\DIRECTORY_SEPARATOR.'source'.\DIRECTORY_SEPARATOR;
+        $targetPath = $this->workspace.\DIRECTORY_SEPARATOR.'target'.\DIRECTORY_SEPARATOR;
+        $sourceFile1 = $sourcePath.'file1';
+        $sourceFile2 = $sourcePath.'file2';
+        $targetFile1 = $targetPath.'file1';
+        $targetFile2 = $targetPath.'file2';
+
+        mkdir($sourcePath);
+        mkdir($targetPath);
+        file_put_contents($sourceFile1, 'FILE1');
+        file_put_contents($targetFile1, 'FILE1');
+        file_put_contents($targetFile2, 'FILE2');
+
+        $originIterator = Finder::create();
+        $originIterator->files()->in($sourcePath)->name('file1');
+
+        $targetIterator = Finder::create();
+        $targetIterator->files()->in($targetPath)->name('file2');
+
+        $this->filesystem->mirror($sourcePath, $targetPath, $originIterator, ['delete' => true], $targetIterator);
+
+        self::assertFileExists($targetFile1);
+        self::assertFileDoesNotExist($targetFile2);
+    }
+
     public function testMirrorCopiesFilesAndDirectoriesRecursively()
     {
         $sourcePath = $this->workspace.\DIRECTORY_SEPARATOR.'source'.\DIRECTORY_SEPARATOR;

--- a/src/Symfony/Component/Filesystem/composer.json
+++ b/src/Symfony/Component/Filesystem/composer.json
@@ -20,6 +20,9 @@
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-mbstring": "~1.8"
     },
+    "require-dev": {
+        "symfony/finder": "^4.0|^5.0"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Filesystem\\": "" },
         "exclude-from-classmap": [

--- a/src/Symfony/Component/Filesystem/composer.json
+++ b/src/Symfony/Component/Filesystem/composer.json
@@ -21,7 +21,7 @@
         "symfony/polyfill-mbstring": "~1.8"
     },
     "require-dev": {
-        "symfony/finder": "^4.4|^5.0"
+        "symfony/finder": "^5.4|^6.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Filesystem\\": "" },

--- a/src/Symfony/Component/Filesystem/composer.json
+++ b/src/Symfony/Component/Filesystem/composer.json
@@ -21,7 +21,7 @@
         "symfony/polyfill-mbstring": "~1.8"
     },
     "require-dev": {
-        "symfony/finder": "^4.0|^5.0"
+        "symfony/finder": "^4.4|^5.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Filesystem\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature? yes
| Deprecations? | no
| Tickets       | Fix #14068
| License       | MIT

The existing `$iterator` parameter is useless and will not behave as expected if `$options['delete'] == true`. There needs to be a separate iterator parameter for the target directory.