### PR TITLE
[Config] Remove double semicolons from autogenerated config classes

### DIFF
--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -339,18 +339,18 @@ public function NAME(TYPE$value): self
     {
         $body = '$output = [];';
         foreach ($class->getProperties() as $p) {
-            $code = '$this->PROPERTY;';
+            $code = '$this->PROPERTY';
             if (null !== $p->getType()) {
                 if ($p->isArray()) {
-                    $code = 'array_map(function($v) { return $v->toArray(); }, $this->PROPERTY);';
+                    $code = 'array_map(function($v) { return $v->toArray(); }, $this->PROPERTY)';
                 } else {
-                    $code = '$this->PROPERTY->toArray();';
+                    $code = '$this->PROPERTY->toArray()';
                 }
             }
 
             $body .= strtr('
     if (null !== $this->PROPERTY) {
-        $output["ORG_NAME"] = '.$code.'
+        $output[\'ORG_NAME\'] = '.$code.';
     }', ['PROPERTY' => $p->getName(), 'ORG_NAME' => $p->getOriginalName()]);
         }
 
@@ -368,19 +368,19 @@ public function NAME(): array
     {
         $body = '';
         foreach ($class->getProperties() as $p) {
-            $code = '$value["ORG_NAME"]';
+            $code = '$value[\'ORG_NAME\']';
             if (null !== $p->getType()) {
                 if ($p->isArray()) {
-                    $code = 'array_map(function($v) { return new '.$p->getType().'($v); }, $value["ORG_NAME"]);';
+                    $code = 'array_map(function($v) { return new '.$p->getType().'($v); }, $value[\'ORG_NAME\'])';
                 } else {
-                    $code = 'new '.$p->getType().'($value["ORG_NAME"])';
+                    $code = 'new '.$p->getType().'($value[\'ORG_NAME\'])';
                 }
             }
 
             $body .= strtr('
-    if (isset($value["ORG_NAME"])) {
+    if (isset($value[\'ORG_NAME\'])) {
         $this->PROPERTY = '.$code.';
-        unset($value["ORG_NAME"]);
+        unset($value[\'ORG_NAME\']);
     }
 ', ['PROPERTY' => $p->getName(), 'ORG_NAME' => $p->getOriginalName()]);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | N/A


In some cases, the autogenerated config classes contain double semicolons:

![image](https://user-images.githubusercontent.com/2445045/116090262-f4b03200-a6a3-11eb-9cdd-135e9dbac084.png)
