### PR TITLE
[Security] Be able to know the reasons of the denied access 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -37,6 +37,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -229,11 +230,22 @@ abstract class AbstractController implements ServiceSubscriberInterface
      */
     protected function denyAccessUnlessGranted($attribute, $subject = null, string $message = 'Access Denied.'): void
     {
-        if (!$this->isGranted($attribute, $subject)) {
+        if (!$this->container->has('security.authorization_checker')) {
+            throw new \LogicException('The SecurityBundle is not registered in your application. Try running "composer require symfony/security-bundle".');
+        }
+
+        $checker = $this->container->get('security.authorization_checker');
+        if (method_exists($checker, 'getDecision')) {
+            $decision = $checker->getDecision($attribute, $subject);
+        } else {
+            $decision = $checker->isGranted($attribute, $subject) ? AccessDecision::createGranted() : AccessDecision::createDenied();
+        }
+
+        if (!$decision->isGranted()) {
             $exception = $this->createAccessDeniedException($message);
             $exception->setAttributes($attribute);
             $exception->setSubject($subject);
-            $exception->setAccessDecision($this->container->get('security.authorization_checker')->getLastAccessDecision());
+            $exception->setAccessDecision($decision);
 
             throw $exception;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -233,6 +233,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
             $exception = $this->createAccessDeniedException($message);
             $exception->setAttributes($attribute);
             $exception->setSubject($subject);
+            $exception->setAccessDecision($this->container->get('security.authorization_checker')->getLastAccessDecision());
 
             throw $exception;
         }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -346,16 +346,17 @@
                                             <td class="font-normal text-small">attribute {{ voter_detail['attributes'][0] }}</td>
                                             {% endif %}
                                             <td class="font-normal text-small">
-                                                {% if voter_detail['vote'] == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_GRANTED') %}
+                                                {% if voter_detail['vote'].access == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_GRANTED') %}
                                                     ACCESS GRANTED
-                                                {% elseif voter_detail['vote'] == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_ABSTAIN') %}
+                                                {% elseif voter_detail['vote'].access == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_ABSTAIN') %}
                                                     ACCESS ABSTAIN
-                                                {% elseif voter_detail['vote'] == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_DENIED') %}
+                                                {% elseif voter_detail['vote'].access == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_DENIED') %}
                                                     ACCESS DENIED
                                                 {% else %}
-                                                    unknown ({{ voter_detail['vote'] }})
+                                                    unknown ({{ voter_detail['vote'].access }})
                                                 {% endif %}
                                             </td>
+                                            <td class="font-normal text-small">{{ voter_detail['vote'].reason|default('~') }}</td>
                                         </tr>
                                     {% endfor %}
                                     </tbody>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/EventListener/VoteListenerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/EventListener/VoteListenerTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\SecurityBundle\Tests\EventListener;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\EventListener\VoteListener;
 use Symfony\Component\Security\Core\Authorization\TraceableAccessDecisionManager;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Event\VoteEvent;
 
@@ -29,10 +30,33 @@ class VoteListenerTest extends TestCase
             ->setMethods(['addVoterVote'])
             ->getMock();
 
+        $vote = Vote::createGranted();
         $traceableAccessDecisionManager
             ->expects($this->once())
             ->method('addVoterVote')
-            ->with($voter, ['myattr1', 'myattr2'], VoterInterface::ACCESS_GRANTED);
+            ->with($voter, ['myattr1', 'myattr2'], $vote);
+
+        $sut = new VoteListener($traceableAccessDecisionManager);
+        $sut->onVoterVote(new VoteEvent($voter, 'mysubject', ['myattr1', 'myattr2'], $vote));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testOnVoterVoteLegacy()
+    {
+        $voter = $this->createMock(VoterInterface::class);
+
+        $traceableAccessDecisionManager = $this
+            ->getMockBuilder(TraceableAccessDecisionManager::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['addVoterVote'])
+            ->getMock();
+
+        $traceableAccessDecisionManager
+            ->expects($this->once())
+            ->method('addVoterVote')
+            ->with($voter, ['myattr1', 'myattr2'], Vote::createGranted());
 
         $sut = new VoteListener($traceableAccessDecisionManager);
         $sut->onVoterVote(new VoteEvent($voter, 'mysubject', ['myattr1', 'myattr2'], VoterInterface::ACCESS_GRANTED));

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecision.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecision.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization;
+
+use Symfony\Component\Security\Core\Authorization\Voter\AccessTrait;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * An AccessDecision is returned by an AccessDecisionManager and contains the access verdict and all the related votes.
+ *
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+final class AccessDecision
+{
+    use AccessTrait;
+
+    /** @var Vote[] */
+    private $votes = [];
+
+    /**
+     * @param int    $access One of the VoterInterface::ACCESS_* constants
+     * @param Vote[] $votes
+     */
+    private function __construct(int $access, array $votes = [])
+    {
+        $this->access = $access;
+        $this->votes = $votes;
+    }
+
+    /**
+     * @param Vote[] $votes
+     */
+    public static function createGranted(array $votes = []): self
+    {
+        return new self(VoterInterface::ACCESS_GRANTED, $votes);
+    }
+
+    /**
+     * @param Vote[] $votes
+     */
+    public static function createDenied(array $votes = []): self
+    {
+        return new self(VoterInterface::ACCESS_DENIED, $votes);
+    }
+
+    /**
+     * @return Vote[]
+     */
+    public function getVotes(): array
+    {
+        return $this->votes;
+    }
+
+    /**
+     * @return Vote[]
+     */
+    public function getGrantedVotes(): array
+    {
+        return $this->getVotesByAccess(Voter::ACCESS_GRANTED);
+    }
+
+    /**
+     * @return Vote[]
+     */
+    public function getAbstainedVotes(): array
+    {
+        return $this->getVotesByAccess(Voter::ACCESS_ABSTAIN);
+    }
+
+    /**
+     * @return Vote[]
+     */
+    public function getDeniedVotes(): array
+    {
+        return $this->getVotesByAccess(Voter::ACCESS_DENIED);
+    }
+
+    private function getVotesByAccess(int $access): array
+    {
+        return array_filter($this->votes, function (Vote $vote) use ($access) { return $vote->getAccess() === $access; });
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecision.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecision.php
@@ -86,8 +86,13 @@ final class AccessDecision
         return $this->getVotesByAccess(Voter::ACCESS_DENIED);
     }
 
+    /**
+     * @return Vote[]
+     */
     private function getVotesByAccess(int $access): array
     {
-        return array_filter($this->votes, function (Vote $vote) use ($access) { return $vote->getAccess() === $access; });
+        return array_filter($this->votes, static function (Vote $vote) use ($access): bool {
+            return $vote->getAccess() === $access;
+        });
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Core\Authorization;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 
@@ -55,13 +56,22 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
         $this->allowIfEqualGrantedDeniedDecisions = $allowIfEqualGrantedDeniedDecisions;
     }
 
+    public function getDecision(TokenInterface $token, array $attributes, object $object = null): AccessDecision
+    {
+        return $this->{$this->strategy}($token, $attributes, $object);
+    }
+
     /**
      * @param bool $allowMultipleAttributes Whether to allow passing multiple values to the $attributes array
      *
      * {@inheritdoc}
+     *
+     * @deprecated since 5.3, use {@see getDecision()} instead.
      */
-    public function decide(TokenInterface $token, array $attributes, $object = null/*, bool $allowMultipleAttributes = false*/)
+    public function decide(TokenInterface $token, array $attributes, $object = null/*, bool $allowMultipleAttributes = false*/): bool
     {
+        trigger_deprecation('symfony/security-core', '5.3', 'Method "%s::decide()" has been deprecated, use "%s::getDecision()" instead.', __CLASS__, __CLASS__);
+
         $allowMultipleAttributes = 3 < \func_num_args() && func_get_arg(3);
 
         // Special case for AccessListener, do not remove the right side of the condition before 6.0
@@ -69,7 +79,7 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
             throw new InvalidArgumentException(sprintf('Passing more than one Security attribute to "%s()" is not supported.', __METHOD__));
         }
 
-        return $this->{$this->strategy}($token, $attributes, $object);
+        return $this->getDecision($token, $attributes, $object)->isGranted();
     }
 
     /**
@@ -83,16 +93,18 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
         $votes = [];
         $deny = 0;
         foreach ($this->voters as $voter) {
-            $votes[] = $vote = $this->vote($voter, $token, $object, $attributes);
+            $vote = $this->vote($voter, $token, $object, $attributes);
+            if (null === $vote) {
+                continue;
+            }
 
+            $votes[] = $vote;
             if ($vote->isGranted()) {
                 return AccessDecision::createGranted($votes);
             }
 
             if ($vote->isDenied()) {
                 ++$deny;
-            } elseif (VoterInterface::ACCESS_ABSTAIN !== $result) {
-                trigger_deprecation('symfony/security-core', '5.3', 'Returning "%s" in "%s::vote()" is deprecated, return one of "%s" constants: "ACCESS_GRANTED", "ACCESS_DENIED" or "ACCESS_ABSTAIN".', var_export($result, true), get_debug_type($voter), VoterInterface::class);
             }
         }
 
@@ -100,7 +112,7 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
             return AccessDecision::createDenied($votes);
         }
 
-        return $this->decideIfAllAbstainDecisions();
+        return $this->decideIfAllAbstainDecisions($votes);
     }
 
     /**
@@ -123,14 +135,16 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
         $grant = 0;
         $deny = 0;
         foreach ($this->voters as $voter) {
-            $votes[] = $vote = $this->vote($voter, $token, $object, $attributes);
+            $vote = $this->vote($voter, $token, $object, $attributes);
+            if (null === $vote) {
+                continue;
+            }
 
+            $votes[] = $vote;
             if ($vote->isGranted()) {
                 ++$grant;
             } elseif ($vote->isDenied()) {
                 ++$deny;
-            } elseif (VoterInterface::ACCESS_ABSTAIN !== $result) {
-                trigger_deprecation('symfony/security-core', '5.3', 'Returning "%s" in "%s::vote()" is deprecated, return one of "%s" constants: "ACCESS_GRANTED", "ACCESS_DENIED" or "ACCESS_ABSTAIN".', var_export($result, true), get_debug_type($voter), VoterInterface::class);
             }
         }
 
@@ -144,12 +158,12 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
 
         if ($grant > 0) {
             return $this->allowIfEqualGrantedDeniedDecisions
-                ? AccessDecision::createGranted()
-                : AccessDecision::createDenied()
+                ? AccessDecision::createGranted($votes)
+                : AccessDecision::createDenied($votes)
             ;
         }
 
-        return $this->decideIfAllAbstainDecisions();
+        return $this->decideIfAllAbstainDecisions($votes);
     }
 
     /**
@@ -164,16 +178,18 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
         $grant = 0;
         foreach ($this->voters as $voter) {
             foreach ($attributes as $attribute) {
-                $votes[] = $vote = $this->vote($voter, $token, $object, [$attribute]);
+                $vote = $this->vote($voter, $token, $object, [$attribute]);
+                if (null === $vote) {
+                    continue;
+                }
 
+                $votes[] = $vote;
                 if ($vote->isDenied()) {
                     return AccessDecision::createDenied($votes);
                 }
 
                 if ($vote->isGranted()) {
                     ++$grant;
-                } elseif (VoterInterface::ACCESS_ABSTAIN !== $result) {
-                    trigger_deprecation('symfony/security-core', '5.3', 'Returning "%s" in "%s::vote()" is deprecated, return one of "%s" constants: "ACCESS_GRANTED", "ACCESS_DENIED" or "ACCESS_ABSTAIN".', var_export($result, true), get_debug_type($voter), VoterInterface::class);
                 }
             }
         }
@@ -183,7 +199,7 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
             return AccessDecision::createGranted($votes);
         }
 
-        return $this->decideIfAllAbstainDecisions();
+        return $this->decideIfAllAbstainDecisions($votes);
     }
 
     /**
@@ -195,40 +211,50 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
      */
     private function decidePriority(TokenInterface $token, array $attributes, $object = null)
     {
+        $votes = [];
         foreach ($this->voters as $voter) {
-            $result = $voter->vote($token, $object, $attributes);
-
-            if (VoterInterface::ACCESS_GRANTED === $result) {
-                return true;
+            $vote = $this->vote($voter, $token, $object, $attributes);
+            if (null === $vote) {
+                continue;
             }
 
-            if (VoterInterface::ACCESS_DENIED === $result) {
-                return false;
+            $votes[] = $vote;
+            if ($vote->isGranted()) {
+                return AccessDecision::createGranted($votes);
             }
 
-            if (VoterInterface::ACCESS_ABSTAIN !== $result) {
-                trigger_deprecation('symfony/security-core', '5.3', 'Returning "%s" in "%s::vote()" is deprecated, return one of "%s" constants: "ACCESS_GRANTED", "ACCESS_DENIED" or "ACCESS_ABSTAIN".', var_export($result, true), get_debug_type($voter), VoterInterface::class);
+            if ($vote->isDenied()) {
+                return AccessDecision::createDenied($votes);
             }
         }
 
-        return $this->allowIfAllAbstainDecisions;
+        return $this->decideIfAllAbstainDecisions($votes);
     }
 
-    private function decideIfAllAbstainDecisions(): AccessDecision
+    /**
+     * @param Vote[] $votes
+     */
+    private function decideIfAllAbstainDecisions(array $votes): AccessDecision
     {
         return $this->allowIfAllAbstainDecisions
-            ? AccessDecision::createGranted()
-            : AccessDecision::createDenied()
+            ? AccessDecision::createGranted($votes)
+            : AccessDecision::createDenied($votes)
         ;
     }
 
-    private function vote(VoterInterface $voter, TokenInterface $token, $subject, array $attributes): Vote
+    private function vote(VoterInterface $voter, TokenInterface $token, $subject, array $attributes): ?Vote
     {
-        if (\is_int($vote = $voter->vote($token, $subject, $attributes))) {
-            trigger_deprecation('symfony/security', 5.1, 'Returning an int from the "%s::vote()" method is deprecated. Return a "%s" object instead.', \get_class($this->voter), Vote::class);
-            $vote = Vote::create($vote);
+        $result = $voter->vote($token, $subject, $attributes);
+        if ($result instanceof Vote) {
+            return $result;
         }
 
-        return $vote;
+        trigger_deprecation('symfony/security-core', '5.3', 'Returning "%s" in "%s::vote()" is deprecated, return a "%s" object instead.', var_export($result, true), get_debug_type($voter), Vote::class);
+
+        if (\in_array($result, [VoterInterface::ACCESS_ABSTAIN, VoterInterface::ACCESS_DENIED, VoterInterface::ACCESS_GRANTED], true)) {
+            return Vote::create($result);
+        }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
@@ -26,7 +26,7 @@ interface AccessDecisionManagerInterface
      * @param array  $attributes An array of attributes associated with the method being invoked
      * @param object $object     The object to secure
      *
-     * @return bool true if the access is granted, false otherwise
+     * @return bool|AccessDecision Returning a boolean is deprecated since Symfony 5.1. Return an AccessDecision object instead.
      */
     public function decide(TokenInterface $token, array $attributes, $object = null);
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
@@ -17,6 +17,8 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  * AccessDecisionManagerInterface makes authorization decisions.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @method AccessDecision getDecision(TokenInterface $token, array $attributes, object $object = null)
  */
 interface AccessDecisionManagerInterface
 {
@@ -26,7 +28,9 @@ interface AccessDecisionManagerInterface
      * @param array  $attributes An array of attributes associated with the method being invoked
      * @param object $object     The object to secure
      *
-     * @return bool|AccessDecision Returning a boolean is deprecated since Symfony 5.1. Return an AccessDecision object instead.
+     * @return bool true if the access is granted, false otherwise
+     *
+     * @deprecated since 5.3, use {@see getDecision()} instead.
      */
-    public function decide(TokenInterface $token, array $attributes, $object = null);
+    public function decide(TokenInterface $token, array $attributes, $object = null): bool;
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
@@ -31,6 +31,8 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
     private $authenticationManager;
     private $alwaysAuthenticate;
     private $exceptionOnNoToken;
+    /** @var AccessDecision */
+    private $lastAccessDecision;
 
     public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authenticationManager, AccessDecisionManagerInterface $accessDecisionManager, bool $alwaysAuthenticate = false, bool $exceptionOnNoToken = true)
     {
@@ -60,6 +62,19 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
             }
         }
 
-        return $this->accessDecisionManager->decide($token, [$attribute], $subject);
+        $this->lastAccessDecision = $this->accessDecisionManager->decide($token, [$attribute], $subject);
+
+        if (\is_bool($this->lastAccessDecision)) {
+            trigger_deprecation('symfony/security', 5.1, 'Returning a boolean from the "%s::decide()" method is deprecated. Return an "%s" object instead', \get_class($this->accessDecisionManager), AccessDecision::class);
+
+            return $this->lastAccessDecision;
+        }
+
+        return $this->lastAccessDecision->isGranted();
+    }
+
+    public function getLastAccessDecision(): AccessDecision
+    {
+        return $this->lastAccessDecision;
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Security\Core\Authorization;
  * The AuthorizationCheckerInterface.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @method AccessDecision getDecision(mixed $attribute, mixed $subject = null)
  */
 interface AuthorizationCheckerInterface
 {

--- a/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Authorization;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 /**
@@ -50,7 +51,7 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
      *
      * @param bool $allowMultipleAttributes Whether to allow passing multiple values to the $attributes array
      */
-    public function decide(TokenInterface $token, array $attributes, $object = null/*, bool $allowMultipleAttributes = false*/): bool
+    public function decide(TokenInterface $token, array $attributes, $object = null/*, bool $allowMultipleAttributes = false*/)
     {
         $currentDecisionLog = [
             'attributes' => $attributes,
@@ -73,9 +74,9 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
      * Adds voter vote and class to the voter details.
      *
      * @param array $attributes attributes used for the vote
-     * @param int   $vote       vote of the voter
+     * @param Vote  $vote       vote of the voter
      */
-    public function addVoterVote(VoterInterface $voter, array $attributes, int $vote)
+    public function addVoterVote(VoterInterface $voter, array $attributes, Vote $vote)
     {
         $currentLogIndex = \count($this->currentLog) - 1;
         $this->currentLog[$currentLogIndex]['voterDetails'][] = [

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AccessTrait.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AccessTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization\Voter;
+
+/**
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+trait AccessTrait
+{
+    /** @var int One of the VoterInterface::ACCESS_* constants */
+    protected $access;
+
+    public function getAccess(): int
+    {
+        return $this->access;
+    }
+
+    public function isGranted(): bool
+    {
+        return VoterInterface::ACCESS_GRANTED === $this->access;
+    }
+
+    public function isAbstain(): bool
+    {
+        return VoterInterface::ACCESS_ABSTAIN === $this->access;
+    }
+
+    public function isDenied(): bool
+    {
+        return VoterInterface::ACCESS_DENIED === $this->access;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
@@ -47,10 +47,10 @@ class AuthenticatedVoter implements VoterInterface
     public function vote(TokenInterface $token, $subject, array $attributes)
     {
         if ($attributes === [self::PUBLIC_ACCESS]) {
-            return VoterInterface::ACCESS_GRANTED;
+            return Vote::createGranted();
         }
 
-        $result = VoterInterface::ACCESS_ABSTAIN;
+        $result = Vote::createAbstain();
         foreach ($attributes as $attribute) {
             if (null === $attribute || (self::IS_AUTHENTICATED_FULLY !== $attribute
                     && self::IS_AUTHENTICATED_REMEMBERED !== $attribute
@@ -61,36 +61,36 @@ class AuthenticatedVoter implements VoterInterface
                 continue;
             }
 
-            $result = VoterInterface::ACCESS_DENIED;
+            $result = Vote::createDenied();
 
             if (self::IS_AUTHENTICATED_FULLY === $attribute
                 && $this->authenticationTrustResolver->isFullFledged($token)) {
-                return VoterInterface::ACCESS_GRANTED;
+                return Vote::createGranted();
             }
 
             if (self::IS_AUTHENTICATED_REMEMBERED === $attribute
                 && ($this->authenticationTrustResolver->isRememberMe($token)
                     || $this->authenticationTrustResolver->isFullFledged($token))) {
-                return VoterInterface::ACCESS_GRANTED;
+                return Vote::createGranted();
             }
 
             if (self::IS_AUTHENTICATED_ANONYMOUSLY === $attribute
                 && ($this->authenticationTrustResolver->isAnonymous($token)
                     || $this->authenticationTrustResolver->isRememberMe($token)
                     || $this->authenticationTrustResolver->isFullFledged($token))) {
-                return VoterInterface::ACCESS_GRANTED;
+                return Vote::createGranted();
             }
 
             if (self::IS_REMEMBERED === $attribute && $this->authenticationTrustResolver->isRememberMe($token)) {
-                return VoterInterface::ACCESS_GRANTED;
+                return Vote::createGranted();
             }
 
             if (self::IS_ANONYMOUS === $attribute && $this->authenticationTrustResolver->isAnonymous($token)) {
-                return VoterInterface::ACCESS_GRANTED;
+                return Vote::createGranted();
             }
 
             if (self::IS_IMPERSONATOR === $attribute && $token instanceof SwitchUserToken) {
-                return VoterInterface::ACCESS_GRANTED;
+                return Vote::createGranted();
             }
         }
 

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
@@ -44,7 +44,7 @@ class ExpressionVoter implements VoterInterface
      */
     public function vote(TokenInterface $token, $subject, array $attributes)
     {
-        $result = VoterInterface::ACCESS_ABSTAIN;
+        $result = Vote::createAbstain();
         $variables = null;
         foreach ($attributes as $attribute) {
             if (!$attribute instanceof Expression) {
@@ -55,9 +55,9 @@ class ExpressionVoter implements VoterInterface
                 $variables = $this->getVariables($token, $subject);
             }
 
-            $result = VoterInterface::ACCESS_DENIED;
+            $result = Vote::createDenied();
             if ($this->expressionLanguage->evaluate($attribute, $variables)) {
-                return VoterInterface::ACCESS_GRANTED;
+                return Vote::createGranted();
             }
         }
 

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
@@ -32,7 +32,7 @@ class RoleVoter implements VoterInterface
      */
     public function vote(TokenInterface $token, $subject, array $attributes)
     {
-        $result = VoterInterface::ACCESS_ABSTAIN;
+        $result = Vote::createAbstain();
         $roles = $this->extractRoles($token);
 
         foreach ($attributes as $attribute) {
@@ -44,10 +44,10 @@ class RoleVoter implements VoterInterface
                 trigger_deprecation('symfony/security-core', '5.1', 'The ROLE_PREVIOUS_ADMIN role is deprecated and will be removed in version 6.0, use the IS_IMPERSONATOR attribute instead.');
             }
 
-            $result = VoterInterface::ACCESS_DENIED;
+            $result = Vote::createDenied();
             foreach ($roles as $role) {
                 if ($attribute === $role) {
-                    return VoterInterface::ACCESS_GRANTED;
+                    return Vote::createGranted();
                 }
             }
         }

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/TraceableVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/TraceableVoter.php
@@ -35,7 +35,7 @@ class TraceableVoter implements VoterInterface
 
     public function vote(TokenInterface $token, $subject, array $attributes)
     {
-        $result = $this->voter->vote($token, $subject, $attributes);
+        $result = \is_int($vote = $this->voter->vote($token, $subject, $attributes)) ? Vote::create($vote) : $vote;
 
         $this->eventDispatcher->dispatch(new VoteEvent($this->voter, $subject, $attributes, $result), 'debug.security.authorization.vote');
 

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/Vote.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/Vote.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Security\Core\Authorization\Voter;
 
 /**
- * A Vote is returned by a Voter and contains the access (granted, abstain or denied). It can also contains a reason
- * explaining the why of the access which has been decided.
+ * A Vote is returned by a Voter and contains the access (granted, abstain or denied).
+ * It can also contains a reason explaining the vote decision.
  *
  * @author Dany Maillard <danymaillard93b@gmail.com>
  */
@@ -39,24 +39,24 @@ final class Vote
         return new self($access, $reason, $parameters);
     }
 
-    public static function createGranted(string $reason, array $parameters = []): self
+    public static function createGranted(string $reason = '', array $parameters = []): self
     {
         return new self(VoterInterface::ACCESS_GRANTED, $reason, $parameters);
     }
 
-    public static function createAbstrain(string $reason, array $parameters = []): self
+    public static function createAbstain(string $reason = '', array $parameters = []): self
     {
         return new self(VoterInterface::ACCESS_ABSTAIN, $reason, $parameters);
     }
 
-    public static function createDenied(string $reason, array $parameters = []): self
+    public static function createDenied(string $reason = '', array $parameters = []): self
     {
         return new self(VoterInterface::ACCESS_DENIED, $reason, $parameters);
     }
 
-    public function merge(self $vote): void
+    public function setReason(string $reason)
     {
-        $this->reason .= trim(' '.$vote->getReason());
+        $this->reason = $reason;
     }
 
     public function getReason(): string

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/Vote.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/Vote.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization\Voter;
+
+/**
+ * A Vote is returned by a Voter and contains the access (granted, abstain or denied). It can also contains a reason
+ * explaining the why of the access which has been decided.
+ *
+ * @author Dany Maillard <danymaillard93b@gmail.com>
+ */
+final class Vote
+{
+    use AccessTrait;
+
+    private $reason;
+    private $parameters;
+
+    /**
+     * @param int $access One of the VoterInterface::ACCESS_* constants
+     */
+    private function __construct(int $access, string $reason = '', array $parameters = [])
+    {
+        $this->access = $access;
+        $this->reason = $reason;
+        $this->parameters = $parameters;
+    }
+
+    public static function create(int $access, string $reason = '', array $parameters = []): self
+    {
+        return new self($access, $reason, $parameters);
+    }
+
+    public static function createGranted(string $reason, array $parameters = []): self
+    {
+        return new self(VoterInterface::ACCESS_GRANTED, $reason, $parameters);
+    }
+
+    public static function createAbstrain(string $reason, array $parameters = []): self
+    {
+        return new self(VoterInterface::ACCESS_ABSTAIN, $reason, $parameters);
+    }
+
+    public static function createDenied(string $reason, array $parameters = []): self
+    {
+        return new self(VoterInterface::ACCESS_DENIED, $reason, $parameters);
+    }
+
+    public function merge(self $vote): void
+    {
+        $this->reason .= trim(' '.$vote->getReason());
+    }
+
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
@@ -33,7 +33,7 @@ interface VoterInterface
      * @param mixed $subject    The subject to secure
      * @param array $attributes An array of attributes associated with the method being invoked
      *
-     * @return int either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
+     * @return int|Vote either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
      */
     public function vote(TokenInterface $token, $subject, array $attributes);
 }

--- a/src/Symfony/Component/Security/Core/Event/VoteEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/VoteEvent.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Event;
 
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
@@ -28,7 +29,7 @@ final class VoteEvent extends Event
     private $attributes;
     private $vote;
 
-    public function __construct(VoterInterface $voter, $subject, array $attributes, int $vote)
+    public function __construct(VoterInterface $voter, $subject, array $attributes, Vote $vote)
     {
         $this->voter = $voter;
         $this->subject = $subject;
@@ -51,7 +52,7 @@ final class VoteEvent extends Event
         return $this->attributes;
     }
 
-    public function getVote(): int
+    public function getVote(): Vote
     {
         return $this->vote;
     }

--- a/src/Symfony/Component/Security/Core/Event/VoteEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/VoteEvent.php
@@ -29,11 +29,20 @@ final class VoteEvent extends Event
     private $attributes;
     private $vote;
 
-    public function __construct(VoterInterface $voter, $subject, array $attributes, Vote $vote)
+    /**
+     * @param Vote|int $vote
+     */
+    public function __construct(VoterInterface $voter, $subject, array $attributes, $vote)
     {
         $this->voter = $voter;
         $this->subject = $subject;
         $this->attributes = $attributes;
+        if (!$vote instanceof Vote) {
+            trigger_deprecation('symfony/security-core', '5.3', 'Passing an int as the fourth argument to "%s::__construct" is deprecated, pass a "%s" instance instead.', __CLASS__, Vote::class);
+
+            $vote = Vote::create($vote);
+        }
+
         $this->vote = $vote;
     }
 

--- a/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
@@ -69,8 +69,15 @@ class AccessDeniedException extends RuntimeException
     public function setAccessDecision(AccessDecision $accessDecision)
     {
         $this->accessDecision = $accessDecision;
-        $reasons = array_map(function (Vote $vote) { return $vote->getReason(); }, $this->accessDecision->getDeniedVotes());
-        $this->message .= rtrim(' '.implode(' ', $reasons));
+        if (!$accessDecision->getDeniedVotes()) {
+            return;
+        }
+
+        $reasons = array_map(static function (Vote $vote) {
+            return $vote->getReason();
+        }, $accessDecision->getDeniedVotes());
+
+        $this->message = 'Access Denied: '.rtrim(' '.implode(' ', $reasons));
     }
 
     public function getAccessDecision(): AccessDecision

--- a/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Security\Core\Exception;
 
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
+
 /**
  * AccessDeniedException is thrown when the account has not the required role.
  *
@@ -20,6 +23,8 @@ class AccessDeniedException extends RuntimeException
 {
     private $attributes = [];
     private $subject;
+    /** @var AccessDecision */
+    private $accessDecision;
 
     public function __construct(string $message = 'Access Denied.', \Throwable $previous = null)
     {
@@ -56,5 +61,20 @@ class AccessDeniedException extends RuntimeException
     public function setSubject($subject)
     {
         $this->subject = $subject;
+    }
+
+    /**
+     * Sets an access decision and appends the denied reasons to the exception message.
+     */
+    public function setAccessDecision(AccessDecision $accessDecision)
+    {
+        $this->accessDecision = $accessDecision;
+        $reasons = array_map(function (Vote $vote) { return $vote->getReason(); }, $this->accessDecision->getDeniedVotes());
+        $this->message .= rtrim(' '.implode(' ', $reasons));
+    }
+
+    public function getAccessDecision(): AccessDecision
+    {
+        return $this->accessDecision;
     }
 }

--- a/src/Symfony/Component/Security/Core/Security.php
+++ b/src/Symfony/Component/Security/Core/Security.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Core;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -61,12 +62,27 @@ class Security implements AuthorizationCheckerInterface
      */
     public function isGranted($attributes, $subject = null): bool
     {
-        return $this->container->get('security.authorization_checker')
-            ->isGranted($attributes, $subject);
+        return $this->getDecision($attributes, $subject)->isGranted();
     }
 
     public function getToken(): ?TokenInterface
     {
         return $this->container->get('security.token_storage')->getToken();
+    }
+
+    /**
+     * Get the access decision against the current authentication token and optionally supplied subject.
+     *
+     * @param mixed $attributes
+     * @param mixed $subject
+     */
+    public function getDecision($attribute, $subject = null): AccessDecision
+    {
+        $checker = $this->container->get('security.authorization_checker');
+        if (method_exists($checker, 'getDecision')) {
+            return $checker->getDecision($attribute, $subject);
+        }
+
+        return $checker->isGranted($attribute, $subject) ? AccessDecision::createGranted() : AccessDecision::createDenied();
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
-use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 
 class AuthenticatedVoterTest extends TestCase
 {
@@ -29,39 +29,39 @@ class AuthenticatedVoterTest extends TestCase
     {
         $voter = new AuthenticatedVoter(new AuthenticationTrustResolver());
 
-        $this->assertSame($expected, $voter->vote($this->getToken($authenticated), null, $attributes));
+        $this->assertEquals($expected, $voter->vote($this->getToken($authenticated), null, $attributes));
     }
 
     public function getVoteTests()
     {
         return [
-            ['fully', [], VoterInterface::ACCESS_ABSTAIN],
-            ['fully', ['FOO'], VoterInterface::ACCESS_ABSTAIN],
-            ['remembered', [], VoterInterface::ACCESS_ABSTAIN],
-            ['remembered', ['FOO'], VoterInterface::ACCESS_ABSTAIN],
-            ['anonymously', [], VoterInterface::ACCESS_ABSTAIN],
-            ['anonymously', ['FOO'], VoterInterface::ACCESS_ABSTAIN],
+            ['fully', [], Vote::createAbstain()],
+            ['fully', ['FOO'], Vote::createAbstain()],
+            ['remembered', [], Vote::createAbstain()],
+            ['remembered', ['FOO'], Vote::createAbstain()],
+            ['anonymously', [], Vote::createAbstain()],
+            ['anonymously', ['FOO'], Vote::createAbstain()],
 
-            ['fully', ['IS_AUTHENTICATED_ANONYMOUSLY'], VoterInterface::ACCESS_GRANTED],
-            ['remembered', ['IS_AUTHENTICATED_ANONYMOUSLY'], VoterInterface::ACCESS_GRANTED],
-            ['anonymously', ['IS_AUTHENTICATED_ANONYMOUSLY'], VoterInterface::ACCESS_GRANTED],
+            ['fully', ['IS_AUTHENTICATED_ANONYMOUSLY'], Vote::createGranted()],
+            ['remembered', ['IS_AUTHENTICATED_ANONYMOUSLY'], Vote::createGranted()],
+            ['anonymously', ['IS_AUTHENTICATED_ANONYMOUSLY'], Vote::createGranted()],
 
-            ['fully', ['IS_AUTHENTICATED_REMEMBERED'], VoterInterface::ACCESS_GRANTED],
-            ['remembered', ['IS_AUTHENTICATED_REMEMBERED'], VoterInterface::ACCESS_GRANTED],
-            ['anonymously', ['IS_AUTHENTICATED_REMEMBERED'], VoterInterface::ACCESS_DENIED],
+            ['fully', ['IS_AUTHENTICATED_REMEMBERED'], Vote::createGranted()],
+            ['remembered', ['IS_AUTHENTICATED_REMEMBERED'], Vote::createGranted()],
+            ['anonymously', ['IS_AUTHENTICATED_REMEMBERED'], Vote::createDenied()],
 
-            ['fully', ['IS_AUTHENTICATED_FULLY'], VoterInterface::ACCESS_GRANTED],
-            ['remembered', ['IS_AUTHENTICATED_FULLY'], VoterInterface::ACCESS_DENIED],
-            ['anonymously', ['IS_AUTHENTICATED_FULLY'], VoterInterface::ACCESS_DENIED],
+            ['fully', ['IS_AUTHENTICATED_FULLY'], Vote::createGranted()],
+            ['remembered', ['IS_AUTHENTICATED_FULLY'], Vote::createDenied()],
+            ['anonymously', ['IS_AUTHENTICATED_FULLY'], Vote::createDenied()],
 
-            ['fully', ['IS_ANONYMOUS'], VoterInterface::ACCESS_DENIED],
-            ['remembered', ['IS_ANONYMOUS'], VoterInterface::ACCESS_DENIED],
-            ['anonymously', ['IS_ANONYMOUS'], VoterInterface::ACCESS_GRANTED],
+            ['fully', ['IS_ANONYMOUS'], Vote::createDenied()],
+            ['remembered', ['IS_ANONYMOUS'], Vote::createDenied()],
+            ['anonymously', ['IS_ANONYMOUS'], Vote::createGranted()],
 
-            ['fully', ['IS_IMPERSONATOR'], VoterInterface::ACCESS_DENIED],
-            ['remembered', ['IS_IMPERSONATOR'], VoterInterface::ACCESS_DENIED],
-            ['anonymously', ['IS_IMPERSONATOR'], VoterInterface::ACCESS_DENIED],
-            ['impersonated', ['IS_IMPERSONATOR'], VoterInterface::ACCESS_GRANTED],
+            ['fully', ['IS_IMPERSONATOR'], Vote::createDenied()],
+            ['remembered', ['IS_IMPERSONATOR'], Vote::createDenied()],
+            ['anonymously', ['IS_IMPERSONATOR'], Vote::createDenied()],
+            ['impersonated', ['IS_IMPERSONATOR'], Vote::createGranted()],
         ];
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/ExpressionVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/ExpressionVoterTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\ExpressionLanguage;
 use Symfony\Component\Security\Core\Authorization\Voter\ExpressionVoter;
-use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 
 class ExpressionVoterTest extends TestCase
 {
@@ -29,19 +29,19 @@ class ExpressionVoterTest extends TestCase
     {
         $voter = new ExpressionVoter($this->createExpressionLanguage($expressionLanguageExpectsEvaluate), $this->createTrustResolver(), $this->createAuthorizationChecker());
 
-        $this->assertSame($expected, $voter->vote($this->getTokenWithRoleNames($roles, $tokenExpectsGetRoles), null, $attributes));
+        $this->assertEquals($expected, $voter->vote($this->getTokenWithRoleNames($roles, $tokenExpectsGetRoles), null, $attributes));
     }
 
     public function getVoteTests()
     {
         return [
-            [[], [], VoterInterface::ACCESS_ABSTAIN, false, false],
-            [[], ['FOO'], VoterInterface::ACCESS_ABSTAIN, false, false],
+            [[], [], Vote::createAbstain(), false, false],
+            [[], ['FOO'], Vote::createAbstain(), false, false],
 
-            [[], [$this->createExpression()], VoterInterface::ACCESS_DENIED, true, false],
+            [[], [$this->createExpression()], Vote::createDenied(), true, false],
 
-            [['ROLE_FOO'], [$this->createExpression(), $this->createExpression()], VoterInterface::ACCESS_GRANTED],
-            [['ROLE_BAR', 'ROLE_FOO'], [$this->createExpression()], VoterInterface::ACCESS_GRANTED],
+            [['ROLE_FOO'], [$this->createExpression(), $this->createExpression()], Vote::createGranted()],
+            [['ROLE_BAR', 'ROLE_FOO'], [$this->createExpression()], Vote::createGranted()],
         ];
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleHierarchyVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleHierarchyVoterTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization\Voter;
 
 use Symfony\Component\Security\Core\Authorization\Voter\RoleHierarchyVoter;
-use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Role\RoleHierarchy;
 
 class RoleHierarchyVoterTest extends RoleVoterTest
@@ -24,13 +24,13 @@ class RoleHierarchyVoterTest extends RoleVoterTest
     {
         $voter = new RoleHierarchyVoter(new RoleHierarchy(['ROLE_FOO' => ['ROLE_FOOBAR']]));
 
-        $this->assertSame($expected, $voter->vote($this->getTokenWithRoleNames($roles), null, $attributes));
+        $this->assertEquals($expected->getAccess(), $voter->vote($this->getTokenWithRoleNames($roles), null, $attributes)->getAccess());
     }
 
     public function getVoteTests()
     {
         return array_merge(parent::getVoteTests(), [
-            [['ROLE_FOO'], ['ROLE_FOOBAR'], VoterInterface::ACCESS_GRANTED],
+            [['ROLE_FOO'], ['ROLE_FOOBAR'], Vote::createGranted()],
         ]);
     }
 
@@ -41,7 +41,7 @@ class RoleHierarchyVoterTest extends RoleVoterTest
     {
         $voter = new RoleHierarchyVoter(new RoleHierarchy([]));
 
-        $this->assertSame($expected, $voter->vote($this->getTokenWithRoleNames($roles), null, $attributes));
+        $this->assertSame($expected->getAccess(), $voter->vote($this->getTokenWithRoleNames($roles), null, $attributes)->getAccess());
     }
 
     public function getVoteWithEmptyHierarchyTests()

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleVoterTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Authorization\Voter\RoleVoter;
-use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 
 class RoleVoterTest extends TestCase
 {
@@ -28,22 +28,22 @@ class RoleVoterTest extends TestCase
     {
         $voter = new RoleVoter();
 
-        $this->assertSame($expected, $voter->vote($this->getTokenWithRoleNames($roles), null, $attributes));
+        $this->assertSame($expected->getAccess(), $voter->vote($this->getTokenWithRoleNames($roles), null, $attributes)->getAccess());
     }
 
     public function getVoteTests()
     {
         return [
-            [[], [], VoterInterface::ACCESS_ABSTAIN],
-            [[], ['FOO'], VoterInterface::ACCESS_ABSTAIN],
-            [[], ['ROLE_FOO'], VoterInterface::ACCESS_DENIED],
-            [['ROLE_FOO'], ['ROLE_FOO'], VoterInterface::ACCESS_GRANTED],
-            [['ROLE_FOO'], ['FOO', 'ROLE_FOO'], VoterInterface::ACCESS_GRANTED],
-            [['ROLE_BAR', 'ROLE_FOO'], ['ROLE_FOO'], VoterInterface::ACCESS_GRANTED],
+            [[], [], Vote::createAbstain()],
+            [[], ['FOO'], Vote::createAbstain()],
+            [[], ['ROLE_FOO'], Vote::createDenied()],
+            [['ROLE_FOO'], ['ROLE_FOO'], Vote::createGranted()],
+            [['ROLE_FOO'], ['FOO', 'ROLE_FOO'], Vote::createGranted()],
+            [['ROLE_BAR', 'ROLE_FOO'], ['ROLE_FOO'], Vote::createGranted()],
 
             // Test mixed Types
-            [[], [[]], VoterInterface::ACCESS_ABSTAIN],
-            [[], [new \stdClass()], VoterInterface::ACCESS_ABSTAIN],
+            [[], [[]], Vote::createAbstain()],
+            [[], [new \stdClass()], Vote::createAbstain()],
         ];
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/VoterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Core\Tests\Authorization\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
@@ -60,7 +61,7 @@ class VoterTest extends TestCase
      */
     public function testVote(VoterInterface $voter, array $attributes, $expectedVote, $object, $message)
     {
-        $this->assertEquals($expectedVote, $voter->vote($this->token, $object, $attributes), $message);
+        $this->assertEquals($expectedVote, $voter->vote($this->token, $object, $attributes)->getAccess(), $message);
     }
 
     public function testVoteWithTypeError()
@@ -74,9 +75,9 @@ class VoterTest extends TestCase
 
 class VoterTest_Voter extends Voter
 {
-    protected function voteOnAttribute(string $attribute, $object, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, $object, TokenInterface $token): Vote
     {
-        return 'EDIT' === $attribute;
+        return 'EDIT' === $attribute ? Vote::createGranted() : Vote::createDenied();
     }
 
     protected function supports(string $attribute, $object): bool
@@ -87,9 +88,9 @@ class VoterTest_Voter extends Voter
 
 class IntegerVoterTest_Voter extends Voter
 {
-    protected function voteOnAttribute($attribute, $object, TokenInterface $token): bool
+    protected function voteOnAttribute($attribute, $object, TokenInterface $token): Vote
     {
-        return 42 === $attribute;
+        return 42 === $attribute ? Vote::createGranted() : Vote::createDenied();
     }
 
     protected function supports($attribute, $object): bool
@@ -100,9 +101,9 @@ class IntegerVoterTest_Voter extends Voter
 
 class TypeErrorVoterTest_Voter extends Voter
 {
-    protected function voteOnAttribute($attribute, $object, TokenInterface $token): bool
+    protected function voteOnAttribute($attribute, $object, TokenInterface $token): Vote
     {
-        return false;
+        return Vote::createDenied();
     }
 
     protected function supports($attribute, $object): bool

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -96,7 +96,13 @@ class AccessListener extends AbstractListener
             $this->tokenStorage->setToken($token);
         }
 
-        if (!$this->accessDecisionManager->decide($token, $attributes, $request, true)) {
+        if (method_exists($this->accessDecisionManager, 'getDecision')) {
+            $denied = $this->accessDecisionManager->getDecision($token, $attributes, $request)->isDenied();
+        } else {
+            $denied = !$this->accessDecisionManager->decide($token, $attributes, $request);
+        }
+
+        if ($denied) {
             throw $this->createAccessDeniedException($request, $attributes);
         }
     }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\Tests\Firewall;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
@@ -21,8 +22,11 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\AccessDecision;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
@@ -33,6 +37,54 @@ use Symfony\Component\Security\Http\Firewall\AccessListener;
 class AccessListenerTest extends TestCase
 {
     public function testHandleWhenTheAccessDecisionManagerDecidesToRefuseAccess()
+    {
+        $this->expectException(AccessDeniedException::class);
+        $request = new Request();
+
+        $accessMap = $this->createMock(AccessMapInterface::class);
+        $accessMap
+            ->expects($this->any())
+            ->method('getPatterns')
+            ->with($this->equalTo($request))
+            ->willReturn([['foo' => 'bar'], null])
+        ;
+
+        $token = $this->createMock(TokenInterface::class);
+        $token
+            ->expects($this->any())
+            ->method('isAuthenticated')
+            ->willReturn(true)
+        ;
+
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage
+            ->expects($this->any())
+            ->method('getToken')
+            ->willReturn($token)
+        ;
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManager::class);
+        $accessDecisionManager
+            ->expects($this->once())
+            ->method('getDecision')
+            ->with($this->equalTo($token), $this->equalTo(['foo' => 'bar']), $this->equalTo($request))
+            ->willReturn(AccessDecision::createDenied())
+        ;
+
+        $listener = new AccessListener(
+            $tokenStorage,
+            $accessDecisionManager,
+            $accessMap,
+            $this->createMock(AuthenticationManagerInterface::class)
+        );
+
+        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyHandleWhenTheAccessDecisionManagerDecidesToRefuseAccess()
     {
         $this->expectException(AccessDeniedException::class);
         $request = new Request();
@@ -78,6 +130,73 @@ class AccessListenerTest extends TestCase
     }
 
     public function testHandleWhenTheTokenIsNotAuthenticated()
+    {
+        $request = new Request();
+
+        $accessMap = $this->createMock(AccessMapInterface::class);
+        $accessMap
+            ->expects($this->any())
+            ->method('getPatterns')
+            ->with($this->equalTo($request))
+            ->willReturn([['foo' => 'bar'], null])
+        ;
+
+        $notAuthenticatedToken = $this->createMock(TokenInterface::class);
+        $notAuthenticatedToken
+            ->expects($this->any())
+            ->method('isAuthenticated')
+            ->willReturn(false)
+        ;
+
+        $authenticatedToken = $this->createMock(TokenInterface::class);
+        $authenticatedToken
+            ->expects($this->any())
+            ->method('isAuthenticated')
+            ->willReturn(true)
+        ;
+
+        $authManager = $this->createMock(AuthenticationManagerInterface::class);
+        $authManager
+            ->expects($this->once())
+            ->method('authenticate')
+            ->with($this->equalTo($notAuthenticatedToken))
+            ->willReturn($authenticatedToken)
+        ;
+
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage
+            ->expects($this->any())
+            ->method('getToken')
+            ->willReturn($notAuthenticatedToken)
+        ;
+        $tokenStorage
+            ->expects($this->once())
+            ->method('setToken')
+            ->with($this->equalTo($authenticatedToken))
+        ;
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManager::class);
+        $accessDecisionManager
+            ->expects($this->once())
+            ->method('getDecision')
+            ->with($this->equalTo($authenticatedToken), $this->equalTo(['foo' => 'bar']), $this->equalTo($request))
+            ->willReturn(AccessDecision::createGranted())
+        ;
+
+        $listener = new AccessListener(
+            $tokenStorage,
+            $accessDecisionManager,
+            $accessMap,
+            $authManager
+        );
+
+        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyHandleWhenTheTokenIsNotAuthenticated()
     {
         $request = new Request();
 
@@ -228,7 +347,7 @@ class AccessListenerTest extends TestCase
 
         $listener = new AccessListener(
             $tokenStorage,
-            $this->createMock(AccessDecisionManagerInterface::class),
+            $this->createMock(AccessDecisionManager::class),
             $accessMap,
             $this->createMock(AuthenticationManagerInterface::class)
         );
@@ -237,6 +356,39 @@ class AccessListenerTest extends TestCase
     }
 
     public function testHandleWhenTheSecurityTokenStorageHasNoTokenAndExceptionOnTokenIsFalse()
+    {
+        $this->expectException(AccessDeniedException::class);
+        $tokenStorage = new TokenStorage();
+        $request = new Request();
+
+        $accessMap = $this->createMock(AccessMapInterface::class);
+        $accessMap->expects($this->any())
+            ->method('getPatterns')
+            ->with($this->equalTo($request))
+            ->willReturn([['foo' => 'bar'], null])
+        ;
+
+        $accessDecisionManager = $this->createMock(AccessDecisionManager::class);
+        $accessDecisionManager->expects($this->once())
+            ->method('getDecision')
+            ->with($this->isInstanceOf(NullToken::class))
+            ->willReturn(AccessDecision::createDenied());
+
+        $listener = new AccessListener(
+            $tokenStorage,
+            $accessDecisionManager,
+            $accessMap,
+            $this->createMock(AuthenticationManagerInterface::class),
+            false
+        );
+
+        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyHandleWhenTheSecurityTokenStorageHasNoTokenAndExceptionOnTokenIsFalse()
     {
         $this->expectException(AccessDeniedException::class);
         $tokenStorage = new TokenStorage();
@@ -278,11 +430,11 @@ class AccessListenerTest extends TestCase
             ->willReturn([[AuthenticatedVoter::PUBLIC_ACCESS], null])
         ;
 
-        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager = $this->createMock(AccessDecisionManager::class);
         $accessDecisionManager->expects($this->once())
-            ->method('decide')
+            ->method('getDecision')
             ->with($this->isInstanceOf(NullToken::class), [AuthenticatedVoter::PUBLIC_ACCESS])
-            ->willReturn(true);
+            ->willReturn(AccessDecision::createGranted());
 
         $listener = new AccessListener(
             $tokenStorage,
@@ -309,11 +461,11 @@ class AccessListenerTest extends TestCase
             ->willReturn([[AuthenticatedVoter::PUBLIC_ACCESS], null])
         ;
 
-        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager = $this->createMock(AccessDecisionManager::class);
         $accessDecisionManager->expects($this->once())
-            ->method('decide')
+            ->method('getDecision')
             ->with($this->equalTo($token), [AuthenticatedVoter::PUBLIC_ACCESS])
-            ->willReturn(true);
+            ->willReturn(AccessDecision::createGranted());
 
         $listener = new AccessListener(
             $tokenStorage,
@@ -343,12 +495,12 @@ class AccessListenerTest extends TestCase
         $tokenStorage = new TokenStorage();
         $tokenStorage->setToken($authenticatedToken);
 
-        $accessDecisionManager = $this->createMock(AccessDecisionManagerInterface::class);
+        $accessDecisionManager = $this->createMock(AccessDecisionManager::class);
         $accessDecisionManager
             ->expects($this->once())
-            ->method('decide')
+            ->method('getDecision')
             ->with($this->equalTo($authenticatedToken), $this->equalTo(['foo' => 'bar', 'bar' => 'baz']), $this->equalTo($request), true)
-            ->willReturn(true)
+            ->willReturn(AccessDecision::createGranted())
         ;
 
         $listener = new AccessListener(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #27995, #26343, #35592
| License       | MIT
| Doc PR        | n/a

This is a PR continuing the work started by @maidmaid and @noniagriconomie in #35592

---

About the voters, the gif of the the original issue sums up the situation well :

![no](https://media.giphy.com/media/kQbMO5X7UA1C8/giphy.gif)

Currently, the voters can only say yes or no. This PR allows to give a reason from the voters.

Before :

```php
class PostVoter extends Voter
{
    // ...

    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
    {
        if ($subject->getAuthor() !== $token->getUser()) {
            return false;
        }

        if ($subject->getStatus() !== 'draft') {
            return false;
        }

        return true;
    }
}
```

After:
```php
class PostVoter extends Voter
{
    // ...

    protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
    {
        if ($subject->getAuthor() !== $token->getUser()) {
            return $this->deny('You are not the author.')
        }

        if ($subject->getStatus() !== 'draft') {
            return $this->deny('The post is no more a draft.')
        }

        return $this->grant();
    }
}
```

A voter returns no more an int based on the constant ACCESS_{GRANTED,ABSTAIN,DENIED} but a Vote object which contains the access result and the reason. Thus, the security panel of the profiler can display the reason of each vote.


![security](https://user-images.githubusercontent.com/4578773/73757347-67fd1980-4769-11ea-8727-a8cecc4c8173.png)

The access decision manager returns no more a bool for the final verdict but an AccessDecision object which contains the final verdict and all the votes. Thus, the 403 response can display all the denied raisons.

![security-ex](https://user-images.githubusercontent.com/4578773/73757456-8cf18c80-4769-11ea-8289-d09ee75255d0.png)

---

TODO:
  - [x] add BC Layer
  - [x] migrate existing voters
  - [ ] update old tests
  - [ ] add new tests