### PR TITLE
[HttpClient] Avoid installation of latest contracts as it's not compatible

### DIFF
--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=7.1.3",
         "psr/log": "^1.0",
-        "symfony/http-client-contracts": "^1.1.10|^2",
+        "symfony/http-client-contracts": "^1.1.10|<2.4",
         "symfony/polyfill-php73": "^1.11",
         "symfony/service-contracts": "^1.0|^2"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ref #40975 #40996 #40893 
| License       | MIT
| Doc PR        |

To be reverted on 5.x (5.3)

Fixes #40975