### PR TITLE
[Routing] Better inline requirements and defaults parsing

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -137,15 +137,15 @@ class Route implements \Serializable
     public function setPath($pattern)
     {
         if (false !== strpbrk($pattern, '?<')) {
-            $pattern = preg_replace_callback('#\{(!?\w++)(<.*?>)?(\?[^\}]*+)?\}#', function ($m) {
-                if (isset($m[3][0])) {
-                    $this->setDefault($m[1], '?' !== $m[3] ? substr($m[3], 1) : null);
+            $pattern = preg_replace_callback('#\{(!?)(\w++)(<.*?>)?(\?[^\}]*+)?\}#', function ($m) {
+                if (isset($m[4][0])) {
+                    $this->setDefault($m[2], '?' !== $m[4] ? substr($m[4], 1) : null);
                 }
-                if (isset($m[2][0])) {
-                    $this->setRequirement($m[1], substr($m[2], 1, -1));
+                if (isset($m[3][0])) {
+                    $this->setRequirement($m[2], substr($m[3], 1, -1));
                 }
 
-                return '{'.$m[1].'}';
+                return '{'.$m[1].$m[2].'}';
             }, $pattern);
         }
 

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -50,6 +50,14 @@ class RouteTest extends TestCase
         $this->assertEquals($route, $route->setPath(''), '->setPath() implements a fluent interface');
         $route->setPath('//path');
         $this->assertEquals('/path', $route->getPath(), '->setPath() does not allow two slashes "//" at the beginning of the path as it would be confused with a network path when generating the path from the route');
+        $route->setPath('/path/{!foo}');
+        $this->assertEquals('/path/{!foo}', $route->getPath(), '->setPath() keeps ! to pass important params');
+        $route->setPath('/path/{bar<\w++>}');
+        $this->assertEquals('/path/{bar}', $route->getPath(), '->setPath() removes inline requirements');
+        $route->setPath('/path/{foo?value}');
+        $this->assertEquals('/path/{foo}', $route->getPath(), '->setPath() removes inline defaults');
+        $route->setPath('/path/{!bar<\d+>?value}');
+        $this->assertEquals('/path/{!bar}', $route->getPath(), '->setPath() removes all inline settings');
     }
 
     public function testOptions()
@@ -211,16 +219,19 @@ class RouteTest extends TestCase
         $this->assertEquals((new Route('/foo/{bar}'))->setDefault('bar', null), new Route('/foo/{bar?}'));
         $this->assertEquals((new Route('/foo/{bar}'))->setDefault('bar', 'baz'), new Route('/foo/{bar?baz}'));
         $this->assertEquals((new Route('/foo/{bar}'))->setDefault('bar', 'baz<buz>'), new Route('/foo/{bar?baz<buz>}'));
-        $this->assertEquals((new Route('/foo/{!bar}'))->setDefault('!bar', 'baz<buz>'), new Route('/foo/{!bar?baz<buz>}'));
+        $this->assertEquals((new Route('/foo/{!bar}'))->setDefault('bar', 'baz<buz>'), new Route('/foo/{!bar?baz<buz>}'));
         $this->assertEquals((new Route('/foo/{bar}'))->setDefault('bar', 'baz'), new Route('/foo/{bar?}', ['bar' => 'baz']));
 
         $this->assertEquals((new Route('/foo/{bar}'))->setRequirement('bar', '.*'), new Route('/foo/{bar<.*>}'));
         $this->assertEquals((new Route('/foo/{bar}'))->setRequirement('bar', '>'), new Route('/foo/{bar<>>}'));
         $this->assertEquals((new Route('/foo/{bar}'))->setRequirement('bar', '\d+'), new Route('/foo/{bar<.*>}', [], ['bar' => '\d+']));
         $this->assertEquals((new Route('/foo/{bar}'))->setRequirement('bar', '[a-z]{2}'), new Route('/foo/{bar<[a-z]{2}>}'));
+        $this->assertEquals((new Route('/foo/{!bar}'))->setRequirement('bar', '\d+'), new Route('/foo/{!bar<\d+>}'));
 
         $this->assertEquals((new Route('/foo/{bar}'))->setDefault('bar', null)->setRequirement('bar', '.*'), new Route('/foo/{bar<.*>?}'));
         $this->assertEquals((new Route('/foo/{bar}'))->setDefault('bar', '<>')->setRequirement('bar', '>'), new Route('/foo/{bar<>>?<>}'));
+
+        $this->assertEquals((new Route('/{foo}/{!bar}'))->setDefaults(['bar' => '<>', 'foo' => '\\'])->setRequirements(['bar' => '\\', 'foo' => '.']), new Route('/{foo<.>?\}/{!bar<\>?<>}'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40749 #40701
| License       | MIT
| Doc PR        | 

Remove `!` symbol from requirements and defaults array keys in Route class. Leave `!` symbol in Route compiled path for correct token creation.
**The only restriction I found:** 
Important variable can't get default value, only in UrlGenerator. 
As mentioned in 
https://github.com/symfony/symfony/blob/0f96ac74847d114c9d9679655bcf3e94b6ba69d1/src/Symfony/Component/Routing/RouteCompiler.php#L217
they are not optional

Feel free to help me with some advice. Thank you in advance
