### PR TITLE
[Form] Use !isset for checks cause this doesn't falsely include 0

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -170,9 +170,9 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
                 empty($value['year']) ? $this->referenceDate->format('Y') : $value['year'],
                 empty($value['month']) ? $this->referenceDate->format('m') : $value['month'],
                 empty($value['day']) ? $this->referenceDate->format('d') : $value['day'],
-                empty($value['hour']) ? $this->referenceDate->format('H') : $value['hour'],
-                empty($value['minute']) ? $this->referenceDate->format('i') : $value['minute'],
-                empty($value['second']) ? $this->referenceDate->format('s') : $value['second']
+                $value['hour'] ?? $this->referenceDate->format('H'),
+                $value['minute'] ?? $this->referenceDate->format('i'),
+                $value['second'] ?? $this->referenceDate->format('s')
                 ),
                 new \DateTimeZone($this->outputTimezone)
             );

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -204,6 +204,32 @@ class DateTypeTest extends BaseTypeTest
         $this->assertEquals('02.06.2010', $form->getViewData());
     }
 
+    public function testArrayDateWithReferenceDoesUseReferenceTimeOnZero()
+    {
+        // we test against "de_DE", so we need the full implementation
+        IntlTestHelper::requireFullIntl($this, false);
+
+        \Locale::setDefault('de_DE');
+
+        $input = [
+            'day' => '0',
+            'month' => '0',
+            'year' => '0',
+        ];
+
+        $form = $this->factory->create(static::TESTED_TYPE, $input, [
+            'format' => \IntlDateFormatter::MEDIUM,
+            'html5' => false,
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'Europe/Berlin',
+            'input' => 'array',
+            'widget' => 'single_text',
+        ]);
+
+        $this->assertSame($input, $form->getData());
+        $this->assertEquals('01.01.1970', $form->getViewData());
+    }
+
     public function testSubmitFromText()
     {
         $form = $this->factory->create(static::TESTED_TYPE, null, [

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -969,6 +969,28 @@ class TimeTypeTest extends BaseTypeTest
         $this->assertSame($expectedData, $form->getData());
     }
 
+    public function testArrayTimeWithReferenceDoesNotUseReferenceTimeOnZero()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'Europe/Berlin',
+            'reference_date' => new \DateTimeImmutable('01-01-2021 12:34:56', new \DateTimeZone('UTC')),
+            'input' => 'array',
+        ]);
+
+        $input = [
+            'hour' => '0',
+            'minute' => '0',
+        ];
+        $form->submit($input);
+
+        $this->assertEquals([
+            'hour' => '23',
+            'minute' => '0',
+        ], $form->getData());
+        $this->assertSame($input, $form->getViewData());
+    }
+
     /**
      * @dataProvider provideEmptyData
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #40999
| License       | MIT

By using isset 0 won't falsely included anymore
