### PR TITLE
[FrameworkBundle] Deprecate the `AdapterInterface` autowiring alias, use `CacheItemPoolInterface` instead

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -1,0 +1,7 @@
+UPGRADE FROM 5.3 to 5.4
+=======================
+
+FrameworkBundle
+---------------
+
+ * Deprecate the `AdapterInterface` autowiring alias, use `CacheItemPoolInterface` instead

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -89,6 +89,7 @@ FrameworkBundle
  * Registered workflow services are now private
  * Remove option `--xliff-version` of the `translation:update` command, use e.g. `--output-format=xlf20` instead
  * Remove option `--output-format` of the `translation:update` command, use e.g. `--output-format=xlf20` instead
+ * Remove the `AdapterInterface` autowiring alias, use `CacheItemPoolInterface` instead
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add autowiring alias for `HttpCache\StoreInterface`
+ * Deprecate the `AdapterInterface` autowiring alias, use `CacheItemPoolInterface` instead
 
 5.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
@@ -238,6 +238,7 @@ return static function (ContainerConfigurator $container) {
         ->alias(CacheItemPoolInterface::class, 'cache.app')
 
         ->alias(AdapterInterface::class, 'cache.app')
+            ->deprecate('symfony/framework-bundle', '5.4', 'The "%alias_id%" alias is deprecated, use "%s" instead.', CacheItemPoolInterface::class)
 
         ->alias(CacheInterface::class, 'cache.app')
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

This alias is mostly noise, ppl should use the interfaces from abstract packages.