### PR TITLE
[SecurityBundle] Allow ips parameter in access_control to accept comma-separated string

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -872,7 +872,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
             foreach ($ips as $ip) {
                 $container->resolveEnvPlaceholders($ip, null, $usedEnvs);
 
-                if (!$usedEnvs && !$this->isValidIp($ip)) {
+                if (!$usedEnvs && !$this->isValidIps($ip)) {
                     throw new \LogicException(sprintf('The given value "%s" in the "security.access_control" config option is not a valid IP address.', $ip));
                 }
 
@@ -928,6 +928,25 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
     {
         // first assemble the factories
         return new MainConfiguration($this->factories, $this->userProviderFactories);
+    }
+
+    private function isValidIps($ips): bool
+    {
+        $ipsList = array_reduce((array) $ips, static function (array $ips, string $ip) {
+            return array_merge($ips, preg_split('/\s*,\s*/', $ip));
+        }, []);
+
+        if (!$ipsList) {
+            return false;
+        }
+
+        foreach ($ipsList as $cidr) {
+            if (!$this->isValidIp($cidr)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function isValidIp(string $cidr): bool

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -388,6 +388,33 @@ class SecurityExtensionTest extends TestCase
         $this->assertEquals($secure, $definition->getArgument(3)['secure']);
     }
 
+    /**
+     * @dataProvider acceptableIpsProvider
+     */
+    public function testAcceptableAccessControlIps($ips)
+    {
+        $container = $this->getRawContainer();
+
+        $container->loadFromExtension('security', [
+            'providers' => [
+                'default' => ['id' => 'foo'],
+            ],
+            'firewalls' => [
+                'some_firewall' => [
+                    'pattern' => '/.*',
+                    'http_basic' => [],
+                ],
+            ],
+            'access_control' => [
+                ['ips' => $ips, 'path' => '/somewhere', 'roles' => 'IS_AUTHENTICATED_FULLY'],
+            ],
+        ]);
+
+        $container->compile();
+
+        $this->assertTrue(true, 'Ip addresses is successfully consumed: '.(\is_string($ips) ? $ips : json_encode($ips)));
+    }
+
     public function sessionConfigurationProvider()
     {
         return [
@@ -406,6 +433,16 @@ class SecurityExtensionTest extends TestCase
                 true,
             ],
         ];
+    }
+
+    public function acceptableIpsProvider(): iterable
+    {
+        yield [['127.0.0.1']];
+        yield ['127.0.0.1'];
+        yield ['127.0.0.1, 127.0.0.2'];
+        yield ['127.0.0.1/8, 127.0.0.2/16'];
+        yield [['127.0.0.1/8, 127.0.0.2/16']];
+        yield [['127.0.0.1/8', '127.0.0.2/16']];
     }
 
     public function testSwitchUserWithSeveralDefinedProvidersButNoFirewallRootProviderConfigured()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #40881, #40864, #40865
| License       | MIT

PR #38149 introduced a new feature to accept a comma-separated string in ip adresses setting in `access_control` configuration  section of security bundle. 

However the feature works in inconsistent manner: comma-separated string can be successfully passed via environment variable, but can not be passed as plain string. This PR changes this inconsistent behavior by allowing validation pass if comma-separated list of ip addresses is given in plain string.

More detailed explanation about the inconsistent behavior can be found [here](https://github.com/symfony/symfony/issues/40881#issuecomment-823906622)