### PR TITLE
[FrameworkBundle][HttpKernel] Move IDE file link formats from FrameworkExtension to FileLinkFormatter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -294,20 +294,7 @@ class FrameworkExtension extends Extension
         }
 
         if (!$container->hasParameter('debug.file_link_format')) {
-            $links = [
-                'textmate' => 'txmt://open?url=file://%%f&line=%%l',
-                'macvim' => 'mvim://open?url=file://%%f&line=%%l',
-                'emacs' => 'emacs://open?url=file://%%f&line=%%l',
-                'sublime' => 'subl://open?url=file://%%f&line=%%l',
-                'phpstorm' => 'phpstorm://open?file=%%f&line=%%l',
-                'atom' => 'atom://core/open/file?filename=%%f&line=%%l',
-                'vscode' => 'vscode://file/%%f:%%l',
-            ];
-            $ide = $config['ide'];
-            // mark any env vars found in the ide setting as used
-            $container->resolveEnvPlaceholders($ide);
-
-            $container->setParameter('debug.file_link_format', str_replace('%', '%%', ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format')) ?: ($links[$ide] ?? $ide));
+            $container->setParameter('debug.file_link_format', $config['ide']);
         }
 
         if (!empty($config['test'])) {

--- a/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
+++ b/src/Symfony/Component/HttpKernel/Debug/FileLinkFormatter.php
@@ -24,6 +24,16 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 class FileLinkFormatter
 {
+    private const FORMATS = [
+        'textmate' => 'txmt://open?url=file://%f&line=%l',
+        'macvim' => 'mvim://open?url=file://%f&line=%l',
+        'emacs' => 'emacs://open?url=file://%f&line=%l',
+        'sublime' => 'subl://open?url=file://%f&line=%l',
+        'phpstorm' => 'phpstorm://open?file=%f&line=%l',
+        'atom' => 'atom://core/open/file?filename=%f&line=%l',
+        'vscode' => 'vscode://file/%f:%l',
+    ];
+
     private $fileLinkFormat;
     private $requestStack;
     private $baseDir;
@@ -34,7 +44,7 @@ class FileLinkFormatter
      */
     public function __construct($fileLinkFormat = null, RequestStack $requestStack = null, string $baseDir = null, $urlFormat = null)
     {
-        $fileLinkFormat = $fileLinkFormat ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
+        $fileLinkFormat = (self::FORMATS[$fileLinkFormat] ?? $fileLinkFormat) ?: ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format');
         if ($fileLinkFormat && !\is_array($fileLinkFormat)) {
             $i = strpos($f = $fileLinkFormat, '&', max(strrpos($f, '%f'), strrpos($f, '%l'))) ?: \strlen($f);
             $fileLinkFormat = [substr($f, 0, $i)] + preg_split('/&([^>]++)>/', substr($f, $i), -1, \PREG_SPLIT_DELIM_CAPTURE);

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/FileLinkFormatterTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/FileLinkFormatterTest.php
@@ -51,4 +51,13 @@ class FileLinkFormatterTest extends TestCase
 
         $this->assertSame('http://www.example.org/_profiler/open?file=file.php&line=3#line3', $sut->format($file, 3));
     }
+
+    public function testIdeFileLinkFormat()
+    {
+        $file = __DIR__.\DIRECTORY_SEPARATOR.'file.php';
+
+        $sut = new FileLinkFormatter('atom');
+
+        $this->assertSame("atom://core/open/file?filename=$file&line=3", $sut->format($file, 3));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40901
| License       | MIT
| Doc PR        | N/A

I made `FileLinkFormatter` aware of IDEs file link formats so that you can set `framework.ide` as an env var containing a name (like `atom`).

Not sure how to test it from the `FrameworkExtension` POV though :thinking: 
