### PR TITLE
[PhpUnitBridge] Fix tests with `@doesNotPerformAssertions` annotations

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
+++ b/src/Symfony/Bridge/PhpUnit/Legacy/SymfonyTestsListenerTrait.php
@@ -239,7 +239,7 @@ class SymfonyTestsListenerTrait
                 }
 
                 if ($this->checkNumAssertions) {
-                    $this->checkNumAssertions = $test->getTestResultObject()->isStrictAboutTestsThatDoNotTestAnything() && !$test->doesNotPerformAssertions();
+                    $this->checkNumAssertions = $test->getTestResultObject()->isStrictAboutTestsThatDoNotTestAnything();
                 }
 
                 $test->getTestResultObject()->beStrictAboutTestsThatDoNotTestAnything(false);
@@ -268,7 +268,10 @@ class SymfonyTestsListenerTrait
         $groups = Test::getGroups($className, $test->getName(false));
 
         if ($this->checkNumAssertions) {
-            if (!self::$expectedDeprecations && !$test->getNumAssertions() && $test->getTestResultObject()->noneSkipped()) {
+            $assertions = \count(self::$expectedDeprecations) + $test->getNumAssertions();
+            if ($test->doesNotPerformAssertions() && $assertions > 0) {
+                $test->getTestResultObject()->addFailure($test, new RiskyTestError(sprintf('This test is annotated with "@doesNotPerformAssertions", but performed %s assertions', $assertions)), $time);
+            } elseif ($assertions === 0 && $test->getTestResultObject()->noneSkipped()) {
                 $test->getTestResultObject()->addFailure($test, new RiskyTestError('This test did not perform any assertions'), $time);
             }
 

--- a/src/Symfony/Bridge/PhpUnit/Tests/FailTests/NoAssertionsTestRisky.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/FailTests/NoAssertionsTestRisky.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\PhpUnit\Tests\FailTests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+
+/**
+ * This class is deliberately suffixed with *TestRisky.php so that it is ignored
+ * by PHPUnit. This test is designed to fail. See ../expectrisky.phpt.
+ */
+final class NoAssertionsTestRisky extends TestCase
+{
+    use ExpectDeprecationTrait;
+
+    /**
+     * Do not remove this test in the next major version.
+     *
+     * @group legacy
+     */
+    public function testOne()
+    {
+        $this->expectNotToPerformAssertions();
+        $this->expectDeprecation('foo');
+        @trigger_error('foo', \E_USER_DEPRECATED);
+    }
+
+    /**
+     * Do not remove this test in the next major version.
+     */
+    public function testTwo()
+    {
+        $this->expectNotToPerformAssertions();
+    }
+}

--- a/src/Symfony/Bridge/PhpUnit/Tests/expectrisky.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/expectrisky.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test NoAssertionsTestRisky risky test
+--FILE--
+<?php
+$test =  realpath(__DIR__.'/FailTests/NoAssertionsTestRisky.php');
+passthru('php '.getenv('SYMFONY_SIMPLE_PHPUNIT_BIN_DIR').'/simple-phpunit.php --fail-on-risky --colors=never '.$test);
+?>
+--EXPECTF--
+PHPUnit %s by Sebastian Bergmann and contributors.
+
+%ATesting Symfony\Bridge\PhpUnit\Tests\FailTests\NoAssertionsTestRisky
+R.                                                                  2 / 2 (100%)
+
+Time: %s, Memory: %s
+
+There was 1 risky test:
+
+1) Symfony\Bridge\PhpUnit\Tests\FailTests\NoAssertionsTestRisky::testOne
+This test is annotated with "@doesNotPerformAssertions", but performed 1 assertions
+
+OK, but incomplete, skipped, or risky tests!
+Tests: 2, Assertions: 1, Risky: 1.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

If a test uses the `@doesNotPerformAssertions` and also has the Symfony Deprecation listener enabled because it is using the trait as well then this does not work as expected. Currently the bridge is checking this annotation/setting prior to running the test. This results in:
* Tests not working as expected when `$this->expectNotToPerformAssertions()` is called during a test
* If this is being used to ensure that a test does not perform an assertion then due to the bridge the test will no longer be marked as risky because we call `$test->getTestResultObject()->beStrictAboutTestsThatDoNotTestAnything(false);`