### PR TITLE
[Notifier] [Bridge] Fix missed messageId for SendMessage object in slack notifier

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
@@ -91,6 +91,9 @@ final class SlackTransport extends AbstractTransport
             throw new TransportException(sprintf('Unable to post the Slack message: "%s".', $result['error']), $response);
         }
 
-        return new SentMessage($message, (string) $this);
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($result['ts']);
+
+        return $sentMessage;
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
@@ -110,7 +110,7 @@ final class SlackTransportTest extends TransportTestCase
 
         $response->expects($this->once())
             ->method('getContent')
-            ->willReturn(json_encode(['ok' => true]));
+            ->willReturn(json_encode(['ok' => true, 'ts' => '1503435956.000247']));
 
         $expectedBody = json_encode(['channel' => $channel, 'text' => $message]);
 
@@ -122,7 +122,9 @@ final class SlackTransportTest extends TransportTestCase
 
         $transport = $this->createTransport($client, $channel);
 
-        $transport->send(new ChatMessage('testMessage'));
+        $sentMessage = $transport->send(new ChatMessage('testMessage'));
+
+        $this->assertSame('1503435956.000247', $sentMessage->getMessageId());
     }
 
     public function testSendWithNotification()
@@ -138,7 +140,7 @@ final class SlackTransportTest extends TransportTestCase
 
         $response->expects($this->once())
             ->method('getContent')
-            ->willReturn(json_encode(['ok' => true]));
+            ->willReturn(json_encode(['ok' => true, 'ts' => '1503435956.000247']));
 
         $notification = new Notification($message);
         $chatMessage = ChatMessage::fromNotification($notification);
@@ -158,7 +160,9 @@ final class SlackTransportTest extends TransportTestCase
 
         $transport = $this->createTransport($client, $channel);
 
-        $transport->send($chatMessage);
+        $sentMessage = $transport->send($chatMessage);
+
+        $this->assertSame('1503435956.000247', $sentMessage->getMessageId());
     }
 
     public function testSendWithInvalidOptions()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | -
| Tickets       | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

There are missed messageId property for SendMessage object in slack notifier.
Regarding slack's documentation: https://api.slack.com/messaging/sending#publishing

> One very important piece of information in this response is the `ts` value, which is essentially the ID of the message,

