### PR TITLE
[FrameworkBundle] Register events in container parameters

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RegisterEventPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RegisterEventPass.php
@@ -22,13 +22,13 @@ class RegisterEventPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $events = [];
-        foreach (\array_keys($container->findTaggedServiceIds('kernel.event')) as $eventServiceId) {
+        foreach (array_keys($container->findTaggedServiceIds('kernel.event')) as $eventServiceId) {
             $events[$container->getDefinition($eventServiceId)->getClass()] = $eventServiceId;
         }
 
-        $container->setParameter('kernel.events', \array_merge(
+        $container->setParameter('kernel.events', array_merge(
             $container->getParameter('kernel.events'),
-            \array_flip($events)
+            array_flip($events)
         ));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RegisterEventPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RegisterEventPass.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RegisterEventPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $events = [];
+        foreach (\array_keys($container->findTaggedServiceIds('kernel.event')) as $eventServiceId) {
+            $events[$container->getDefinition($eventServiceId)->getClass()] = $eventServiceId;
+        }
+
+        $container->setParameter('kernel.events', \array_merge(
+            $container->getParameter('kernel.events'),
+            \array_flip($events)
+        ));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -190,6 +190,7 @@ use Symfony\Component\Yaml\Yaml;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\CallbackInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -227,6 +228,7 @@ class FrameworkExtension extends Extension
         $loader->load('services.php');
         $loader->load('fragment_renderer.php');
         $loader->load('error_renderer.php');
+        $loader->load('events.php');
 
         if (ContainerBuilder::willBeAvailable('psr/event-dispatcher', PsrEventDispatcherInterface::class, ['symfony/framework-bundle'])) {
             $container->setAlias(PsrEventDispatcherInterface::class, 'event_dispatcher');
@@ -548,6 +550,8 @@ class FrameworkExtension extends Extension
             ->addTag('mime.mime_type_guesser');
         $container->registerForAutoconfiguration(LoggerAwareInterface::class)
             ->addMethodCall('setLogger', [new Reference('logger')]);
+        $container->registerForAutoconfiguration(Event::class)
+            ->addTag('kernel.event');
 
         $container->registerAttributeForAutoconfiguration(AsEventListener::class, static function (ChildDefinition $definition, AsEventListener $attribute): void {
             $definition->addTag('kernel.event_listener', get_object_vars($attribute));

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -19,6 +19,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilder
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\DataCollectorTranslatorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\LoggingTranslatorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RegisterEventPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RemoveUnusedSessionMarshallingHandlerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\SessionPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TestServiceContainerRealRefPass;
@@ -160,6 +161,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new RegisterReverseContainerPass(false), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new RemoveUnusedSessionMarshallingHandlerPass());
         $container->addCompilerPass(new SessionPass());
+        $container->addCompilerPass(new RegisterEventPass());
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 2);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/events.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/events.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\HttpKernel\Event\ControllerArgumentsEvent;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\Security\Core\Event\AuthenticationEvent;
+use Symfony\Component\Security\Core\Event\AuthenticationFailureEvent;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\Event\SwitchUserEvent;
+
+$filterExistingClass = static function (array $eventsMap = []): array {
+    return \array_filter($eventsMap, static function (string $eventClass): bool {
+        return \class_exists($eventClass);
+    });
+};
+
+return static function (ContainerConfigurator $container) use ($filterExistingClass) {
+    // list of *known* events to always include (if they exist)
+    $newEventsMap = [
+        'kernel.exception' => ExceptionEvent::class,
+        'kernel.request' => RequestEvent::class,
+        'kernel.response' => ResponseEvent::class,
+        'kernel.view' => ViewEvent::class,
+        'kernel.controller_arguments' => ControllerArgumentsEvent::class,
+        'kernel.controller' => ControllerEvent::class,
+        'kernel.terminate' => TerminateEvent::class,
+    ];
+
+    $eventsMap = [
+        'console.command' => ConsoleCommandEvent::class,
+        'console.terminate' => ConsoleTerminateEvent::class,
+        'console.error' => ConsoleErrorEvent::class,
+        'kernel.request' => GetResponseEvent::class,
+        'kernel.exception' => GetResponseForExceptionEvent::class,
+        'kernel.view' => GetResponseForControllerResultEvent::class,
+        'kernel.controller' => FilterControllerEvent::class,
+        'kernel.controller_arguments' => FilterControllerArgumentsEvent::class,
+        'kernel.response' => FilterResponseEvent::class,
+        'kernel.terminate' => PostResponseEvent::class,
+        'kernel.finish_request' => FinishRequestEvent::class,
+        'security.authentication.success' => AuthenticationEvent::class,
+        'security.authentication.failure' => AuthenticationFailureEvent::class,
+        'security.interactive_login' => InteractiveLoginEvent::class,
+        'security.switch_user' => SwitchUserEvent::class,
+    ];
+
+    // Replace old event with the new one if exist.
+    foreach ($filterExistingClass($newEventsMap) as $eventName => $newEventClass) {
+        if (isset($eventsMap[$eventName])) {
+            $eventsMap[$eventName] = $newEventClass;
+        }
+    }
+
+    $container->parameters()
+        ->set('kernel.events', $filterExistingClass($eventsMap));
+};

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/events.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/events.php
@@ -28,8 +28,8 @@ use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\Event\SwitchUserEvent;
 
 $filterExistingClass = static function (array $eventsMap = []): array {
-    return \array_filter($eventsMap, static function (string $eventClass): bool {
-        return \class_exists($eventClass);
+    return array_filter($eventsMap, static function (string $eventClass): bool {
+        return class_exists($eventClass);
     });
 };
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RegisterEventPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RegisterEventPassTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RegisterEventPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RegisterEventPassTest extends TestCase
+{
+    private const REGISTERED_EVENTS = [
+        'console.command' => 'Symfony\Component\Console\Event\ConsoleCommandEvent',
+        'console.terminate' => 'Symfony\Component\Console\Event\ConsoleTerminateEvent',
+    ];
+
+    private $container;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container = new ContainerBuilder();
+        $this->container->setParameter('kernel.events', self::REGISTERED_EVENTS);
+        $this->container->register('app.not_event.service', 'Acme\Store\NotEvent\Service');
+    }
+
+    public function testRegisterEventsOnlyFromContainer(): void
+    {
+        $registerEventPass = new RegisterEventPass();
+        $registerEventPass->process($this->container);
+
+        $this->assertSame(self::REGISTERED_EVENTS, $this->container->getParameter('kernel.events'));
+    }
+
+    public function testRegisterEventsFromServicesAndContainer(): void
+    {
+        $this->container->register('app.event.order_placed', 'Acme\Store\Event\OrderPlacedEvent')
+            ->addTag('kernel.event', ['template' => 'foo']);
+
+        $registerEventPass = new RegisterEventPass();
+        $registerEventPass->process($this->container);
+
+        $this->assertSame(
+            self::REGISTERED_EVENTS + ['app.event.order_placed' => 'Acme\Store\Event\OrderPlacedEvent'],
+            $this->container->getParameter('kernel.events')
+        );
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RegisterEventPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/RegisterEventPassTest.php
@@ -36,7 +36,7 @@ class RegisterEventPassTest extends TestCase
         $this->container->register('app.not_event.service', 'Acme\Store\NotEvent\Service');
     }
 
-    public function testRegisterEventsOnlyFromContainer(): void
+    public function testRegisterEventsOnlyFromContainer()
     {
         $registerEventPass = new RegisterEventPass();
         $registerEventPass->process($this->container);
@@ -44,7 +44,7 @@ class RegisterEventPassTest extends TestCase
         $this->assertSame(self::REGISTERED_EVENTS, $this->container->getParameter('kernel.events'));
     }
 
-    public function testRegisterEventsFromServicesAndContainer(): void
+    public function testRegisterEventsFromServicesAndContainer()
     {
         $this->container->register('app.event.order_placed', 'Acme\Store\Event\OrderPlacedEvent')
             ->addTag('kernel.event', ['template' => 'foo']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix [#885 (Maker-bundle)](https://github.com/symfony/maker-bundle/issues/885)
| License       | MIT
| Doc PR | N/A

  
This PR provides a way of registering events in the container in order to be reused anywhere.

I chose a new parameter named `kernel.events` to store them over a collection in the EventDispacher (too much work and BC break) or a service tag as events are, most likely, not meant to be services. 

As explained in the [issue](https://github.com/symfony/maker-bundle/issues/885) the command `bin/console make:subscriber` only lists, as Suggested events, a list of "listened" events from `$this->eventDispatcher->getListeners()`. 

With this new parameter, it would be easy to list every events that are available in a project.

Let me know what you think