### PR TITLE
[Messenger] Add Transport attribute to configure message to transport mapping

### DIFF
--- a/src/Symfony/Component/Messenger/Attribute/Senders.php
+++ b/src/Symfony/Component/Messenger/Attribute/Senders.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types=1);
-
 namespace Symfony\Component\Messenger\Attribute;
 
 /**

--- a/src/Symfony/Component/Messenger/Attribute/Senders.php
+++ b/src/Symfony/Component/Messenger/Attribute/Senders.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Messenger\Attribute;
+
+/**
+ * @author Maxim Dovydenok <dovydenok.maxim@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class Senders
+{
+    public array $senders;
+
+    /**
+     * @param string[] $senders
+     */
+    public function __construct(string ...$senders)
+    {
+        $this->senders = $senders;
+    }
+}

--- a/src/Symfony/Component/Messenger/Attribute/Senders.php
+++ b/src/Symfony/Component/Messenger/Attribute/Senders.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Symfony\Component\Messenger\Attribute;

--- a/src/Symfony/Component/Messenger/Attribute/Transport.php
+++ b/src/Symfony/Component/Messenger/Attribute/Transport.php
@@ -17,10 +17,7 @@ namespace Symfony\Component\Messenger\Attribute;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class Transport
 {
-    public string $name;
-
-    public function __construct(string $name)
+    public function __construct(public readonly string $name)
     {
-        $this->name = $name;
     }
 }

--- a/src/Symfony/Component/Messenger/Attribute/Transport.php
+++ b/src/Symfony/Component/Messenger/Attribute/Transport.php
@@ -14,16 +14,13 @@ namespace Symfony\Component\Messenger\Attribute;
 /**
  * @author Maxim Dovydenok <dovydenok.maxim@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_CLASS)]
-class Senders
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+class Transport
 {
-    public array $senders;
+    public string $name;
 
-    /**
-     * @param string[] $senders
-     */
-    public function __construct(string ...$senders)
+    public function __construct(string $name)
     {
-        $this->senders = $senders;
+        $this->name = $name;
     }
 }

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * Add `SerializedMessageStamp` to avoid serializing a message when a retry occurs.
  * Automatically resolve handled message type when method different from `__invoke` is used as handler.
- * Add `Senders` attribute to configure message to sender mapping
+ * Add `Transport` attribute to configure message to sender mapping
 
 6.0
 ---

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `SerializedMessageStamp` to avoid serializing a message when a retry occurs.
  * Automatically resolve handled message type when method different from `__invoke` is used as handler.
+ * Add `Senders` attribute to configure message to sender mapping
 
 6.0
 ---

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageInterfaceWithAttribute.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageInterfaceWithAttribute.php
@@ -4,7 +4,7 @@ namespace Symfony\Component\Messenger\Tests\Fixtures;
 
 use Symfony\Component\Messenger\Attribute\Transport;
 
