### PR TITLE
[Yaml] Fixed infinite loop when parser goes through an additional and invalid closing tag

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -1225,6 +1225,10 @@ class Parser
         $offset = $cursor;
         $cursor += strcspn($this->currentLine, '[]{},: ', $cursor);
 
+        if ($cursor === $offset) {
+            throw new ParseException('Malformed unquoted YAML string.');
+        }
+
         return substr($this->currentLine, $offset, $cursor - $offset);
     }
 

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -2676,6 +2676,25 @@ YAML;
         );
     }
 
+    public function testThrowExceptionIfInvalidAdditionalClosingTagOccurs()
+    {
+        $yaml = '{
+            "object": {
+                    "array": [
+                        "a",
+                        "b",
+                        "c"
+                    ]
+                ],
+            }
+        }';
+
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Malformed unquoted YAML string at line 8 (near "                ],").');
+
+        $this->parser->parse($yaml);
+    }
+
     public function testWhitespaceAtEndOfLine()
     {
         $yaml = "\nfoo:\n    arguments: [ '@bar' ]  \n";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 and above
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #40706 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

Instead of letting the parser goes in an infinite loop because it can't get the right closing tag, throw an exception when the additional and invalid closing tag is found