### PR TITLE
[Security] Fix Http\Authenticator\AbstractAuthenticator PhpDoc

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractAuthenticator.php
@@ -28,7 +28,7 @@ abstract class AbstractAuthenticator implements AuthenticatorInterface
      * Shortcut to create a PostAuthenticationToken for you, if you don't really
      * care about which authenticated token you're using.
      *
-     * @return PostAuthenticationToken
+     * @return TokenInterface
      */
     public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
     {


### PR DESCRIPTION
The PhpDoc is not totally incorect, but it doesn't pass the PhpStan analysis at level 3.

| Q             | A
| ------------- | ---
| Branch?       | 5.x for features / 4.4 or 5.2 for bug fixes <!-- see below -->
| Bug fix?      | maybe
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
