### PR TITLE
[Validator] Add optional conditionExpression to Count Assertion

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,6 +5,15 @@ CHANGELOG
 ---
  * Add the `normalizer` option to the `Unique` constraint
  * Add `Validation::createIsValidCallable()` that returns true/false instead of throwing exceptions
+ * Add optional `conditionExpression` to the `Count` constraint to count only items matching the given symfony expression language
+
+   ```php
+   use Symfony\Component\Validator\Constraints as Assert;
+
+   /**
+    * @Assert\Count(exactly=3, conditionExpression="42 < item.getValue()")
+    */
+   ```
 
 5.2.0
 -----

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,15 +5,7 @@ CHANGELOG
 ---
  * Add the `normalizer` option to the `Unique` constraint
  * Add `Validation::createIsValidCallable()` that returns true/false instead of throwing exceptions
- * Add optional `conditionExpression` to the `Count` constraint to count only items matching the given symfony expression language
-
-   ```php
-   use Symfony\Component\Validator\Constraints as Assert;
-
-   /**
-    * @Assert\Count(exactly=3, conditionExpression="42 < item.getValue()")
-    */
-   ```
+ * Add optional `condition` to the `Count` constraint to count only items matching the given symfony expression language
 
 5.2.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/Count.php
+++ b/src/Symfony/Component/Validator/Constraints/Count.php
@@ -90,7 +90,7 @@ class Count extends Constraint
         $this->minMessage = $minMessage ?? $this->minMessage;
         $this->maxMessage = $maxMessage ?? $this->maxMessage;
         $this->divisibleByMessage = $divisibleByMessage ?? $this->divisibleByMessage;
