### PR TITLE
[Notifier] Microsoft Teams: JSON structure error fix for simple message

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/MicrosoftTeamsTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/MicrosoftTeamsTransport.php
@@ -60,7 +60,7 @@ final class MicrosoftTeamsTransport extends AbstractTransport
         $endpoint = sprintf('https://%s%s', $this->getEndpoint(), $path);
         $response = $this->client->request('POST', $endpoint, [
             'json' => [
-                'title' => $message->getSubject(),
+                'text' => $message->getSubject(),
             ],
         ]);
 

--- a/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/Tests/MicrosoftTeamsTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/MicrosoftTeams/Tests/MicrosoftTeamsTransportTest.php
@@ -79,7 +79,7 @@ final class MicrosoftTeamsTransportTest extends TransportTestCase
     {
         $message = 'testMessage';
 
-        $expectedBody = json_encode(['title' => $message]);
+        $expectedBody = json_encode(['text' => $message]);
 
         $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($expectedBody): ResponseInterface {
             $this->assertJsonStringEqualsJsonString($expectedBody, $options['body']);


### PR DESCRIPTION
Code caused following error - 'Unable to post the Microsoft Teams message: ... Summary or Text is required. '. The structure of the message should contain the 'text' attribute instead of 'title'.

| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix
| License       | MIT
