### PR TITLE
Cleanup notifier CHANGELOG

### DIFF
--- a/src/Symfony/Component/Notifier/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/CHANGELOG.md
@@ -10,36 +10,30 @@ CHANGELOG
    to:
    `public function __construct(string $dsn)`
  * [BC BREAK] Remove `Dsn::fromString()` method
- * [BC BREAK] Changed the return type of `AbstractTransportFactory::getEndpoint()` from `?string` to `string`
- * Added `DSN::getRequiredOption` method which throws a new `MissingRequiredOptionException`.
+ * [BC BREAK] Change the return type of `AbstractTransportFactory::getEndpoint()` from `?string` to `string`
+ * Add `DSN::getRequiredOption` method which throws a new `MissingRequiredOptionException`
 
 5.2.0
 -----
 
- * [BC BREAK] The `TransportInterface::send()` and `AbstractTransport::doSend()` methods changed to return a `?SentMessage` instance instead of `void`.
- * The `EmailRecipientInterface` and `RecipientInterface` were introduced.
- * Added `email` and `phone` properties to `Recipient`.
- * [BC BREAK] Changed the type-hint of the `$recipient` argument in the `as*Message()` method
-   of `EmailNotificationInterface` and `SmsNotificationInterface` to `EmailRecipientInterface`
-   and `SmsRecipientInterface`.
- * [BC BREAK] Removed the `AdminRecipient`.
- * The `EmailRecipientInterface` and `SmsRecipientInterface` now extend the `RecipientInterface`.
- * The `EmailRecipient` and `SmsRecipient` were introduced.
- * [BC BREAK] Changed the type-hint of the `$recipient` argument in `NotifierInterface::send()`,
-   `Notifier::getChannels()`, `ChannelInterface::notifiy()` and `ChannelInterface::supports()` to
-   `RecipientInterface`.
- * Changed `EmailChannel` to only support recipients which implement the `EmailRecipientInterface`.
- * Changed `SmsChannel` to only support recipients which implement the `SmsRecipientInterface`.
+ * [BC BREAK] Change the `TransportInterface::send()` and `AbstractTransport::doSend()` methods to return a `?SentMessage` instance instead of `void`
+ * Introduce the `EmailRecipientInterface` and `RecipientInterface`
+ * Add `email` and `phone` properties to `Recipient`
+ * [BC BREAK] Change the type-hint of the `$recipient` argument in the `as*Message()` method of `EmailNotificationInterface` and `SmsNotificationInterface` to `EmailRecipientInterface`and `SmsRecipientInterface`
+ * [BC BREAK] Remove the `AdminRecipient`
+ * The `EmailRecipientInterface` and `SmsRecipientInterface` now extend the `RecipientInterface`
+ * Introduce the `EmailRecipient` and `SmsRecipient`
+ * [BC BREAK] Change the type-hint of the `$recipient` argument in `NotifierInterface::send()`, `Notifier::getChannels()`, `ChannelInterface::notifiy()` and `ChannelInterface::supports()` to `RecipientInterface`
+ * Change `EmailChannel` to only support recipients which implement the `EmailRecipientInterface`
+ * Change `SmsChannel` to only support recipients which implement the `SmsRecipientInterface`
 
 5.1.0
 -----
 
- * [BC BREAK] The `ChatMessage::fromNotification()` method's `$recipient` and `$transport`
-   arguments were removed.
- * [BC BREAK] The `EmailMessage::fromNotification()` and `SmsMessage::fromNotification()`
-   methods' `$transport` argument was removed.
+ * [BC BREAK] Remove the `ChatMessage::fromNotification()` method's `$recipient` and `$transport` arguments
+ * [BC BREAK] Remove the `EmailMessage::fromNotification()` and `SmsMessage::fromNotification()` methods' `$transport` argument
 
 5.0.0
 -----
 
- * Introduced the component as experimental
+ * Introduce the component as experimental


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0 <!-- see below -->
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | . <!-- required for new features -->

The conventions to write CHANGELOG entries described in https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry have not been strictly followed in the Notifier CHANGELOG. The entries are corrected now.