### PR TITLE
[Filesystem] fix readlink() for Windows

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -416,14 +416,14 @@ class Filesystem
                 return null;
             }
 
-            if ('\\' === \DIRECTORY_SEPARATOR) {
+            if ('\\' === \DIRECTORY_SEPARATOR && \PHP_VERSION_ID < 70410) {
                 $path = readlink($path);
             }
 
             return realpath($path);
         }
 
-        if ('\\' === \DIRECTORY_SEPARATOR) {
+        if ('\\' === \DIRECTORY_SEPARATOR && \PHP_VERSION_ID < 70400) {
             return realpath($path);
         }
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -376,7 +376,7 @@ class FilesystemTest extends FilesystemTestCase
 
         // create symlink to nonexistent dir
         rmdir($basePath.'dir');
-        $this->assertFalse('\\' === \DIRECTORY_SEPARATOR ? @readlink($basePath.'dir-link') : is_dir($basePath.'dir-link'));
+        $this->assertFalse('\\' === \DIRECTORY_SEPARATOR && \PHP_VERSION_ID < 70400 ? @readlink($basePath.'dir-link') : is_dir($basePath.'dir-link'));
 
         $this->filesystem->remove($basePath);
 
@@ -1032,7 +1032,12 @@ class FilesystemTest extends FilesystemTestCase
         $this->filesystem->symlink($link1, $link2);
 
         $this->assertEquals($file, $this->filesystem->readlink($link1));
-        $this->assertEquals($link1, $this->filesystem->readlink($link2));
+
+        if (!('\\' == \DIRECTORY_SEPARATOR && \PHP_MAJOR_VERSION === 7 && \PHP_MINOR_VERSION === 3)) {
+            // Skip for Windows with PHP 7.3.*
+            $this->assertEquals($link1, $this->filesystem->readlink($link2));
+        }
+
         $this->assertEquals($file, $this->filesystem->readlink($link1, true));
         $this->assertEquals($file, $this->filesystem->readlink($link2, true));
         $this->assertEquals($file, $this->filesystem->readlink($file, true));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       |  4.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

**How to reproduce**

Windows 10.0.19042.928, PHP 8.0.3, PHPUnit 9.5.4
run as Administrator
C:\php\php.exe ./phpunit --bootstrap ./vendor/autoload.php --configuration ./phpunit.xml.dist ./src/Symfony/Component/Filesystem/Tests

There were 2 failures:

1) Symfony\Component\Filesystem\Tests\FilesystemTest::testRemoveCleansInvalidLinks
Failed asserting that 'C:\Users\albat\AppData\Local\Temp\1618836823.005.2057903605\directory\dir\' is false.

D:\Z__PHP_PROJECT\symfony\src\Symfony\Component\Filesystem\Tests\FilesystemTest.php:379

2) Symfony\Component\Filesystem\Tests\FilesystemTest::testReadAbsoluteLink
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'C:\Users\albat\AppData\Local\Temp\1618836823.1681.131301953\dir\link'
+'C:\Users\albat\AppData\Local\Temp\1618836823.1681.131301953\file'
