### PR TITLE
[Security] NullToken signature

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
@@ -33,7 +33,7 @@ class NullToken implements TokenInterface
 
     public function getUser()
     {
-        return null;
+        return '';
     }
 
     public function setUser($user)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


The signature of `TokenInterface::getUser` does not allow returning null. But `NullToken` returns `null`.
https://github.com/symfony/symfony/blob/0f96ac74847d114c9d9679655bcf3e94b6ba69d1/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php#L49-L56

This PR update `NullToken::getUser` to return an empty string instead of null. 
I wonder if the fix shouldn't be to change the return type in the interface, but that would be a BC break, right?