### PR TITLE
[Console] Fix Windows code page support

### DIFF
--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -110,11 +110,6 @@ class QuestionHelper extends Helper
         $inputStream = $this->inputStream ?: \STDIN;
         $autocomplete = $question->getAutocompleterCallback();
 
-        if (\function_exists('sapi_windows_cp_set')) {
-            // Codepage used by cmd.exe on Windows to allow special characters (éàüñ).
-            @sapi_windows_cp_set(1252);
-        }
-
         if (null === $autocomplete || !self::$stty || !Terminal::hasSttyAvailable()) {
             $ret = false;
             if ($question->isHidden()) {
@@ -514,7 +509,10 @@ class QuestionHelper extends Helper
     private function readInput($inputStream, Question $question)
     {
         if (!$question->isMultiline()) {
-            return fgets($inputStream, 4096);
+            $cp = $this->setIOCodepage();
+            $ret = fgets($inputStream, 4096);
+
+            return $this->resetIOCodepage($cp, $ret);
         }
 
         $multiLineStreamReader = $this->cloneInputStream($inputStream);
@@ -523,6 +521,7 @@ class QuestionHelper extends Helper
         }
 
         $ret = '';
+        $cp = $this->setIOCodepage();
         while (false !== ($char = fgetc($multiLineStreamReader))) {
             if (\PHP_EOL === "{$ret}{$char}") {
                 break;
@@ -530,7 +529,37 @@ class QuestionHelper extends Helper
             $ret .= $char;
         }
 
-        return $ret;
+        return $this->resetIOCodepage($cp, $ret);
+    }
+
+    /**
+     * Set console I/O to the host code page.
+     *
+     * @return int Previous code page in IBM/EBCDIC format
+     */
+    private function setIOCodepage(): int
+    {
+        if (\function_exists('sapi_windows_cp_set')) {
+            $cp = sapi_windows_cp_get();
+            sapi_windows_cp_set(sapi_windows_cp_get('oem'));
+
+            return $cp;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Set console I/O to the specified code page and convert the user input.
+     */
+    private function resetIOCodepage(int $cp, string $input): string
+    {
+        if (\function_exists('sapi_windows_cp_set') && 0 < $cp) {
+            sapi_windows_cp_set($cp);
+            $input = sapi_windows_cp_conv(sapi_windows_cp_get('oem'), $cp, $input);
+        }
+
+        return $input;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #37385, Fix #35842, Fix #36324, Fix #37495, Fix #37278
| License       | MIT

Corrects previous fixes that dealt with the mojibake problem on Windows where an OEM code page was applied to an input string and then messed with PHP.internal_encoding setting used by the script. This caused strings with different encodings to be displayed on the console output.