### PR TITLE
[Serializer] Need to clear cache when updating Annotation Groups on Entities

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Factory/CacheClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/CacheClassMetadataFactory.php
@@ -59,7 +59,6 @@ class CacheClassMetadataFactory implements ClassMetadataFactoryInterface
         if ($item->isHit()) {
             return $this->loadedClasses[$class] = $item->get();
         }
-        
         $this->cacheItemPool->save($item->set($metadata));
 
         return $this->loadedClasses[$class] = $metadata;

--- a/src/Symfony/Component/Serializer/Mapping/Factory/CacheClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/CacheClassMetadataFactory.php
@@ -51,14 +51,15 @@ class CacheClassMetadataFactory implements ClassMetadataFactoryInterface
             return $this->loadedClasses[$class];
         }
 
-        $key = rawurlencode(strtr($class, '\\', '_'));
-
+        $metadata = $this->decorated->getMetadataFor($value);
+        $metadataHash = hash('sha256', serialize($metadata->getAttributesMetadata()));
+        $key = rawurlencode(strtr($class, '\\', '_')) . '_' . $metadataHash;
+        
         $item = $this->cacheItemPool->getItem($key);
         if ($item->isHit()) {
             return $this->loadedClasses[$class] = $item->get();
         }
-
-        $metadata = $this->decorated->getMetadataFor($value);
+        
         $this->cacheItemPool->save($item->set($metadata));
 
         return $this->loadedClasses[$class] = $metadata;

--- a/src/Symfony/Component/Serializer/Mapping/Factory/CacheClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/CacheClassMetadataFactory.php
@@ -53,8 +53,8 @@ class CacheClassMetadataFactory implements ClassMetadataFactoryInterface
 
         $metadata = $this->decorated->getMetadataFor($value);
         $metadataHash = hash('sha256', serialize($metadata->getAttributesMetadata()));
-        $key = rawurlencode(strtr($class, '\\', '_')) . '_' . $metadataHash;
-        
+        $key = rawurlencode(strtr($class, '\\', '_')).'_'.$metadataHash;
+
         $item = $this->cacheItemPool->getItem($key);
         if ($item->isHit()) {
             return $this->loadedClasses[$class] = $item->get();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #40034 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

Sample project that mimics this behavior: https://github.com/monteiro/PR-40856

The solution proposed is just appending an hash of the metadata, so it gets refreshed every time there is a change.
Don't know if this impacts performance, but fixes the issue in development which does not refresh the metadata of the annotation during development.
