### PR TITLE
[Translation] Dont test full string output

### DIFF
--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPullCommandTest.php
@@ -58,7 +58,7 @@ class TranslationPullCommandTest extends TranslationProviderTestCase
         $tester = $this->createCommandTester($provider, $locales, $domains);
         $tester->execute(['--locales' => ['en', 'fr'], '--domains' => ['messages']]);
 
-        $this->assertStringContainsString('[OK] New translations from "null" has been written locally (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] New translations from "null"', trim($tester->getDisplay()));
         $this->assertXmlStringEqualsXmlString(<<<XLIFF
 <?xml version="1.0"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
@@ -134,7 +134,7 @@ XLIFF
         $tester = $this->createCommandTester($provider, $locales, $domains);
         $tester->execute(['--locales' => ['en', 'fr'], '--domains' => ['messages'], '--format' => 'xlf20']);
 
-        $this->assertStringContainsString('[OK] New translations from "null" has been written locally (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] New translations from "null"', trim($tester->getDisplay()));
         $this->assertXmlStringEqualsXmlString(<<<XLIFF
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en" trgLang="en">
@@ -208,7 +208,7 @@ XLIFF
         $tester = $this->createCommandTester($provider, $locales, $domains);
         $tester->execute(['--locales' => ['en', 'fr'], '--domains' => ['messages'], '--force' => true]);
 
-        $this->assertStringContainsString('[OK] Local translations has been updated from "null" (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] Local translations has been updated from "null"', trim($tester->getDisplay()));
         $this->assertXmlStringEqualsXmlString(<<<XLIFF
 <?xml version="1.0"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
@@ -288,7 +288,7 @@ XLIFF
         $tester = $this->createCommandTester($provider, $locales, $domains);
         $tester->execute(['--locales' => ['en', 'fr'], '--domains' => ['messages'], '--force' => true, '--intl-icu' => true]);
 
-        $this->assertStringContainsString('[OK] Local translations has been updated from "null" (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] Local translations has been updated from "null"', trim($tester->getDisplay()));
         $this->assertXmlStringEqualsXmlString(<<<XLIFF
 <?xml version="1.0"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationPushCommandTest.php
@@ -69,7 +69,7 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
 
         $tester->execute(['--locales' => ['en', 'fr'], '--domains' => ['messages']]);
 
-        $this->assertStringContainsString('[OK] New local translations has been sent to "null" (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] New local translations has been sent to "null"', trim($tester->getDisplay()));
     }
 
     public function testPushForceMessages()
@@ -104,7 +104,7 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
 
         $tester->execute(['--locales' => ['en', 'fr'], '--domains' => ['messages'], '--force' => true]);
 
-        $this->assertStringContainsString('[OK] All local translations has been sent to "null" (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] All local translations has been sent to "null"', trim($tester->getDisplay()));
     }
 
     public function testDeleteMissingMessages()
@@ -165,8 +165,8 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
 
         $tester->execute(['--locales' => ['en', 'fr'], '--domains' => ['messages'], '--delete-missing' => true]);
 
-        $this->assertStringContainsString('[OK] Missing translations on "null" has been deleted (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
-        $this->assertStringContainsString('[OK] New local translations has been sent to "null" (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] Missing translations on "null" has been deleted', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] New local translations has been sent to "null"', trim($tester->getDisplay()));
     }
 
     public function testPushForceAndDeleteMissingMessages()
@@ -230,8 +230,8 @@ class TranslationPushCommandTest extends TranslationProviderTestCase
 
         $tester->execute(['--locales' => ['en', 'fr'], '--domains' => ['messages'], '--force' => true, '--delete-missing' => true]);
 
-        $this->assertStringContainsString('[OK] Missing translations on "null" has been deleted (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
-        $this->assertStringContainsString('[OK] All local translations has been sent to "null" (for "en, fr" locale(s), and "messages" domain(s)).', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] Missing translations on "null" has been deleted', trim($tester->getDisplay()));
+        $this->assertStringContainsString('[OK] All local translations has been sent to "null"', trim($tester->getDisplay()));
     }
 
     private function createCommandTester(ProviderInterface $provider, array $locales = ['en'], array $domains = ['messages']): CommandTester


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | 

`SymfonyStyle` will automatically detect the terminal width and insert line breaks. When we test for "super long" string in the output, it will likely fail because of those line breaks. 
This is a quick fix, I think we can solve this in a more generic and elegant way in the future.. But Im not sure exactly how atm. 
