### PR TITLE
[Security] Mark ExpiredLoginLinkStorage as experimental

### DIFF
--- a/src/Symfony/Component/Security/Http/LoginLink/ExpiredLoginLinkStorage.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/ExpiredLoginLinkStorage.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Security\Http\LoginLink;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
+ * @experimental in 5.2
+ *
  * @final
  */
 class ExpiredLoginLinkStorage


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

We missed marking this as experimental together with the other "LoginLink" features. 

This PR follows the discussion in https://github.com/symfony/symfony/pull/40145/files#r589072524
