### PR TITLE
Add a GitHub Action for tests against PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,4 +149,21 @@ jobs:
           echo "::endgroup::"
 
       - name: Run tests
-        run: find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -print0 | xargs -0 -n1 dirname | sort | parallel ./phpunit --colors=always --exclude-group tty,benchmark,intl-dat
+        run: |
+          _run_tests() {
+            ok=0
+            echo "::group::$1"
+
+            # Run the tests
+            ./phpunit --colors=always --exclude-group tty,benchmark,intl-dat ./$1 2>&1 || ok=1
+            echo ::endgroup::
+
+            if [ $ok -ne 0 ]; then
+              echo "::error::$1 failed"
+            fi
+
+            return $ok
+          }
+          export -f _run_tests
+
+          find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -print0 | xargs -0 -n1 dirname | sort | parallel _run_tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,3 +114,39 @@ jobs:
           docker run --rm -e COMPOSER_ROOT_VERSION -v $(pwd):/app -v $(which composer):/usr/local/bin/composer -v /usr/local/bin/vulcain:/usr/local/bin/vulcain -w /app php:7.4-alpine ./phpunit src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php --filter testHttp2Push
           sudo rm -rf .phpunit
           [ -d .phpunit.bak ] && mv .phpunit.bak .phpunit
+
+  nightly:
+    name: PHPUnit on PHP nightly
+    runs-on: Ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: "none"
+          ini-values: "memory_limit=-1"
+          php-version: "8.1"
+
+      - name: Configure composer
+        run: |
+          COMPOSER_HOME="$(composer config home)"
+          composer self-update
+          ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
+          echo "COMPOSER_ROOT_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*').x-dev" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: |
+          echo "::group::fake PHP version"
+          composer config platform.php 8.0.99
+          echo "::group::composer update"
+          composer update --no-progress --ansi
+          echo "::endgroup::"
+          echo "::group::install phpunit"
+          ./phpunit install
+          echo "::endgroup::"
+
+      - name: Run tests
+        run: find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -print0 | xargs -0 -n1 dirname | sort | parallel ./phpunit --colors=always --exclude-group tty,benchmark,intl-dat

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,7 +155,7 @@ jobs:
             echo "::group::$1"
 
             # Run the tests
-            ./phpunit --colors=always --exclude-group tty,benchmark,intl-dat ./$1 2>&1 || ok=1
+            ./phpunit --colors=always --exclude-group tty,benchmark,intl-data ./$1 2>&1 || ok=1
             echo ::endgroup::
 
             if [ $ok -ne 0 ]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,7 +162,9 @@ jobs:
               echo "::error::$1 failed"
             fi
 
-            return $ok
+            # Make the tests always pass because we don't want the build to fail (yet).
+            return 0
+            #return $ok
           }
           export -f _run_tests
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

I'd like to monitor our compatibility with the upcoming PHP 8.1 release. Because I failed miserably at convincing Travis to run our tests with PHP 8.1 (see #40532), I tried to do the same with GitHub Actions.