### PR TITLE
Add and improve docblock typing for static analysis

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/DataTransformer/CollectionToArrayTransformer.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DataTransformer/CollectionToArrayTransformer.php
@@ -18,13 +18,15 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @implements DataTransformerInterface<Collection, array>
  */
 class CollectionToArrayTransformer implements DataTransformerInterface
 {
     /**
      * Transforms a collection into an array.
      *
-     * @return mixed An array of entities
+     * @return mixed[] An array of entities
      *
      * @throws TransformationFailedException
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -338,6 +339,13 @@ abstract class AbstractController implements ServiceSubscriberInterface
 
     /**
      * Creates and returns a Form instance from the type of the form.
+     *
+     * @template TData
+     * @template TFormType of FormTypeInterface<TData>
+     *
+     * @param class-string<TFormType> $type
+     *
+     * @return FormInterface<TData>
      */
     protected function createForm(string $type, $data = null, array $options = []): FormInterface
     {

--- a/src/Symfony/Component/Config/Resource/GlobResource.php
+++ b/src/Symfony/Component/Config/Resource/GlobResource.php
@@ -21,6 +21,8 @@ use Symfony\Component\Finder\Glob;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  *
+ * @implements \IteratorAggregate<mixed, \SplFileInfo>
+ *
  * @final
  */
 class GlobResource implements \IteratorAggregate, SelfCheckingResourceInterface

--- a/src/Symfony/Component/Console/Helper/HelperSet.php
+++ b/src/Symfony/Component/Console/Helper/HelperSet.php
@@ -18,6 +18,8 @@ use Symfony\Component\Console\Exception\InvalidArgumentException;
  * HelperSet represents a set of helpers to be used with a command.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @implements \IteratorAggregate<Helper>
  */
 class HelperSet implements \IteratorAggregate
 {
@@ -89,7 +91,7 @@ class HelperSet implements \IteratorAggregate
     }
 
     /**
-     * @return Helper[]
+     * @return \Traversable<Helper>
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -18,6 +18,8 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
  * Crawler eases navigation of a list of \DOMNode objects.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @implements \IteratorAggregate<\DomNode>
  */
 class Crawler implements \Countable, \IteratorAggregate
 {
@@ -1109,7 +1111,7 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
-     * @return \ArrayIterator|\DOMNode[]
+     * @return \Traversable<\DomNode>
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -19,7 +19,7 @@ use Symfony\Component\CssSelector\CssSelectorConverter;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @implements \IteratorAggregate<\DomNode>
+ * @implements \IteratorAggregate<\DOMNode>
  */
 class Crawler implements \Countable, \IteratorAggregate
 {
@@ -1111,7 +1111,7 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
-     * @return \Traversable<\DomNode>
+     * @return \Traversable<\DOMNode>
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/EventDispatcher/GenericEvent.php
+++ b/src/Symfony/Component/EventDispatcher/GenericEvent.php
@@ -19,6 +19,8 @@ use Symfony\Contracts\EventDispatcher\Event;
  * Encapsulates events thus decoupling the observer from the subject they encapsulate.
  *
  * @author Drak <drak@zikula.org>
+ *
+ * @implements \IteratorAggregate<string, mixed>
  */
 class GenericEvent extends Event implements \ArrayAccess, \IteratorAggregate
 {
@@ -161,7 +163,7 @@ class GenericEvent extends Event implements \ArrayAccess, \IteratorAggregate
     /**
      * IteratorAggregate for iterating over the object like an array.
      *
-     * @return \ArrayIterator
+     * @return \Traversable<string, mixed>
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -36,6 +36,8 @@ use Symfony\Component\Finder\Iterator\SortableIterator;
  *     $finder = Finder::create()->files()->name('*.php')->in(__DIR__);
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @implements \IteratorAggregate<SplFileInfo>
  */
 class Finder implements \IteratorAggregate, \Countable
 {
@@ -601,7 +603,7 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * This method implements the IteratorAggregate interface.
      *
-     * @return \Iterator|SplFileInfo[] An iterator
+     * @return \Traversable<SplFileInfo> An iterator
      *
      * @throws \LogicException if the in() method has not been called
      */

--- a/src/Symfony/Component/Form/AbstractType.php
+++ b/src/Symfony/Component/Form/AbstractType.php
@@ -17,6 +17,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T
+ * @implements FormTypeInterface<T>
  */
 abstract class AbstractType implements FormTypeInterface
 {

--- a/src/Symfony/Component/Form/AbstractTypeExtension.php
+++ b/src/Symfony/Component/Form/AbstractTypeExtension.php
@@ -15,6 +15,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T
+ * @implements FormTypeExtensionInterface<T>
  */
 abstract class AbstractTypeExtension implements FormTypeExtensionInterface
 {

--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -18,6 +18,10 @@ use Symfony\Component\Form\Exception\BadMethodCallException;
  * A form button.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T
+ *
+ * @implements FormInterface<T>
  */
 class Button implements \IteratorAggregate, FormInterface
 {

--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -19,6 +19,10 @@ use Symfony\Component\Form\Exception\InvalidArgumentException;
  * A builder for {@link Button} instances.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T
+ *
+ * @implements FormBuilderInterface<T>
  */
 class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
 {
@@ -135,7 +139,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Creates the button.
      *
-     * @return Button The button
+     * @return FormInterface<T> The button
      */
     public function getForm()
     {

--- a/src/Symfony/Component/Form/CallbackTransformer.php
+++ b/src/Symfony/Component/Form/CallbackTransformer.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Form;
 
+/**
+ * @implements DataTransformerInterface<mixed, mixed>
+ */
 class CallbackTransformer implements DataTransformerInterface
 {
     private $transform;

--- a/src/Symfony/Component/Form/CallbackTransformer.php
+++ b/src/Symfony/Component/Form/CallbackTransformer.php
@@ -12,7 +12,10 @@
 namespace Symfony\Component\Form;
 
 /**
- * @implements DataTransformerInterface<mixed, mixed>
+ * @template T
+ * @template R
+ *
+ * @implements DataTransformerInterface<T, R>
  */
 class CallbackTransformer implements DataTransformerInterface
 {
@@ -20,8 +23,8 @@ class CallbackTransformer implements DataTransformerInterface
     private $reverseTransform;
 
     /**
-     * @param callable $transform        The forward transform callback
-     * @param callable $reverseTransform The reverse transform callback
+     * @param callable(T):R $transform        The forward transform callback
+     * @param callable(R):T $reverseTransform The reverse transform callback
      */
     public function __construct(callable $transform, callable $reverseTransform)
     {

--- a/src/Symfony/Component/Form/ChoiceList/View/ChoiceGroupView.php
+++ b/src/Symfony/Component/Form/ChoiceList/View/ChoiceGroupView.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Form\ChoiceList\View;
  * Represents a group of choices in templates.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @implements \IteratorAggregate<self|ChoiceView>
  */
 class ChoiceGroupView implements \IteratorAggregate
 {
@@ -35,7 +37,7 @@ class ChoiceGroupView implements \IteratorAggregate
     /**
      * {@inheritdoc}
      *
-     * @return self[]|ChoiceView[]
+     * @return \Traversable<self|ChoiceView>
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Form/DataTransformerInterface.php
+++ b/src/Symfony/Component/Form/DataTransformerInterface.php
@@ -17,6 +17,9 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  * Transforms a value between different representations.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T
+ * @template R
  */
 interface DataTransformerInterface
 {
@@ -53,9 +56,9 @@ interface DataTransformerInterface
      * of the first data transformer outputs NULL, the second must be able to
      * process that value.
      *
-     * @param mixed $value The value in the original representation
+     * @param T|null $value The value in the original representation
      *
-     * @return mixed The value in the transformed representation
+     * @return R|null The value in the transformed representation
      *
      * @throws TransformationFailedException when the transformation fails
      */
@@ -82,9 +85,9 @@ interface DataTransformerInterface
      * By convention, reverseTransform() should return NULL if an empty string
      * is passed.
      *
-     * @param mixed $value The value in the transformed representation
+     * @param R|null $value The value in the transformed representation
      *
-     * @return mixed The value in the original representation
+     * @return T|null The value in the original representation
      *
      * @throws TransformationFailedException when the transformation fails
      */

--- a/src/Symfony/Component/Form/DataTransformerInterface.php
+++ b/src/Symfony/Component/Form/DataTransformerInterface.php
@@ -56,9 +56,9 @@ interface DataTransformerInterface
      * of the first data transformer outputs NULL, the second must be able to
      * process that value.
      *
-     * @param T|null $value The value in the original representation
+     * @param T $value The value in the original representation
      *
-     * @return R|null The value in the transformed representation
+     * @return R The value in the transformed representation
      *
      * @throws TransformationFailedException when the transformation fails
      */
@@ -85,9 +85,9 @@ interface DataTransformerInterface
      * By convention, reverseTransform() should return NULL if an empty string
      * is passed.
      *
-     * @param R|null $value The value in the transformed representation
+     * @param R $value The value in the transformed representation
      *
-     * @return T|null The value in the original representation
+     * @return T The value in the original representation
      *
      * @throws TransformationFailedException when the transformation fails
      */

--- a/src/Symfony/Component/Form/Event/PostSetDataEvent.php
+++ b/src/Symfony/Component/Form/Event/PostSetDataEvent.php
@@ -17,6 +17,9 @@ use Symfony\Component\Form\FormEvent;
  * This event is dispatched at the end of the Form::setData() method.
  *
  * This event is mostly here for reading data after having pre-populated the form.
+ *
+ * @template T
+ * @extends FormEvent<T>
  */
 final class PostSetDataEvent extends FormEvent
 {

--- a/src/Symfony/Component/Form/Event/PreSetDataEvent.php
+++ b/src/Symfony/Component/Form/Event/PreSetDataEvent.php
@@ -19,6 +19,9 @@ use Symfony\Component\Form\FormEvent;
  * It can be used to:
  *  - Modify the data given during pre-population;
  *  - Modify a form depending on the pre-populated data (adding or removing fields dynamically).
+ *
+ * @template T
+ * @extends FormEvent<T>
  */
 final class PreSetDataEvent extends FormEvent
 {

--- a/src/Symfony/Component/Form/Event/PreSubmitEvent.php
+++ b/src/Symfony/Component/Form/Event/PreSubmitEvent.php
@@ -19,6 +19,8 @@ use Symfony\Component\Form\FormEvent;
  * It can be used to:
  *  - Change data from the request, before submitting the data to the form.
  *  - Add or remove form fields, before submitting the data to the form.
+ *
+ * @extends FormEvent<array<string, mixed>>
  */
 final class PreSubmitEvent extends FormEvent
 {

--- a/src/Symfony/Component/Form/Event/SubmitEvent.php
+++ b/src/Symfony/Component/Form/Event/SubmitEvent.php
@@ -18,6 +18,9 @@ use Symfony\Component\Form\FormEvent;
  * transforms back the normalized data to the model and view data.
  *
  * It can be used to change data from the normalized representation of the data.
+ *
+ * @template T
+ * @extends FormEvent<T>
  */
 final class SubmitEvent extends FormEvent
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ArrayToPartsTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ArrayToPartsTransformer.php
@@ -16,6 +16,8 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @implements DataTransformerInterface<array, array>
  */
 class ArrayToPartsTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ArrayToPartsTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ArrayToPartsTransformer.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @implements DataTransformerInterface<array, array>
+ * @implements DataTransformerInterface<array|null, array|null>
  */
 class ArrayToPartsTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
@@ -14,6 +14,12 @@ namespace Symfony\Component\Form\Extension\Core\DataTransformer;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\InvalidArgumentException;
 
+/**
+ * @template T
+ * @template R
+ *
+ * @implements DataTransformerInterface<T, R>
+ */
 abstract class BaseDateTimeTransformer implements DataTransformerInterface
 {
     protected static $formats = [

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
@@ -20,6 +20,8 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Florian Eckerstorfer <florian@eckerstorfer.org>
+ *
+ * @implements DataTransformerInterface<bool, string>
  */
 class BooleanToStringTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
@@ -17,6 +17,8 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @implements DataTransformerInterface<mixed, string>
  */
 class ChoiceToValueTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
@@ -17,6 +17,8 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @implements DataTransformerInterface<array, array>
  */
 class ChoicesToValuesTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @implements DataTransformerInterface<array, array>
+ * @implements DataTransformerInterface<array, string[]>
  */
 class ChoicesToValuesTransformer implements DataTransformerInterface
 {
@@ -30,7 +30,7 @@ class ChoicesToValuesTransformer implements DataTransformerInterface
     }
 
     /**
-     * @return array
+     * @return string[]
      *
      * @throws TransformationFailedException if the given value is not an array
      */

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DataTransformerChain.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DataTransformerChain.php
@@ -18,6 +18,8 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  * Passes a value through multiple value transformers.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @implements DataTransformerInterface<mixed, mixed>
  */
 class DataTransformerChain implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToArrayTransformer.php
@@ -19,6 +19,8 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
  * Transforms between a normalized date interval and an interval string/array.
  *
  * @author Steffen Roßkamp <steffen.rosskamp@gimmickmedia.de>
+ *
+ * @implements DataTransformerInterface<\DateInterval, array>
  */
 class DateIntervalToArrayTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToStringTransformer.php
@@ -19,6 +19,8 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
  * Transforms between a date string and a DateInterval object.
  *
  * @author Steffen Roßkamp <steffen.rosskamp@gimmickmedia.de>
+ *
+ * @implements DataTransformerInterface<\DateInterval, string>
  */
 class DateIntervalToStringTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeImmutableToDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeImmutableToDateTimeTransformer.php
@@ -18,6 +18,8 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  * Transforms between a DateTimeImmutable object and a DateTime object.
  *
  * @author Valentin Udaltsov <udaltsov.valentin@gmail.com>
+ *
+ * @implements DataTransformerInterface<\DateTimeImmutable|null, \DateTime|null>
  */
 final class DateTimeImmutableToDateTimeTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeZoneToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeZoneToStringTransformer.php
@@ -44,6 +44,7 @@ class DateTimeZoneToStringTransformer implements DataTransformerInterface
                 throw new TransformationFailedException('Expected an array of \DateTimeZone objects.');
             }
 
+            /** @var string[] */
             return array_map([new self(), 'transform'], $dateTimeZone);
         }
 
@@ -68,6 +69,7 @@ class DateTimeZoneToStringTransformer implements DataTransformerInterface
                 throw new TransformationFailedException('Expected an array of timezone identifier strings.');
             }
 
+            /** @var \DateTimeZone[] */
             return array_map([new self(), 'reverseTransform'], $value);
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeZoneToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeZoneToStringTransformer.php
@@ -18,6 +18,8 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  * Transforms between a timezone identifier string and a DateTimeZone object.
  *
  * @author Roland Franssen <franssen.roland@gmail.com>
+ *
+ * @implements DataTransformerInterface<\DateTimeZone|\DateTimeZone[]|null, string|string[]|null>
  */
 class DateTimeZoneToStringTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntlTimeZoneToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntlTimeZoneToStringTransformer.php
@@ -18,6 +18,8 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  * Transforms between a timezone identifier string and a IntlTimeZone object.
  *
  * @author Roland Franssen <franssen.roland@gmail.com>
+ *
+ * @implements DataTransformerInterface<\IntlTimeZone|\IntlTimeZone[]|null, string|string[]|null>
  */
 class IntlTimeZoneToStringTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntlTimeZoneToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntlTimeZoneToStringTransformer.php
@@ -44,6 +44,7 @@ class IntlTimeZoneToStringTransformer implements DataTransformerInterface
                 throw new TransformationFailedException('Expected an array of \IntlTimeZone objects.');
             }
 
+            /** @var string[] */
             return array_map([new self(), 'transform'], $intlTimeZone);
         }
 
@@ -60,7 +61,7 @@ class IntlTimeZoneToStringTransformer implements DataTransformerInterface
     public function reverseTransform($value)
     {
         if (null === $value) {
-            return;
+            return null;
         }
 
         if ($this->multiple) {
@@ -68,6 +69,7 @@ class IntlTimeZoneToStringTransformer implements DataTransformerInterface
                 throw new TransformationFailedException('Expected an array of timezone identifier strings.');
             }
 
+            /** @var \IntlTimeZone[] */
             return array_map([new self(), 'reverseTransform'], $value);
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -20,6 +20,8 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Florian Eckerstorfer <florian@eckerstorfer.org>
+ *
+ * @implements DataTransformerInterface<int|float, string>
  */
 class NumberToLocalizedStringTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformer.php
@@ -20,6 +20,8 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Florian Eckerstorfer <florian@eckerstorfer.org>
+ *
+ * @implements DataTransformerInterface<int|float, string>
  */
 class PercentToLocalizedStringTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/StringToFloatTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/StringToFloatTransformer.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Form\Extension\Core\DataTransformer;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
+/**
+ * @implements DataTransformerInterface<string|null, int|float|null>
+ */
 class StringToFloatTransformer implements DataTransformerInterface
 {
     private $scale;

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/UlidToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/UlidToStringTransformer.php
@@ -19,6 +19,8 @@ use Symfony\Component\Uid\Ulid;
  * Transforms between a ULID string and a Ulid object.
  *
  * @author Pavel Dyakonov <wapinet@mail.ru>
+ *
+ * @implements DataTransformerInterface<Ulid, string>
  */
 class UlidToStringTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/UuidToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/UuidToStringTransformer.php
@@ -19,6 +19,8 @@ use Symfony\Component\Uid\Uuid;
  * Transforms between a UUID string and a Uuid object.
  *
  * @author Pavel Dyakonov <wapinet@mail.ru>
+ *
+ * @implements DataTransformerInterface<Uuid, string>
  */
 class UuidToStringTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -16,6 +16,8 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @implements DataTransformerInterface<mixed, mixed>
  */
 class ValueToDuplicatesTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -17,7 +17,9 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @implements DataTransformerInterface<mixed, mixed>
+ * @template T
+ *
+ * @implements DataTransformerInterface<T, array<string, T>>
  */
 class ValueToDuplicatesTransformer implements DataTransformerInterface
 {
@@ -31,9 +33,9 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
     /**
      * Duplicates the given value through the array.
      *
-     * @param mixed $value The value
+     * @param T $value The value
      *
-     * @return array The array
+     * @return array<string, T> The array
      */
     public function transform($value)
     {
@@ -49,7 +51,9 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
     /**
      * Extracts the duplicated value from an array.
      *
-     * @return mixed The value
+     * @param array<string, T> The array
+     *
+     * @return T The value
      *
      * @throws TransformationFailedException if the given value is not an array or
      *                                       if the given array can not be transformed

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/WeekToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/WeekToArrayTransformer.php
@@ -18,6 +18,8 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
  * Transforms between an ISO 8601 week date string and an array.
  *
  * @author Damien Fayet <damienf1521@gmail.com>
+ *
+ * @implements DataTransformerInterface<string|null, array>
  */
 class WeekToArrayTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -25,6 +25,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * cannot be extended (via {@link \Symfony\Component\Form\FormExtensionInterface}) nor themed.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T
+ * @implements FormTypeInterface<T>
  */
 abstract class BaseType extends AbstractType
 {

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -287,7 +287,7 @@ class ChoiceType extends AbstractType
             $view->vars['placeholder'] = $options['placeholder'];
         }
 
-        if ($options['multiple'] && !$options['expanded']) {
+        if ($options['multiple'] && !$options['expanded'] && isset($view->vars['full_name'])) {
             // Add "[]" to the name in case a select tag with multiple options is
             // displayed. Otherwise only one of the selected options is sent in the
             // POST request.

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -287,7 +287,7 @@ class ChoiceType extends AbstractType
             $view->vars['placeholder'] = $options['placeholder'];
         }
 
-        if ($options['multiple'] && !$options['expanded'] && isset($view->vars['full_name'])) {
+        if ($options['multiple'] && !$options['expanded']) {
             // Add "[]" to the name in case a select tag with multiple options is
             // displayed. Otherwise only one of the selected options is sent in the
             // POST request.

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -26,6 +26,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
+/**
+ * @extends BaseType<self>
+ */
 class FormType extends BaseType
 {
     private $dataMapper;

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -27,7 +27,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
- * @extends BaseType<self>
+ * @extends BaseType<mixed>
  */
 class FormType extends BaseType
 {

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
@@ -16,6 +16,9 @@ use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+/**
+ * @implements DataTransformerInterface<mixed, mixed>
+ */
 class TextType extends AbstractType implements DataTransformerInterface
 {
     public function buildForm(FormBuilderInterface $builder, array $options)

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -67,7 +67,9 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @template T
+ *
  * @implements FormInterface<T>
+ * @implements \IteratorAggregate<FormInterface>
  */
 class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterface
 {
@@ -82,7 +84,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
     private $parent;
 
     /**
-     * @var FormInterface[]|OrderedHashMap A map of FormInterface instances
+     * @var OrderedHashMap<string, FormInterface> A map of FormInterface instances
      */
     private $children;
 
@@ -1007,7 +1009,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
     /**
      * Returns the iterator for this group.
      *
-     * @return \Traversable|FormInterface[]
+     * @return OrderedHashMap<string, FormInterface>
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -65,6 +65,9 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T
+ * @implements FormInterface<T>
  */
 class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterface
 {

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -20,6 +20,8 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
  * A builder for creating {@link Form} instances.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @implements \IteratorAggregate<FormBuilderInterface>
  */
 class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormBuilderInterface
 {
@@ -212,7 +214,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     /**
      * {@inheritdoc}
      *
-     * @return FormBuilderInterface[]|\Traversable
+     * @return \Traversable<FormBuilderInterface>
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Form/FormBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormBuilderInterface.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Form;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T
+ * @extends FormConfigBuilderInterface<T>
  */
 interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuilderInterface
 {
@@ -33,7 +36,7 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
      * Creates a form builder.
      *
      * @param string      $name The name of the form or the name of the property
-     * @param string|null $type The type of the form or null if name is a property
+     * @param class-string<FormTypeInterface>|null $type The type of the form or null if name is a property
      *
      * @return self
      */
@@ -72,7 +75,7 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
     /**
      * Creates the form.
      *
-     * @return FormInterface The form
+     * @return FormInterface<T> The form
      */
     public function getForm();
 }

--- a/src/Symfony/Component/Form/FormBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormBuilderInterface.php
@@ -35,8 +35,8 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
     /**
      * Creates a form builder.
      *
-     * @param string                               $name The name of the form or the name of the property
-     * @param class-string<FormTypeInterface>|null $type The type of the form or null if name is a property
+     * @param string               $name The name of the form or the name of the property
+     * @param class-string<T>|null $type The type of the form or null if name is a property
      *
      * @return self
      */

--- a/src/Symfony/Component/Form/FormBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormBuilderInterface.php
@@ -35,7 +35,7 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
     /**
      * Creates a form builder.
      *
-     * @param string      $name The name of the form or the name of the property
+     * @param string                               $name The name of the form or the name of the property
      * @param class-string<FormTypeInterface>|null $type The type of the form or null if name is a property
      *
      * @return self

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Form;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Form\Event\PreSetDataEvent;
 use Symfony\Component\Form\Event\PostSetDataEvent;
+use Symfony\Component\Form\Event\PreSetDataEvent;
 use Symfony\Component\Form\Event\PreSubmitEvent;
 use Symfony\Component\Form\Event\SubmitEvent;
 use Symfony\Component\PropertyAccess\PropertyPathInterface;
@@ -31,11 +31,11 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     /**
      * Adds an event listener to an event on this form.
      *
-     * @param FormEvents::* $eventName
+     * @param FormEvents::*                                                                                                $eventName
      * @param callable(PreSetDataEvent<T>)|callable(PostSetDataEvent<T>)|callable(PreSubmitEvent)|callable(SubmitEvent<T>) $listener
-     * @param int $priority The priority of the listener. Listeners
-     *                      with a higher priority are called before
-     *                      listeners with a lower priority.
+     * @param int                                                                                                          $priority  The priority of the listener. Listeners
+     *                                                                                                                                with a higher priority are called before
+     *                                                                                                                                listeners with a lower priority.
      *
      * @return $this The configuration object
      */

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -12,10 +12,17 @@
 namespace Symfony\Component\Form;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\Event\PreSetDataEvent;
+use Symfony\Component\Form\Event\PostSetDataEvent;
+use Symfony\Component\Form\Event\PreSubmitEvent;
+use Symfony\Component\Form\Event\SubmitEvent;
 use Symfony\Component\PropertyAccess\PropertyPathInterface;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T
+ * @extends FormConfigInterface<T>
  *
  * @method $this setIsEmptyCallback(callable|null $isEmptyCallback) Sets the callback that will be called to determine if the model data of the form is empty or not - not implementing it is deprecated since Symfony 5.1
  */
@@ -24,6 +31,8 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     /**
      * Adds an event listener to an event on this form.
      *
+     * @param FormEvents::* $eventName
+     * @param callable(PreSetDataEvent<T>)|callable(PostSetDataEvent<T>)|callable(PreSubmitEvent)|callable(SubmitEvent<T>) $listener
      * @param int $priority The priority of the listener. Listeners
      *                      with a higher priority are called before
      *                      listeners with a lower priority.
@@ -248,7 +257,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     /**
      * Builds and returns the form configuration.
      *
-     * @return FormConfigInterface
+     * @return FormConfigInterface<T>
      */
     public function getFormConfig();
 }

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -19,6 +19,8 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
+ * @template T
+ *
  * @method callable|null getIsEmptyCallback() Returns a callable that takes the model data as argument and that returns if it is empty or not - not implementing it is deprecated since Symfony 5.1
  */
 interface FormConfigInterface
@@ -167,7 +169,7 @@ interface FormConfigInterface
     /**
      * Returns the initial data of the form.
      *
-     * @return mixed The initial form data
+     * @return T|null The initial form data
      */
     public function getData();
 

--- a/src/Symfony/Component/Form/FormEvent.php
+++ b/src/Symfony/Component/Form/FormEvent.php
@@ -15,6 +15,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T
  */
 class FormEvent extends Event
 {
@@ -33,7 +35,7 @@ class FormEvent extends Event
     /**
      * Returns the form at the source of the event.
      *
-     * @return FormInterface
+     * @return FormInterface<T>
      */
     public function getForm()
     {
@@ -43,7 +45,7 @@ class FormEvent extends Event
     /**
      * Returns the data associated with this event.
      *
-     * @return mixed
+     * @return T|null
      */
     public function getData()
     {

--- a/src/Symfony/Component/Form/FormFactoryInterface.php
+++ b/src/Symfony/Component/Form/FormFactoryInterface.php
@@ -24,7 +24,7 @@ interface FormFactoryInterface
      * @see createBuilder()
      *
      * @param class-string<FormTypeInterface>|'Symfony\Component\Form\Extension\Core\Type\FormType' $type
-     * @param mixed $data The initial data
+     * @param mixed                                                                                 $data The initial data
      *
      * @return FormInterface The form named after the type
      *
@@ -38,7 +38,7 @@ interface FormFactoryInterface
      * @see createNamedBuilder()
      *
      * @param class-string<FormTypeInterface>|'Symfony\Component\Form\Extension\Core\Type\FormType' $type
-     * @param mixed $data The initial data
+     * @param mixed                                                                                 $data The initial data
      *
      * @return FormInterface The form
      *
@@ -65,7 +65,7 @@ interface FormFactoryInterface
      * Returns a form builder.
      *
      * @param class-string<FormTypeInterface>|'Symfony\Component\Form\Extension\Core\Type\FormType' $type
-     * @param mixed $data The initial data
+     * @param mixed                                                                                 $data The initial data
      *
      * @return FormBuilderInterface The form builder
      *
@@ -77,7 +77,7 @@ interface FormFactoryInterface
      * Returns a form builder.
      *
      * @param class-string<FormTypeInterface>|'Symfony\Component\Form\Extension\Core\Type\FormType' $type
-     * @param mixed $data The initial data
+     * @param mixed                                                                                 $data The initial data
      *
      * @return FormBuilderInterface The form builder
      *

--- a/src/Symfony/Component/Form/FormFactoryInterface.php
+++ b/src/Symfony/Component/Form/FormFactoryInterface.php
@@ -23,6 +23,7 @@ interface FormFactoryInterface
      *
      * @see createBuilder()
      *
+     * @param class-string<FormTypeInterface>|'Symfony\Component\Form\Extension\Core\Type\FormType' $type
      * @param mixed $data The initial data
      *
      * @return FormInterface The form named after the type
@@ -36,6 +37,7 @@ interface FormFactoryInterface
      *
      * @see createNamedBuilder()
      *
+     * @param class-string<FormTypeInterface>|'Symfony\Component\Form\Extension\Core\Type\FormType' $type
      * @param mixed $data The initial data
      *
      * @return FormInterface The form
@@ -62,6 +64,7 @@ interface FormFactoryInterface
     /**
      * Returns a form builder.
      *
+     * @param class-string<FormTypeInterface>|'Symfony\Component\Form\Extension\Core\Type\FormType' $type
      * @param mixed $data The initial data
      *
      * @return FormBuilderInterface The form builder
@@ -73,6 +76,7 @@ interface FormFactoryInterface
     /**
      * Returns a form builder.
      *
+     * @param class-string<FormTypeInterface>|'Symfony\Component\Form\Extension\Core\Type\FormType' $type
      * @param mixed $data The initial data
      *
      * @return FormBuilderInterface The form builder

--- a/src/Symfony/Component/Form/FormFactoryInterface.php
+++ b/src/Symfony/Component/Form/FormFactoryInterface.php
@@ -23,8 +23,7 @@ interface FormFactoryInterface
      *
      * @see createBuilder()
      *
-     * @param class-string<FormTypeInterface>|'Symfony\Component\Form\Extension\Core\Type\FormType' $type
-     * @param mixed                                                                                 $data The initial data
+     * @param mixed $data The initial data
      *
      * @return FormInterface The form named after the type
      *
@@ -37,8 +36,7 @@ interface FormFactoryInterface
      *
      * @see createNamedBuilder()
      *
-     * @param class-string<FormTypeInterface>|'Symfony\Component\Form\Extension\Core\Type\FormType' $type
-     * @param mixed                                                                                 $data The initial data
+     * @param mixed $data The initial data
      *
      * @return FormInterface The form
      *
@@ -64,8 +62,7 @@ interface FormFactoryInterface
     /**
      * Returns a form builder.
      *
-     * @param class-string<FormTypeInterface>|'Symfony\Component\Form\Extension\Core\Type\FormType' $type
-     * @param mixed                                                                                 $data The initial data
+     * @param mixed $data The initial data
      *
      * @return FormBuilderInterface The form builder
      *
@@ -76,8 +73,7 @@ interface FormFactoryInterface
     /**
      * Returns a form builder.
      *
-     * @param class-string<FormTypeInterface>|'Symfony\Component\Form\Extension\Core\Type\FormType' $type
-     * @param mixed                                                                                 $data The initial data
+     * @param mixed $data The initial data
      *
      * @return FormBuilderInterface The form builder
      *

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -17,6 +17,10 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  * A form group bundling multiple forms in a hierarchical structure.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T
+ *
+ * @method void clearErrors(bool $deep)
  */
 interface FormInterface extends \ArrayAccess, \Traversable, \Countable
 {
@@ -118,9 +122,9 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns the model data in the format needed for the underlying object.
      *
-     * @return mixed When the field is not submitted, the default data is returned.
-     *               When the field is submitted, the default data has been bound
-     *               to the submitted view data.
+     * @return T|null When the field is not submitted, the default data is returned.
+     *                When the field is submitted, the default data has been bound
+     *                to the submitted view data.
      *
      * @throws Exception\RuntimeException If the form inherits data but has no parent
      */
@@ -320,7 +324,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     public function isRoot();
 
     /**
-     * @return FormView The view
+     * @return FormView<T> The view
      */
     public function createView(FormView $parent = null);
 }

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -19,8 +19,6 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @template T
- *
- * @method void clearErrors(bool $deep)
  */
 interface FormInterface extends \ArrayAccess, \Traversable, \Countable
 {

--- a/src/Symfony/Component/Form/FormTypeExtensionInterface.php
+++ b/src/Symfony/Component/Form/FormTypeExtensionInterface.php
@@ -40,7 +40,7 @@ interface FormTypeExtensionInterface
      *
      * @see FormTypeInterface::buildView()
      *
-     * @param FormView<T> $view
+     * @param FormView<T>      $view
      * @param FormInterface<T> $form
      */
     public function buildView(FormView $view, FormInterface $form, array $options);
@@ -53,7 +53,7 @@ interface FormTypeExtensionInterface
      *
      * @see FormTypeInterface::finishView()
      *
-     * @param FormView<T> $view
+     * @param FormView<T>      $view
      * @param FormInterface<T> $form
      */
     public function finishView(FormView $view, FormInterface $form, array $options);

--- a/src/Symfony/Component/Form/FormTypeExtensionInterface.php
+++ b/src/Symfony/Component/Form/FormTypeExtensionInterface.php
@@ -63,7 +63,7 @@ interface FormTypeExtensionInterface
     /**
      * Gets the extended types.
      *
-     * @return iterable<class-string<FormTypeInterface>>
+     * @return string[]
      */
     public static function getExtendedTypes(): iterable;
 }

--- a/src/Symfony/Component/Form/FormTypeExtensionInterface.php
+++ b/src/Symfony/Component/Form/FormTypeExtensionInterface.php
@@ -15,6 +15,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T
  */
 interface FormTypeExtensionInterface
 {
@@ -25,6 +27,8 @@ interface FormTypeExtensionInterface
      * further modify it.
      *
      * @see FormTypeInterface::buildForm()
+     *
+     * @param FormBuilderInterface<T> $builder
      */
     public function buildForm(FormBuilderInterface $builder, array $options);
 
@@ -35,6 +39,9 @@ interface FormTypeExtensionInterface
      * further modify it.
      *
      * @see FormTypeInterface::buildView()
+     *
+     * @param FormView<T> $view
+     * @param FormInterface<T> $form
      */
     public function buildView(FormView $view, FormInterface $form, array $options);
 
@@ -45,6 +52,9 @@ interface FormTypeExtensionInterface
      * further modify it.
      *
      * @see FormTypeInterface::finishView()
+     *
+     * @param FormView<T> $view
+     * @param FormInterface<T> $form
      */
     public function finishView(FormView $view, FormInterface $form, array $options);
 
@@ -53,7 +63,7 @@ interface FormTypeExtensionInterface
     /**
      * Gets the extended types.
      *
-     * @return string[]
+     * @return iterable<class-string<FormTypeInterface>>
      */
     public static function getExtendedTypes(): iterable;
 }

--- a/src/Symfony/Component/Form/FormTypeInterface.php
+++ b/src/Symfony/Component/Form/FormTypeInterface.php
@@ -15,6 +15,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T
  */
 interface FormTypeInterface
 {
@@ -25,6 +27,8 @@ interface FormTypeInterface
      * top most type. Type extensions can further modify the form.
      *
      * @see FormTypeExtensionInterface::buildForm()
+     *
+     * @param FormBuilderInterface<T> $builder
      */
     public function buildForm(FormBuilderInterface $builder, array $options);
 
@@ -39,6 +43,9 @@ interface FormTypeInterface
      * to do so, move your logic to {@link finishView()} instead.
      *
      * @see FormTypeExtensionInterface::buildView()
+     *
+     * @param FormView<T> $view
+     * @param FormInterface<T> $form
      */
     public function buildView(FormView $view, FormInterface $form, array $options);
 
@@ -54,6 +61,9 @@ interface FormTypeInterface
      * else you are recommended to implement {@link buildView()} instead.
      *
      * @see FormTypeExtensionInterface::finishView()
+     *
+     * @param FormView<T> $view
+     * @param FormInterface<T> $form
      */
     public function finishView(FormView $view, FormInterface $form, array $options);
 

--- a/src/Symfony/Component/Form/FormTypeInterface.php
+++ b/src/Symfony/Component/Form/FormTypeInterface.php
@@ -44,7 +44,7 @@ interface FormTypeInterface
      *
      * @see FormTypeExtensionInterface::buildView()
      *
-     * @param FormView<T> $view
+     * @param FormView<T>      $view
      * @param FormInterface<T> $form
      */
     public function buildView(FormView $view, FormInterface $form, array $options);
@@ -62,7 +62,7 @@ interface FormTypeInterface
      *
      * @see FormTypeExtensionInterface::finishView()
      *
-     * @param FormView<T> $view
+     * @param FormView<T>      $view
      * @param FormInterface<T> $form
      */
     public function finishView(FormView $view, FormInterface $form, array $options);

--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -17,6 +17,8 @@ use Symfony\Component\Form\Exception\BadMethodCallException;
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @template T
+ *
+ * @implements \IteratorAggregate<string, FormView>
  */
 class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
 {
@@ -154,7 +156,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * Returns an iterator to iterate over children (implements \IteratorAggregate).
      *
-     * @return \ArrayIterator<string, FormView> The iterator
+     * @return \Traversable<string, FormView>
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -15,11 +15,15 @@ use Symfony\Component\Form\Exception\BadMethodCallException;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template T
  */
 class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
 {
     /**
      * The variables assigned to this view.
+     *
+     * @var array{value: ?T, attr: array<array-key, mixed>}&array<string, mixed>
      */
     public $vars = [
         'value' => null,
@@ -28,6 +32,8 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * The parent view.
+     *
+     * @var self|null
      */
     public $parent;
 

--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -25,7 +25,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * The variables assigned to this view.
      *
-     * @var array{value: ?T, attr: array<array-key, mixed>}&array<string, mixed>
+     * @var array{value: mixed, attr: array<array-key, mixed>}&array<string, mixed>
      */
     public $vars = [
         'value' => null,

--- a/src/Symfony/Component/Form/ReversedTransformer.php
+++ b/src/Symfony/Component/Form/ReversedTransformer.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\Form;
  * reverseTransform() method is called and vice versa.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @implements DataTransformerInterface<mixed, mixed>
  */
 class ReversedTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/ReversedTransformer.php
+++ b/src/Symfony/Component/Form/ReversedTransformer.php
@@ -19,12 +19,18 @@ namespace Symfony\Component\Form;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @implements DataTransformerInterface<mixed, mixed>
+ * @template T
+ * @template R
+ *
+ * @implements DataTransformerInterface<T, R>
  */
 class ReversedTransformer implements DataTransformerInterface
 {
     protected $reversedTransformer;
 
+    /**
+     * @param DataTransformerInterface<R, T> $reversedTransformer
+     */
     public function __construct(DataTransformerInterface $reversedTransformer)
     {
         $this->reversedTransformer = $reversedTransformer;

--- a/src/Symfony/Component/Form/SubmitButton.php
+++ b/src/Symfony/Component/Form/SubmitButton.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Form;
  * A button that submits the form.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @extends Button<SubmitButton>
  */
 class SubmitButton extends Button implements ClickableInterface
 {

--- a/src/Symfony/Component/Form/SubmitButtonBuilder.php
+++ b/src/Symfony/Component/Form/SubmitButtonBuilder.php
@@ -15,13 +15,13 @@ namespace Symfony\Component\Form;
  * A builder for {@link SubmitButton} instances.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @extends ButtonBuilder<SubmitButton>
  */
 class SubmitButtonBuilder extends ButtonBuilder
 {
     /**
-     * Creates the button.
-     *
-     * @return SubmitButton The button
+     * {@inheritdoc}
      */
     public function getForm()
     {

--- a/src/Symfony/Component/Form/Tests/Fixtures/FixedDataTransformer.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FixedDataTransformer.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Form\Tests\Fixtures;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 
+/**
+ * @implements DataTransformerInterface<mixed, mixed>
+ */
 class FixedDataTransformer implements DataTransformerInterface
 {
     private $mapping;
@@ -23,6 +26,9 @@ class FixedDataTransformer implements DataTransformerInterface
         $this->mapping = $mapping;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function transform($value)
     {
         if (!\array_key_exists($value, $this->mapping)) {
@@ -32,6 +38,9 @@ class FixedDataTransformer implements DataTransformerInterface
         return $this->mapping[$value];
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function reverseTransform($value)
     {
         $result = array_search($value, $this->mapping, true);

--- a/src/Symfony/Component/Form/Util/OrderedHashMap.php
+++ b/src/Symfony/Component/Form/Util/OrderedHashMap.php
@@ -63,6 +63,12 @@ namespace Symfony\Component\Form\Util;
  *     }
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @template TKey
+ * @template TValue
+ *
+ * @implements \IteratorAggregate<TKey, TValue>
+ * @implements \ArrayAccess<TKey, TValue>
  */
 class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
 {

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -81,8 +81,6 @@ class Cookie
      * @param bool                          $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
      * @param bool                          $raw      Whether the cookie value should be sent with no url encoding
      * @param self::SAMESITE_*|''|null      $sameSite Whether the cookie will be available for cross-site requests
-     *
-     * @throws \InvalidArgumentException
      */
     public static function create(string $name, string $value = null, $expire = 0, ?string $path = '/', string $domain = null, bool $secure = null, bool $httpOnly = true, bool $raw = false, ?string $sameSite = self::SAMESITE_LAX): self
     {
@@ -99,8 +97,6 @@ class Cookie
      * @param bool                          $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
      * @param bool                          $raw      Whether the cookie value should be sent with no url encoding
      * @param self::SAMESITE_*|''|null      $sameSite Whether the cookie will be available for cross-site requests
-     *
-     * @throws \InvalidArgumentException
      */
     public function __construct(string $name, string $value = null, $expire = 0, ?string $path = '/', string $domain = null, bool $secure = null, bool $httpOnly = true, bool $raw = false, ?string $sameSite = self::SAMESITE_LAX)
     {

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -71,6 +71,19 @@ class Cookie
         return new static($name, $value, $data['expires'], $data['path'], $data['domain'], $data['secure'], $data['httponly'], $data['raw'], $data['samesite']);
     }
 
+    /**
+     * @param string                        $name     The name of the cookie
+     * @param string|null                   $value    The value of the cookie
+     * @param int|string|\DateTimeInterface $expire   The time the cookie expires
+     * @param string                        $path     The path on the server in which the cookie will be available on
+     * @param string|null                   $domain   The domain that the cookie is available to
+     * @param bool|null                     $secure   Whether the client should send back the cookie only over HTTPS or null to auto-enable this when the request is already using HTTPS
+     * @param bool                          $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
+     * @param bool                          $raw      Whether the cookie value should be sent with no url encoding
+     * @param self::SAMESITE_*|''|null      $sameSite Whether the cookie will be available for cross-site requests
+     *
+     * @throws \InvalidArgumentException
+     */
     public static function create(string $name, string $value = null, $expire = 0, ?string $path = '/', string $domain = null, bool $secure = null, bool $httpOnly = true, bool $raw = false, ?string $sameSite = self::SAMESITE_LAX): self
     {
         return new self($name, $value, $expire, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
@@ -85,11 +98,11 @@ class Cookie
      * @param bool|null                     $secure   Whether the client should send back the cookie only over HTTPS or null to auto-enable this when the request is already using HTTPS
      * @param bool                          $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
      * @param bool                          $raw      Whether the cookie value should be sent with no url encoding
-     * @param string|null                   $sameSite Whether the cookie will be available for cross-site requests
+     * @param self::SAMESITE_*|''|null      $sameSite Whether the cookie will be available for cross-site requests
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(string $name, string $value = null, $expire = 0, ?string $path = '/', string $domain = null, bool $secure = null, bool $httpOnly = true, bool $raw = false, ?string $sameSite = 'lax')
+    public function __construct(string $name, string $value = null, $expire = 0, ?string $path = '/', string $domain = null, bool $secure = null, bool $httpOnly = true, bool $raw = false, ?string $sameSite = self::SAMESITE_LAX)
     {
         // from PHP source code
         if ($raw && false !== strpbrk($name, self::$reservedCharsList)) {
@@ -233,6 +246,8 @@ class Cookie
 
     /**
      * Creates a cookie copy with SameSite attribute.
+     *
+     * @param self::SAMESITE_*|null $sameSite
      *
      * @return static
      */
@@ -407,7 +422,7 @@ class Cookie
     /**
      * Gets the SameSite attribute.
      *
-     * @return string|null
+     * @return self::SAMESITE_*|null
      */
     public function getSameSite()
     {

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\HttpFoundation;
  * HeaderBag is a container for HTTP headers.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @implements \IteratorAggregate<string, string|string[]>
  */
 class HeaderBag implements \IteratorAggregate, \Countable
 {
@@ -250,7 +252,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
     /**
      * Returns an iterator for headers.
      *
-     * @return \ArrayIterator An \ArrayIterator instance
+     * @return \Traversable<string, string|string[]>
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -17,6 +17,8 @@ use Symfony\Component\HttpFoundation\Exception\BadRequestException;
  * ParameterBag is a container for key/value pairs.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @implements \IteratorAggregate<string, mixed>
  */
 class ParameterBag implements \IteratorAggregate, \Countable
 {
@@ -205,7 +207,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns an iterator for parameters.
      *
-     * @return \ArrayIterator An \ArrayIterator instance
+     * @return \Traversable<string, mixed>
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Attribute/AttributeBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Attribute/AttributeBag.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\HttpFoundation\Session\Attribute;
 
 /**
  * This class relates to session attribute storage.
+ *
+ * @implements \IteratorAggregate<string, mixed>
  */
 class AttributeBag implements AttributeBagInterface, \IteratorAggregate, \Countable
 {
@@ -129,7 +131,7 @@ class AttributeBag implements AttributeBagInterface, \IteratorAggregate, \Counta
     /**
      * Returns an iterator for attributes.
      *
-     * @return \ArrayIterator An \ArrayIterator instance
+     * @return \Traversable<string, mixed>
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -26,6 +26,8 @@ class_exists(SessionBagProxy::class);
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Drak <drak@zikula.org>
+ *
+ * @implements \IteratorAggregate<string, mixed>
  */
 class Session implements SessionInterface, \IteratorAggregate, \Countable
 {
@@ -126,7 +128,7 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
     /**
      * Returns an iterator for attributes.
      *
-     * @return \ArrayIterator An \ArrayIterator instance
+     * @return \Traversable<string, mixed>
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -27,6 +27,8 @@ use Symfony\Component\Process\Pipes\WindowsPipes;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Romain Neutron <imprec@gmail.com>
+ *
+ * @implements \IteratorAggregate<string, string>
  */
 class Process implements \IteratorAggregate
 {
@@ -615,7 +617,7 @@ class Process implements \IteratorAggregate
      * @throws LogicException in case the output has been disabled
      * @throws LogicException In case the process is not started
      *
-     * @return \Generator
+     * @return \Generator<string, string>
      */
     public function getIterator(int $flags = 0)
     {

--- a/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\PropertyAccess;
  * A sequence of property names or array indices.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @extends \Traversable<int, string>
  */
 interface PropertyPathInterface extends \Traversable
 {

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -22,6 +22,8 @@ use Symfony\Component\Config\Resource\ResourceInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Tobias Schultze <http://tobion.de>
+ *
+ * @implements \IteratorAggregate<Route>
  */
 class RouteCollection implements \IteratorAggregate, \Countable
 {
@@ -54,7 +56,7 @@ class RouteCollection implements \IteratorAggregate, \Countable
      *
      * @see all()
      *
-     * @return \ArrayIterator|Route[] An \ArrayIterator object for iterating over routes
+     * @return \Traversable<Route> An \ArrayIterator object for iterating over routes
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/PassportInterface.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/PassportInterface.php
@@ -39,6 +39,13 @@ interface PassportInterface
 
     public function hasBadge(string $badgeFqcn): bool;
 
+    /**
+     * @template T of BadgeInterface
+     *
+     * @param class-string<T> $badgeFqcn
+     *
+     * @return T|null
+     */
     public function getBadge(string $badgeFqcn): ?BadgeInterface;
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -27,12 +27,14 @@ interface DenormalizerInterface
     /**
      * Denormalizes data back into an object of the given class.
      *
-     * @param mixed  $data    Data to restore
-     * @param string $type    The expected class to instantiate
-     * @param string $format  Format the given data was extracted from
-     * @param array  $context Options available to the denormalizer
+     * @template TObject of object
      *
-     * @return mixed
+     * @param mixed                        $data    Data to restore
+     * @param string|class-string<TObject> $type    The expected class to instantiate
+     * @param string|null                  $format  Format the given data was extracted from
+     * @param array                        $context Options available to the denormalizer
+     *
+     * @return TObject|mixed
      *
      * @throws BadMethodCallException   Occurs when the normalizer is not called in an expected context
      * @throws InvalidArgumentException Occurs when the arguments are not coherent or not supported

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -27,14 +27,12 @@ interface DenormalizerInterface
     /**
      * Denormalizes data back into an object of the given class.
      *
-     * @template TObject of object
+     * @param mixed  $data    Data to restore
+     * @param string $type    The expected class to instantiate
+     * @param string $format  Format the given data was extracted from
+     * @param array  $context Options available to the denormalizer
      *
-     * @param mixed                        $data    Data to restore
-     * @param string|class-string<TObject> $type    The expected class to instantiate
-     * @param string|null                  $format  Format the given data was extracted from
-     * @param array                        $context Options available to the denormalizer
-     *
-     * @return TObject|mixed
+     * @return mixed
      *
      * @throws BadMethodCallException   Occurs when the normalizer is not called in an expected context
      * @throws InvalidArgumentException Occurs when the arguments are not coherent or not supported

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -30,9 +30,12 @@ interface SerializerInterface
     /**
      * Deserializes data into the given type.
      *
-     * @param mixed $data
+     * @template TObject of object
      *
-     * @return mixed
+     * @param mixed                        $data
+     * @param string|class-string<TObject> $type
+     *
+     * @return TObject|mixed
      */
     public function deserialize($data, string $type, string $format, array $context = []);
 }

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -30,12 +30,9 @@ interface SerializerInterface
     /**
      * Deserializes data into the given type.
      *
-     * @template TObject of object
+     * @param mixed $data
      *
-     * @param mixed                        $data
-     * @param string|class-string<TObject> $type
-     *
-     * @return TObject|mixed
+     * @return mixed
      */
     public function deserialize($data, string $type, string $format, array $context = []);
 }

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Validator;
  * Default implementation of {@ConstraintViolationListInterface}.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @implements \IteratorAggregate<ConstraintViolationInterface>
  */
 class ConstraintViolationList implements \IteratorAggregate, ConstraintViolationListInterface
 {
@@ -108,7 +110,7 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
     /**
      * {@inheritdoc}
      *
-     * @return \ArrayIterator|ConstraintViolationInterface[]
+     * @return \Traversable<ConstraintViolationInterface>
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Validator;
  * A list of constraint violations.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @extends \Traversable<int, ConstraintViolationInterface>
  */
 interface ConstraintViolationListInterface extends \Traversable, \Countable, \ArrayAccess
 {

--- a/src/Symfony/Component/Workflow/TransitionBlockerList.php
+++ b/src/Symfony/Component/Workflow/TransitionBlockerList.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Workflow;
  * A list of transition blockers.
  *
  * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ *
+ * @implements \IteratorAggregate<TransitionBlocker>
  */
 final class TransitionBlockerList implements \IteratorAggregate, \Countable
 {
@@ -61,7 +63,7 @@ final class TransitionBlockerList implements \IteratorAggregate, \Countable
     /**
      * {@inheritdoc}
      *
-     * @return \ArrayIterator|TransitionBlocker[]
+     * @return \Traversable<TransitionBlocker>
      */
     public function getIterator(): \Traversable
     {

--- a/src/Symfony/Contracts/Cache/CacheInterface.php
+++ b/src/Symfony/Contracts/Cache/CacheInterface.php
@@ -29,14 +29,16 @@ interface CacheInterface
      * requested key, that could be used e.g. for expiration control. It could also
      * be an ItemInterface instance when its additional features are needed.
      *
-     * @param string                     $key       The key of the item to retrieve from the cache
-     * @param callable|CallbackInterface $callback  Should return the computed value for the given key/item
-     * @param float|null                 $beta      A float that, as it grows, controls the likeliness of triggering
-     *                                              early expiration. 0 disables it, INF forces immediate expiration.
-     *                                              The default (or providing null) is implementation dependent but should
-     *                                              typically be 1.0, which should provide optimal stampede protection.
-     *                                              See https://en.wikipedia.org/wiki/Cache_stampede#Probabilistic_early_expiration
-     * @param array                      &$metadata The metadata of the cached item {@see ItemInterface::getMetadata()}
+     * @template T
+     *
+     * @param string                                               $key       The key of the item to retrieve from the cache
+     * @param callable(CacheItemInterface, bool)|CallbackInterface $callback  Should return the computed value for the given key/item
+     * @param float|null                                           $beta      A float that, as it grows, controls the likeliness of triggering
+     *                                                                        early expiration. 0 disables it, INF forces immediate expiration.
+     *                                                                        The default (or providing null) is implementation dependent but should
+     *                                                                        typically be 1.0, which should provide optimal stampede protection.
+     *                                                                        See https://en.wikipedia.org/wiki/Cache_stampede#Probabilistic_early_expiration
+     * @param array|null                                           &$metadata The metadata of the cached item {@see ItemInterface::getMetadata()}
      *
      * @return mixed The value corresponding to the provided key
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

I noticed that both PhpStorm and Psalm were both not inferring the correct return type for `PassportInterface::getBadge()`, instead they would type it as `BadgeInterface|null`. Essentially this is correct but if a not-null value is returned, it's always an instance of the type of `$badgeFqcn`.

In PhpStorm I at first fixed this with the following snippet in `.phpstorm.meta.php` but Psalm does not pick it up for some reason:

```php
<?php

namespace PHPSTORM_META {
    use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;

    override(PassportInterface::getBadge(), type(0));
}
```

So with this commit I propose to add the following docblock to `PassportInterface::getBadge()`:

```php
/**
 * @template T of BadgeInterface
 *
 * @param class-string<T> $badgeFqcn
 *
 * @return T|null
 */
```

This works with both PhpStorm and Psalm but if this causes issues for other IDEs, they can be prefixed with `psalm-`. Not sure what the policy is for docblocks in this case 😄 