### PR TITLE
[AMQP-MESSENGER] Add type property in amqp envelope.

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpReceiverTest.php
@@ -78,6 +78,7 @@ class AmqpReceiverTest extends TestCase
     {
         $envelope = $this->createMock(\AMQPEnvelope::class);
         $envelope->method('getBody')->willReturn('{"message": "Hi"}');
+        $envelope->method('getType')->willReturn('event.microservice.dummy.created');
         $envelope->method('getHeaders')->willReturn([
             'type' => DummyMessage::class,
         ]);

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpTransportTest.php
@@ -44,7 +44,7 @@ class AmqpTransportTest extends TestCase
         $amqpEnvelope->method('getBody')->willReturn('body');
         $amqpEnvelope->method('getHeaders')->willReturn(['my' => 'header']);
 
-        $serializer->method('decode')->with(['body' => 'body', 'headers' => ['my' => 'header']])->willReturn(new Envelope($decodedMessage));
+        $serializer->method('decode')->with(['body' => 'body', 'headers' => ['my' => 'header'], 'type' => null])->willReturn(new Envelope($decodedMessage));
         $connection->method('getQueueNames')->willReturn(['queueName']);
         $connection->method('get')->with('queueName')->willReturn($amqpEnvelope);
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
@@ -72,6 +72,7 @@ class AmqpReceiver implements QueueReceiverInterface, MessageCountAwareInterface
             $envelope = $this->serializer->decode([
                 'body' => false === $body ? '' : $body, // workaround https://github.com/pdezwart/php-amqp/issues/351
                 'headers' => $amqpEnvelope->getHeaders(),
+                'type' => $amqpEnvelope->getType(),
             ]);
         } catch (MessageDecodingFailedException $exception) {
             // invalid message of some type

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpSender.php
@@ -48,13 +48,22 @@ class AmqpSender implements SenderInterface
 
         /** @var AmqpStamp|null $amqpStamp */
         $amqpStamp = $envelope->last(AmqpStamp::class);
+        $attributes = [];
         if (isset($encodedMessage['headers']['Content-Type'])) {
             $contentType = $encodedMessage['headers']['Content-Type'];
             unset($encodedMessage['headers']['Content-Type']);
 
             if (!$amqpStamp || !isset($amqpStamp->getAttributes()['content_type'])) {
-                $amqpStamp = AmqpStamp::createWithAttributes(['content_type' => $contentType], $amqpStamp);
+                $attributes['content_type'] = $contentType;
             }
+        }
+
+        if (isset($encodedMessage['type'])) {
+            $attributes['type'] = $encodedMessage['type'];
+        }
+
+        if (!empty($attributes)) {
+            $amqpStamp = AmqpStamp::createWithAttributes($attributes, $amqpStamp);
         }
 
         $amqpReceivedStamp = $envelope->last(AmqpReceivedStamp::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| License       | MIT

Hello, I would like to add "type" for decode and encode envelop in custom Messenger Serializer. In RabbitMQ documentation we have "type" property and I think this is the best way to get correct type of message instead of headers['type'].

https://www.rabbitmq.com/publishers.html#:~:text=The%20type%20property%20on%20messages,kind%20of%20message%20that%20is.&text=The%20value%20can%20be%20any,plugins%20to%20use%20and%20interpret.
