### PR TITLE
[Mime] DataPart: remove confusing fix-me comment

### DIFF
--- a/src/Symfony/Component/Mime/Part/DataPart.php
+++ b/src/Symfony/Component/Mime/Part/DataPart.php
@@ -46,8 +46,6 @@ class DataPart extends TextPart
 
     public static function fromPath(string $path, string $name = null, string $contentType = null): self
     {
-        // FIXME: if file is not readable, exception?
-
         if (null === $contentType) {
             $ext = strtolower(substr($path, strrpos($path, '.') + 1));
             if (null === self::$mimeTypes) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


I don't think this comment is correct? There is an exception thrown [below](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Mime/Part/DataPart.php#L60).