### PR TITLE
[FrameworkBundle] Fix the event debug command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -30,7 +30,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class EventDispatcherDebugCommand extends Command
 {
-    private const DEFAULT_DISPATCHER = 'event_dispatcher';
+    private const DEFAULT_DISPATCHER = 'debug.event_dispatcher';
 
     protected static $defaultName = 'debug:event-dispatcher';
     protected static $defaultDescription = 'Display configured listeners for an application';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In Symfony 5.3 (both beta1 and 5.x-dev) if you try to run `debug:event-dispatcher` command without arguments you see this error:

![image](https://user-images.githubusercontent.com/73419/116100363-2083e580-a6ad-11eb-8d65-3b604150f750.png)

I run this:

```
$ php bin/console debug:container event_dispatcher

  // This service is a public alias for the service debug.event_dispatcher

  Information for Service "debug.event_dispatcher"
  ================================================

  Collects some data about event listeners.

  // ....
```

That's why I changed the service name to `debug.event_dispatcher` ... and the problem seems to be solved now.