### PR TITLE
[EventDispatcher] Removed deprecated code

### DIFF
--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/AddEventAliasesPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/AddEventAliasesPass.php
@@ -22,24 +22,18 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class AddEventAliasesPass implements CompilerPassInterface
 {
     private $eventAliases;
-    private $eventAliasesParameter;
 
-    public function __construct(array $eventAliases, string $eventAliasesParameter = 'event_dispatcher.event_aliases')
+    public function __construct(array $eventAliases)
     {
-        if (1 < \func_num_args()) {
-            trigger_deprecation('symfony/event-dispatcher', '5.3', 'Configuring "%s" is deprecated.', __CLASS__);
-        }
-
         $this->eventAliases = $eventAliases;
-        $this->eventAliasesParameter = $eventAliasesParameter;
     }
 
     public function process(ContainerBuilder $container): void
     {
-        $eventAliases = $container->hasParameter($this->eventAliasesParameter) ? $container->getParameter($this->eventAliasesParameter) : [];
+        $eventAliases = $container->hasParameter('event_dispatcher.event_aliases') ? $container->getParameter('event_dispatcher.event_aliases') : [];
 
         $container->setParameter(
-            $this->eventAliasesParameter,
+            'event_dispatcher.event_aliases',
             array_merge($eventAliases, $this->eventAliases)
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

This remove deprecated code from EventDispatcher.

The `LegacyEventDispatcherProxy` is removed in #41304.

Is it necessary to update the Changelog or Upgrade.md that the classes are not configurable any more?