### PR TITLE
Interfaces for http kernel events

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -13,6 +13,17 @@ CHANGELOG
  * Deprecate `KernelEvent::isMasterRequest()` and add `isMainRequest()` as replacement
  * Add `#[AsController]` attribute for declaring standalone controllers on PHP 8
  * Add `FragmentUriGeneratorInterface` and `FragmentUriGenerator` to generate the URI of a fragment
+ * Add HttpKernel Event Interfaces
+   * `ControllerArgumentsEventInterface`
+   * `ControllerEventInterface`
+   * `ExceptionEventInterface`
+   * `FinishRequestEventInterface`
+   * `KernelEventInterface`
+   * `RequestEventInterface`
+   * `ResponseEventInterface`
+   * `TerminateEventInterface`
+   * `ViewEventInterface`
+ * Add `KernelEventTest`
 
 5.2.0
 -----

--- a/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEvent.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author Christophe Coevoet <stof@notk.org>
  */
-final class ControllerArgumentsEvent extends KernelEvent
+final class ControllerArgumentsEvent extends KernelEvent implements ControllerArgumentsEventInterface
 {
     private $controller;
     private $arguments;

--- a/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEventInterface.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerArgumentsEventInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Event;
+
+/**
+ * Represents an event containing a controller and arguments.
+ *
+ * @author Lukasz Goworko <info@lukaszgoworko.de>
+ */
+interface ControllerArgumentsEventInterface
+{
+    public function getController(): callable;
+
+    public function setController(callable $controller);
+
+    public function getArguments(): array;
+
+    public function setArguments(array $arguments);
+}

--- a/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerEvent.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-final class ControllerEvent extends KernelEvent
+final class ControllerEvent extends KernelEvent implements ControllerEventInterface
 {
     private $controller;
 

--- a/src/Symfony/Component/HttpKernel/Event/ControllerEventInterface.php
+++ b/src/Symfony/Component/HttpKernel/Event/ControllerEventInterface.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\HttpKernel\Event;
 
 /**
- * Triggered whenever a request is fully processed.
+ * Represents an event containing a controller.
  *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Lukasz Goworko <info@lukaszgoworko.de>
  */
-final class FinishRequestEvent extends KernelEvent implements FinishRequestEventInterface
+interface ControllerEventInterface
 {
+    public function getController(): callable;
+
+    public function setController(callable $controller): void;
 }

--- a/src/Symfony/Component/HttpKernel/Event/ExceptionEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ExceptionEvent.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-final class ExceptionEvent extends RequestEvent
+final class ExceptionEvent extends RequestEvent implements ExceptionEventInterface
 {
     private $throwable;
 

--- a/src/Symfony/Component/HttpKernel/Event/ExceptionEventInterface.php
+++ b/src/Symfony/Component/HttpKernel/Event/ExceptionEventInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Event;
+
+/**
+ * Represents an event containing a throwable.
+ *
+ * @author Lukasz Goworko <info@lukaszgoworko.de>
+ */
+interface ExceptionEventInterface
+{
+    public function getThrowable(): \Throwable;
+
+    public function setThrowable(\Throwable $exception): void;
+
+    public function allowCustomResponseCode(): void;
+
+    public function isAllowingCustomResponseCode(): bool;
+}

--- a/src/Symfony/Component/HttpKernel/Event/FinishRequestEventInterface.php
+++ b/src/Symfony/Component/HttpKernel/Event/FinishRequestEventInterface.php
@@ -11,11 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\Event;
 
-/**
- * Triggered whenever a request is fully processed.
- *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
- */
-final class FinishRequestEvent extends KernelEvent implements FinishRequestEventInterface
+interface FinishRequestEventInterface
 {
 }

--- a/src/Symfony/Component/HttpKernel/Event/KernelEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/KernelEvent.php
@@ -20,7 +20,7 @@ use Symfony\Contracts\EventDispatcher\Event;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class KernelEvent extends Event
+class KernelEvent extends Event implements KernelEventInterface
 {
     private $kernel;
     private $request;

--- a/src/Symfony/Component/HttpKernel/Event/KernelEventInterface.php
+++ b/src/Symfony/Component/HttpKernel/Event/KernelEventInterface.php
@@ -12,10 +12,17 @@
 namespace Symfony\Component\HttpKernel\Event;
 
 /**
- * Triggered whenever a request is fully processed.
+ * Represents an event containing a kernel and a request.
  *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Lukasz Goworko <info@lukaszgoworko.de>
  */
-final class FinishRequestEvent extends KernelEvent implements FinishRequestEventInterface
+interface KernelEventInterface
 {
+    public function getKernel();
+
+    public function getRequest();
+
+    public function getRequestType();
+
+    public function isMainRequest(): bool;
 }

--- a/src/Symfony/Component/HttpKernel/Event/RequestEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/RequestEvent.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class RequestEvent extends KernelEvent
+class RequestEvent extends KernelEvent implements RequestEventInterface
 {
     private $response;
 

--- a/src/Symfony/Component/HttpKernel/Event/RequestEventInterface.php
+++ b/src/Symfony/Component/HttpKernel/Event/RequestEventInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Event;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Represents an event containing probably a response.
+ *
+ * @author Lukasz Goworko <info@lukaszgoworko.de>
+ */
+interface RequestEventInterface
+{
+    /**
+     * Returns the response object.
+     *
+     * @return Response|null
+     */
+    public function getResponse();
+
+    public function setResponse(Response $response);
+
+    /**
+     * Returns whether a response was set.
+     *
+     * @return bool Whether a response was set
+     */
+    public function hasResponse();
+}

--- a/src/Symfony/Component/HttpKernel/Event/ResponseEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ResponseEvent.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-final class ResponseEvent extends KernelEvent
+final class ResponseEvent extends KernelEvent implements ResponseEventInterface
 {
     private $response;
 

--- a/src/Symfony/Component/HttpKernel/Event/ResponseEventInterface.php
+++ b/src/Symfony/Component/HttpKernel/Event/ResponseEventInterface.php
@@ -11,11 +11,16 @@
 
 namespace Symfony\Component\HttpKernel\Event;
 
+use Symfony\Component\HttpFoundation\Response;
+
 /**
- * Triggered whenever a request is fully processed.
+ * Represents an event containing response.
  *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Lukasz Goworko <info@lukaszgoworko.de>
  */
-final class FinishRequestEvent extends KernelEvent implements FinishRequestEventInterface
+interface ResponseEventInterface
 {
+    public function getResponse(): Response;
+
+    public function setResponse(Response $response): void;
 }

--- a/src/Symfony/Component/HttpKernel/Event/TerminateEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/TerminateEvent.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-final class TerminateEvent extends KernelEvent
+final class TerminateEvent extends KernelEvent implements TerminateEventInterface
 {
     private $response;
 

--- a/src/Symfony/Component/HttpKernel/Event/TerminateEventInterface.php
+++ b/src/Symfony/Component/HttpKernel/Event/TerminateEventInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Event;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Represents an terminate event containing a response.
+ *
+ * @author Lukasz Goworko <info@lukaszgoworko.de>
+ */
+interface TerminateEventInterface
+{
+    public function getResponse(): Response;
+}

--- a/src/Symfony/Component/HttpKernel/Event/TerminateEventInterface.php
+++ b/src/Symfony/Component/HttpKernel/Event/TerminateEventInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\HttpKernel\Event;
 
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Symfony/Component/HttpKernel/Event/ViewEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/ViewEvent.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-final class ViewEvent extends RequestEvent
+final class ViewEvent extends RequestEvent implements ViewEventInterface
 {
     /**
      * The return value of the controller.

--- a/src/Symfony/Component/HttpKernel/Event/ViewEventInterface.php
+++ b/src/Symfony/Component/HttpKernel/Event/ViewEventInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Event;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Represents an event containing a controller result.
+ *
+ * @author Lukasz Goworko <info@lukaszgoworko.de>
+ */
+interface ViewEventInterface
+{
+    /**
+     * Returns the return value of the controller.
+     *
+     * @return mixed The controller return value
+     */
+    public function getControllerResult();
+
+    /**
+     * Assigns the return value of the controller.
+     *
+     * @param mixed $controllerResult The controller return value
+     */
+    public function setControllerResult($controllerResult): void;
+}

--- a/src/Symfony/Component/HttpKernel/Event/ViewEventInterface.php
+++ b/src/Symfony/Component/HttpKernel/Event/ViewEventInterface.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\Event;
 
-use Symfony\Component\HttpFoundation\Response;
-
 /**
  * Represents an event containing a controller result.
  *

--- a/src/Symfony/Component/HttpKernel/Tests/Event/KernelEventTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Event/KernelEventTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Event;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Tests\TestHttpKernel;
+
+class KernelEventTest extends TestCase
+{
+
+    public function testIsMainRequestTrue()
+    {
+        $kernelEvent = new KernelEvent(new TestHttpKernel(), new Request(), HttpKernelInterface::MAIN_REQUEST);
+        self::assertTrue($kernelEvent->isMainRequest());
+    }
+
+    public function testIsMainRequestFalse()
+    {
+        $kernelEvent = new KernelEvent(new TestHttpKernel(), new Request(), HttpKernelInterface::SUB_REQUEST);
+        self::assertFalse($kernelEvent->isMainRequest());
+    }
+
+    public function testGetRequestType()
+    {
+        $kernelEvent = new KernelEvent(new TestHttpKernel(), new Request(), HttpKernelInterface::MAIN_REQUEST);
+        self::assertSame(HttpKernelInterface::MAIN_REQUEST, $kernelEvent->getRequestType());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Event/KernelEventTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Event/KernelEventTest.php
@@ -19,7 +19,6 @@ use Symfony\Component\HttpKernel\Tests\TestHttpKernel;
 
 class KernelEventTest extends TestCase
 {
-
     public function testIsMainRequestTrue()
     {
         $kernelEvent = new KernelEvent(new TestHttpKernel(), new Request(), HttpKernelInterface::MAIN_REQUEST);


### PR DESCRIPTION
```
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | 
| License       | MIT
| Doc PR        | Do not know if needed

In my project I had struggles to create Unit Tests for a KernelExceptionListner as the event classes are final. With this interfaces a Mock can be created easily. Also the Lister can now depend on an interface and not on a concrete class

```