### PR TITLE
[Mailer] Fix SES API call with UTF-8 Addresses

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -65,6 +65,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
 
             $this->assertSame('Hello!', $content['Content']['Simple']['Subject']['Data']);
             $this->assertSame('"Saif Eddin" <saif.gmati@symfony.com>', $content['Destination']['ToAddresses'][0]);
+            $this->assertSame('=?UTF-8?B?SsOpcsOpbXk=?= <jeremy@derusse.com>', $content['Destination']['CcAddresses'][0]);
             $this->assertSame('"Fabien" <fabpot@symfony.com>', $content['FromEmailAddress']);
             $this->assertSame('Hello There!', $content['Content']['Simple']['Body']['Text']['Data']);
             $this->assertSame('<b>Hello There!</b>', $content['Content']['Simple']['Body']['Html']['Data']);
@@ -84,6 +85,7 @@ class SesApiAsyncAwsTransportTest extends TestCase
         $mail = new Email();
         $mail->subject('Hello!')
             ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->cc(new Address('jeremy@derusse.com', 'Jérémy'))
             ->from(new Address('fabpot@symfony.com', 'Fabien'))
             ->text('Hello There!')
             ->html('<b>Hello There!</b>')

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiTransportTest.php
@@ -66,6 +66,7 @@ class SesApiTransportTest extends TestCase
 
             $this->assertSame('Hello!', $content['Message_Subject_Data']);
             $this->assertSame('"Saif Eddin" <saif.gmati@symfony.com>', $content['Destination_ToAddresses_member'][0]);
+            $this->assertSame('=?UTF-8?B?SsOpcsOpbXk=?= <jeremy@derusse.com>', $content['Destination_CcAddresses_member'][0]);
             $this->assertSame('"Fabien" <fabpot@symfony.com>', $content['Source']);
             $this->assertSame('Hello There!', $content['Message_Body_Text_Data']);
             $this->assertSame('aws-configuration-set-name', $content['ConfigurationSetName']);
@@ -86,6 +87,7 @@ class SesApiTransportTest extends TestCase
         $mail = new Email();
         $mail->subject('Hello!')
             ->to(new Address('saif.gmati@symfony.com', 'Saif Eddin'))
+            ->cc(new Address('jeremy@derusse.com', 'Jérémy'))
             ->from(new Address('fabpot@symfony.com', 'Fabien'))
             ->text('Hello There!');
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiAsyncAwsTransport.php
@@ -107,4 +107,19 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
             return !\in_array($address, $emailRecipients, true);
         });
     }
+
+    protected function stringifyAddresses(array $addresses): array
+    {
+        return array_map(function (Address $a) {
+            // AWS does not support UTF-8 address
+            if (preg_match('~[\x00-\x08\x10-\x19\x7F-\xFF\r\n]~', $name = $a->getName())) {
+                return sprintf('=?UTF-8?B?%s?= <%s>',
+                    base64_encode($name),
+                    $a->getEncodedAddress()
+                );
+            }
+
+            return $a->toString();
+        }, $addresses);
+    }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesApiTransport.php
@@ -16,6 +16,7 @@ use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
+use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -129,5 +130,20 @@ class SesApiTransport extends AbstractApiTransport
         }
 
         return $payload;
+    }
+
+    protected function stringifyAddresses(array $addresses): array
+    {
+        return array_map(function (Address $a) {
+            // AWS does not support UTF-8 address
+            if (preg_match('~[\x00-\x08\x10-\x19\x7F-\xFF\r\n]~', $name = $a->getName())) {
+                return sprintf('=?UTF-8?B?%s?= <%s>',
+                    base64_encode($name),
+                    $a->getEncodedAddress()
+                );
+            }
+
+            return $a->toString();
+        }, $addresses);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


The address (including email and name) used in Amazon SES API (`ses+api://`) must not contain unicode chars  (https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_Destination.html)

This PR encodes name with base64 as suggested by issues in Official AWS SDKs (https://github.com/aws/aws-sdk-php/issues/1196, https://github.com/aws/aws-sdk-js/issues/1585)

note: I did not use the Base64Encoder, because the address could not be chunked (API Call failed) and it looks like addresses wider than 64 chars are allowed.