### PR TITLE
[Translation] Separate parameters formatting

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * Add new implementations of `TranslatableInterface` to format parameters
+  separately as recommended per the ICU for DateTime, money, and decimal values.
+
 5.4
 ---
 

--- a/src/Symfony/Component/Translation/Tests/Translatable/DateTimeTranslatableTest.php
+++ b/src/Symfony/Component/Translation/Tests/Translatable/DateTimeTranslatableTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Translatable;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Translatable\DateTimeTranslatable;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class DateTimeTranslatableTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!\extension_loaded('intl')) {
+            $this->markTestSkipped('Extension intl is required.');
+        }
+    }
+
+    /**
+     * @dataProvider getValues()
+     */
+    public function testFormat(string $expected, DateTimeTranslatable $parameter, string $locale)
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $this->assertSame($expected, $parameter->trans($translator, $locale));
+    }
+
+    public function getValues(): iterable
+    {
+        $dateTime = new \DateTime('2021-01-01 23:55:00', new \DateTimeZone('UTC'));
+
+        $parameterDateTime = new DateTimeTranslatable($dateTime);
+        yield 'DateTime in French' => ['01/01/2021 23:55', $parameterDateTime, 'fr_FR'];
+        yield 'DateTime in GB English' => ['01/01/2021, 23:55', $parameterDateTime, 'en_GB'];
+        yield 'DateTime in US English' => ['1/1/21, 11:55 PM', $parameterDateTime, 'en_US'];
+
+        $dateTimeParis = new \DateTime('2021-01-01 23:55:00', new \DateTimeZone('UTC'));
+        $dateTimeParis->setTimezone(new \DateTimeZone('Europe/Paris'));
+
+        $parameterDateTimeParis = new DateTimeTranslatable($dateTimeParis);
+        yield 'DateTime in Paris in French' => ['02/01/2021 00:55', $parameterDateTimeParis, 'fr_FR'];
+        yield 'DateTime in Paris in GB English' => ['02/01/2021, 00:55', $parameterDateTimeParis, 'en_GB'];
+        yield 'DateTime in Paris in US English' => ['1/2/21, 12:55 AM', $parameterDateTimeParis, 'en_US'];
+
+        $parameterDateParis = DateTimeTranslatable::date($dateTimeParis);
+        yield 'Date in Paris in French' => ['02/01/2021', $parameterDateParis, 'fr_FR'];
+        yield 'Date in Paris in GB English' => ['02/01/2021', $parameterDateParis, 'en_GB'];
+        yield 'Date in Paris in US English' => ['1/2/21', $parameterDateParis, 'en_US'];
+
+        $parameterTimeParis = DateTimeTranslatable::time($dateTimeParis);
+        yield 'Time in Paris in French' => ['00:55', $parameterTimeParis, 'fr_FR'];
+        yield 'Time in Paris in GB English' => ['00:55', $parameterTimeParis, 'en_GB'];
+        yield 'Time in Paris in US English' => ['12:55 AM', $parameterTimeParis, 'en_US'];
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Translatable/DecimalTranslatableTest.php
+++ b/src/Symfony/Component/Translation/Tests/Translatable/DecimalTranslatableTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Translatable;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Translatable\DecimalTranslatable;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class DecimalTranslatableTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!\extension_loaded('intl')) {
+            $this->markTestSkipped('Extension intl is required.');
+        }
+    }
+
+    /**
+     * @dataProvider getValues()
+     */
+    public function testFormat(string $expected, DecimalTranslatable $parameter, string $locale)
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        // Non-breakable spaces are added differently depending the PHP version
+        $cleaned = str_replace(["\u{202f}", "\u{a0}"], ['', ''], $parameter->trans($translator, $locale));
+        $this->assertSame($expected, $cleaned);
+    }
+
+    public function getValues(): iterable
+    {
+        $parameter = new DecimalTranslatable(1000);
+
+        yield 'French' => ['1000', $parameter, 'fr_FR'];
+        yield 'US English' => ['1,000', $parameter, 'en_US'];
+
+        $parameter = new DecimalTranslatable(1000.01);
+
+        yield 'Float in French' => ['1000,01', $parameter, 'fr_FR'];
+        yield 'Float in US English' => ['1,000.01', $parameter, 'en_US'];
+
+        $parameter = new DecimalTranslatable(1, \NumberFormatter::PERCENT);
+
+        yield 'Styled in French' => ['100%', $parameter, 'fr_FR'];
+        yield 'Styled in US English' => ['100%', $parameter, 'en_US'];
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Translatable/MoneyTranslatableTest.php
+++ b/src/Symfony/Component/Translation/Tests/Translatable/MoneyTranslatableTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Translatable;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Translation\Translatable\MoneyTranslatable;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class MoneyTranslatableTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!\extension_loaded('intl')) {
+            $this->markTestSkipped('Extension intl is required.');
+        }
+    }
+
+    /**
+     * @dataProvider getValues()
+     */
+    public function testTrans(string $expected, MoneyTranslatable $parameter, string $locale)
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        // DecimalMoneyFormatter output may contain non-breakable spaces:
+        // - this is done for good reasons
+        // - output "style" changes depending on the PHP version
+        // This normalization in only done here in the test so a new PHP version won't break the test
+        $normalized = str_replace(["\u{202f}", "\u{a0}"], ['', ''], $parameter->trans($translator, $locale));
+        $this->assertSame($expected, $normalized);
+    }
+
+    public function getValues(): iterable
+    {
+        $parameterEuros = new MoneyTranslatable(1000, 'EUR');
+        $parameterDollars = new MoneyTranslatable(1000, 'USD');
+
+        yield 'Euros in French' => ['1000,00€', $parameterEuros, 'fr_FR'];
+        yield 'Euros in US English' => ['€1,000.00', $parameterEuros, 'en_US'];
+        yield 'US Dollars in French' => ['1000,00$US', $parameterDollars, 'fr_FR'];
+        yield 'US Dollars in US English' => ['$1,000.00', $parameterDollars, 'en_US'];
+
+        if (\defined('\NumberFormatter::CURRENCY_ACCOUNTING')) {
+            $parameterEuros = new MoneyTranslatable(-1000, 'EUR', \NumberFormatter::CURRENCY_ACCOUNTING);
+            yield 'Accounting style in French' => ['(1000,00€)', $parameterEuros, 'fr_FR'];
+            yield 'Accounting style in US English' => ['(€1,000.00)', $parameterEuros, 'en_US'];
+        }
+    }
+}

