### PR TITLE
[Mailer] Fix SocketStreamTest for windows

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/Stream/SocketStreamTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/Stream/SocketStreamTest.php
@@ -20,7 +20,7 @@ class SocketStreamTest extends TestCase
     public function testSocketErrorNoConnection()
     {
         $this->expectException(TransportException::class);
-        $this->expectExceptionMessageMatches('/Connection refused|unable to connect/');
+        $this->expectExceptionMessageMatches('/Connection refused|unable to connect/i');
         $s = new SocketStream();
         $s->setTimeout(0.1);
         $s->setPort(9999);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no 
| Tickets       | -
| License       | MIT
| Doc PR        | -

**How to reproduce**
PHP 8.0.3 
PHPUnit 9.5.4

c:\php\php ./phpunit --bootstrap ./vendor/autoload.php --configuration ./phpunit.xml.dist --filter "/(SocketStreamTest::testSocketErrorNoConnection)( .*)?$/" --test-suffix SocketStreamTest.php ./src/Symfony/Component/Mailer/Tests/Transport/Smtp/Stream --testdox

Failed asserting that exception message 'Connection could not be established with host "ssl://localhost:9999": stream_socket_client(): Unable to connect to ssl://localhost:9999 (A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond)' matches '/Connection refused|unable to connect/'.
