### PR TITLE
[CS] Replace easy occurences of ?: with ??

### DIFF
--- a/src/Symfony/Bridge/Monolog/Formatter/VarDumperFormatter.php
+++ b/src/Symfony/Bridge/Monolog/Formatter/VarDumperFormatter.php
@@ -23,7 +23,7 @@ class VarDumperFormatter implements FormatterInterface
 
     public function __construct(VarCloner $cloner = null)
     {
-        $this->cloner = $cloner ?: new VarCloner();
+        $this->cloner = $cloner ?? new VarCloner();
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Extension/DumpExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/DumpExtension.php
@@ -82,7 +82,7 @@ class DumpExtension extends AbstractExtension
         }
 
         $dump = fopen('php://memory', 'r+');
-        $this->dumper = $this->dumper ?: new HtmlDumper();
+        $this->dumper = $this->dumper ?? new HtmlDumper();
         $this->dumper->setCharset($env->getCharset());
 
         foreach ($vars as $value) {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -44,7 +44,7 @@ class CacheClearCommand extends Command
         parent::__construct();
 
         $this->cacheClearer = $cacheClearer;
-        $this->filesystem = $filesystem ?: new Filesystem();
+        $this->filesystem = $filesystem ?? new Filesystem();
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -49,7 +49,7 @@ class Router extends BaseRouter implements WarmableInterface, ServiceSubscriberI
     {
         $this->container = $container;
         $this->resource = $resource;
-        $this->context = $context ?: new RequestContext();
+        $this->context = $context ?? new RequestContext();
         $this->logger = $logger;
         $this->setOptions($options);
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Twig/WebProfilerExtension.php
@@ -44,7 +44,7 @@ class WebProfilerExtension extends ProfilerExtension
 
     public function __construct(HtmlDumper $dumper = null)
     {
-        $this->dumper = $dumper ?: new HtmlDumper();
+        $this->dumper = $dumper ?? new HtmlDumper();
         $this->dumper->setOutput($this->output = fopen('php://memory', 'r+'));
     }
 

--- a/src/Symfony/Component/Asset/Package.php
+++ b/src/Symfony/Component/Asset/Package.php
@@ -29,7 +29,7 @@ class Package implements PackageInterface
     public function __construct(VersionStrategyInterface $versionStrategy, ContextInterface $context = null)
     {
         $this->versionStrategy = $versionStrategy;
-        $this->context = $context ?: new NullContext();
+        $this->context = $context ?? new NullContext();
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -55,8 +55,8 @@ abstract class Client
     public function __construct(array $server = [], History $history = null, CookieJar $cookieJar = null)
     {
         $this->setServerParameters($server);
-        $this->history = $history ?: new History();
-        $this->cookieJar = $cookieJar ?: new CookieJar();
+        $this->history = $history ?? new History();
+        $this->cookieJar = $cookieJar ?? new CookieJar();
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
@@ -29,7 +29,7 @@ class TreeBuilder implements NodeParentInterface
         if (null === $name) {
             @trigger_error('A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.', \E_USER_DEPRECATED);
         } else {
-            $builder = $builder ?: new NodeBuilder();
+            $builder = $builder ?? new NodeBuilder();
             $this->root = $builder->node($name, $type)->setParent($this);
         }
     }
@@ -50,7 +50,7 @@ class TreeBuilder implements NodeParentInterface
     {
         @trigger_error(sprintf('The "%s()" method called for the "%s" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.', __METHOD__, $name), \E_USER_DEPRECATED);
 
-        $builder = $builder ?: new NodeBuilder();
+        $builder = $builder ?? new NodeBuilder();
 
         return $this->root = $builder->node($name, $type)->setParent($this);
     }

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
@@ -28,7 +28,7 @@ class OutputFormatterStyleStack implements ResetInterface
 
     public function __construct(OutputFormatterStyleInterface $emptyStyle = null)
     {
-        $this->emptyStyle = $emptyStyle ?: new OutputFormatterStyle();
+        $this->emptyStyle = $emptyStyle ?? new OutputFormatterStyle();
         $this->reset();
     }
 

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -40,7 +40,7 @@ abstract class Output implements OutputInterface
     public function __construct(?int $verbosity = self::VERBOSITY_NORMAL, bool $decorated = false, OutputFormatterInterface $formatter = null)
     {
         $this->verbosity = null === $verbosity ? self::VERBOSITY_NORMAL : $verbosity;
-        $this->formatter = $formatter ?: new OutputFormatter();
+        $this->formatter = $formatter ?? new OutputFormatter();
         $this->formatter->setDecorated($decorated);
     }
 

--- a/src/Symfony/Component/CssSelector/Parser/Parser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Parser.php
@@ -31,7 +31,7 @@ class Parser implements ParserInterface
 
     public function __construct(Tokenizer $tokenizer = null)
     {
-        $this->tokenizer = $tokenizer ?: new Tokenizer();
+        $this->tokenizer = $tokenizer ?? new Tokenizer();
     }
 
     /**

--- a/src/Symfony/Component/CssSelector/XPath/Translator.php
+++ b/src/Symfony/Component/CssSelector/XPath/Translator.php
@@ -50,7 +50,7 @@ class Translator implements TranslatorInterface
 
     public function __construct(ParserInterface $parser = null)
     {
-        $this->mainParser = $parser ?: new Parser();
+        $this->mainParser = $parser ?? new Parser();
 
         $this
             ->registerExtension(new Extension\NodeExtension())

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -64,7 +64,7 @@ class Container implements ResettableContainerInterface
 
     public function __construct(ParameterBagInterface $parameterBag = null)
     {
-        $this->parameterBag = $parameterBag ?: new EnvPlaceholderParameterBag();
+        $this->parameterBag = $parameterBag ?? new EnvPlaceholderParameterBag();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -362,7 +362,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
         if ($this->trackResources) {
             if (!$classReflector) {
-                $this->addResource($resource ?: new ClassExistenceResource($class, false));
+                $this->addResource($resource ?? new ClassExistenceResource($class, false));
             } elseif (!$classReflector->isInternal()) {
                 $path = $classReflector->getFileName();
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -173,7 +173,7 @@ class IntegrationTest extends TestCase
     public function testYamlContainerCompiles($directory, $actualServiceId, $expectedServiceId, ContainerBuilder $mainContainer = null)
     {
         // allow a container to be passed in, which might have autoconfigure settings
-        $container = $mainContainer ?: new ContainerBuilder();
+        $container = $mainContainer ?? new ContainerBuilder();
         $container->setResourceTracking(false);
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Fixtures/yaml/integration/'.$directory));
         $loader->load('main.yml');

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -33,7 +33,7 @@ class ExpressionLanguage
      */
     public function __construct(CacheItemPoolInterface $cache = null, array $providers = [])
     {
-        $this->cache = $cache ?: new ArrayAdapter();
+        $this->cache = $cache ?? new ArrayAdapter();
         $this->registerFunctions();
         foreach ($providers as $provider) {
             $this->registerProvider($provider);

--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -42,7 +42,7 @@ class CoreExtension extends AbstractExtension
             throw new \TypeError(sprintf('Argument 3 passed to "%s()" must be an instance of "%s", "%s" given.', __METHOD__, TranslatorInterface::class, \is_object($translator) ? \get_class($translator) : \gettype($translator)));
         }
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
-        $this->choiceListFactory = $choiceListFactory ?: new CachingFactoryDecorator(new PropertyAccessDecorator(new DefaultChoiceListFactory(), $this->propertyAccessor));
+        $this->choiceListFactory = $choiceListFactory ?? new CachingFactoryDecorator(new PropertyAccessDecorator(new DefaultChoiceListFactory(), $this->propertyAccessor));
         $this->translator = $translator;
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -42,7 +42,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
 
         $this->fields = $fields;
         $this->pad = $pad;
-        $this->referenceDate = $referenceDate ?: new \DateTimeImmutable('1970-01-01 00:00:00');
+        $this->referenceDate = $referenceDate ?? new \DateTimeImmutable('1970-01-01 00:00:00');
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -49,7 +49,7 @@ class ChoiceType extends AbstractType
      */
     public function __construct(ChoiceListFactoryInterface $choiceListFactory = null, $translator = null)
     {
-        $this->choiceListFactory = $choiceListFactory ?: new CachingFactoryDecorator(
+        $this->choiceListFactory = $choiceListFactory ?? new CachingFactoryDecorator(
             new PropertyAccessDecorator(
                 new DefaultChoiceListFactory()
             )

--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
@@ -55,7 +55,7 @@ class CsrfValidationListener implements EventSubscriberInterface
         $this->errorMessage = $errorMessage;
         $this->translator = $translator;
         $this->translationDomain = $translationDomain;
-        $this->serverParams = $serverParams ?: new ServerParams();
+        $this->serverParams = $serverParams ?? new ServerParams();
     }
 
     public function preSubmit(FormEvent $event)

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -32,7 +32,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
 
     public function __construct(ServerParams $serverParams = null)
     {
-        $this->serverParams = $serverParams ?: new ServerParams();
+        $this->serverParams = $serverParams ?? new ServerParams();
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/Type/FormTypeHttpFoundationExtension.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/Type/FormTypeHttpFoundationExtension.php
@@ -26,7 +26,7 @@ class FormTypeHttpFoundationExtension extends AbstractTypeExtension
 
     public function __construct(RequestHandlerInterface $requestHandler = null)
     {
-        $this->requestHandler = $requestHandler ?: new HttpFoundationRequestHandler();
+        $this->requestHandler = $requestHandler ?? new HttpFoundationRequestHandler();
     }
 
     /**

--- a/src/Symfony/Component/Form/FormFactoryBuilder.php
+++ b/src/Symfony/Component/Form/FormFactoryBuilder.php
@@ -184,7 +184,7 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
             $extensions[] = new PreloadedExtension($this->types, $this->typeExtensions, $typeGuesser);
         }
 
-        $registry = new FormRegistry($extensions, $this->resolvedTypeFactory ?: new ResolvedFormTypeFactory());
+        $registry = new FormRegistry($extensions, $this->resolvedTypeFactory ?? new ResolvedFormTypeFactory());
 
         return new FormFactory($registry);
     }

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -36,7 +36,7 @@ class NativeRequestHandler implements RequestHandlerInterface
 
     public function __construct(ServerParams $params = null)
     {
-        $this->serverParams = $params ?: new ServerParams();
+        $this->serverParams = $params ?? new ServerParams();
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -38,13 +38,13 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
 
     public function __construct(SessionStorageInterface $storage = null, AttributeBagInterface $attributes = null, FlashBagInterface $flashes = null)
     {
-        $this->storage = $storage ?: new NativeSessionStorage();
+        $this->storage = $storage ?? new NativeSessionStorage();
 
-        $attributes = $attributes ?: new AttributeBag();
+        $attributes = $attributes ?? new AttributeBag();
         $this->attributeName = $attributes->getName();
         $this->registerBag($attributes);
 
-        $flashes = $flashes ?: new FlashBag();
+        $flashes = $flashes ?? new FlashBag();
         $this->flashName = $flashes->getName();
         $this->registerBag($flashes);
     }

--- a/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ArgumentResolver.php
@@ -36,7 +36,7 @@ final class ArgumentResolver implements ArgumentResolverInterface
 
     public function __construct(ArgumentMetadataFactoryInterface $argumentMetadataFactory = null, iterable $argumentValueResolvers = [])
     {
-        $this->argumentMetadataFactory = $argumentMetadataFactory ?: new ArgumentMetadataFactory();
+        $this->argumentMetadataFactory = $argumentMetadataFactory ?? new ArgumentMetadataFactory();
         $this->argumentValueResolvers = $argumentValueResolvers ?: self::getDefaultArgumentValueResolvers();
     }
 

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -61,7 +61,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
     {
         $this->dispatcher = LegacyEventDispatcherProxy::decorate($dispatcher);
         $this->resolver = $resolver;
-        $this->requestStack = $requestStack ?: new RequestStack();
+        $this->requestStack = $requestStack ?? new RequestStack();
         $this->argumentResolver = $argumentResolver;
 
         if (null === $this->argumentResolver) {

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
@@ -158,7 +158,7 @@ class TestSessionListenerTest extends TestCase
     private function filterResponse(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, Response $response = null)
     {
         $request->setSession($this->session);
-        $response = $response ?: new Response();
+        $response = $response ?? new Response();
         $kernel = $this->createMock(HttpKernelInterface::class);
         $event = new ResponseEvent($kernel, $request, $type, $response);
 

--- a/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/AbstractTransport.php
@@ -34,7 +34,7 @@ abstract class AbstractTransport implements TransportInterface
     public function __construct(EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         $this->dispatcher = LegacyEventDispatcherProxy::decorate($dispatcher);
-        $this->logger = $logger ?: new NullLogger();
+        $this->logger = $logger ?? new NullLogger();
     }
 
     /**

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -44,7 +44,7 @@ class SmtpTransport extends AbstractTransport
     {
         parent::__construct($dispatcher, $logger);
 
-        $this->stream = $stream ?: new SocketStream();
+        $this->stream = $stream ?? new SocketStream();
     }
 
     public function getStream(): AbstractStream

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/AmqpTransportTest.php
@@ -54,8 +54,8 @@ class AmqpTransportTest extends TestCase
 
     private function getTransport(SerializerInterface $serializer = null, Connection $connection = null): AmqpTransport
     {
-        $serializer = $serializer ?: $this->createMock(SerializerInterface::class);
-        $connection = $connection ?: $this->createMock(Connection::class);
+        $serializer = $serializer ?? $this->createMock(SerializerInterface::class);
+        $connection = $connection ?? $this->createMock(Connection::class);
 
         return new AmqpTransport($connection, $serializer);
     }

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineTransportTest.php
@@ -52,8 +52,8 @@ class DoctrineTransportTest extends TestCase
 
     private function getTransport(SerializerInterface $serializer = null, Connection $connection = null): DoctrineTransport
     {
-        $serializer = $serializer ?: $this->createMock(SerializerInterface::class);
-        $connection = $connection ?: $this->createMock(Connection::class);
+        $serializer = $serializer ?? $this->createMock(SerializerInterface::class);
+        $connection = $connection ?? $this->createMock(Connection::class);
 
         return new DoctrineTransport($connection, $serializer);
     }

--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisTransportTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/RedisTransportTest.php
@@ -52,8 +52,8 @@ class RedisTransportTest extends TestCase
 
     private function getTransport(SerializerInterface $serializer = null, Connection $connection = null): RedisTransport
     {
-        $serializer = $serializer ?: $this->createMock(SerializerInterface::class);
-        $connection = $connection ?: $this->createMock(Connection::class);
+        $serializer = $serializer ?? $this->createMock(SerializerInterface::class);
+        $connection = $connection ?? $this->createMock(Connection::class);
 
         return new RedisTransport($connection, $serializer);
     }

--- a/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/AmqpExt/Connection.php
@@ -71,7 +71,7 @@ class Connection
         ], $connectionOptions);
         $this->exchangeOptions = $exchangeOptions;
         $this->queuesOptions = $queuesOptions;
-        $this->amqpFactory = $amqpFactory ?: new AmqpFactory();
+        $this->amqpFactory = $amqpFactory ?? new AmqpFactory();
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -51,7 +51,7 @@ class Connection
             throw new LogicException('The redis transport requires php-redis 4.3.0 or higher.');
         }
 
-        $this->connection = $redis ?: new \Redis();
+        $this->connection = $redis ?? new \Redis();
         $this->connection->connect($connectionCredentials['host'] ?? '127.0.0.1', $connectionCredentials['port'] ?? 6379);
         $this->connection->setOption(\Redis::OPT_SERIALIZER, $redisOptions['serializer'] ?? \Redis::SERIALIZER_PHP);
 

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -107,7 +107,7 @@ class Router implements RouterInterface, RequestMatcherInterface
         $this->loader = $loader;
         $this->resource = $resource;
         $this->logger = $logger;
-        $this->context = $context ?: new RequestContext();
+        $this->context = $context ?? new RequestContext();
         $this->setOptions($options);
         $this->defaultLocale = $defaultLocale;
     }

--- a/src/Symfony/Component/Routing/Tests/Matcher/CompiledRedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/CompiledRedirectableUrlMatcherTest.php
@@ -25,7 +25,7 @@ class CompiledRedirectableUrlMatcherTest extends RedirectableUrlMatcherTest
         $compiledRoutes = $dumper->getCompiledRoutes();
 
         return $this->getMockBuilder(TestCompiledRedirectableUrlMatcher::class)
-            ->setConstructorArgs([$compiledRoutes, $context ?: new RequestContext()])
+            ->setConstructorArgs([$compiledRoutes, $context ?? new RequestContext()])
             ->setMethods(['redirect'])
             ->getMock();
     }

--- a/src/Symfony/Component/Routing/Tests/Matcher/CompiledUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/CompiledUrlMatcherTest.php
@@ -22,6 +22,6 @@ class CompiledUrlMatcherTest extends UrlMatcherTest
     {
         $dumper = new CompiledUrlMatcherDumper($routes);
 
-        return new CompiledUrlMatcher($dumper->getCompiledRoutes(), $context ?: new RequestContext());
+        return new CompiledUrlMatcher($dumper->getCompiledRoutes(), $context ?? new RequestContext());
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Matcher/DumpedRedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/DumpedRedirectableUrlMatcherTest.php
@@ -31,7 +31,7 @@ class DumpedRedirectableUrlMatcherTest extends RedirectableUrlMatcherTest
         eval('?>'.$dumper->dump(['class' => $class, 'base_class' => 'Symfony\Component\Routing\Tests\Matcher\TestDumpedRedirectableUrlMatcher']));
 
         return $this->getMockBuilder($class)
-            ->setConstructorArgs([$context ?: new RequestContext()])
+            ->setConstructorArgs([$context ?? new RequestContext()])
             ->setMethods(['redirect'])
             ->getMock();
     }

--- a/src/Symfony/Component/Routing/Tests/Matcher/DumpedUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/DumpedUrlMatcherTest.php
@@ -28,6 +28,6 @@ class DumpedUrlMatcherTest extends UrlMatcherTest
         $dumper = new PhpMatcherDumper($routes);
         eval('?>'.$dumper->dump(['class' => $class]));
 
-        return new $class($context ?: new RequestContext());
+        return new $class($context ?? new RequestContext());
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/RedirectableUrlMatcherTest.php
@@ -211,6 +211,6 @@ class RedirectableUrlMatcherTest extends UrlMatcherTest
 
     protected function getUrlMatcher(RouteCollection $routes, RequestContext $context = null)
     {
-        return $this->getMockForAbstractClass(RedirectableUrlMatcher::class, [$routes, $context ?: new RequestContext()]);
+        return $this->getMockForAbstractClass(RedirectableUrlMatcher::class, [$routes, $context ?? new RequestContext()]);
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Matcher/TraceableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/TraceableUrlMatcherTest.php
@@ -121,6 +121,6 @@ class TraceableUrlMatcherTest extends UrlMatcherTest
 
     protected function getUrlMatcher(RouteCollection $routes, RequestContext $context = null)
     {
-        return new TraceableUrlMatcher($routes, $context ?: new RequestContext());
+        return new TraceableUrlMatcher($routes, $context ?? new RequestContext());
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -943,6 +943,6 @@ class UrlMatcherTest extends TestCase
 
     protected function getUrlMatcher(RouteCollection $routes, RequestContext $context = null)
     {
-        return new UrlMatcher($routes, $context ?: new RequestContext());
+        return new UrlMatcher($routes, $context ?? new RequestContext());
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/SimpleAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/SimpleAuthenticationProvider.php
@@ -38,7 +38,7 @@ class SimpleAuthenticationProvider implements AuthenticationProviderInterface
         $this->simpleAuthenticator = $simpleAuthenticator;
         $this->userProvider = $userProvider;
         $this->providerKey = $providerKey;
-        $this->userChecker = $userChecker ?: new UserChecker();
+        $this->userChecker = $userChecker ?? new UserChecker();
     }
 
     public function authenticate(TokenInterface $token)

--- a/src/Symfony/Component/Security/Csrf/CsrfTokenManager.php
+++ b/src/Symfony/Component/Security/Csrf/CsrfTokenManager.php
@@ -39,8 +39,8 @@ class CsrfTokenManager implements CsrfTokenManagerInterface
      */
     public function __construct(TokenGeneratorInterface $generator = null, TokenStorageInterface $storage = null, $namespace = null)
     {
-        $this->generator = $generator ?: new UriSafeTokenGenerator();
-        $this->storage = $storage ?: new NativeSessionTokenStorage();
+        $this->generator = $generator ?? new UriSafeTokenGenerator();
+        $this->storage = $storage ?? new NativeSessionTokenStorage();
 
         $superGlobalNamespaceGenerator = function () {
             return !empty($_SERVER['HTTPS']) && 'off' !== strtolower($_SERVER['HTTPS']) ? 'https-' : '';

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -76,7 +76,7 @@ class ContextListener extends AbstractListener implements ListenerInterface
             $this->dispatcher = $dispatcher;
         }
 
-        $this->trustResolver = $trustResolver ?: new AuthenticationTrustResolver(AnonymousToken::class, RememberMeToken::class);
+        $this->trustResolver = $trustResolver ?? new AuthenticationTrustResolver(AnonymousToken::class, RememberMeToken::class);
         $this->sessionTrackerEnabler = $sessionTrackerEnabler;
     }
 

--- a/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimplePreAuthenticationListener.php
@@ -72,7 +72,7 @@ class SimplePreAuthenticationListener extends AbstractListener implements Listen
             $this->dispatcher = $dispatcher;
         }
 
-        $this->trustResolver = $trustResolver ?: new AuthenticationTrustResolver(AnonymousToken::class, RememberMeToken::class);
+        $this->trustResolver = $trustResolver ?? new AuthenticationTrustResolver(AnonymousToken::class, RememberMeToken::class);
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -405,7 +405,7 @@ class ContextListenerTest extends TestCase
 
     private function handleEventWithPreviousSession($userProviders, UserInterface $user = null, RememberMeServicesInterface $rememberMeServices = null)
     {
-        $tokenUser = $user ?: new User('foo', 'bar');
+        $tokenUser = $user ?? new User('foo', 'bar');
         $session = new Session(new MockArraySessionStorage());
         $session->set('_security_context_key', serialize(new UsernamePasswordToken($tokenUser, '', 'context_key', ['ROLE_USER'])));
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
@@ -184,7 +184,7 @@ class ExceptionListenerTest extends TestCase
     private function createEntryPoint(Response $response = null)
     {
         $entryPoint = $this->createMock(AuthenticationEntryPointInterface::class);
-        $entryPoint->expects($this->once())->method('start')->willReturn($response ?: new Response('OK'));
+        $entryPoint->expects($this->once())->method('start')->willReturn($response ?? new Response('OK'));
 
         return $entryPoint;
     }
@@ -209,9 +209,9 @@ class ExceptionListenerTest extends TestCase
     private function createExceptionListener(TokenStorageInterface $tokenStorage = null, AuthenticationTrustResolverInterface $trustResolver = null, HttpUtils $httpUtils = null, AuthenticationEntryPointInterface $authenticationEntryPoint = null, $errorPage = null, AccessDeniedHandlerInterface $accessDeniedHandler = null)
     {
         return new ExceptionListener(
-            $tokenStorage ?: $this->createMock(TokenStorageInterface::class),
-            $trustResolver ?: $this->createMock(AuthenticationTrustResolverInterface::class),
-            $httpUtils ?: $this->createMock(HttpUtils::class),
+            $tokenStorage ?? $this->createMock(TokenStorageInterface::class),
+            $trustResolver ?? $this->createMock(AuthenticationTrustResolverInterface::class),
+            $httpUtils ?? $this->createMock(HttpUtils::class),
             'key',
             $authenticationEntryPoint,
             $errorPage,

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
@@ -25,8 +25,8 @@ class JsonEncoder implements EncoderInterface, DecoderInterface
 
     public function __construct(JsonEncode $encodingImpl = null, JsonDecode $decodingImpl = null)
     {
-        $this->encodingImpl = $encodingImpl ?: new JsonEncode();
-        $this->decodingImpl = $decodingImpl ?: new JsonDecode([JsonDecode::ASSOCIATIVE => true]);
+        $this->encodingImpl = $encodingImpl ?? new JsonEncode();
+        $this->decodingImpl = $decodingImpl ?? new JsonDecode([JsonDecode::ASSOCIATIVE => true]);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/YamlEncoder.php
@@ -38,8 +38,8 @@ class YamlEncoder implements EncoderInterface, DecoderInterface
             throw new RuntimeException('The YamlEncoder class requires the "Yaml" component. Install "symfony/yaml" to use it.');
         }
 
-        $this->dumper = $dumper ?: new Dumper();
-        $this->parser = $parser ?: new Parser();
+        $this->dumper = $dumper ?? new Dumper();
+        $this->parser = $parser ?? new Parser();
         $this->defaultContext = array_merge($this->defaultContext, $defaultContext);
     }
 

--- a/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
@@ -35,7 +35,7 @@ class CustomNormalizer implements NormalizerInterface, DenormalizerInterface, Se
      */
     public function denormalize($data, $type, $format = null, array $context = [])
     {
-        $object = $this->extractObjectToPopulate($type, $context) ?: new $type();
+        $object = $this->extractObjectToPopulate($type, $context) ?? new $type();
         $object->denormalize($this->serializer, $data, $format, $context);
 
         return $object;

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -368,7 +368,7 @@ class ValidatorBuilder implements ValidatorBuilderInterface
             $metadataFactory = new LazyLoadingMetadataFactory($loader, $this->mappingCache);
         }
 
-        $validatorFactory = $this->validatorFactory ?: new ConstraintValidatorFactory();
+        $validatorFactory = $this->validatorFactory ?? new ConstraintValidatorFactory();
         $translator = $this->translator;
 
         if (null === $translator) {

--- a/src/Symfony/Component/Workflow/Definition.php
+++ b/src/Symfony/Component/Workflow/Definition.php
@@ -44,7 +44,7 @@ final class Definition
 
         $this->setInitialPlaces($initialPlaces);
 
-        $this->metadataStore = $metadataStore ?: new InMemoryMetadataStore();
+        $this->metadataStore = $metadataStore ?? new InMemoryMetadataStore();
     }
 
     /**

--- a/src/Symfony/Component/Workflow/Metadata/InMemoryMetadataStore.php
+++ b/src/Symfony/Component/Workflow/Metadata/InMemoryMetadataStore.php
@@ -28,7 +28,7 @@ final class InMemoryMetadataStore implements MetadataStoreInterface
     {
         $this->workflowMetadata = $workflowMetadata;
         $this->placesMetadata = $placesMetadata;
-        $this->transitionsMetadata = $transitionsMetadata ?: new \SplObjectStorage();
+        $this->transitionsMetadata = $transitionsMetadata ?? new \SplObjectStorage();
     }
 
     public function getWorkflowMetadata(): array

--- a/src/Symfony/Component/Workflow/StateMachine.php
+++ b/src/Symfony/Component/Workflow/StateMachine.php
@@ -22,6 +22,6 @@ class StateMachine extends Workflow
 {
     public function __construct(Definition $definition, MarkingStoreInterface $markingStore = null, EventDispatcherInterface $dispatcher = null, string $name = 'unnamed')
     {
-        parent::__construct($definition, $markingStore ?: new MethodMarkingStore(true, 'marking'), $dispatcher, $name);
+        parent::__construct($definition, $markingStore ?? new MethodMarkingStore(true, 'marking'), $dispatcher, $name);
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/EventListener/GuardListenerTest.php
+++ b/src/Symfony/Component/Workflow/Tests/EventListener/GuardListenerTest.php
@@ -136,7 +136,7 @@ class GuardListenerTest extends TestCase
     private function createEvent(Transition $transition = null)
     {
         $subject = new Subject();
-        $transition = $transition ?: new Transition('name', 'from', 'to');
+        $transition = $transition ?? new Transition('name', 'from', 'to');
 
         $workflow = $this->createMock(WorkflowInterface::class);
 

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -42,7 +42,7 @@ class Workflow implements WorkflowInterface
     public function __construct(Definition $definition, MarkingStoreInterface $markingStore = null, EventDispatcherInterface $dispatcher = null, string $name = 'unnamed')
     {
         $this->definition = $definition;
-        $this->markingStore = $markingStore ?: new MultipleStateMarkingStore();
+        $this->markingStore = $markingStore ?? new MultipleStateMarkingStore();
 
         if (null !== $dispatcher && class_exists(LegacyEventDispatcherProxy::class)) {
             $this->dispatcher = LegacyEventDispatcherProxy::decorate($dispatcher);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Since we don't support PHP 5 anymore, we can easily replace `?:` with `??` when dealing with "nullable" objects. It seems more modern to me (make the code evolve with the new language features). Once we do not support < PHP 7.4, we can replace with `??=`.