### PR TITLE
[Cache] Apply NullAdapter as Null Object

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/NullAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/NullAdapter.php
@@ -114,7 +114,7 @@ class NullAdapter implements AdapterInterface, CacheInterface
      */
     public function save(CacheItemInterface $item)
     {
-        return false;
+        return true;
     }
 
     /**
@@ -124,7 +124,7 @@ class NullAdapter implements AdapterInterface, CacheInterface
      */
     public function saveDeferred(CacheItemInterface $item)
     {
-        return false;
+        return true;
     }
 
     /**
@@ -134,7 +134,7 @@ class NullAdapter implements AdapterInterface, CacheInterface
      */
     public function commit()
     {
-        return false;
+        return true;
     }
 
     /**

--- a/src/Symfony/Component/Cache/Tests/Adapter/NullAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/NullAdapterTest.php
@@ -113,7 +113,7 @@ class NullAdapterTest extends TestCase
         $this->assertFalse($item->isHit());
         $this->assertNull($item->get(), "Item's value must be null when isHit is false.");
 
-        $this->assertFalse($adapter->save($item));
+        $this->assertTrue($adapter->save($item));
     }
 
     public function testDeferredSave()
@@ -124,7 +124,7 @@ class NullAdapterTest extends TestCase
         $this->assertFalse($item->isHit());
         $this->assertNull($item->get(), "Item's value must be null when isHit is false.");
 
-        $this->assertFalse($adapter->saveDeferred($item));
+        $this->assertTrue($adapter->saveDeferred($item));
     }
 
     public function testCommit()
@@ -135,7 +135,7 @@ class NullAdapterTest extends TestCase
         $this->assertFalse($item->isHit());
         $this->assertNull($item->get(), "Item's value must be null when isHit is false.");
 
-        $this->assertFalse($adapter->saveDeferred($item));
-        $this->assertFalse($this->createCachePool()->commit());
+        $this->assertTrue($adapter->saveDeferred($item));
+        $this->assertTrue($this->createCachePool()->commit());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/symfony/symfony/issues/40753
| License       | MIT
<!--| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

There is a problem with the NullAdapter if I have to add an expression to work:

```php
$adapter = new NullAdapter();
$item = new CacheItem();
$item->set('FooBar');
if (!$adapter->save($item) && !($adapter instanceof NullAdapter)) {
    throw new Exception('Uoh oh');
}
```

So the goal here is to modify the methods that are causing a problem to behave as a Null Object.