### PR TITLE
[FrameworkBundle][Notifier] Add missing entries and order transport factory services alphabetically

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -122,9 +122,11 @@ use Symfony\Component\Notifier\Bridge\Gitter\GitterTransportFactory;
 use Symfony\Component\Notifier\Bridge\GoogleChat\GoogleChatTransportFactory;
 use Symfony\Component\Notifier\Bridge\Infobip\InfobipTransportFactory;
 use Symfony\Component\Notifier\Bridge\Iqsms\IqsmsTransportFactory;
+use Symfony\Component\Notifier\Bridge\LightSms\LightSmsTransportFactory;
 use Symfony\Component\Notifier\Bridge\LinkedIn\LinkedInTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mercure\MercureTransportFactory;
+use Symfony\Component\Notifier\Bridge\MessageBird\MessageBirdTransport;
 use Symfony\Component\Notifier\Bridge\MicrosoftTeams\MicrosoftTeamsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Mobyt\MobytTransportFactory;
 use Symfony\Component\Notifier\Bridge\Nexmo\NexmoTransportFactory;
@@ -135,6 +137,7 @@ use Symfony\Component\Notifier\Bridge\Sendinblue\SendinblueTransportFactory as S
 use Symfony\Component\Notifier\Bridge\Sinch\SinchTransportFactory;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
 use Symfony\Component\Notifier\Bridge\Smsapi\SmsapiTransportFactory;
+use Symfony\Component\Notifier\Bridge\SmsBiuras\SmsBiurasTransportFactory;
 use Symfony\Component\Notifier\Bridge\SpotHit\SpotHitTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransportFactory;
 use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory;
