### PR TITLE
[FrameworkBundle] Fix fragment.uri_generator definition

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.php
@@ -34,7 +34,7 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('fragment.uri_generator', FragmentUriGenerator::class)
-            ->args([param('fragment.path'), service('uri_signer')])
+            ->args([param('fragment.path'), service('uri_signer'), service('request_stack')])
         ->alias(FragmentUriGeneratorInterface::class, 'fragment.uri_generator')
 
         ->set('fragment.renderer.inline', InlineFragmentRenderer::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

Fix for a bug I introduced in #40575 (missing service).