### PR TITLE
[CI] Make sure to restore default locale

### DIFF
--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -26,6 +26,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     protected $csrfTokenManager;
     protected $testableFeatures = [];
+    private $defaultLocale;
 
     protected function setUp(): void
     {
@@ -33,6 +34,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
             $this->markTestSkipped('Extension intl is required.');
         }
 
+        $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
 
         $this->csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
@@ -50,6 +52,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     protected function tearDown(): void
     {
         $this->csrfTokenManager = null;
+        \Locale::setDefault($this->defaultLocale);
 
         parent::tearDown();
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -23,6 +23,7 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
 
     protected $dateTime;
     protected $dateTimeWithoutSeconds;
+    private $defaultLocale;
 
     protected function setUp(): void
     {
@@ -37,6 +38,7 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
         // Since we test against "de_AT", we need the full implementation
         IntlTestHelper::requireFullIntl($this, '57.1');
 
+        $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('de_AT');
 
         $this->dateTime = new \DateTime('2010-02-03 04:05:06 UTC');
@@ -47,6 +49,7 @@ class DateTimeToLocalizedStringTransformerTest extends TestCase
     {
         $this->dateTime = null;
         $this->dateTimeWithoutSeconds = null;
+        \Locale::setDefault($this->defaultLocale);
     }
 
     public function dataProvider()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -19,15 +19,18 @@ use Symfony\Component\Intl\Util\IntlTestHelper;
 class MoneyToLocalizedStringTransformerTest extends TestCase
 {
     private $previousLocale;
+    private $defaultLocale;
 
     protected function setUp(): void
     {
         $this->previousLocale = setlocale(\LC_ALL, '0');
+        $this->defaultLocale = \Locale::getDefault();
     }
 
     protected function tearDown(): void
     {
         setlocale(\LC_ALL, $this->previousLocale);
+        \Locale::setDefault($this->defaultLocale);
     }
 
     public function testTransform()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -18,11 +18,18 @@ class DateTimeTypeTest extends BaseTypeTest
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\DateTimeType';
 
+    private $defaultLocale;
+
     protected function setUp(): void
     {
+        $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
-
         parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        \Locale::setDefault($this->defaultLocale);
     }
 
     public function testSubmitDateTime()

--- a/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractDataProviderTest.php
+++ b/src/Symfony/Component/Intl/Tests/Data/Provider/AbstractDataProviderTest.php
@@ -733,10 +733,18 @@ abstract class AbstractDataProviderTest extends TestCase
 
     private static $rootLocales;
 
+    private $defaultLocale;
+
     protected function setUp(): void
     {
+        $this->defaultLocale = \Locale::getDefault();
         \Locale::setDefault('en');
         Locale::setDefaultFallback('en');
+    }
+
+    protected function tearDown(): void
+    {
+        \Locale::setDefault($this->defaultLocale);
     }
 
     public function provideLocales()

--- a/src/Symfony/Component/Intl/Tests/ResourceBundleTestCase.php
+++ b/src/Symfony/Component/Intl/Tests/ResourceBundleTestCase.php
@@ -725,11 +725,18 @@ abstract class ResourceBundleTestCase extends TestCase
     ];
 
     private static $rootLocales;
+    private $defaultLocale;
 
     protected function setUp(): void
     {
+        $this->defaultLocale = \Locale::getDefault();
         Locale::setDefault('en');
         Locale::setDefaultFallback('en');
+    }
+
+    protected function tearDown(): void
+    {
+        \Locale::setDefault($this->defaultLocale);
     }
 
     public function provideLocales()

--- a/src/Symfony/Contracts/Translation/Test/TranslatorTest.php
+++ b/src/Symfony/Contracts/Translation/Test/TranslatorTest.php
@@ -30,6 +30,18 @@ use Symfony\Contracts\Translation\TranslatorTrait;
  */
 class TranslatorTest extends TestCase
 {
+    private $defaultLocale;
+
+    protected function setUp(): void
+    {
+        $this->defaultLocale = \Locale::getDefault();
+    }
+
+    protected function tearDown(): void
+    {
+        \Locale::setDefault($this->defaultLocale);
+    }
+
     public function getTranslator()
     {
         return new class() implements TranslatorInterface {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | F
| License       | MIT
| Doc PR        | 

Whenever we have a test that do `\Locale::setDefault()` we must make sure to restore it to the original value. 
