### PR TITLE
[Translation] Move ProviderTestCase out of the Tests namespace

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/Tests/LocoProviderTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\Provider\ProviderInterface;
-use Symfony\Component\Translation\Tests\ProviderTestCase;
+use Symfony\Component\Translation\Test\ProviderTestCase;
 use Symfony\Component\Translation\TranslatorBag;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;

--- a/src/Symfony/Component/Translation/Test/ProviderTestCase.php
+++ b/src/Symfony/Component/Translation/Test/ProviderTestCase.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Translation\Tests;
+namespace Symfony\Component\Translation\Test;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -24,6 +24,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  * A test case to ease testing a translation provider.
  *
  * @author Mathieu Santostefano <msantostefano@protonmail.com>
+ *
+ * @internal
  */
 abstract class ProviderTestCase extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Because the `Tests` namespace is stripped from our distribution packages, the new Loco translation bridge cannot use the abstract `ProviderTestCase` class. This PR suggests to move it into a dedicated `Test` namespace to make it reusable for the Loco bridge and potential future bridges.