### PR TITLE
ref #41087: missing security turksih translations

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.tr.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.tr.xlf
@@ -70,6 +70,14 @@
                 <source>Invalid or expired login link.</source>
                 <target>Geçersiz veya süresi dolmuş oturum açma bağlantısı.</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+                <target>Çok fazla başarısız giriş denemesi, lütfen %minutes% dakika sonra tekrar deneyin.</target>
+            </trans-unit>
+            <trans-unit id="20">
+                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+                <target>Çok fazla başarısız giriş denemesi, lütfen %minutes% dakika sonra tekrar deneyin.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41087
| License       | MIT

Missing Türkish Translations from Security Component.
