### PR TITLE
[Mailer] use correct spelling when accessing the SMTP php.ini value

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/NativeTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/NativeTransportFactoryTest.php
@@ -111,7 +111,7 @@ EOT;
     {
         self::$fakeConfiguration = [
             'sendmail_path' => $sendmailPath,
-            'smtp' => $smtp,
+            'SMTP' => $smtp,
             'smtp_port' => $smtpPort,
         ];
 

--- a/src/Symfony/Component/Mailer/Transport/NativeTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Transport/NativeTransportFactory.php
@@ -39,7 +39,7 @@ final class NativeTransportFactory extends AbstractTransportFactory
 
         // Only for windows hosts; at this point non-windows
         // host have already thrown an exception or returned a transport
-        $host = ini_get('smtp');
+        $host = ini_get('SMTP');
         $port = (int) ini_get('smtp_port');
 
         if (!$host || !$port) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40899
| License       | MIT
| Doc PR        | 