### PR TITLE
[DependencyInjection][ProxyManagerBridge] Don't call class_exists() on null

### DIFF
--- a/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/LazyLoadingValueHolderGenerator.php
+++ b/src/Symfony/Bridge/ProxyManager/LazyProxy/PhpDumper/LazyLoadingValueHolderGenerator.php
@@ -43,7 +43,7 @@ class LazyLoadingValueHolderGenerator extends BaseGenerator
     public function getProxifiedClass(Definition $definition): ?string
     {
         if (!$definition->hasTag('proxy')) {
-            return class_exists($class = $definition->getClass()) || interface_exists($class, false) ? $class : null;
+            return ($class = $definition->getClass()) && (class_exists($class) || interface_exists($class, false)) ? $class : null;
         }
         if (!$definition->isLazy()) {
             throw new \InvalidArgumentException(sprintf('Invalid definition for service of class "%s": setting the "proxy" tag on a service requires it to be "lazy".', $definition->getClass()));

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckTypeDeclarationsPass.php
@@ -88,8 +88,13 @@ final class CheckTypeDeclarationsPass extends AbstractRecursivePass
             return parent::processValue($value, $isRoot);
         }
 
-        if (!$this->autoload && !class_exists($class = $value->getClass(), false) && !interface_exists($class, false)) {
-            return parent::processValue($value, $isRoot);
+        if (!$this->autoload) {
+            if (!$class = $value->getClass()) {
+                return parent::processValue($value, $isRoot);
+            }
+            if (!class_exists($class, false) && !interface_exists($class, false)) {
+                return parent::processValue($value, $isRoot);
+            }
         }
 
         if (ServiceLocator::class === $value->getClass()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

PHP 8.1 complains if we pass `null` to `class_exists()` or `interface_exists()`:

> class_exists(): Passing null to parameter `#1` ($class) of type string is deprecated