### PR TITLE
[TwigBundle] Require TwigBridge 5.3 for SerializerExtension

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/config": "^4.4|^5.0",
-        "symfony/twig-bridge": "^5.0",
+        "symfony/twig-bridge": "^5.3",
         "symfony/http-foundation": "^4.4|^5.0",
         "symfony/http-kernel": "^5.0",
         "symfony/polyfill-ctype": "~1.8",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Caught while testing 5.x in one of our apps. Without this, you'll get an error when you're using TwigBridge <5.3 with TwigBundle 5.3+:

```
In KernelDevDebugContainer.php line 944:

  Attempted to load class "SerializerExtension" from namespace "Symfony\Bridge\Twig\Extension".
```