### PR TITLE
Fixed the deprecation message about Master/Main requests

### DIFF
--- a/src/Symfony/Component/HttpKernel/Event/KernelEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/KernelEvent.php
@@ -85,7 +85,7 @@ class KernelEvent extends Event
      */
     public function isMasterRequest()
     {
-        trigger_deprecation('symfony/http-kernel', '5.3', '"%s()" is deprecated, use "isMainRequest()" instead.');
+        trigger_deprecation('symfony/http-kernel', '5.3', '"%s()" is deprecated, use "isMainRequest()" instead.', __METHOD__);
 
         return $this->isMainRequest();
     }

--- a/src/Symfony/Component/Security/Http/Event/LazyResponseEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/LazyResponseEvent.php
@@ -78,7 +78,7 @@ final class LazyResponseEvent extends RequestEvent
      */
     public function isMasterRequest(): bool
     {
-        trigger_deprecation('symfony/security-http', '5.3', '"%s()" is deprecated, use "isMainRequest()" instead.');
+        trigger_deprecation('symfony/security-http', '5.3', '"%s()" is deprecated, use "isMainRequest()" instead.', __METHOD__);
 
         return $this->event->isMainRequest();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I saw this while running tests in an app just updated to 5.x version:

```
Remaining direct deprecation notices (61)

  61x: Since symfony/http-kernel 5.3: "%s()" is deprecated, use "isMainRequest()" instead.
```