### PR TITLE
[Workflow] Add support for getting updated context after a transition

### DIFF
--- a/src/Symfony/Component/Workflow/CHANGELOG.md
+++ b/src/Symfony/Component/Workflow/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Add support for getting updated context after a transition
+
 5.3
 ---
 

--- a/src/Symfony/Component/Workflow/Marking.php
+++ b/src/Symfony/Component/Workflow/Marking.php
@@ -19,6 +19,7 @@ namespace Symfony\Component\Workflow;
 class Marking
 {
     private $places = [];
+    private $context = null;
 
     /**
      * @param int[] $representation Keys are the place name and values should be 1
@@ -48,5 +49,21 @@ class Marking
     public function getPlaces()
     {
         return $this->places;
+    }
+
+    /**
+     * @internal
+     */
+    public function setContext(array $context): void
+    {
+        $this->context = $context;
+    }
+
+    /**
+     * Returns the context after the subject has transitioned.
+     */
+    public function getContext(): ?array
+    {
+        return $this->context;
     }
 }

--- a/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
+++ b/src/Symfony/Component/Workflow/Tests/WorkflowTest.php
@@ -637,7 +637,28 @@ class WorkflowTest extends TestCase
             $dispatcher->addListener($eventName, $assertWorkflowContext);
         }
 
-        $workflow->apply($subject, 't1', $context);
+        $marking = $workflow->apply($subject, 't1', $context);
+
+        $this->assertInstanceOf(Marking::class, $marking);
+        $this->assertSame($context, $marking->getContext());
+    }
+
+    public function testEventContextUpdated()
+    {
+        $definition = $this->createComplexWorkflowDefinition();
+        $subject = new Subject();
+        $dispatcher = new EventDispatcher();
+
+        $workflow = new Workflow($definition, new MethodMarkingStore(), $dispatcher);
+
+        $dispatcher->addListener('workflow.transition', function (TransitionEvent $event) {
+            $event->setContext(['foo' => 'bar']);
+        });
+
+        $marking = $workflow->apply($subject, 't1', ['initial']);
+
+        $this->assertInstanceOf(Marking::class, $marking);
+        $this->assertSame(['foo' => 'bar'], $marking->getContext());
     }
 
     public function testEventDefaultInitialContext()

--- a/src/Symfony/Component/Workflow/Workflow.php
+++ b/src/Symfony/Component/Workflow/Workflow.php
@@ -244,6 +244,8 @@ class Workflow implements WorkflowInterface
             $this->announce($subject, $transition, $marking, $context);
         }
 
+        $marking->setContext($context);
+
         return $marking;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

I have a listener that lock the transition. Then, I need to give this
lock to my consumer. ATM, there is no easy way to pass a new resource
from a listener to the caller. I could add a new `tmpLock` property on my
subject (this is what I did temporary), but I'm not confortable with
this hack.

By adding the final context (it could be updated, that the point of
listener) to the marking, I could easily get data back.

Finally, the PHP doc of WorkflowInterface::apply() tells us:
```php
 * @return Marking The new Marking
```
So I think it's legit to add also the new context