### PR TITLE
[Cache] Deprecate DoctrineProvider

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 5.3 to 5.4
 =======================
 
+Cache
+-----
+
+ * Deprecate `DoctrineProvider` because this class has been added to the `doctrine/cache` package`
+
 FrameworkBundle
 ---------------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -11,6 +11,11 @@ DoctrineBridge
 
  * Remove `UserLoaderInterface::loadUserByUsername()` in favor of `UserLoaderInterface::loadUserByIdentifier()`
 
+Cache
+-----
+
+ * Remove `DoctrineProvider` because it has been added to the `doctrine/cache` package
+
 Config
 ------
 

--- a/composer.json
+++ b/composer.json
@@ -125,7 +125,7 @@
         "cache/integration-tests": "dev-master",
         "composer/package-versions-deprecated": "^1.8",
         "doctrine/annotations": "^1.12",
-        "doctrine/cache": "^1.6|^2.0",
+        "doctrine/cache": "^1.11|^2.0",
         "doctrine/collections": "~1.0",
         "doctrine/data-fixtures": "^1.1",
         "doctrine/dbal": "^2.10|^3.0",

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -15,9 +15,9 @@ use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
-use Symfony\Component\Cache\DoctrineProvider;
 
 /**
  * Warms up annotation caches for classes found in composer's autoload class map
@@ -56,7 +56,7 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
         $annotatedClasses = include $annotatedClassPatterns;
         $reader = class_exists(PsrCachedReader::class)
             ? new PsrCachedReader($this->annotationReader, $arrayAdapter, $this->debug)
-            : new CachedReader($this->annotationReader, new DoctrineProvider($arrayAdapter), $this->debug)
+            : new CachedReader($this->annotationReader, DoctrineProvider::wrap($arrayAdapter), $this->debug)
         ;
 
         foreach ($annotatedClasses as $class) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
@@ -16,11 +16,11 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
-use Symfony\Component\Cache\DoctrineProvider;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -36,9 +36,11 @@ return static function (ContainerConfigurator $container) {
         ->set('annotations.cached_reader', CachedReader::class)
             ->args([
                 service('annotations.reader'),
-                inline_service(DoctrineProvider::class)->args([
-                    inline_service(ArrayAdapter::class),
-                ]),
+                inline_service(DoctrineProvider::class)
+                    ->factory([DoctrineProvider::class, 'wrap'])
+                    ->args([
+                        inline_service(ArrayAdapter::class),
+                    ]),
                 abstract_arg('Debug-Flag'),
             ])
 
@@ -50,6 +52,7 @@ return static function (ContainerConfigurator $container) {
             ])
 
         ->set('annotations.filesystem_cache', DoctrineProvider::class)
+            ->factory([DoctrineProvider::class, 'wrap'])
             ->args([
                 service('annotations.filesystem_cache_adapter'),
             ])
@@ -71,6 +74,7 @@ return static function (ContainerConfigurator $container) {
             ->tag('container.hot_path')
 
         ->set('annotations.cache', DoctrineProvider::class)
+            ->factory([DoctrineProvider::class, 'wrap'])
             ->args([
                 service('annotations.cache_adapter'),
             ])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
@@ -6,13 +6,13 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
-use Symfony\Component\Cache\DoctrineProvider;
 use Symfony\Component\Filesystem\Filesystem;
 
 class AnnotationsCacheWarmerTest extends TestCase
@@ -51,7 +51,7 @@ class AnnotationsCacheWarmerTest extends TestCase
             )
             : new CachedReader(
                 $this->getReadOnlyReader(),
-                new DoctrineProvider(new PhpArrayAdapter($cacheFile, new NullAdapter()))
+                DoctrineProvider::wrap(new PhpArrayAdapter($cacheFile, new NullAdapter()))
             )
         ;
         $refClass = new \ReflectionClass($this);
@@ -79,7 +79,7 @@ class AnnotationsCacheWarmerTest extends TestCase
             )
             : new CachedReader(
                 $this->getReadOnlyReader(),
-                new DoctrineProvider($phpArrayAdapter),
+                DoctrineProvider::wrap($phpArrayAdapter),
                 true
             )
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.10.4",
-        "doctrine/cache": "^1.0|^2.0",
+        "doctrine/cache": "^1.11|^2.0",
         "doctrine/persistence": "^1.3|^2.0",
         "symfony/asset": "^5.3|^6.0",
         "symfony/browser-kit": "^5.4|^6.0",
@@ -70,6 +70,7 @@
         "symfony/phpunit-bridge": "^5.3|^6.0"
     },
     "conflict": {
+        "doctrine/cache": "<1.11",
         "doctrine/persistence": "<1.3",
         "phpdocumentor/reflection-docblock": "<3.2.2",
         "phpdocumentor/type-resolver": "<1.4.0",

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Deprecate `DoctrineProvider` because this class has been added to the `doctrine/cache` package
+
 5.3
 ---
 

--- a/src/Symfony/Component/Cache/DoctrineProvider.php
+++ b/src/Symfony/Component/Cache/DoctrineProvider.php
@@ -17,6 +17,8 @@ use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @deprecated Use Doctrine\Common\Cache\Psr6\DoctrineProvider instead
  */
 class DoctrineProvider extends CacheProvider implements PruneableInterface, ResettableInterface
 {
@@ -24,6 +26,8 @@ class DoctrineProvider extends CacheProvider implements PruneableInterface, Rese
 
     public function __construct(CacheItemPoolInterface $pool)
     {
+        trigger_deprecation('symfony/cache', '5.4', '"%s" is deprecated, use "Doctrine\Common\Cache\Psr6\DoctrineProvider" instead.');
+
         $this->pool = $pool;
     }
 

--- a/src/Symfony/Component/Cache/Tests/DoctrineProviderTest.php
+++ b/src/Symfony/Component/Cache/Tests/DoctrineProviderTest.php
@@ -16,6 +16,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\DoctrineProvider;
 
+/**
+ * @group legacy
+ */
 class DoctrineProviderTest extends TestCase
 {
     public function testProvider()

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -19,7 +19,6 @@ use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\DoctrineProvider as SymfonyDoctrineProvider;
 use Symfony\Component\Validator\Context\ExecutionContextFactory;
 use Symfony\Component\Validator\Exception\LogicException;
 use Symfony\Component\Validator\Exception\ValidatorException;
@@ -437,18 +436,8 @@ class ValidatorBuilder
         }
 
         // Doctrine Annotations < 1.13, Doctrine Cache >= 1.11, Symfony Cache
-        if (class_exists(CachedReader::class) && class_exists(DoctrineProvider::class) && class_exists(ArrayAdapter::class)) {
+        if (class_exists(CachedReader::class) && class_exists(ArrayAdapter::class)) {
             return new CachedReader(new AnnotationReader(), DoctrineProvider::wrap(new ArrayAdapter()));
-        }
-
-        // Doctrine Annotations < 1.13, Doctrine Cache < 1.11, Symfony Cache
-        if (class_exists(CachedReader::class) && !class_exists(DoctrineProvider::class) && class_exists(ArrayAdapter::class)) {
-            return new CachedReader(new AnnotationReader(), new SymfonyDoctrineProvider(new ArrayAdapter()));
-        }
-
-        // Doctrine Annotations < 1.13, Doctrine Cache < 1.11
-        if (class_exists(CachedReader::class) && class_exists(ArrayCache::class)) {
-            return new CachedReader(new AnnotationReader(), new ArrayCache());
         }
 
         // Doctrine Annotation >= 1.13, Doctrine Cache >= 2, no Symfony Cache

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -41,10 +41,11 @@
         "symfony/property-info": "^5.3|^6.0",
         "symfony/translation": "^4.4|^5.0|^6.0",
         "doctrine/annotations": "^1.10.4",
-        "doctrine/cache": "^1.0|^2.0",
+        "doctrine/cache": "^1.11|^2.0",
         "egulias/email-validator": "^2.1.10|^3"
     },
     "conflict": {
+        "doctrine/cache": "<1.11",
         "doctrine/lexer": "<1.0.2",
         "phpunit/phpunit": "<5.4.3",
         "symfony/dependency-injection": "<4.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | TODO

The `DoctrineProvider` class has been reimplemented in the `doctrine/cache` package, so we don't have to maintain it anymore.