### PR TITLE
[ErrorHandler] Skip "same vendor" `@method` deprecations for `Symfony\*` classes unless symfony/symfony is being tested

### DIFF
--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\ErrorHandler;
 
+use Composer\InstalledVersions;
 use Doctrine\Common\Persistence\Proxy as LegacyProxy;
 use Doctrine\Persistence\Proxy;
 use Mockery\MockInterface;
@@ -492,6 +493,14 @@ class DebugClassLoader
                         self::$method[$class] = self::$method[$use];
                     }
                 } elseif (!$refl->isInterface()) {
+                    if (!strncmp($vendor, str_replace('_', '\\', $use), $vendorLen)
+                        && 0 === strpos($className, 'Symfony\\')
+                        && (!class_exists(InstalledVersions::class)
+                            || 'symfony/symfony' !== InstalledVersions::getRootPackage()['name'])
+                    ) {
+                        // skip "same vendor" @method deprecations for Symfony\* classes unless symfony/symfony is being tested
+                        continue;
+                    }
                     $hasCall = $refl->hasMethod('__call');
                     $hasStaticCall = $refl->hasMethod('__callStatic');
                     foreach (self::$method[$use] as $method) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ref #40975 #40996 #40893 
| License       | MIT
| Doc PR        |

Replaces #41001