### PR TITLE
Remove always-true requirement

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
@@ -122,9 +122,6 @@ class SessionHandlerProxyTest extends TestCase
         $this->proxy->gc(86400);
     }
 
-    /**
-     * @requires PHPUnit 5.1
-     */
     public function testValidateId()
     {
         $mock = $this->createMock(TestSessionHandler::class);
@@ -137,9 +134,6 @@ class SessionHandlerProxyTest extends TestCase
         $this->assertTrue($this->proxy->validateId('id'));
     }
 
-    /**
-     * @requires PHPUnit 5.1
-     */
     public function testUpdateTimestamp()
     {
         $mock = $this->createMock(TestSessionHandler::class);

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorTest.php
@@ -148,9 +148,6 @@ class PropertyAccessorTest extends TestCase
         $this->propertyAccessor->getValue(new UninitializedProperty(), 'uninitialized');
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testGetValueThrowsExceptionIfUninitializedPropertyWithGetter()
     {
         $this->expectException(AccessException::class);
@@ -159,9 +156,6 @@ class PropertyAccessorTest extends TestCase
         $this->propertyAccessor->getValue(new UninitializedPrivateProperty(), 'uninitialized');
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testGetValueThrowsExceptionIfUninitializedPropertyWithGetterOfAnonymousClass()
     {
         $this->expectException(AccessException::class);
@@ -179,9 +173,6 @@ class PropertyAccessorTest extends TestCase
         $this->propertyAccessor->getValue($object, 'uninitialized');
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testGetValueThrowsExceptionIfUninitializedPropertyWithGetterOfAnonymousStdClass()
     {
         $this->expectException(AccessException::class);
@@ -199,9 +190,6 @@ class PropertyAccessorTest extends TestCase
         $this->propertyAccessor->getValue($object, 'uninitialized');
     }
 
-    /**
-     * @requires PHP 7
-     */
     public function testGetValueThrowsExceptionIfUninitializedPropertyWithGetterOfAnonymousChildClass()
     {
         $this->expectException(AccessException::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


This requirement is always true for our version constraint 