### PR TITLE
Release v5.3.0-RC1

### DIFF
--- a/CHANGELOG-5.3.md
+++ b/CHANGELOG-5.3.md
@@ -7,6 +7,25 @@ in 5.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v5.3.0...v5.3.1
 
+* 5.3.0-RC1 (2021-05-19)
+
+ * security #cve-2021-21424 [Security\Core] Fix user enumeration via response body on invalid credentials (chalasr)
+ * bug #41275 Fixes Undefined method call (faizanakram99)
+ * feature #41175 [Security] [RememberMe] Add support for parallel requests doing remember-me re-authentication (Seldaek)
+ * bug #41269 [SecurityBundle] Remove invalid unused service (chalasr)
+ * feature #41247 [Security] Deprecate the old authentication mechanisms (chalasr)
+ * bug #41139 [Security] [DataCollector] Remove allows anonymous information in datacollector (ismail1432)
+ * bug #41254 [Security\Http] Fix handling `secure: auto` using the new RememberMeAuthenticator (chalasr)
+ * bug #41230 [FrameworkBundle][Validator] Fix deprecations from Doctrine Annotations+Cache (derrabus)
+ * bug #41206 [Mailer] Fix SES API call with UTF-8 Addresses (jderusse)
+ * bug #41240 Fixed deprecation warnings about passing null as parameter (derrabus)
+ * bug #41241 [Finder] Fix gitignore regex build with "**" (mvorisek)
+ * bug #41224 [HttpClient] fix adding query string to relative URLs with scoped clients (nicolas-grekas)
+ * bug #41233 [DependencyInjection][ProxyManagerBridge] Don't call class_exists() on null (derrabus)
+ * bug #41214 [Console] fix registering command aliases when using the new "cmd|alias" syntax for names (nicolas-grekas)
+ * bug #41211 [Notifier] Add missing charset to content-type for Slack notifier (norkunas)
+ * bug #41210 [Console] Fix Windows code page support (orkan)
+
 * 5.3.0-BETA4 (2021-05-12)
 
  * security #cve-2021-21424 [Security][Guard] Prevent user enumeration (chalasr)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -75,12 +75,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     private static $freshCache = [];
 
-    public const VERSION = '5.3.0-DEV';
+    public const VERSION = '5.3.0-RC1';
     public const VERSION_ID = 50300;
     public const MAJOR_VERSION = 5;
     public const MINOR_VERSION = 3;
     public const RELEASE_VERSION = 0;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = 'RC1';
 
     public const END_OF_MAINTENANCE = '05/2021';
     public const END_OF_LIFE = '01/2022';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v5.3.0-BETA4...v5.3.0-RC1)

 * security #cve-2021-21424 [Security\Core] Fix user enumeration via response body on invalid credentials (@chalasr)
 * bug #41275 Fixes Undefined method call (@faizanakram99)
 * feature #41175 [Security] [RememberMe] Add support for parallel requests doing remember-me re-authentication (@Seldaek)
 * bug #41269 [SecurityBundle] Remove invalid unused service (@chalasr)
 * feature #41247 [Security] Deprecate the old authentication mechanisms (@chalasr)
 * bug #41139 [Security] [DataCollector] Remove allows anonymous information in datacollector (@ismail1432)
 * bug #41254 [Security\Http] Fix handling `secure: auto` using the new RememberMeAuthenticator (@chalasr)
 * bug #41230 [FrameworkBundle][Validator] Fix deprecations from Doctrine Annotations+Cache (@derrabus)
 * bug #41206 [Mailer] Fix SES API call with UTF-8 Addresses (@jderusse)
 * bug #41240 Fixed deprecation warnings about passing null as parameter (@derrabus)
 * bug #41241 [Finder] Fix gitignore regex build with "**" (@mvorisek)
 * bug #41224 [HttpClient] fix adding query string to relative URLs with scoped clients (@nicolas-grekas)
 * bug #41233 [DependencyInjection][ProxyManagerBridge] Don't call class_exists() on null (@derrabus)
 * bug #41214 [Console] fix registering command aliases when using the new "cmd|alias" syntax for names (@nicolas-grekas)
 * bug #41211 [Notifier] Add missing charset to content-type for Slack notifier (@norkunas)
 * bug #41210 [Console] Fix Windows code page support (@orkan)
