### PR TITLE
[Cache] Removed depreacted code

### DIFF
--- a/src/Symfony/Component/Cache/DependencyInjection/CacheCollectorPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CacheCollectorPass.php
@@ -26,31 +26,16 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class CacheCollectorPass implements CompilerPassInterface
 {
-    private $dataCollectorCacheId;
-    private $cachePoolTag;
-    private $cachePoolRecorderInnerSuffix;
-
-    public function __construct(string $dataCollectorCacheId = 'data_collector.cache', string $cachePoolTag = 'cache.pool', string $cachePoolRecorderInnerSuffix = '.recorder_inner')
-    {
-        if (0 < \func_num_args()) {
-            trigger_deprecation('symfony/cache', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
-        }
-
-        $this->dataCollectorCacheId = $dataCollectorCacheId;
-        $this->cachePoolTag = $cachePoolTag;
-        $this->cachePoolRecorderInnerSuffix = $cachePoolRecorderInnerSuffix;
-    }
-
     /**
      * {@inheritdoc}
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition($this->dataCollectorCacheId)) {
+        if (!$container->hasDefinition('data_collector.cache')) {
             return;
         }
 
-        foreach ($container->findTaggedServiceIds($this->cachePoolTag) as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds('cache.pool') as $id => $attributes) {
             $poolName = $attributes[0]['name'] ?? $id;
 
             $this->addToCollector($id, $poolName, $container);
@@ -64,13 +49,13 @@ class CacheCollectorPass implements CompilerPassInterface
             return;
         }
 
-        $collectorDefinition = $container->getDefinition($this->dataCollectorCacheId);
+        $collectorDefinition = $container->getDefinition('data_collector.cache');
         $recorder = new Definition(is_subclass_of($definition->getClass(), TagAwareAdapterInterface::class) ? TraceableTagAwareAdapter::class : TraceableAdapter::class);
         $recorder->setTags($definition->getTags());
         if (!$definition->isPublic() || !$definition->isPrivate()) {
             $recorder->setPublic($definition->isPublic());
         }
-        $recorder->setArguments([new Reference($innerId = $id.$this->cachePoolRecorderInnerSuffix)]);
+        $recorder->setArguments([new Reference($innerId = $id.'.recorder_inner')]);
 
         $definition->setTags([]);
         $definition->setPublic(false);

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolClearerPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolClearerPass.php
@@ -20,17 +20,6 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class CachePoolClearerPass implements CompilerPassInterface
 {
-    private $cachePoolClearerTag;
-
-    public function __construct(string $cachePoolClearerTag = 'cache.pool.clearer')
-    {
-        if (0 < \func_num_args()) {
-            trigger_deprecation('symfony/cache', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
-        }
-
-        $this->cachePoolClearerTag = $cachePoolClearerTag;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -38,7 +27,7 @@ class CachePoolClearerPass implements CompilerPassInterface
     {
         $container->getParameterBag()->remove('cache.prefix.seed');
 
-        foreach ($container->findTaggedServiceIds($this->cachePoolClearerTag) as $id => $attr) {
+        foreach ($container->findTaggedServiceIds('cache.pool.clearer') as $id => $attr) {
             $clearer = $container->getDefinition($id);
             $pools = [];
             foreach ($clearer->getArgument(0) as $name => $ref) {

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -28,33 +28,6 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class CachePoolPass implements CompilerPassInterface
 {
-    private $cachePoolTag;
-    private $kernelResetTag;
-    private $cacheClearerId;
-    private $cachePoolClearerTag;
-    private $cacheSystemClearerId;
-    private $cacheSystemClearerTag;
-    private $reverseContainerId;
-    private $reversibleTag;
-    private $messageHandlerId;
-
-    public function __construct(string $cachePoolTag = 'cache.pool', string $kernelResetTag = 'kernel.reset', string $cacheClearerId = 'cache.global_clearer', string $cachePoolClearerTag = 'cache.pool.clearer', string $cacheSystemClearerId = 'cache.system_clearer', string $cacheSystemClearerTag = 'kernel.cache_clearer', string $reverseContainerId = 'reverse_container', string $reversibleTag = 'container.reversible', string $messageHandlerId = 'cache.early_expiration_handler')
-    {
-        if (0 < \func_num_args()) {
-            trigger_deprecation('symfony/cache', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
-        }
-
-        $this->cachePoolTag = $cachePoolTag;
-        $this->kernelResetTag = $kernelResetTag;
-        $this->cacheClearerId = $cacheClearerId;
-        $this->cachePoolClearerTag = $cachePoolClearerTag;
-        $this->cacheSystemClearerId = $cacheSystemClearerId;
-        $this->cacheSystemClearerTag = $cacheSystemClearerTag;
-        $this->reverseContainerId = $reverseContainerId;
-        $this->reversibleTag = $reversibleTag;
-        $this->messageHandlerId = $messageHandlerId;
-    }
-
     /**
      * {@inheritdoc}
      */
@@ -78,7 +51,7 @@ class CachePoolPass implements CompilerPassInterface
             'early_expiration_message_bus',
             'reset',
         ];
-        foreach ($container->findTaggedServiceIds($this->cachePoolTag) as $id => $tags) {
+        foreach ($container->findTaggedServiceIds('cache.pool') as $id => $tags) {
             $adapter = $pool = $container->getDefinition($id);
             if ($pool->isAbstract()) {
                 continue;
@@ -87,7 +60,7 @@ class CachePoolPass implements CompilerPassInterface
             while ($adapter instanceof ChildDefinition) {
                 $adapter = $container->findDefinition($adapter->getParent());
                 $class = $class ?: $adapter->getClass();
-                if ($t = $adapter->getTag($this->cachePoolTag)) {
+                if ($t = $adapter->getTag('cache.pool')) {
                     $tags[0] += $t[0];
                 }
             }
@@ -129,7 +102,7 @@ class CachePoolPass implements CompilerPassInterface
                     while ($adapter instanceof ChildDefinition) {
                         $adapter = $container->findDefinition($adapter->getParent());
                         $chainedClass = $chainedClass ?: $adapter->getClass();
-                        if ($t = $adapter->getTag($this->cachePoolTag)) {
+                        if ($t = $adapter->getTag('cache.pool')) {
                             $chainedTags[0] += $t[0];
                         }
                     }
@@ -167,19 +140,19 @@ class CachePoolPass implements CompilerPassInterface
                     // no-op
                 } elseif ('reset' === $attr) {
                     if ($tags[0][$attr]) {
-                        $pool->addTag($this->kernelResetTag, ['method' => $tags[0][$attr]]);
+                        $pool->addTag('kernel.reset', ['method' => $tags[0][$attr]]);
                     }
                 } elseif ('early_expiration_message_bus' === $attr) {
                     $needsMessageHandler = true;
                     $pool->addMethodCall('setCallbackWrapper', [(new Definition(EarlyExpirationDispatcher::class))
                         ->addArgument(new Reference($tags[0]['early_expiration_message_bus']))
-                        ->addArgument(new Reference($this->reverseContainerId))
+                        ->addArgument(new Reference('reverse_container'))
                         ->addArgument((new Definition('callable'))
                             ->setFactory([new Reference($id), 'setCallbackWrapper'])
                             ->addArgument(null)
                         ),
                     ]);
-                    $pool->addTag($this->reversibleTag);
+                    $pool->addTag('container.reversible');
                 } elseif ('namespace' !== $attr || ArrayAdapter::class !== $class) {
                     $argument = $tags[0][$attr];
 
@@ -193,7 +166,7 @@ class CachePoolPass implements CompilerPassInterface
                 unset($tags[0][$attr]);
             }
             if (!empty($tags[0])) {
-                throw new InvalidArgumentException(sprintf('Invalid "%s" tag for service "%s": accepted attributes are "clearer", "provider", "name", "namespace", "default_lifetime", "early_expiration_message_bus" and "reset", found "%s".', $this->cachePoolTag, $id, implode('", "', array_keys($tags[0]))));
+                throw new InvalidArgumentException(sprintf('Invalid "cache.pool" tag for service "%s": accepted attributes are "clearer", "provider", "name", "namespace", "default_lifetime", "early_expiration_message_bus" and "reset", found "%s".', $id, implode('", "', array_keys($tags[0]))));
             }
 
             if (null !== $clearer) {
@@ -204,14 +177,14 @@ class CachePoolPass implements CompilerPassInterface
         }
 
         if (!$needsMessageHandler) {
-            $container->removeDefinition($this->messageHandlerId);
+            $container->removeDefinition('cache.early_expiration_handler');
         }
 
-        $notAliasedCacheClearerId = $this->cacheClearerId;
-        while ($container->hasAlias($this->cacheClearerId)) {
-            $this->cacheClearerId = (string) $container->getAlias($this->cacheClearerId);
+        $notAliasedCacheClearerId = $aliasedCacheClearerId = 'cache.global_clearer';
+        while ($container->hasAlias('cache.global_clearer')) {
+            $aliasedCacheClearerId = (string) $container->getAlias('cache.global_clearer');
         }
-        if ($container->hasDefinition($this->cacheClearerId)) {
+        if ($container->hasDefinition($aliasedCacheClearerId)) {
             $clearers[$notAliasedCacheClearerId] = $allPools;
         }
 
@@ -222,10 +195,10 @@ class CachePoolPass implements CompilerPassInterface
             } else {
                 $clearer->setArgument(0, $pools);
             }
-            $clearer->addTag($this->cachePoolClearerTag);
+            $clearer->addTag('cache.pool.clearer');
 
-            if ($this->cacheSystemClearerId === $id) {
-                $clearer->addTag($this->cacheSystemClearerTag);
+            if ('cache.system_clearer' === $id) {
+                $clearer->addTag('kernel.cache_clearer');
             }
         }
 

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPrunerPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPrunerPass.php
@@ -23,31 +23,18 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class CachePoolPrunerPass implements CompilerPassInterface
 {
-    private $cacheCommandServiceId;
-    private $cachePoolTag;
-
-    public function __construct(string $cacheCommandServiceId = 'console.command.cache_pool_prune', string $cachePoolTag = 'cache.pool')
-    {
-        if (0 < \func_num_args()) {
-            trigger_deprecation('symfony/cache', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
-        }
-
-        $this->cacheCommandServiceId = $cacheCommandServiceId;
-        $this->cachePoolTag = $cachePoolTag;
-    }
-
     /**
      * {@inheritdoc}
      */
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition($this->cacheCommandServiceId)) {
+        if (!$container->hasDefinition('console.command.cache_pool_prune')) {
             return;
         }
 
         $services = [];
 
-        foreach ($container->findTaggedServiceIds($this->cachePoolTag) as $id => $tags) {
+        foreach ($container->findTaggedServiceIds('cache.pool') as $id => $tags) {
             $class = $container->getParameterBag()->resolveValue($container->getDefinition($id)->getClass());
 
             if (!$reflection = $container->getReflectionClass($class)) {
@@ -59,6 +46,6 @@ class CachePoolPrunerPass implements CompilerPassInterface
             }
         }
 
-        $container->getDefinition($this->cacheCommandServiceId)->replaceArgument(0, new IteratorArgument($services));
+        $container->getDefinition('console.command.cache_pool_prune')->replaceArgument(0, new IteratorArgument($services));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

This remove deprecated code from Cache.

Is it necessary for the Changelog or Upgrade.md that the classes are not configurable anymore?