### PR TITLE
[Mailer][Notifier][Translation] Add tests for UnsupportedSchemeException

### DIFF
--- a/src/Symfony/Component/Mailer/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Mailer/Exception/UnsupportedSchemeException.php
@@ -28,6 +28,14 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Mailgun\Transport\MailgunTransportFactory::class,
             'package' => 'symfony/mailgun-mailer',
         ],
+        'mailjet' => [
+            'class' => Bridge\Mailjet\Transport\MailjetTransportFactory::class,
+            'package' => 'symfony/mailjet-mailer',
+        ],
+        'mandrill' => [
+            'class' => Bridge\Mailchimp\Transport\MandrillTransportFactory::class,
+            'package' => 'symfony/mailchimp-mailer',
+        ],
         'postmark' => [
             'class' => Bridge\Postmark\Transport\PostmarkTransportFactory::class,
             'package' => 'symfony/postmark-mailer',
@@ -36,21 +44,13 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Sendgrid\Transport\SendgridTransportFactory::class,
             'package' => 'symfony/sendgrid-mailer',
         ],
-        'ses' => [
-            'class' => Bridge\Amazon\Transport\SesTransportFactory::class,
-            'package' => 'symfony/amazon-mailer',
-        ],
-        'mandrill' => [
-            'class' => Bridge\Mailchimp\Transport\MandrillTransportFactory::class,
-            'package' => 'symfony/mailchimp-mailer',
-        ],
-        'mailjet' => [
-            'class' => Bridge\Mailjet\Transport\MailjetTransportFactory::class,
-            'package' => 'symfony/mailjet-mailer',
-        ],
         'sendinblue' => [
             'class' => Bridge\Sendinblue\Transport\SendinblueTransportFactory::class,
             'package' => 'symfony/sendinblue-mailer',
+        ],
+        'ses' => [
+            'class' => Bridge\Amazon\Transport\SesTransportFactory::class,
+            'package' => 'symfony/amazon-mailer',
         ],
     ];
 

--- a/src/Symfony/Component/Mailer/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Tests\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ClassExistsMock;
+use Symfony\Component\Mailer\Bridge\Amazon\Transport\SesTransportFactory;
+use Symfony\Component\Mailer\Bridge\Google\Transport\GmailTransportFactory;
+use Symfony\Component\Mailer\Bridge\Mailchimp\Transport\MandrillTransportFactory;
+use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunTransportFactory;
+use Symfony\Component\Mailer\Bridge\Mailjet\Transport\MailjetTransportFactory;
+use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkTransportFactory;
+use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
+use Symfony\Component\Mailer\Bridge\Sendinblue\Transport\SendinblueTransportFactory;
+use Symfony\Component\Mailer\Exception\UnsupportedSchemeException;
+use Symfony\Component\Mailer\Transport\Dsn;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+final class UnsupportedSchemeExceptionTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        ClassExistsMock::register(__CLASS__);
+        ClassExistsMock::withMockedClasses([
+            GmailTransportFactory::class => false,
+            MailgunTransportFactory::class => false,
+            MailjetTransportFactory::class => false,
+            MandrillTransportFactory::class => false,
+            PostmarkTransportFactory::class => false,
+            SendgridTransportFactory::class => false,
+            SendinblueTransportFactory::class => false,
+            SesTransportFactory::class => false,
+        ]);
+    }
+
+    /**
+     * @dataProvider messageWhereSchemeIsPartOfSchemeToPackageMapProvider
+     */
+    public function testMessageWhereSchemeIsPartOfSchemeToPackageMap(string $scheme, string $package)
+    {
+        $dsn = new Dsn($scheme, 'localhost');
+
+        $this->assertSame(
+            sprintf('Unable to send emails via "%s" as the bridge is not installed; try running "composer require %s".', $scheme, $package),
+            (new UnsupportedSchemeException($dsn))->getMessage()
+        );
+    }
+
+    public function messageWhereSchemeIsPartOfSchemeToPackageMapProvider(): \Generator
+    {
+        yield ['gmail', 'symfony/google-mailer'];
+        yield ['mailgun', 'symfony/mailgun-mailer'];
+        yield ['mailjet', 'symfony/mailjet-mailer'];
+        yield ['mandrill', 'symfony/mailchimp-mailer'];
+        yield ['postmark', 'symfony/postmark-mailer'];
+        yield ['sendgrid', 'symfony/sendgrid-mailer'];
+        yield ['sendinblue', 'symfony/sendinblue-mailer'];
+        yield ['ses', 'symfony/amazon-mailer'];
+    }
+
+    /**
+     * @dataProvider messageWhereSchemeIsNotPartOfSchemeToPackageMapProvider
+     */
+    public function testMessageWhereSchemeIsNotPartOfSchemeToPackageMap(string $expected, Dsn $dsn, ?string $name, array $supported)
+    {
+        $this->assertSame(
+            $expected,
+            (new UnsupportedSchemeException($dsn, $name, $supported))->getMessage()
+        );
+    }
+
+    public function messageWhereSchemeIsNotPartOfSchemeToPackageMapProvider(): \Generator
+    {
+        yield [
+            'The "somethingElse" scheme is not supported.',
+            new Dsn('somethingElse', 'localhost'),
+            null,
+            [],
+        ];
+
+        yield [
+            'The "somethingElse" scheme is not supported.',
+            new Dsn('somethingElse', 'localhost'),
+            'foo',
+            [],
+        ];
+
+        yield [
+            'The "somethingElse" scheme is not supported; supported schemes for mailer "one" are: "one", "two".',
+            new Dsn('somethingElse', 'localhost'),
+            'one',
+            ['one', 'two'],
+        ];
+    }
+}

