### PR TITLE
[CI] Sort packages by length to match modified package better

### DIFF
--- a/.github/get-modified-packages.php
+++ b/.github/get-modified-packages.php
@@ -12,6 +12,11 @@ if (3 > $_SERVER['argc']) {
 $allPackages = json_decode($_SERVER['argv'][1], true, 512, \JSON_THROW_ON_ERROR);
 $modifiedFiles = json_decode($_SERVER['argv'][2], true, 512, \JSON_THROW_ON_ERROR);
 
+// Sort to get the longest name first (match bridge not component)
+usort($allPackages, function($a, $b) {
+    return strlen($b) <=> strlen($a) ?: $a <=> $b;
+});
+
 function isComponentBridge(string $packageDir): bool
 {
     return 0 < preg_match('@Symfony/Component/.*/Bridge/@', $packageDir);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Given the build error in #40927, I saw that we match "modified packages" wrong. The script things we modified `symfony/translation` rather than the new bridge. This is because we are using a simple [string matchning](https://github.com/symfony/symfony/blob/18658a29a37d6de3e73c95f96fb9e51bf1d5f59d/.github/get-modified-packages.php#L24). If we sort the packages by length, we make sure we match the most detailed (longest) string first. 
