### PR TITLE
[Form] Use reference date in reverse transform

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -204,7 +204,7 @@ class TimeType extends AbstractType
             ));
         } elseif ('array' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToArrayTransformer($options['model_timezone'], $options['model_timezone'], $parts)
+                new DateTimeToArrayTransformer($options['model_timezone'], $options['model_timezone'], $parts, 'text' === $options['widget'], $options['reference_date'])
             ));
         }
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -991,6 +991,27 @@ class TimeTypeTest extends BaseTypeTest
         $this->assertSame($input, $form->getViewData());
     }
 
+    public function testArrayTimeWithReferenceDoesUseReferenceDateOnModelTransform()
+    {
+        $input = [
+            'hour' => '21',
+            'minute' => '45',
+        ];
+
+        $form = $this->factory->create(static::TESTED_TYPE, $input, [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'Europe/Berlin',
+            'reference_date' => new \DateTimeImmutable('01-05-2021 12:34:56', new \DateTimeZone('UTC')),
+            'input' => 'array',
+        ]);
+
+        $this->assertSame($input, $form->getData());
+        $this->assertEquals([
+            'hour' => '23',
+            'minute' => '45',
+        ], $form->getViewData());
+    }
+
     /**
      * @dataProvider provideEmptyData
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #40997
| License       | MIT

Use reference time in reverse transform to fix the display inconsistancies 
