### PR TITLE
[Validator] Expression language allow null

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntax.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntax.php
@@ -42,8 +42,8 @@ class ExpressionLanguageSyntax extends Constraint
         $this->allowedVariables = $allowedVariables ?? $this->allowedVariables;
         $this->allowNullAndEmptyString = $allowNullAndEmptyString ?? $this->allowNullAndEmptyString;
 
-        if (isset($options['allowNullAndEmptyString'])) {
-            trigger_deprecation('symfony/validator', '5.4', sprintf('The "allowNullAndEmptyString" option of the "%s" constraint is deprecated.', self::class));
+        if (!$this->allowNullAndEmptyString) {
+            trigger_deprecation('symfony/validator', '5.4', 'Not setting "allowNullAndEmptyString" of the "%s" constraint to "true" is deprecated.', __CLASS__);
         }
     }
 

--- a/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntax.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntax.php
@@ -43,7 +43,7 @@ class ExpressionLanguageSyntax extends Constraint
         $this->allowNullAndEmptyString = $allowNullAndEmptyString ?? $this->allowNullAndEmptyString;
 
         if (!$this->allowNullAndEmptyString) {
-            trigger_deprecation('symfony/validator', '5.4', 'Not setting "allowNullAndEmptyString" of the "%s" constraint to "true" is deprecated.', __CLASS__);
+            trigger_deprecation('symfony/validator', '5.4', 'Validating empty expressions with "%s" constraint is deprecated. Set "allowNullAndEmptyString" option to "true" instead and add explicit constraint like NotNull or NotBlank.', __CLASS__);
         }
     }
 

--- a/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntax.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntax.php
@@ -31,14 +31,20 @@ class ExpressionLanguageSyntax extends Constraint
     public $message = 'This value should be a valid expression.';
     public $service;
     public $allowedVariables;
+    public $allowNullAndEmptyString = false;
 
-    public function __construct(array $options = null, string $message = null, string $service = null, array $allowedVariables = null, array $groups = null, $payload = null)
+    public function __construct(array $options = null, string $message = null, string $service = null, array $allowedVariables = null, bool $allowNullAndEmptyString = null, array $groups = null, $payload = null)
     {
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;
         $this->service = $service ?? $this->service;
         $this->allowedVariables = $allowedVariables ?? $this->allowedVariables;
+        $this->allowNullAndEmptyString = $allowNullAndEmptyString ?? $this->allowNullAndEmptyString;
+
+        if (isset($options['allowNullAndEmptyString'])) {
+            trigger_deprecation('symfony/validator', '5.4', sprintf('The "allowNullAndEmptyString" option of the "%s" constraint is deprecated.', self::class));
+        }
     }
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntaxValidator.php
@@ -39,6 +39,10 @@ class ExpressionLanguageSyntaxValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, ExpressionLanguageSyntax::class);
         }
 
+        if (null === $expression || '' === $expression) {
+            return;
+        }
+
         if (!\is_string($expression)) {
             throw new UnexpectedValueException($expression, 'string');
         }

--- a/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntaxValidator.php
@@ -39,7 +39,7 @@ class ExpressionLanguageSyntaxValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, ExpressionLanguageSyntax::class);
         }
 
-        if (null === $expression || '' === $expression) {
+        if (true === $constraint->allowNullAndEmptyString && (null === $expression || '' === $expression)) {
             return;
         }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxTest.php
@@ -61,6 +61,7 @@ class ExpressionLanguageSyntaxTest extends TestCase
         [$aConstraint] = $metadata->properties['a']->getConstraints();
         self::assertNull($aConstraint->service);
         self::assertNull($aConstraint->allowedVariables);
+        self::assertFalse($aConstraint->allowNullAndEmptyString);
 
         [$bConstraint] = $metadata->properties['b']->getConstraints();
         self::assertSame('my_service', $bConstraint->service);
@@ -70,6 +71,9 @@ class ExpressionLanguageSyntaxTest extends TestCase
         [$cConstraint] = $metadata->properties['c']->getConstraints();
         self::assertSame(['foo', 'bar'], $cConstraint->allowedVariables);
         self::assertSame(['my_group'], $cConstraint->groups);
+
+        [$dConstraint] = $metadata->properties['d']->getConstraints();
+        self::assertTrue($dConstraint->allowNullAndEmptyString);
     }
 }
 
@@ -83,4 +87,7 @@ class ExpressionLanguageSyntaxDummy
 
     #[ExpressionLanguageSyntax(allowedVariables: ['foo', 'bar'], groups: ['my_group'])]
     private $c;
+
+    #[ExpressionLanguageSyntax(allowNullAndEmptyString: true)]
+    private $d;
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
@@ -65,4 +65,18 @@ class ExpressionLanguageSyntaxValidatorTest extends ConstraintValidatorTestCase
             ->setCode(ExpressionLanguageSyntax::EXPRESSION_LANGUAGE_SYNTAX_ERROR)
             ->assertRaised();
     }
+
+    public function testNullIsValid()
+    {
+        $this->validator->validate(null, new ExpressionLanguageSyntax());
+
+        $this->assertNoViolation();
+    }
+
+    public function testEmptyStringIsValid()
+    {
+        $this->validator->validate('', new ExpressionLanguageSyntax());
+
+        $this->assertNoViolation();
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
@@ -68,15 +68,37 @@ class ExpressionLanguageSyntaxValidatorTest extends ConstraintValidatorTestCase
 
     public function testNullIsValid()
     {
-        $this->validator->validate(null, new ExpressionLanguageSyntax());
+        $this->validator->validate(null, new ExpressionLanguageSyntax([
+            'allowNullAndEmptyString' => true,
+        ]));
 
         $this->assertNoViolation();
     }
 
+    public function testNullWithoutAllowOptionIsNotValid()
+    {
+        $this->expectExceptionMessage('Expected argument of type "string", "null" given');
+
+        $this->validator->validate(null, new ExpressionLanguageSyntax());
+    }
+
     public function testEmptyStringIsValid()
+    {
+        $this->validator->validate('', new ExpressionLanguageSyntax([
+            'allowNullAndEmptyString' => true,
+        ]));
+
+        $this->assertNoViolation();
+    }
+
+    public function testEmptyStringWithoutAllowOptionIsNotValid()
     {
         $this->validator->validate('', new ExpressionLanguageSyntax());
 
-        $this->assertNoViolation();
+        $this->buildViolation('This value should be a valid expression.')
+            ->setParameter('{{ syntax_error }}', '"Unexpected token "end of expression" of value "" around position 1."')
+            ->setInvalidValue('')
+            ->setCode(ExpressionLanguageSyntax::EXPRESSION_LANGUAGE_SYNTAX_ERROR)
+            ->assertRaised();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
@@ -75,6 +75,9 @@ class ExpressionLanguageSyntaxValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    /**
+     * @group legacy
+     */
     public function testNullWithoutAllowOptionIsNotValid()
     {
         $this->expectExceptionMessage('Expected argument of type "string", "null" given');
@@ -91,6 +94,9 @@ class ExpressionLanguageSyntaxValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    /**
+     * @group legacy
+     */
     public function testEmptyStringWithoutAllowOptionIsNotValid()
     {
         $this->validator->validate('', new ExpressionLanguageSyntax());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | 
| License       | MIT
| Doc PR        | 

Like other validators, ExpressionLanguageSyntax validator should be ignored when the value is null or receive an empty string, add NotNull or NotBlank if needed.