### PR TITLE
[Console] Fixed output glitches when trying to use sectioned output larger then terminal and made terminal utility aware of resizes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: "none"
-          extensions: "memcached,redis,xsl,ldap" # todo: need to add pcntl here?
+          extensions: "memcached,redis,xsl,ldap" # todo: need to add pcntl and posix here?
           ini-values: "memory_limit=-1"
           php-version: "${{ matrix.php }}"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: "none"
-          extensions: "memcached,redis,xsl,ldap"
+          extensions: "memcached,redis,xsl,ldap" # todo: need to add pcntl here?
           ini-values: "memory_limit=-1"
           php-version: "${{ matrix.php }}"
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,7 +1,9 @@
 CHANGELOG
 =========
 
-* Added support for console section contents larger than terminal size
+* Fixed output glitches when trying to use sectioned output larger then terminal
+* Fixed returning of old dimensions from `Terminal::{getWidth,getHeight}` when output terminal has been resized
+* Added capability to notify listeners on terminal resize using `Terminal::registerResizeListener` and `Terminal::installWindowResizeSignalHandler`
 
 4.4.0
 -----

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,8 @@
 CHANGELOG
 =========
 
+* Added support for console section contents larger than terminal size
+
 4.4.0
 -----
 

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -95,16 +95,11 @@ class ConsoleSectionOutput extends StreamOutput
         // also triggers flushing of dirty lines in lower sections
         $terminalHeight = $this->terminal->getHeight();
 
-        $linesToClear = $this->dirtyLines + ($lines ?? $this->lines);
+        $lines = ($lines === null) ? $this->lines : min($lines, $this->lines);
+        $linesToClear = $this->dirtyLines + $lines;
         $visibleLinesToClear = min($linesToClear, $this->getVisibleLines($terminalHeight));
 
-        if ($lines) {
-            array_splice($this->content, -$lines);
-        } else {
-            $lines = $this->lines;
-            $this->content = [];
-        }
-
+        array_splice($this->content, -$lines);
         $this->lines -= $lines;
         $this->dirtyLines = $linesToClear - $visibleLinesToClear;
 

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -119,6 +119,8 @@ class ConsoleSectionOutput extends StreamOutput
             $message = implode('', $message);
         }
 
