### PR TITLE
[FrameworkBundle] Introduce `AbstractController::renderForm()` instead of `handleForm()`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * Deprecate the `session.storage` alias and `session.storage.*` services, use the `session.storage.factory` alias and `session.storage.factory.*` services instead
  * Deprecate the `framework.session.storage_id` configuration option, use the `framework.session.storage_factory_id` configuration option instead
  * Deprecate the `session` service and the `SessionInterface` alias, use the `Request::getSession()` or the new `RequestStack::getSession()` methods instead
- * Added `AbstractController::handleForm()` to handle a form and set the appropriate HTTP status code
+ * Added `AbstractController::renderForm()` to render a form and set the appropriate HTTP status code
  * Added support for configuring PHP error level to log levels
  * Added the `dispatcher` option to `debug:event-dispatcher`
  * Added the `event_dispatcher.dispatcher` tag

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormConfigInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 use Symfony\Component\HttpFoundation\File\File;
@@ -411,6 +412,52 @@ class AbstractControllerTest extends TestCase
         $this->assertEquals('bar', $controller->render('foo')->getContent());
     }
 
+    public function testRenderFormNew()
+    {
+        $formView = new FormView();
+
+        $form = $this->getMockBuilder(FormInterface::class)->getMock();
+        $form->expects($this->once())->method('createView')->willReturn($formView);
+
+        $twig = $this->getMockBuilder(Environment::class)->disableOriginalConstructor()->getMock();
+        $twig->expects($this->once())->method('render')->with('foo', ['form' => $formView, 'bar' => 'bar'])->willReturn('bar');
+
+        $container = new Container();
+        $container->set('twig', $twig);
+
+        $controller = $this->createController();
+        $controller->setContainer($container);
+
+        $response = $controller->renderForm('foo', $form, ['bar' => 'bar']);
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('bar', $response->getContent());
+    }
+
+    public function testRenderFormSubmittedAndInvalid()
+    {
+        $formView = new FormView();
+
+        $form = $this->getMockBuilder(FormInterface::class)->getMock();
+        $form->expects($this->once())->method('createView')->willReturn($formView);
+        $form->expects($this->once())->method('isSubmitted')->willReturn(true);
+        $form->expects($this->once())->method('isValid')->willReturn(false);
+
+        $twig = $this->getMockBuilder(Environment::class)->disableOriginalConstructor()->getMock();
+        $twig->expects($this->once())->method('render')->with('foo', ['myForm' => $formView, 'bar' => 'bar'])->willReturn('bar');
+
+        $container = new Container();
+        $container->set('twig', $twig);
+
+        $controller = $this->createController();
+        $controller->setContainer($container);
+
+        $response = $controller->renderForm('foo', $form, ['bar' => 'bar'], null, 'myForm');
+
+        $this->assertSame(422, $response->getStatusCode());
+        $this->assertSame('bar', $response->getContent());
+    }
+
     public function testStreamTwig()
     {
         $twig = $this->createMock(Environment::class);
@@ -422,91 +469,6 @@ class AbstractControllerTest extends TestCase
         $controller->setContainer($container);
 
         $this->assertInstanceOf(StreamedResponse::class, $controller->stream('foo'));
-    }
-
-    public function testHandleFormNotSubmitted()
-    {
-        $form = $this->createMock(FormInterface::class);
-        $form->expects($this->once())->method('isSubmitted')->willReturn(false);
-
-        $controller = $this->createController();
-        $response = $controller->handleForm(
-            $form,
-            Request::create('https://example.com'),
-            function (FormInterface $form, $data, Request $request): Response {
-                return new RedirectResponse('https://example.com/redir', Response::HTTP_SEE_OTHER);
-            },
-            function (FormInterface $form, $data, Request $request): Response {
-                return new Response('rendered');
-            }
-        );
-
-        $this->assertTrue($response->isSuccessful());
-        $this->assertSame('rendered', $response->getContent());
-    }
-
-    public function testHandleFormInvalid()
-    {
-        $form = $this->createMock(FormInterface::class);
-        $form->expects($this->once())->method('isSubmitted')->willReturn(true);
-        $form->expects($this->once())->method('isValid')->willReturn(false);
-
-        $controller = $this->createController();
-        $response = $controller->handleForm(
-            $form,
-            Request::create('https://example.com'),
-            function (FormInterface $form, $data, Request $request): Response {
-                return new RedirectResponse('https://example.com/redir', Response::HTTP_SEE_OTHER);
-            },
-            function (FormInterface $form, $data, Request $request): Response {
-                return new Response('rendered');
-            }
-        );
-
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
-        $this->assertSame('rendered', $response->getContent());
-    }
-
-    public function testHandleFormValid()
-    {
-        $form = $this->createMock(FormInterface::class);
-        $form->expects($this->once())->method('isSubmitted')->willReturn(true);
-        $form->expects($this->once())->method('isValid')->willReturn(true);
-
-        $controller = $this->createController();
-        $response = $controller->handleForm(
-            $form,
-            Request::create('https://example.com'),
-            function (FormInterface $form, $data, Request $request): Response {
-                return new RedirectResponse('https://example.com/redir', Response::HTTP_SEE_OTHER);
-            },
-            function (FormInterface $form, $data, Request $request): Response {
-                return new Response('rendered');
-            }
-        );
-
-        $this->assertInstanceOf(RedirectResponse::class, $response);
-        $this->assertSame(Response::HTTP_SEE_OTHER, $response->getStatusCode());
-        $this->assertSame('https://example.com/redir', $response->getTargetUrl());
-    }
-
-    public function testHandleFormTypeError()
-    {
-        $form = $this->createMock(FormInterface::class);
-        $form->expects($this->once())->method('isSubmitted')->willReturn(true);
-        $form->expects($this->once())->method('isValid')->willReturn(false);
-
-        $controller = $this->createController();
-
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('The "$render" callable passed to "Symfony\Bundle\FrameworkBundle\Tests\Controller\TestAbstractController::handleForm()" must return a Response, "string" returned.');
-
-        $response = $controller->handleForm(
-            $form,
-            Request::create('https://example.com'),
-            function () { return 'abc'; },
-            function () { return 'abc'; }
-        );
     }
 
     public function testRedirectToRoute()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | 
