### PR TITLE
[PasswordHasher] accept hashing passwords with nul bytes or longer than 72 bytes when using bcrypt

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Hasher/SodiumPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/SodiumPasswordHasher.php
@@ -80,8 +80,12 @@ final class SodiumPasswordHasher implements PasswordHasherInterface
         }
 
         if (0 !== strpos($hashedPassword, '$argon')) {
+            if (0 === strpos($hashedPassword, '$2') && (72 < \strlen($plainPassword) || false !== strpos($plainPassword, "\0"))) {
+                $plainPassword = base64_encode(hash('sha512', $plainPassword, true));
+            }
+
             // Accept validating non-argon passwords for seamless migrations
-            return (72 >= \strlen($plainPassword) || 0 !== strpos($hashedPassword, '$2')) && password_verify($plainPassword, $hashedPassword);
+            return password_verify($plainPassword, $hashedPassword);
         }
 
         if (\function_exists('sodium_crypto_pwhash_str_verify')) {

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/NativePasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/NativePasswordHasherTest.php
@@ -89,13 +89,22 @@ class NativePasswordHasherTest extends TestCase
         $this->assertStringStartsWith('$2', $result);
     }
 
-    public function testCheckPasswordLength()
+    public function testBcryptWithLongPassword()
     {
-        $hasher = new NativePasswordHasher(null, null, 4);
-        $result = password_hash(str_repeat('a', 72), \PASSWORD_BCRYPT, ['cost' => 4]);
+        $hasher = new NativePasswordHasher(null, null, 4, \PASSWORD_BCRYPT);
+        $plainPassword = str_repeat('a', 100);
 
-        $this->assertFalse($hasher->verify($result, str_repeat('a', 73), 'salt'));
-        $this->assertTrue($hasher->verify($result, str_repeat('a', 72), 'salt'));
+        $this->assertFalse($hasher->verify(password_hash($plainPassword, \PASSWORD_BCRYPT, ['cost' => 4]), $plainPassword, 'salt'));
+        $this->assertTrue($hasher->verify($hasher->hash($plainPassword), $plainPassword, 'salt'));
+    }
+
+    public function testBcryptWithNulByte()
+    {
+        $hasher = new NativePasswordHasher(null, null, 4, \PASSWORD_BCRYPT);
+        $plainPassword = "a\0b";
+
+        $this->assertFalse($hasher->verify(password_hash($plainPassword, \PASSWORD_BCRYPT, ['cost' => 4]), $plainPassword, 'salt'));
+        $this->assertTrue($hasher->verify($hasher->hash($plainPassword), $plainPassword, 'salt'));
     }
 
     public function testNeedsRehash()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This limitation of bcrypt creates a risk for migrations. But we can remove it, so here we are.