### PR TITLE
[Security] Add passport to AuthenticationTokenCreatedEvent

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -6,6 +6,7 @@ The CHANGELOG for version 5.4 and newer can be found in the security sub-package
 5.3
 ---
 
+ * Add `getPassport()` method and a second `$passport` constructor argument to `AuthenticationTokenCreatedEvent`
  * The authenticator system is no longer experimental
  * Login Link functionality is no longer experimental
  * Add `RememberMeConditionsListener` to check if remember me is requested and supported, and set priority of `RememberMeListener` to -63

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticatorManager.php
@@ -74,7 +74,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
         $token = $authenticator->createAuthenticatedToken($passport = new SelfValidatingPassport(new UserBadge(method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername(), function () use ($user) { return $user; }), $badges), $this->firewallName);
 
         // announce the authenticated token
-        $token = $this->eventDispatcher->dispatch(new AuthenticationTokenCreatedEvent($token))->getAuthenticatedToken();
+        $token = $this->eventDispatcher->dispatch(new AuthenticationTokenCreatedEvent($token, $passport))->getAuthenticatedToken();
 
         // authenticate this in the system
         return $this->handleAuthenticationSuccess($token, $passport, $request, $authenticator);
@@ -188,7 +188,7 @@ class AuthenticatorManager implements AuthenticatorManagerInterface, UserAuthent
             $authenticatedToken = $authenticator->createAuthenticatedToken($passport, $this->firewallName);
 
             // announce the authenticated token
-            $authenticatedToken = $this->eventDispatcher->dispatch(new AuthenticationTokenCreatedEvent($authenticatedToken))->getAuthenticatedToken();
+            $authenticatedToken = $this->eventDispatcher->dispatch(new AuthenticationTokenCreatedEvent($authenticatedToken, $passport))->getAuthenticatedToken();
 
             if (true === $this->eraseCredentials) {
                 $authenticatedToken->eraseCredentials();

--- a/src/Symfony/Component/Security/Http/Event/AuthenticationTokenCreatedEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/AuthenticationTokenCreatedEvent.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Event;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
@@ -22,10 +23,12 @@ use Symfony\Contracts\EventDispatcher\Event;
 class AuthenticationTokenCreatedEvent extends Event
 {
     private $authenticatedToken;
+    private $passport;
 
-    public function __construct(TokenInterface $token)
+    public function __construct(TokenInterface $token, PassportInterface $passport)
     {
         $this->authenticatedToken = $token;
+        $this->passport = $passport;
     }
 
     public function getAuthenticatedToken(): TokenInterface
@@ -36,5 +39,10 @@ class AuthenticationTokenCreatedEvent extends Event
     public function setAuthenticatedToken(TokenInterface $authenticatedToken): void
     {
         $this->authenticatedToken = $authenticatedToken;
+    }
+
+    public function getPassport(): PassportInterface
+    {
+        return $this->passport;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

This is a follow-up to my previous PR #37359, which added `AuthenticationTokenCreatedEvent` to the new authenticator-based security system to inspect the security token before it becomes effective to the security system. It **adds the passport** that was used to generate that token to the event, so that it can be inspected as well.

Reasoning:
1) It makes the event more aligned with other security events (which are also providing the passport)
2) I see valid use-cases when you'd want to look into the passport/badges to decide if you'd want to make modifications to the security token. @seldaek mentioned to me in scheb/2fa#74 that he'd like to have the ability to add a badge from his custom authenticator class, which then influences 2fa being triggered or not. Having the passport in the event would make that a straight forward task.

I would like to add this to Symfony 5.3, since @wouterj plans to stabilize the authenticator security system for that release, so I believe this is worth adding it now rather than later. The constructor change could be considered a BC break, but since authenticator system is experimental, I believe it's fair to make that change now before declaring it "stable".