### PR TITLE
[Yaml] Allow retaining YAML references when parsing and dumping files

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Yaml;
 
 use Symfony\Component\Yaml\Exception\DumpException;
 use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Reference\Anchor;
+use Symfony\Component\Yaml\Reference\Reference;
 use Symfony\Component\Yaml\Tag\TaggedValue;
 
 /**
@@ -125,6 +127,10 @@ class Inline
                 }
 
                 return self::dumpNull($flags);
+            case $value instanceof Anchor:
+                return '&'.$value->getName().' '.self::dump($value->getValue(), $flags);
+            case $value instanceof Reference:
+                return '*'.$value->getName();
             case $value instanceof \DateTimeInterface:
                 return $value->format('c');
             case \is_object($value):

--- a/src/Symfony/Component/Yaml/Reference/Anchor.php
+++ b/src/Symfony/Component/Yaml/Reference/Anchor.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\Reference;
+
+/**
+ * @author Andreas Braun <git@alcaeus.org>
+ */
+class Anchor
+{
+    private $name;
+    private $value;
+
+    /**
+     * @param mixed $value
+     */
+    public function __construct(string $name, $value)
+    {
+        $this->name = $name;
+        $this->value = $value;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/src/Symfony/Component/Yaml/Reference/Reference.php
+++ b/src/Symfony/Component/Yaml/Reference/Reference.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Yaml\Reference;
+
+/**
+ * @author Andreas Braun <git@alcaeus.org>
+ */
+class Reference
+{
+    private $name;
+    private $anchor;
+
+    public function __construct(string $name, ?Anchor $anchor = null)
+    {
+        $this->name = $name;
+        $this->anchor = $anchor;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getValue()
+    {
+        return $this->anchor ? $this->anchor->getValue() : null;
+    }
+}

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Dumper;
 use Symfony\Component\Yaml\Exception\DumpException;
 use Symfony\Component\Yaml\Parser;
+use Symfony\Component\Yaml\Reference\Anchor;
+use Symfony\Component\Yaml\Reference\Reference;
 use Symfony\Component\Yaml\Tag\TaggedValue;
 use Symfony\Component\Yaml\Yaml;
 
@@ -650,6 +652,33 @@ YAML;
             'within_string' => 'a　b',
             'regular_space' => 'a b',
         ], 2));
+    }
+
+    public function testDumpReferences()
+    {
+        $expected = <<<YAML
+some_reference: &refname refValue
+referenced_value: *refname
+YAML;
+
+        $this->assertSame($expected, $this->dumper->dump([
+            'some_reference' => new Anchor('refname', 'refValue'),
+            'referenced_value' => new Reference('refname'),
+        ], 2));
+    }
+
+    public function testDumpInlineReference()
+    {
+        $expected = '{ foo: &structure { bar: 1, baz: 1 }, some: { nested: { structure: *structure } } }';
+
+        $this->assertSame(trim($expected), trim($this->dumper->dump([
+            'foo' => new Anchor('structure', ['bar' => 1, 'baz' => 1]),
+            'some' => [
+                'nested' => [
+                    'structure' => new Reference('structure'),
+                ],
+            ],
+        ], 3)));
     }
 }
 

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -34,6 +34,7 @@ class Yaml
     public const PARSE_CUSTOM_TAGS = 512;
     public const DUMP_EMPTY_ARRAY_AS_SEQUENCE = 1024;
     public const DUMP_NULL_AS_TILDE = 2048;
