### PR TITLE
[DependencyInjection] allow PHP-DSL files to be env-conditional

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/When.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/When.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\DependencyInjection\Attribute;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class When
 {
     public function __construct(

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/config_builder.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/config_builder.php
@@ -2,6 +2,10 @@
 
 use Symfony\Component\DependencyInjection\Tests\Fixtures\AcmeConfig;
 
-return static function (AcmeConfig $config) {
+if ('prod' !== $env) {
+    return;
+}
+
+return function (AcmeConfig $config) {
     $config->color('blue');
 };

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/env_configurator.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/env_configurator.php
@@ -2,7 +2,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-return static function (ContainerConfigurator $configurator): void {
+return function (ContainerConfigurator $configurator): void {
     $services = $configurator->services();
 
     $services

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/nested_bundle_config.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/nested_bundle_config.php
@@ -2,6 +2,6 @@
 
 use Symfony\Config\AcmeConfig\NestedConfig;
 
-return static function (NestedConfig $config) {
+return function (NestedConfig $config) {
     throw new RuntimeException('This code should not be run.');
 };

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/when_env.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/when_env.php
@@ -1,0 +1,7 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Attribute\When;
+
+return #[When(env: 'prod')] function () {
+    throw new RuntimeException('This code should not be run.');
+};

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -176,4 +176,16 @@ class PhpFileLoaderTest extends TestCase
 
         $loader->load($fixtures.'/config/nested_bundle_config.php');
     }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testWhenEnv()
+    {
+        $fixtures = realpath(__DIR__.'/../Fixtures');
+        $container = new ContainerBuilder();
+        $loader = new PhpFileLoader($container, new FileLocator(), 'dev', new ConfigBuilderGenerator(sys_get_temp_dir()));
+
+        $loader->load($fixtures.'/config/when_env.php');
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR makes config builders compatible with conditional configuration based on the $env.

See fixture for an example:
```php
use Symfony\Component\DependencyInjection\Tests\Fixtures\AcmeConfig;

if ('prod' !== $env) {
    return;
}

return static function (AcmeConfig $config) {
    $config->color('blue');
};
```

On PHP8, the PR allows using `#[When(env: 'prod')]`:
```php
use Symfony\Component\DependencyInjection\Attribute\When;
use Symfony\Component\DependencyInjection\Tests\Fixtures\AcmeConfig;

return #[When(env: 'prod')] function (AcmeConfig $config) {
    $config->color('blue');
};
```

Without this patch, such a config file cannot be used if AcmeBundle is not loaded in the current $env.

This is a follow up of https://symfony.com/blog/new-in-symfony-5-3-configure-multiple-environments-in-a-single-file#comment-24521 by @a-menshchikov