### PR TITLE
[Security] Do not try to rehash null-passwords

### DIFF
--- a/src/Symfony/Component/Security/Http/EventListener/PasswordMigratingListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/PasswordMigratingListener.php
@@ -50,6 +50,10 @@ class PasswordMigratingListener implements EventSubscriberInterface
         }
 
         $user = $passport->getUser();
+        if (null === $user->getPassword()) {
+            return;
+        }
+
         $passwordEncoder = $this->encoderFactory->getEncoder($user);
         if (!$passwordEncoder->needsRehash($user->getPassword())) {
             return;

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
@@ -108,6 +108,16 @@ class PasswordMigratingListenerTest extends TestCase
         $this->listener->onLoginSuccess($event);
     }
 
+    public function testUserWithoutPassword()
+    {
+        $this->user = new User('test', null);
+
+        $this->encoderFactory->expects($this->never())->method('getEncoder');
+
+        $event = $this->createEvent(new SelfValidatingPassport(new UserBadge('test', function () { return $this->user; }), [new PasswordUpgradeBadge('pa$$word')]));
+        $this->listener->onLoginSuccess($event);
+    }
+
     private function createPasswordUpgrader()
     {
         return $this->createMock(MigratingUserProvider::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41005
| License       | MIT
| Doc PR        | -

Make sure no exception occurs when a passwordless user logs in.