### PR TITLE
[FrameworkBundle] Make debug:event-dispatcher search case insensitive

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -123,9 +123,10 @@ EOF
     private function searchForEvent(EventDispatcherInterface $dispatcher, $needle): array
     {
         $output = [];
+        $lcNeedle = strtolower($needle);
         $allEvents = array_keys($dispatcher->getListeners());
         foreach ($allEvents as $event) {
-            if (str_contains($event, $needle)) {
+            if (str_contains(strtolower($event), $lcNeedle)) {
                 $output[] = $event;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I was playing with the new features of `debug:event-dispatcher` and I thought that making the new search feature case insensitive could be better:

### Before

```
$ php bin/console debug:event-dispatcher mailer


 [WARNING] The event "mailer" does not have any registered listeners.
```

### After

```
$ php bin/console debug:event-dispatcher mailer

Registered Listeners of Event Dispatcher "debug.event_dispatcher" for "Symfony\Component\Mailer\Event\MessageEvent" Event
=========================================================================================================================

 ------- --------------------------------------------------------------------------- ----------
  Order   Callable                                                                    Priority
 ------- --------------------------------------------------------------------------- ----------
  #1      Symfony\Component\Mailer\EventListener\MessageListener::onMessage()         0
  #2      Symfony\Component\Mailer\EventListener\EnvelopeListener::onMessage()        -255
  #3      Symfony\Component\Mailer\EventListener\MessageLoggerListener::onMessage()   -255
 ------- --------------------------------------------------------------------------- ----------
```