### PR TITLE
[HttpClient] Revert "minor #40768  [PHPDoc] Fix 2 remaining return mixed

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/HttplugPromise.php
+++ b/src/Symfony/Component/HttpClient/Response/HttplugPromise.php
@@ -49,8 +49,10 @@ final class HttplugPromise implements HttplugPromiseInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return Psr7ResponseInterface|mixed
      */
-    public function wait($unwrap = true): ?Psr7ResponseInterface
+    public function wait($unwrap = true)
     {
         $result = $this->promise->wait($unwrap);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This reverts commit 40d73152027fc63f2b63beaddb0fc454af8971c1, reversing
changes made to 4e904ec1081ef7888acc2e8277e55859ad275a25.

As spotted by the CI and reported in https://github.com/symfony/symfony/pull/40768#issuecomment-817388657

Using `Psr7ResponseInterface|mixed` instead of just `mixed` provides a better DX, by making autocompletion more useful.