### PR TITLE
[VarDumper] Don't pass null to parse_url()

### DIFF
--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -71,7 +71,7 @@ class VarDumper
                 $dumper = new CliDumper();
                 break;
             case 'server' === $format:
-            case 'tcp' === parse_url($format, \PHP_URL_SCHEME):
+            case $format && 'tcp' === parse_url($format, \PHP_URL_SCHEME):
                 $host = 'server' === $format ? $_SERVER['VAR_DUMPER_SERVER'] ?? '127.0.0.1:9912' : $format;
                 $dumper = \in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) ? new CliDumper() : new HtmlDumper();
                 $dumper = new ServerDumper($host, $dumper, self::getDefaultContextProviders());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR fixes a deprecation warning on PHP 8.1:

> parse_url(): Passing null to parameter `#1` ($url) of type string is deprecated