### PR TITLE
[Form] Add missing TranslatableMessage support to choice_label option of ChoiceType

### DIFF
--- a/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/DefaultChoiceListFactory.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\ChoiceList\Loader\FilterChoiceLoaderDecorator;
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceListView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
+use Symfony\Component\Translation\TranslatableMessage;
 
 /**
  * Default implementation of {@link ChoiceListFactoryInterface}.
@@ -177,7 +178,14 @@ class DefaultChoiceListFactory implements ChoiceListFactoryInterface
             // If "choice_label" is set to false and "expanded" is true, the value false
             // should be passed on to the "label" option of the checkboxes/radio buttons
             $dynamicLabel = $label($choice, $key, $value);
-            $label = false === $dynamicLabel ? false : (string) $dynamicLabel;
+
+            if (false === $dynamicLabel) {
+                $label = false;
+            } elseif ($dynamicLabel instanceof TranslatableMessage) {
+                $label = $dynamicLabel;
+            } else {
+                $label = (string) $dynamicLabel;
+            }
         }
 
         $view = new ChoiceView(

--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\ChoiceList\View;
 
+use Symfony\Component\Translation\TranslatableMessage;
+
 /**
  * Represents a choice in templates.
  *
@@ -30,10 +32,10 @@ class ChoiceView
     /**
      * Creates a new choice view.
      *
-     * @param mixed        $data  The original choice
-     * @param string       $value The view representation of the choice
-     * @param string|false $label The label displayed to humans; pass false to discard the label
-     * @param array        $attr  Additional attributes for the HTML tag
+     * @param mixed                            $data  The original choice
+     * @param string                           $value The view representation of the choice
+     * @param string|TranslatableMessage|false $label The label displayed to humans; pass false to discard the label
+     * @param array                            $attr  Additional attributes for the HTML tag
      */
     public function __construct($data, string $value, $label, array $attr = [])
     {

--- a/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/ChoiceList/Factory/DefaultChoiceListFactoryTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\ChoiceList\Loader\FilterChoiceLoaderDecorator;
 use Symfony\Component\Form\ChoiceList\View\ChoiceGroupView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceListView;
 use Symfony\Component\Form\ChoiceList\View\ChoiceView;
+use Symfony\Component\Translation\TranslatableMessage;
 
 class DefaultChoiceListFactoryTest extends TestCase
 {
@@ -752,6 +753,24 @@ class DefaultChoiceListFactoryTest extends TestCase
         );
 
         $this->assertFlatViewWithAttr($view);
+    }
+
+    /**
+     * @requires function Symfony\Component\Translation\TranslatableMessage::__construct
+     */
+    public function testPassTranslatableMessageAsLabelDoesntCastItToString()
+    {
+        $view = $this->factory->createView(
+            $this->list,
+            [$this->obj1],
+            static function ($choice, $key, $value) {
+                return new TranslatableMessage('my_message', ['param1' => 'value1']);
+            }
+        );
+
+        $this->assertInstanceOf(TranslatableMessage::class, $view->choices[0]->label);
+        $this->assertEquals('my_message', $view->choices[0]->label->getMessage());
+        $this->assertArrayHasKey('param1', $view->choices[0]->label->getParameters());
     }
 
     private function assertScalarListWithChoiceValues(ChoiceListInterface $list)


### PR DESCRIPTION
It leads to loss of information because it'll use `__toString` to cast, which is incompatible with newly added `TranslatableMessage`, for example.

| Q             | A
| ------------- | ---
| Branch?       | 5.2 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #40622 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | _none_

So this one's a bit tricky in my mind. I didn't want to check if `$dynamicLabel instanceof TranslatableMessage`, because of course it doesn't belong to the same component.

Aside, it would sound so strange to me to add `|object` to `$label` here: https://github.com/symfony/symfony/blob/bb1e1e58aea5318e96d1c22cc8a91668ed7baaaa/src/Symfony/Component/Form/ChoiceList/View/ChoiceView.php#L40

But maybe that's the way to go? Requiring your help here. I'm fully open to your ideas, as we're loosing a big feature here by losing `TranslatableMessage` translation parameters.

If the passed object doesn't implement `__toString`, it'll lead to an exception during template rendering, as expected.