### PR TITLE
[TwigBridge] Add `encore_entry_*_tags()` to UndefinedCallableHandler, as no-op

### DIFF
--- a/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
+++ b/src/Symfony/Bridge/Twig/UndefinedCallableHandler.php
@@ -13,6 +13,8 @@ namespace Symfony\Bridge\Twig;
 
 use Symfony\Bundle\FullStack;
 use Twig\Error\SyntaxError;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 /**
  * @internal
@@ -30,6 +32,8 @@ class UndefinedCallableHandler
         'asset' => 'asset',
         'asset_version' => 'asset',
         'dump' => 'debug-bundle',
+        'encore_entry_link_tags' => 'webpack-encore-bundle',
+        'encore_entry_script_tags' => 'webpack-encore-bundle',
         'expression' => 'expression-language',
         'form_widget' => 'form',
         'form_errors' => 'form',
@@ -64,34 +68,40 @@ class UndefinedCallableHandler
         'workflow' => 'enable "framework.workflows"',
     ];
 
-    public static function onUndefinedFilter(string $name): bool
+    /**
+     * @return TwigFilter|false
+     */
+    public static function onUndefinedFilter(string $name)
     {
         if (!isset(self::FILTER_COMPONENTS[$name])) {
             return false;
         }
 
-        self::onUndefined($name, 'filter', self::FILTER_COMPONENTS[$name]);
-
-        return true;
+        throw new SyntaxError(self::onUndefined($name, 'filter', self::FILTER_COMPONENTS[$name]));
     }
 
-    public static function onUndefinedFunction(string $name): bool
+    /**
+     * @return TwigFunction|false
+     */
+    public static function onUndefinedFunction(string $name)
     {
         if (!isset(self::FUNCTION_COMPONENTS[$name])) {
             return false;
         }
 
-        self::onUndefined($name, 'function', self::FUNCTION_COMPONENTS[$name]);
-
-        return true;
-    }
-
-    private static function onUndefined(string $name, string $type, string $component)
-    {
-        if (class_exists(FullStack::class) && isset(self::FULL_STACK_ENABLE[$component])) {
-            throw new SyntaxError(sprintf('Did you forget to %s? Unknown %s "%s".', self::FULL_STACK_ENABLE[$component], $type, $name));
+        if ('webpack-encore-bundle' === self::FUNCTION_COMPONENTS[$name]) {
+            return new TwigFunction($name, static function () { return ''; });
         }
 
-        throw new SyntaxError(sprintf('Did you forget to run "composer require symfony/%s"? Unknown %s "%s".', $component, $type, $name));
+        throw new SyntaxError(self::onUndefined($name, 'function', self::FUNCTION_COMPONENTS[$name]));
+    }
+
+    private static function onUndefined(string $name, string $type, string $component): string
+    {
+        if (class_exists(FullStack::class) && isset(self::FULL_STACK_ENABLE[$component])) {
+            return sprintf('Did you forget to %s? Unknown %s "%s".', self::FULL_STACK_ENABLE[$component], $type, $name);
+        }
+
+        return sprintf('Did you forget to run "composer require symfony/%s"? Unknown %s "%s".', $component, $type, $name);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Turning them into no-ops to allow uncommenting them in [the default base.html.twig](https://github.com/symfony/recipes/blob/ce8ee13f217ad077807c2b9b7f9947ee94230ab4/symfony/twig-bundle/3.3/templates/base.html.twig)

See https://github.com/symfony/recipes/pull/948

/cc @weaverryan 