### PR TITLE
[Console] Fix invalid PhpDoc for InputOption::VALUE_NEGATABLE

### DIFF
--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -42,7 +42,7 @@ class InputOption
     public const VALUE_IS_ARRAY = 8;
 
     /**
-     * The option accepts multiple values (e.g. --dir=/foo --dir=/bar).
+     * The option may have either positive or negative value (e.g. --ansi or --no-ansi).
      */
     public const VALUE_NEGATABLE = 16;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |