### PR TITLE
[Security] [LoginLink] remove experimental

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.3
 ---
 
+ * Login Link functionality is no longer experimental
  * Add `required_badges` firewall config option
  * [BC break] Add `login_throttling.lock_factory` setting defaulting to `null` (instead of `lock.factory`)
  * Add a `login_throttling.interval` (in `security.firewalls`) option to change the default throttling interval.

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginLinkFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginLinkFactory.php
@@ -24,7 +24,6 @@ use Symfony\Component\Security\Http\LoginLink\LoginLinkHandler;
 
 /**
  * @internal
- * @experimental in 5.3
  */
 class LoginLinkFactory extends AbstractFactory implements AuthenticatorFactoryInterface
 {

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.3
 ---
 
+ * Login Link functionality is no longer experimental
  * Add `RememberMeConditionsListener` to check if remember me is requested and supported, and set priority of `RememberMeListener` to -63
  * Add `RememberMeHandlerInterface` and implementations, used as a replacement of `RememberMeServicesInterface` when using the AuthenticatorManager
  * Add `TokenDeauthenticatedEvent` that is dispatched when the current security token is deauthenticated

--- a/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/LoginLinkAuthenticator.php
@@ -28,7 +28,6 @@ use Symfony\Component\Security\Http\LoginLink\LoginLinkHandlerInterface;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- * @experimental in 5.3
  */
 final class LoginLinkAuthenticator extends AbstractAuthenticator implements InteractiveAuthenticatorInterface
 {

--- a/src/Symfony/Component/Security/Http/LoginLink/Exception/ExpiredLoginLinkException.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/Exception/ExpiredLoginLinkException.php
@@ -15,7 +15,6 @@ use Symfony\Component\Security\Core\Signature\Exception\ExpiredSignatureExceptio
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- * @experimental in 5.3
  */
 class ExpiredLoginLinkException extends ExpiredSignatureException implements InvalidLoginLinkExceptionInterface
 {

--- a/src/Symfony/Component/Security/Http/LoginLink/Exception/InvalidLoginLinkAuthenticationException.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/Exception/InvalidLoginLinkAuthenticationException.php
@@ -17,7 +17,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  * Thrown when a login link is invalid.
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
- * @experimental in 5.3
  */
 class InvalidLoginLinkAuthenticationException extends AuthenticationException
 {

--- a/src/Symfony/Component/Security/Http/LoginLink/Exception/InvalidLoginLinkException.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/Exception/InvalidLoginLinkException.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Security\Http\LoginLink\Exception;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- * @experimental in 5.3
  */
 class InvalidLoginLinkException extends \RuntimeException implements InvalidLoginLinkExceptionInterface
 {

--- a/src/Symfony/Component/Security/Http/LoginLink/Exception/InvalidLoginLinkExceptionInterface.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/Exception/InvalidLoginLinkExceptionInterface.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Security\Http\LoginLink\Exception;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- * @experimental in 5.3
  */
 interface InvalidLoginLinkExceptionInterface extends \Throwable
 {

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkDetails.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkDetails.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Security\Http\LoginLink;
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- * @experimental in 5.3
  */
 class LoginLinkDetails
 {

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandler.php
@@ -25,7 +25,6 @@ use Symfony\Component\Security\Http\LoginLink\Exception\InvalidLoginLinkExceptio
 
 /**
  * @author Ryan Weaver <ryan@symfonycasts.com>
- * @experimental in 5.3
  */
 final class LoginLinkHandler implements LoginLinkHandlerInterface
 {

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkHandlerInterface.php
@@ -18,7 +18,6 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * A class that is able to create and handle "magic" login links.
  *
  * @author Ryan Weaver <ryan@symfonycasts.com>
- * @experimental in 5.3
  */
 interface LoginLinkHandlerInterface
 {

--- a/src/Symfony/Component/Security/Http/LoginLink/LoginLinkNotification.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/LoginLinkNotification.php
@@ -25,8 +25,6 @@ use Symfony\Component\Notifier\Recipient\SmsRecipientInterface;
  * emails/SMS using the Notifier component.
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
- *
- * @experimental in 5.3
  */
 class LoginLinkNotification extends Notification implements EmailNotificationInterface, SmsNotificationInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | tbd

Symfony's new security Login Link functionality is no longer experimental as of 5.3
