### PR TITLE
[Config] Handle ignoreExtraKeys in config builder

### DIFF
--- a/src/Symfony/Component/Config/Builder/ClassBuilder.php
+++ b/src/Symfony/Component/Config/Builder/ClassBuilder.php
@@ -34,6 +34,7 @@ class ClassBuilder
     private $require = [];
     private $use = [];
     private $implements = [];
+    private $allowExtraKeys = false;
 
     public function __construct(string $namespace, string $name)
     {
@@ -127,7 +128,7 @@ BODY
 
     public function addProperty(string $name, string $classType = null): Property
     {
-        $property = new Property($name, $this->camelCase($name));
+        $property = new Property($name, '_' !== $name[0] ? $this->camelCase($name) : $name);
         if (null !== $classType) {
             $property->setType($classType);
         }
@@ -162,5 +163,15 @@ BODY
     public function getFqcn(): string
     {
         return '\\'.$this->namespace.'\\'.$this->name;
+    }
+
+    public function setAllowExtraKeys(bool $allowExtraKeys): void
+    {
+        $this->allowExtraKeys = $allowExtraKeys;
+    }
+
+    public function shouldAllowExtraKeys(): bool
+    {
+        return $this->allowExtraKeys;
     }
 }

--- a/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
+++ b/src/Symfony/Component/Config/Builder/ConfigBuilderGenerator.php
@@ -59,8 +59,7 @@ class ConfigBuilderGenerator implements ConfigBuilderGeneratorInterface
 public function NAME(): string
 {
     return \'ALIAS\';
-}
-        ', ['ALIAS' => $rootNode->getPath()]);
+}', ['ALIAS' => $rootNode->getPath()]);
 
             $this->writeClasses();
         }
@@ -90,6 +89,7 @@ public function NAME(): string
         foreach ($this->classes as $class) {
             $this->buildConstructor($class);
             $this->buildToArray($class);
+            $this->buildSetExtraKey($class);
 
             file_put_contents($this->getFullPath($class), $class->build());
         }
@@ -126,6 +126,7 @@ public function NAME(): string
     private function handleArrayNode(ArrayNode $node, ClassBuilder $class, string $namespace): void
     {
         $childClass = new ClassBuilder($namespace, $node->getName());
+        $childClass->setAllowExtraKeys($node->shouldIgnoreExtraKeys());
         $class->addRequire($childClass);
         $this->classes[] = $childClass;
 
@@ -163,7 +164,7 @@ public function NAME($valueDEFAULT): self
 
     return $this;
 }';
-        $class->addMethod($node->getName(), $body, ['PROPERTY' => $property->getName(),  'COMMENT' => $comment, 'DEFAULT' => $node->hasDefaultValue() ? ' = '.var_export($node->getDefaultValue(), true) : '']);
+        $class->addMethod($node->getName(), $body, ['PROPERTY' => $property->getName(), 'COMMENT' => $comment, 'DEFAULT' => $node->hasDefaultValue() ? ' = '.var_export($node->getDefaultValue(), true) : '']);
     }
 
     private function handlePrototypedArrayNode(PrototypedArrayNode $node, ClassBuilder $class, string $namespace): void
@@ -211,6 +212,9 @@ public function NAME(string $VAR, $VALUE): self
         }
 
         $childClass = new ClassBuilder($namespace, $name);
+        if ($prototype instanceof ArrayNode) {
+            $childClass->setAllowExtraKeys($prototype->shouldIgnoreExtraKeys());
+        }
         $class->addRequire($childClass);
         $this->classes[] = $childClass;
         $property = $class->addProperty($node->getName(), $childClass->getFqcn().'[]');
@@ -368,14 +372,15 @@ public function NAME($value): self
     }', ['PROPERTY' => $p->getName(), 'ORG_NAME' => $p->getOriginalName()]);
         }
 
+        $extraKeys = $class->shouldAllowExtraKeys() ? ' + $this->_extraKeys' : '';
+
         $class->addMethod('toArray', '
 public function NAME(): array
 {
     '.$body.'
 
-    return $output;
-}
-');
+    return $output'.$extraKeys.';
+}');
     }
 
     private function buildConstructor(ClassBuilder $class): void
@@ -399,18 +404,49 @@ public function NAME(): array
 ', ['PROPERTY' => $p->getName(), 'ORG_NAME' => $p->getOriginalName()]);
         }
 
