### PR TITLE
[Serializer] Construct annotations using named arguments

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -92,7 +92,7 @@ PropertyInfo
 Routing
 -------
 
- * Deprecated creating instances of the `Route` annotation class by passing an array of parameters, use named arguments instead
+ * Deprecate creating instances of the `Route` annotation class by passing an array of parameters, use named arguments instead
 
 Security
 --------
@@ -209,7 +209,8 @@ SecurityBundle
 Serializer
 ----------
 
- * Deprecated `ArrayDenormalizer::setSerializer()`, call `setDenormalizer()` instead
+ * Deprecate `ArrayDenormalizer::setSerializer()`, call `setDenormalizer()` instead
+ * Deprecate creating instances of the annotation classes by passing an array of parameters, use named arguments instead
 
 Uid
 ---

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -305,6 +305,7 @@ Serializer
 
  * Removed `ArrayDenormalizer::setSerializer()`, call `setDenormalizer()` instead.
  * `ArrayDenormalizer` does not implement `SerializerAwareInterface` anymore.
+ * The annotation classes cannot be constructed by passing an array of parameters as first argument anymore, use named arguments instead
 
 TwigBundle
 ----------

--- a/src/Symfony/Component/Serializer/Annotation/Context.php
+++ b/src/Symfony/Component/Serializer/Annotation/Context.php
@@ -17,6 +17,7 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * Annotation class for @Context().
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"PROPERTY", "METHOD"})
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
@@ -30,18 +31,25 @@ final class Context
     private $groups;
 
     /**
+     * @param string|string[] $groups
+     *
      * @throws InvalidArgumentException
      */
-    public function __construct(array $options = [], array $context = [], array $normalizationContext = [], array $denormalizationContext = [], array $groups = [])
+    public function __construct(array $options = [], array $context = [], array $normalizationContext = [], array $denormalizationContext = [], $groups = [])
     {
         if (!$context) {
             if (!array_intersect((array_keys($options)), ['normalizationContext', 'groups', 'context', 'value', 'denormalizationContext'])) {
                 // gracefully supports context as first, unnamed attribute argument if it cannot be confused with Doctrine-style options
                 $context = $options;
             } else {
+                trigger_deprecation('symfony/serializer', '5.3', 'Passing an array of properties as first argument to "%s" is deprecated. Use named arguments instead.', __METHOD__);
+
                 // If at least one of the options match, it's likely to be Doctrine-style options. Search for the context inside:
                 $context = $options['value'] ?? $options['context'] ?? [];
             }
+        }
+        if (!\is_string($groups) && !\is_array($groups)) {
+            throw new \TypeError(sprintf('"%s": Expected parameter $groups to be a string or an array of strings, got "%s".', __METHOD__, get_debug_type($groups)));
         }
 
         $normalizationContext = $options['normalizationContext'] ?? $normalizationContext;

--- a/src/Symfony/Component/Serializer/Annotation/DiscriminatorMap.php
+++ b/src/Symfony/Component/Serializer/Annotation/DiscriminatorMap.php
@@ -17,6 +17,7 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * Annotation class for @DiscriminatorMap().
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"CLASS"})
  *
  * @author Samuel Roze <samuel.roze@gmail.com>
@@ -35,13 +36,15 @@ class DiscriminatorMap
     private $mapping;
 
     /**
-     * @param string|array $typeProperty
+     * @param string $typeProperty
      *
      * @throws InvalidArgumentException
      */
     public function __construct($typeProperty, array $mapping = null)
     {
         if (\is_array($typeProperty)) {
+            trigger_deprecation('symfony/serializer', '5.3', 'Passing an array as first argument to "%s" is deprecated. Use named arguments instead.', __METHOD__);
+
             $mapping = $typeProperty['mapping'] ?? null;
             $typeProperty = $typeProperty['typeProperty'] ?? null;
         } elseif (!\is_string($typeProperty)) {

--- a/src/Symfony/Component/Serializer/Annotation/Groups.php
+++ b/src/Symfony/Component/Serializer/Annotation/Groups.php
@@ -17,6 +17,7 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * Annotation class for @Groups().
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"PROPERTY", "METHOD"})
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -30,11 +31,19 @@ class Groups
     private $groups;
 
     /**
+     * @param string|string[] $groups
+     *
      * @throws InvalidArgumentException
      */
