### PR TITLE
Migrate configuration file for PHP CS Fixer 2.19/3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 vendor/
 composer.lock
 phpunit.xml
-.php_cs.cache
+.php-cs-fixer.cache
+.php-cs-fixer.php
 .phpunit.result.cache
 composer.phar
 package.tar

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,7 +4,7 @@ if (!file_exists(__DIR__.'/src')) {
     exit(0);
 }
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
         '@PHP71Migration' => true,
         '@PHPUnit75Migration:risky' => true,
@@ -14,7 +14,7 @@ return PhpCsFixer\Config::create()
     ])
     ->setRiskyAllowed(true)
     ->setFinder(
-        PhpCsFixer\Finder::create()
+        (new PhpCsFixer\Finder())
             ->in(__DIR__.'/src')
             ->append([__FILE__])
             ->notPath('#/Fixtures/#')
@@ -39,4 +39,5 @@ return PhpCsFixer\Config::create()
             ->notPath('Symfony/Component/Debug/Tests/DebugClassLoaderTest.php')
             ->notPath('Symfony/Component/ErrorHandler/Tests/DebugClassLoaderTest.php')
     )
+    ->setCacheFile('.php-cs-fixer.cache')
 ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR suggests to rename the PHP CS Fixer configuration file as expected by version 2.19 and 3.0. I don't know what version Fabbot is currently running, but as soon as it is updated to 2.19, we can merge this PR.