-        $this->condition = $$condition ?? $this->condition;
+        $this->condition = $condition ?? $this->condition;
 
         if (null === $this->min && null === $this->max && null === $this->divisibleBy) {
             throw new MissingOptionsException(sprintf('Either option "min", "max" or "divisibleBy" must be given for constraint "%s".', __CLASS__), ['min', 'max', 'divisibleBy']);

--- a/src/Symfony/Component/Validator/Constraints/Count.php
+++ b/src/Symfony/Component/Validator/Constraints/Count.php
@@ -40,6 +40,7 @@ class Count extends Constraint
     public $min;
     public $max;
     public $divisibleBy;
+    public $conditionExpression;
 
     /**
      * {@inheritdoc}
@@ -55,6 +56,7 @@ class Count extends Constraint
         string $minMessage = null,
         string $maxMessage = null,
         string $divisibleByMessage = null,
+        string $conditionExpression = null,
         array $groups = null,
         $payload = null,
         array $options = []
@@ -82,6 +84,7 @@ class Count extends Constraint
         $this->minMessage = $minMessage ?? $this->minMessage;
         $this->maxMessage = $maxMessage ?? $this->maxMessage;
         $this->divisibleByMessage = $divisibleByMessage ?? $this->divisibleByMessage;
+        $this->conditionExpression = $conditionExpression ?? $this->conditionExpression;
 
         if (null === $this->min && null === $this->max && null === $this->divisibleBy) {
             throw new MissingOptionsException(sprintf('Either option "min", "max" or "divisibleBy" must be given for constraint "%s".', __CLASS__), ['min', 'max', 'divisibleBy']);

--- a/src/Symfony/Component/Validator/Constraints/Count.php
+++ b/src/Symfony/Component/Validator/Constraints/Count.php
@@ -42,7 +42,7 @@ class Count extends Constraint
     public $min;
     public $max;
     public $divisibleBy;
-    public $conditionExpression;
+    public $condition;
 
     /**
      * {@inheritdoc}
@@ -58,17 +58,17 @@ class Count extends Constraint
         string $minMessage = null,
         string $maxMessage = null,
         string $divisibleByMessage = null,
-        string $conditionExpression = null,
         array $groups = null,
         $payload = null,
-        array $options = []
+        array $options = [],
+        string $condition = null
     ) {
         if (\is_array($exactly)) {
             $options = array_merge($exactly, $options);
             $exactly = $options['value'] ?? null;
         }
 
-        if (null !== $conditionExpression && !class_exists(ExpressionLanguage::class)) {
+        if (null !== $condition && !class_exists(ExpressionLanguage::class)) {
             throw new LogicException(sprintf('The "symfony/expression-language" component is required to use the "%s" constraint with a condition expression.', __CLASS__));
         }
 
@@ -90,7 +90,7 @@ class Count extends Constraint
         $this->minMessage = $minMessage ?? $this->minMessage;
         $this->maxMessage = $maxMessage ?? $this->maxMessage;
         $this->divisibleByMessage = $divisibleByMessage ?? $this->divisibleByMessage;
-        $this->conditionExpression = $conditionExpression ?? $this->conditionExpression;
+        $this->condition = $$condition ?? $this->condition;
 
         if (null === $this->min && null === $this->max && null === $this->divisibleBy) {
             throw new MissingOptionsException(sprintf('Either option "min", "max" or "divisibleBy" must be given for constraint "%s".', __CLASS__), ['min', 'max', 'divisibleBy']);

--- a/src/Symfony/Component/Validator/Constraints/Count.php
+++ b/src/Symfony/Component/Validator/Constraints/Count.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\LogicException;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
 
 /**
@@ -64,6 +66,10 @@ class Count extends Constraint
         if (\is_array($exactly)) {
             $options = array_merge($exactly, $options);
             $exactly = $options['value'] ?? null;
+        }
+
+        if (null !== $conditionExpression && !class_exists(ExpressionLanguage::class)) {
+            throw new LogicException(sprintf('The "symfony/expression-language" component is required to use the "%s" constraint with a condition expression.', __CLASS__));
         }
 
         $min = $min ?? $options['min'] ?? null;

--- a/src/Symfony/Component/Validator/Constraints/CountValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountValidator.php
@@ -42,7 +42,7 @@ class CountValidator extends ConstraintValidator
             return;
         }
 
-        if (null !== $constraint->conditionExpression) {
+        if (null !== $constraint->condition) {
             if (!is_iterable($value)) {
                 throw new UnexpectedValueException($value, 'array|iterable');
             }
@@ -50,7 +50,7 @@ class CountValidator extends ConstraintValidator
             $count = 0;
             $expressionLanguage = $this->expressionLanguage ?? new ExpressionLanguage();
             foreach ($value as $item) {
-                if (true === (bool) $expressionLanguage->evaluate($constraint->conditionExpression, ['item' => $item])) {
+                if (true === (bool) $expressionLanguage->evaluate($constraint->condition, ['item' => $item])) {
                     ++$count;
                 }
             }

--- a/src/Symfony/Component/Validator/Constraints/CountValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountValidator.php
@@ -43,14 +43,14 @@ class CountValidator extends ConstraintValidator
         }
 
         if (null !== $constraint->conditionExpression) {
-            if (!\is_iterable($value)) {
+            if (!is_iterable($value)) {
                 throw new UnexpectedValueException($value, 'array|iterable');
             }
 
             $count = 0;
             $expressionLanguage = $this->expressionLanguage ?? new ExpressionLanguage();
             foreach ($value as $item) {
-                if (true === (bool)$expressionLanguage->evaluate($constraint->conditionExpression, ['item' => $item])) {
+                if (true === (bool) $expressionLanguage->evaluate($constraint->conditionExpression, ['item' => $item])) {
                     ++$count;
                 }
             }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorArrayObjectTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorArrayObjectTest.php
@@ -11,19 +11,13 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
-use Doctrine\Common\Collections\ArrayCollection;
-
 /**
  * @author Andreas Linden <linden.andreas@gmx.de>
  */
-class CountValidatorCollectionTest extends CountValidatorIterableTest
+class CountValidatorArrayObjectTest extends CountValidatorIterableTest
 {
     protected function createCollection(array $content)
     {
-        // travis uses deps=low with PHP 8.0 that does not include doctrine/collections.
-        // for now just return the array until it was decided how to proceed.
-        // return new ArrayCollection($content);
-
-        return $content;
+        return new \ArrayObject($content);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorCollectionTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorCollectionTest.php
@@ -11,13 +11,15 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Doctrine\Common\Collections\ArrayCollection;
+
 /**
- * @author Bernhard Schussek <bschussek@gmail.com>
+ * @author Andreas Linden <linden.andreas@gmx.de>
  */
-class CountValidatorArrayTest extends CountValidatorIterableTest
+class CountValidatorCollectionTest extends CountValidatorIterableTest
 {
     protected function createCollection(array $content)
     {
-        return $content;
+        return new ArrayCollection($content);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorCollectionTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorCollectionTest.php
@@ -20,6 +20,10 @@ class CountValidatorCollectionTest extends CountValidatorIterableTest
 {
     protected function createCollection(array $content)
     {
-        return new ArrayCollection($content);
+        // travis uses deps=low with PHP 8.0 that does not include doctrine/collections.
+        // for now just return the array until it was decided how to proceed.
+        // return new ArrayCollection($content);
+
+        return $content;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorIterableTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorIterableTest.php
@@ -27,7 +27,7 @@ abstract class CountValidatorIterableTest extends CountValidatorTest
             'min' => 2,
             'max' => 2,
             'exactMessage' => 'myMessage',
-            'conditionExpression' => 'item > 2',
+            'condition' => 'item > 2',
         ]);
 
         $this->validator->validate($value, $constraint);
@@ -44,7 +44,7 @@ abstract class CountValidatorIterableTest extends CountValidatorTest
             'min' => 2,
             'max' => 2,
             'exactMessage' => 'myMessage',
-            'conditionExpression' => 'item > 42',
+            'condition' => 'item > 42',
         ]);
 
         $this->validator->validate($value, $constraint);
@@ -67,7 +67,7 @@ abstract class CountValidatorIterableTest extends CountValidatorTest
             'min' => 2,
             'max' => 2,
             'exactMessage' => 'myMessage',
-            'conditionExpression' => 'item.getValue() === "value_1"',
+            'condition' => 'item.getValue() === "value_1"',
         ]);
 
         $this->validator->validate($value, $constraint);
@@ -84,7 +84,7 @@ abstract class CountValidatorIterableTest extends CountValidatorTest
             'min' => 2,
             'max' => 2,
             'exactMessage' => 'myMessage',
-            'conditionExpression' => 'item.getValue() === "value_42"',
+            'condition' => 'item.getValue() === "value_42"',
         ]);
 
         $this->validator->validate($value, $constraint);

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorIterableTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorIterableTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Count;
+
+/**
+ * @author Andreas Linden <linden.andreas@gmx.de>
+ */
+abstract class CountValidatorIterableTest extends CountValidatorTest
+{
+    /**
+     * @dataProvider getFourElements
+     */
+    public function testSimpleConditionExpression($value)
+    {
+        $constraint = new Count([
+            'min' => 2,
+            'max' => 2,
+            'exactMessage' => 'myMessage',
+            'conditionExpression' => 'item > 2',
+        ]);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getFourElements
+     */
+    public function testSimpleConditionExpressionFailed($value)
+    {
+        $constraint = new Count([
+            'min' => 2,
+            'max' => 2,
+            'exactMessage' => 'myMessage',
+            'conditionExpression' => 'item > 42',
+        ]);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ count }}', 0)
+            ->setParameter('{{ limit }}', 2)
+            ->setInvalidValue($value)
+            ->setPlural(2)
+            ->setCode(Count::TOO_FEW_ERROR)
+            ->assertRaised();
+    }
+
+    /**
+     * @dataProvider getFourObjectElements
+     */
+    public function testObjectConditionExpression($value)
+    {
+        $constraint = new Count([
+            'min' => 2,
+            'max' => 2,
+            'exactMessage' => 'myMessage',
+            'conditionExpression' => 'item.getValue() === "value_1"',
+        ]);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->assertNoViolation();
+    }
+
+    /**
+     * @dataProvider getFourObjectElements
+     */
+    public function testObjectConditionExpressionFailed($value)
+    {
+        $constraint = new Count([
+            'min' => 2,
+            'max' => 2,
+            'exactMessage' => 'myMessage',
+            'conditionExpression' => 'item.getValue() === "value_42"',
+        ]);
+
+        $this->validator->validate($value, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ count }}', 0)
+            ->setParameter('{{ limit }}', 2)
+            ->setInvalidValue($value)
+            ->setPlural(2)
+            ->setCode(Count::TOO_FEW_ERROR)
+            ->assertRaised();
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
@@ -76,26 +76,26 @@ abstract class CountValidatorTest extends ConstraintValidatorTestCase
     {
         return [
             [$this->createCollection([
-                new class {
-                    function getValue()
+                new class() {
+                    public function getValue()
                     {
                         return 'value_1';
                     }
                 },
-                new class {
-                    function getValue()
+                new class() {
+                    public function getValue()
                     {
                         return 'value_2';
                     }
                 },
-                new class {
-                    function getValue()
+                new class() {
+                    public function getValue()
                     {
                         return 'value_1';
                     }
                 },
-                new class {
-                    function getValue()
+                new class() {
+                    public function getValue()
                     {
                         return 'value_3';
                     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\Constraints\CountValidator;
 use Symfony\Component\Validator\Constraints\DivisibleBy;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Tests\Fixtures\Countable;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -42,6 +43,17 @@ abstract class CountValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate(new \stdClass(), new Count(5));
     }
 
+    public function testConditionExpressionExpectsIterableType()
+    {
+        $constraint = new Count([
+            'min' => 1,
+            'conditionExpression' => 'true',
+        ]);
+
+        $this->expectException(UnexpectedValueException::class);
+        $this->validator->validate(new Countable([]), $constraint);
+    }
+
     public function getThreeOrLessElements()
     {
         return [
@@ -57,6 +69,38 @@ abstract class CountValidatorTest extends ConstraintValidatorTestCase
         return [
             [$this->createCollection([1, 2, 3, 4])],
             [$this->createCollection(['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4])],
+        ];
+    }
+
+    public function getFourObjectElements()
+    {
+        return [
+            [$this->createCollection([
+                new class {
+                    function getValue()
+                    {
+                        return 'value_1';
+                    }
+                },
+                new class {
+                    function getValue()
+                    {
+                        return 'value_2';
+                    }
+                },
+                new class {
+                    function getValue()
+                    {
+                        return 'value_1';
+                    }
+                },
+                new class {
+                    function getValue()
+                    {
+                        return 'value_3';
+                    }
+                },
+            ])],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
@@ -47,7 +47,7 @@ abstract class CountValidatorTest extends ConstraintValidatorTestCase
     {
         $constraint = new Count([
             'min' => 1,
-            'conditionExpression' => 'true',
+            'condition' => 'true',
         ]);
 
         $this->expectException(UnexpectedValueException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

With the conditionExpression option for the count assertion, it is possible to count only those elements in the iterable, that match the given symfony expression language. Each item from the iterable will be passed as variable 'item' into the expression language.

Add CountValidatorCollectionTest to test the new feature against an iterable type that is not an array.
Let test classes for array and collection extend the new CountValidatorIterable test to only run the new tests for iterable types.

