### PR TITLE
[Translation] The tests for the Loco bridge require symfony/config

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Loco/composer.json
+++ b/src/Symfony/Component/Translation/Bridge/Loco/composer.json
@@ -20,6 +20,9 @@
         "symfony/http-client": "^5.3",
         "symfony/translation": "^5.3"
     },
+    "require-dev": {
+        "symfony/config": "^4.4|^5.2"
+    },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Translation\\Bridge\\Loco\\": "" },
         "exclude-from-classmap": [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The Loco bridge test suite currently fails with the following error message:

```
Loading translations from the Xliff format requires the Symfony Config component.
```

Let's add the config component then.