### PR TITLE
[Routing] Fix supporting string "methods" and "schemes" on the Route annotation

### DIFF
--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -41,8 +41,8 @@ class Route
      * @param array|string      $data         data array managed by the Doctrine Annotations library or the path
      * @param array|string|null $path
      * @param string[]          $requirements
-     * @param string[]          $methods
-     * @param string[]          $schemes
+     * @param string[]|string   $methods
+     * @param string[]|string   $schemes
      *
      * @throws \BadMethodCallException
      */
@@ -54,8 +54,8 @@ class Route
         array $options = [],
         array $defaults = [],
         string $host = null,
-        array $methods = [],
-        array $schemes = [],
+        $methods = [],
+        $schemes = [],
         string $condition = null,
         int $priority = null,
         string $locale = null,

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/MethodsAndSchemes.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotationFixtures/MethodsAndSchemes.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotationFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+final class MethodsAndSchemes
+{
+    /**
+     * @Route("/array-many", name="array_many", methods={"GET", "POST"}, schemes={"http", "https"})
+     */
+    public function arrayMany(): void
+    {
+    }
+
+    /**
+     * @Route("/array-one", name="array_one", methods={"GET"}, schemes={"http"})
+     */
+    public function arrayOne(): void
+    {
+    }
+
+    /**
+     * @Route("/string", name="string", methods="POST", schemes="https")
+     */
+    public function string(): void
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/MethodsAndSchemes.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AttributeFixtures/MethodsAndSchemes.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AttributeFixtures;
+
+use Symfony\Component\Routing\Annotation\Route;
+
+final class MethodsAndSchemes
+{
+    #[Route(path: '/array-many', name: 'array_many', methods: ['GET', 'POST'], schemes: ['http', 'https'])]
+    public function arrayMany(): void
+    {
+    }
+
+    #[Route(path: '/array-one', name: 'array_one', methods: ['GET'], schemes: ['http'])]
+    public function arrayOne(): void
+    {
+    }
+
+    #[Route(path: '/string', name: 'string', methods: 'POST', schemes: 'https')]
+    public function string(): void
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -258,5 +258,17 @@ abstract class AnnotationClassLoaderTest extends TestCase
         $this->assertSame('/path', $routes->get('action')->getPath());
     }
 
+    public function testMethodsAndSchemes()
+    {
+        $routes = $this->loader->load($this->getNamespace().'\MethodsAndSchemes');
+
+        $this->assertSame(['GET', 'POST'], $routes->get('array_many')->getMethods());
+        $this->assertSame(['http', 'https'], $routes->get('array_many')->getSchemes());
+        $this->assertSame(['GET'], $routes->get('array_one')->getMethods());
+        $this->assertSame(['http'], $routes->get('array_one')->getSchemes());
+        $this->assertSame(['POST'], $routes->get('string')->getMethods());
+        $this->assertSame(['https'], $routes->get('string')->getSchemes());
+    }
+
     abstract protected function getNamespace(): string;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/40796
| License       | MIT
| Doc PR        | -