### PR TITLE
[Security\Http] Fix handling `secure: auto` using the new RememberMeAuthenticator

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -104,6 +104,10 @@ class RememberMeFactory implements SecurityFactoryInterface, AuthenticatorFactor
             $loader->load('security_authenticator_remember_me.php');
         }
 
+        if ('auto' === $config['secure']) {
+            $config['secure'] = null;
+        }
+
         // create remember me handler (which manage the remember-me cookies)
         $rememberMeHandlerId = 'security.authenticator.remember_me_handler.'.$firewallName;
         if (isset($config['service']) && isset($config['token_provider'])) {

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/RememberMeCookieTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/RememberMeCookieTest.php
@@ -19,8 +19,23 @@ class RememberMeCookieTest extends AbstractWebTestCase
         ]);
 
         $cookies = $client->getResponse()->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
+        $this->assertSame($expectedSecureFlag, $cookies['']['/']['REMEMBERME']->isSecure());
+    }
 
-        $this->assertEquals($expectedSecureFlag, $cookies['']['/']['REMEMBERME']->isSecure());
+    /** @dataProvider getSessionRememberMeSecureCookieFlagAutoHttpsMap */
+    public function testOldSessionRememberMeSecureCookieFlagAuto($https, $expectedSecureFlag)
+    {
+        $client = $this->createClient(['test_case' => 'RememberMeCookie', 'root_config' => 'legacy_config.yml']);
+
+        $client->request('POST', '/login', [
+            '_username' => 'test',
+            '_password' => 'test',
+        ], [], [
+            'HTTPS' => (int) $https,
+        ]);
+
+        $cookies = $client->getResponse()->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
+        $this->assertSame($expectedSecureFlag, $cookies['']['/']['REMEMBERME']->isSecure());
     }
 
     public function getSessionRememberMeSecureCookieFlagAutoHttpsMap()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/legacy_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/RememberMeCookie/legacy_config.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/framework.yml }
 
 security:
-    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\InMemoryUser: plaintext
 
@@ -23,3 +22,4 @@ security:
                 secret: key
                 secure: auto
             logout: ~
+            anonymous: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The created cookie was always secure when using `auto` because of some missing config normalization that should have been copied from the legacy rememberme implementation. 
