### PR TITLE
[FrameworkBundle] Add basic tests for the notifier framework bundle integration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -36,6 +36,7 @@
             <xsd:element name="http-cache" type="http_cache" minOccurs="0" maxOccurs="1" />
             <xsd:element name="rate-limiter" type="rate_limiter" minOccurs="0" maxOccurs="1" />
             <xsd:element name="uid" type="uid" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="notifier" type="notifier" minOccurs="0" maxOccurs="1" />
         </xsd:choice>
 
         <xsd:attribute name="http-method-override" type="xsd:boolean" />
@@ -627,6 +628,7 @@
             <xsd:element name="envelope" type="mailer_envelope" minOccurs="0" maxOccurs="1" />
             <xsd:element name="header" type="header" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
+        <xsd:attribute name="enabled" type="xsd:boolean" />
         <xsd:attribute name="dsn" type="xsd:string" />
         <xsd:attribute name="message-bus" type="xsd:string" />
     </xsd:complexType>
@@ -727,4 +729,42 @@
             <xsd:enumeration value="1" />
         </xsd:restriction>
     </xsd:simpleType>
+
+    <xsd:complexType name="notifier">
+        <xsd:sequence>
+            <xsd:element name="chatter-transport" type="chatter-transport" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="texter-transport" type="texter-transport" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="channel-policy" type="channel-policy" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="admin-recipients" type="admin-recipients" minOccurs="0" maxOccurs="1" />
+        </xsd:sequence>
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="notification-on-failed-messages" type="xsd:boolean" />
+        <xsd:attribute name="message-bus" type="xsd:string" />
+    </xsd:complexType>
+
+    <xsd:complexType name="chatter-transport" mixed="true">
+        <xsd:attribute name="name" type="xsd:string" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="texter-transport" mixed="true">
+        <xsd:attribute name="name" type="xsd:string" use="required"/>
+    </xsd:complexType>
+
+    <xsd:complexType name="channel-policy" mixed="true">
+        <xsd:sequence>
+            <xsd:element name="channel" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+        <xsd:attribute name="name" type="xsd:string" use="required" />
+    </xsd:complexType>
+
+    <xsd:complexType name="admin-recipients" mixed="true">
+        <xsd:sequence>
+            <xsd:element name="admin-recipient" type="admin-recipient" minOccurs="1" maxOccurs="unbounded" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="admin-recipient" mixed="true">
+        <xsd:attribute name="email" type="xsd:string" use="required" />
+        <xsd:attribute name="phone" type="xsd:string" />
+    </xsd:complexType>
 </xsd:schema>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier.php
