### PR TITLE
Fix 'Cannot access parent:: when current class scope has no parent' error

### DIFF
--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -154,13 +154,15 @@ class ReflectionClassResource implements SelfCheckingResourceInterface
                     continue;
                 }
 
-                if (!$p->isDefaultValueConstant() || \defined($p->getDefaultValueConstantName())) {
+                $defaultValueConstantName = preg_replace('/^parent::/', 'pimax\Messages\Message::', $p->getDefaultValueConstantName());
+
+                if (!$p->isDefaultValueConstant() || \defined($defaultValueConstantName)) {
                     $defaults[$p->name] = $p->getDefaultValue();
 
                     continue;
                 }
 
-                $defaults[$p->name] = $p->getDefaultValueConstantName();
+                $defaults[$p->name] = $defaultValueConstantName;
                 $parametersWithUndefinedConstants[$p->name] = true;
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

```
Script Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache handling the symfony-scripts event terminated with an exception

  [RuntimeException]
  An error occurred when executing the "'cache:clear --no-warmup'" command:

  PHP Fatal error: Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Cannot access parent:: when current class scope has no parent in ./vendor/symfony/symfony/src/Symfony/Component/Config/Resource/ReflectionClassResource.php:167
  Stack trace:
  #0 ./vendor/symfony/symfony/src/Symfony/Component/Config/Resource/ReflectionClassResource.php(167): defined()
  #1 ./vendor/symfony/symfony/src/Symfony/Component/Config/Resource/ReflectionClassResource.php(117): Symfony\Component\Config\Resource\ReflectionClassResource->generateSignature()
  #2 ./vendor/symfony/symfony/src/Symfony/Component/Config/Resource/ReflectionClassResource.php(66): Symfony\Component\Config\Resource\ReflectionClassResource->computeHash()
  #3 [internal function]: Symfony\Component\Config\Resource\ReflectionClassResource->serialize()
  #4 ./vendor/symfony/s in ./vendor/symfony/symfony/src/Symfony/Component/Config/Resource/ReflectionClassResource.php on line 167
```