@@ -2368,47 +2371,57 @@ class FrameworkExtension extends Extension
         $container->getDefinition('notifier.channel_policy')->setArgument(0, $config['channel_policy']);
 
         $classToServices = [
-            SlackTransportFactory::class => 'notifier.transport_factory.slack',
-            TelegramTransportFactory::class => 'notifier.transport_factory.telegram',
-            MattermostTransportFactory::class => 'notifier.transport_factory.mattermost',
-            GoogleChatTransportFactory::class => 'notifier.transport_factory.googlechat',
-            NexmoTransportFactory::class => 'notifier.transport_factory.nexmo',
-            IqsmsTransportFactory::class => 'notifier.transport_factory.iqsms',
-            RocketChatTransportFactory::class => 'notifier.transport_factory.rocketchat',
-            InfobipTransportFactory::class => 'notifier.transport_factory.infobip',
-            TwilioTransportFactory::class => 'notifier.transport_factory.twilio',
             AllMySmsTransportFactory::class => 'notifier.transport_factory.allmysms',
-            FirebaseTransportFactory::class => 'notifier.transport_factory.firebase',
-            FreeMobileTransportFactory::class => 'notifier.transport_factory.freemobile',
-            SpotHitTransportFactory::class => 'notifier.transport_factory.spothit',
+            ClickatellTransportFactory::class => 'notifier.transport_factory.clickatell',
+            DiscordTransportFactory::class => 'notifier.transport_factory.discord',
+            EsendexTransportFactory::class => 'notifier.transport_factory.esendex',
             FakeChatTransportFactory::class => 'notifier.transport_factory.fakechat',
             FakeSmsTransportFactory::class => 'notifier.transport_factory.fakesms',
-            OvhCloudTransportFactory::class => 'notifier.transport_factory.ovhcloud',
-            SinchTransportFactory::class => 'notifier.transport_factory.sinch',
-            ZulipTransportFactory::class => 'notifier.transport_factory.zulip',
-            MobytTransportFactory::class => 'notifier.transport_factory.mobyt',
-            SmsapiTransportFactory::class => 'notifier.transport_factory.smsapi',
-            EsendexTransportFactory::class => 'notifier.transport_factory.esendex',
-            SendinblueNotifierTransportFactory::class => 'notifier.transport_factory.sendinblue',
-            DiscordTransportFactory::class => 'notifier.transport_factory.discord',
-            LinkedInTransportFactory::class => 'notifier.transport_factory.linkedin',
+            FirebaseTransportFactory::class => 'notifier.transport_factory.firebase',
+            FreeMobileTransportFactory::class => 'notifier.transport_factory.freemobile',
             GatewayApiTransportFactory::class => 'notifier.transport_factory.gatewayapi',
-            OctopushTransportFactory::class => 'notifier.transport_factory.octopush',
-            MercureTransportFactory::class => 'notifier.transport_factory.mercure',
             GitterTransportFactory::class => 'notifier.transport_factory.gitter',
-            ClickatellTransportFactory::class => 'notifier.transport_factory.clickatell',
+            GoogleChatTransportFactory::class => 'notifier.transport_factory.googlechat',
+            InfobipTransportFactory::class => 'notifier.transport_factory.infobip',
+            IqsmsTransportFactory::class => 'notifier.transport_factory.iqsms',
+            LightSmsTransportFactory::class => 'notifier.transport_factory.lightsms',
+            LinkedInTransportFactory::class => 'notifier.transport_factory.linkedin',
+            MattermostTransportFactory::class => 'notifier.transport_factory.mattermost',
+            MercureTransportFactory::class => 'notifier.transport_factory.mercure',
+            MessageBirdTransport::class => 'notifier.transport_factory.messagebird',
             MicrosoftTeamsTransportFactory::class => 'notifier.transport_factory.microsoftteams',
+            MobytTransportFactory::class => 'notifier.transport_factory.mobyt',
+            NexmoTransportFactory::class => 'notifier.transport_factory.nexmo',
+            OctopushTransportFactory::class => 'notifier.transport_factory.octopush',
+            OvhCloudTransportFactory::class => 'notifier.transport_factory.ovhcloud',
+            RocketChatTransportFactory::class => 'notifier.transport_factory.rocketchat',
+            SendinblueNotifierTransportFactory::class => 'notifier.transport_factory.sendinblue',
+            SinchTransportFactory::class => 'notifier.transport_factory.sinch',
+            SlackTransportFactory::class => 'notifier.transport_factory.slack',
+            SmsapiTransportFactory::class => 'notifier.transport_factory.smsapi',
+            SmsBiurasTransportFactory::class => 'notifier.transport_factory.smsbiuras',
+            SpotHitTransportFactory::class => 'notifier.transport_factory.spothit',
+            TelegramTransportFactory::class => 'notifier.transport_factory.telegram',
+            TwilioTransportFactory::class => 'notifier.transport_factory.twilio',
+            ZulipTransportFactory::class => 'notifier.transport_factory.zulip',
         ];
 
         $parentPackages = ['symfony/framework-bundle', 'symfony/notifier'];
 
         foreach ($classToServices as $class => $service) {
             switch ($package = substr($service, \strlen('notifier.transport_factory.'))) {
+                case 'fakechat': $package = 'fake-chat'; break;
+                case 'fakesms': $package = 'fake-sms'; break;
                 case 'freemobile': $package = 'free-mobile'; break;
                 case 'googlechat': $package = 'google-chat'; break;
+                case 'lightsms': $package = 'light-sms'; break;
                 case 'linkedin': $package = 'linked-in'; break;
+                case 'messagebird': $package = 'message-bird'; break;
+                case 'microsoftteams': $package = 'microsoft-teams'; break;
                 case 'ovhcloud': $package = 'ovh-cloud'; break;
                 case 'rocketchat': $package = 'rocket-chat'; break;
+                case 'smsbiuras': $package = 'sms-biuras'; break;
+                case 'spothit': $package = 'spot-hit'; break;
             }
 
             if (!ContainerBuilder::willBeAvailable(sprintf('symfony/%s-notifier', $package), $class, $parentPackages)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -36,6 +36,7 @@
             <xsd:element name="http-cache" type="http_cache" minOccurs="0" maxOccurs="1" />
             <xsd:element name="rate-limiter" type="rate_limiter" minOccurs="0" maxOccurs="1" />
             <xsd:element name="uid" type="uid" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="notifier" type="notifier" minOccurs="0" maxOccurs="1" />
         </xsd:choice>
 
         <xsd:attribute name="http-method-override" type="xsd:boolean" />
@@ -727,4 +728,8 @@
             <xsd:enumeration value="1" />
         </xsd:restriction>
     </xsd:simpleType>
+
+    <xsd:complexType name="notifier">
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+    </xsd:complexType>
 </xsd:schema>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
+
+$container->loadFromExtension('framework', [
+    'notifier' => [
+        'enabled' => true,
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:notifier enabled="true"></framework:notifier>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier.yml
@@ -1,0 +1,3 @@
+framework:
+    notifier:
+        enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -45,6 +45,7 @@ use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\RetryableHttpClient;
@@ -1834,6 +1835,17 @@ abstract class FrameworkExtensionTest extends TestCase
             'kernel.locale_aware',
             'kernel.reset',
         ], $container->getParameter('container.behavior_describing_tags'));
+    }
+
+    public function testIfNotifierTransportsAreKnownByFrameworkExtension()
+    {
+        $container = $this->createContainerFromFile('notifier');
+
+        $finder = new Finder();
+        foreach ($finder->in(dirname(__DIR__, 4).'/Component/Notifier/Bridge')->directories()->depth(0)->exclude('Mercure') as $bridgeDir) {
+            $transportFactoryName = strtolower($bridgeDir->getFilename());
+            $this->assertTrue($container->hasDefinition('notifier.transport_factory.'.$transportFactoryName), sprintf('Did you forget to add the TransportFactory "%s" to the $classToServices in the FrameworkBundleExtension?', $bridgeDir->getFilename()) );
+        }
     }
 
     protected function createContainer(array $data = [])


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

Tests on https://github.com/symfony/symfony/pull/39353 were failing because of missing entries in the `$classToServices` array. They are now added and the list is ordered alphabetically.

Missing entries:

- LightSmsTransportFactory
- SmsBiurasTransportFactory
- MessageBirdTransport