### PR TITLE
[WebProfilerBundle] Use ControllerReference instead of URL in twig render()

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
@@ -3,7 +3,7 @@
 {% block head %}
     {% if collector.hasexception %}
         <style>
-            {{ render(path('_profiler_exception_css', { token: token })) }}
+            {{ render(controller('web_profiler.controller.exception_panel::stylesheet', { token: token })) }}
             {{ include('@WebProfiler/Collector/exception.css.twig') }}
         </style>
     {% endif %}
@@ -31,7 +31,7 @@
         </div>
     {% else %}
         <div class="sf-reset">
-            {{ render(path('_profiler_exception', { token: token })) }}
+            {{ render(controller('web_profiler.controller.exception_panel::body', { token: token })) }}
         </div>
     {% endif %}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/router.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/router.html.twig
@@ -10,5 +10,5 @@
 {% endblock %}
 
 {% block panel %}
-    {{ render(path('_profiler_router', { token: token })) }}
+    {{ render(controller('web_profiler.controller.router::panelAction', { token: token })) }}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -108,7 +108,7 @@
                             {{ include('@WebProfiler/Icon/search.svg') }} <span class="hidden-small">Search</span>
                         </a>
 
-                        {{ render(path('_profiler_search_bar', request.query.all)) }}
+                        {{ render(controller('web_profiler.controller.profiler::searchBarAction', request.query.all)) }}
                     </div>
                 </div>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40709
| License       | MIT
| Doc PR        | 

Use `ControllerReference` instead of `UrlGenerator`'s URL. Helps to deal with different baseUrl

Feel free to help me with some advice. Thank you in advance

