### PR TITLE
[PasswordHasher] fix copy paste typos from UserPasswordEncoderInterface

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasherInterface.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasherInterface.php
@@ -19,8 +19,8 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
  * @author Ariel Ferrandini <arielferrandini@gmail.com>
  *
  * @method string hashPassword(PasswordAuthenticatedUserInterface $user, string $plainPassword)    Hashes the plain password for the given user.
- * @method string isPasswordValid(PasswordAuthenticatedUserInterface $user, string $plainPassword) Checks if the plaintext password matches the user's password.
- * @method bool   needsRehash(PasswordAuthenticatedUserInterface $user)                            Checks if the plaintext password matches the user's password.
+ * @method bool   isPasswordValid(PasswordAuthenticatedUserInterface $user, string $plainPassword) Checks if the plaintext password matches the user's password.
+ * @method bool   needsRehash(PasswordAuthenticatedUserInterface $user)                            Checks if an encoded password would benefit from rehashing.
  */
 interface UserPasswordHasherInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| License       | MIT

Fix typos introduced when extracting the PasswordHasher component from `UserPasswordEncoderInterface` https://github.com/symfony/symfony/blob/abeb8e4ca9adfcc1494df22af9fd9a1c0181b532/src/Symfony/Component/Security/Core/Encoder/UserPasswordEncoderInterface.php#L36

Discovered in 5.3.0BETA1.