+    public const PARSE_REFERENCES_AS_OBJECTS = 4096;
 
     /**
      * Parses a YAML file into a PHP value.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | will create once functionality is finalised

### The Problem

YAML supports anchors (identified by `&<name>`) and references (identified by `*<name>`). The YAML parser supports these and inlines the referenced value in the resulting structure. This concept allows reusing previously defined values in a YAML file, making for more readable files. Take this example:
```yml
foo: &structure
  bar: 1
  baz: 2
some:
  nested:
    structure: *structure
```

After parsing, the values are inlined:
```
array(2) {
  ["foo"]=>
  array(2) {
    ["bar"]=>
    int(1)
    ["baz"]=>
    int(2)
  }
  ["some"]=>
  array(1) {
    ["nested"]=>
    array(1) {
      ["structure"]=>
      array(2) {
        ["bar"]=>
        int(1)
        ["baz"]=>
        int(2)
      }
    }
  }
}
```

This functionality is sufficient for everyday use, but when one is not interested in the data but rather the file itself, there are some problems. For a project I need to read YAML files, modify the structure, then dump them again. When dumping the structure above, the reference is not retained:
```yml
foo:
  bar: 1
  baz: 2
some:
  nested:
    structure:
      bar: 1
      baz: 2
```

In my case, this would've required me to manually re-introduce these references in hundreds of file, and I don't like this kind of work.

### Changes to the Parser

The parser supports a new flag (`PARSE_REFERENCES_AS_OBJECTS`) that instructs it to not inline the values but rather return value objects for these references. Here is the same structure as above, but parsed using the new flag:
```
array(2) {
  ["foo"]=>
  object(Symfony\Component\Yaml\Reference\Anchor)#7 (2) {
    ["name":"Symfony\Component\Yaml\Reference\Anchor":private]=>
    string(9) "structure"
    ["value":"Symfony\Component\Yaml\Reference\Anchor":private]=>
    array(2) {
      ["bar"]=>
      int(1)
      ["baz"]=>
      int(2)
    }
  }
  ["some"]=>
  array(1) {
    ["nested"]=>
    array(1) {
      ["structure"]=>
      object(Symfony\Component\Yaml\Reference\Reference)#8 (2) {
        ["name":"Symfony\Component\Yaml\Reference\Reference":private]=>
        string(9) "structure"
        ["anchor":"Symfony\Component\Yaml\Reference\Reference":private]=>
        object(Symfony\Component\Yaml\Reference\Anchor)#7 (2) {
          ["name":"Symfony\Component\Yaml\Reference\Anchor":private]=>
          string(9) "structure"
          ["value":"Symfony\Component\Yaml\Reference\Anchor":private]=>
          array(2) {
            ["bar"]=>
            int(1)
            ["baz"]=>
            int(2)
          }
        }
      }
    }
  }
}
```

Anchors and references are exposed as value objects, with the reference keeping track of the anchor it references. This allows you to always retrieve the value of such a value object using the `getValue()` method. Both `Anchor` and `Reference` classes expose the same methods, but they currently don't share an interface. This can be added if desired.

### Changes to the Dumper

The dumper was changed to handle anchors and references. Dumping the structure above gives us the following YAML:
```yml
foo: &structure
  bar: 1
  baz: 2
some:
  nested:
    structure: *structure
```

References and anchors can be created manually when preparing data to be dumped. To create the YAML code above, I used the following logic:
```php
$data = [
    'foo' => new Anchor('structure', [
        'bar' => 1,
        'baz' => 2,
    ]),
    'some' => [
        'nested' => [
            'structure' => new Reference('structure'),
        ],
    ],
];
Yaml::dump($data, 3);
```

The referenced value is not needed during dumping, so you can assemble the data structure without knowing the anchor being referenced. Missing anchors are no problem during dumping, but parsing such a YAML file will lead to parse errors. This is expected behaviour.

The dumper changes are not tied to a flag, as users need to opt-in to dumping references by either manually creating them in the structure to be dumped, or by loading the data with the corresponding parser flag.

### Limitations

Due to how the parser works, certain references can't be retained. Take the following example:
```yml
foo: &FOO
    bar: 1
bar:
    baz: 2
    <<: *FOO
```

This results in the following structure:
```
array(2) {
  ["foo"]=>
  object(Symfony\Component\Yaml\Reference\Anchor)#8 (2) {
    ["name":"Symfony\Component\Yaml\Reference\Anchor":private]=>
    string(3) "FOO"
    ["value":"Symfony\Component\Yaml\Reference\Anchor":private]=>
    array(1) {
      ["bar"]=>
      int(1)
    }
  }
  ["bar"]=>
  array(2) {
    ["baz"]=>
    int(2)
    ["bar"]=>
    int(1)
  }
}
```

The parser can't provide a reference here since the usage of the reference was inlined into the parent block. The root cause for this is similar to the reference problem: the parser would have to expose a value object for this structure, which falls outside of the scope of my needs (at least for now).

### Open questions

- [ ] Should we introduce a common interface for anchors and references? If so, what should we name this?
- [ ] Are the tests sufficient? It would be helpful if people could provide some of their usages of references so I can add them to the test suite