### PR TITLE
[Messenger] Add a middleware to log when transaction has been left open

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+5.4
+---
+ * Add a middleware to log when transaction has been left open `DoctrineOpenTransactionLoggerMiddleware`
+
 5.3
 ---
 

--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineOpenTransactionLoggerMiddleware.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineOpenTransactionLoggerMiddleware.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Messenger;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Middleware\StackInterface;
+
+/**
+ * Middleware to log when transaction has been left open.
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+class DoctrineOpenTransactionLoggerMiddleware extends AbstractDoctrineMiddleware
+{
+    private $logger;
+
+    public function __construct(ManagerRegistry $managerRegistry, string $entityManagerName = null, LoggerInterface $logger = null)
+    {
+        parent::__construct($managerRegistry, $entityManagerName);
+
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    protected function handleForManager(EntityManagerInterface $entityManager, Envelope $envelope, StackInterface $stack): Envelope
+    {
+        try {
+            return $stack->next()->handle($envelope, $stack);
+        } finally {
+            if ($entityManager->getConnection()->isTransactionActive()) {
+                $this->logger->error('A handler opened a transaction but did not close it.', [
+                    'message' => $envelope->getMessage(),
+                ]);
+            }
+        }
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrineOpenTransactionLoggerMiddlewareTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Messenger;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Log\AbstractLogger;
+use Symfony\Bridge\Doctrine\Messenger\DoctrineOpenTransactionLoggerMiddleware;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+
+class DoctrineOpenTransactionLoggerMiddlewareTest extends MiddlewareTestCase
+{
+    private $logger;
+    private $connection;
+    private $entityManager;
+    private $middleware;
+
+    protected function setUp(): void
+    {
+        $this->logger = new class() extends AbstractLogger {
+            public $logs = [];
+
+            public function log($level, $message, $context = []): void
+            {
+                $this->logs[$level][] = $message;
+            }
+        };
+
+        $this->connection = $this->createMock(Connection::class);
+
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager->method('getConnection')->willReturn($this->connection);
+
+        $managerRegistry = $this->createMock(ManagerRegistry::class);
+        $managerRegistry->method('getManager')->willReturn($this->entityManager);
+
+        $this->middleware = new DoctrineOpenTransactionLoggerMiddleware($managerRegistry, null, $this->logger);
+    }
+
+    public function testMiddlewareWrapsInTransactionAndFlushes()
+    {
+        $this->connection->expects($this->exactly(1))
+            ->method('isTransactionActive')
+            ->will($this->onConsecutiveCalls(true, true, false))
+        ;
+
+        $this->middleware->handle(new Envelope(new \stdClass()), $this->getStackMock());
+
+        $this->assertSame(['error' => ['A handler opened a transaction but did not close it.']], $this->logger->logs);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -48,7 +48,8 @@
         "doctrine/collections": "~1.0",
         "doctrine/data-fixtures": "^1.1",
         "doctrine/dbal": "^2.13|^3.0",
-        "doctrine/orm": "^2.7.3"
+        "doctrine/orm": "^2.7.3",
+        "psr/log": "^1|^2|^3"
     },
     "conflict": {
         "doctrine/dbal": "<2.13",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

I notice something that can hurt applications: If one open a transaction
in a handler, but don't close it, the transaction is not close by
Doctrine nor Symfony. So all others messages are still handled in the
transaction. More over, when the retry limit is reach, messenger will
try to save the message in the failed transport. In my case it's
doctrine. So the failed message is save, but inner a transaction. When
the worker stop, the transaction is rollbacked, and so the message is
lost.