--- a/src/Symfony/Component/Translation/Translatable/DateTimeTranslatable.php
+++ b/src/Symfony/Component/Translation/Translatable/DateTimeTranslatable.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Translatable;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Wrapper around PHP IntlDateFormatter for date and time
+ * The timezone from the DateTime instance is used instead of the server's timezone.
+ *
+ * Implementation of the ICU recommendation to first format advanced parameters before translation.
+ *
+ * @see https://unicode-org.github.io/icu/userguide/format_parse/messages/#format-the-parameters-separately-recommended
+ *
+ * @author Sylvain Fabre <syl.fabre@gmail.com>
+ */
+class DateTimeTranslatable implements TranslatableInterface
+{
+    private \DateTimeInterface $dateTime;
+    private int $dateType;
+    private int $timeType;
+
+    private static array $formatters = [];
+
+    public function __construct(
+        \DateTimeInterface $dateTime,
+        int $dateType = \IntlDateFormatter::SHORT,
+        int $timeType = \IntlDateFormatter::SHORT
+    ) {
+        $this->dateTime = $dateTime;
+        $this->dateType = $dateType;
+        $this->timeType = $timeType;
+    }
+
+    public function trans(TranslatorInterface $translator, string $locale = null): string
+    {
+        if (!$locale) {
+            $locale = $translator->getLocale();
+        }
+
+        $timezone = $this->dateTime->getTimezone();
+        $key = implode('.', [$locale, $this->dateType, $this->timeType, $timezone->getName()]);
+        if (!isset(self::$formatters[$key])) {
+            self::$formatters[$key] = new \IntlDateFormatter(
+                $locale ?? $translator->getLocale(),
+                $this->dateType,
+                $this->timeType,
+                $timezone
+            );
+        }
+
+        return self::$formatters[$key]->format($this->dateTime);
+    }
+
+    /**
+     * Short-hand to only format a date.
+     */
+    public static function date(\DateTimeInterface $dateTime, int $type = \IntlDateFormatter::SHORT): self
+    {
+        return new self($dateTime, $type, \IntlDateFormatter::NONE);
+    }
+
+    /**
+     * Short-hand to only format a time.
+     */
+    public static function time(\DateTimeInterface $dateTime, int $type = \IntlDateFormatter::SHORT): self
+    {
+        return new self($dateTime, \IntlDateFormatter::NONE, $type);
+    }
+}

