### PR TITLE
[WebProfilerBundle] Add simple backoff strategy on 404

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -37,10 +37,12 @@
             };
         }
 
-        var request = function(url, onSuccess, onError, payload, options) {
+        var request = function(url, onSuccess, onError, payload, options, tries) {
             var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
             options = options || {};
             options.maxTries = options.maxTries || 0;
+            tries = tries || 1;
+            var delay = Math.pow(2, tries - 1) * 1000;
             xhr.open(options.method || 'GET', url, true);
             xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
             xhr.onreadystatechange = function(state) {
@@ -51,8 +53,8 @@
                 if (xhr.status == 404 && options.maxTries > 1) {
                     setTimeout(function(){
                         options.maxTries--;
-                        request(url, onSuccess, onError, payload, options);
-                    }, 1000);
+                        request(url, onSuccess, onError, payload, options, tries + 1);
+                    }, delay);
 
                     return null;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/41112
| License       | MIT

Instead of just retrying every second 5 times, this PR implements a very basic backoff strategy where it waits 1, 1, 2, 3, 5 seconds between the respective requests instead which amounts to a total wait of 12 seconds instead of 5.