### PR TITLE
[CI] Make sure packages contain all metafiles

### DIFF
--- a/.github/get-modified-packages.php
+++ b/.github/get-modified-packages.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Given a list of all packages, find the package that have been modified.
+ */
+
+if (3 > $_SERVER['argc']) {
+    echo "Usage: app-packages modified-files\n";
+    exit(1);
+}
+
+$allPackages = json_decode($_SERVER['argv'][1], true, 512, \JSON_THROW_ON_ERROR);
+$modifiedFiles = json_decode($_SERVER['argv'][2], true, 512, \JSON_THROW_ON_ERROR);
+
+function isComponentBridge(string $packageDir): bool
+{
+    return 0 < preg_match('@Symfony/Component/.*/Bridge/@', $packageDir);
+}
+
+$newPackage = [];
+$modifiedPackages = [];
+foreach ($modifiedFiles as $file) {
+    foreach ($allPackages as $package) {
+        if (0 === strpos($file, $package)) {
+            $modifiedPackages[$package] = true;
+            if ('LICENSE' === substr($file, -7)) {
+                /*
+                 * There is never a reason to modify the LICENSE file, this diff
+                 * must be adding a new package
+                 */
+                $newPackage[$package] = true;
+            }
+            break;
+        }
+    }
+}
+
+$output = [];
+foreach ($modifiedPackages as $directory => $bool) {
+    $name = json_decode(file_get_contents($directory.'/composer.json'), true)['name'] ?? 'unknown';
+    $output[] = ['name' => $name, 'directory' => $directory, 'new' => $newPackage[$directory] ?? false, 'component_bridge' => isComponentBridge($directory)];
+}
+
+echo json_encode($output);

--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -1,0 +1,95 @@
+name: Package
+
+on:
+  pull_request:
+    paths:
+      - src/**
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: Ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Fetch branch from where the PR started
+        run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+
+      - name: Find packages
+        id: find-packages
+        run: echo "::set-output name=packages::$(php .github/get-modified-packages.php $(find src/Symfony -mindepth 2 -type f -name composer.json -printf '%h\n' | jq -R -s -c 'split("\n")[:-1]') $(git diff --name-only origin/${{ github.base_ref }} HEAD | grep src/ | jq -R -s -c 'split("\n")[:-1]'))"
+
+      - name: Verify meta files are correct
+        run: |
+          ok=0
+
+          _file_exist() {
+            if [ ! -f "${1}" ]; then
+              echo "File ${1} does not exist"
+              return 1
+            fi
+          }
+
+          _file_not_exist() {
+            if [ -f "${1}" ]; then
+              echo "File ${1} should not be here"
+              return 1
+            fi
+          }
+
+          _correct_license_file() {
+            FIRST_LINE="Copyright (c) $(date +"%Y") Fabien Potencier"
+            PACKAGE_FIRST_LINE=$(head -1 ${1})
+            if [[ "$FIRST_LINE" != "$PACKAGE_FIRST_LINE" ]]; then
+              echo "First line of the license file is wrong. Maybe it is the wrong year?"
+              return 1
+            fi
+
+            TEMPLATE=$(tail -n +2 LICENSE)
+            PACKAGE_LICENSE=$(tail -n +2 ${1})
+            if [[ "$TEMPLATE" != "$PACKAGE_LICENSE" ]]; then
+              echo "Wrong content in license file"
+              return 1
+            fi
+          }
+
+          json='${{ steps.find-packages.outputs.packages }}'
+          for package in $(echo "${json}" | jq -r '.[] | @base64'); do
+              _jq() {
+                echo ${package} | base64 --decode | jq -r ${1}
+              }
+
+              DIR=$(_jq '.directory')
+              NAME=$(_jq '.name')
+              echo "::group::$NAME"
+              localExit=0
+
+              _file_exist $DIR/.gitattributes || localExit=1
+              _file_exist $DIR/.gitignore || localExit=1
+              _file_exist $DIR/CHANGELOG.md || localExit=1
+              _file_exist $DIR/LICENSE || localExit=1
+              _file_exist $DIR/phpunit.xml.dist || localExit=1
+              _file_exist $DIR/README.md || localExit=1
+              _file_not_exist $DIR/phpunit.xml || localExit=1
+
+              if [ $(_jq '.new') == true ]; then
+                echo "Verifying new package"
+                _correct_license_file $DIR/LICENSE || localExit=1
+
+                if [ $(_jq '.component_bridge') == false ]; then
+                  if [ ! $(cat composer.json | jq -e ".replace.\"$NAME\"|test(\"self.version\")") ]; then
+                    echo "Composer.json's replace section needs to contain $NAME"
+                    localExit=1
+                  fi
+                fi
+              fi
+
+              ok=$(( $localExit || $ok ))
+              echo ::endgroup::
+              if [ $localExit -ne 0 ]; then
+                echo "::error::$NAME failed"
+              fi
+          done
+
+          exit $ok


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

This PR introduce a new CI job to just do some checks on a package. It first looks at the git diff to figure out what packages have changed. Then for each changed package it verifies: 

- .gitattributes exists
- .gitignore exists
- CHANGELOG.md exists
- LICENSE exists
- phpunit.xml.dist exists
- README.md exists
- The LICENSE file includes "Fabien Potencier", the correct year and has same content as /LICENSE

If the package is new (license file changed), we also make sure that the package is present in composer.json's replace.

I got this idea after seeing PRs like #40696. And we do add one or two package every month. 
