### PR TITLE
[ErrorHandler] Avoid calling xdebug_get_function_stack() in xdebug >= 3.0 when not in develop mode

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Error/FatalError.php
+++ b/src/Symfony/Component/ErrorHandler/Error/FatalError.php
@@ -33,7 +33,9 @@ class FatalError extends \Error
                 }
             }
         } elseif (null !== $traceOffset) {
-            if (\function_exists('xdebug_get_function_stack') && $trace = @xdebug_get_function_stack()) {
+            // xdebug >= 3.0 has an ini xdebug.mode (not present in v2) that must be set to 'develop' for xdebug_get_function_stack()
+            if (\function_exists('xdebug_get_function_stack') && in_array(ini_get('xdebug.mode'), ['develop', false], true)) {
+                $trace = xdebug_get_function_stack();
                 if (0 < $traceOffset) {
                     array_splice($trace, -$traceOffset);
                 }

--- a/src/Symfony/Component/ErrorHandler/Error/FatalError.php
+++ b/src/Symfony/Component/ErrorHandler/Error/FatalError.php
@@ -34,7 +34,7 @@ class FatalError extends \Error
             }
         } elseif (null !== $traceOffset) {
             // xdebug >= 3.0 has an ini xdebug.mode (not present in v2) that must be set to 'develop' for xdebug_get_function_stack()
-            if (\function_exists('xdebug_get_function_stack') && in_array(ini_get('xdebug.mode'), ['develop', false], true)) {
+            if (\function_exists('xdebug_get_function_stack') && \in_array(ini_get('xdebug.mode'), ['develop', false], true)) {
                 $trace = xdebug_get_function_stack();
                 if (0 < $traceOffset) {
                     array_splice($trace, -$traceOffset);


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #40679
| License       | MIT
| Doc PR        | none

When the application is already dealing with a FatalError, we should avoid calling `xdebug_get_function_stack()` in situations we know will produce another php_error from within xdebug itself.

https://github.com/xdebug/xdebug/blob/90fa09d230603f3d972dd00cf02440cf3d35d2ee/src/develop/stack.c#L1003-L1007

`xdebug_get_function_stack()` can be called in xdebug < 3.0 (ie: `ini_get('xdebug.mode')` will return false since it doesn't not exist

OR

`xdebug_get_function_stack()` can be called in xdebug >= 3.0 when `ini_get('xdebug.mode')` returns `develop`.