### PR TITLE
[Notifier] Regroup test in one directory

### DIFF
--- a/src/Symfony/Component/Notifier/Tests/Transport/TransportFactoryTestCase.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/TransportFactoryTestCase.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Notifier\Test;
+namespace Symfony\Component\Notifier\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Exception\IncompleteDsnException;

--- a/src/Symfony/Component/Notifier/Tests/Transport/TransportTestCase.php
+++ b/src/Symfony/Component/Notifier/Tests/Transport/TransportTestCase.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Notifier\Test;
+namespace Symfony\Component\Notifier\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| License       | MIT

I'm wondering why there is 2 directories for tests, I propose to group them
