### PR TITLE
[Security] Fix PasswordMigratingListenerTest

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/PasswordMigratingListenerTest.php
@@ -114,7 +114,7 @@ class PasswordMigratingListenerTest extends TestCase
     {
         $this->user = new User('test', null);
 
-        $this->encoderFactory->expects($this->never())->method('getEncoder');
+        $this->hasherFactory->expects($this->never())->method('getPasswordHasher');
 
         $event = $this->createEvent(new SelfValidatingPassport(new UserBadge('test', function () { return $this->user; }), [new PasswordUpgradeBadge('pa$$word')]));
         $this->listener->onLoginSuccess($event);
@@ -134,6 +134,7 @@ class PasswordMigratingListenerTest extends TestCase
 abstract class TestMigratingUserProvider implements UserProviderInterface, PasswordUpgraderInterface
 {
     abstract public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void;
+
     abstract public function loadUserByIdentifier(string $identifier): UserInterface;
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Follow-up #41008. The new test was not adjusted to the new password hasher component when merging it up to 5.x. This PR should make the test green again.