### PR TITLE
[Mailer] Override recipient with mailer.envelope.recipients configuration

### DIFF
--- a/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/SendmailTransport.php
@@ -89,6 +89,20 @@ class SendmailTransport extends AbstractTransport
 
     protected function doSend(SentMessage $message): void
     {
+        
+        $originalMessage = $message->getOriginalMessage();
+        $envelope = $message->getEnvelope();
+
+        foreach ($envelope->getRecipients() as $key => $recipient) {
+            if($key === 0) {
+                $originalMessage->to($recipient->getAddress());
+            }else{
+                $originalMessage->addto($recipient->getAddress());
+            }
+        }
+
+        $message = new SentMessage($originalMessage, $envelope);
+        
         $this->getLogger()->debug(sprintf('Email transport "%s" starting', __CLASS__));
 
         $command = $this->command;


### PR DESCRIPTION
https://github.com/symfony/symfony/issues/41149

| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41149
| License       | MIT
| Doc PR        | https://symfony.com/doc/current/mailer.html#always-send-to-the-same-address

Symfony/Mailer : The recipients feature ("Always Send to the same Address") does not work with sendmail