### PR TITLE
[Config][FrameworkBundle] Add CacheWarmer for ConfigBuilder

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Command\BuildDebugContainerTrait;
+use Symfony\Component\Config\Builder\ConfigBuilderGenerator;
+use Symfony\Component\Config\Builder\ConfigBuilderGeneratorInterface;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Generate all config builders.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class ConfigBuilderCacheWarmer implements CacheWarmerInterface
+{
+    use BuildDebugContainerTrait;
+
+    private $kernel;
+    private $logger;
+
+    public function __construct(KernelInterface $kernel, LoggerInterface $logger = null)
+    {
+        $this->kernel = $kernel;
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string[]
+     */
+    public function warmUp(string $cacheDir)
+    {
+        $generator = new ConfigBuilderGenerator($cacheDir);
+
+        foreach ($this->kernel->getBundles() as $bundle) {
+            $extension = $bundle->getContainerExtension();
+            if (null === $extension) {
+                continue;
+            }
+
+            try {
+                $this->dumpExtension($extension, $generator);
+            } catch (\Exception $e) {
+                if ($this->logger) {
+                    $this->logger->warning('Failed to generate ConfigBuilder for extension {extensionClass}.', ['exception' => $e, 'extensionClass' => \get_class($extension)]);
+                }
+            }
+        }
+
+        // No need to preload anything
+        return [];
+    }
+
+    private function dumpExtension(ExtensionInterface $extension, ConfigBuilderGeneratorInterface $generator): void
+    {
+        if ($extension instanceof ConfigurationInterface) {
+            $configuration = $extension;
+        } elseif ($extension instanceof ConfigurationExtensionInterface) {
+            $configuration = $extension->getConfiguration([], $this->getContainerBuilder($this->kernel));
+        } else {
+            throw new \LogicException(sprintf('Could not get configuration for extension "%s".', \get_class($extension)));
+        }
+
+        $generator->build($configuration);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isOptional()
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Bundle\FrameworkBundle\CacheWarmer\ConfigBuilderCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
 use Symfony\Component\Config\Resource\SelfCheckingResourceChecker;
 use Symfony\Component\Config\ResourceCheckerConfigCacheFactory;
@@ -208,5 +209,8 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('container.getenv'),
             ])
+        ->set('config_builder.warmer', ConfigBuilderCacheWarmer::class)
+            ->args([service(KernelInterface::class), service('logger')->nullOnInvalid()])
+            ->tag('kernel.cache_warmer')
     ;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | 
| Tickets       | 
| License       | MIT
| Doc PR        | 

Make sure ConfigBuilder exists before you write your first line of config.

This is similar to #40803
