### PR TITLE
[Form] Add callable as allowed type for choices option in ChoiceType

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
  * Added a `choice_translation_parameters` option to `ChoiceType`
  * Add `UuidType` and `UlidType`
  * Dependency on `symfony/intl` was removed. Install `symfony/intl` if you are using `LocaleType`, `CountryType`, `CurrencyType`, `LanguageType` or `TimezoneType`.
+ * Add `callable` as allowed types for `choices` option of `ChoiceType`
 
 5.2.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -399,7 +399,7 @@ class ChoiceType extends AbstractType
         $resolver->setNormalizer('placeholder', $placeholderNormalizer);
         $resolver->setNormalizer('choice_translation_domain', $choiceTranslationDomainNormalizer);
 
-        $resolver->setAllowedTypes('choices', ['null', 'array', \Traversable::class]);
+        $resolver->setAllowedTypes('choices', ['null', 'array', \Traversable::class, 'callable']);
         $resolver->setAllowedTypes('choice_translation_domain', ['null', 'bool', 'string']);
         $resolver->setAllowedTypes('choice_loader', ['null', ChoiceLoaderInterface::class, ChoiceLoader::class]);
         $resolver->setAllowedTypes('choice_filter', ['null', 'callable', 'string', PropertyPath::class, ChoiceFilter::class]);
@@ -475,8 +475,7 @@ class ChoiceType extends AbstractType
             );
         }
 
-        // Harden against NULL values (like in EntityType and ModelType)
-        $choices = null !== $options['choices'] ? $options['choices'] : [];
+        $choices = \is_callable($options['choices']) ? $options['choices']() : ($options['choices'] ?? []);
 
         return $this->choiceListFactory->createListFromChoices(
             $choices,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -68,6 +68,24 @@ class ChoiceTypeTest extends BaseTypeTest
         ],
     ];
 
+    protected function choicesGenerator(): \Generator
+    {
+        yield 'Bernhard' => 'a';
+        yield 'Fabien' => 'b';
+        yield 'Kris' => 'c';
+        yield 'Alex' => 'd';
+    }
+
+    protected function choicesFromArray(): array
+    {
+        return [
+            'Bernhard' => 'a',
+            'Fabien' => 'b',
+            'Kris' => 'c',
+            'Alex' => 'd',
+        ];
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -2224,6 +2242,40 @@ class ChoiceTypeTest extends BaseTypeTest
             new ChoiceView('a', 'a', 'Bernhard'),
             new ChoiceView('b', 'b', 'Fabien'),
             new ChoiceView('c', 'c', 'Kris'),
+        ], $form->createView()->vars['choices']);
+    }
+
+    public function testChoicesFromGenerator()
+    {
+        $self = $this;
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'choices' => static function () use ($self) {
+                yield from $self->choicesGenerator();
+            },
+        ]);
+
+        $this->assertEquals([
+            new ChoiceView('a', 'a', 'Bernhard'),
+            new ChoiceView('b', 'b', 'Fabien'),
+            new ChoiceView('c', 'c', 'Kris'),
+            new ChoiceView('d', 'd', 'Alex'),
+        ], $form->createView()->vars['choices']);
+    }
+
+    public function testChoicesFromCallable()
+    {
+        $self = $this;
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'choices' => static function () use ($self) {
+                return $self->choicesFromArray();
+            },
+        ]);
+
+        $this->assertEquals([
+            new ChoiceView('a', 'a', 'Bernhard'),
+            new ChoiceView('b', 'b', 'Fabien'),
+            new ChoiceView('c', 'c', 'Kris'),
+            new ChoiceView('d', 'd', 'Alex'),
         ], $form->createView()->vars['choices']);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #39165 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#15207 <!-- required for new features -->

As said in #39165, `choice_attr`, `choice_label`, and `choice_loader` already accept callable. This change seems enough to me to fully use generators (for example) in `ChoiceType`.