--- a/src/Symfony/Component/Translation/Translatable/DecimalTranslatable.php
+++ b/src/Symfony/Component/Translation/Translatable/DecimalTranslatable.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Translatable;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Wrapper around PHP NumberFormatter for decimal values.
+ *
+ * Implementation of the ICU recommendation to first format advanced parameters before translation.
+ *
+ * @see https://unicode-org.github.io/icu/userguide/format_parse/messages/#format-the-parameters-separately-recommended
+ *
+ * @author Sylvain Fabre <syl.fabre@gmail.com>
+ */
+class DecimalTranslatable implements TranslatableInterface
+{
+    private float|int $value;
+    private int $style;
+
+    private static array $formatters = [];
+
+    public function __construct(float|int $value, int $style = \NumberFormatter::DECIMAL)
+    {
+        $this->value = $value;
+        $this->style = $style;
+    }
+
+    public function trans(TranslatorInterface $translator, string $locale = null): string
+    {
+        if (!$locale) {
+            $locale = $translator->getLocale();
+        }
+
+        $key = implode('.', [$locale, $this->style]);
+        if (!isset(self::$formatters[$key])) {
+            self::$formatters[$key] = new \NumberFormatter($locale, $this->style);
+        }
+
+        return self::$formatters[$key]->format($this->value);
+    }
+}