-        $body .= '
+        if ($class->shouldAllowExtraKeys()) {
+            $body .= '
+    $this->_extraKeys = $value;
+';
+        } else {
+            $body .= '
     if ([] !== $value) {
         throw new InvalidConfigurationException(sprintf(\'The following keys are not supported by "%s": \', __CLASS__).implode(\', \', array_keys($value)));
     }';
 
-        $class->addUse(InvalidConfigurationException::class);
+            $class->addUse(InvalidConfigurationException::class);
+        }
+
         $class->addMethod('__construct', '
 public function __construct(array $value = [])
 {
 '.$body.'
-}
-');
+}');
+    }
+
+    private function buildSetExtraKey(ClassBuilder $class): void
+    {
+        if (!$class->shouldAllowExtraKeys()) {
+            return;
+        }
+
+        $class->addProperty('_extraKeys');
+
+        $class->addMethod('set', '
+/**
+ * @param ParamConfigurator|mixed $value
+ * @return $this
+ */
+public function NAME(string $key, $value): self
+{
+    if (null === $value) {
+        unset($this->_extraKeys[$key]);
+    } else {
+        $this->_extraKeys[$key] = $value;
+    }
+
+    return $this;
+}');
     }
 
     private function getSubNamespace(ClassBuilder $rootClass): string

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -141,6 +141,14 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     }
 
     /**
+     * Returns true when extra keys should be ignored without an exception.
+     */
+    public function shouldIgnoreExtraKeys(): bool
+    {
+        return $this->ignoreExtraKeys;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function setName(string $name)

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.config.php
@@ -12,7 +12,7 @@ return static function (AddToListConfig $config) {
             'Foo\\MyArrayMessage' => [
                 'senders' => ['workqueue'],
             ],
-        ]
+        ],
     ]);
     $config->messenger()
         ->routing('Foo\\Message')->senders(['workqueue']);

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.output.php
@@ -6,17 +6,17 @@ return [
         'sources' => [
             '\\Acme\\Foo' => 'yellow',
             '\\Acme\\Bar' => 'green',
-        ]
+        ],
     ],
     'messenger' => [
         'routing' => [
-            'Foo\\MyArrayMessage'=> ['senders'=>['workqueue']],
-            'Foo\\Message'=> ['senders'=>['workqueue']],
-            'Foo\\DoubleMessage' => ['senders'=>['sync', 'workqueue']],
+            'Foo\\MyArrayMessage' => ['senders' => ['workqueue']],
+            'Foo\\Message' => ['senders' => ['workqueue']],
+            'Foo\\DoubleMessage' => ['senders' => ['sync', 'workqueue']],
         ],
         'receiving' => [
-            ['priority'=>10, 'color'=>'blue'],
-            ['priority'=>5, 'color'=>'red'],
-        ]
+            ['priority' => 10, 'color' => 'blue'],
+            ['priority' => 5, 'color' => 'red'],
+        ],
     ],
 ];

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/AddToList.php
@@ -4,7 +4,6 @@ namespace Symfony\Component\Config\Tests\Builder\Fixtures;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\Translation\Translator;
 
 class AddToList implements ConfigurationInterface
 {

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.config.php
@@ -1,0 +1,31 @@
+<?php
+
+use Symfony\Config\ArrayExtraKeysConfig;
+
+return static function (ArrayExtraKeysConfig $config) {
+    $config->foo([
+        'extra1' => 'foo_extra1',
+    ])
+        ->baz('foo_baz')
+        ->qux('foo_qux')
+        ->set('extra2', 'foo_extra2')
+        ->set('extra3', 'foo_extra3');
+
+    $config->bar([
+        'extra1' => 'bar1_extra1',
+    ])
+        ->corge('bar1_corge')
+        ->grault('bar1_grault')
+        ->set('extra2', 'bar1_extra2')
+        ->set('extra3', 'bar1_extra3');
+
+    $config->bar([
+        'extra1' => 'bar2_extra1',
+        'extra4' => 'bar2_extra4',
+    ])
+        ->corge('bar2_corge')
+        ->grault('bar2_grault')
+        ->set('extra2', 'bar2_extra2')
+        ->set('extra3', 'bar2_extra3')
+        ->set('extra4', null);
+};

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.output.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    'foo' => [
+        'baz' => 'foo_baz',
+        'qux' => 'foo_qux',
+        'extra1' => 'foo_extra1',
+        'extra2' => 'foo_extra2',
+        'extra3' => 'foo_extra3',
+    ],
+    'bar' => [
+        [
+            'corge' => 'bar1_corge',
+            'grault' => 'bar1_grault',
+            'extra1' => 'bar1_extra1',
+            'extra2' => 'bar1_extra2',
+            'extra3' => 'bar1_extra3',
+        ],
+        [
+            'corge' => 'bar2_corge',
+            'grault' => 'bar2_grault',
+            'extra1' => 'bar2_extra1',
+            'extra2' => 'bar2_extra2',
+            'extra3' => 'bar2_extra3',
+        ],
+    ],
+];

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/ArrayExtraKeys.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Symfony\Component\Config\Tests\Builder\Fixtures;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class ArrayExtraKeys implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $tb = new TreeBuilder('array_extra_keys');
+        $rootNode = $tb->getRootNode();
+        $rootNode
+            ->children()
+                ->arrayNode('foo')
+                    ->ignoreExtraKeys(false)
+                    ->children()
+                        ->scalarNode('baz')->end()
+                        ->scalarNode('qux')->end()
+                    ->end()
+                ->end()
+                ->arrayNode('bar')
+                    ->prototype('array')
+                        ->ignoreExtraKeys(false)
+                        ->children()
+                            ->scalarNode('corge')->end()
+                            ->scalarNode('grault')->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ;
+
+        return $tb;
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.config.php
@@ -3,13 +3,13 @@
 use Symfony\Config\NodeInitialValuesConfig;
 
 return static function (NodeInitialValuesConfig $config) {
-    $config->someCleverName(['second'=>'foo'])->first('bar');
+    $config->someCleverName(['second' => 'foo'])->first('bar');
     $config->messenger()
-        ->transports('fast_queue', ['dsn'=>'sync://'])
+        ->transports('fast_queue', ['dsn' => 'sync://'])
         ->serializer('acme');
 
     $config->messenger()
         ->transports('slow_queue')
         ->dsn('doctrine://')
-        ->options(['table'=>'my_messages']);
+        ->options(['table' => 'my_messages']);
 };

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.output.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.output.php
@@ -8,13 +8,13 @@ return [
     'messenger' => [
         'transports' => [
             'fast_queue' => [
-                'dsn'=>'sync://',
-                'serializer'=>'acme',
+                'dsn' => 'sync://',
+                'serializer' => 'acme',
             ],
             'slow_queue' => [
-                'dsn'=>'doctrine://',
-                'options'=>['table'=>'my_messages'],
-            ]
-        ]
-    ]
+                'dsn' => 'doctrine://',
+                'options' => ['table' => 'my_messages'],
+            ],
+        ],
+    ],
 ];

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/NodeInitialValues.php
@@ -4,7 +4,6 @@ namespace Symfony\Component\Config\Tests\Builder\Fixtures;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\Translation\Translator;
 
 class NodeInitialValues implements ConfigurationInterface
 {

--- a/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders.config.php
+++ b/src/Symfony/Component/Config/Tests/Builder/Fixtures/Placeholders.config.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
 use Symfony\Config\PlaceholdersConfig;
 
 return static function (PlaceholdersConfig $config) {

--- a/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
+++ b/src/Symfony/Component/Config/Tests/Builder/GeneratedConfigTest.php
@@ -27,6 +27,7 @@ class GeneratedConfigTest extends TestCase
             'VariableType' => 'variable_type',
             'AddToList' => 'add_to_list',
             'NodeInitialValues' => 'node_initial_values',
+            'ArrayExtraKeys' => 'array_extra_keys',
         ];
 
         foreach ($array as $name => $alias) {
@@ -103,6 +104,15 @@ class GeneratedConfigTest extends TestCase
         $configBuilder = $this->generateConfigBuilder(NodeInitialValues::class);
         $this->expectException(InvalidConfigurationException::class);
         $configBuilder->someCleverName(['not_exists' => 'foo']);
+    }
+
+    public function testSetExtraKeyMethodIsNotGeneratedWhenAllowExtraKeysIsFalse()
+    {
+        /** @var AddToListConfig $configBuilder */
+        $configBuilder = $this->generateConfigBuilder(AddToList::class);
+
+        $this->assertFalse(method_exists($configBuilder->translator(), 'set'));
+        $this->assertFalse(method_exists($configBuilder->messenger()->receiving(), 'set'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently the config builder doesn't handle the `ignoreExtraKeys` option. This is an attempt to fix that.

#### TODO
- [x] Tests, but I was hoping for some initial feedback first