### PR TITLE
[Config] Use plural name on array values

### DIFF
--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -172,17 +172,20 @@ public function NAME($valueDEFAULT): self
         if (null !== $parameterType || $prototype instanceof ScalarNode) {
             $property = $class->addProperty($node->getName());
             if (null === $key = $node->getKeyAttribute()) {
+                // This is an array of values; don't use singular name
                 $body = '
 /**
+ * @param list<TYPE> $value
  * @return $this
  */
-public function NAME(TYPE$value): self
+public function NAME(array $value): self
 {
     $this->PROPERTY = $value;
 
     return $this;
 }';
-                $class->addMethod($methodName, $body, ['PROPERTY' => $property->getName(), 'TYPE' => '' === $parameterType ? '' : $parameterType.' ']);
+
+                $class->addMethod($node->getName(), $body, ['PROPERTY' => $property->getName(), 'TYPE' => '' === $parameterType ? 'mixed' : $parameterType]);
             } else {
                 $body = '
 /**

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.config.php
@@ -3,7 +3,7 @@
 use Symfony\Config\AddToListConfig;
 
 return static function (AddToListConfig $config) {
-    $config->translator()->fallback(['sv', 'fr', 'es']);
+    $config->translator()->fallbacks(['sv', 'fr', 'es']);
     $config->translator()->source('\\Acme\\Foo', 'yellow');
     $config->translator()->source('\\Acme\\Bar', 'green');
 

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.php
@@ -35,6 +35,7 @@ class AddToList implements ConfigurationInterface
                             ->useAttributeAsKey('message_class')
                             ->prototype('array')
                                 ->performNoDeepMerging()
+                                ->fixXmlConfig('sender')
                                 ->children()
                                     ->arrayNode('senders')
                                         ->requiresAtLeastOneElement()

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.config.php
@@ -11,5 +11,5 @@ return static function (NodeInitialValuesConfig $config) {
     $config->messenger()
         ->transports('slow_queue')
         ->dsn('doctrine://')
-        ->option(['table'=>'my_messages']);
+        ->options(['table'=>'my_messages']);
 };

--- a/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
@@ -104,7 +104,8 @@ class GeneratedConfigTest extends TestCase
             return new $fqcn();
         }
 
-        $outputDir = sys_get_temp_dir();
+        $outputDir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.uniqid('sf_config_builder', true);
+
         // This line is helpful for debugging
         // $outputDir = __DIR__.'/.build';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | Related: https://github.com/symfony/symfony-docs/pull/15264

If we have a PrototypedArrayNode and the prototype is does not have a key (`->useAttributeAsKey('name')`). Then we know for sure that the value should be an array. 

See this example from `$framework->assets()`

```diff
    /**
+    * @param list<mixed>
     * @return $this
     */
-   public function baseUrl($value): self 
+   public function baseUrls(array $value): self
    {
        $this->baseUrls = $value;
    
        return $this;
    }
```
