### PR TITLE
[HttpFoundation] Small phpdoc improvement

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -687,7 +687,7 @@ class Request
      * flexibility in controllers, it is better to explicitly get request parameters from the appropriate
      * public property instead (attributes, query, request).
      *
-     * Order of precedence: PATH (routing placeholders or custom attributes), GET, BODY
+     * Order of precedence: PATH (routing placeholders or custom attributes), GET, POST
      *
      * @param string $key     The key
      * @param mixed  $default The default value if the parameter key does not exist


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | 

I have been looking for a way to emulate `$_REQUEST` in Symfony, and I always thought the `get` method is useless for that, because it only looks at some custom routing stuff, GET and whatever BODY might be. Only today I actually looked at the source code and found out that it's actually (almost) doing what I was looking for, i.e. check `$_GET`, and then `$_POST`. So I figured it would be good to be a bit more explicit in the phpdoc (analoguous to the phpdoc for `$request->request`, which says "Request body parameters ($_POST).").
