### PR TITLE
[DependencyInjection] [AliasDeprecatedPublicServicesPass] Noop when the service is private

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AliasDeprecatedPublicServicesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AliasDeprecatedPublicServicesPass.php
@@ -54,7 +54,7 @@ final class AliasDeprecatedPublicServicesPass extends AbstractRecursivePass
 
             $definition = $container->getDefinition($id);
             if (!$definition->isPublic() || $definition->isPrivate()) {
-                throw new InvalidArgumentException(sprintf('The "%s" service is private: it cannot have the "%s" tag.', $id, $this->tagName));
+                continue;
             }
 
             $container

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AliasDeprecatedPublicServicesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AliasDeprecatedPublicServicesPassTest.php
@@ -59,14 +59,13 @@ final class AliasDeprecatedPublicServicesPassTest extends TestCase
 
     public function testProcessWithNonPublicService()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The "foo" service is private: it cannot have the "container.private" tag.');
-
         $container = new ContainerBuilder();
         $container
             ->register('foo')
             ->addTag('container.private', ['package' => 'foo/bar', 'version' => '1.2']);
 
         (new AliasDeprecatedPublicServicesPass())->process($container);
+
+        $this->assertTrue($container->hasDefinition('foo'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

If the service is already private, I think we can just ignore the tag and do nothing.

Moreover, when we deprecate a public service, if an user already sets its definition to private, it will be transparent instead of throwing.