### PR TITLE
[Messenger] Add `AsMessageHandler` attribute to declare message handlers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -95,6 +95,7 @@ use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridTransportFactory;
 use Symfony\Component\Mailer\Bridge\Sendinblue\Transport\SendinblueTransportFactory;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mercure\HubRegistry;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Bridge\AmazonSqs\Transport\AmazonSqsTransportFactory;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpTransportFactory;
 use Symfony\Component\Messenger\Bridge\Beanstalkd\Transport\BeanstalkdTransportFactory;
@@ -554,6 +555,9 @@ class FrameworkExtension extends Extension
         });
         $container->registerAttributeForAutoconfiguration(AsController::class, static function (ChildDefinition $definition, AsController $attribute): void {
             $definition->addTag('controller.service_arguments');
+        });
+        $container->registerAttributeForAutoconfiguration(AsMessageHandler::class, static function (ChildDefinition $definition, AsMessageHandler $attribute): void {
+            $definition->addTag('messenger.message_handler');
         });
 
         if (!$container->getParameter('kernel.debug')) {

--- a/src/Symfony/Component/Messenger/Attribute/AsMessageHandler.php
+++ b/src/Symfony/Component/Messenger/Attribute/AsMessageHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Attribute;
+
+/**
+ * Service tag to autoconfigure message handlers.
+ *
+ * @author Maxim Dovydenok <dovydenok.maxim@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AsMessageHandler
+{
+}

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -1,10 +1,14 @@
 CHANGELOG
 =========
 
-5.3
+5.4
 ---
 
  * Add `AsMessageHandler` attribute for declaring message handlers on PHP 8.
+
+5.3
+---
+
  * Add the `RouterContextMiddleware` to restore the original router context when handling a message
  * `InMemoryTransport` can perform message serialization through dsn `in-memory://?serialize=true`.
  * Added `queues` option to `Worker` to only fetch messages from a specific queue from a receiver implementing `QueueReceiverInterface`.

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.3
 ---
 
+ * Add `AsMessageHandler` attribute for declaring message handlers on PHP 8.
  * Add the `RouterContextMiddleware` to restore the original router context when handling a message
  * `InMemoryTransport` can perform message serialization through dsn `in-memory://?serialize=true`.
  * Added `queues` option to `Worker` to only fetch messages from a specific queue from a receiver implementing `QueueReceiverInterface`.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #41106
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Added `AsMessageHandler` attribute to autoconfigure message handler