### PR TITLE
[Security] Stop using a shared changelog for our security packages

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -1,6 +1,8 @@
 CHANGELOG
 =========
 
+The CHANGELOG for version 5.4 and newer can be found in the security sub-packages (e.g. `Http/`).
+
 5.3
 ---
 

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.3
+---
+
+The CHANGELOG for version 5.3 and earlier can be found at https://github.com/symfony/symfony/blob/5.3/src/Symfony/Component/Security/CHANGELOG.md

--- a/src/Symfony/Component/Security/Csrf/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Csrf/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.3
+---
+
+The CHANGELOG for version 5.3 and earlier can be found at https://github.com/symfony/symfony/blob/5.3/src/Symfony/Component/Security/CHANGELOG.md

--- a/src/Symfony/Component/Security/Guard/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Guard/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.3
+---
+
+The CHANGELOG for version 5.3 and earlier can be found at https://github.com/symfony/symfony/blob/5.3/src/Symfony/Component/Security/CHANGELOG.md

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.3
+---
+
+The CHANGELOG for version 5.3 and earlier can be found at https://github.com/symfony/symfony/blob/5.3/src/Symfony/Component/Security/CHANGELOG.md


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I understand there are historical reasons for why our four security packages share a changelog. However, I dont believe it makes much sense moving forward. 

I suggest that ~~6.0~~ will start using separate changelogs. 

#### Update

Lets start in 5.4 for the reasons explained by Christophe
