### PR TITLE
[Security] Keep Bulgarian wording consistent across all texts

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.bg.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.bg.xlf
@@ -72,11 +72,11 @@
             </trans-unit>
             <trans-unit id="19">
 				<source>Too many failed login attempts, please try again in %minutes% minute.</source>
-				<target>Прекалено много неуспешни опити за вход, моля опитайте отново след %minutes% минута.</target>
+				<target>Твърде много неуспешни опити за вход, моля опитайте отново след %minutes% минута.</target>
 			</trans-unit>
 			<trans-unit id="20">
 				<source>Too many failed login attempts, please try again in %minutes% minutes.</source>
-				<target>Прекалено много неуспешни опити за вход, моля опитайте отново след %minutes% минути.</target>
+				<target>Твърде много неуспешни опити за вход, моля опитайте отново след %minutes% минути.</target>
 			</trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Keep wording consistent across all texts in translations:

Trans unit id=17:
Too many === Твърде много
Trans unit id=19:
Too many === Прекалено много

I put word "Твърде", because it was used before. 
