### PR TITLE
[Translation] Improved Translation Providers

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/Tests/CrowdinProviderTest.php
@@ -28,9 +28,7 @@ class CrowdinProviderTest extends ProviderTestCase
         yield [
             $this->createProvider($this->getClient()->withOptions([
                 'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
-                'headers' => [
-                    'Authorization' => 'Bearer API_TOKEN',
-                ],
+                'auth_bearer' => 'API_TOKEN',
             ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com'),
             'crowdin://api.crowdin.com',
         ];
@@ -38,9 +36,7 @@ class CrowdinProviderTest extends ProviderTestCase
         yield [
             $this->createProvider($this->getClient()->withOptions([
                 'base_uri' => 'https://domain.api.crowdin.com/api/v2/projects/1/',
-                'headers' => [
-                    'Authorization' => 'Bearer API_TOKEN',
-                ],
+                'auth_bearer' => 'API_TOKEN',
             ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'domain.api.crowdin.com'),
             'crowdin://domain.api.crowdin.com',
         ];
@@ -48,9 +44,7 @@ class CrowdinProviderTest extends ProviderTestCase
         yield [
             $this->createProvider($this->getClient()->withOptions([
                 'base_uri' => 'https://api.crowdin.com:99/api/v2/projects/1/',
-                'headers' => [
-                    'Authorization' => 'Bearer API_TOKEN',
-                ],
+                'auth_bearer' => 'API_TOKEN',
             ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com:99'),
             'crowdin://api.crowdin.com:99',
         ];
@@ -146,9 +140,7 @@ XLIFF;
 
         $provider = $this->createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
-            'headers' => [
-                'Authorization' => 'Bearer API_TOKEN',
-            ],
+            'auth_bearer' => 'API_TOKEN',
         ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
 
         $provider->write($translatorBag);
@@ -219,9 +211,7 @@ XLIFF;
 
         $provider = $this->createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
-            'headers' => [
-                'Authorization' => 'Bearer API_TOKEN',
-            ],
+            'auth_bearer' => 'API_TOKEN',
         ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
 
         $provider->write($translatorBag);
@@ -325,9 +315,7 @@ XLIFF;
 
         $provider = $this->createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
-            'headers' => [
-                'Authorization' => 'Bearer API_TOKEN',
-            ],
+            'auth_bearer' => 'API_TOKEN',
         ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
 
         $provider->write($translatorBag);
@@ -374,9 +362,7 @@ XLIFF;
 
         $crowdinProvider = $this->createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
-            'headers' => [
-                'Authorization' => 'Bearer API_TOKEN',
-            ],
+            'auth_bearer' => 'API_TOKEN',
         ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2');
 
         $translatorBag = $crowdinProvider->read([$domain], [$locale]);
@@ -459,9 +445,7 @@ XLIFF
 
         $crowdinProvider = $this->createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
-            'headers' => [
-                'Authorization' => 'Bearer API_TOKEN',
-            ],
+            'auth_bearer' => 'API_TOKEN',
         ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2');
 
         $translatorBag = $crowdinProvider->read([$domain], [$locale]);
@@ -567,9 +551,7 @@ XLIFF
 
         $provider = $this->createProvider((new MockHttpClient($responses))->withOptions([
             'base_uri' => 'https://api.crowdin.com/api/v2/projects/1/',
-            'headers' => [
-                'Authorization' => 'Bearer API_TOKEN',
-            ],
+            'auth_bearer' => 'API_TOKEN',
         ]), $this->getLoader(), $this->getLogger(), $this->getDefaultLocale(), 'api.crowdin.com/api/v2/projects/1/');
 
         $provider->delete($translatorBag);

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/composer.json
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/composer.json
@@ -21,11 +21,9 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/config": "^5.3",
         "symfony/http-client": "^5.3",
         "symfony/translation": "^5.3"
-    },
-    "require-dev": {
-        "symfony/config": "^4.4|^5.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Translation\\Bridge\\Crowdin\\": "" },

--- a/src/Symfony/Component/Translation/Bridge/Loco/composer.json
+++ b/src/Symfony/Component/Translation/Bridge/Loco/composer.json
@@ -18,10 +18,8 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^5.3",
+        "symfony/config": "^5.3",
         "symfony/translation": "^5.3"
-    },
-    "require-dev": {
-        "symfony/config": "^4.4|^5.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Translation\\Bridge\\Loco\\": "" },

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProviderFactory.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProviderFactory.php
@@ -52,7 +52,7 @@ final class LokaliseProviderFactory extends AbstractProviderFactory
 
         $endpoint = sprintf('%s%s', 'default' === $dsn->getHost() ? self::HOST : $dsn->getHost(), $dsn->getPort() ? ':'.$dsn->getPort() : '');
         $client = $this->client->withOptions([
-            'base_uri' => sprintf('https://%sprojects/%s/api2/', $endpoint, $this->getUser($dsn)),
+            'base_uri' => 'https://'.$endpoint.'/projects/'.$this->getUser($dsn).'/api2/',
             'headers' => [
                 'X-Api-Token' => $this->getPassword($dsn),
             ],

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/composer.json
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/composer.json
@@ -17,11 +17,9 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/config": "^5.3",
         "symfony/http-client": "^5.3",
         "symfony/translation": "^5.3"
-    },
-    "require-dev": {
-        "symfony/config": "^4.4|^5.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Translation\\Bridge\\Lokalise\\": "" },

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/composer.json
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/composer.json
@@ -17,11 +17,9 @@
     ],
     "require": {
         "php": ">=7.2.5",
+        "symfony/config": "^5.3",
         "symfony/http-client": "^5.3",
         "symfony/translation": "^5.3"
-    },
-    "require-dev": {
-        "symfony/config": "^4.4|^5.2"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Translation\\Bridge\\PoEditor\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Some small improvements on Translation Providers:
- move symfony/config from dev dependency to hard dependency for all Bridges as all providers use XliffFileLoader to load pulled translations (cf. https://github.com/symfony/symfony/pull/40927#issuecomment-836569888)
- replace all instances of 
```
'headers' => [
    'Authorization' => 'Bearer API_TOKEN',
]
``` 
with `'auth_bearer' => 'API_TOKEN',` even in tests files.
- Fix Lokalise base_uri concatenation