### PR TITLE
[Security] Make Login Rate Limiter case insensitive

### DIFF
--- a/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
+++ b/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
@@ -41,7 +41,7 @@ final class DefaultLoginRateLimiter extends AbstractRequestRateLimiter
     {
         return [
             $this->globalFactory->create($request->getClientIp()),
-            $this->localFactory->create($request->attributes->get(Security::LAST_USERNAME).'-'.$request->getClientIp()),
+            $this->localFactory->create(strtolower($request->attributes->get(Security::LAST_USERNAME)).'-'.$request->getClientIp()),
         ];
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/LoginThrottlingListenerTest.php
@@ -73,6 +73,21 @@ class LoginThrottlingListenerTest extends TestCase
         $this->listener->checkPassport($this->createCheckPassportEvent($passport));
     }
 
+    public function testPreventsLoginWithMultipleCase()
+    {
+        $request = $this->createRequest();
+        $passports = [$this->createPassport('wouter'), $this->createPassport('Wouter'), $this->createPassport('wOuter')];
+
+        $this->requestStack->push($request);
+
+        for ($i = 0; $i < 3; ++$i) {
+            $this->listener->checkPassport($this->createCheckPassportEvent($passports[$i % 3]));
+        }
+
+        $this->expectException(TooManyLoginAttemptsAuthenticationException::class);
+        $this->listener->checkPassport($this->createCheckPassportEvent($passports[0]));
+    }
+
     public function testPreventsLoginWhenOverGlobalThreshold()
     {
         $request = $this->createRequest();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Login RateLimiter is case sensitive, while most login forms aren't case sensitive. 
This PR makes `DefaultLoginRateLimiter` case insensitive.