### PR TITLE
[Notifier] Add NotificationInterface

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatOptions.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\GoogleChat;
 use Symfony\Component\Notifier\Bridge\GoogleChat\Component\Card;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 
 /**
  * @author Jérôme Tamarelle <jerome@tamarelle.net>
@@ -29,7 +29,7 @@ final class GoogleChatOptions implements MessageOptionsInterface
         $this->options = $options;
     }
 
-    public static function fromNotification(Notification $notification): self
+    public static function fromNotification(NotificationInterface $notification): self
     {
         $options = new self();
 

--- a/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/LinkedIn/LinkedInOptions.php
@@ -16,7 +16,7 @@ use Symfony\Component\Notifier\Bridge\LinkedIn\Share\LifecycleStateShare;
 use Symfony\Component\Notifier\Bridge\LinkedIn\Share\ShareContentShare;
 use Symfony\Component\Notifier\Bridge\LinkedIn\Share\VisibilityShare;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 
 /**
  * @author Smaïne Milianni <smaine.milianni@gmail.com>
@@ -40,7 +40,7 @@ final class LinkedInOptions implements MessageOptionsInterface
         return null;
     }
 
-    public static function fromNotification(Notification $notification): self
+    public static function fromNotification(NotificationInterface $notification): self
     {
         $options = new self();
         $options->specificContent(new ShareContentShare($notification->getSubject()));

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytOptions.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Notifier\Bridge\Mobyt;
 
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 
 /**
  * @author Bastien Durand <bdurand-dev@outlook.com>
@@ -35,18 +35,18 @@ final class MobytOptions implements MessageOptionsInterface
         $this->options = $options;
     }
 
-    public static function fromNotification(Notification $notification): self
+    public static function fromNotification(NotificationInterface $notification): self
     {
         $options = new self();
         switch ($notification->getImportance()) {
-            case Notification::IMPORTANCE_HIGH:
-            case Notification::IMPORTANCE_URGENT:
+            case NotificationInterface::IMPORTANCE_HIGH:
+            case NotificationInterface::IMPORTANCE_URGENT:
                 $options->messageType(self::MESSAGE_TYPE_QUALITY_HIGH);
                 break;
-            case Notification::IMPORTANCE_MEDIUM:
+            case NotificationInterface::IMPORTANCE_MEDIUM:
                 $options->messageType(self::MESSAGE_TYPE_QUALITY_MEDIUM);
                 break;
-            case Notification::IMPORTANCE_LOW:
+            case NotificationInterface::IMPORTANCE_LOW:
                 $options->messageType(self::MESSAGE_TYPE_QUALITY_LOW);
                 break;
             default:

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/MobytOptions.php
@@ -79,7 +79,7 @@ final class MobytOptions implements MessageOptionsInterface
     public static function validateMessageType($type): string
     {
         if (!\in_array($type, $supported = [self::MESSAGE_TYPE_QUALITY_HIGH, self::MESSAGE_TYPE_QUALITY_MEDIUM, self::MESSAGE_TYPE_QUALITY_LOW], true)) {
-            throw new InvalidArgumentException(sprintf('The message type "%s" is not supported; supported message types are: "%s"', $type, implode('", "', $supported)));
+            throw new InvalidArgumentException(sprintf('The message type "%s" is not supported; supported message types are: "%s".', $type, implode('", "', $supported)));
         }
 
         return $type;

--- a/src/Symfony/Component/Notifier/Bridge/Mobyt/Tests/MobytOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mobyt/Tests/MobytOptionsTest.php
@@ -14,7 +14,7 @@ final class MobytOptionsTest extends TestCase
      */
     public function testFromNotification(string $importance, string $expectedMessageType)
     {
-        $notification = (new Notification('Foo'))->importance($importance);
+        $notification = (new Notification('Foo'))->setImportance($importance);
 
         $options = (MobytOptions::fromNotification($notification))->toArray();
 
@@ -34,7 +34,7 @@ final class MobytOptionsTest extends TestCase
 
     public function testFromNotificationDefaultLevel()
     {
-        $notification = (new Notification('Foo'))->importance('Bar');
+        $notification = (new Notification('Foo'))->setImportance('Bar');
 
         $options = (MobytOptions::fromNotification($notification))->toArray();
 

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
@@ -15,7 +15,7 @@ use Symfony\Component\Notifier\Bridge\Slack\Block\SlackBlockInterface;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackDividerBlock;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -29,7 +29,7 @@ final class SlackOptions implements MessageOptionsInterface
         $this->options = $options;
     }
 
-    public static function fromNotification(Notification $notification): self
+    public static function fromNotification(NotificationInterface $notification): self
     {
         $options = new self();
         $options->iconEmoji($notification->getEmoji());

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackOptionsTest.php
@@ -183,7 +183,7 @@ final class SlackOptionsTest extends TestCase
                     ],
                 ],
             ],
