### PR TITLE
[PropertyAccess] bugfix dot in index in propertyPath

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -142,7 +142,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
         $parent = clone $this;
 
         --$parent->length;
-        if (substr($parent->pathAsString, -1) == ']') {
+        if (']' == substr($parent->pathAsString, -1)) {
             $parent->pathAsString = substr($parent->pathAsString, 0, strrpos($parent->pathAsString, '['));
         } else {
             $parent->pathAsString = substr($parent->pathAsString, 0, strrpos($parent->pathAsString, '.'));

--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -142,7 +142,11 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
         $parent = clone $this;
 
         --$parent->length;
-        $parent->pathAsString = substr($parent->pathAsString, 0, max(strrpos($parent->pathAsString, '.'), strrpos($parent->pathAsString, '[')));
+        if (substr($parent->pathAsString, -1) == ']') {
+            $parent->pathAsString = substr($parent->pathAsString, 0, strrpos($parent->pathAsString, '['));
+        } else {
+            $parent->pathAsString = substr($parent->pathAsString, 0, strrpos($parent->pathAsString, '.'));
+        }
         array_pop($parent->elements);
         array_pop($parent->isIndex);
 

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyPathTest.php
@@ -98,6 +98,13 @@ class PropertyPathTest extends TestCase
         $this->assertEquals(new PropertyPath('grandpa.parent'), $propertyPath->getParent());
     }
 
+    public function testGetParentWithDotInIndex()
+    {
+        $propertyPath = new PropertyPath('grandpa.parent[child-2.0]');
+
+        $this->assertEquals(new PropertyPath('grandpa.parent'), $propertyPath->getParent());
+    }
+
     public function testGetParentWhenThereIsNoParent()
     {
         $propertyPath = new PropertyPath('path');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

If use a dot in the index of the property path, getParent() doesn't work.