### PR TITLE
[Console] Add Helper::width() and Helper::length()

### DIFF
--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -46,6 +46,17 @@ abstract class Helper implements HelperInterface
      */
     public static function strlen(?string $string)
     {
+        return self::width($string);
+    }
+
+    /**
+     * Returns the width of a string, using mb_strwidth if it is available.
+     * The width is how many characters positions the string will use.
+     *
+     * @internal in Symfony 5.2
+     */
+    public static function width(?string $string): int
+    {
         $string ?? $string = '';
 
         if (preg_match('//u', $string)) {
@@ -57,6 +68,27 @@ abstract class Helper implements HelperInterface
         }
 
         return mb_strwidth($string, $encoding);
+    }
+
+    /**
+     * Returns the length of a string, using mb_strlen if it is available.
+     * The length is related to how many bytes the string will use.
+     *
+     * @internal in Symfony 5.2
+     */
+    public static function length(?string $string): int
+    {
+        $string ?? $string = '';
+
+        if (preg_match('//u', $string)) {
+            return (new UnicodeString($string))->length();
+        }
+
+        if (false === $encoding = mb_detect_encoding($string, null, true)) {
+            return \strlen($string);
+        }
+
+        return mb_strlen($string, $encoding);
     }
 
     /**
@@ -123,13 +155,7 @@ abstract class Helper implements HelperInterface
 
     public static function strlenWithoutDecoration(OutputFormatterInterface $formatter, ?string $string)
     {
-        $string = self::removeDecoration($formatter, $string);
-
-        if (preg_match('//u', $string)) {
-            return (new UnicodeString($string))->width(true);
-        }
-
-        return self::strlen($string);
+        return self::width(self::removeDecoration($formatter, $string));
     }
 
     public static function removeDecoration(OutputFormatterInterface $formatter, ?string $string)

--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -513,7 +513,7 @@ final class ProgressBar
                 $completeBars = $bar->getBarOffset();
                 $display = str_repeat($bar->getBarCharacter(), $completeBars);
                 if ($completeBars < $bar->getBarWidth()) {
-                    $emptyBars = $bar->getBarWidth() - $completeBars - Helper::strlenWithoutDecoration($output->getFormatter(), $bar->getProgressCharacter());
+                    $emptyBars = $bar->getBarWidth() - $completeBars - Helper::length(Helper::removeDecoration($output->getFormatter(), $bar->getProgressCharacter()));
                     $display .= $bar->getProgressCharacter().str_repeat($bar->getEmptyBarCharacter(), $emptyBars);
                 }
 

--- a/src/Symfony/Component/Console/Helper/Table.php
+++ b/src/Symfony/Component/Console/Helper/Table.php
@@ -511,7 +511,7 @@ class Table
             return sprintf($style->getBorderFormat(), str_repeat($style->getBorderChars()[2], $width));
         }
 
-        $width += Helper::strlen($cell) - Helper::strlenWithoutDecoration($this->output->getFormatter(), $cell);
+        $width += Helper::length($cell) - Helper::length(Helper::removeDecoration($this->output->getFormatter(), $cell));
         $content = sprintf($style->getCellRowContentFormat(), $cell);
 
         $padType = $style->getPadType();

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -899,6 +899,21 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         );
     }
 
+    public function testUnicode()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 10, 0);
+        ProgressBar::setFormatDefinition('test', '%current%/%max% [%bar%] %percent:3s%% %message% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.');
+        $bar->setFormat('test');
+        $bar->setProgressCharacter('💧');
+        $bar->start();
+        rewind($output->getStream());
+        $this->assertStringContainsString(
+            ' 0/10 [💧]   0%',
+            stream_get_contents($output->getStream())
+        );
+        $bar->finish();
+    }
+
     /**
      * @dataProvider provideFormat
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Close #40697 Fix #40634, fix #40635
| License       | MIT
| Doc PR        | 

This PR will add add a Helper::strwidth() and a Helper::strlength(). Same with with the Helper::strlenWithoutDecoration(). It does not deprecate anything. That is done in #40695

With this PR we dont have to revert the emoji issue (ie close #40697)

FYI @grasmash, I used your tests from #40635