### PR TITLE
[FrameworkBundle][Notifier] Fix wrong class name usage

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2436,12 +2436,12 @@ class FrameworkExtension extends Extension
             $container->removeDefinition($classToServices[MercureTransportFactory::class]);
         }
 
-        if (ContainerBuilder::willBeAvailable('symfony/fake-chat-notifier', FakeSmsTransportFactory::class, ['symfony/framework-bundle']) && ContainerBuilder::willBeAvailable('symfony/fake-chat-notifier', FakeSmsTransportFactory::class, ['symfony/notifier']) && ContainerBuilder::willBeAvailable('symfony/fake-chat-notifier', FakeSmsTransportFactory::class, ['symfony/mailer'])) {
+        if (ContainerBuilder::willBeAvailable('symfony/fake-chat-notifier', FakeChatTransportFactory::class, ['symfony/framework-bundle', 'symfony/notifier', 'symfony/mailer'])) {
             $container->getDefinition($classToServices[FakeChatTransportFactory::class])
                 ->replaceArgument('$mailer', new Reference('mailer'));
         }
 
-        if (ContainerBuilder::willBeAvailable('symfony/fake-sms-notifier', FakeSmsTransportFactory::class, ['symfony/framework-bundle']) && ContainerBuilder::willBeAvailable('symfony/fake-sms-notifier', FakeSmsTransportFactory::class, ['symfony/notifier']) && ContainerBuilder::willBeAvailable('symfony/fake-sms-notifier', FakeSmsTransportFactory::class, ['symfony/mailer'])) {
+        if (ContainerBuilder::willBeAvailable('symfony/fake-sms-notifier', FakeSmsTransportFactory::class, ['symfony/framework-bundle', 'symfony/notifier', 'symfony/mailer'])) {
             $container->getDefinition($classToServices[FakeSmsTransportFactory::class])
                 ->replaceArgument('$mailer', new Reference('mailer'));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

I got the following error message a new symfony installation while trying to require fake-sms and fake-chat:

```
symfony new --version=next --dir=new

cd new

composer req notifier
composer req symfony/fake-chat-notifier

```

```
Executing script cache:clear [KO]
 [KO]
Script cache:clear returned with error code 1
!!  
!!  In ContainerBuilder.php line 994:
!!                                                                                 
!!    You have requested a non-existent service "notifier.transport_factory.fakechat".                                                                        
!!                                                                                 
!!  
!!  
Script @auto-scripts was called via post-update-cmd

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```