### PR TITLE
[DependencyInjection] Add conflict rules for incompatible ext-psr versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -151,6 +151,7 @@
         "twig/markdown-extra": "^2.12|^3"
     },
     "conflict": {
+        "ext-psr": "<1.1|>=2",
         "async-aws/core": "<1.5",
         "doctrine/annotations": "<1.12",
         "doctrine/dbal": "<2.10",

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -35,6 +35,7 @@
         "symfony/proxy-manager-bridge": "Generate service proxies to lazy load them"
     },
     "conflict": {
+        "ext-psr": "<1.1|>=2",
         "symfony/config": "<5.3",
         "symfony/finder": "<4.4",
         "symfony/proxy-manager-bridge": "<4.4",

--- a/src/Symfony/Contracts/Service/composer.json
+++ b/src/Symfony/Contracts/Service/composer.json
@@ -19,6 +19,9 @@
         "php": ">=7.2.5",
         "psr/container": "^1.1"
     },
+    "conflict": {
+        "ext-psr": "<1.1|>=2"
+    },
     "suggest": {
         "symfony/service-implementation": ""
     },

--- a/src/Symfony/Contracts/composer.json
+++ b/src/Symfony/Contracts/composer.json
@@ -24,6 +24,9 @@
     "require-dev": {
         "symfony/polyfill-intl-idn": "^1.10"
     },
+    "conflict": {
+        "ext-psr": "<1.1|>=2"
+    },
     "replace": {
         "symfony/cache-contracts": "self.version",
         "symfony/deprecation-contracts": "self.version",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR adds conflict rules for outdated versions of the PECL extension `psr` which are known to cause compatibility issues with DependencyInjection 5.3 and ServiceContracts 2.4.