### PR TITLE
[CI][Psalm] Install stable/released PHPUnit

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           echo "::group::modify composer.json"
           composer remove --no-update --no-interaction symfony/phpunit-bridge
-          composer require --no-update psalm/phar phpunit/phpunit:@stable php-http/discovery psr/event-dispatcher
+          composer require --no-update psalm/phar phpunit/phpunit:^9.5 php-http/discovery psr/event-dispatcher
           echo "::endgroup::"
           echo "::group::composer update"
           composer update --no-progress --ansi


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

PHPUnit 10 is soon released. We dont need to install it before it is actually released. 

Currently, PHPUnit is updating dependencies and we get psalm failing with things like: 

<img width="918" alt="Screenshot 2021-05-12 at 08 28 29" src="https://user-images.githubusercontent.com/1275206/117930440-468cc500-b2fe-11eb-8028-579478c001cf.png">
<img width="972" alt="Screenshot 2021-05-12 at 08 33 54" src="https://user-images.githubusercontent.com/1275206/117930443-47bdf200-b2fe-11eb-8cb7-79255532e899.png">

