### PR TITLE
[Notifier] Add SlackOptions::threadTs() to send message as reply

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Check for maximum number of buttons in Slack action block
  * Add HeaderBlock
  * Slack access tokens needs to start with "xox" (see https://api.slack.com/authentication/token-types)
+ * Add `SlackOptions::threadTs()` to send message as reply
 
 5.2.0
 -----

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
@@ -181,4 +181,14 @@ final class SlackOptions implements MessageOptionsInterface
 
         return $this;
     }
+
+    /**
+     * @return $this
+     */
+    public function threadTs(string $threadTs): self
+    {
+        $this->options['thread_ts'] = $threadTs;
+
+        return $this;
+    }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackOptionsTest.php
@@ -70,6 +70,7 @@ final class SlackOptionsTest extends TestCase
         yield [['unfurl_links' => true]];
         yield [['unfurl_media' => true]];
         yield [['username' => 'baz']];
+        yield [['thread_ts' => '1503435956.000247']];
     }
 
     /**
@@ -111,6 +112,7 @@ final class SlackOptionsTest extends TestCase
         yield ['unfurlLinks', 'unfurl_links', true];
         yield ['unfurlMedia', 'unfurl_media', true];
         yield ['username', 'username', 'baz'];
+        yield ['threadTs', 'thread_ts', '1503435956.000247'];
     }
 
     public function testSetBlock()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

Allow specify argument [thread_ts](https://api.slack.com/methods/chat.postMessage#arg_thread_ts) to send reply message.