### PR TITLE
[Notifier] Add missing charset to content-type for Slack notifier

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
@@ -80,6 +80,9 @@ final class SlackTransport extends AbstractTransport
         $response = $this->client->request('POST', 'https://'.$this->getEndpoint().'/api/chat.postMessage', [
             'json' => array_filter($options),
             'auth_bearer' => $this->accessToken,
+            'headers' => [
+                'Content-Type' => 'application/json; charset=utf-8',
+            ],
         ]);
 
         if (200 !== $response->getStatusCode()) {

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackTransportTest.php
@@ -207,4 +207,27 @@ final class SlackTransportTest extends TransportTestCase
 
         $transport->send(new ChatMessage('testMessage'));
     }
+
+    public function testSendIncludesContentTypeWithCharset()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+
+        $response->expects($this->exactly(2))
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $response->expects($this->once())
+            ->method('getContent')
+            ->willReturn(json_encode(['ok' => true, 'ts' => '1503435956.000247']));
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response): ResponseInterface {
+            $this->assertContains('Content-Type: application/json; charset=utf-8', $options['headers']);
+
+            return $response;
+        });
+
+        $transport = $this->createTransport($client);
+
+        $transport->send(new ChatMessage('testMessage'));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Symfony HttpClient doesn't set charset for the Content-Type header when used with `json` request option so with each response slack includes:
```
"response_metadata" => array:1 [
  "warnings" => array:1 [
    0 => "missing_charset"
  ]
]
```