### PR TITLE
[Security] Make Login Rate Limiter also case insensitive for non-ascii user identifiers

### DIFF
--- a/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
+++ b/src/Symfony/Component/Security/Http/RateLimiter/DefaultLoginRateLimiter.php
@@ -39,9 +39,12 @@ final class DefaultLoginRateLimiter extends AbstractRequestRateLimiter
 
     protected function getLimiters(Request $request): array
     {
+        $username = $request->attributes->get(Security::LAST_USERNAME);
+        $username = preg_match('//u', $username) ? mb_strtolower($username, 'UTF-8') : strtolower($username);
+
         return [
             $this->globalFactory->create($request->getClientIp()),
-            $this->localFactory->create(strtolower($request->attributes->get(Security::LAST_USERNAME)).'-'.$request->getClientIp()),
+            $this->localFactory->create($username.'-'.$request->getClientIp()),
         ];
     }
 }

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -21,6 +21,7 @@
         "symfony/security-core": "^5.2",
         "symfony/http-foundation": "^5.2",
         "symfony/http-kernel": "^5.2",
+        "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php80": "^1.15",
         "symfony/property-access": "^4.4|^5.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As per discussion in https://github.com/symfony/symfony/pull/41156