### PR TITLE
[HttpKernel] Fix compatibility with Symfony6

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
@@ -146,6 +146,7 @@ return static function (ContainerConfigurator $container) {
         ->set('session_listener', SessionListener::class)
             ->args([
                 service_locator([
+                    'session_factory' => service('session.factory')->ignoreOnInvalid(),
                     'session' => service('.session.do-not-use')->ignoreOnInvalid(),
                     'initialized_session' => service('.session.do-not-use')->ignoreOnUninitialized(),
                     'logger' => service('logger')->ignoreOnInvalid(),

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.php
@@ -38,6 +38,7 @@ return static function (ContainerConfigurator $container) {
         ->set('test.session.listener', TestSessionListener::class)
             ->args([
                 service_locator([
+                    'session_factory' => service('session.factory')->ignoreOnInvalid(),
                     'session' => service('.session.do-not-use')->ignoreOnInvalid(),
                 ]),
             ])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -581,7 +581,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertNull($container->getDefinition('session.storage.factory.php_bridge')->getArgument(0));
         $this->assertSame('session.handler.native_file', (string) $container->getAlias('session.handler'));
 
-        $expected = ['session', 'initialized_session', 'logger', 'session_collector'];
+        $expected = ['session_factory', 'session', 'initialized_session', 'logger', 'session_collector'];
         $this->assertEquals($expected, array_keys($container->getDefinition('session_listener')->getArgument(0)->getValues()));
         $this->assertFalse($container->getDefinition('session.storage.factory.native')->getArgument(3));
     }
@@ -600,7 +600,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertNull($container->getDefinition('session.storage.php_bridge')->getArgument(0));
         $this->assertSame('session.handler.native_file', (string) $container->getAlias('session.handler'));
 
-        $expected = ['session', 'initialized_session', 'logger', 'session_collector'];
+        $expected = ['session_factory', 'session', 'initialized_session', 'logger', 'session_collector'];
         $this->assertEquals($expected, array_keys($container->getDefinition('session_listener')->getArgument(0)->getValues()));
         $this->assertFalse($container->getDefinition('session.storage.factory.native')->getArgument(3));
     }
@@ -1618,7 +1618,7 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainerFromFile('session_cookie_secure_auto');
 
-        $expected = ['session', 'initialized_session', 'logger', 'session_collector'];
+        $expected = ['session_factory', 'session', 'initialized_session', 'logger', 'session_collector'];
         $this->assertEquals($expected, array_keys($container->getDefinition('session_listener')->getArgument(0)->getValues()));
     }
 
@@ -1631,7 +1631,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $container = $this->createContainerFromFile('session_cookie_secure_auto_legacy');
 
-        $expected = ['session', 'initialized_session', 'logger', 'session_collector', 'session_storage', 'request_stack'];
+        $expected = ['session_factory', 'session', 'initialized_session', 'logger', 'session_collector', 'session_storage', 'request_stack'];
         $this->assertEquals($expected, array_keys($container->getDefinition('session_listener')->getArgument(0)->getValues()));
     }
 

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -58,6 +58,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
 
         $request = $event->getRequest();
         if (!$request->hasSession()) {
+            // This variable prevents calling `$this->getSession()` twice in case the Request (and the below factory) is cloned
             $sess = null;
             $request->setSessionFactory(function () use (&$sess) { return $sess ?? $sess = $this->getSession(); });
         }

--- a/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
@@ -53,10 +53,14 @@ class SessionListener extends AbstractSessionListener
 
     protected function getSession(): ?SessionInterface
     {
-        if (!$this->container->has('session')) {
-            return null;
+        if ($this->container->has('session')) {
+            return $this->container->get('session');
         }
 
-        return $this->container->get('session');
+        if ($this->container->has('session_factory')) {
+            return $this->container->get('session_factory')->createSession();
+        }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
@@ -33,10 +33,14 @@ class TestSessionListener extends AbstractTestSessionListener
 
     protected function getSession(): ?SessionInterface
     {
-        if (!$this->container->has('session')) {
-            return null;
+        if ($this->container->has('session')) {
+            return $this->container->get('session');
         }
 
-        return $this->container->get('session');
+        if ($this->container->has('session_factory')) {
+            return $this->container->get('session_factory')->createSession();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The `session` service will be removed in FrameworkBundle 6, this PR make sure the session listener 5.4 will be compatible with FrameworkBundle 6.0