--- a/src/Symfony/Component/Translation/Translatable/MoneyTranslatable.php
+++ b/src/Symfony/Component/Translation/Translatable/MoneyTranslatable.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Translatable;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Wrapper around PHP NumberFormatter for money
+ * The provided currency is used instead of the locale's currency.
+ *
+ * Implementation of the ICU recommendation to first format advanced parameters before translation.
+ *
+ * @see https://unicode-org.github.io/icu/userguide/format_parse/messages/#format-the-parameters-separately-recommended
+ *
+ * @author Sylvain Fabre <syl.fabre@gmail.com>
+ */
+class MoneyTranslatable implements TranslatableInterface
+{
+    private float|int $value;
+    private string $currency;
+    private int $style;
+
+    private static array $formatters = [];
+
+    public function __construct(float|int $value, string $currency, int $style = \NumberFormatter::CURRENCY)
+    {
+        $this->value = $value;
+        $this->currency = $currency;
+        $this->style = $style;
+    }
+
+    public function trans(TranslatorInterface $translator, string $locale = null): string
+    {
+        if (!$locale) {
+            $locale = $translator->getLocale();
+        }
+
+        $key = implode('.', [$locale, $this->style]);
+        if (!isset(self::$formatters[$key])) {
+            self::$formatters[$key] = new \NumberFormatter($locale, $this->style);
+        }
+
+        return self::$formatters[$key]->formatCurrency($this->value, $this->currency);
+    }
+}

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -47,7 +47,8 @@
     "suggest": {
         "symfony/config": "",
         "symfony/yaml": "",
-        "psr/log-implementation": "To use logging capability in translator"
+        "psr/log-implementation": "To use logging capability in translator",
+        "moneyphp/money":  "To use money capability in translator"
     },
     "autoload": {
         "files": [ "Resources/functions.php" ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/32652
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

ICU recommends to first format advanced parameters before translation (https://unicode-org.github.io/icu/userguide/format_parse/messages/#format-the-parameters-separately-recommended).

Thanks to https://github.com/symfony/symfony/pull/41858, `TranslatableMessage` now supports recursive `TranslatableInterface`as params.

This PR implements a few common use-cases for arguments that must be first formatted to improve DX:
* `DateTimeParameter` to format date and time
* `MoneyParameter` to format monetary values with the support of https://github.com/moneyphp/money
* `DecimalParameter` to format decimal values as per locale specs

The following implementations could be considered in later PRs:
* `CountryParameter` to format the ISO 3166-2 into a localized country name



```yaml
# Translation file app+intl-icu.en_US.yml
payment: "{date, date, short} at {date, time, short} - {value, number, currency}"
payment2: "{date} at {time} - {value}"

# Translation file app+intl-icu.fr_FR.yml
payment: "{date, date, short} at {date, time, short} - {value, number, currency}"
payment2: "{date} at {time} - {value}"
```

**Before this PR**

```php
// BASIC USAGE

// en_US: 1/25/19 at 7:30 PM - $100.00
// fr_FR: 25/01/2019 à 19:30 - 100,00 €
$this->translator->trans('payment', [
    'date' => new \DateTime('2019-01-25 11:30:00', 'America/Los_Angeles'),
    'value' => 100
]);
// en_US: 1/25/19 at 10:30 AM - $100.00
// fr_FR: 25/01/2019 à 10:30 - 100,00 €
$this->translator->trans('payment', [
    'date' => new \DateTime('2019-01-25 11:30:00', 'Europe/Paris'),
    'value' => 100
]);

// ADVANCED USAGE

// en_US: 1/25/19 at 11:30 AM - $100.00
// fr_FR: 25/01/2019 à 11:30 - 100,00 $
$userCurrency = 'USD';
$datetime = new \DateTime('2019-01-25 11:30:00', 'Europe/Paris');
$dateFormatter = new IntlDateFormatter($this->translator->getLocale(), IntlDateFormatter::SHORT, IntlDateFormatter::NONE, $datetime->getTimezone());
$timeFormatter = new IntlDateFormatter($this->translator->getLocale(), IntlDateFormatter::NONE, IntlDateFormatter::SHORT, $datetime->getTimezone());
$numberFormatter = new NumberFormatter($this->translator->getLocale(), NumberFormatter::CURRENCY);
$this->translator->trans('payment2', [
    'date' => $dateFormatter->format($datetime),
    'time' => $timeFormatter->format($datetime),
    'value' => $numberFormatter->formatCurrency(100, $userCurrency)
]);
```

**After this PR**

```php
// BASIC USAGE
// No change

// ADVANCED USAGE

// en_US: 1/25/19 at 11:30 AM - $100.00
// fr_FR: 25/01/2019 à 11:30 - 100,00 $

$datetime = new \DateTime('2019-01-25 11:30:00', 'Europe/Paris');
$this->translator->trans('payment2', [
    'date' => DateTimeTranslatable::date($datetime),
    'time' => DateTimeTranslatable::time($datetime),
    'value' => new MoneyTranslatable(100, 'USD'),
    'value' => MoneyTranslatable::fromMoney(Money::USD(10000)), // Alternative with money-php
]);

// Or with TranslatableMessage for Twig
new TranslatableMessage('payment2', [
    'date' => DateTimeTranslatable::date($datetime),
    'time' => DateTimeTranslatable::time($datetime),
    'value' => new MoneyTranslatable(100, 'USD'),
    'value' => MoneyTranslatable::fromMoney(Money::USD(10000)), // Alternative with money-php
]);

```


TODO
* [x] Fix tests
* [x] Add `DecimalParameter`
* [ ] Documentation PR