### PR TITLE
[FrameworkBundle] Add autowiring alias for `HttpCache\StoreInterface`

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Add autowiring alias for `HttpCache\StoreInterface`
+
 5.3
 ---
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.php
@@ -34,6 +34,7 @@ use Symfony\Component\HttpKernel\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\ServicesResetter;
 use Symfony\Component\HttpKernel\EventListener\LocaleAwareListener;
 use Symfony\Component\HttpKernel\HttpCache\Store;
+use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -104,6 +105,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 param('kernel.cache_dir').'/http_cache',
             ])
+        ->alias(StoreInterface::class, 'http_cache.store')
 
         ->set('url_helper', UrlHelper::class)
             ->args([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Will be useful for eg [the-fast-track](https://symfony.com/doc/current/the-fast-track/en/21-cache.html#purging-the-http-cache-for-testing) book.