### PR TITLE
[Security] Missing lt translations

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.lt.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.lt.xlf
@@ -70,6 +70,14 @@
                 <source>Invalid or expired login link.</source>
                 <target>Netinkama arba pasibaigusio galiojimo laiko prisijungimo nuoroda.</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+                <target>Per daug nepavykusių prisijungimo bandymų, pabandykite dar kartą po %minutes% minutės.</target>
+            </trans-unit>
+            <trans-unit id="20">
+                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+                <target>Per daug nepavykusių prisijungimo bandymų, pabandykite dar kartą po %minutes% minutės.|Per daug nepavykusių prisijungimo bandymų, pabandykite dar kartą po %minutes% minučių.|Per daug nepavykusių prisijungimo bandymų, pabandykite dar kartą po %minutes% minučių.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41054
| License       | MIT

For minute/minutes translation I decided to use "min." abbreviation, because in lithuanian language the plural translation might not always match the word case.
For example:
1 minute -> 1 minutė
2 minutes -> 2 minutės
...
10 minutes -> 10 minučių
...
21 minutes -> 21 minutė
22 minutes -> 22 minutės
...
30 minutes -> 30 minučių

and so on...