### PR TITLE
[DependencyInjection] Allow calling custom processors directly on EnvConfigurator

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/EnvConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/EnvConfigurator.php
@@ -34,6 +34,18 @@ class EnvConfigurator
     /**
      * @return $this
      */
+    public function __call(string $name, array $arguments): self
+    {
+        $processor = strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], '\1_\2', $name));
+
+        $this->custom($processor, ...$arguments);
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
     public function custom(string $processor, ...$args): self
     {
         array_unshift($this->stack, $processor, ...$args);

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/Configurator/EnvConfiguratorTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/Configurator/EnvConfiguratorTest.php
@@ -31,5 +31,6 @@ final class EnvConfiguratorTest extends TestCase
         yield ['%env(string:FOO)%', (new EnvConfigurator('FOO'))->string()];
         yield ['%env(key:path:url:FOO)%', (new EnvConfigurator('FOO'))->url()->key('path')];
         yield ['%env(default:fallback:bar:arg1:FOO)%', (new EnvConfigurator('FOO'))->custom('bar', 'arg1')->default('fallback')];
+        yield ['%env(my_processor:my_argument:FOO)%', (new EnvConfigurator('FOO'))->myProcessor('my_argument')];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

This is a proposition of addition to the feature added by https://github.com/symfony/symfony/pull/40682 to allow calling custom processors in the same way we call builtin ones. This is not perfect since it doesn't allow auto-completion for these custom methods but I think this provides a cleaner API for custom processors.
