### PR TITLE
[Validator] Add support for `ConstraintViolationList::createFromMessage()`

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+5.4
+---
+ * Add support for `ConstraintViolationList::createFromMessage()`
+
 5.3
 ---
  * Add the `normalizer` option to the `Unique` constraint

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -35,6 +35,14 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
         }
     }
 
+    public static function createFromMessage(string $message): self
+    {
+        $self = new self();
+        $self->add(new ConstraintViolation($message, '', [], null, '', null));
+
+        return $self;
+    }
+
     /**
      * Converts the violation into a string for debugging purposes.
      *

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
@@ -155,6 +155,15 @@ EOF;
         ];
     }
 
+    public function testCreateFromMessage()
+    {
+        $list = ConstraintViolationList::createFromMessage('my message');
+
+        $this->assertCount(1, $list);
+        $this->assertInstanceOf(ConstraintViolation::class, $list[0]);
+        $this->assertSame('my message', $list[0]->getMessage());
+    }
+
     protected function getViolation($message, $root = null, $propertyPath = null, $code = null)
     {
         return new ConstraintViolation($message, $message, [], $root, $propertyPath, null, null, $code);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x (5.4)
| Bug fix?      | no
| New feature?  | ye
| Deprecations? | no
| Tickets       | Fix #41111
| License       | MIT
| Doc PR        |