### PR TITLE
[FrameworkBundle] Fix array controller link in debug:router

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Descriptor/TextDescriptor.php
@@ -554,6 +554,10 @@ class TextDescriptor extends Descriptor
                 $r = new \ReflectionFunction($controller);
             }
         } catch (\ReflectionException $e) {
+            if (\is_array($controller)) {
+                $controller = implode('::', $controller);
+            }
+
             $id = $controller;
             $method = '__invoke';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`debug:router` is broken when you add a route in the Kernel (see https://symfony.com/doc/current/configuration/micro_kernel_trait.html) because `kernel` is not a class and triggers a `\ReflectionException`. The code in the exception handling always expect `$controller` to be a string.