### PR TITLE
[Console] added phpdocs to InputOption constants

### DIFF
--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -21,9 +21,24 @@ use Symfony\Component\Console\Exception\LogicException;
  */
 class InputOption
 {
+    /**
+     * Do not accept input for the option (e.g. --yell). This is the default behavior of options.
+     */
     public const VALUE_NONE = 1;
+
+    /**
+     * A value must be passed when the option is used (e.g. --iterations=5 or -i5).
+     */
     public const VALUE_REQUIRED = 2;
+
+    /**
+     * The option may or may not have a value (e.g. --yell or --yell=loud).
+     */
     public const VALUE_OPTIONAL = 4;
+
+    /**
+     * The option accepts multiple values (e.g. --dir=/foo --dir=/bar).
+     */
     public const VALUE_IS_ARRAY = 8;
 
     private $name;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x for features / 4.4 or 5.2 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a <!-- required for new features -->

This PR adds phpdocs to the `InputOption` constants. The docs itself were copied over from the docs on https://symfony.com/doc/current/console/input.html#using-command-options.

Over and over again people (including myself) confuse the different available constants.
having the meaning carried with the implementation should help to use the one which actually fits the use-case.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