--- a/src/Symfony/Component/Mailer/composer.json
+++ b/src/Symfony/Component/Mailer/composer.json
@@ -25,15 +25,8 @@
         "symfony/service-contracts": "^1.1|^2"
     },
     "require-dev": {
-        "symfony/amazon-mailer": "^4.4|^5.0",
-        "symfony/google-mailer": "^4.4|^5.0",
         "symfony/http-client-contracts": "^1.1|^2",
-        "symfony/mailjet-mailer": "^4.4|^5.0",
-        "symfony/mailgun-mailer": "^4.4|^5.0",
-        "symfony/mailchimp-mailer": "^4.4|^5.0",
-        "symfony/messenger": "^4.4|^5.0",
-        "symfony/postmark-mailer": "^4.4|^5.0",
-        "symfony/sendgrid-mailer": "^4.4|^5.0"
+        "symfony/messenger": "^4.4|^5.0"
     },
     "conflict": {
         "symfony/http-kernel": "<4.4"

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -20,57 +20,21 @@ use Symfony\Component\Notifier\Transport\Dsn;
 class UnsupportedSchemeException extends LogicException
 {
     private const SCHEME_TO_PACKAGE_MAP = [
-        'slack' => [
-            'class' => Bridge\Slack\SlackTransportFactory::class,
-            'package' => 'symfony/slack-notifier',
-        ],
-        'telegram' => [
-            'class' => Bridge\Telegram\TelegramTransportFactory::class,
-            'package' => 'symfony/telegram-notifier',
-        ],
-        'mattermost' => [
-            'class' => Bridge\Mattermost\MattermostTransportFactory::class,
-            'package' => 'symfony/mattermost-notifier',
-        ],
-        'googlechat' => [
-            'class' => Bridge\GoogleChat\GoogleChatTransportFactory::class,
-            'package' => 'symfony/google-chat-notifier',
-        ],
-        'nexmo' => [
-            'class' => Bridge\Nexmo\NexmoTransportFactory::class,
-            'package' => 'symfony/nexmo-notifier',
-        ],
-        'iqsms' => [
-            'class' => Bridge\Iqsms\IqsmsTransportFactory::class,
-            'package' => 'symfony/iqsms-notifier',
-        ],
-        'rocketchat' => [
-            'class' => Bridge\RocketChat\RocketChatTransportFactory::class,
-            'package' => 'symfony/rocket-chat-notifier',
-        ],
-        'twilio' => [
-            'class' => Bridge\Twilio\TwilioTransportFactory::class,
-            'package' => 'symfony/twilio-notifier',
-        ],
         'allmysms' => [
             'class' => Bridge\AllMySms\AllMySmsTransportFactory::class,
             'package' => 'symfony/allmysms-notifier',
         ],
-        'infobip' => [
-            'class' => Bridge\Infobip\InfobipTransportFactory::class,
-            'package' => 'symfony/infobip-notifier',
+        'clickatell' => [
+            'class' => Bridge\Clickatell\ClickatellTransportFactory::class,
+            'package' => 'symfony/clickatell-notifier',
         ],
-        'firebase' => [
-            'class' => Bridge\Firebase\FirebaseTransportFactory::class,
-            'package' => 'symfony/firebase-notifier',
+        'discord' => [
+            'class' => Bridge\Discord\DiscordTransportFactory::class,
+            'package' => 'symfony/discord-notifier',
         ],
-        'freemobile' => [
-            'class' => Bridge\FreeMobile\FreeMobileTransportFactory::class,
-            'package' => 'symfony/free-mobile-notifier',
-        ],
-        'spothit' => [
-            'class' => Bridge\SpotHit\SpotHitTransportFactory::class,
-            'package' => 'symfony/spot-hit-notifier',
+        'esendex' => [
+            'class' => Bridge\Esendex\EsendexTransportFactory::class,
+            'package' => 'symfony/esendex-notifier',
         ],
         'fakechat' => [
             'class' => Bridge\FakeChat\FakeChatTransportFactory::class,
@@ -80,77 +44,113 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\FakeSms\FakeSmsTransportFactory::class,
             'package' => 'symfony/fake-sms-notifier',
         ],
-        'ovhcloud' => [
-            'class' => Bridge\OvhCloud\OvhCloudTransportFactory::class,
-            'package' => 'symfony/ovh-cloud-notifier',
+        'firebase' => [
+            'class' => Bridge\Firebase\FirebaseTransportFactory::class,
+            'package' => 'symfony/firebase-notifier',
         ],
-        'sinch' => [
-            'class' => Bridge\Sinch\SinchTransportFactory::class,
-            'package' => 'symfony/sinch-notifier',
-        ],
-        'zulip' => [
-            'class' => Bridge\Zulip\ZulipTransportFactory::class,
-            'package' => 'symfony/zulip-notifier',
-        ],
-        'smsapi' => [
-            'class' => Bridge\Smsapi\SmsapiTransportFactory::class,
-            'package' => 'symfony/smsapi-notifier',
-        ],
-        'esendex' => [
-            'class' => Bridge\Esendex\EsendexTransportFactory::class,
-            'package' => 'symfony/esendex-notifier',
-        ],
-        'discord' => [
-            'class' => Bridge\Discord\DiscordTransportFactory::class,
-            'package' => 'symfony/discord-notifier',
+        'freemobile' => [
+            'class' => Bridge\FreeMobile\FreeMobileTransportFactory::class,
+            'package' => 'symfony/free-mobile-notifier',
         ],
         'gatewayapi' => [
             'class' => Bridge\GatewayApi\GatewayApiTransportFactory::class,
             'package' => 'symfony/gatewayapi-notifier',
         ],
-        'octopush' => [
-            'class' => Bridge\Octopush\OctopushTransportFactory::class,
-            'package' => 'symfony/octopush-notifier',
-        ],
-        'mercure' => [
-            'class' => Bridge\Mercure\MercureTransportFactory::class,
-            'package' => 'symfony/mercure-notifier',
-        ],
         'gitter' => [
             'class' => Bridge\Gitter\GitterTransportFactory::class,
             'package' => 'symfony/gitter-notifier',
         ],
-        'clickatell' => [
-            'class' => Bridge\Clickatell\ClickatellTransportFactory::class,
-            'package' => 'symfony/clickatell-notifier',
+        'googlechat' => [
+            'class' => Bridge\GoogleChat\GoogleChatTransportFactory::class,
+            'package' => 'symfony/google-chat-notifier',
+        ],
+        'infobip' => [
+            'class' => Bridge\Infobip\InfobipTransportFactory::class,
+            'package' => 'symfony/infobip-notifier',
+        ],
+        'iqsms' => [
+            'class' => Bridge\Iqsms\IqsmsTransportFactory::class,
+            'package' => 'symfony/iqsms-notifier',
         ],
         'lightsms' => [
             'class' => Bridge\LightSms\LightSmsTransportFactory::class,
             'package' => 'symfony/light-sms-notifier',
         ],
-        'microsoftteams' => [
-            'class' => Bridge\MicrosoftTeams\MicrosoftTeamsTransportFactory::class,
-            'package' => 'symfony/microsoft-teams-notifier',
+        'linkedin' => [
+            'class' => Bridge\LinkedIn\LinkedInTransportFactory::class,
+            'package' => 'symfony/linked-in-notifier',
         ],
-        'smsbiuras' => [
-            'class' => Bridge\SmsBiuras\SmsBiurasTransportFactory::class,
-            'package' => 'symfony/sms-biuras-notifier',
+        'mattermost' => [
+            'class' => Bridge\Mattermost\MattermostTransportFactory::class,
+            'package' => 'symfony/mattermost-notifier',
+        ],
+        'mercure' => [
+            'class' => Bridge\Mercure\MercureTransportFactory::class,
+            'package' => 'symfony/mercure-notifier',
         ],
         'messagebird' => [
             'class' => Bridge\MessageBird\MessageBirdTransportFactory::class,
             'package' => 'symfony/message-bird-notifier',
         ],
+        'microsoftteams' => [
+            'class' => Bridge\MicrosoftTeams\MicrosoftTeamsTransportFactory::class,
+            'package' => 'symfony/microsoft-teams-notifier',
+        ],
         'mobyt' => [
             'class' => Bridge\Mobyt\MobytTransportFactory::class,
             'package' => 'symfony/mobyt-notifier',
         ],
-        'linkedin' => [
-            'class' => Bridge\LinkedIn\LinkedInTransportFactory::class,
-            'package' => 'symfony/linked-in-notifier',
+        'nexmo' => [
+            'class' => Bridge\Nexmo\NexmoTransportFactory::class,
+            'package' => 'symfony/nexmo-notifier',
+        ],
+        'octopush' => [
+            'class' => Bridge\Octopush\OctopushTransportFactory::class,
+            'package' => 'symfony/octopush-notifier',
+        ],
+        'ovhcloud' => [
+            'class' => Bridge\OvhCloud\OvhCloudTransportFactory::class,
+            'package' => 'symfony/ovh-cloud-notifier',
+        ],
+        'rocketchat' => [
+            'class' => Bridge\RocketChat\RocketChatTransportFactory::class,
+            'package' => 'symfony/rocket-chat-notifier',
         ],
         'sendinblue' => [
             'class' => Bridge\Sendinblue\SendinblueTransportFactory::class,
             'package' => 'symfony/sendinblue-notifier',
+        ],
+        'sinch' => [
+            'class' => Bridge\Sinch\SinchTransportFactory::class,
+            'package' => 'symfony/sinch-notifier',
+        ],
+        'slack' => [
+            'class' => Bridge\Slack\SlackTransportFactory::class,
+            'package' => 'symfony/slack-notifier',
+        ],
+        'smsapi' => [
+            'class' => Bridge\Smsapi\SmsapiTransportFactory::class,
+            'package' => 'symfony/smsapi-notifier',
+        ],
+        'smsbiuras' => [
+            'class' => Bridge\SmsBiuras\SmsBiurasTransportFactory::class,
+            'package' => 'symfony/sms-biuras-notifier',
+        ],
+        'spothit' => [
+            'class' => Bridge\SpotHit\SpotHitTransportFactory::class,
+            'package' => 'symfony/spot-hit-notifier',
+        ],
+        'telegram' => [
+            'class' => Bridge\Telegram\TelegramTransportFactory::class,
+            'package' => 'symfony/telegram-notifier',
+        ],
+        'twilio' => [
+            'class' => Bridge\Twilio\TwilioTransportFactory::class,
+            'package' => 'symfony/twilio-notifier',
+        ],
+        'zulip' => [
+            'class' => Bridge\Zulip\ZulipTransportFactory::class,
+            'package' => 'symfony/zulip-notifier',
         ],
     ];
 

--- a/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Tests\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ClassExistsMock;
+use Symfony\Component\Notifier\Bridge\AllMySms\AllMySmsTransportFactory;
+use Symfony\Component\Notifier\Bridge\Clickatell\ClickatellTransportFactory;
+use Symfony\Component\Notifier\Bridge\Discord\DiscordTransportFactory;
+use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
+use Symfony\Component\Notifier\Bridge\FakeChat\FakeChatTransportFactory;
+use Symfony\Component\Notifier\Bridge\FakeSms\FakeSmsTransportFactory;
+use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransportFactory;
+use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransportFactory;
+use Symfony\Component\Notifier\Bridge\GatewayApi\GatewayApiTransportFactory;
+use Symfony\Component\Notifier\Bridge\Gitter\GitterTransportFactory;
+use Symfony\Component\Notifier\Bridge\GoogleChat\GoogleChatTransportFactory;
+use Symfony\Component\Notifier\Bridge\Infobip\InfobipTransportFactory;
+use Symfony\Component\Notifier\Bridge\Iqsms\IqsmsTransportFactory;
+use Symfony\Component\Notifier\Bridge\LightSms\LightSmsTransportFactory;
+use Symfony\Component\Notifier\Bridge\LinkedIn\LinkedInTransportFactory;
+use Symfony\Component\Notifier\Bridge\Mattermost\MattermostTransportFactory;
+use Symfony\Component\Notifier\Bridge\Mercure\MercureTransportFactory;
+use Symfony\Component\Notifier\Bridge\MessageBird\MessageBirdTransportFactory;
+use Symfony\Component\Notifier\Bridge\MicrosoftTeams\MicrosoftTeamsTransportFactory;
+use Symfony\Component\Notifier\Bridge\Mobyt\MobytTransportFactory;
+use Symfony\Component\Notifier\Bridge\Nexmo\NexmoTransportFactory;
+use Symfony\Component\Notifier\Bridge\Octopush\OctopushTransportFactory;
+use Symfony\Component\Notifier\Bridge\OvhCloud\OvhCloudTransportFactory;
+use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
+use Symfony\Component\Notifier\Bridge\Sendinblue\SendinblueTransportFactory;
+use Symfony\Component\Notifier\Bridge\Sinch\SinchTransportFactory;
+use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
+use Symfony\Component\Notifier\Bridge\Smsapi\SmsapiTransportFactory;
+use Symfony\Component\Notifier\Bridge\SmsBiuras\SmsBiurasTransportFactory;
+use Symfony\Component\Notifier\Bridge\SpotHit\SpotHitTransportFactory;
+use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransportFactory;
+use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory;
+use Symfony\Component\Notifier\Bridge\Zulip\ZulipTransportFactory;
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\Dsn;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+final class UnsupportedSchemeExceptionTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        ClassExistsMock::register(__CLASS__);
+        ClassExistsMock::withMockedClasses([
+            AllMySmsTransportFactory::class => false,
+            ClickatellTransportFactory::class => false,
+            DiscordTransportFactory::class => false,
+            EsendexTransportFactory::class => false,
+            FakeChatTransportFactory::class => false,
+            FakeSmsTransportFactory::class => false,
+            FirebaseTransportFactory::class => false,
+            FreeMobileTransportFactory::class => false,
+            GatewayApiTransportFactory::class => false,
+            GitterTransportFactory::class => false,
+            GoogleChatTransportFactory::class => false,
+            InfobipTransportFactory::class => false,
+            IqsmsTransportFactory::class => false,
+            LightSmsTransportFactory::class => false,
+            LinkedInTransportFactory::class => false,
+            MattermostTransportFactory::class => false,
+            MercureTransportFactory::class => false,
+            MessageBirdTransportFactory::class => false,
+            MicrosoftTeamsTransportFactory::class => false,
+            MobytTransportFactory::class => false,
+            NexmoTransportFactory::class => false,
+            OctopushTransportFactory::class => false,
+            OvhCloudTransportFactory::class => false,
+            RocketChatTransportFactory::class => false,
+            SendinblueTransportFactory::class => false,
+            SinchTransportFactory::class => false,
+            SlackTransportFactory::class => false,
+            SmsapiTransportFactory::class => false,
+            SmsBiurasTransportFactory::class => false,
+            SpotHitTransportFactory::class => false,
+            TelegramTransportFactory::class => false,
+            TwilioTransportFactory::class => false,
+            ZulipTransportFactory::class => false,
+        ]);
+    }
+
+    /**
+     * @dataProvider messageWhereSchemeIsPartOfSchemeToPackageMapProvider
+     */
+    public function testMessageWhereSchemeIsPartOfSchemeToPackageMap(string $scheme, string $package)
+    {
+        $dsn = new Dsn(sprintf('%s://localhost', $scheme));
+
+        $this->assertSame(
+            sprintf('Unable to send notification via "%s" as the bridge is not installed; try running "composer require %s".', $scheme, $package),
+            (new UnsupportedSchemeException($dsn))->getMessage()
+        );
+    }
+
+    public function messageWhereSchemeIsPartOfSchemeToPackageMapProvider(): \Generator
+    {
+        yield ['allmysms', 'symfony/allmysms-notifier'];
+        yield ['clickatell', 'symfony/clickatell-notifier'];
+        yield ['discord', 'symfony/discord-notifier'];
+        yield ['esendex', 'symfony/esendex-notifier'];
+        yield ['fakechat', 'symfony/fake-chat-notifier'];
+        yield ['fakesms', 'symfony/fake-sms-notifier'];
+        yield ['firebase', 'symfony/firebase-notifier'];
+        yield ['freemobile', 'symfony/free-mobile-notifier'];
+        yield ['gatewayapi', 'symfony/gatewayapi-notifier'];
+        yield ['gitter', 'symfony/gitter-notifier'];
+        yield ['googlechat', 'symfony/google-chat-notifier'];
+        yield ['infobip', 'symfony/infobip-notifier'];
+        yield ['iqsms', 'symfony/iqsms-notifier'];
+        yield ['lightsms', 'symfony/light-sms-notifier'];
+        yield ['linkedin', 'symfony/linked-in-notifier'];
+        yield ['mattermost', 'symfony/mattermost-notifier'];
+        yield ['mercure', 'symfony/mercure-notifier'];
+        yield ['messagebird', 'symfony/message-bird-notifier'];
+        yield ['microsoftteams', 'symfony/microsoft-teams-notifier'];
+        yield ['mobyt', 'symfony/mobyt-notifier'];
+        yield ['nexmo', 'symfony/nexmo-notifier'];
+        yield ['octopush', 'symfony/octopush-notifier'];
+        yield ['ovhcloud', 'symfony/ovh-cloud-notifier'];
+        yield ['rocketchat', 'symfony/rocket-chat-notifier'];
+        yield ['sendinblue', 'symfony/sendinblue-notifier'];
+        yield ['sinch', 'symfony/sinch-notifier'];
+        yield ['slack', 'symfony/slack-notifier'];
+        yield ['smsapi', 'symfony/smsapi-notifier'];
+        yield ['smsbiuras', 'symfony/sms-biuras-notifier'];
+        yield ['spothit', 'symfony/spot-hit-notifier'];
+        yield ['telegram', 'symfony/telegram-notifier'];
+        yield ['twilio', 'symfony/twilio-notifier'];
+        yield ['zulip', 'symfony/zulip-notifier'];
+    }
+
+    /**
+     * @dataProvider messageWhereSchemeIsNotPartOfSchemeToPackageMapProvider
+     */
+    public function testMessageWhereSchemeIsNotPartOfSchemeToPackageMap(string $expected, Dsn $dsn, ?string $name, array $supported)
+    {
+        $this->assertSame(
+            $expected,
+            (new UnsupportedSchemeException($dsn, $name, $supported))->getMessage()
+        );
+    }
+
+    public function messageWhereSchemeIsNotPartOfSchemeToPackageMapProvider(): \Generator
+    {
+        yield [
+            'The "somethingElse" scheme is not supported.',
+            new Dsn('somethingElse://localhost'),
+            null,
+            [],
+        ];
+
+        yield [
+            'The "somethingElse" scheme is not supported.',
+            new Dsn('somethingElse://localhost'),
+            'foo',
+            [],
+        ];
+
+        yield [
+            'The "somethingElse" scheme is not supported; supported schemes for notifier "one" are: "one", "two".',
+            new Dsn('somethingElse://localhost'),
+            'one',
+            ['one', 'two'],
+        ];
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Translation/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ClassExistsMock;
+use Symfony\Component\Translation\Bridge\Crowdin\CrowdinProviderFactory;
+use Symfony\Component\Translation\Bridge\Loco\LocoProviderFactory;
+use Symfony\Component\Translation\Bridge\Lokalise\LokaliseProviderFactory;
+use Symfony\Component\Translation\Bridge\PoEditor\PoEditorProviderFactory;
+use Symfony\Component\Translation\Exception\UnsupportedSchemeException;
+use Symfony\Component\Translation\Provider\Dsn;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+final class UnsupportedSchemeExceptionTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        ClassExistsMock::register(__CLASS__);
+        ClassExistsMock::withMockedClasses([
+            CrowdinProviderFactory::class => false,
+            LocoProviderFactory::class => false,
+            LokaliseProviderFactory::class => false,
+            PoEditorProviderFactory::class => false,
+        ]);
+    }
+
+    /**
+     * @dataProvider messageWhereSchemeIsPartOfSchemeToPackageMapProvider
+     */
+    public function testMessageWhereSchemeIsPartOfSchemeToPackageMap(string $scheme, string $package)
+    {
+        $dsn = new Dsn(sprintf('%s://localhost', $scheme));
+
+        $this->assertSame(
+            sprintf('Unable to synchronize translations via "%s" as the provider is not installed; try running "composer require %s".', $scheme, $package),
+            (new UnsupportedSchemeException($dsn))->getMessage()
+        );
+    }
+
+    public function messageWhereSchemeIsPartOfSchemeToPackageMapProvider(): \Generator
+    {
+        yield ['crowdin', 'symfony/crowdin-translation-provider'];
+        yield ['loco', 'symfony/loco-translation-provider'];
+        yield ['lokalise', 'symfony/lokalise-translation-provider'];
+        yield ['poeditor', 'symfony/po-editor-translation-provider'];
+    }
+
+    /**
+     * @dataProvider messageWhereSchemeIsNotPartOfSchemeToPackageMapProvider
+     */
+    public function testMessageWhereSchemeIsNotPartOfSchemeToPackageMap(string $expected, Dsn $dsn, ?string $name, array $supported)
+    {
+        $this->assertSame(
+            $expected,
+            (new UnsupportedSchemeException($dsn, $name, $supported))->getMessage()
+        );
+    }
+
+    public function messageWhereSchemeIsNotPartOfSchemeToPackageMapProvider(): \Generator
+    {
+        yield [
+            'The "somethingElse" scheme is not supported.',
+            new Dsn('somethingElse://localhost'),
+            null,
+            [],
+        ];
+
+        yield [
+            'The "somethingElse" scheme is not supported.',
+            new Dsn('somethingElse://localhost'),
+            'foo',
+            [],
+        ];
+
+        yield [
+            'The "somethingElse" scheme is not supported; supported schemes for translation provider "one" are: "one", "two".',
+            new Dsn('somethingElse://localhost'),
+            'one',
+            ['one', 'two'],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This way we make sure a third party which is not known by `symfony/translation` can reuse this exception without being part of the `SCHEME_TO_PACKAGE_MAP`.

@Nyholm I agree that the exception should not know about the bridges, any ideas? The DX ist great to tell the user a package is missing and can be installed via composer 🤔 

### Todos
* [x] add this test for `symfony/notifier`
* [x] add this test for `symfony/mailer`

cc @welcoMattic 