### PR TITLE
Release v4.4.24

### DIFF
--- a/CHANGELOG-4.4.md
+++ b/CHANGELOG-4.4.md
@@ -7,6 +7,16 @@ in 4.4 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v4.4.0...v4.4.1
 
+* 4.4.24 (2021-05-19)
+
+ * security #cve-2021-21424 [Security\Core] Fix user enumeration via response body on invalid credentials (chalasr)
+ * bug #41230 [FrameworkBundle][Validator] Fix deprecations from Doctrine Annotations+Cache (derrabus)
+ * bug #41240 Fixed deprecation warnings about passing null as parameter (derrabus)
+ * bug #41241 [Finder] Fix gitignore regex build with "**" (mvorisek)
+ * bug #41224 [HttpClient] fix adding query string to relative URLs with scoped clients (nicolas-grekas)
+ * bug #41233 [DependencyInjection][ProxyManagerBridge] Don't call class_exists() on null (derrabus)
+ * bug #41210 [Console] Fix Windows code page support (orkan)
+
 * 4.4.23 (2021-05-12)
 
  * security #cve-2021-21424 [Security][Guard] Prevent user enumeration (chalasr)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -146,12 +146,12 @@ The Symfony Connect username in parenthesis allows to get more information
  - Colin Frei
  - Javier Spagnoletti (phansys)
  - Joshua Thijssen
+ - Tomas Norkūnas (norkunas)
  - Yanick Witschi (toflar)
  - Daniel Wehner (dawehner)
  - Tugdual Saunier (tucksaun)
  - excelwebzone
  - Gordon Franke (gimler)
- - Tomas Norkūnas (norkunas)
  - Jesse Rushlow (geeshoe)
  - Fabien Pennequin (fabienpennequin)
  - Théo FIDRY (theofidry)
@@ -280,6 +280,7 @@ The Symfony Connect username in parenthesis allows to get more information
  - Stadly
  - Stepan Anchugov (kix)
  - François Pluchino (francoispluchino)
+ - Rokas Mikalkėnas (rokasm)
  - bronze1man
  - Jeroen Noten (jeroennoten)
  - sun (sun)
@@ -318,7 +319,6 @@ The Symfony Connect username in parenthesis allows to get more information
  - Clara van Miert
  - Bastien Jaillot (bastnic)
  - Rui Marinho (ruimarinho)
- - Rokas Mikalkėnas (rokasm)
  - Alexandre Daubois (alexandre-daubois)
  - Eugene Wissner
  - Bohan Yang (brentybh)
@@ -387,6 +387,7 @@ The Symfony Connect username in parenthesis allows to get more information
  - Nguyen Xuan Quynh (xuanquynh)
  - Jan Sorgalla (jsor)
  - Ray
+ - Bozhidar Hristov (warxcell)
  - Chekote
  - Thomas Adam
  - Jhonny Lidfors (jhonne)
@@ -403,6 +404,7 @@ The Symfony Connect username in parenthesis allows to get more information
  - Mohammad Emran Hasan (phpfour)
  - Dmitriy Mamontov (mamontovdmitriy)
  - Ben Ramsey (ramsey)
+ - Michael Voříšek
  - Laurent Masforné (heisenberg)
  - Giorgio Premi
  - Guillaume (guill)
@@ -453,7 +455,6 @@ The Symfony Connect username in parenthesis allows to get more information
  - realmfoo
  - Thomas Tourlourat (armetiz)
  - Andrey Esaulov (andremaha)
- - Bozhidar Hristov (warxcell)
  - Grégoire Passault (gregwar)
  - Jerzy Zawadzki (jzawadzki)
  - Ismael Ambrosi (iambrosi)
@@ -492,7 +493,6 @@ The Symfony Connect username in parenthesis allows to get more information
  - Gennady Telegin (gtelegin)
  - Krystian Marcisz (simivar)
  - Toni Rudolf (toooni)
- - Michael Voříšek
  - Erin Millard
  - Artur Melo (restless)
  - Matthew Lewinski (lewinski)
@@ -610,6 +610,7 @@ The Symfony Connect username in parenthesis allows to get more information
  - Steffen Roßkamp
  - Alexandru Furculita (afurculita)
  - Valentin Jonovs (valentins-jonovs)
+ - Andrii Bodnar
  - Bastien DURAND (deamon)
  - Jeanmonod David (jeanmonod)
  - Christopher Davis (chrisguitarguy)
@@ -693,6 +694,7 @@ The Symfony Connect username in parenthesis allows to get more information
  - Andreas Leathley (iquito)
  - Soufian EZ-ZANTAR (soezz)
  - Zander Baldwin
+ - Marek Zajac
  - Adam Harvey
  - Anton Bakai
  - Rhodri Pugh (rodnaph)
@@ -1394,7 +1396,6 @@ The Symfony Connect username in parenthesis allows to get more information
  - Gary Houbre (thegarious)
  - Romain Monteil (ker0x)
  - sensio
- - Andrii Bodnar
  - Thomas Jarrand
  - Antoine Bluchet (soyuka)
  - Patrick Kaufmann
@@ -1713,7 +1714,6 @@ The Symfony Connect username in parenthesis allows to get more information
  - David Legatt (dlegatt)
  - Alain Flaus (halundra)
  - tsufeki
- - Marek Zajac
  - Philipp Strube
  - Clement Herreman (clemherreman)
  - Dan Ionut Dumitriu (danionut90)
@@ -1910,6 +1910,7 @@ The Symfony Connect username in parenthesis allows to get more information
  - Nicolas Eeckeloo (neeckeloo)
  - Andriy Prokopenko (sleepyboy)
  - Mathieu Morlon
+ - Ivo Valchev
  - Daniel Tschinder
  - Arnaud CHASSEUX
  - Wojciech Gorczyca
@@ -2216,6 +2217,7 @@ The Symfony Connect username in parenthesis allows to get more information
  - Oliver Klee
  - Simon Sargeant
  - efeen
+ - Mikko Ala-Fossi
  - Jan Christoph Beyer
  - Nicolas Pion
  - Muhammed Akbulut

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -76,12 +76,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     private static $freshCache = [];
 
-    public const VERSION = '4.4.24-DEV';
+    public const VERSION = '4.4.24';
     public const VERSION_ID = 40424;
     public const MAJOR_VERSION = 4;
     public const MINOR_VERSION = 4;
     public const RELEASE_VERSION = 24;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '11/2022';
     public const END_OF_LIFE = '11/2023';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v4.4.23...v4.4.24)

 * security #cve-2021-21424 [Security\Core] Fix user enumeration via response body on invalid credentials (@chalasr)
 * bug #41230 [FrameworkBundle][Validator] Fix deprecations from Doctrine Annotations+Cache (@derrabus)
 * bug #41240 Fixed deprecation warnings about passing null as parameter (@derrabus)
 * bug #41241 [Finder] Fix gitignore regex build with "**" (@mvorisek)
 * bug #41224 [HttpClient] fix adding query string to relative URLs with scoped clients (@nicolas-grekas)
 * bug #41233 [DependencyInjection][ProxyManagerBridge] Don't call class_exists() on null (@derrabus)
 * bug #41210 [Console] Fix Windows code page support (@orkan)
