### PR TITLE
[Security] Translation count argument for TooManyLoginAttemptsAuthenticationException

### DIFF
--- a/src/Symfony/Component/Security/Core/Exception/TooManyLoginAttemptsAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/TooManyLoginAttemptsAuthenticationException.php
@@ -33,6 +33,7 @@ class TooManyLoginAttemptsAuthenticationException extends AuthenticationExceptio
     {
         return [
             '%minutes%' => $this->threshold,
+            '%count%' => (int) $this->threshold,
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Added `%count%` argument to leverage translator's pluralization functionality as discussed in https://github.com/symfony/symfony/pull/41097