### PR TITLE
[HttpFoundation] Request::getProtocolVersion may return null

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1497,7 +1497,7 @@ class Request
      * if the proxy is trusted (see "setTrustedProxies()"), otherwise it returns
      * the latter (from the "SERVER_PROTOCOL" server parameter).
      *
-     * @return string
+     * @return string|null
      */
     public function getProtocolVersion()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

This is just a minor PHPDoc fix, but we stumbled on it in https://github.com/getsentry/sentry-symfony/pull/495, and static analysis complains about our fix. 

Basically, `SERVER_PROTOCOL` may not be set, even if it shouldn't be missing according to [RFC 3875 (GCI spec)](https://tools.ietf.org/html/rfc3875#section-4.1.16). In our case, the user reported the issue because the request was issued interally by a pod health check inside Kubernetes.