### PR TITLE
[DependencyInjection] Support psr/container 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "doctrine/persistence": "^2",
         "twig/twig": "^2.13|^3.0.4",
         "psr/cache": "^1.0|^2.0",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0|^2.0",
         "psr/event-dispatcher": "^1.0",
         "psr/link": "^1.0",
         "psr/log": "~1.0",

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -192,7 +192,7 @@ class Container implements ContainerInterface, ResetInterface
      *
      * @return bool true if the service is defined, false otherwise
      */
-    public function has(string $id)
+    public function has(string $id): bool
     {
         if (isset($this->aliases[$id])) {
             $id = $this->aliases[$id];

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -517,7 +517,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @return bool true if the service is defined, false otherwise
      */
-    public function has(string $id)
+    public function has(string $id): bool
     {
         return isset($this->definitions[$id]) || isset($this->aliasDefinitions[$id]) || parent::has($id);
     }

--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -57,7 +57,7 @@ interface ContainerInterface extends PsrContainerInterface
      *
      * @return bool true if the service is defined, false otherwise
      */
-    public function has(string $id);
+    public function has(string $id): bool;
 
     /**
      * Check for whether or not a service has been initialized.

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ContainerBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ContainerBag.php
@@ -44,7 +44,7 @@ class ContainerBag extends FrozenParameterBag implements ContainerBagInterface
     /**
      * {@inheritdoc}
      */
-    public function has($name)
+    public function has($name): bool
     {
         return $this->container->hasParameter($name);
     }

--- a/src/Symfony/Contracts/Service/ServiceLocatorTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceLocatorTrait.php
@@ -40,10 +40,8 @@ trait ServiceLocatorTrait
 
     /**
      * {@inheritdoc}
-     *
-     * @return bool
      */
-    public function has(string $id)
+    public function has(string $id): bool
     {
         return isset($this->factories[$id]);
     }

--- a/src/Symfony/Contracts/composer.json
+++ b/src/Symfony/Contracts/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "psr/cache": "^1.0|^2.0|^3.0",
-        "psr/container": "^1.1",
+        "psr/container": "^1.1|^2.0",
         "psr/event-dispatcher": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | maybe
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

This should allow usage with both psr/container 1.1 and 2.0.

If we wanted to be extra thorough, we might want to add a CI build under PHP 8.0 with something like `composer update --prefer-lowest` to force 1.1 to be installed under PHP 8.0 (if you don't have something like that already).

See also: #40613