### PR TITLE
Introduce SYMFONY_FEATURE_BRANCH variable in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ before_install:
       export COMPOSER_UP='composer update --no-progress --ansi'
       export COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -printf '%h\n' | sort)
       export SYMFONY_DEPRECATIONS_HELPER=max[indirect]=170
+      export SYMFONY_FEATURE_BRANCH=$(curl -s https://flex.symfony.com/versions.json | jq -r '."dev-name"')
 
       nanoseconds () {
           local cmd="date"
@@ -201,7 +202,7 @@ install:
 
     - |
       # For the feature-branch, when deps=high, the version before it is checked out and tested with the locally patched components
-      if [[ $deps = high && $TRAVIS_BRANCH = *.x ]]; then
+      if [[ $deps = high && $TRAVIS_BRANCH = $SYMFONY_FEATURE_BRANCH ]]; then
           export FLIP='^'
           export SYMFONY_VERSION=$(echo "$SYMFONY_VERSIONS" | grep -o '/[1-9]\.[0-9].*' | tail -n 1 | sed s/.//) &&
           git fetch --depth=2 origin $SYMFONY_VERSION &&
@@ -211,7 +212,7 @@ install:
 
     - |
       # Skip the phpunit-bridge on bugfix-branches when $deps is empty
-      if [[ ! $deps && ! $TRAVIS_BRANCH = *.x ]]; then
+      if [[ ! $deps && ! $TRAVIS_BRANCH = $SYMFONY_FEATURE_BRANCH ]]; then
           export COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -printf '%h\n' | sort)
       fi
 
@@ -263,7 +264,7 @@ install:
               (cd src/Symfony/Component/HttpFoundation; mv composer.bak composer.json)
               COMPONENTS=$(git diff --name-only src/ | grep composer.json || true)
 
-              if [[ $COMPONENTS && $LEGACY && ! $TRAVIS_BRANCH = *.x && $TRAVIS_PULL_REQUEST != false && $(echo "$SYMFONY_VERSIONS" | cut -f2 | grep -FA1 /$SYMFONY_VERSION | tail -n 1) = *.x ]]; then
+              if [[ $COMPONENTS && $LEGACY && ! $TRAVIS_BRANCH = $SYMFONY_FEATURE_BRANCH && $TRAVIS_PULL_REQUEST != false && $(echo "$SYMFONY_VERSIONS" | cut -f2 | grep -FA1 /$SYMFONY_VERSION | tail -n 1) = $SYMFONY_FEATURE_BRANCH ]]; then
                   export FLIP='^'
                   SYMFONY_VERSION=$(echo $SYMFONY_VERSION | awk '{print $1 - 1}')
                   echo -e "\\n\\e[33;1mChecking out Symfony $SYMFONY_VERSION and running tests with patched components as deps\\e[0m"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | #40887
| License       | MIT
| Doc PR        | not needed

This PR proposes to introduce a `SYMFONY_FEATURE_BRANCH` variable that always points to the branch of Symfony's next feature release. This is a setting that we need to adjust twice a year. This way, the branch does not have to follow the `.x` suffix convention anymore.

~~I'm currently testing my changes against the 5.x branch. As soon as the PR is ready, I will target 4.4.~~

Update: `SYMFONY_FEATURE_BRANCH` is now populated via an API request.