### PR TITLE
[FrameworkBundle] improve AbstractController::renderForm()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,11 +7,11 @@ CHANGELOG
  * Deprecate the `session.storage` alias and `session.storage.*` services, use the `session.storage.factory` alias and `session.storage.factory.*` services instead
  * Deprecate the `framework.session.storage_id` configuration option, use the `framework.session.storage_factory_id` configuration option instead
  * Deprecate the `session` service and the `SessionInterface` alias, use the `Request::getSession()` or the new `RequestStack::getSession()` methods instead
- * Added `AbstractController::renderForm()` to render a form and set the appropriate HTTP status code
- * Added support for configuring PHP error level to log levels
- * Added the `dispatcher` option to `debug:event-dispatcher`
- * Added the `event_dispatcher.dispatcher` tag
- * Added `assertResponseFormatSame()` in `BrowserKitAssertionsTrait`
+ * Add `AbstractController::renderForm()` to render a form and set the appropriate HTTP status code
+ * Add support for configuring PHP error level to log levels
+ * Add the `dispatcher` option to `debug:event-dispatcher`
+ * Add the `event_dispatcher.dispatcher` tag
+ * Add `assertResponseFormatSame()` in `BrowserKitAssertionsTrait`
  * Add support for configuring UUID factory services
  * Add tag `assets.package` to register asset packages
  * Add support to use a PSR-6 compatible cache for Doctrine annotations

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -420,7 +420,7 @@ class AbstractControllerTest extends TestCase
         $form->expects($this->once())->method('createView')->willReturn($formView);
 
         $twig = $this->getMockBuilder(Environment::class)->disableOriginalConstructor()->getMock();
-        $twig->expects($this->once())->method('render')->with('foo', ['form' => $formView, 'bar' => 'bar'])->willReturn('bar');
+        $twig->expects($this->once())->method('render')->with('foo', ['bar' => $formView])->willReturn('bar');
 
         $container = new Container();
         $container->set('twig', $twig);
@@ -428,7 +428,7 @@ class AbstractControllerTest extends TestCase
         $controller = $this->createController();
         $controller->setContainer($container);
 
-        $response = $controller->renderForm('foo', $form, ['bar' => 'bar']);
+        $response = $controller->renderForm('foo', ['bar' => $form]);
 
         $this->assertTrue($response->isSuccessful());
         $this->assertSame('bar', $response->getContent());
@@ -444,7 +444,7 @@ class AbstractControllerTest extends TestCase
         $form->expects($this->once())->method('isValid')->willReturn(false);
 
         $twig = $this->getMockBuilder(Environment::class)->disableOriginalConstructor()->getMock();
-        $twig->expects($this->once())->method('render')->with('foo', ['myForm' => $formView, 'bar' => 'bar'])->willReturn('bar');
+        $twig->expects($this->once())->method('render')->with('foo', ['bar' => $formView])->willReturn('bar');
 
         $container = new Container();
         $container->set('twig', $twig);
@@ -452,7 +452,7 @@ class AbstractControllerTest extends TestCase
         $controller = $this->createController();
         $controller->setContainer($container);
 
-        $response = $controller->renderForm('foo', $form, ['bar' => 'bar'], null, 'myForm');
+        $response = $controller->renderForm('foo', ['bar' => $form]);
 
         $this->assertSame(422, $response->getStatusCode());
         $this->assertSame('bar', $response->getContent());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Even better than #41178, this requires a simple change on apps, and is compatible with multiple forms.

Usage:
```diff
-        return $this->render('thing/new.html.twig', [
+        return $this->renderForm('thing/new.html.twig', [
             'thing' => $thing,
-            'form' => $form->createView(),
+            'form' => $form,
         ]);
```

In 5.4, we could even deprecate passing a FormView to render() so that we can always set the 422.