### PR TITLE
[PropertyInfo] fix attribute namespace with recursive traits

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/PhpDocExtractor.php
@@ -220,17 +220,15 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
             return null;
         }
 
-        try {
-            $reflector = $reflectionProperty->getDeclaringClass();
+        $reflector = $reflectionProperty->getDeclaringClass();
 
-            foreach ($reflector->getTraits() as $trait) {
-                if ($trait->hasProperty($property)) {
-                    $reflector = $trait;
-
-                    break;
-                }
+        foreach ($reflector->getTraits() as $trait) {
+            if ($trait->hasProperty($property)) {
+                return $this->getDocBlockFromProperty($trait->getName(), $property);
             }
+        }
 
+        try {
             return $this->docBlockFactory->create($reflectionProperty, $this->createFromReflector($reflector));
         } catch (\InvalidArgumentException $e) {
             return null;
@@ -268,17 +266,15 @@ class PhpDocExtractor implements PropertyDescriptionExtractorInterface, Property
             return null;
         }
 
-        try {
-            $reflector = $reflectionMethod->getDeclaringClass();
+        $reflector = $reflectionMethod->getDeclaringClass();
 
-            foreach ($reflector->getTraits() as $trait) {
-                if ($trait->hasMethod($methodName)) {
-                    $reflector = $trait;
-
-                    break;
-                }
+        foreach ($reflector->getTraits() as $trait) {
+            if ($trait->hasMethod($methodName)) {
+                return $this->getDocBlockFromMethod($trait->getName(), $ucFirstProperty, $type);
             }
+        }
 
+        try {
             return [$this->docBlockFactory->create($reflectionMethod, $this->createFromReflector($reflector)), $prefix];
         } catch (\InvalidArgumentException $e) {
             return null;

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/PhpDocExtractorTest.php
@@ -292,6 +292,9 @@ class PhpDocExtractorTest extends TestCase
             ['propertyInTraitPrimitiveType', new Type(Type::BUILTIN_TYPE_STRING)],
             ['propertyInTraitObjectSameNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyUsedInTrait::class)],
             ['propertyInTraitObjectDifferentNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)],
+            ['propertyInExternalTraitPrimitiveType', new Type(Type::BUILTIN_TYPE_STRING)],
+            ['propertyInExternalTraitObjectSameNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)],
+            ['propertyInExternalTraitObjectDifferentNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyUsedInTrait::class)],
         ];
     }
 
@@ -309,6 +312,9 @@ class PhpDocExtractorTest extends TestCase
             ['methodInTraitPrimitiveType', new Type(Type::BUILTIN_TYPE_STRING)],
             ['methodInTraitObjectSameNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyUsedInTrait::class)],
             ['methodInTraitObjectDifferentNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)],
+            ['methodInExternalTraitPrimitiveType', new Type(Type::BUILTIN_TYPE_STRING)],
+            ['methodInExternalTraitObjectSameNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, Dummy::class)],
+            ['methodInExternalTraitObjectDifferentNamespace', new Type(Type::BUILTIN_TYPE_OBJECT, false, DummyUsedInTrait::class)],
         ];
     }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyTraitExternal.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/DummyTraitExternal.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+use Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage\DummyUsedInTrait;
+
+trait DummyTraitExternal
+{
+    /**
+     * @var string
+     */
+    private $propertyInExternalTraitPrimitiveType;
+
+    /**
+     * @var Dummy
+     */
+    private $propertyInExternalTraitObjectSameNamespace;
+
+    /**
+     * @var DummyUsedInTrait
+     */
+    private $propertyInExternalTraitObjectDifferentNamespace;
+
+    /**
+     * @return string
+     */
+    public function getMethodInExternalTraitPrimitiveType()
+    {
+        return 'value';
+    }
+
+    /**
+     * @return Dummy
+     */
+    public function getMethodInExternalTraitObjectSameNamespace()
+    {
+        return new Dummy();
+    }
+
+    /**
+     * @return DummyUsedInTrait
+     */
+    public function getMethodInExternalTraitObjectDifferentNamespace()
+    {
+        return new DummyUsedInTrait();
+    }
+}

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/DummyTrait.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/TraitUsage/DummyTrait.php
@@ -12,9 +12,12 @@
 namespace Symfony\Component\PropertyInfo\Tests\Fixtures\TraitUsage;
 
 use Symfony\Component\PropertyInfo\Tests\Fixtures\Dummy;
+use Symfony\Component\PropertyInfo\Tests\Fixtures\DummyTraitExternal;
 
 trait DummyTrait
 {
+    use DummyTraitExternal;
+
     /**
      * @var string
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #36997 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The targeted issue is closed because considered as solved by https://github.com/symfony/symfony/pull/40175.

However, the fix is not enough and is not working with recursive trait inclusion. (see https://github.com/symfony/symfony/issues/36997#issuecomment-822572640).

This pull request is completing the first fix of @xabbuh, trying to follow the same coding style. :wink: 