### PR TITLE
[Routing] Remove legacy group from Doctrine Annotations test

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Annotation/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/Annotation/RouteTest.php
@@ -74,17 +74,16 @@ class RouteTest extends TestCase
      * @requires PHP 8
      * @dataProvider getValidParameters
      */
-    public function testRouteParameters(string $methodName, string $getter, $expectedReturn)
+    public function testLoadFromAttribute(string $methodName, string $getter, $expectedReturn)
     {
         $route = $this->getMethodAnnotation($methodName, true);
         $this->assertEquals($route->$getter(), $expectedReturn);
     }
 
     /**
-     * @group legacy
      * @dataProvider getValidParameters
      */
-    public function testLegacyRouteParameters(string $methodName, string $getter, $expectedReturn)
+    public function testLoadFromDoctrineAnnotation(string $methodName, string $getter, $expectedReturn)
     {
         $route = $this->getMethodAnnotation($methodName, false);
         $this->assertEquals($route->$getter(), $expectedReturn);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

A test case in `RoutingTest` is incorrectly flagged as legacy. I've removed the legacy group and changed the wording of the test cases to make clear what they're actually testing.