| License       | MIT
| Doc PR        | -

I'm know I'm a bit late on this once, but I don't really like the `handleForm()` method:

1. It uses callable and PHP does not support type hint on callable so it's error prone. While trying the feature I forgot to return a response and I got a fatal error "cannot call getStatusCode() on null". Not really user friendly;
1. callables receive `mixed $data`: it's too generic. Static analysis could not work properly and so autocompletion does not work;
1. This is a new syntax to learn;
1. All documentation, blog post, etc should be updated, and it's not fixable with `sed` or similar tool;
1. This is not really flexible. We are going to lock people with this flow, and they will hesitate to use the "old" syntax when they need more flexibility;

That's why I propose this alternative, which is  more simple I guess and addresses issues I leveraged.

I read somewhere that calling `isValid()` trigger twice the validation logic: This is wrong. The validation occurs during form submitting via an event listener. calling `isValid()` only check if there is some errors attached to the form.

---

Usage:
```diff
     #[Route('/new', name: 'thing_new', methods: ['GET', 'POST'])]
     public function new(Request $request): Response
     {
         $thing = new Thing();
         $form = $this->createForm(ThingType::class, $thing);
 
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
             $entityManager = $this->getDoctrine()->getManager();
             $entityManager->persist($thing);
             $entityManager->flush();
 
             return $this->redirectToRoute('thing_index');
         }
 
-        return $this->render('thing/new.html.twig', [
+        return $this->renderForm('thing/new.html.twig', $form, [
             'thing' => $thing,
             'form' => $form->createView(),
         ]);
     }
```