### PR TITLE
[DependencyInjection] Add missing bool type in procesValue()

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -78,7 +78,7 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
     /**
      * {@inheritdoc}
      */
-    protected function processValue($value, $isRoot = false)
+    protected function processValue($value, bool $isRoot = false)
     {
         if (isset($this->skippedIds[$this->currentId])) {
             return $value;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

This method is the only one missing `bool` type. Inside the method is used parent call, that has `bool` type already, so nothing else can be used in it.

![image](https://user-images.githubusercontent.com/924196/115951249-0052fb80-a4e0-11eb-8ee5-601b1d90038f.png)
