### PR TITLE
[HttpClient] fix adding query string to relative URLs with scoped clients

### DIFF
--- a/src/Symfony/Component/HttpClient/ScopingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/ScopingHttpClient.php
@@ -71,11 +71,12 @@ class ScopingHttpClient implements HttpClientInterface, ResetInterface
                 throw $e;
             }
 
-            $options = self::mergeDefaultOptions($options, $this->defaultOptionsByRegexp[$this->defaultRegexp], true);
+            $defaultOptions = $this->defaultOptionsByRegexp[$this->defaultRegexp];
+            $options = self::mergeDefaultOptions($options, $defaultOptions, true);
             if (\is_string($options['base_uri'] ?? null)) {
                 $options['base_uri'] = self::parseUrl($options['base_uri']);
             }
-            $url = implode('', self::resolveUrl($url, $options['base_uri'] ?? null));
+            $url = implode('', self::resolveUrl($url, $options['base_uri'] ?? null, $defaultOptions['query'] ?? []));
         }
 
         foreach ($this->defaultOptionsByRegexp as $regexp => $defaultOptions) {

--- a/src/Symfony/Component/HttpClient/Tests/ScopingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/ScopingHttpClientTest.php
@@ -30,9 +30,9 @@ class ScopingHttpClientTest extends TestCase
     public function testRelativeUrlWithDefaultRegexp()
     {
         $mockClient = new MockHttpClient();
-        $client = new ScopingHttpClient($mockClient, ['.*' => ['base_uri' => 'http://example.com']], '.*');
+        $client = new ScopingHttpClient($mockClient, ['.*' => ['base_uri' => 'http://example.com', 'query' => ['a' => 'b']]], '.*');
 
-        $this->assertSame('http://example.com/foo', $client->request('GET', '/foo')->getInfo('url'));
+        $this->assertSame('http://example.com/foo?f=g&a=b', $client->request('GET', '/foo?f=g')->getInfo('url'));
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41220
| License       | MIT
| Doc PR        | -