### PR TITLE
[BrowserKit] Merge fields and files recursively if they are multidimensional array

### DIFF
--- a/src/Symfony/Component/BrowserKit/HttpBrowser.php
+++ b/src/Symfony/Component/BrowserKit/HttpBrowser.php
@@ -82,7 +82,7 @@ class HttpBrowser extends AbstractBrowser
         $fields = $request->getParameters();
 
         if ($uploadedFiles = $this->getUploadedFiles($request->getFiles())) {
-            $part = new FormDataPart(array_merge($fields, $uploadedFiles));
+            $part = new FormDataPart(array_replace_recursive($fields, $uploadedFiles));
 
             return [$part->bodyToIterable(), $part->getPreparedHeaders()->toArray()];
         }

--- a/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/HttpBrowserTest.php
@@ -86,7 +86,11 @@ class HttpBrowserTest extends AbstractBrowserTest
             ->with('POST', 'http://example.com/', $this->callback(function ($options) {
                 $this->assertStringContainsString('Content-Type: multipart/form-data', implode('', $options['headers']));
                 $this->assertInstanceOf(\Generator::class, $options['body']);
-                $this->assertStringContainsString('my_file', implode('', iterator_to_array($options['body'])));
+                $values = implode('', iterator_to_array($options['body'], false));
+                $this->assertStringContainsString('name="foo[file]"', $values);
+                $this->assertStringContainsString('my_file', $values);
+                $this->assertStringContainsString('name="foo[bar]"', $values);
+                $this->assertStringContainsString('foo2', $values);
 
                 return true;
             }))
@@ -95,7 +99,7 @@ class HttpBrowserTest extends AbstractBrowserTest
         $browser = new HttpBrowser($client);
         $path = tempnam(sys_get_temp_dir(), 'http');
         file_put_contents($path, 'my_file');
-        $browser->request('POST', 'http://example.com/', [], ['file' => ['tmp_name' => $path, 'name' => 'foo']]);
+        $browser->request('POST', 'http://example.com/', ['foo' => ['bar' => 'foo2']], ['foo' => ['file' => ['tmp_name' => $path, 'name' => 'foo']]]);
     }
 
     public function testMultiPartRequestWithNormalFlatArray()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

if we have a form that is prefixed, with form fields like: text: `foo[name]`, file: `foo[file]`, request is loosing non-files fields. encountered this issue while submitting `Symfony\Component\DomCrawler\Form` in tests