### PR TITLE
[WebProfilerBundle] Load toolbar "forever", allow users to cancel

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -41,9 +41,11 @@ if (typeof Sfjs === 'undefined') {
         var request = function(url, onSuccess, onError, payload, options, tries) {
             var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
             options = options || {};
-            options.maxTries = options.maxTries || 0;
+            options.retry = options.retry || false;
             tries = tries || 1;
-            var delay = Math.pow(2, tries - 1) * 1000;
+            /* this delays for 125, 375, 625, 875, and 1000, ... */
+            var delay = tries < 5 ? (tries - 0.5) * 250 : 1000;
+
             xhr.open(options.method || 'GET', url, true);
             xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
             xhr.onreadystatechange = function(state) {
@@ -51,9 +53,8 @@ if (typeof Sfjs === 'undefined') {
                     return null;
                 }
 
-                if (xhr.status == 404 && options.maxTries > 1) {
+                if (xhr.status == 404 && options.retry && !options.stop) {
                     setTimeout(function(){
-                        options.maxTries--;
                         request(url, onSuccess, onError, payload, options, tries + 1);
                     }, delay);
 
@@ -66,6 +67,11 @@ if (typeof Sfjs === 'undefined') {
                     (onError || noop)(xhr);
                 }
             };
+
+            if (options.onSend) {
+                options.onSend(tries);
+            }
+
             xhr.send(payload || '');
         };
 
@@ -421,8 +427,94 @@ if (typeof Sfjs === 'undefined') {
                 return this;
             },
 
+            showToolbar: function(token) {
+                var sfwdt = document.getElementById('sfwdt' + token);
+                removeClass(sfwdt, 'sf-display-none');
+
+                if (getPreference('toolbar/displayState') == 'none') {
+                    document.getElementById('sfToolbarMainContent-' + token).style.display = 'none';
+                    document.getElementById('sfToolbarClearer-' + token).style.display = 'none';
+                    document.getElementById('sfMiniToolbar-' + token).style.display = 'block';
+                } else {
+                    document.getElementById('sfToolbarMainContent-' + token).style.display = 'block';
+                    document.getElementById('sfToolbarClearer-' + token).style.display = 'block';
+                    document.getElementById('sfMiniToolbar-' + token).style.display = 'none';
+                }
+            },
+
+            hideToolbar: function(token) {
+                var sfwdt = document.getElementById('sfwdt' + token);
+                addClass(sfwdt, 'sf-display-none');
+            },
+
+            initToolbar: function(token) {
+                this.showToolbar(token);
+
+                var hideButton = document.getElementById('sfToolbarHideButton-' + token);
+                var hideButtonSvg = hideButton.querySelector('svg');
+                hideButtonSvg.setAttribute('aria-hidden', 'true');
+                hideButtonSvg.setAttribute('focusable', 'false');
+                addEventListener(hideButton, 'click', function (event) {
+                    event.preventDefault();
+
+                    var p = this.parentNode;
+                    p.style.display = 'none';
+                    (p.previousElementSibling || p.previousSibling).style.display = 'none';
+                    document.getElementById('sfMiniToolbar-' + token).style.display = 'block';
+                    setPreference('toolbar/displayState', 'none');
+                });
+
+                var showButton = document.getElementById('sfToolbarMiniToggler-' + token);
+                var showButtonSvg = showButton.querySelector('svg');
+                showButtonSvg.setAttribute('aria-hidden', 'true');
+                showButtonSvg.setAttribute('focusable', 'false');
+                addEventListener(showButton, 'click', function (event) {
+                    event.preventDefault();
+
+                    var elem = this.parentNode;
+                    if (elem.style.display == 'none') {
+                        document.getElementById('sfToolbarMainContent-' + token).style.display = 'none';
+                        document.getElementById('sfToolbarClearer-' + token).style.display = 'none';
+                        elem.style.display = 'block';
+                    } else {
+                        document.getElementById('sfToolbarMainContent-' + token).style.display = 'block';
+                        document.getElementById('sfToolbarClearer-' + token).style.display = 'block';
+                        elem.style.display = 'none'
+                    }
+
+                    setPreference('toolbar/displayState', 'block');
+                });
+            },
+
             loadToolbar: function(token, newToken) {
+                var that = this;
+                var triesCounter = document.getElementById('sfLoadCounter-' + token);
+
+                var options = {
+                    retry: true,
+                    onSend: function (count) {
+                        if (count > 5) {
+                            that.initToolbar(token);
+                        }
+
+                        if (triesCounter) {
+                            triesCounter.innerHTML = count;
+                        }
+                    },
+                };
+
+                var cancelButton = document.getElementById('sfLoadCancel-' + token);
+                if (cancelButton) {
+                    addEventListener(cancelButton, 'click', function (event) {
+                        event.preventDefault();
+
+                        options.stop = true;
+                        that.hideToolbar(token);
+                    });
+                }
+
                 newToken = (newToken || token);
+
                 this.load(
                     'sfwdt' + token,
                     '{{ url("_wdt", { "token": "xxxxxx" })|escape('js') }}'.replace(/xxxxxx/, newToken),
@@ -444,15 +536,7 @@ if (typeof Sfjs === 'undefined') {
                             return;
                         }
 
-                        if (getPreference('toolbar/displayState') == 'none') {
-                            document.getElementById('sfToolbarMainContent-' + newToken).style.display = 'none';
-                            document.getElementById('sfToolbarClearer-' + newToken).style.display = 'none';
-                            document.getElementById('sfMiniToolbar-' + newToken).style.display = 'block';
-                        } else {
-                            document.getElementById('sfToolbarMainContent-' + newToken).style.display = 'block';
-                            document.getElementById('sfToolbarClearer-' + newToken).style.display = 'block';
-                            document.getElementById('sfMiniToolbar-' + newToken).style.display = 'none';
-                        }
+                        that.initToolbar(newToken);
 
                         /* Handle toolbar-info position */
                         var toolbarBlocks = [].slice.call(el.querySelectorAll('.sf-toolbar-block'));
@@ -480,39 +564,7 @@ if (typeof Sfjs === 'undefined') {
                                 }
                             };
                         }
-                        var hideButton = document.getElementById('sfToolbarHideButton-' + newToken);
-                        var hideButtonSvg = hideButton.querySelector('svg');
-                        hideButtonSvg.setAttribute('aria-hidden', 'true');
-                        hideButtonSvg.setAttribute('focusable', 'false');
-                        addEventListener(hideButton, 'click', function (event) {
-                            event.preventDefault();
 
-                            var p = this.parentNode;
-                            p.style.display = 'none';
-                            (p.previousElementSibling || p.previousSibling).style.display = 'none';
-                            document.getElementById('sfMiniToolbar-' + newToken).style.display = 'block';
-                            setPreference('toolbar/displayState', 'none');
-                        });
-                        var showButton = document.getElementById('sfToolbarMiniToggler-' + newToken);
-                        var showButtonSvg = showButton.querySelector('svg');
-                        showButtonSvg.setAttribute('aria-hidden', 'true');
-                        showButtonSvg.setAttribute('focusable', 'false');
-                        addEventListener(showButton, 'click', function (event) {
-                            event.preventDefault();
-
-                            var elem = this.parentNode;
-                            if (elem.style.display == 'none') {
-                                document.getElementById('sfToolbarMainContent-' + newToken).style.display = 'none';
-                                document.getElementById('sfToolbarClearer-' + newToken).style.display = 'none';
-                                elem.style.display = 'block';
-                            } else {
-                                document.getElementById('sfToolbarMainContent-' + newToken).style.display = 'block';
-                                document.getElementById('sfToolbarClearer-' + newToken).style.display = 'block';
-                                elem.style.display = 'none'
-                            }
-
-                            setPreference('toolbar/displayState', 'block');
-                        });
                         renderAjaxRequests();
                         addEventListener(document.querySelector('.sf-toolbar-ajax-clear'), 'click', function() {
                             requestStack = [];
@@ -541,7 +593,7 @@ if (typeof Sfjs === 'undefined') {
                         }
                     },
                     function(xhr) {
-                        if (xhr.status !== 0) {
+                        if (xhr.status !== 0 && !options.stop) {
                             var sfwdt = document.getElementById('sfwdt' + token);
                             sfwdt.innerHTML = '\
                                 <div class="sf-toolbarreset">\
@@ -552,7 +604,7 @@ if (typeof Sfjs === 'undefined') {
                             sfwdt.setAttribute('class', 'sf-toolbar sf-error-toolbar');
                         }
                     },
-                    { maxTries: 5 }
+                    options
                 );
 
                 return this;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -54,7 +54,10 @@ if (typeof Sfjs === 'undefined') {
                 }
 
                 if (xhr.status == 404 && options.retry && !options.stop) {
-                    setTimeout(function(){
+                    setTimeout(function() {
+                        if (options.stop) {
+                            return;
+                        }
                         request(url, onSuccess, onError, payload, options, tries + 1);
                     }, delay);
 
@@ -493,12 +496,12 @@ if (typeof Sfjs === 'undefined') {
                 var options = {
                     retry: true,
                     onSend: function (count) {
-                        if (count > 5) {
+                        if (count === 3) {
                             that.initToolbar(token);
                         }
 
                         if (triesCounter) {
-                            triesCounter.innerHTML = count;
+                            triesCounter.textContent = count;
                         }
                     },
                 };

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/cancel.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/cancel.html.twig
@@ -1,0 +1,23 @@
+{% block toolbar %}
+    {% set icon %}
+        {{ include('@WebProfiler/Icon/symfony.svg') }}
+
+        <span class="sf-toolbar-value sf-toolbar-ajax-request-counter">
+            Loading&hellip;
+            <span id="sfLoadCounter-{{ token }}"></span>
+        </span>
+    {% endset %}
+
+    {% set text %}
+        <div class="sf-toolbar-info-piece">
+            <b>Loading the web debug toolbar&hellip;</b>
+        </div>
+        <div class="sf-toolbar-info-piece">
+            <b>
+                <a id="sfLoadCancel-{{ token }}" href="#">Cancel</a>
+            </b>
+        </div>
+    {% endset %}
+
+    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url }) }}
+{% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/cancel.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/cancel.html.twig
@@ -4,7 +4,6 @@
 
         <span class="sf-toolbar-value sf-toolbar-ajax-request-counter">
             Loading&hellip;
-            <span id="sfLoadCounter-{{ token }}"></span>
         </span>
     {% endset %}
 
@@ -13,8 +12,11 @@
             <b>Loading the web debug toolbar&hellip;</b>
         </div>
         <div class="sf-toolbar-info-piece">
+            Attempt #<span id="sfLoadCounter-{{ token }}"></span>
+        </div>
+        <div class="sf-toolbar-info-piece">
             <b>
-                <a id="sfLoadCancel-{{ token }}" href="#">Cancel</a>
+                <button class="sf-cancel-button" type="button" id="sfLoadCancel-{{ token }}" title="Cancel loading">Cancel</button>
             </b>
         </div>
     {% endset %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -73,6 +73,10 @@
     display: inline-block;
 }
 
+.sf-toolbarreset .sf-cancel-button {
+    color: #444;
+}
+
 .sf-toolbarreset .hide-button {
     background: #444;
     display: block;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -10,9 +10,9 @@
     {% for name, template in templates %}
         {% if block('toolbar', template) is defined %}
             {% with {
-                collector: profile.getcollector(name),
+                collector: profile ? profile.getcollector(name) : null,
                 profiler_url: profiler_url,
-                token: profile.token,
+                token: token ?? (profile ? profile.token : null),
                 name: name,
                 profiler_markup_version: profiler_markup_version,
                 csp_script_nonce: csp_script_nonce,

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -1,5 +1,16 @@
-<div id="sfwdt{{ token }}" class="sf-toolbar sf-display-none" role="region" aria-label="Symfony Web Debug Toolbar"></div>
+<div id="sfwdt{{ token }}" class="sf-toolbar sf-display-none" role="region" aria-label="Symfony Web Debug Toolbar">
+    {% include('@WebProfiler/Profiler/toolbar.html.twig') with {
+        templates: {
+            'request': '@WebProfiler/Profiler/cancel.html.twig'
+        },
+        profile: null,
+        profiler_url: url('_profiler', {token: token}),
+        profiler_markup_version: 2,
+    } %}
+</div>
+
 {{ include('@WebProfiler/Profiler/base_js.html.twig') }}
+
 <style{% if csp_style_nonce %} nonce="{{ csp_style_nonce }}"{% endif %}>
     {{ include('@WebProfiler/Profiler/toolbar.css.twig') }}
 </style>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Refs #41112
| License       | MIT


On projects where finishing the request takes some time, loading should not be stopped after a definitive amount of time.

The latest changes introducing an increasing hold-off timer make failures to load the toolbar less likely, although not impossible. They also increase the loading times too much in a too short period of time in my opinion and they don't account for the most common cases where only a short delay is needed.

These changes make the toolbar appear almost instantly in the projects I tested, even if the first request failed.

![toolbar](https://user-images.githubusercontent.com/138721/118528879-2700fc80-b743-11eb-9e57-880cd3e4d787.png)

The toolbar with loading counter will only be shown after the original amount of requests (5) were unsuccessful to flash as little as possible. It allows to cancel the loop, if needed.
