### PR TITLE
[Console] Remove spaces between arguments GithubActionReporter

### DIFF
--- a/src/Symfony/Component/Console/CI/GithubActionReporter.php
+++ b/src/Symfony/Component/Console/CI/GithubActionReporter.php
@@ -94,6 +94,6 @@ class GithubActionReporter
             return;
         }
 
-        $this->output->writeln(sprintf('::%s file=%s, line=%s, col=%s::%s', $type, strtr($file, self::ESCAPED_PROPERTIES), strtr($line ?? 1, self::ESCAPED_PROPERTIES), strtr($col ?? 0, self::ESCAPED_PROPERTIES), $message));
+        $this->output->writeln(sprintf('::%s file=%s,line=%s,col=%s::%s', $type, strtr($file, self::ESCAPED_PROPERTIES), strtr($line ?? 1, self::ESCAPED_PROPERTIES), strtr($col ?? 0, self::ESCAPED_PROPERTIES), $message));
     }
 }

--- a/src/Symfony/Component/Console/Tests/CI/GithubActionReporterTest.php
+++ b/src/Symfony/Component/Console/Tests/CI/GithubActionReporterTest.php
@@ -64,7 +64,7 @@ class GithubActionReporterTest extends TestCase
             'foo/bar.php',
             2,
             4,
-            '::warning file=foo/bar.php, line=2, col=4::A warning',
+            '::warning file=foo/bar.php,line=2,col=4::A warning',
         ];
 
         yield 'with file property to escape' => [
@@ -73,7 +73,7 @@ class GithubActionReporterTest extends TestCase
             'foo,bar:baz%quz.php',
             2,
             4,
-            '::warning file=foo%2Cbar%3Abaz%25quz.php, line=2, col=4::A warning',
+            '::warning file=foo%2Cbar%3Abaz%25quz.php,line=2,col=4::A warning',
         ];
 
         yield 'without file ignores col & line' => ['warning', 'A warning', null, 2, 4, '::warning::A warning'];

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -85,7 +85,7 @@ YAML;
         }
 
         self::assertEquals(1, $tester->getStatusCode(), 'Returns 1 in case of error');
-        self::assertStringMatchesFormat('%A::error file=%s, line=2, col=0::Unable to parse at line 2 (near "bar")%A', trim($tester->getDisplay()));
+        self::assertStringMatchesFormat('%A::error file=%s,line=2,col=0::Unable to parse at line 2 (near "bar")%A', trim($tester->getDisplay()));
     }
 
     public function testLintAutodetectsGithubActionEnvironment()
@@ -109,7 +109,7 @@ YAML;
 
             $tester->execute(['filename' => $filename], ['decorated' => false]);
 
-            self::assertStringMatchesFormat('%A::error file=%s, line=2, col=0::Unable to parse at line 2 (near "bar")%A', trim($tester->getDisplay()));
+            self::assertStringMatchesFormat('%A::error file=%s,line=2,col=0::Unable to parse at line 2 (near "bar")%A', trim($tester->getDisplay()));
         } finally {
             putenv('GITHUB_ACTIONS'.($prev ? "=$prev" : ''));
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no (there is not release yet)
| New feature?  | no
| Deprecations? | no
| Tickets       |  -
| License       | MIT
| Doc PR        |  -

There shouldn't be blank spaces between the arguments of the `GithubActionReporter`, otherwise it shows the message in the wrong line, it can be seen here: https://github.com/franmomu/test_yaml_lint/pull/3/files

Both messages are supposed to be for line 3, but the warning one (with blank spaces) appears on line 1 (Check warning on line 1 in wrong_yaml.yaml).