+        $message = $this->getFormatter()->format($message);
+
         // make sure a non-empty message ends with a newline
         if ($message !== '' && substr($message, -1) !== PHP_EOL) {
             $message .= PHP_EOL;

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -146,7 +146,8 @@ class ConsoleSectionOutput extends StreamOutput
                 // only overwrite visible portion if it differs from what is already visible
                 if ($flushableLines > 0 || substr($this->getContent(), -strlen($newVisibleContent)) !== $newVisibleContent) {
 
-                    $erasedContent = $this->popStreamContentUntilCurrentSection(max($flushableLines, $this->getVisibleLines($terminalHeight)));
+                    $sectionLinesToPop = max($flushableLines, $this->getVisibleLines($terminalHeight, false));
+                    $erasedContent = $this->popStreamContentUntilCurrentSection($sectionLinesToPop);
 
                     parent::doWrite($newVisibleContent, false);
                     parent::doWrite($erasedContent, false);
@@ -316,11 +317,13 @@ class ConsoleSectionOutput extends StreamOutput
     }
 
     /**
-     * Returns the number of lines (including dirty lines) that are visible with the current terminal size.
+     * Returns the number of lines that are visible with the current terminal size.
+     * This number may be smaller than $this->lines in case the section is higher than the terminal.
+     * This number may be larger than $this->lines in case there are dirty lines on the terminal as it has been resized.
      */
-    private function getVisibleLines(int $terminalHeight): int
+    private function getVisibleLines(int $terminalHeight, bool $includeDirty = true): int
     {
-        return min($this->getDisplayableLines($terminalHeight), $this->lines + $this->dirtyLines);
+        return min($this->getDisplayableLines($terminalHeight), $this->lines + ($includeDirty ? $this->dirtyLines : 0));
     }
 
     /**

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -78,6 +78,8 @@ class ConsoleSectionOutput extends StreamOutput
             return;
         }
 
+        Terminal::updateDimensions();
+
         $visibleLinesToClear = min($lines ?? $this->lines, $this->getVisibleLines());
 
         if ($lines) {
@@ -104,6 +106,8 @@ class ConsoleSectionOutput extends StreamOutput
         if (is_iterable($message)) {
             $message = implode('', $message);
         }
+
+        Terminal::updateDimensions();
 
         // only overwrite section if it is visible
         if ($this->getDisplayableLines() > 0) {
@@ -154,6 +158,8 @@ class ConsoleSectionOutput extends StreamOutput
 
             return;
         }
+
+        Terminal::updateDimensions();
 
         $isLastSection = $this === $this->sections[0];
 
@@ -236,7 +242,7 @@ class ConsoleSectionOutput extends StreamOutput
 
     private function getDisplayHeight(string $text): int
     {
-        return substr_count($text, PHP_EOL) + ceil($this->getDisplayLength($text) / $this->terminal->getWidth(true)) ?: 1;
+        return substr_count($text, PHP_EOL) + ceil($this->getDisplayLength($text) / $this->terminal->getWidth()) ?: 1;
     }
 
     private function getDisplayLength(string $text): string
@@ -261,7 +267,7 @@ class ConsoleSectionOutput extends StreamOutput
      */
     private function getDisplayableLines(): int
     {
-        $remainingHeight = $this->terminal->getHeight(true);
+        $remainingHeight = $this->terminal->getHeight();
 
         foreach ($this->sections as $section) {
 

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -122,8 +122,9 @@ class ConsoleSectionOutput extends StreamOutput
         $message = $this->getFormatter()->format($message);
 
         // make sure a non-empty message ends with a newline
-        if ($message !== '' && substr($message, -1) !== PHP_EOL) {
-            $message .= PHP_EOL;
+        $messageWithNewline = $message;
+        if ($messageWithNewline !== '' && substr($messageWithNewline, -1) !== PHP_EOL) {
+            $messageWithNewline .= PHP_EOL;
         }
 
         $terminalWidth = null;
@@ -138,7 +139,7 @@ class ConsoleSectionOutput extends StreamOutput
             // only overwrite section if it is visible
             if ($displayableLines > 0) {
 
-                [, $newVisibleContent, $newVisibleLines] = $this->divideMessageByDisplayability($message, $terminalWidth, $terminalHeight);
+                [, $newVisibleContent, $newVisibleLines] = $this->divideMessageByDisplayability($messageWithNewline, $terminalWidth, $terminalHeight);
 
                 $flushableLines = min($this->dirtyLines, $displayableLines - $newVisibleLines);
 
@@ -155,7 +156,7 @@ class ConsoleSectionOutput extends StreamOutput
             }
         } else {
             // output is not decorated
-            parent::doWrite($message, true);
+            parent::doWrite($messageWithNewline, false);
         }
 
         $this->content = [];

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -107,22 +107,28 @@ class ConsoleSectionOutput extends StreamOutput
             $message = implode('', $message);
         }
 
-        Terminal::updateDimensions();
+        if ($this->isDecorated()) {
 
-        // only overwrite section if it is visible
-        if ($this->getDisplayableLines() > 0) {
+            Terminal::updateDimensions();
 
-            [, $visibleContent, $visibleLines] = $this->divideMessageByDisplayability($message);
-            $visibleContent .= PHP_EOL;
+            // only overwrite section if it is visible
+            if ($this->getDisplayableLines() > 0) {
 
-            // only overwrite visible portion if it differs from what is already visible
-            if (substr($this->getContent(), -strlen($visibleContent)) !== $visibleContent) {
+                [, $visibleContent, $visibleLines] = $this->divideMessageByDisplayability($message);
+                $visibleContent .= PHP_EOL;
 
-                $erasedContent = $this->popStreamContentUntilCurrentSection(max($visibleLines, $this->getVisibleLines()));
+                // only overwrite visible portion if it differs from what is already visible
+                if (substr($this->getContent(), -strlen($visibleContent)) !== $visibleContent) {
 
-                parent::doWrite($visibleContent, false);
-                parent::doWrite($erasedContent, false);
+                    $erasedContent = $this->popStreamContentUntilCurrentSection(max($visibleLines, $this->getVisibleLines()));
+
+                    parent::doWrite($visibleContent, false);
+                    parent::doWrite($erasedContent, false);
+                }
             }
+        } else {
+            // output is not decorated
+            parent::doWrite($message, true);
         }
 
         $this->content = [];

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -304,7 +304,7 @@ class ConsoleSectionOutput extends StreamOutput
 
     private function getDisplayHeight(string $text, int $terminalWidth): int
     {
-        return substr_count($text, PHP_EOL) + floor($this->getDisplayLength($text) / $terminalWidth);
+        return substr_count($text, PHP_EOL) + (int)floor($this->getDisplayLength($text) / $terminalWidth);
     }
 
     private function getDisplayLength(string $text): string

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -91,7 +91,7 @@ class ConsoleSectionOutput extends StreamOutput
             return;
         }
 
-        // trigger flushing of dirty lines in lower sections
+        // also triggers flushing of dirty lines in lower sections
         $terminalHeight = $this->terminal->getHeight();
 
         $linesToClear = $this->dirtyLines + ($lines ?? $this->lines);
@@ -132,7 +132,7 @@ class ConsoleSectionOutput extends StreamOutput
 
         if ($this->isDecorated()) {
 
-            // trigger flushing of dirty lines in lower sections
+            // also triggers flushing of dirty lines in lower sections
             [$terminalWidth, $terminalHeight] = $this->terminal->getDimensions();
 
             $displayableLines = $this->getDisplayableLines($terminalHeight);
@@ -224,7 +224,7 @@ class ConsoleSectionOutput extends StreamOutput
             return;
         }
 
-        // trigger flushing of dirty lines in lower sections
+        // also triggers flushing of dirty lines in lower sections
         [$terminalWidth, $terminalHeight] = $this->terminal->getDimensions();
 
         $isLastSection = $this === $this->sections[0];

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -20,6 +20,7 @@ use function strlen;
 use const PHP_EOL;
 
 /**
+ * @author Arne Groskurth <arne.groskurth@gmail.com>
  * @author Pierre du Plessis <pdples@gmail.com>
  * @author Gabriel Ostrolucký <gabriel.ostrolucky@gmail.com>
  */

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -163,7 +163,7 @@ class ConsoleSectionOutput extends StreamOutput
 
         $isLastSection = $this === $this->sections[0];
 
-        // only write anything to the terminal if it is visible
+        // only write anything to the terminal if section is visible
         if (!$isLastSection && $this->getDisplayableLines() > 0) {
 
             $erasedContent = $this->popStreamContentUntilCurrentSection();
@@ -177,7 +177,7 @@ class ConsoleSectionOutput extends StreamOutput
 
         $this->addContent($message);
 
-        // just append to the terminal
+        // just append to the terminal if this is the last section
         if ($isLastSection) {
             parent::doWrite($message, true);
         }

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -175,9 +175,9 @@ class ConsoleSectionOutput extends StreamOutput
      *
      * @internal
      */
-    public function flushDirtyLines(): void
+    public function flushDirtyLines(array $dimensions): void
     {
-        $terminalHeight = $this->terminal->getHeight();
+        [, $terminalHeight] = $dimensions;
 
         // flush all sections, starting with the bottom-most
         // flushing all sections at once to be independent of order this function is called among the sections

--- a/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleSectionOutput.php
@@ -143,7 +143,7 @@ class ConsoleSectionOutput extends StreamOutput
                 // only overwrite visible portion if it differs from what is already visible
                 if ($flushableLines > 0 || substr($this->getContent(), -strlen($newVisibleContent)) !== $newVisibleContent) {
 
-                    $erasedContent = $this->popStreamContentUntilCurrentSection(max($newVisibleLines + $flushableLines, $this->getVisibleLines($terminalHeight)));
+                    $erasedContent = $this->popStreamContentUntilCurrentSection(max($flushableLines, $this->getVisibleLines($terminalHeight)));
 
                     parent::doWrite($newVisibleContent, false);
                     parent::doWrite($erasedContent, false);

--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -95,8 +95,20 @@ class Terminal
      */
     public static function registerResizeListener(callable $listener): void
     {
-        if (array_search($listener, self::$windowResizeListeners) === false) {
+        if (array_search($listener, self::$windowResizeListeners, true) === false) {
             self::$windowResizeListeners[] = $listener;
+        }
+    }
+
+    /**
+     * Removes a resize listener previously added with registerResizeListener().
+     *
+     * @param callable $listener
+     */
+    public static function unregisterResizeListener(callable $listener): void
+    {
+        if (($key = array_search($listener, self::$windowResizeListeners, true)) !== false) {
+            unset(self::$windowResizeListeners[$key]);
         }
     }
 

--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -64,6 +64,7 @@ class Terminal
      *
      * todo: Any chance to support Windows here?
      *
+     * @param bool $overwrite Whether to overwrite a potentially already existing handler for the SIGWINCH signal.
      * @param bool $activateAsyncSignalHandling Whether to also activate asynchronous signal processing to ensure immediate event processing.
      * @return bool Returns true if the signal handler has been successfully installed and false otherwise.
      */

--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -45,6 +45,19 @@ class Terminal
     }
 
     /**
+     * @return int[]
+     */
+    public function getDimensions(): array
+    {
+        self::updateDimensions();
+
+        return [
+            self::$width,
+            self::$height,
+        ];
+    }
+
+    /**
      * Sets up a handler for the SIGWINCH process signal to detect resizes of the terminal window.
      *
      * See: https://www.gnu.org/software/libc/manual/html_node/Miscellaneous-Signals.html

--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -20,18 +20,17 @@ class Terminal
     /**
      * Gets the terminal width.
      *
-     * @param bool $forceRefresh
      * @return int
      */
-    public function getWidth(bool $forceRefresh = false)
+    public function getWidth()
     {
         $width = getenv('COLUMNS');
         if (false !== $width) {
             return (int) trim($width);
         }
 
-        if ($forceRefresh || null === self::$width) {
-            self::initDimensions();
+        if (null === self::$width) {
+            self::updateDimensions();
         }
 
         return self::$width ?: 80;
@@ -40,18 +39,17 @@ class Terminal
     /**
      * Gets the terminal height.
      *
-     * @param bool $forceRefresh
      * @return int
      */
-    public function getHeight(bool $forceRefresh = false)
+    public function getHeight()
     {
         $height = getenv('LINES');
         if (false !== $height) {
             return (int) trim($height);
         }
 
-        if ($forceRefresh || null === self::$height) {
-            self::initDimensions();
+        if (null === self::$height) {
+            self::updateDimensions();
         }
 
         return self::$height ?: 50;
@@ -78,7 +76,10 @@ class Terminal
         return self::$stty = 0 === $exitcode;
     }
 
-    private static function initDimensions()
+    /**
+     * @internal
+     */
+    public static function updateDimensions()
     {
         if ('\\' === \DIRECTORY_SEPARATOR) {
             if (preg_match('/^(\d+)x(\d+)(?: \((\d+)x(\d+)\))?$/', trim(getenv('ANSICON')), $matches)) {

--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -49,7 +49,7 @@ class Terminal
      *
      * See: https://www.gnu.org/software/libc/manual/html_node/Miscellaneous-Signals.html
      *
-     * todo: Any change to support Windows here?
+     * todo: Any chance to support Windows here?
      *
      * @param bool $activateAsyncSignalHandling Whether to also activate asynchronous signal processing to ensure immediate event processing.
      * @return bool Returns true if the signal handler has been successfully installed and false otherwise.

--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -20,16 +20,17 @@ class Terminal
     /**
      * Gets the terminal width.
      *
+     * @param bool $forceRefresh
      * @return int
      */
-    public function getWidth()
+    public function getWidth(bool $forceRefresh = false)
     {
         $width = getenv('COLUMNS');
         if (false !== $width) {
             return (int) trim($width);
         }
 
-        if (null === self::$width) {
+        if ($forceRefresh || null === self::$width) {
             self::initDimensions();
         }
 
@@ -39,16 +40,17 @@ class Terminal
     /**
      * Gets the terminal height.
      *
+     * @param bool $forceRefresh
      * @return int
      */
-    public function getHeight()
+    public function getHeight(bool $forceRefresh = false)
     {
         $height = getenv('LINES');
         if (false !== $height) {
             return (int) trim($height);
         }
 
-        if (null === self::$height) {
+        if ($forceRefresh || null === self::$height) {
             self::initDimensions();
         }
 

--- a/src/Symfony/Component/Console/Terminal.php
+++ b/src/Symfony/Component/Console/Terminal.php
@@ -184,14 +184,14 @@ class Terminal
         self::$height = self::$height ?? 50;
 
         if ($lastWidth !== self::$width || $lastHeight !== self::$height) {
-            self::triggerWindowResizeListeners();
+            self::triggerWindowResizeListeners([self::$width, self::$height]);
         }
     }
 
-    private static function triggerWindowResizeListeners(): void
+    private static function triggerWindowResizeListeners(array $dimensions): void
     {
         foreach (self::$windowResizeListeners as $listener) {
-            \call_user_func($listener);
+            \call_user_func($listener, $dimensions);
         }
     }
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/SizableTerminalMock.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/SizableTerminalMock.php
@@ -24,4 +24,12 @@ class SizableTerminalMock extends Terminal
     {
         return $this->height;
     }
+
+    public function getDimensions(): array
+    {
+        return [
+            $this->width,
+            $this->height,
+        ];
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/SizableTerminalMock.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/SizableTerminalMock.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Symfony\Component\Console\Tests\Fixtures;
+
+use Symfony\Component\Console\Terminal;
+
+class SizableTerminalMock extends Terminal
+{
+    private $width;
+    private $height;
+
+    public function __construct(int $width, int $height)
+    {
+        $this->width = $width;
+        $this->height = $height;
+    }
+
+    public function getWidth()
+    {
+        return $this->width;
+    }
+
+    public function getHeight()
+    {
+        return $this->height;
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -419,7 +419,7 @@ class ProgressBarTest extends TestCase
             ' 0/50 [>]   0% %message% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.'.\PHP_EOL.
             "\x1b[3A\x1b[0J 1/50 [>]   2% Twas brillig, and the slithy toves. Did gyre and gimble in the wabe: All mimsy were the borogoves, And the mome raths outgrabe.
 Beware the Jabberwock, my son! The jaws that bite, the claws that catch! Beware the Jubjub bird, and shun The frumious Bandersnatch! Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.".\PHP_EOL.
-            "\x1b[3A\x1b[0J 2/50 [>]   4% He took his vorpal sword in hand; Long time the manxome foe he sought— So rested he by the Tumtum tree And stood awhile in thought.
+            "\x1b[6A\x1b[0J 2/50 [>]   4% He took his vorpal sword in hand; Long time the manxome foe he sought— So rested he by the Tumtum tree And stood awhile in thought.
 And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whiffling through the tulgey wood, And burbled as it came! Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.".\PHP_EOL,
             stream_get_contents($output->getStream())
         );

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -417,9 +417,9 @@ class ProgressBarTest extends TestCase
         rewind($output->getStream());
         $this->assertEquals(
             ' 0/50 [>]   0% %message% Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.'.\PHP_EOL.
-            "\x1b[6A\x1b[0J 1/50 [>]   2% Twas brillig, and the slithy toves. Did gyre and gimble in the wabe: All mimsy were the borogoves, And the mome raths outgrabe.
+            "\x1b[3A\x1b[0J 1/50 [>]   2% Twas brillig, and the slithy toves. Did gyre and gimble in the wabe: All mimsy were the borogoves, And the mome raths outgrabe.
 Beware the Jabberwock, my son! The jaws that bite, the claws that catch! Beware the Jubjub bird, and shun The frumious Bandersnatch! Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.".\PHP_EOL.
-            "\x1b[6A\x1b[0J 2/50 [>]   4% He took his vorpal sword in hand; Long time the manxome foe he sought— So rested he by the Tumtum tree And stood awhile in thought.
+            "\x1b[3A\x1b[0J 2/50 [>]   4% He took his vorpal sword in hand; Long time the manxome foe he sought— So rested he by the Tumtum tree And stood awhile in thought.
 And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whiffling through the tulgey wood, And burbled as it came! Fruitcake marzipan toffee. Cupcake gummi bears tart dessert ice cream chupa chups cupcake chocolate bar sesame snaps. Croissant halvah cookie jujubes powder macaroon. Fruitcake bear claw bonbon jelly beans oat cake pie muffin Fruitcake marzipan toffee.".\PHP_EOL,
             stream_get_contents($output->getStream())
         );

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
@@ -143,6 +143,28 @@ class ConsoleSectionOutputTest extends TestCase
         $this->assertEquals('Foobar'.\PHP_EOL, stream_get_contents($output->getStream()));
     }
 
+    public function testOverwriteWithFormat()
+    {
+        $sections = [];
+        $output = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $output->overwrite('<info>Foobar</info>');
+
+        rewind($output->getStream());
+        $this->assertEquals('[32mFoobar[39m'.\PHP_EOL, stream_get_contents($output->getStream()));
+    }
+
+    public function testOverwriteWithFormatButDisabledDecoration()
+    {
+        $sections = [];
+        $output = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, false, new OutputFormatter());
+
+        $output->overwrite('<info>Foobar</info>');
+
+        rewind($output->getStream());
+        $this->assertEquals('Foobar'.\PHP_EOL, stream_get_contents($output->getStream()));
+    }
+
     public function testAddingMultipleSections()
     {
         $sections = [];

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
@@ -93,6 +93,21 @@ class ConsoleSectionOutputTest extends TestCase
         $this->assertEquals(\PHP_EOL.'foo'.\PHP_EOL."\x1b[1A\x1b[0J\x1b[1A\x1b[0J".'bar'.\PHP_EOL.\PHP_EOL, stream_get_contents($output->getStream()));
     }
 
+    public function testClearMoreLinesThenExisting()
+    {
+        [$section,] = $this->prepareSectionsInSizedTerminal(1, 5, 10);
+
+        $section->writeln("foo1");
+        $section->writeln("foo2");
+        $section->clear(10);
+        $section->writeln("foo3");
+        $section->writeln("foo4");
+        $section->clear(1);
+
+        rewind($this->stream);
+        $this->assertEquals(implode(\PHP_EOL, ['foo1', 'foo2', "\x1b[2A\x1b[0Jfoo3", 'foo4', "\x1b[1A\x1b[0J"]), stream_get_contents($this->stream));
+    }
+
     public function testOverwrite()
     {
         $sections = [];

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
@@ -165,6 +165,23 @@ class ConsoleSectionOutputTest extends TestCase
         $this->assertEquals('Foobar'.\PHP_EOL, stream_get_contents($output->getStream()));
     }
 
+    public function testOverwriteWithDirtyLines()
+    {
+        [$section] = $this->prepareSectionsInSizedTerminal(1, 3, 10);
+
+        // write something larger then terminal
+        $section->writeln(implode(\PHP_EOL, ['1', '2', '3', '4', '5']));
+
+        // first two lines are now dirty
+        $section->clear();
+
+        // should only re-write last three lines onto terminal
+        $section->overwrite(implode(\PHP_EOL, ['1', '2', '3', '4', '5']));
+
+        rewind($this->stream);
+        $this->assertEquals(implode(\PHP_EOL, ['1', '2', '3', '4', '5', "\x1b[3A\x1b[0J3", '4', '5', '']), stream_get_contents($this->stream));
+    }
+
     public function testAddingMultipleSections()
     {
         $sections = [];

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
@@ -132,6 +132,17 @@ class ConsoleSectionOutputTest extends TestCase
         $this->assertEquals('Foo'.\PHP_EOL.'Bar'.\PHP_EOL.'Baz'.\PHP_EOL.sprintf("\x1b[%dA", 3)."\x1b[0J".'Bar'.\PHP_EOL, stream_get_contents($output->getStream()));
     }
 
+    public function testOverwriteEmptySection()
+    {
+        $sections = [];
+        $output = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $output->overwrite('Foobar');
+
+        rewind($output->getStream());
+        $this->assertEquals('Foobar'.\PHP_EOL, stream_get_contents($output->getStream()));
+    }
+
     public function testAddingMultipleSections()
     {
         $sections = [];

--- a/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
+++ b/src/Symfony/Component/Console/Tests/Output/ConsoleSectionOutputTest.php
@@ -211,6 +211,18 @@ class ConsoleSectionOutputTest extends TestCase
         $this->assertSame('What\'s your favorite super hero?'.\PHP_EOL."\x1b[2A\x1b[0J", stream_get_contents($output->getStream()));
     }
 
+    public function testClearAfterOverwriteClearsCorrectNumberOfLines()
+    {
+        $sections = [];
+        $output = new ConsoleSectionOutput($this->stream, $sections, OutputInterface::VERBOSITY_NORMAL, true, new OutputFormatter());
+
+        $output->overwrite('foo');
+        $output->clear();
+
+        rewind($output->getStream());
+        $this->assertEquals(implode(\PHP_EOL, ['foo', "\x1b[1A\x1b[0J"]), stream_get_contents($output->getStream()));
+    }
+
     public function testClearAboveTerminal()
     {
         [$section1, $section2] = $this->prepareSectionsInSizedTerminal(2, 3, 10);

--- a/src/Symfony/Component/Console/Tests/TerminalTest.php
+++ b/src/Symfony/Component/Console/Tests/TerminalTest.php
@@ -130,6 +130,7 @@ class TerminalTest extends TestCase
         $this->assertEquals(11, $terminal->getWidth());
         $this->assertEquals(11, $terminal->getWidth());
 
+        // listener should have been triggered once more for the detected resize
         $this->assertEquals(2, $called);
 
         Terminal::unregisterResizeListener($listener);

--- a/src/Symfony/Component/Console/Tests/TerminalTest.php
+++ b/src/Symfony/Component/Console/Tests/TerminalTest.php
@@ -103,7 +103,7 @@ class TerminalTest extends TestCase
     public function testWindowResizeListener()
     {
         $called = 0;
-        Terminal::registerResizeListener(function() use (&$called) {
+        Terminal::registerResizeListener($listener = function() use (&$called) {
             $called++;
         });
 
@@ -130,6 +130,16 @@ class TerminalTest extends TestCase
         $this->assertEquals(11, $terminal->getWidth());
         $this->assertEquals(11, $terminal->getWidth());
 
+        $this->assertEquals(2, $called);
+
+        Terminal::unregisterResizeListener($listener);
+
+        putenv('LINES=7');
+
+        $this->assertEquals(7, $terminal->getHeight());
+        $this->assertEquals(7, $terminal->getHeight());
+
+        // listener should not have been called anymore
         $this->assertEquals(2, $called);
     }
 

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -35,6 +35,7 @@
         "psr/log-implementation": "1.0"
     },
     "suggest": {
+        "ext-pcntl": "To listen for terminal resizes",
         "symfony/event-dispatcher": "",
         "symfony/lock": "",
         "symfony/process": "",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #24224 , Fix #29746 , Fix #35012
| Tickets (maybe) | Fix #37304
| License       | MIT
| Doc PR        | -

The current console section utility implementation was not aware of the output terminals dimensions causing a variety of rendering glitches when trying to cear or overwrite section contents that are larger then the displaying terminal.

Root of the problem is the inability to move the cursor above the terminal home position using ANSI/VT100 control escape sequences. The implementation has been extended to:

- compute and apply partial differences limited to the visible part of the terminal
- react on terminal window resizes by redrawing the now visible part of the section
- keep track of _dirty_ lines above the terminal that are still to be cleared/overwritten in case they are loaded back onto the terminal due to the terminal being resized

However, there a couple of things I'm not sure about:
- To detect terminal window resizes, the implementation uses the `pcntl` extension to listen for the POSIX `SIGWINCH` signal - is there anything similar to this on Windows?