### PR TITLE
[TwigBridge] Fix HTML for translatable custom-file label in Bootstrap 4 theme

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_4_layout.html.twig
@@ -121,11 +121,12 @@
 {% block file_widget -%}
     <{{ element|default('div') }} class="custom-file">
         {%- set type = type|default('file') -%}
-        {{- block('form_widget_simple') -}}
-        {%- set label_attr = label_attr|merge({ class: (label_attr.class|default('') ~ ' custom-file-label')|trim }) -%}
         {%- set input_lang = 'en' -%}
         {% if app is defined and app.request is defined %}{%- set input_lang = app.request.locale -%}{%- endif -%}
-        <label for="{{ form.vars.id }}" lang="{{ input_lang }}" {% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}>
+        {%- set attr = {lang: input_lang} | merge(attr) -%}
+        {{- block('form_widget_simple') -}}
+        {%- set label_attr = label_attr|merge({ class: (label_attr.class|default('') ~ ' custom-file-label')|trim }) -%}
+        <label for="{{ form.vars.id }}" {% with { attr: label_attr } %}{{ block('attributes') }}{% endwith %}>
             {%- if attr.placeholder is defined and attr.placeholder is not none -%}
                 {{- translation_domain is same as(false) ? attr.placeholder : attr.placeholder|trans({}, translation_domain) -}}
             {%- endif -%}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Bootstrap allows to translate/change the label of the upload button of a `custom-file` input via SCSS, see [Bootstrap docs](https://getbootstrap.com/docs/4.6/components/forms/#translating-or-customizing-the-strings-with-scss):
~~~scss
$custom-file-text: (
  en: "Browse",
  es: "Elegir"
);
~~~

This works by generating the following CSS which depends on the `lang` attribute of the input:

~~~css
.custom-file-input:lang(es) ~ .custom-file-label::after {
	content: "Elegir";
}
~~~

This however currently does not work with the HTML generated by the theme since the resulting HTML is of the form (redacted here to the relevant parts):
~~~html
<div class="custom-file">
  <input type="file" id="..." class="custom-file-input">
  <label for="..." lang="es" class="custom-file-label"></label>
</div>
~~~
while it should be of the form
~~~html
<div class="custom-file">
  <input type="file" id="..." lang="es" class="custom-file-input">
  <label for="..." class="custom-file-label"></label>
</div>
~~~

i.e. the `lang` was placed on the `label` instead of the `input`.

This PR fixes this to be compatible with Bootstrap 4.