### PR TITLE
[Config] Improve exception messages when extension could not be found

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -102,7 +102,7 @@ class PhpFileLoader extends FileLoader
         foreach ($parameters as $parameter) {
             $reflectionType = $parameter->getType();
             if (!$reflectionType instanceof \ReflectionNamedType) {
-                throw new \InvalidArgumentException(sprintf('Could not resolve argument "%s" for "%s".', $parameter->getName(), $path));
+                throw new \InvalidArgumentException(sprintf('Could not resolve argument "$%s" for "%s".', $parameter->getName(), $path));
             }
             $type = $reflectionType->getName();
 
@@ -121,7 +121,7 @@ class PhpFileLoader extends FileLoader
                     try {
                         $configBuilder = $this->configBuilder($type);
                     } catch (InvalidArgumentException | \LogicException $e) {
-                        throw new \InvalidArgumentException(sprintf('Could not resolve argument "%s" for "%s".', $type.' '.$parameter->getName(), $path), 0, $e);
+                        throw new \InvalidArgumentException(sprintf('Could not resolve argument "%s" for "%s".', $type.' $'.$parameter->getName(), $path), 0, $e);
                     }
                     $configBuilders[] = $configBuilder;
                     $arguments[] = $configBuilder;
@@ -164,7 +164,7 @@ class PhpFileLoader extends FileLoader
 
         if (!$this->container->hasExtension($alias)) {
             $extensions = array_filter(array_map(function (ExtensionInterface $ext) { return $ext->getAlias(); }, $this->container->getExtensions()));
-            throw new InvalidArgumentException(sprintf('There is no extension able to load the configuration for "%s". Looked for namespace "%s", found "%s".', $namespace, $namespace, $extensions ? implode('", "', $extensions) : 'none'));
+            throw new InvalidArgumentException(sprintf('There is no extension able to load the configuration for "%s". Looked for namespace "%s", found "%s".', $namespace, $alias, $extensions ? implode('", "', $extensions) : 'none'));
         }
 
         $extension = $this->container->getExtension($alias);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The error message we currently get if we are using some `AcmeSocialConifg` (bundle is not installed) is currently not perfect. Here are the suggested changes

```diff
 In FileLoader.php line 174: 
    
-   Could not resolve argument "Symfony\Config\AcmeSocialConfig acmeSocial" for 
+   Could not resolve argument "Symfony\Config\AcmeSocialConfig $acmeSocial" for 
    "app/config/packages/acme_social.php" in app/config/packages/acme_social.php 
    (which is loaded in resource "app/config/p ackages/acme_social.php"). 
    
 In PhpFileLoader.php line 124: 
    
-   Could not resolve argument "Symfony\Config\AcmeSocialConfig acmeSocial" for 
+   Could not resolve argument "Symfony\Config\AcmeSocialConfig $acmeSocial" for 
    "app/config/packages/acme_social.php". 
    
 In PhpFileLoader.php line 167: 
    
    There is no extension able to load the configuration for "Symfony\Config\AcmeSocialConfig". 
-   Looked for namespace "Symfony\Config\AcmeSocialConfig", found "framework", 
+   Looked for namespace "acme_social", found "framework", 
    "sensio_framework_extra","twig", "web_profiler", "monolog ", "debug", "maker", "doctrine",
    "doctrine_migrations", "security", "twig_extra", "mercure", "webpack_encore".
```

