### PR TITLE
[Console] [PHP 8.0] Add property promotion to commands

### DIFF
--- a/src/Symfony/Component/Console/Command/LazyCommand.php
+++ b/src/Symfony/Component/Console/Command/LazyCommand.php
@@ -22,18 +22,12 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class LazyCommand extends Command
 {
-    private $command;
-    private $isEnabled;
-
-    public function __construct(string $name, array $aliases, string $description, bool $isHidden, \Closure $commandFactory, ?bool $isEnabled = true)
+    public function __construct(string $name, array $aliases, string $description, bool $isHidden, private \Closure $command, private ?bool $isEnabled = true)
     {
         $this->setName($name)
             ->setAliases($aliases)
             ->setHidden($isHidden)
             ->setDescription($description);
-
-        $this->command = $commandFactory;
-        $this->isEnabled = $isEnabled;
     }
 
     public function ignoreValidationErrors(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Follow up to https://github.com/symfony/symfony/pull/41282

<br>

Hi, congrats on PHP 8 version as minimum!

Now we can use new features like promoted properties.
They're not breaking BC, as [they unwrap to its former property + param + assign syntax](https://wiki.php.net/rfc/constructor_promotion#desugaring).


This is just a demo for single class. 
Would you be interested in series of PRs to add promoted properies with PR per component?