### PR TITLE
[Lock] Expand `LockConflictedException` docs

### DIFF
--- a/src/Symfony/Component/Lock/Exception/LockConflictedException.php
+++ b/src/Symfony/Component/Lock/Exception/LockConflictedException.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Component\Lock\Exception;
 
+use Symfony\Component\Lock\Lock;
+
 /**
  * LockConflictedException is thrown when a lock is acquired by someone else.
+ *
+ * In non-blocking mode it is caught by {@see Lock::acquire()} and {@see Lock::acquireRead()}.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */


### PR DESCRIPTION
The goal of this is to reduce the chance of bad assumptions about lock acquisition behaviour. Fixes #40969

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40969
| License       | MIT
| Doc PR        | N/A

The goal of this tweak is to reduce the chance of bad assumptions about lock acquisition behaviour.

As per #40970 with suggested fixes, except now targeting the correct branch.