### PR TITLE
[HttpKernel] opt-out from Google FLoC by default

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -210,6 +210,7 @@ class FrameworkExtension extends Extension
         $container->setParameter('kernel.trusted_hosts', $config['trusted_hosts']);
         $container->setParameter('kernel.default_locale', $config['default_locale']);
         $container->setParameter('kernel.error_controller', $config['error_controller']);
+        $container->setParameter('kernel.permissions_policy', 'interest-cohort=()');
 
         if (!$container->hasParameter('debug.file_link_format')) {
             if (!$container->hasParameter('templating.helper.code.file_link_format')) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -59,6 +59,7 @@
         <service id="response_listener" class="Symfony\Component\HttpKernel\EventListener\ResponseListener">
             <tag name="kernel.event_subscriber" />
             <argument>%kernel.charset%</argument>
+            <argument>%kernel.permissions_policy%</argument>
         </service>
 
         <service id="streamed_response_listener" class="Symfony\Component\HttpKernel\EventListener\StreamedResponseListener">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40835
| License       | MIT
| Doc PR        | -

Google decided that FLoC should be opt-out, but web communities are opposing this idea.

Instead, I think we should make FLoC opt-in in Symfony. Since FLoC did not exist before, this PR doesn't change anything in terms of BC from the browser-side pov for Symfony apps. I'm therefor submitting this as a bugfix: to keep things working as always.

This PR introduces a `kernel.permissions_policy` parameter that defaults to `interest-cohort=()` when FrameworkBundle is used:

```yaml
parameters:
    kernel.permissions_policy: null # "interest-cohort=()" by default
```