-            (new Notification($subject))->emoji($emoji)->content($content),
+            (new Notification($subject))->emoji($emoji)->setContent($content),
         ];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackOptionsTest.php
@@ -16,6 +16,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackDividerBlock;
 use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
 use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
@@ -133,7 +134,7 @@ final class SlackOptionsTest extends TestCase
     /**
      * @dataProvider fromNotificationProvider
      */
-    public function testFromNotification(array $expected, Notification $notification)
+    public function testFromNotification(array $expected, NotificationInterface $notification)
     {
         $options = SlackOptions::fromNotification($notification);
 

--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -12,6 +12,8 @@ CHANGELOG
  * [BC BREAK] Remove `Dsn::fromString()` method
  * [BC BREAK] Changed the return type of `AbstractTransportFactory::getEndpoint()` from `?string` to `string`
  * Added `DSN::getRequiredOption` method which throws a new `MissingRequiredOptionException`.
+ * Added `NotificationInterface` to enable composition for notifications 
+ * Changed visibility of `Notification` properties to protected in order to make inheritance easier 
 
 5.2.0
 -----

--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -13,7 +13,6 @@ CHANGELOG
  * [BC BREAK] Changed the return type of `AbstractTransportFactory::getEndpoint()` from `?string` to `string`
  * Added `DSN::getRequiredOption` method which throws a new `MissingRequiredOptionException`.
  * Added `NotificationInterface` to enable composition for notifications 
- * Changed visibility of `Notification` properties to protected in order to make inheritance easier 
 
 5.2.0
 -----

--- a/src/Symfony/Component/Notifier/Channel/BrowserChannel.php
+++ b/src/Symfony/Component/Notifier/Channel/BrowserChannel.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Channel;
 
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 use Symfony\Component\Notifier\Recipient\RecipientInterface;
 
 /**
@@ -27,7 +27,7 @@ final class BrowserChannel implements ChannelInterface
         $this->stack = $stack;
     }
 
-    public function notify(Notification $notification, RecipientInterface $recipient, string $transportName = null): void
+    public function notify(NotificationInterface $notification, RecipientInterface $recipient, string $transportName = null): void
     {
         if (null === $request = $this->stack->getCurrentRequest()) {
             return;
@@ -40,7 +40,7 @@ final class BrowserChannel implements ChannelInterface
         $request->getSession()->getFlashBag()->add('notification', $message);
     }
 
-    public function supports(Notification $notification, RecipientInterface $recipient): bool
+    public function supports(NotificationInterface $notification, RecipientInterface $recipient): bool
     {
         return true;
     }

--- a/src/Symfony/Component/Notifier/Channel/ChannelInterface.php
+++ b/src/Symfony/Component/Notifier/Channel/ChannelInterface.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Notifier\Channel;
 
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 use Symfony\Component\Notifier\Recipient\RecipientInterface;
 
 /**
@@ -19,7 +19,7 @@ use Symfony\Component\Notifier\Recipient\RecipientInterface;
  */
 interface ChannelInterface
 {
-    public function notify(Notification $notification, RecipientInterface $recipient, string $transportName = null): void;
+    public function notify(NotificationInterface $notification, RecipientInterface $recipient, string $transportName = null): void;
 
-    public function supports(Notification $notification, RecipientInterface $recipient): bool;
+    public function supports(NotificationInterface $notification, RecipientInterface $recipient): bool;
 }

--- a/src/Symfony/Component/Notifier/Channel/ChatChannel.php
+++ b/src/Symfony/Component/Notifier/Channel/ChatChannel.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Notifier\Channel;
 
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Notification\ChatNotificationInterface;
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 use Symfony\Component\Notifier\Recipient\RecipientInterface;
 
 /**
@@ -21,7 +21,7 @@ use Symfony\Component\Notifier\Recipient\RecipientInterface;
  */
 class ChatChannel extends AbstractChannel
 {
-    public function notify(Notification $notification, RecipientInterface $recipient, string $transportName = null): void
+    public function notify(NotificationInterface $notification, RecipientInterface $recipient, string $transportName = null): void
     {
         $message = null;
         if ($notification instanceof ChatNotificationInterface) {
@@ -43,7 +43,7 @@ class ChatChannel extends AbstractChannel
         }
     }
 
-    public function supports(Notification $notification, RecipientInterface $recipient): bool
+    public function supports(NotificationInterface $notification, RecipientInterface $recipient): bool
     {
         return true;
     }

--- a/src/Symfony/Component/Notifier/Channel/EmailChannel.php
+++ b/src/Symfony/Component/Notifier/Channel/EmailChannel.php
@@ -19,7 +19,7 @@ use Symfony\Component\Mime\Email;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Message\EmailMessage;
 use Symfony\Component\Notifier\Notification\EmailNotificationInterface;
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 use Symfony\Component\Notifier\Recipient\EmailRecipientInterface;
 use Symfony\Component\Notifier\Recipient\RecipientInterface;
 
@@ -45,7 +45,7 @@ class EmailChannel implements ChannelInterface
         $this->envelope = $envelope;
     }
 
-    public function notify(Notification $notification, RecipientInterface $recipient, string $transportName = null): void
+    public function notify(NotificationInterface $notification, RecipientInterface $recipient, string $transportName = null): void
     {
         $message = null;
         if ($notification instanceof EmailNotificationInterface) {
@@ -83,7 +83,7 @@ class EmailChannel implements ChannelInterface
         }
     }
 
-    public function supports(Notification $notification, RecipientInterface $recipient): bool
+    public function supports(NotificationInterface $notification, RecipientInterface $recipient): bool
     {
         return $recipient instanceof EmailRecipientInterface;
     }

--- a/src/Symfony/Component/Notifier/Channel/SmsChannel.php
+++ b/src/Symfony/Component/Notifier/Channel/SmsChannel.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Channel;
 
 use Symfony\Component\Notifier\Message\SmsMessage;
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 use Symfony\Component\Notifier\Notification\SmsNotificationInterface;
 use Symfony\Component\Notifier\Recipient\RecipientInterface;
 use Symfony\Component\Notifier\Recipient\SmsRecipientInterface;
@@ -22,7 +22,7 @@ use Symfony\Component\Notifier\Recipient\SmsRecipientInterface;
  */
 class SmsChannel extends AbstractChannel
 {
-    public function notify(Notification $notification, RecipientInterface $recipient, string $transportName = null): void
+    public function notify(NotificationInterface $notification, RecipientInterface $recipient, string $transportName = null): void
     {
         $message = null;
         if ($notification instanceof SmsNotificationInterface) {
@@ -44,7 +44,7 @@ class SmsChannel extends AbstractChannel
         }
     }
 
-    public function supports(Notification $notification, RecipientInterface $recipient): bool
+    public function supports(NotificationInterface $notification, RecipientInterface $recipient): bool
     {
         return $recipient instanceof SmsRecipientInterface;
     }

--- a/src/Symfony/Component/Notifier/Message/ChatMessage.php
+++ b/src/Symfony/Component/Notifier/Message/ChatMessage.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Notifier\Message;
 
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
@@ -29,7 +29,7 @@ final class ChatMessage implements MessageInterface
         $this->options = $options;
     }
 
-    public static function fromNotification(Notification $notification): self
+    public static function fromNotification(NotificationInterface $notification): self
     {
         $message = new self($notification->getSubject());
         $message->notification = $notification;
@@ -87,7 +87,7 @@ final class ChatMessage implements MessageInterface
         return $this->transport;
     }
 
-    public function getNotification(): ?Notification
+    public function getNotification(): ?NotificationInterface
     {
         return $this->notification;
     }

--- a/src/Symfony/Component/Notifier/Message/EmailMessage.php
+++ b/src/Symfony/Component/Notifier/Message/EmailMessage.php
@@ -17,7 +17,7 @@ use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\RawMessage;
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Exception\LogicException;
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 use Symfony\Component\Notifier\Recipient\EmailRecipientInterface;
 
 /**
@@ -34,7 +34,7 @@ final class EmailMessage implements MessageInterface
         $this->envelope = $envelope;
     }
 
-    public static function fromNotification(Notification $notification, EmailRecipientInterface $recipient): self
+    public static function fromNotification(NotificationInterface $notification, EmailRecipientInterface $recipient): self
     {
         if ('' === $recipient->getEmail()) {
             throw new InvalidArgumentException(sprintf('"%s" needs an email, it cannot be empty.', static::class));

--- a/src/Symfony/Component/Notifier/Message/SmsMessage.php
+++ b/src/Symfony/Component/Notifier/Message/SmsMessage.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Notifier\Message;
 
 use Symfony\Component\Notifier\Exception\InvalidArgumentException;
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 use Symfony\Component\Notifier\Recipient\SmsRecipientInterface;
 
 /**
@@ -34,7 +34,7 @@ final class SmsMessage implements MessageInterface
         $this->phone = $phone;
     }
 
-    public static function fromNotification(Notification $notification, SmsRecipientInterface $recipient): self
+    public static function fromNotification(NotificationInterface $notification, SmsRecipientInterface $recipient): self
     {
         return new self($recipient->getPhone(), $notification->getSubject());
     }

--- a/src/Symfony/Component/Notifier/Notification/Notification.php
+++ b/src/Symfony/Component/Notifier/Notification/Notification.php
@@ -20,7 +20,7 @@ use Symfony\Component\Notifier\Recipient\RecipientInterface;
  */
 class Notification implements NotificationInterface
 {
-    protected const LEVELS = [
+    private const LEVELS = [
         LogLevel::DEBUG => 100,
         LogLevel::INFO => 200,
         LogLevel::NOTICE => 250,
@@ -31,13 +31,13 @@ class Notification implements NotificationInterface
         LogLevel::EMERGENCY => 600,
     ];
 
-    protected $channels = [];
-    protected $subject = '';
-    protected $content = '';
-    protected $emoji = '';
-    protected $exception;
-    protected $exceptionAsString = '';
-    protected $importance = self::IMPORTANCE_HIGH;
+    private $channels = [];
+    private $subject = '';
+    private $content = '';
+    private $emoji = '';
+    private $exception;
+    private $exceptionAsString = '';
+    private $importance = self::IMPORTANCE_HIGH;
 
     public function __construct(string $subject = '', array $channels = [])
     {

--- a/src/Symfony/Component/Notifier/Notification/Notification.php
+++ b/src/Symfony/Component/Notifier/Notification/Notification.php
@@ -18,9 +18,9 @@ use Symfony\Component\Notifier\Recipient\RecipientInterface;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Notification
+class Notification implements NotificationInterface
 {
-    private const LEVELS = [
+    protected const LEVELS = [
         LogLevel::DEBUG => 100,
         LogLevel::INFO => 200,
         LogLevel::NOTICE => 250,
@@ -31,18 +31,13 @@ class Notification
         LogLevel::EMERGENCY => 600,
     ];
 
-    public const IMPORTANCE_URGENT = 'urgent';
-    public const IMPORTANCE_HIGH = 'high';
-    public const IMPORTANCE_MEDIUM = 'medium';
-    public const IMPORTANCE_LOW = 'low';
-
-    private $channels = [];
-    private $subject = '';
-    private $content = '';
-    private $emoji = '';
-    private $exception;
-    private $exceptionAsString = '';
-    private $importance = self::IMPORTANCE_HIGH;
+    protected $channels = [];
+    protected $subject = '';
+    protected $content = '';
+    protected $emoji = '';
+    protected $exception;
+    protected $exceptionAsString = '';
+    protected $importance = self::IMPORTANCE_HIGH;
 
     public function __construct(string $subject = '', array $channels = [])
     {
@@ -66,7 +61,7 @@ class Notification
     /**
      * @return $this
      */
-    public function subject(string $subject): self
+    public function setSubject(string $subject): self
     {
         $this->subject = $subject;
 
@@ -81,7 +76,7 @@ class Notification
     /**
      * @return $this
      */
-    public function content(string $content): self
+    public function setContent(string $content): self
     {
         $this->content = $content;
 
@@ -96,7 +91,7 @@ class Notification
     /**
      * @return $this
      */
-    public function importance(string $importance): self
+    public function setImportance(string $importance): self
     {
         $this->importance = $importance;
 
@@ -149,7 +144,7 @@ class Notification
     /**
      * @return $this
      */
-    public function channels(array $channels): self
+    public function setChannels(array $channels): self
     {
         $this->channels = $channels;
 

--- a/src/Symfony/Component/Notifier/Notification/NotificationInterface.php
+++ b/src/Symfony/Component/Notifier/Notification/NotificationInterface.php
@@ -26,28 +26,28 @@ interface NotificationInterface
     /**
      * @return $this
      */
-    public function setSubject(string $subject): self;
+    public function setSubject(string $subject);
 
     public function getSubject(): string;
 
     /**
      * @return $this
      */
-    public function setContent(string $content): self;
+    public function setContent(string $content);
 
     public function getContent(): string;
 
     /**
      * @return $this
      */
-    public function setImportance(string $importance): self;
+    public function setImportance(string $importance);
 
     public function getImportance(): string;
 
     /**
      * @return $this
      */
-    public function setChannels(array $channels): self;
+    public function setChannels(array $channels);
 
     public function getChannels(RecipientInterface $recipient): array;
 }

--- a/src/Symfony/Component/Notifier/Notification/NotificationInterface.php
+++ b/src/Symfony/Component/Notifier/Notification/NotificationInterface.php
@@ -28,9 +28,6 @@ interface NotificationInterface
      */
     public function setSubject(string $subject): self;
 
-    /**
-     * @return string
-     */
     public function getSubject(): string;
 
     /**
@@ -38,9 +35,6 @@ interface NotificationInterface
      */
     public function setContent(string $content): self;
 
-    /**
-     * @return string
-     */
     public function getContent(): string;
 
     /**
@@ -48,9 +42,6 @@ interface NotificationInterface
      */
     public function setImportance(string $importance): self;
 
-    /**
-     * @return string
-     */
     public function getImportance(): string;
 
     /**
@@ -58,10 +49,5 @@ interface NotificationInterface
      */
     public function setChannels(array $channels): self;
 
-    /**
-     * @param \Symfony\Component\Notifier\Recipient\RecipientInterface $recipient
-     *
-     * @return array
-     */
     public function getChannels(RecipientInterface $recipient): array;
 }

--- a/src/Symfony/Component/Notifier/Notification/NotificationInterface.php
+++ b/src/Symfony/Component/Notifier/Notification/NotificationInterface.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Notification;
+
+use Symfony\Component\Notifier\Recipient\RecipientInterface;
+
+/**
+ * @author Tim Werdin <t.werdin86@gmail.com>
+ */
+interface NotificationInterface
+{
+    public const IMPORTANCE_URGENT = 'urgent';
+    public const IMPORTANCE_HIGH = 'high';
+    public const IMPORTANCE_MEDIUM = 'medium';
+    public const IMPORTANCE_LOW = 'low';
+
+    /**
+     * @return $this
+     */
+    public function setSubject(string $subject): self;
+
+    /**
+     * @return string
+     */
+    public function getSubject(): string;
+
+    /**
+     * @return $this
+     */
+    public function setContent(string $content): self;
+
+    /**
+     * @return string
+     */
+    public function getContent(): string;
+
+    /**
+     * @return $this
+     */
+    public function setImportance(string $importance): self;
+
+    /**
+     * @return string
+     */
+    public function getImportance(): string;
+
+    /**
+     * @return $this
+     */
+    public function setChannels(array $channels): self;
+
+    /**
+     * @param \Symfony\Component\Notifier\Recipient\RecipientInterface $recipient
+     *
+     * @return array
+     */
+    public function getChannels(RecipientInterface $recipient): array;
+}

--- a/src/Symfony/Component/Notifier/Notifier.php
+++ b/src/Symfony/Component/Notifier/Notifier.php
@@ -71,10 +71,10 @@ final class Notifier implements NotifierInterface
             $errorPrefix = sprintf('Unable to determine which channels to use to send the "%s" notification', \get_class($notification));
             $error = 'you should either pass channels in the constructor, override its "getChannels()" method';
             if (null === $this->policy) {
-                throw new LogicException(sprintf('%s; %s, or configure a "%s".', $errorPrefix, $error, ChannelPolicy::class));
+                throw new LogicException(sprintf('"%s"; "%s", or configure a "%s".', $errorPrefix, $error, ChannelPolicy::class));
             }
             if (!$channels = $this->policy->getChannels($notification->getImportance())) {
-                throw new LogicException(sprintf('%s; the "%s" returns no channels for importance "%s"; %s.', $errorPrefix, ChannelPolicy::class, $notification->getImportance(), $error));
+                throw new LogicException(sprintf('"%s"; the "%s" returns no channels for importance "%s"; "%s".', $errorPrefix, ChannelPolicy::class, $notification->getImportance(), $error));
             }
         }
 

--- a/src/Symfony/Component/Notifier/Notifier.php
+++ b/src/Symfony/Component/Notifier/Notifier.php
@@ -16,7 +16,7 @@ use Symfony\Component\Notifier\Channel\ChannelInterface;
 use Symfony\Component\Notifier\Channel\ChannelPolicy;
 use Symfony\Component\Notifier\Channel\ChannelPolicyInterface;
 use Symfony\Component\Notifier\Exception\LogicException;
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 use Symfony\Component\Notifier\Recipient\NoRecipient;
 use Symfony\Component\Notifier\Recipient\RecipientInterface;
 
@@ -38,7 +38,7 @@ final class Notifier implements NotifierInterface
         $this->policy = $policy;
     }
 
-    public function send(Notification $notification, RecipientInterface ...$recipients): void
+    public function send(NotificationInterface $notification, RecipientInterface ...$recipients): void
     {
         if (!$recipients) {
             $recipients = [new NoRecipient()];
@@ -64,7 +64,7 @@ final class Notifier implements NotifierInterface
         return $this->adminRecipients;
     }
 
-    private function getChannels(Notification $notification, RecipientInterface $recipient): iterable
+    private function getChannels(NotificationInterface $notification, RecipientInterface $recipient): iterable
     {
         $channels = $notification->getChannels($recipient);
         if (!$channels) {

--- a/src/Symfony/Component/Notifier/NotifierInterface.php
+++ b/src/Symfony/Component/Notifier/NotifierInterface.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Notifier;
 
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 use Symfony\Component\Notifier\Recipient\RecipientInterface;
 
 /**
@@ -21,5 +21,5 @@ use Symfony\Component\Notifier\Recipient\RecipientInterface;
  */
 interface NotifierInterface
 {
-    public function send(Notification $notification, RecipientInterface ...$recipients): void;
+    public function send(NotificationInterface $notification, RecipientInterface ...$recipients): void;
 }

--- a/src/Symfony/Component/Notifier/Tests/Channel/AbstractChannelTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Channel/AbstractChannelTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Notifier\Tests\Channel;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Channel\AbstractChannel;
 use Symfony\Component\Notifier\Exception\LogicException;
-use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notification\NotificationInterface;
 use Symfony\Component\Notifier\Recipient\RecipientInterface;
 
 /**
@@ -32,12 +32,12 @@ class AbstractChannelTest extends TestCase
 
 class DummyChannel extends AbstractChannel
 {
-    public function notify(Notification $notification, RecipientInterface $recipient, string $transportName = null): void
+    public function notify(NotificationInterface $notification, RecipientInterface $recipient, string $transportName = null): void
     {
         return;
     }
 
-    public function supports(Notification $notification, RecipientInterface $recipient): bool
+    public function supports(NotificationInterface $notification, RecipientInterface $recipient): bool
     {
         return false;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x <!-- see below -->
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

In order to make it easier to build your own notifications I added a `NotificationInterface` as composition should be used over inheritance.
As the `Notification` class is already a good base but is hard to extend as all properties are private I changed the visibility of the properties to protected.
To follow the naming conventions for methods I changed the setters to have `set` in front of them like documented here: https://symfony.com/doc/current/contributing/code/conventions.html#naming-a-method