-#[Transport('my_common_sender')]
+#[Transport('interface_attribute_sender')]
 interface DummyMessageInterfaceWithAttribute
 {
 }

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageInterfaceWithAttribute.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageInterfaceWithAttribute.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Attribute\Transport;
+
+#[Transport('my_common_sender')]
+interface DummyMessageInterfaceWithAttribute
+{
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithAttribute.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithAttribute.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Attribute\Senders;
+
+#[Senders('my_sender')]
+class DummyMessageWithAttribute implements DummyMessageInterface
+{
+    private $message;
+
+    public function __construct(string $message)
+    {
+        $this->message = $message;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithAttribute.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithAttribute.php
@@ -4,8 +4,8 @@ namespace Symfony\Component\Messenger\Tests\Fixtures;
 
 use Symfony\Component\Messenger\Attribute\Transport;
 
-#[Transport('my_sender')]
-#[Transport('my_second_sender')]
+#[Transport('message_attribute_sender')]
+#[Transport('message_attribute_sender_2')]
 class DummyMessageWithAttribute implements DummyMessageInterface
 {
     private $message;

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithAttribute.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithAttribute.php
@@ -5,7 +5,7 @@ namespace Symfony\Component\Messenger\Tests\Fixtures;
 use Symfony\Component\Messenger\Attribute\Transport;
 
 #[Transport('message_attribute_sender')]
-#[Transport('message_attribute_sender_2')]
+#[CustomTransport]
 class DummyMessageWithAttribute implements DummyMessageInterface
 {
     private $message;
@@ -18,5 +18,14 @@ class DummyMessageWithAttribute implements DummyMessageInterface
     public function getMessage(): string
     {
         return $this->message;
+    }
+}
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class CustomTransport extends Transport
+{
+    public function __construct()
+    {
+        parent::__construct('message_attribute_sender_2');
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithAttribute.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithAttribute.php
@@ -5,6 +5,7 @@ namespace Symfony\Component\Messenger\Tests\Fixtures;
 use Symfony\Component\Messenger\Attribute\Transport;
 
 #[Transport('my_sender')]
+#[Transport('my_second_sender')]
 class DummyMessageWithAttribute implements DummyMessageInterface
 {
     private $message;

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithAttributeAndInterface.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithAttributeAndInterface.php
@@ -4,7 +4,7 @@ namespace Symfony\Component\Messenger\Tests\Fixtures;
 
 use Symfony\Component\Messenger\Attribute\Transport;
 
-#[Transport('my_sender')]
+#[Transport('message_attribute_sender')]
 class DummyMessageWithAttributeAndInterface implements DummyMessageInterfaceWithAttribute
 {
     private $message;

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithAttributeAndInterface.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/DummyMessageWithAttributeAndInterface.php
@@ -5,7 +5,7 @@ namespace Symfony\Component\Messenger\Tests\Fixtures;
 use Symfony\Component\Messenger\Attribute\Transport;
 
 #[Transport('my_sender')]
-class DummyMessageWithAttribute implements DummyMessageInterface
+class DummyMessageWithAttributeAndInterface implements DummyMessageInterfaceWithAttribute
 {
     private $message;
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
@@ -24,9 +24,6 @@ use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
 
 class SendersLocatorTest extends TestCase
 {
-    /**
-     * @requires PHP 8
-     */
     public function testAttributeMapping()
     {
         $sender = $this->createMock(SenderInterface::class);

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
@@ -35,11 +35,8 @@ class SendersLocatorTest extends TestCase
             'my_common_sender' => $sender,
             'my_merged_sender' => $sender,
         ]);
-        $locator = new SendersLocator([], $sendersLocator);
-        $locatorWithRouting = new SendersLocator([
-            DummyMessageWithAttribute::class => ['my_merged_sender'],
-        ], $sendersLocator);
 
+        $locator = new SendersLocator([], $sendersLocator);
         $this->assertSame([], iterator_to_array($locator->getSenders(new Envelope(new DummyMessage('a')))));
         $this->assertSame(
             ['my_sender' => $sender, 'my_second_sender' => $sender],
@@ -50,8 +47,11 @@ class SendersLocatorTest extends TestCase
             iterator_to_array($locator->getSenders(new Envelope(new DummyMessageWithAttributeAndInterface('a'))))
         );
 
+        $locatorWithRouting = new SendersLocator([
+            DummyMessageWithAttribute::class => ['my_merged_sender'],
+        ], $sendersLocator);
         $this->assertSame(
-            ['my_sender' => $sender, 'my_second_sender' => $sender],
+            ['my_merged_sender' => $sender],
             iterator_to_array($locatorWithRouting->getSenders(new Envelope(new DummyMessageWithAttribute('a'))))
         );
     }

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
@@ -15,12 +15,25 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessageWithAttribute;
 use Symfony\Component\Messenger\Tests\Fixtures\SecondMessage;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
 
 class SendersLocatorTest extends TestCase
 {
+    public function testAttributeMapping()
+    {
+        $sender = $this->createMock(SenderInterface::class);
+        $sendersLocator = $this->createContainer([
+            'my_sender' => $sender,
+        ]);
+        $locator = new SendersLocator([], $sendersLocator);
+
+        $this->assertSame(['my_sender' => $sender], iterator_to_array($locator->getSenders(new Envelope(new DummyMessageWithAttribute('a')))));
+        $this->assertSame([], iterator_to_array($locator->getSenders(new Envelope(new DummyMessage('a')))));
+    }
+
     public function testItReturnsTheSenderBasedOnTheMessageClass()
     {
         $sender = $this->createMock(SenderInterface::class);

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
@@ -31,6 +31,7 @@ class SendersLocatorTest extends TestCase
         $sender = $this->createMock(SenderInterface::class);
         $sendersLocator = $this->createContainer([
             'my_sender' => $sender,
+            'my_second_sender' => $sender,
             'my_common_sender' => $sender,
             'my_merged_sender' => $sender,
         ]);
@@ -41,7 +42,7 @@ class SendersLocatorTest extends TestCase
 
         $this->assertSame([], iterator_to_array($locator->getSenders(new Envelope(new DummyMessage('a')))));
         $this->assertSame(
-            ['my_sender' => $sender],
+            ['my_sender' => $sender, 'my_second_sender' => $sender],
             iterator_to_array($locator->getSenders(new Envelope(new DummyMessageWithAttribute('a'))))
         );
         $this->assertSame(
@@ -50,7 +51,7 @@ class SendersLocatorTest extends TestCase
         );
 
         $this->assertSame(
-            ['my_sender' => $sender],
+            ['my_sender' => $sender, 'my_second_sender' => $sender],
             iterator_to_array($locatorWithRouting->getSenders(new Envelope(new DummyMessageWithAttribute('a'))))
         );
     }

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
@@ -36,6 +36,7 @@ class SendersLocatorTest extends TestCase
             'interface_attribute_sender' => $sender,
             'message_config_sender' => $sender,
             'interface_config_sender' => $sender,
+            'all_config_sender' => $sender,
         ]);
 
         $locator = new SendersLocator([], $sendersLocator);
@@ -49,18 +50,37 @@ class SendersLocatorTest extends TestCase
             iterator_to_array($locator->getSenders(new Envelope(new DummyMessageWithAttributeAndInterface('a'))))
         );
 
-        $locatorWithRouting = new SendersLocator([
+        $locatorWithFullRouting = new SendersLocator([
             DummyMessageWithAttribute::class => ['message_config_sender'],
             DummyMessageWithAttributeAndInterface::class => ['message_config_sender'],
             DummyMessageInterfaceWithAttribute::class => ['interface_config_sender'],
+            '*' => ['all_config_sender'],
         ], $sendersLocator);
         $this->assertSame(
-            ['message_config_sender' => $sender],
-            iterator_to_array($locatorWithRouting->getSenders(new Envelope(new DummyMessageWithAttribute('a'))))
+            ['message_config_sender' => $sender, 'all_config_sender' => $sender],
+            iterator_to_array($locatorWithFullRouting->getSenders(new Envelope(new DummyMessageWithAttribute('a'))))
         );
         $this->assertSame(
-            ['message_config_sender' => $sender, 'interface_config_sender' => $sender],
-            iterator_to_array($locatorWithRouting->getSenders(new Envelope(new DummyMessageWithAttributeAndInterface('a'))))
+            ['message_config_sender' => $sender, 'interface_config_sender' => $sender, 'all_config_sender' => $sender],
+            iterator_to_array($locatorWithFullRouting->getSenders(new Envelope(new DummyMessageWithAttributeAndInterface('a'))))
+        );
+
+        $locatorWithClassRouting = new SendersLocator([
+            DummyMessageWithAttributeAndInterface::class => ['message_config_sender'],
+            '*' => ['all_config_sender'],
+        ], $sendersLocator);
+        $this->assertSame(
+            ['message_config_sender' => $sender, 'interface_attribute_sender' => $sender, 'all_config_sender' => $sender],
+            iterator_to_array($locatorWithClassRouting->getSenders(new Envelope(new DummyMessageWithAttributeAndInterface('a'))))
+        );
+
+        $locatorWithInterfaceRouting = new SendersLocator([
+            DummyMessageInterfaceWithAttribute::class => ['interface_config_sender'],
+            '*' => ['all_config_sender'],
+        ], $sendersLocator);
+        $this->assertSame(
+            ['message_attribute_sender' => $sender, 'interface_config_sender' => $sender, 'all_config_sender' => $sender],
+            iterator_to_array($locatorWithInterfaceRouting->getSenders(new Envelope(new DummyMessageWithAttributeAndInterface('a'))))
         );
     }
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Sender/SendersLocatorTest.php
@@ -22,6 +22,9 @@ use Symfony\Component\Messenger\Transport\Sender\SendersLocator;
 
 class SendersLocatorTest extends TestCase
 {
+    /**
+     * @requires PHP 8
+     */
     public function testAttributeMapping()
     {
         $sender = $this->createMock(SenderInterface::class);

--- a/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
@@ -85,7 +85,7 @@ class SendersLocator implements SendersLocatorInterface
             return [];
         }
 
-        $attributes = $reflectionClass->getAttributes(Transport::class);
+        $attributes = $reflectionClass->getAttributes(Transport::class, \ReflectionAttribute::IS_INSTANCEOF);
 
         return array_map(function (\ReflectionAttribute $attribute): string {
             /** @var Transport $attributeInstance */

--- a/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
@@ -42,7 +42,11 @@ class SendersLocator implements SendersLocatorInterface
      */
     public function getSenders(Envelope $envelope): iterable
     {
-        $senderAliases = $this->getSendersFromAttributes($envelope);
+        $senderAliases = [];
+
+        if (\PHP_VERSION_ID >= 80000) {
+            $senderAliases = $this->getSendersFromAttributes($envelope);
+        }
 
         foreach (HandlersLocator::listTypes($envelope) as $type) {
             foreach ($this->sendersMap[$type] ?? [] as $senderAlias) {

--- a/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
@@ -55,7 +55,7 @@ class SendersLocator implements SendersLocatorInterface
                 $typeSenderAliases = $this->getSendersFromAttributes($type);
             }
 
-            array_push($senderAliases, ...$typeSenderAliases);
+            $senderAliases = array_merge($senderAliases, $typeSenderAliases);
         }
 
         $senderAliases = array_unique($senderAliases);

--- a/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
@@ -50,12 +50,8 @@ class SendersLocator implements SendersLocatorInterface
             }
         }
 
-        if (\PHP_VERSION_ID >= 80000) {
-            $senderAliasesFromAttributes = $this->getSendersFromAttributes($envelope);
-
-            if (!empty($senderAliasesFromAttributes)) {
-                $senderAliases = $senderAliasesFromAttributes;
-            }
+        if (\PHP_VERSION_ID >= 80000 && empty($senderAliases)) {
+            $senderAliases = $this->getSendersFromAttributes($envelope);
         }
 
         $senderAliases = array_unique($senderAliases);

--- a/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
@@ -51,7 +51,7 @@ class SendersLocator implements SendersLocatorInterface
                 $typeSenderAliases[] = $senderAlias;
             }
 
-            if (\PHP_VERSION_ID >= 80000 && empty($typeSenderAliases)) {
+            if (empty($typeSenderAliases)) {
                 $typeSenderAliases = $this->getSendersFromAttributes($type);
             }
 

--- a/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
@@ -67,13 +67,11 @@ class SendersLocator implements SendersLocatorInterface
     }
 
     /**
-     * @param Envelope $envelope
-     *
      * @return string[]
      */
     private function getSendersFromAttributes(Envelope $envelope): array
     {
-        $messageClass = get_class($envelope->getMessage());
+        $messageClass = \get_class($envelope->getMessage());
 
         try {
             $reflectionClass = new \ReflectionClass($messageClass);

--- a/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
+++ b/src/Symfony/Component/Messenger/Transport/Sender/SendersLocator.php
@@ -51,7 +51,7 @@ class SendersLocator implements SendersLocatorInterface
                 $typeSenderAliases[] = $senderAlias;
             }
 
-            if (empty($typeSenderAliases)) {
+            if (!$typeSenderAliases) {
                 $typeSenderAliases = $this->getSendersFromAttributes($type);
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #41106 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#15332 <!-- required for new features -->

This PR adds `Transport` attribute to configure Message->Transport mapping. This attribute is read in the SenderLocator class.
Using this attribute it will be possible to configure transport for the message in the message class file instead of messenger.yaml.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
