### PR TITLE
[DependencyInjection] fix empty instanceof-conditionals created by AttributeAutoconfigurationPass

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AttributeAutoconfigurationPass.php
@@ -48,8 +48,10 @@ final class AttributeAutoconfigurationPass extends AbstractRecursivePass
                 $configurator($conditionals, $attribute->newInstance(), $reflector);
             }
         }
-        $instanceof[$reflector->getName()] = $conditionals;
-        $value->setInstanceofConditionals($instanceof);
+        if (!isset($instanceof[$reflector->getName()]) && new ChildDefinition('') != $conditionals) {
+            $instanceof[$reflector->getName()] = $conditionals;
+            $value->setInstanceofConditionals($instanceof);
+        }
 
         return parent::processValue($value, $isRoot);
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AttributeAutoconfigurationPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AttributeAutoconfigurationPassTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
+use Symfony\Component\DependencyInjection\Compiler\AttributeAutoconfigurationPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @requires PHP 8
+ */
+class AttributeAutoconfigurationPassTest extends TestCase
+{
+    public function testProcessAddsNoEmptyInstanceofConditionals()
+    {
+        $container = new ContainerBuilder();
+        $container->registerAttributeForAutoconfiguration(AsTaggedItem::class, static function () {});
+        $container->register('foo', \stdClass::class)
+            ->setAutoconfigured(true)
+        ;
+
+        (new AttributeAutoconfigurationPass())->process($container);
+
+        $this->assertSame([], $container->getDefinition('foo')->getInstanceofConditionals());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40868
| License       | MIT
| Doc PR        | -