### PR TITLE
[PhpUnitBridge] Declare relative path for phpunit-bridge repository

### DIFF
--- a/CHANGELOG-5.3.md
+++ b/CHANGELOG-5.3.md
@@ -180,4 +180,5 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * feature #38596 [BrowserKit] Add jsonRequest function to the browser-kit client (alexander-schranz)
  * feature #38998 [Messenger][SQS] Make sure one can enable debug logs (Nyholm)
  * feature #38974 [Intl] deprecate polyfills in favor of symfony/polyfill-intl-icu (nicolas-grekas)
+ * feature #37099 [PhpUnitBridge] Declare relative path for phpunit-bridge repository (toilal)
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #37099
| License       | MIT
| Doc PR        | ---

I'm not sure it's a bugfix or a minor feature, please tell me if I need to rebase this on 4.4 branch.

When running symfony from a docker container with a volume mapped to the host, it may cause issues when symlinks are generated from container root, as absolute links.

For composer to generate a relative symlink, declaration of the path repository should be relative. Anyway, it seems better to configure this repository with relative, i.e. to avoid breaking the link when moving the project directory around the filesystem.

This change compute the relative path before invoking composer to configure phpunit-bridge repository.