### PR TITLE
WDT: Only load "Sfjs" if it is not present already

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -5,6 +5,7 @@
                 them as JavaScript source code. Always use '/*' comments instead
                 of '//' comments to avoid impossible-to-debug side-effects #}
 
+if (typeof Sfjs === 'undefined') {
     Sfjs = (function() {
         "use strict";
 
@@ -424,6 +425,10 @@
                     'sfwdt' + token,
                     '{{ url("_wdt", { "token": "xxxxxx" })|escape('js') }}'.replace(/xxxxxx/, newToken),
                     function(xhr, el) {
+                        /* Do nothing in the edge case where the toolbar has already been replaced with a new one */
+                        if (!document.getElementById('sfToolbarMainContent-' + newToken)) {
+                            return;
+                        }
 
                         /* Evaluate in global scope scripts embedded inside the toolbar */
                         var i, scripts = [].slice.call(el.querySelectorAll('script'));
@@ -799,5 +804,5 @@
         Sfjs.createTabs();
         Sfjs.createToggles();
     });
-
+}
 /*]]>*/</script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | not needed

Hi!

Playing with Turbo, I noticed two small issues with the WDT:

1) When you click a link (which Turbo loads via AJAX), the new toolbar would correctly load, but its "AJAX tab" would be missing/empty. At first, that seems.. at least... "correct enough". After all, we *did* just load a new web debug toolbar. However, this can be avoided by simply *not* redefining the `Sfjs` variable: if it already exists, just use it. And this is the intention of that object, I believe: for it to be loaded *once*, and then reused over and over again via its `loadToolbar()` method.

2) Additionally, I was experimenting with some crazy prefetch + Turbo functionality. It works, but caused one minor issue with the web debug toolbar. The flow is this:

A) A prefetch request is made to pre-cache a URL in Turbo.
B) When that links is actually clicked, the cached version from (A) is used as the "Preview". It's HTML calls `Sfjs.loadToolbar()`.
C) At the same moment as (B), another AJAX request is made to the same URL from (A) to get the full, fresh page (in case it's out of date).
D) When (C) finishes, it will have its own `Sfjs.loadToolbar()` call.

The problem is that the AJAX request for the first web debug toolbar (from B) sometimes finishes *after* the AJAX call made by Turbo for (C). The result is that the first web debug toolbar tries to activate itself... but it's already gone from the page.

I realize this is a... kind of crazy scenario, but I think the fix is legit: if, for any reason, the web debug toolbar element is not on the page, we should not try to initialize it. It results in:

<img width="431" alt="Screen Shot 2021-05-10 at 3 49 06 PM" src="https://user-images.githubusercontent.com/121003/117716165-429a5f00-b1a7-11eb-9b99-bf08591d2ff4.png">

## To Test

JUST to be on the safe side, I prepared a symfony-demo app with Turbo installed, and using these changes. You can try it here - https://github.com/weaverryan/symfony-demo/tree/turbo - the README is updated to quickly get it running (no need to even run yarn, the JavaScript files are committed).

Thanks!