### PR TITLE
[Messenger] Fix `ErrorDetailsStamp` denormalization

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/ErrorDetailsStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/ErrorDetailsStamp.php
@@ -23,7 +23,7 @@ final class ErrorDetailsStamp implements StampInterface
     /** @var string */
     private $exceptionClass;
 
-    /** @var int|mixed */
+    /** @var int|string */
     private $exceptionCode;
 
     /** @var string */
@@ -33,7 +33,7 @@ final class ErrorDetailsStamp implements StampInterface
     private $flattenException;
 
     /**
-     * @param int|mixed $exceptionCode
+     * @param int|string $exceptionCode
      */
     public function __construct(string $exceptionClass, $exceptionCode, string $exceptionMessage, FlattenException $flattenException = null)
     {

--- a/src/Symfony/Component/Messenger/Tests/Stamp/StringErrorCodeException.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/StringErrorCodeException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\Messenger\Tests\Stamp;
+
+class StringErrorCodeException extends \Exception
+{
+    public function __construct(string $message, string $code)
+    {
+        parent::__construct($message);
+        $this->code = $code;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2.1+ <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #39689 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

Fixes #39689

Trouble is, tests did not cover cases where a `PropertyTypeExtractorInterface` is used, in conjunction with a variable type such as `int|mixed`

IMO this does not really fix the issue with the Serializer component, it being that if we have mixed, we should really be allowing anything. Another point is whether that type makes sense and shouldn't be just `mixed` instead.

I've changed it to `int|string` as in that context, those are the possible types, string being rather rare. I suspect a PDO Exception as I've had those in the past, there was a similar bug with FlattenException. This was a nightmare to debug/reproduce because it happened once a fortnight in production.