### PR TITLE
[DependencyInjection] Inherit "public" option when creating aliases with the auto_alias tag

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -18,6 +18,8 @@ CHANGELOG
  * Add support for `ConfigBuilder` in the `PhpFileLoader`
  * Add `ContainerConfigurator::env()` to get the current environment
  * Add `#[Target]` to tell how a dependency is used and hint named autowiring aliases
+ * Add inheriting of the `public` option when creating aliases with the `auto_alias` tag
+ * Deprecate aliases created with the `auto_alias` tag being `public` by default
 
 5.2.0
 -----

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutoAliasServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutoAliasServicePass.php
@@ -33,7 +33,14 @@ class AutoAliasServicePass implements CompilerPassInterface
 
                 $aliasId = $container->getParameterBag()->resolveValue($tag['format']);
                 if ($container->hasDefinition($aliasId) || $container->hasAlias($aliasId)) {
-                    $container->setAlias($serviceId, new Alias($aliasId, true));
+                    $definition = $container->getDefinition($serviceId);
+
+                    $public = ($definition->getChanges()['public'] ?? false) ? $definition->isPublic() : null;
+                    if (null === $public) {
+                        trigger_deprecation('symfony/dependency-injection', '5.4', 'Aliases created with the "auto_alias" tag will be private by default in the future, you can set them to public by using the "public" option.');
+                    }
+
+                    $container->setAlias($serviceId, new Alias($aliasId, $public ?? true));
                 }
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutoAliasServicePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutoAliasServicePassTest.php
@@ -63,6 +63,7 @@ class AutoAliasServicePassTest extends TestCase
         $container = new ContainerBuilder();
 
         $container->register('example', 'Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassDefault')
+            ->setPublic(false)
             ->addTag('auto_alias', ['format' => '%existing%.example']);
 
         $container->register('mysql.example', 'Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassMysql');
@@ -74,6 +75,31 @@ class AutoAliasServicePassTest extends TestCase
         $this->assertTrue($container->hasAlias('example'));
         $this->assertEquals('mysql.example', $container->getAlias('example'));
         $this->assertSame('Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassMysql', $container->getDefinition('mysql.example')->getClass());
+    }
+
+    public function testProcessWithPublicAttribute()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('example-private', 'Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassDefault')
+            ->setPublic(false)
+            ->addTag('auto_alias', ['format' => '%existing%.example']);
+
+        $container->register('example-public', 'Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassDefault')
+            ->setPublic(true)
+            ->addTag('auto_alias', ['format' => '%existing%.example']);
+
+        $container->register('mysql.example', 'Symfony\Component\DependencyInjection\Tests\Compiler\ServiceClassMysql');
+        $container->setParameter('existing', 'mysql');
+
+        $pass = new AutoAliasServicePass();
+        $pass->process($container);
+
+        $this->assertTrue($container->hasAlias('example-private'));
+        $this->assertFalse($container->getAlias('example-private')->isPublic());
+
+        $this->assertTrue($container->hasAlias('example-public'));
+        $this->assertTrue($container->getAlias('example-public')->isPublic());
     }
 
     public function testProcessWithManualAlias()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TODO

Currently when using the `auto_alias` tag, the aliases created are always `public`. With this PR the public option is inherited from the definition:

```yaml
App\Service\SomeInterface:
    public: true # The alias inherits the public option
    tags:
        - { name: auto_alias, format: '%my_class%' }
```
