### PR TITLE
[FrameworkBundle][Validator] Fix deprecations from Doctrine Annotations+Cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -119,7 +119,7 @@
         "cache/integration-tests": "dev-master",
         "composer/package-versions-deprecated": "^1.8",
         "doctrine/annotations": "^1.10.4",
-        "doctrine/cache": "~1.6",
+        "doctrine/cache": "^1.6|^2.0",
         "doctrine/collections": "~1.0",
         "doctrine/data-fixtures": "^1.1",
         "doctrine/dbal": "^2.6|^3.0",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -40,7 +40,6 @@
         "symfony/var-dumper": "^3.4|^4.0|^5.0",
         "symfony/translation": "^3.4|^4.0|^5.0",
         "doctrine/annotations": "^1.10.4",
-        "doctrine/cache": "~1.6",
         "doctrine/collections": "~1.0",
         "doctrine/data-fixtures": "^1.1",
         "doctrine/dbal": "^2.6|^3.0",

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
 
 use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\CachedReader;
+use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -61,7 +62,10 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
         }
 
         $annotatedClasses = include $annotatedClassPatterns;
-        $reader = new CachedReader($this->annotationReader, new DoctrineProvider($arrayAdapter), $this->debug);
+        $reader = class_exists(PsrCachedReader::class)
+            ? new PsrCachedReader($this->annotationReader, $arrayAdapter, $this->debug)
+            : new CachedReader($this->annotationReader, new DoctrineProvider($arrayAdapter), $this->debug)
+        ;
 
         foreach ($annotatedClasses as $class) {
             if (null !== $this->excludeRegexp && preg_match($this->excludeRegexp, $class)) {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -50,14 +50,15 @@
             <argument>%kernel.debug%</argument>
         </service>
 
+        <service id="annotations.cache_adapter" class="Symfony\Component\Cache\Adapter\PhpArrayAdapter">
+            <factory class="Symfony\Component\Cache\Adapter\PhpArrayAdapter" method="create" />
+            <argument>%kernel.cache_dir%/annotations.php</argument>
+            <argument type="service" id="cache.annotations" />
+            <tag name="container.hot_path" />
+        </service>
+
         <service id="annotations.cache" class="Symfony\Component\Cache\DoctrineProvider">
-            <argument type="service">
-                <service class="Symfony\Component\Cache\Adapter\PhpArrayAdapter">
-                    <factory class="Symfony\Component\Cache\Adapter\PhpArrayAdapter" method="create" />
-                    <argument>%kernel.cache_dir%/annotations.php</argument>
-                    <argument type="service" id="cache.annotations" />
-                </service>
-            </argument>
+            <argument type="service" id="annotations.cache_adapter" />
             <tag name="container.hot_path" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection;
 
 use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Common\Annotations\PsrCachedReader;
 use Psr\Log\LoggerAwareInterface;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddAnnotationsCachedReaderPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension;
@@ -999,7 +1000,11 @@ abstract class FrameworkExtensionTest extends TestCase
         $container->compile();
 
         $this->assertEquals($container->getParameter('kernel.cache_dir').'/annotations', $container->getDefinition('annotations.filesystem_cache_adapter')->getArgument(2));
-        $this->assertSame('annotations.filesystem_cache', (string) $container->getDefinition('annotation_reader')->getArgument(1));
+        if (class_exists(PsrCachedReader::class)) {
+            $this->assertSame('annotations.filesystem_cache_adapter', (string) $container->getDefinition('annotation_reader')->getArgument(1));
+        } else {
+            $this->assertSame('annotations.filesystem_cache', (string) $container->getDefinition('annotation_reader')->getArgument(1));
+        }
     }
 
     public function testFileLinkFormat()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\CachedReader;
+use Doctrine\Common\Annotations\PsrCachedReader;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface as FrameworkBundleEngineInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -35,7 +36,11 @@ class AutowiringTypesTest extends AbstractWebTestCase
         static::bootKernel();
 
         $annotationReader = static::$container->get('test.autowiring_types.autowired_services')->getAnnotationReader();
-        $this->assertInstanceOf(CachedReader::class, $annotationReader);
+        if (class_exists(PsrCachedReader::class)) {
+            $this->assertInstanceOf(PsrCachedReader::class, $annotationReader);
+        } else {
+            $this->assertInstanceOf(CachedReader::class, $annotationReader);
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.1.3",
         "ext-xml": "*",
         "symfony/cache": "^4.4|^5.0",
-        "symfony/config": "^4.3.4|^5.0",
+        "symfony/config": "^4.4.11|~5.0.11|^5.1.3",
         "symfony/dependency-injection": "^4.4.1|^5.0.1",
         "symfony/error-handler": "^4.4.1|^5.0.1",
         "symfony/http-foundation": "^4.4|^5.0",
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.10.4",
-        "doctrine/cache": "~1.0",
+        "doctrine/cache": "^1.0|^2.0",
         "doctrine/persistence": "^1.3|^2.0",
         "paragonie/sodium_compat": "^1.8",
         "symfony/asset": "^3.4|^4.0|^5.0",

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -37,7 +37,7 @@
         "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/web-link": "^3.4|^4.0|^5.0",
         "doctrine/annotations": "^1.10.4",
-        "doctrine/cache": "~1.0"
+        "doctrine/cache": "^1.0|^2.0"
     },
     "conflict": {
         "symfony/dependency-injection": "<4.1",

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "cache/integration-tests": "dev-master",
-        "doctrine/cache": "^1.6",
+        "doctrine/cache": "^1.6|^2.0",
         "doctrine/dbal": "^2.6|^3.0",
         "predis/predis": "^1.1",
         "psr/simple-cache": "^1.0",

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -21,7 +21,6 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.10.4",
-        "doctrine/cache": "~1.0",
         "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
         "symfony/cache": "^3.4|^4.0|^5.0",
         "symfony/config": "^3.4|^4.0|^5.0",
@@ -49,8 +48,7 @@
         "symfony/config": "For using the XML mapping loader.",
         "symfony/property-access": "For using the ObjectNormalizer.",
         "symfony/http-foundation": "For using a MIME type guesser within the DataUriNormalizer.",
-        "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
-        "doctrine/cache": "For using the default cached annotation reader and metadata cache."
+        "doctrine/annotations": "For using the annotation mapping."
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Serializer\\": "" },

--- a/src/Symfony/Component/Validator/Tests/Mapping/Cache/DoctrineCacheTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Cache/DoctrineCacheTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Validator\Tests\Mapping\Cache;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Psr6\DoctrineProvider;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Validator\Mapping\Cache\DoctrineCache;
 
 /**
@@ -21,6 +23,9 @@ class DoctrineCacheTest extends AbstractCacheTest
 {
     protected function setUp(): void
     {
-        $this->cache = new DoctrineCache(new ArrayCache());
+        $this->cache = class_exists(DoctrineProvider::class)
+            ? new DoctrineCache(DoctrineProvider::wrap(new ArrayAdapter()))
+            : new DoctrineCache(new ArrayCache())
+        ;
     }
 }

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -36,7 +36,7 @@
         "symfony/property-info": "^3.4|^4.0|^5.0",
         "symfony/translation": "^4.2",
         "doctrine/annotations": "^1.10.4",
-        "doctrine/cache": "~1.0",
+        "doctrine/cache": "^1.0|^2.0",
         "egulias/email-validator": "^2.1.10|^3"
     },
     "conflict": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

* Doctrine Annotations' `CachedReader` is deprecated. Let's not use it if we don't have to.
* Doctrine Cache 2 has been released. Since we're mostly only using the interfaces, we can indicate compatibility.

Paslm is going to complain about missing classes, which is kind-of expected here. 🙂 