### PR TITLE
[Config] Support extensions without configuration in ConfigBuilder warmup

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/ConfigBuilderCacheWarmer.php
@@ -69,12 +69,19 @@ class ConfigBuilderCacheWarmer implements CacheWarmerInterface
 
     private function dumpExtension(ExtensionInterface $extension, ConfigBuilderGeneratorInterface $generator): void
     {
+        $configuration = null;
         if ($extension instanceof ConfigurationInterface) {
             $configuration = $extension;
         } elseif ($extension instanceof ConfigurationExtensionInterface) {
             $configuration = $extension->getConfiguration([], $this->getContainerBuilder($this->kernel));
-        } else {
-            throw new \LogicException(sprintf('Could not get configuration for extension "%s".', \get_class($extension)));
+        }
+
+        if (!$configuration) {
+            if ($this->logger) {
+                $this->logger->info('No configuration found for extension {extensionClass}.', ['extensionClass' => \get_class($extension)]);
+            }
+
+            return;
         }
 
         $generator->build($configuration);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`ConfigurationExtensionInterface::getConfiguration()` is nullable.

As a real use-case: A small internal bundle in my company just uses `array_merge` to manage a very limited set of configuration. We don't have these fancy Configuration classes.