### PR TITLE
[Notifier] Fix return SentMessage then Messenger not used

### DIFF
--- a/src/Symfony/Component/Notifier/Chatter.php
+++ b/src/Symfony/Component/Notifier/Chatter.php
@@ -51,9 +51,7 @@ final class Chatter implements ChatterInterface
     public function send(MessageInterface $message): ?SentMessage
     {
         if (null === $this->bus) {
-            $this->transport->send($message);
-
-            return null;
+            return $this->transport->send($message);
         }
 
         if (null !== $this->dispatcher) {

--- a/src/Symfony/Component/Notifier/Tests/ChatterTest.php
+++ b/src/Symfony/Component/Notifier/Tests/ChatterTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Symfony\Component\Notifier\Tests;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Notifier\Chatter;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+
+class ChatterTest extends TestCase
+{
+    /** @var MockObject&TransportInterface */
+    private $transport;
+
+    /** @var MockObject&MessageBusInterface */
+    private $bus;
+
+    protected function setUp(): void
+    {
+        $this->transport = $this->createMock(TransportInterface::class);
+        $this->bus = $this->createMock(MessageBusInterface::class);
+    }
+
+    public function testSendWithoutBus()
+    {
+        $message = new DummyMessage();
+
+        $sentMessage = new SentMessage($message, 'any');
+
+        $this->transport
+            ->expects($this->once())
+            ->method('send')
+            ->with($message)
+            ->willReturn($sentMessage);
+
+        $chatter = new Chatter($this->transport);
+        $this->assertSame($sentMessage, $chatter->send($message));
+        $this->assertSame($message, $sentMessage->getOriginalMessage());
+    }
+
+    public function testSendWithBus()
+    {
+        $message = new DummyMessage();
+
+        $this->transport
+            ->expects($this->never())
+            ->method('send')
+            ->with($message);
+
+        $this->bus
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($message)
+            ->willReturn(new Envelope(new \stdClass()));
+
+        $chatter = new Chatter($this->transport, $this->bus);
+        $this->assertNull($chatter->send($message));
+    }
+}

--- a/src/Symfony/Component/Notifier/Tests/TexterTest.php
+++ b/src/Symfony/Component/Notifier/Tests/TexterTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Symfony\Component\Notifier\Tests;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Tests\Transport\DummyMessage;
+use Symfony\Component\Notifier\Texter;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+
+class TexterTest extends TestCase
+{
+    /** @var MockObject&TransportInterface */
+    private $transport;
+
+    /** @var MockObject&MessageBusInterface */
+    private $bus;
+
+    protected function setUp(): void
+    {
+        $this->transport = $this->createMock(TransportInterface::class);
+        $this->bus = $this->createMock(MessageBusInterface::class);
+    }
+
+    public function testSendWithoutBus()
+    {
+        $message = new DummyMessage();
+        $sentMessage = new SentMessage($message, 'any');
+
+        $this->transport
+            ->expects($this->once())
+            ->method('send')
+            ->with($message)
+            ->willReturn($sentMessage);
+
+        $texter = new Texter($this->transport);
+        $this->assertSame($sentMessage, $texter->send($message));
+        $this->assertSame($message, $sentMessage->getOriginalMessage());
+    }
+
+    public function testSendWithBus()
+    {
+        $message = new DummyMessage();
+
+        $this->transport
+            ->expects($this->never())
+            ->method('send')
+            ->with($message);
+
+        $this->bus
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($message)
+            ->willReturn(new Envelope(new \stdClass()));
+
+        $texter = new Texter($this->transport, $this->bus);
+        $this->assertNull($texter->send($message));
+    }
+}

--- a/src/Symfony/Component/Notifier/Texter.php
+++ b/src/Symfony/Component/Notifier/Texter.php
@@ -51,9 +51,7 @@ final class Texter implements TexterInterface
     public function send(MessageInterface $message): ?SentMessage
     {
         if (null === $this->bus) {
-            $this->transport->send($message);
-
-            return null;
+            return $this->transport->send($message);
         }
 
         if (null !== $this->dispatcher) {

--- a/src/Symfony/Component/Notifier/composer.json
+++ b/src/Symfony/Component/Notifier/composer.json
@@ -22,7 +22,8 @@
     },
     "require-dev": {
         "symfony/event-dispatcher-contracts": "^2",
-        "symfony/http-client-contracts": "^2"
+        "symfony/http-client-contracts": "^2",
+        "symfony/messenger": "^4.4 || ^5.0"
     },
     "conflict": {
         "symfony/http-kernel": "<4.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | --
| License       | MIT
| Doc PR        | --

https://github.com/symfony/symfony/pull/37748 Broke the Notifier when Transport not used.
