### PR TITLE
[HttpClient] Don't prepare the request in ScopingHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/ScopingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/ScopingHttpClient.php
@@ -57,6 +57,7 @@ class ScopingHttpClient implements HttpClientInterface, ResetInterface
      */
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
+        $e = null;
         $url = self::parseUrl($url, $options['query'] ?? []);
 
         if (\is_string($options['base_uri'] ?? null)) {
@@ -70,13 +71,18 @@ class ScopingHttpClient implements HttpClientInterface, ResetInterface
                 throw $e;
             }
 
-            [$url, $options] = self::prepareRequest($method, implode('', $url), $options, $this->defaultOptionsByRegexp[$this->defaultRegexp], true);
-            $url = implode('', $url);
+            $options = self::mergeDefaultOptions($options, $this->defaultOptionsByRegexp[$this->defaultRegexp], true);
+            if (\is_string($options['base_uri'] ?? null)) {
+                $options['base_uri'] = self::parseUrl($options['base_uri']);
+            }
+            $url = implode('', self::resolveUrl($url, $options['base_uri'] ?? null));
         }
 
         foreach ($this->defaultOptionsByRegexp as $regexp => $defaultOptions) {
             if (preg_match("{{$regexp}}A", $url)) {
-                $options = self::mergeDefaultOptions($options, $defaultOptions, true);
+                if (null === $e || $regexp !== $this->defaultRegexp) {
+                    $options = self::mergeDefaultOptions($options, $defaultOptions, true);
+                }
                 break;
             }
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Spotted while working on #41159 (needed by it.)