@@ -1,0 +1,28 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
+
+$container->loadFromExtension('framework', [
+    'messenger' => null,
+    'mailer' => [
+        'dsn' => 'smtp://example.com',
+    ],
+    'notifier' => [
+        'enabled' => true,
+        'notification_on_failed_messages' => true,
+        'chatter_transports' => [
+            'slack' => 'null'
+        ],
+        'texter_transports' => [
+            'twilio' => 'null'
+        ],
+        'channel_policy' => [
+            'low' => ['slack'],
+            'high' => ['slack', 'twilio'],
+        ],
+        'admin_recipients' => [
+            ['email' => 'test@test.de', 'phone' => '+490815',],
+        ]
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_mailer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_mailer.php
@@ -1,0 +1,30 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
+
+$container->loadFromExtension('framework', [
+    'mailer' => [
+        'enabled' => false,
+    ],
+    'messenger' => [
+        'enabled' => true,
+    ],
+    'notifier' => [
+        'enabled' => true,
+        'notification_on_failed_messages' => true,
+        'chatter_transports' => [
+            'slack' => 'null'
+        ],
+        'texter_transports' => [
+            'twilio' => 'null'
+        ],
+        'channel_policy' => [
+            'low' => ['slack'],
+            'high' => ['slack', 'twilio'],
+        ],
+        'admin_recipients' => [
+            ['email' => 'test@test.de', 'phone' => '+490815',],
+        ]
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_messenger.php
@@ -1,0 +1,30 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
+
+$container->loadFromExtension('framework', [
+    'mailer' => [
+        'dsn' => 'smtp://example.com',
+    ],
+    'messenger' => [
+        'enabled' => false,
+    ],
+    'notifier' => [
+        'enabled' => true,
+        'notification_on_failed_messages' => true,
+        'chatter_transports' => [
+            'slack' => 'null'
+        ],
+        'texter_transports' => [
+            'twilio' => 'null'
+        ],
+        'channel_policy' => [
+            'low' => ['slack'],
+            'high' => ['slack', 'twilio'],
+        ],
+        'admin_recipients' => [
+            ['email' => 'test@test.de', 'phone' => '+490815',],
+        ]
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/notifier_without_transports.php
@@ -1,0 +1,10 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\BarMessage;
+use Symfony\Bundle\FrameworkBundle\Tests\Fixtures\Messenger\FooMessage;
+
+$container->loadFromExtension('framework', [
+    'notifier' => [
+        'enabled' => true,
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:messenger enabled="true" />
+        <framework:mailer dsn="smtp://example.com" />
+        <framework:notifier enabled="true" notification-on-failed-messages="true">
+            <framework:chatter-transport name="slack">null</framework:chatter-transport>
+            <framework:texter-transport name="twilio">null</framework:texter-transport>
+            <framework:channel-policy name="low">slack</framework:channel-policy>
+            <framework:channel-policy name="high">twilio</framework:channel-policy>
+            <framework:admin-recipients>
+                <framework:admin-recipient email="test@test.de" phone="+490815" />
+            </framework:admin-recipients>
+        </framework:notifier>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_mailer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_mailer.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:mailer enabled="false" />
+        <framework:messenger enabled="true" />
+        <framework:notifier enabled="true" notification-on-failed-messages="true">
+            <framework:chatter-transport name="slack">null</framework:chatter-transport>
+            <framework:texter-transport name="twilio">null</framework:texter-transport>
+            <framework:channel-policy name="low">slack</framework:channel-policy>
+            <framework:channel-policy name="high">twilio</framework:channel-policy>
+            <framework:admin-recipients>
+                <framework:admin-recipient email="test@test.de" phone="+490815" />
+            </framework:admin-recipients>
+        </framework:notifier>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_messenger.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_messenger.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:mailer dsn="smtp://example.com" />
+        <framework:messenger enabled="false" />
+        <framework:notifier enabled="true" notification-on-failed-messages="true">
+            <framework:chatter-transport name="slack">null</framework:chatter-transport>
+            <framework:texter-transport name="twilio">null</framework:texter-transport>
+            <framework:channel-policy name="low">slack</framework:channel-policy>
+            <framework:channel-policy name="high">twilio</framework:channel-policy>
+            <framework:admin-recipients>
+                <framework:admin-recipient email="test@test.de" phone="+490815" />
+            </framework:admin-recipients>
+        </framework:notifier>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_transports.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/notifier_without_transports.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:notifier enabled="true"></framework:notifier>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier.yml
@@ -1,0 +1,16 @@
+framework:
+    messenger: ~
+    mailer:
+        dsn: 'smtp://example.com'
+    notifier:
+        enabled: true
+        notification_on_failed_messages: true
+        chatter_transports:
+            slack: 'null'
+        texter_transports:
+            twilio: 'null'
+        channel_policy:
+            low: ['slack']
+            high: ['slack', 'twilio']
+        admin_recipients:
+            - { email: 'test@test.de', phone: '+490815' }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_mailer.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_mailer.yml
@@ -1,0 +1,17 @@
+framework:
+    mailer:
+        enabled: false
+    messenger:
+        enabled: true
+    notifier:
+        enabled: true
+        notification_on_failed_messages: true
+        chatter_transports:
+            slack: 'null'
+        texter_transports:
+            twilio: 'null'
+        channel_policy:
+            low: ['slack']
+            high: ['slack', 'twilio']
+        admin_recipients:
+            - { email: 'test@test.de', phone: '+490815' }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_messenger.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_messenger.yml
@@ -1,0 +1,17 @@
+framework:
+    mailer:
+        dsn: 'smtp://example.com'
+    messenger:
+        enabled: false
+    notifier:
+        enabled: true
+        notification_on_failed_messages: true
+        chatter_transports:
+            slack: 'null'
+        texter_transports:
+            twilio: 'null'
+        channel_policy:
+            low: ['slack']
+            high: ['slack', 'twilio']
+        admin_recipients:
+            - { email: 'test@test.de', phone: '+490815' }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_transports.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/notifier_without_transports.yml
@@ -1,0 +1,3 @@
+framework:
+    notifier:
+        enabled: true

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1836,6 +1836,43 @@ abstract class FrameworkExtensionTest extends TestCase
         ], $container->getParameter('container.behavior_describing_tags'));
     }
 
+    public function testNotifierWithoutMailer()
+    {
+        $container = $this->createContainerFromFile('notifier_without_mailer');
+
+        $this->assertFalse($container->hasDefinition('notifier.channel.email'));
+    }
+
+    public function testNotifierWithoutMessenger()
+    {
+        $container = $this->createContainerFromFile('notifier_without_messenger');
+
+        $this->assertFalse($container->getDefinition('notifier.failed_message_listener')->hasTag('kernel.event_subscriber'));
+    }
+
+    public function testNotifierWithMailerAndMessenger()
+    {
+        $container = $this->createContainerFromFile('notifier');
+
+        $this->assertTrue($container->hasDefinition('notifier'));
+        $this->assertTrue($container->hasDefinition('chatter'));
+        $this->assertTrue($container->hasDefinition('texter'));
+        $this->assertTrue($container->hasDefinition('notifier.channel.chat'));
+        $this->assertTrue($container->hasDefinition('notifier.channel.email'));
+        $this->assertTrue($container->hasDefinition('notifier.channel.sms'));
+        $this->assertTrue($container->hasDefinition('notifier.channel_policy'));
+        $this->assertTrue($container->getDefinition('notifier.failed_message_listener')->hasTag('kernel.event_subscriber'));
+    }
+
+    public function testNotifierWithoutTransports()
+    {
+        $container = $this->createContainerFromFile('notifier_without_transports');
+
+        $this->assertTrue($container->hasDefinition('notifier'));
+        $this->assertFalse($container->hasDefinition('chatter'));
+        $this->assertFalse($container->hasDefinition('texter'));
+    }
+
     protected function createContainer(array $data = [])
     {
         return new ContainerBuilder(new EnvPlaceholderParameterBag(array_merge([

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -50,6 +50,7 @@
         "symfony/mailer": "^5.2",
         "symfony/messenger": "^5.2",
         "symfony/mime": "^4.4|^5.0",
+        "symfony/notifier": "^5.3",
         "symfony/process": "^4.4|^5.0",
         "symfony/rate-limiter": "^5.2",
         "symfony/security-bundle": "^5.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        |  <!-- required for new features -->

This PR adds basic tests for the notifier framework bundle integration:

- [x] Adjust the symfony-1.0.xsd and define the notifier type
- [x] Add general notifier configuration tests in FrameworkExtensionTest
