### PR TITLE
[FrameworkBundle] Fix missing class in messenger service locator definitions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.xml
@@ -57,7 +57,7 @@
         </service>
 
         <!-- Discovery -->
-        <service id="messenger.receiver_locator">
+        <service id="messenger.receiver_locator" class="Symfony\Component\DependencyInjection\ServiceLocator">
             <tag name="container.service_locator" />
             <argument type="collection" />
         </service>
@@ -82,7 +82,7 @@
         </service>
 
         <!-- retry -->
-        <service id="messenger.retry_strategy_locator">
+        <service id="messenger.retry_strategy_locator" class="Symfony\Component\DependencyInjection\ServiceLocator">
             <tag name="container.service_locator" />
             <argument type="collection" />
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Should make travis green once merged up to 5.x.