### PR TITLE
[Notifier] LightSMS duplicated $errorCode variable fix

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/LightSms/LightSmsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/LightSms/LightSmsTransport.php
@@ -124,8 +124,8 @@ final class LightSmsTransport extends AbstractTransport
 
         $content = $response->toArray(false);
 
-        if (0 !== (int) ($content['error'] ?? $content['']['error'] ?? $content[$phone]['error']) ?? -1) {
-            $errorCode = (int) ($content['error'] ?? $content['']['error'] ?? $content[$phone]['error']) ?? -1;
+        $errorCode = (int) ($content['error'] ?? $content['']['error'] ?? $content[$phone]['error']) ?? -1;
+        if (0 !== $errorCode) {
             if (-1 === $errorCode) {
                 throw new TransportException('Unable to send the SMS.', $response);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40712, #40733
| License       | MIT
| Doc PR        | -

Removed duplicated variable $errorCode.

Many thanks for:
@OskarStark, @jderusse and special thanks for @chalasr for fast rebase course at night :)))