### PR TITLE
[PropertyInfo] Use the right context for methods defined in traits

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -269,7 +269,17 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
         }
 
         try {
-            return [$this->docBlockFactory->create($reflectionMethod, $this->createFromReflector($reflectionMethod->getDeclaringClass())), $prefix];
+            $reflector = $reflectionMethod->getDeclaringClass();
+
+            foreach ($reflector->getTraits() as $trait) {
+                if ($trait->hasMethod($methodName)) {
+                    $reflector = $trait;
+
+                    break;
+                }
+            }
+
+            return [$this->docBlockFactory->create($reflectionMethod, $this->createFromReflector($reflector)), $prefix];
         } catch (\InvalidArgumentException $e) {
             return null;
         } catch (\RuntimeException $e) {

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -296,6 +296,23 @@ class PhpDocExtractorTest extends TestCase
     }
 
     /**
+     * @dataProvider methodsDefinedByTraitsProvider
+     */
+    public function testMethodsDefinedByTraits(string $property, Type $type)
+    {
+        $this->assertEquals([$type], $this->extractor->getTypes(DummyUsingTrait::class, $property));
+    }
+
+    public function methodsDefinedByTraitsProvider(): array
+    {
+        return [
+            ['methodInTraitPrimitiveType', new Type(Type::BUILTIN_TYPE_STRING)],
+            ['methodInTraitObjectSameNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyUsedInTrait::class)],
+            ['methodInTraitObjectDifferentNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)],
+        ];
+    }
+
+    /**
      * @dataProvider propertiesStaticTypeProvider
      */
     public function testPropertiesStaticType(string $class, string $property, Type $type)

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/DummyTrait.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/DummyTrait.php
@@ -29,4 +29,28 @@ trait DummyTrait
      * @var Dummy
      */
     private $propertyInTraitObjectDifferentNamespace;
+
+    /**
+     * @return string
+     */
+    public function getMethodInTraitPrimitiveType()
+    {
+        return 'value';
+    }
+
+    /**
+     * @return DummyUsedInTrait
+     */
+    public function getMethodInTraitObjectSameNamespace()
+    {
+        return new DummyUsedInTrait();
+    }
+
+    /**
+     * @return Dummy
+     */
+    public function getMethodInTraitObjectDifferentNamespace()
+    {
+        return new Dummy();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34191
| License       | MIT
| Doc PR        | 

Pull request #40175 only partially fixed #34191 - it solved the problem for properties used in traits but it did not address the same issue with methods.

I have therefore applied the same style of fix and confirmed it works properly with tests.
