### PR TITLE
[Serializer] add context in support methods.

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -129,7 +129,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null, array $context = [])
     {
         return \is_object($data) && !$data instanceof \Traversable;
     }
@@ -314,7 +314,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null, array $context = [])
     {
         return class_exists($type) || (interface_exists($type, false) && $this->classDiscriminatorResolver && null !== $this->classDiscriminatorResolver->getMappingForClass($type));
     }

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -47,9 +47,10 @@ interface DenormalizerInterface
     /**
      * Checks whether the given class is supported for denormalization by this normalizer.
      *
-     * @param mixed  $data   Data to denormalize from
-     * @param string $type   The class to which the data should be denormalized
-     * @param string $format The format being deserialized from
+     * @param mixed  $data    Data to denormalize from
+     * @param string $type    The class to which the data should be denormalized
+     * @param string $format  The format being deserialized from
+     * @param array  $context Options available to the denormalizer
      *
      * @return bool
      */

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -39,17 +39,17 @@ class GetSetMethodNormalizer extends AbstractObjectNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null, array $context = [])
     {
-        return parent::supportsNormalization($data, $format) && $this->supports(\get_class($data));
+        return parent::supportsNormalization($data, $format, $context) && $this->supports(\get_class($data));
     }
 
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null, array $context = [])
     {
-        return parent::supportsDenormalization($data, $type, $format) && $this->supports($type);
+        return parent::supportsDenormalization($data, $type, $format, $context) && $this->supports($type);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -41,8 +41,9 @@ interface NormalizerInterface
     /**
      * Checks whether the given class is supported for normalization by this normalizer.
      *
-     * @param mixed  $data   Data to normalize
-     * @param string $format The format being (de-)serialized from or into
+     * @param mixed  $data    Data to normalize
+     * @param string $format  The format being (de-)serialized from or into
+     * @param array  $context Context options for the normalizer
      *
      * @return bool
      */

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -33,17 +33,17 @@ class PropertyNormalizer extends AbstractObjectNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null, array $context = [])
     {
-        return parent::supportsNormalization($data, $format) && $this->supports(\get_class($data));
+        return parent::supportsNormalization($data, $format, $context) && $this->supports(\get_class($data));
     }
 
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null, array $context = [])
     {
-        return parent::supportsDenormalization($data, $type, $format) && $this->supports($type);
+        return parent::supportsDenormalization($data, $type, $format, $context) && $this->supports($type);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -412,7 +412,7 @@ class SerializerCollectionDummy implements SerializerInterface, DenormalizerInte
         return null;
     }
 
-    public function supportsDenormalization($data, $type, $format = null): bool
+    public function supportsDenormalization($data, $type, $format = null, array $context = []): bool
     {
         return true;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 (not really sure)
| Bug fix?      | kinda yes / improvement
| New feature?  | no
| Deprecations? | yes
| Tickets       | 
| License       | MIT
| Doc PR        | 

It's possible that normalizer/denormalizer could support object depending on context.
Use case: Normalize entities only with ID for [Messenger](https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php#L44), but normalize whole object in all other cases (export/import for example).

In same time - this PR is bugfix, because context is already passed on root level, by serializer - so it's breaking the contract from interface:
https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Serializer/Serializer.php#L243
https://github.com/symfony/symfony/blob/4.4/src/Symfony/Component/Serializer/Serializer.php#L284

Additionally (see https://symfony.com/releases):
Need help on BC Layer. I didn't added arguments to interface, because that would break existing code.

Edit: Wow, I guess there is automatic tool that do that for me:

```
 1x: The "Symfony\Component\Serializer\Tests\Normalizer\SerializerCollectionDummy::supportsDenormalization()" method will require a new "array $context" argument in the next major version of its interface "Symfony\Component\Serializer\Normalizer\DenormalizerInterface", not defining it is deprecated.
 ```

 Then I guess I only need to add tests?
