### PR TITLE
[Console] fix registering command aliases when using the new "cmd|alias" syntax for names

### DIFF
--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -94,6 +94,10 @@ class AddConsoleCommandPass implements CompilerPassInterface
             $lazyCommandMap[$commandName] = $id;
             $lazyCommandRefs[$id] = new TypedReference($id, $class);
 
+            foreach ($aliases as $alias) {
+                $lazyCommandMap[$alias] = $id;
+            }
+
             foreach ($tags as $tag) {
                 if (isset($tag['command'])) {
                     $aliases[] = $tag['command'];

--- a/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
+++ b/src/Symfony/Component/Console/Tests/DependencyInjection/AddConsoleCommandPassTest.php
@@ -135,7 +135,7 @@ class AddConsoleCommandPassTest extends TestCase
         $commandLocator = $container->getDefinition((string) $commandLoader->getArgument(0));
 
         $this->assertSame(ContainerCommandLoader::class, $commandLoader->getClass());
-        $this->assertSame(['cmdname' => 'with-defaults'], $commandLoader->getArgument(1));
+        $this->assertSame(['cmdname' => 'with-defaults', 'cmdalias' => 'with-defaults'], $commandLoader->getArgument(1));
         $this->assertEquals([['with-defaults' => new ServiceClosureArgument(new Reference('.with-defaults.lazy'))]], $commandLocator->getArguments());
         $this->assertSame([], $container->getParameter('console.command.ids'));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41212
| License       | MIT
| Doc PR        | -
