### PR TITLE
Fake PHP version on PHP nightly builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -216,6 +216,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          echo "::group::fake PHP version"
+          composer config platform.php 8.0.99
           echo "::group::composer update"
           composer update --no-progress --ansi
           echo "::endgroup::"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

These two lines have been removed in #41282. Unfortunately, we still need them because people set upper boundaries in their composer.json. Without lying to composer, we cannot install dependencies on PHP 8.1 (yet).