### PR TITLE
* LightSmsTransport.php - suggestion for pull request #40712

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/LightSms/LightSmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/LightSmsTransport.php
@@ -124,8 +124,8 @@ final class LightSmsTransport extends AbstractTransport
 
         $content = $response->toArray(false);
 
-        if (0 !== (int) $content[$phone]['error'] ?? -1) {
-            $errorCode = (int) $content['error'] ?? $content['']['error'] ?? $content[$phone]['error'] ?? -1;
+        if (0 !== (int) ($content['error'] ?? $content['']['error'] ?? $content[$phone]['error']) ?? -1) {
+            $errorCode = (int) ($content['error'] ?? $content['']['error'] ?? $content[$phone]['error']) ?? -1;
             if (-1 === $errorCode) {
                 throw new TransportException('Unable to send the SMS.', $response);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40712
| License       | MIT
| Doc PR        | -

After remove issets still get warnings about undefined variables. My solution for this:
1. Create method which have all issets cases.
2. Return (int) errorCode