### PR TITLE
[Config] Add command to dump ConfigBuilders

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpBuilderCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpBuilderCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Config\Builder\ConfigBuilderGeneratorInterface;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+/**
+ * A command for dumping all config builder for your bundles.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * @final
+ */
+class ConfigDumpBuilderCommand extends AbstractConfigCommand
+{
+    protected static $defaultName = 'config:dump-builders';
+    protected static $defaultDescription = 'Dump the config builder for an extension';
+
+    private $generator;
+
+    public function __construct(ConfigBuilderGeneratorInterface $generator)
+    {
+        $this->generator = $generator;
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setDefinition([
+                new InputArgument('name', InputArgument::OPTIONAL, 'The Bundle name or the extension alias'),
+            ])
+            ->setDescription(self::$defaultDescription)
+            ->setHelp(<<<'EOF'
+The <info>%command.name%</info> command dumps "configuration bundles" that help
+writing configuration for an extension/bundle.
+
+Either the extension alias or bundle name can be used:
+
+  <info>php %command.full_name% framework</info>
+  <info>php %command.full_name% FrameworkBundle</info>
+
+EOF
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \LogicException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $errorIo = $io->getErrorStyle();
+
+        if (null !== $name = $input->getArgument('name')) {
+            $extensions = [$this->findExtension($name)];
+        } else {
+            $extensions = array_map(function (BundleInterface $a) {
+                return $a->getContainerExtension();
+            }, $this->getApplication()->getKernel()->getBundles());
+        }
+
+        foreach ($extensions as $extension) {
+            if (null === $extension) {
+                continue;
+            }
+
+            try {
+                $this->dumpExtension($extension);
+            } catch (\Throwable $e) {
+                $errorIo->error(sprintf('Could not dump configuration for "%s". Exception: %s', \get_class($extension), $e->getMessage()));
+            }
+        }
+
+        return 0;
+    }
+
+    private function dumpExtension(ExtensionInterface $extension): void
+    {
+        if ($extension instanceof ConfigurationInterface) {
+            $configuration = $extension;
+        } else {
+            $configuration = $extension->getConfiguration([], $this->getContainerBuilder());
+        }
+
+        $this->generator->build($configuration);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -425,6 +425,7 @@ class FrameworkExtension extends Extension
         $this->registerAnnotationsConfiguration($config['annotations'], $container, $loader);
         $this->registerPropertyAccessConfiguration($config['property_access'], $container, $loader);
         $this->registerSecretsConfiguration($config['secrets'], $container, $loader);
+        $loader->load('config.php');
 
         if ($this->isConfigEnabled($container, $config['serializer'])) {
             if (!class_exists(\Symfony\Component\Serializer\Serializer::class)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/config.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/config.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\Config\Builder\ConfigBuilderGenerator;
+use Symfony\Component\Config\Builder\ConfigBuilderGeneratorInterface;
+
+return static function (ContainerConfigurator $container) {
+    $container->services()
+        ->set('config.builder_generator', ConfigBuilderGenerator::class)
+        ->args([
+                param('kernel.build_dir'),
+            ])
+        ->alias(ConfigBuilderGeneratorInterface::class, 'config.builder_generator')
+    ;
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -20,6 +20,7 @@ use Symfony\Bundle\FrameworkBundle\Command\CachePoolListCommand;
 use Symfony\Bundle\FrameworkBundle\Command\CachePoolPruneCommand;
 use Symfony\Bundle\FrameworkBundle\Command\CacheWarmupCommand;
 use Symfony\Bundle\FrameworkBundle\Command\ConfigDebugCommand;
+use Symfony\Bundle\FrameworkBundle\Command\ConfigDumpBuilderCommand;
 use Symfony\Bundle\FrameworkBundle\Command\ConfigDumpReferenceCommand;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerDebugCommand;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerLintCommand;
@@ -38,6 +39,7 @@ use Symfony\Bundle\FrameworkBundle\Command\TranslationUpdateCommand;
 use Symfony\Bundle\FrameworkBundle\Command\WorkflowDumpCommand;
 use Symfony\Bundle\FrameworkBundle\Command\YamlLintCommand;
 use Symfony\Bundle\FrameworkBundle\EventListener\SuggestMissingPackageSubscriber;
+use Symfony\Component\Config\Builder\ConfigBuilderGeneratorInterface;
 use Symfony\Component\Console\EventListener\ErrorListener;
 use Symfony\Component\Messenger\Command\ConsumeMessagesCommand;
 use Symfony\Component\Messenger\Command\DebugCommand;
@@ -109,6 +111,12 @@ return static function (ContainerConfigurator $container) {
             ->tag('console.command')
 
         ->set('console.command.config_debug', ConfigDebugCommand::class)
+            ->tag('console.command')
+
+        ->set('console.command.config_dump_builder', ConfigDumpBuilderCommand::class)
+            ->args([
+                service(ConfigBuilderGeneratorInterface::class),
+            ])
             ->tag('console.command')
 
         ->set('console.command.config_dump_reference', ConfigDumpReferenceCommand::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes/no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This will add a command `config:dump-builders` that you can force to dump ConfigBuilders. 

We can discuss if this is needed if we have a cache warmer. Ie, then the ConfigBuilders will be generated on `cache:warmup`. See #40804


