### PR TITLE
Make Mailgun Header compatible with other Bridges

### DIFF
--- a/UPGRADE-5.1.md
+++ b/UPGRADE-5.1.md
@@ -80,7 +80,6 @@ Inflector
 Mailer
 ------
 
- * Deprecated passing Mailgun headers without their "h:" prefix.
  * Deprecated the `SesApiTransport` class. It has been replaced by SesApiAsyncAwsTransport Run `composer require async-aws/ses` to use the new classes.
  * Deprecated the `SesHttpTransport` class. It has been replaced by SesHttpAsyncAwsTransport Run `composer require async-aws/ses` to use the new classes.
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/CHANGELOG.md
@@ -1,7 +1,13 @@
 CHANGELOG
 =========
 
+5.2
+---
+
+ * Not prefixing headers with "h:" is no more deprecated
+
 5.1.0
+-----
 
  * Not prefixing headers with "h:" is deprecated.
 

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Tests/Transport/MailgunApiTransportTest.php
@@ -214,6 +214,7 @@ class MailgunApiTransportTest extends TestCase
         $json = json_encode(['foo' => 'bar']);
         $email = new Email();
         $email->getHeaders()->addTextHeader('h:X-Mailgun-Variables', $json);
+        $email->getHeaders()->addTextHeader('Custom-Header', 'value');
         $email->getHeaders()->add(new TagHeader('password-reset'));
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
@@ -223,9 +224,10 @@ class MailgunApiTransportTest extends TestCase
         $method = new \ReflectionMethod(MailgunApiTransport::class, 'getPayload');
         $method->setAccessible(true);
         $payload = $method->invoke($transport, $email, $envelope);
-
         $this->assertArrayHasKey('h:x-mailgun-variables', $payload);
         $this->assertEquals($json, $payload['h:x-mailgun-variables']);
+        $this->assertArrayHasKey('h:custom-header', $payload);
+        $this->assertEquals('value', $payload['h:custom-header']);
         $this->assertArrayHasKey('o:tag', $payload);
         $this->assertSame('password-reset', $payload['o:tag']);
         $this->assertArrayHasKey('v:Color', $payload);

--- a/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailgun/Transport/MailgunApiTransport.php
@@ -135,9 +135,7 @@ class MailgunApiTransport extends AbstractApiTransport
             if (\in_array($prefix, ['h:', 't:', 'o:', 'v:']) || \in_array($name, ['recipient-variables', 'template', 'amp-html'])) {
                 $headerName = $name;
             } else {
-                // fallback to prefix with "h:" to not break BC
                 $headerName = 'h:'.$name;
-                @trigger_error(sprintf('Not prefixing the Mailgun header name with "h:" is deprecated since Symfony  5.1. Use header name "%s" instead.', $headerName), \E_USER_DEPRECATED);
             }
 
             $payload[$headerName] = $header->getBodyAsString();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This revert deprecating passing a header without the required Mailgun `h:` prefix.
And makes the bridge compatible with other bridges.

See:
- https://github.com/symfony/symfony/pull/36148#discussion_r619232776
- https://github.com/symfony/symfony/pull/41308#discussion_r637197208
