### PR TITLE
[FrameworkBundle] Deprecate creating public workflow services

### DIFF
--- a/UPGRADE-5.3.md
+++ b/UPGRADE-5.3.md
@@ -43,6 +43,7 @@ FrameworkBundle
  * Deprecate the `session` service and the `SessionInterface` alias, use the `\Symfony\Component\HttpFoundation\Request::getSession()` or the new `\Symfony\Component\HttpFoundation\RequestStack::getSession()` methods instead
  * Deprecate the `KernelTestCase::$container` property, use `KernelTestCase::getContainer()` instead
  * Rename the container parameter `profiler_listener.only_master_requests` to `profiler_listener.only_main_requests`
+ * Deprecate registering workflow services as public
 
 HttpFoundation
 --------------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -85,6 +85,7 @@ FrameworkBundle
    `cache_clearer`, `filesystem` and `validator` services are now private.
  * Removed the `lock.RESOURCE_NAME` and `lock.RESOURCE_NAME.store` services and the `lock`, `LockInterface`, `lock.store` and `PersistingStoreInterface` aliases, use `lock.RESOURCE_NAME.factory`, `lock.factory` or `LockFactory` instead.
  * Remove the `KernelTestCase::$container` property, use `KernelTestCase::getContainer()` instead
+ * Registered workflow services are now private
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -19,6 +19,7 @@ CHANGELOG
  * Add `KernelTestCase::getContainer()` as the best way to get a container in tests
  * Rename the container parameter `profiler_listener.only_master_requests` to `profiler_listener.only_main_requests`
  * Add service `fragment.uri_generator` to generate the URI of a fragment
+ * Deprecate registering workflow services as public
 
 5.2.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -863,6 +863,10 @@ class FrameworkExtension extends Extension
             $workflowDefinition->replaceArgument(1, $markingStoreDefinition ?? null);
             $workflowDefinition->replaceArgument(3, $name);
             $workflowDefinition->replaceArgument(4, $workflow['events_to_dispatch']);
+            $workflowDefinition->addTag('container.private', [
+                'package' => 'symfony/framework-bundle',
+                'version' => '5.3',
+            ]);
 
             // Store to container
             $container->setDefinition($workflowId, $workflowDefinition);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/workflow.php
@@ -29,6 +29,7 @@ return static function (ContainerConfigurator $container) {
             ])
             ->abstract()
             ->public()
+            ->tag('container.private', ['package' => 'symfony/framework-bundle', 'version' => '5.3'])
         ->set('state_machine.abstract', StateMachine::class)
             ->args([
                 abstract_arg('workflow definition'),
@@ -39,6 +40,7 @@ return static function (ContainerConfigurator $container) {
             ])
             ->abstract()
             ->public()
+            ->tag('container.private', ['package' => 'symfony/framework-bundle', 'version' => '5.3'])
         ->set('workflow.marking_store.method', MethodMarkingStore::class)
             ->abstract()
         ->set('workflow.registry', Registry::class)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

AFAIK, workflow services don't need to be public. friendly ping to @lyrixx as a reviewer.