### PR TITLE
[BrowserKit] Don't pass null to rawurlencode()

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -46,7 +46,7 @@ class Cookie
      * Sets a cookie.
      *
      * @param string      $name         The cookie name
-     * @param string      $value        The value of the cookie
+     * @param string|null $value        The value of the cookie
      * @param string|null $expires      The time the cookie expires
      * @param string|null $path         The path on the server in which the cookie will be available on
      * @param string      $domain       The domain that the cookie is available
@@ -62,7 +62,7 @@ class Cookie
             $this->rawValue = $value;
         } else {
             $this->value = $value;
-            $this->rawValue = rawurlencode($value);
+            $this->rawValue = rawurlencode($value ?? '');
         }
         $this->name = $name;
         $this->path = empty($path) ? '/' : $path;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

PHP 8.1 will trigger a deprecation:

> rawurlencode(): Passing null to parameter `#1` ($string) of type string is deprecated