### PR TITLE
[DoctrineBridge] Conflict with doctrine/orm v3

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -47,6 +47,7 @@
         "doctrine/orm": "^2.6.3"
     },
     "conflict": {
+        "doctrine/orm": ">=3",
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
         "symfony/dependency-injection": "<3.4",
         "symfony/form": "<4.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | o
| Tickets       | -
| License       | MIT
| Doc PR        | -

Right now, running `symfony new --full --version=next some-project`  fails hard with:
```
Script cache:clear returned with error code 255
!!  Symfony\Component\ErrorHandler\Error\UndefinedMethodError {#5628
!!    #message: """
!!      Attempted to call an undefined method named "setMetadataCache" of class "Doctrine\ORM\Configuration".\n
!!      Did you mean to call e.g. "getMetadataCacheImpl" or "setMetadataCacheImpl"?
!!      """
!!    #code: 0
!!    #file: "./var/cache/dev/ContainerMdSJEGR/App_KernelDevDebugContainer.php"
!!    #line: 706
!!    trace: {
!!      ./var/cache/dev/ContainerMdSJEGR/App_KernelDevDebugContainer.php:706 {
!!        ContainerMdSJEGR\App_KernelDevDebugContainer->getDoctrine_Orm_DefaultEntityManagerService($lazyLoad = true)
!!        › $a->setEntityNamespaces(['App' => 'App\\Entity']);
!!        › $a->setMetadataCache(($this->privates['cache.doctrine.orm.default.metadata'] ?? $this->getCache_Doctrine_Orm_Default_MetadataService()));
!!        › $a->setQueryCacheImpl(\Doctrine\Common\Cache\Psr6\DoctrineProvider::wrap(($this->privates['cache.doctrine.orm.default.query'] ?? $this->getCache_Doctrine_Orm_Default_QueryService())));
!!      }
```

Forcing `doctrine/orm: ^2.8` fixes it.
This PR adds a conflict rule to fix it as we are not ready for doctrine/orm v3. 