### PR TITLE
[Ldap] Removed deprecated code

### DIFF
--- a/src/Symfony/Component/Ldap/CHANGELOG.md
+++ b/src/Symfony/Component/Ldap/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+6.0
+---
+
+ * Removed `LdapUser::getUsername()` method, use `getUserIdentifier()` instead
+ * Removed `LdapUserProvider::loadUserByUsername()` method, use `loadUserByIdentifier()` instead
+
 5.3
 ---
 

--- a/src/Symfony/Component/Ldap/Security/LdapUser.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUser.php
@@ -71,16 +71,6 @@ class LdapUser implements UserInterface, PasswordAuthenticatedUserInterface, Equ
         return null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getUsername(): string
-    {
-        trigger_deprecation('symfony/ldap', '5.3', 'Method "%s()" is deprecated and will be removed in 6.0, use getUserIdentifier() instead.', __METHOD__);
-
-        return $this->username;
-    }
-
     public function getUserIdentifier(): string
     {
         return $this->username;

--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -62,16 +62,6 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
         $this->extraFields = $extraFields;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function loadUserByUsername(string $username)
-    {
-        trigger_deprecation('symfony/ldap', '5.3', 'Method "%s()" is deprecated, use loadUserByIdentifier() instead.', __METHOD__);
-
-        return $this->loadUserByIdentifier($username);
-    }
-
     public function loadUserByIdentifier(string $identifier): UserInterface
     {
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This remove deprecated code from Ldap.

Do I have to update the upgrade log for the two method deletions or is it unnecessary because it's mentioned in the security?