### PR TITLE
[Routing] Fix localized paths

### DIFF
--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -69,7 +69,19 @@ class Route
         } elseif (!\is_array($data)) {
             throw new \TypeError(sprintf('"%s": Argument $data is expected to be a string or array, got "%s".', __METHOD__, get_debug_type($data)));
         } elseif ([] !== $data) {
-            trigger_deprecation('symfony/routing', '5.3', 'Passing an array as first argument to "%s" is deprecated. Use named arguments instead.', __METHOD__);
+            $deprecation = false;
+            foreach ($data as $key => $val) {
+                if (\in_array($key, ['path', 'name', 'requirements', 'options', 'defaults', 'host', 'methods', 'schemes', 'condition', 'priority', 'locale', 'format', 'utf8', 'stateless', 'env', 'value'])) {
+                    $deprecation = true;
+                }
+            }
+
+            if ($deprecation) {
+                trigger_deprecation('symfony/routing', '5.3', 'Passing an array as first argument to "%s" is deprecated. Use named arguments instead.', __METHOD__);
+            } else {
+                $localizedPaths = $data;
+                $data = ['path' => $localizedPaths];
+            }
         }
         if (null !== $path && !\is_string($path) && !\is_array($path)) {
             throw new \TypeError(sprintf('"%s": Argument $path is expected to be a string, array or null, got "%s".', __METHOD__, get_debug_type($path)));

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/FooController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/FooController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class FooController
+{
+    /**
+     * @Route("/Blog")
+     */
+    public function simplePath()
+    {
+    }
+
+    /**
+     * @Route({"nl":"/hier","en":"/here"})
+     */
+    public function localized()
+    {
+    }
+
+    /**
+     * @Route(requirements={"locale":"en"})
+     */
+    public function requirements()
+    {
+    }
+
+    /**
+     * @Route(options={"compiler_class":"RouteCompiler"})
+     */
+    public function options()
+    {
+    }
+
+    /**
+     * @Route(name="blog_index")
+     */
+    public function name()
+    {
+    }
+
+    /**
+     * @Route(defaults={"_controller":"MyBlogBundle:Blog:index"})
+     */
+    public function defaults()
+    {
+    }
+
+    /**
+     * @Route(schemes={"https"})
+     */
+    public function schemes()
+    {
+    }
+
+    /**
+     * @Route(methods={"GET","POST"})
+     */
+    public function methods()
+    {
+    }
+
+    /**
+     * @Route(host="{locale}.example.com")
+     */
+    public function host()
+    {
+    }
+
+    /**
+     * @Route(condition="context.getMethod() == 'GET'")
+     */
+    public function condition()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/FooController.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/FooController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+class FooController
+{
+    #[Route('/Blog')]
+    public function simplePath()
+    {
+    }
+
+    #[Route(['nl' => '/hier', 'en' => '/here'])]
+    public function localized()
+    {
+    }
+
+    #[Route(requirements: ['locale' => 'en'])]
+    public function requirements()
+    {
+    }
+
+    #[Route(options: ['compiler_class' => 'RouteCompiler'])]
+    public function options()
+    {
+    }
+
+    #[Route(name: 'blog_index')]
+    public function name()
+    {
+    }
+
+    #[Route(defaults: ['_controller' => 'MyBlogBundle:Blog:index'])]
+    public function defaults()
+    {
+    }
+
+    #[Route(schemes: ['https'])]
+    public function schemes()
+    {
+    }
+
+    #[Route(methods: ['GET', 'POST'])]
+    public function methods()
+    {
+    }
+
+    #[Route(host: '{locale}.example.com')]
+    public function host()
+    {
+    }
+
+    #[Route(condition: 'context.getMethod() == \'GET\'')]
+    public function condition()
+    {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Related to #40266, localized paths does not work anymore. This PR aims to fix that and add a rework on the tests (using real annotations/attributes instead of guessing the parsing that may lead to errors).