-    public function __construct(array $groups)
+    public function __construct($groups)
     {
-        if (isset($groups['value'])) {
+        if (\is_string($groups)) {
+            $groups = (array) $groups;
+        } elseif (!\is_array($groups)) {
+            throw new \TypeError(sprintf('"%s": Parameter $groups is expected to be a string or an array of strings, got "%s".', __METHOD__, get_debug_type($groups)));
+        } elseif (isset($groups['value'])) {
+            trigger_deprecation('symfony/serializer', '5.3', 'Passing an array of properties as first argument to "%s" is deprecated. Use named arguments instead.', __METHOD__);
+
             $groups = (array) $groups['value'];
         }
         if (empty($groups)) {

--- a/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
+++ b/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
@@ -17,6 +17,7 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * Annotation class for @MaxDepth().
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"PROPERTY", "METHOD"})
  *
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -30,11 +31,13 @@ class MaxDepth
     private $maxDepth;
 
     /**
-     * @param int|array $maxDepth
+     * @param int $maxDepth
      */
     public function __construct($maxDepth)
     {
         if (\is_array($maxDepth)) {
+            trigger_deprecation('symfony/serializer', '5.3', 'Passing an array as first argument to "%s" is deprecated. Use named arguments instead.', __METHOD__);
+
             if (!isset($maxDepth['value'])) {
                 throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" should be set.', static::class));
             }

--- a/src/Symfony/Component/Serializer/Annotation/SerializedName.php
+++ b/src/Symfony/Component/Serializer/Annotation/SerializedName.php
@@ -17,6 +17,7 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  * Annotation class for @SerializedName().
  *
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"PROPERTY", "METHOD"})
  *
  * @author Fabien Bourigault <bourigaultfabien@gmail.com>
@@ -30,11 +31,13 @@ final class SerializedName
     private $serializedName;
 
     /**
-     * @param string|array $serializedName
+     * @param string $serializedName
      */
     public function __construct($serializedName)
     {
         if (\is_array($serializedName)) {
+            trigger_deprecation('symfony/serializer', '5.3', 'Passing an array as first argument to "%s" is deprecated. Use named arguments instead.', __METHOD__);
+
             if (!isset($serializedName['value'])) {
                 throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" should be set.', static::class));
             }

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate `ArrayDenormalizer::setSerializer()`, call `setDenormalizer()` instead
  * Add normalization formats to `UidNormalizer`
  * Add `CsvEncoder::END_OF_LINE` context option
+ * Deprecate creating instances of the annotation classes by passing an array of parameters, use named arguments instead
 
 5.2.0
 -----

--- a/src/Symfony/Component/Serializer/Tests/Annotation/DiscriminatorMapTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/DiscriminatorMapTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Annotation;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Serializer\Annotation\DiscriminatorMap;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
@@ -20,8 +21,31 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  */
 class DiscriminatorMapTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
+    /**
+     * @requires PHP 8
+     */
     public function testGetTypePropertyAndMapping()
     {
+        $annotation = new DiscriminatorMap(...['typeProperty' => 'type', 'mapping' => [
+            'foo' => 'FooClass',
+            'bar' => 'BarClass',
+        ]]);
+
+        $this->assertEquals('type', $annotation->getTypeProperty());
+        $this->assertEquals([
+            'foo' => 'FooClass',
+            'bar' => 'BarClass',
+        ], $annotation->getMapping());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testGetTypePropertyAndMappingLegacy()
+    {
+        $this->expectDeprecation('Since symfony/serializer 5.3: Passing an array as first argument to "Symfony\Component\Serializer\Annotation\DiscriminatorMap::__construct" is deprecated. Use named arguments instead.');
         $annotation = new DiscriminatorMap(['typeProperty' => 'type', 'mapping' => [
             'foo' => 'FooClass',
             'bar' => 'BarClass',
@@ -34,25 +58,64 @@ class DiscriminatorMapTest extends TestCase
         ], $annotation->getMapping());
     }
 
+    /**
+     * @group legacy
+     */
     public function testExceptionWithoutTypeProperty()
     {
         $this->expectException(InvalidArgumentException::class);
         new DiscriminatorMap(['mapping' => ['foo' => 'FooClass']]);
     }
 
+    /**
+     * @requires PHP 8
+     */
     public function testExceptionWithEmptyTypeProperty()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new DiscriminatorMap(...['typeProperty' => '', 'mapping' => ['foo' => 'FooClass']]);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testExceptionWithEmptyTypePropertyLegacy()
     {
         $this->expectException(InvalidArgumentException::class);
         new DiscriminatorMap(['typeProperty' => '', 'mapping' => ['foo' => 'FooClass']]);
     }
 
+    /**
+     * @requires PHP 8
+     */
     public function testExceptionWithoutMappingProperty()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new DiscriminatorMap(...['typeProperty' => 'type']);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testExceptionWithoutMappingPropertyLegacy()
     {
         $this->expectException(InvalidArgumentException::class);
         new DiscriminatorMap(['typeProperty' => 'type']);
     }
 
+    /**
+     * @requires PHP 8
+     */
     public function testExceptionWitEmptyMappingProperty()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new DiscriminatorMap(...['typeProperty' => 'type', 'mapping' => []]);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testExceptionWitEmptyMappingPropertyLegacy()
     {
         $this->expectException(InvalidArgumentException::class);
         new DiscriminatorMap(['typeProperty' => 'type', 'mapping' => []]);

--- a/src/Symfony/Component/Serializer/Tests/Annotation/GroupsTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/GroupsTest.php
@@ -23,9 +23,21 @@ class GroupsTest extends TestCase
     public function testEmptyGroupsParameter()
     {
         $this->expectException(InvalidArgumentException::class);
+        new Groups([]);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testEmptyGroupsParameterLegacy()
+    {
+        $this->expectException(InvalidArgumentException::class);
         new Groups(['value' => []]);
     }
 
+    /**
+     * @group legacy
+     */
     public function testNotAnArrayGroupsParameter()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -35,10 +47,21 @@ class GroupsTest extends TestCase
     public function testInvalidGroupsParameter()
     {
         $this->expectException(InvalidArgumentException::class);
-        new Groups(['value' => ['a', 1, new \stdClass()]]);
+        new Groups(['a', 1, new \stdClass()]);
     }
 
     public function testGroupsParameters()
+    {
+        $validData = ['a', 'b'];
+
+        $groups = new Groups($validData);
+        $this->assertEquals($validData, $groups->getGroups());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testGroupsParametersLegacy()
     {
         $validData = ['a', 'b'];
 
@@ -47,6 +70,15 @@ class GroupsTest extends TestCase
     }
 
     public function testSingleGroup()
+    {
+        $groups = new Groups('a');
+        $this->assertEquals(['a'], $groups->getGroups());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testSingleGroupLegacy()
     {
         $groups = new Groups(['value' => 'a']);
         $this->assertEquals(['a'], $groups->getGroups());

--- a/src/Symfony/Component/Serializer/Tests/Annotation/MaxDepthTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/MaxDepthTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Annotation;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Serializer\Annotation\MaxDepth;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
@@ -20,6 +21,11 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  */
 class MaxDepthTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
     public function testNotSetMaxDepthParameter()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -44,11 +50,22 @@ class MaxDepthTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Parameter of annotation "Symfony\Component\Serializer\Annotation\MaxDepth" must be a positive integer.');
-        new MaxDepth(['value' => $value]);
+        new MaxDepth($value);
     }
 
     public function testMaxDepthParameters()
     {
+        $maxDepth = new MaxDepth(3);
+        $this->assertEquals(3, $maxDepth->getMaxDepth());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testMaxDepthParametersLegacy()
+    {
+        $this->expectDeprecation('Since symfony/serializer 5.3: Passing an array as first argument to "Symfony\Component\Serializer\Annotation\MaxDepth::__construct" is deprecated. Use named arguments instead.');
+
         $maxDepth = new MaxDepth(['value' => 3]);
         $this->assertEquals(3, $maxDepth->getMaxDepth());
     }

--- a/src/Symfony/Component/Serializer/Tests/Annotation/SerializedNameTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/SerializedNameTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Annotation;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
@@ -20,6 +21,11 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  */
 class SerializedNameTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
     public function testNotSetSerializedNameParameter()
     {
         $this->expectException(InvalidArgumentException::class);
@@ -27,7 +33,7 @@ class SerializedNameTest extends TestCase
         new SerializedName([]);
     }
 
-    public function provideInvalidValues()
+    public function provideInvalidValues(): array
     {
         return [
             [''],
@@ -42,11 +48,23 @@ class SerializedNameTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Parameter of annotation "Symfony\Component\Serializer\Annotation\SerializedName" must be a non-empty string.');
-        new SerializedName(['value' => $value]);
+
+        new SerializedName($value);
     }
 
     public function testSerializedNameParameters()
     {
+        $maxDepth = new SerializedName(['value' => 'foo']);
+        $this->assertEquals('foo', $maxDepth->getSerializedName());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testSerializedNameParametersLegacy()
+    {
+        $this->expectDeprecation('Since symfony/serializer 5.3: Passing an array as first argument to "Symfony\Component\Serializer\Annotation\SerializedName::__construct" is deprecated. Use named arguments instead.');
+
         $maxDepth = new SerializedName(['value' => 'foo']);
         $this->assertEquals('foo', $maxDepth->getSerializedName());
     }

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -22,7 +22,7 @@
         "symfony/polyfill-php80": "^1.15"
     },
     "require-dev": {
-        "doctrine/annotations": "^1.10.4",
+        "doctrine/annotations": "^1.12",
         "doctrine/cache": "~1.0",
         "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
         "symfony/cache": "^4.4|^5.0",
@@ -43,6 +43,7 @@
         "symfony/yaml": "^4.4|^5.0"
     },
     "conflict": {
+        "doctrine/annotations": "<1.12",
         "phpdocumentor/reflection-docblock": "<3.2.2",
         "phpdocumentor/type-resolver": "<1.4.0",
         "symfony/dependency-injection": "<4.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | Not needed

This is the same as #40266, but applied to the serializer annotations.

This PR proposes to bump the `doctrine/annotations` library to 1.12 to gain access to its emulation layer for named arguments. Furthermore, constructing any of the serializer's annotation classes the old way by passing an array of parameters is deprecated.

### Reasons for this change

The constructors of our annotation classes have become unnecessarily complicated because we have to support two ways of calling them:
* An array of parameters, passed as first argument, because that's the default behavior `doctrine/annotations`.
* A set of named arguments because that's how PHP 8 attributes work.

Since we can now tell the Doctrine annotation reader to use named arguments as well, we can simplify the constructors of our annotations significantly.

### Drawback

After this change, there is no easy way anymore to construct instances of most of the annotation classes directly on PHP 7. The PR has been built under the assumption that instances of this class are usually created using either Doctrine annotations or a PHP 8 attribute. Thus, most applications should be unaffected by this change.