### PR TITLE
Remove age and date headers from cached response

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -356,7 +356,8 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
 
         $this->record($request, 'fresh');
 
-        $entry->headers->set('Age', $entry->getAge());
+        $entry->headers->remove('Age');
+        $entry->headers->remove('Date');
 
         return $entry;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Suppose you are generating a response like this:

```php
public function __invoke(): Response
{
    $response = new Response('Hello World!');

    $response->setPublic();
    $response->setMaxAge(10);
    $response->setSharedMaxAge(31536000);

    return $response;
}
```

i.e. the response should be cacheable by a public cache for up to 1 year and it should be cacheable by a private cache (the browser's cache) for up to 10 seconds. The expected behaviour for this resource would be the following:

1. Client requests the resource.
2. Server responds with `Cache-Control: max-age=10, public, s-maxage=31536000`.
3. Client puts resource into cache. ✔️ 
4. Client accesses the resource again within 10 seconds of the original request.
5. Client checks its own cache freshness and loads the resource from the cache.
6. Client accesses the resource after more than 10 seconds of the original request.
7. Client checks its own cache freshness and sends a request to the server.
8. Server responds with `Cache-Control: max-age=10, public, s-maxage=31536000`.
9. Client puts the resource into cache. ✔️ 
10. Client accesses the resource again within 10 seconds of the previous request.
11. Client checks its own cache freshness and loads the resource from the cache.
12. …

However, when using the `Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache` the following actually happens:

1. Client requests the resource.
2. Server responds with `Cache-Control: max-age=10, public, s-maxage=31536000`.
3. Client puts resource into cache. ✔️ 
4. Client accesses the resource again within 10 seconds of the original request.
5. Client checks its own cache freshness and loads the resource from the cache.
6. Client accesses the resource after more than 10 seconds of the original request.
7. Client checks its own cache freshness and sends a request to the server.
8. Server responds with `Cache-Control: max-age=10, public, s-maxage=31536000`.
9. Client **does not put the resource into cache**. ❌
10. Client accesses the resource again within 10 seconds of the previous request.
11. Client checks its own cache freshness and sends a request to the server.
12. Server responds with `Cache-Control: max-age=10, public, s-maxage=31536000`.
13. Client **does not put the resource into cache**. ❌
14. Client accesses the resource again within 10 seconds of the previous request.
15. Server responds with `Cache-Control: max-age=10, public, s-maxage=31536000`.
16. Client **does not put the resource into cache**. ❌
17. …

The reason why the browser does not put the resource into the cache anymore is because of the contents of the `Age` and `Date` header that the `HttpCache` responds with. The `Date` header of the original request is actually stored in the cache and then restored. The `Age` header will then be greater than `0` due to the value of the `Date` header, which now lies somewhere in the past (the date where the resource was put into the cache originally).

This will prevent private caches from ever caching the resource again, once the `Date` (and `Age`) is past `max-age`. In order to fix this, the `Age` response header needs to be removed and the `Date` header must need to be set to the current date (which Symfony automatically does for every response).

The `Date` header is never supposed to be in the past at all, I think? The client needs to be able to use the `Date` from the server, in order to check against an `Expires` header - or to check against its own cached resources for example.

This PR fixes this behaviour by always removing the `Age` and `Date` headers from any response created from out of the cache.

Browser behaviour before:

<img src="https://user-images.githubusercontent.com/4970961/119174739-de0db880-ba60-11eb-921c-db77e86f2615.png" width="502">

Browser behaviour after:

<img src="https://user-images.githubusercontent.com/4970961/119174793-f251b580-ba60-11eb-8420-516aa253f9ed.png" width="502">

* First request is the initial request.
* Second request is within `max-age`.
* Third request is after `max-age`.
* Fourth request is within `max-age` of the third request.

