### PR TITLE
[Security] [DataCollector] Remove allows anonymous information in datacollector

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -44,8 +44,9 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     private $firewallMap;
     private $firewall;
     private $hasVarDumper;
+    private $authenticatorManagerEnabled;
 
-    public function __construct(TokenStorageInterface $tokenStorage = null, RoleHierarchyInterface $roleHierarchy = null, LogoutUrlGenerator $logoutUrlGenerator = null, AccessDecisionManagerInterface $accessDecisionManager = null, FirewallMapInterface $firewallMap = null, TraceableFirewallListener $firewall = null)
+    public function __construct(TokenStorageInterface $tokenStorage = null, RoleHierarchyInterface $roleHierarchy = null, LogoutUrlGenerator $logoutUrlGenerator = null, AccessDecisionManagerInterface $accessDecisionManager = null, FirewallMapInterface $firewallMap = null, TraceableFirewallListener $firewall = null, $authenticatorManagerEnabled = false)
     {
         $this->tokenStorage = $tokenStorage;
         $this->roleHierarchy = $roleHierarchy;
@@ -54,6 +55,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
         $this->firewallMap = $firewallMap;
         $this->firewall = $firewall;
         $this->hasVarDumper = class_exists(ClassStub::class);
+        $this->authenticatorManagerEnabled = $authenticatorManagerEnabled;
     }
 
     /**
@@ -204,6 +206,8 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
         if ($this->firewall) {
             $this->data['listeners'] = $this->firewall->getWrappedListeners();
         }
+
+        $this->data['authenticator_manager_enabled'] = $this->authenticatorManagerEnabled;
     }
 
     /**
@@ -388,5 +392,10 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     public function getName()
     {
         return 'security';
+    }
+
+    public function isAuthenticatorManagerEnabled(): bool
+    {
+        return $this->data['authenticator_manager_enabled'];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -132,6 +132,8 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $loader->load('collectors.php');
         $loader->load('guard.php');
 
+        $container->getDefinition('data_collector.security')->addArgument($this->authenticatorManagerEnabled);
+
         if ($container->hasParameter('kernel.debug') && $container->getParameter('kernel.debug')) {
             $loader->load('security_debug.php');
         }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -159,10 +159,12 @@
                     <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.firewall.stateless ? 'yes' : 'no') ~ '.svg') }}</span>
                     <span class="label">Stateless</span>
                 </div>
+                {% if collector.authenticatorManagerEnabled == false %}
                 <div class="metric">
                     <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.firewall.allows_anonymous ? 'yes' : 'no') ~ '.svg') }}</span>
                     <span class="label">Allows anonymous</span>
                 </div>
+                {% endif %}
             </div>
 
             {% if collector.firewall.security_enabled %}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -71,6 +71,7 @@ class SecurityDataCollectorTest extends TestCase
         $this->assertCount(0, $collector->getInheritedRoles());
         $this->assertEmpty($collector->getUser());
         $this->assertNull($collector->getFirewall());
+        $this->assertFalse($collector->isAuthenticatorManagerEnabled());
     }
 
     /** @dataProvider provideRoles */
@@ -93,6 +94,7 @@ class SecurityDataCollectorTest extends TestCase
         $this->assertSame($normalizedRoles, $collector->getRoles()->getValue(true));
         $this->assertSame($inheritedRoles, $collector->getInheritedRoles()->getValue(true));
         $this->assertSame('hhamon', $collector->getUser());
+        $this->assertFalse($collector->isAuthenticatorManagerEnabled());
     }
 
     public function testCollectSwitchUserToken()
@@ -132,7 +134,7 @@ class SecurityDataCollectorTest extends TestCase
             ->with($request)
             ->willReturn($firewallConfig);
 
-        $collector = new SecurityDataCollector(null, null, null, null, $firewallMap, new TraceableFirewallListener($firewallMap, new EventDispatcher(), new LogoutUrlGenerator()));
+        $collector = new SecurityDataCollector(null, null, null, null, $firewallMap, new TraceableFirewallListener($firewallMap, new EventDispatcher(), new LogoutUrlGenerator()), true);
         $collector->collect($request, new Response());
         $collector->lateCollect();
         $collected = $collector->getFirewall();
@@ -149,6 +151,7 @@ class SecurityDataCollectorTest extends TestCase
         $this->assertSame($firewallConfig->getAccessDeniedUrl(), $collected['access_denied_url']);
         $this->assertSame($firewallConfig->getUserChecker(), $collected['user_checker']);
         $this->assertSame($firewallConfig->getListeners(), $collected['listeners']->getValue());
+        $this->assertTrue($collector->isAuthenticatorManagerEnabled());
     }
 
     public function testGetFirewallReturnsNull()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #40907
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

As mentioned In https://github.com/symfony/symfony/issues/40907 there is no longer anonymous users no longer in the new authentication system. This PR remove this information **if the new system is used** as it always a red cross 

With  `enable_authenticator_manager` at `false`
![image](https://user-images.githubusercontent.com/13260307/117574692-34c8d900-b0d6-11eb-9bef-a6c9abdfad2f.png)

With  `enable_authenticator_manager` at `true` 
![image](https://user-images.githubusercontent.com/13260307/117574619-f3382e00-b0d5-11eb-945a-3613425ccdbe.png)

