### PR TITLE
Improve deprecation message for session

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/SessionPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/SessionPass.php
@@ -26,20 +26,22 @@ class SessionPass implements CompilerPassInterface
             return;
         }
 
-        // BC layer: Make "session" an alias of ".session.do-not-use" when not overriden by the user
+        // BC layer: Make "session" an alias of ".session.do-not-use" when not overridden by the user
         if (!$container->has('session')) {
             $alias = $container->setAlias('session', '.session.do-not-use');
-            $alias->setDeprecated('symfony/framework-bundle', '5.3', 'The "%alias_id%" service is deprecated, use "$requestStack->getSession()" instead.');
+            $alias->setDeprecated('symfony/framework-bundle', '5.3', 'The "%alias_id%" service and "SessionInterface" alias are deprecated, use "$requestStack->getSession()" instead.');
+            // restore previous behavior
+            $alias->setPublic(true);
 
             return;
         }
 
         if ($container->hasDefinition('session')) {
             $definition = $container->getDefinition('session');
-            $definition->setDeprecated('symfony/framework-bundle', '5.3', 'The "%service_id%" service is deprecated, use "$requestStack->getSession()" instead.');
+            $definition->setDeprecated('symfony/framework-bundle', '5.3', 'The "%service_id%" service and "SessionInterface" alias are deprecated, use "$requestStack->getSession()" instead.');
         } else {
             $alias = $container->getAlias('session');
-            $alias->setDeprecated('symfony/framework-bundle', '5.3', 'The "%alias_id%" alias is deprecated, use "$requestStack->getSession()" instead.');
+            $alias->setDeprecated('symfony/framework-bundle', '5.3', 'The "%alias_id%" and "SessionInterface" aliases are deprecated, use "$requestStack->getSession()" instead.');
             $definition = $container->findDefinition('session');
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
@@ -88,7 +88,7 @@ return static function (ContainerConfigurator $container) {
         ->set('.session.deprecated', SessionInterface::class) // to be removed in 6.0
             ->factory([inline_service(DeprecatedSessionFactory::class)->args([service('request_stack')]), 'getSession'])
         ->alias(SessionInterface::class, '.session.do-not-use')
-            ->deprecate('symfony/framework-bundle', '5.3', 'The "%alias_id%" alias is deprecated, use "$requestStack->getSession()" instead.')
+            ->deprecate('symfony/framework-bundle', '5.3', 'The "%alias_id%" and "SessionInterface" aliases are deprecated, use "$requestStack->getSession()" instead.')
         ->alias(SessionStorageInterface::class, 'session.storage')
             ->deprecate('symfony/framework-bundle', '5.3', 'The "%alias_id%" alias is deprecated, use "session.storage.factory" instead.')
         ->alias(\SessionHandlerInterface::class, 'session.handler')

--- a/src/Symfony/Bundle/FrameworkBundle/Session/DeprecatedSessionFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Session/DeprecatedSessionFactory.php
@@ -35,7 +35,7 @@ class DeprecatedSessionFactory
 
     public function getSession(): ?SessionInterface
     {
-        trigger_deprecation('symfony/framework-bundle', '5.3', 'The "session" service is deprecated, use "$requestStack->getSession()" instead.');
+        trigger_deprecation('symfony/framework-bundle', '5.3', 'The "session" service and "SessionInterface" alias are deprecated, use "$requestStack->getSession()" instead.');
 
         try {
             return $this->requestStack->getSession();

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SessionTest.php
@@ -105,7 +105,7 @@ class SessionTest extends AbstractWebTestCase
      */
     public function testSessionServiceTriggerDeprecation($config, $insulate)
     {
-        $this->expectDeprecation('Since symfony/framework-bundle 5.3: The "session" service is deprecated, use "$requestStack->getSession()" instead.');
+        $this->expectDeprecation('Since symfony/framework-bundle 5.3: The "session" service and "SessionInterface" alias are deprecated, use "$requestStack->getSession()" instead.');
 
         $client = $this->createClient(['test_case' => 'Session', 'root_config' => $config]);
         if ($insulate) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The `session` service is not public since we deprecate it, which lead to headache when people migrate to 5.3:
When people expect the service to be public (like in tests), the service does not exist anymore (removed or inlined), it's now an alias to `.session.do-not-use` and deprecation telling how to migrate has not been triggered because the service has been removed / inlined.

This PR makes the `session` service/alias public, and also improves the deprecation message a little bit.

/cc @javiereguiluz , @wouterj 