### PR TITLE
[Translation] compare translations and display the difference

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -188,9 +188,11 @@ EOF
 
             // Load defined messages
             $compares = [$this->loadCurrentMessages($locales[] = $locale, $transPaths)->all($domain), $this->loadCurrentMessages($locales[] = $input->getOption('compare'), $transPaths)->all($domain)];
-            !$domain ?: $compares = array_map(function ($compare) use($domain) {
-                        return [$domain => $compare];
-                    }, $compares);
+            if (null !== $domain) {
+                $compares = array_map(function ($compare) use($domain) {
+                    return [$domain => $compare];
+                }, $compares);
+            }
 
             // No defined or extracted messages
             if (empty($compares[0]) || empty($compares[1])) {
@@ -211,7 +213,7 @@ EOF
                     $io->text(sprintf('"%1$s" total of messages in locale "%2$s" that are not present in locale "%3$s", with domain "%4$s".', $this->formatId(count($diffs)), $this->formatId($locales[$index]), $this->formatId($locales[abs($index - 1)]), $this->formatId($domain)));
                     foreach ($diffs as $diff) {
                         $text = sprintf('<fg=white>%1$s to %2$s in %3$s : "%4$s"</>', $this->formatId($locales[$index]), $this->formatId($locales[abs($index - 1)]), $this->formatId($domain), $diff);
-                        $all ?? false == true ? $io->text($text) : $all = $io->confirm($text.', show all?', false);
+                        true == $all ?? false ? $io->text($text) : $all = $io->confirm($text.', show all?', false);
                     }
                 }
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -208,9 +208,9 @@ EOF
                 }
                 for ($index = 0; $index < 2; $index++) {
                     $diffs = array_diff(array_keys($compares[$index][$domain]), array_keys($compares[abs($index - 1)][$domain]));
-                    $io->text(sprintf('"<fg=green>%1$s</>" total of messages in locale "<fg=yellow>%2$s</>" that are not present in locale "<fg=yellow>%3$s</>", with domain "<fg=yellow>%4$s</>".', count($diffs), $locales[$index], $locales[abs($index - 1)], $domain));
+                    $io->text(sprintf('"%1$s" total of messages in locale "%2$s" that are not present in locale "%3$s", with domain "%4$s".', $this->formatId(count($diffs)), $this->formatId($locales[$index]), $this->formatId($locales[abs($index - 1)]), $this->formatId($domain)));
                     foreach ($diffs as $diff) {
-                        $text = sprintf('<fg=yellow>%1$s</> <fg=white>to</> <fg=yellow>%2$s</> <fg=white>in</> <fg=yellow>%3$s</> <fg=white>: "%4$s"</>', $locales[$index], $locales[abs($index - 1)], $domain, $diff);
+                        $text = sprintf('%1$s <fg=white>to</> %2$s <fg=white>in</> %3$s <fg=white>: "%4$s"</>', $this->formatId($locales[$index]), $this->formatId($locales[abs($index - 1)]), $this->formatId($domain), $diff);
                         $all ?? false == true ? $io->text($text) : $all = $io->confirm($text.', show all?', false);
                     }
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -184,10 +184,10 @@ EOF
         }
         
         // If computes the difference of locales
-        if ($locale_compare = $input->getOption('compare')) {
+        if ($input->getOption('compare')) {
 
             // Load defined messages
-            $compares = [$this->loadCurrentMessages($locales[] = $locale, $transPaths)->all($domain), $this->loadCurrentMessages($locales[] = $locale_compare, $transPaths)->all($domain)];
+            $compares = [$this->loadCurrentMessages($locales[] = $locale, $transPaths)->all($domain), $this->loadCurrentMessages($locales[] = $input->getOption('compare'), $transPaths)->all($domain)];
             !$domain ?: $compares = array_map(function ($compare) use($domain) {
                         return [$domain => $compare];
                     }, $compares);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -210,7 +210,7 @@ EOF
                     $diffs = array_diff(array_keys($compares[$index][$domain]), array_keys($compares[abs($index - 1)][$domain]));
                     $io->text(sprintf('"%1$s" total of messages in locale "%2$s" that are not present in locale "%3$s", with domain "%4$s".', $this->formatId(count($diffs)), $this->formatId($locales[$index]), $this->formatId($locales[abs($index - 1)]), $this->formatId($domain)));
                     foreach ($diffs as $diff) {
-                        $text = sprintf('%1$s <fg=white>to</> %2$s <fg=white>in</> %3$s <fg=white>: "%4$s"</>', $this->formatId($locales[$index]), $this->formatId($locales[abs($index - 1)]), $this->formatId($domain), $diff);
+                        $text = sprintf('<fg=white>%1$s to %2$s in %3$s : "%4$s"</>', $this->formatId($locales[$index]), $this->formatId($locales[abs($index - 1)]), $this->formatId($domain), $diff);
                         $all ?? false == true ? $io->text($text) : $all = $io->confirm($text.', show all?', false);
                     }
                 }


### PR DESCRIPTION
You can display the the difference in messages between two locales in a specific option locale compare.

| Q             | A
| ------------- | ---
| Branch?       | 5.x for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

- [ ] fix the tests as they have not been updated yet
- [ ] submit changes to the documentation

I modified the TranslationDebugCommand.php class to display the difference between two locales

example :
```
$ php bin/console debug:translation --compare=fr en
```
we can also add the domain

it compares the first local with the second then the second with the first 
display line by line or display all

screenshot:
<img src="https://lh3.googleusercontent.com/pw/ACtC-3cSeV1S-Y4N3q4RyE8x93wPoEU9h8APlthM0mLyhr-kKXH_yqzVK_-PQo3VWFTXBKz8S7iQvVivO_wrIYO9oLLogWTi7PUjuxsyTOv0zXwg3HQ39u01YQKKejCC4FWYxXt7vUpQTVBcg8WKgxmvcQxv=w604-h381-no" alt="compare translations" style="height: 604px; width:381px;"/>

Sorry for the spelling mistakes, I don't speak English.





