### PR TITLE
Fix SkippedTestSuite

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AbstractRedisAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 
@@ -32,12 +33,12 @@ abstract class AbstractRedisAdapterTest extends AdapterTestCase
     public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('redis')) {
-            self::markTestSkipped('Extension redis required.');
+            throw new SkippedTestSuiteError('Extension redis required.');
         }
         try {
             (new \Redis())->connect(getenv('REDIS_HOST'));
         } catch (\Exception $e) {
-            self::markTestSkipped($e->getMessage());
+            throw new SkippedTestSuiteError($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
@@ -32,14 +33,14 @@ class MemcachedAdapterTest extends AdapterTestCase
     public static function setUpBeforeClass(): void
     {
         if (!MemcachedAdapter::isSupported()) {
-            self::markTestSkipped('Extension memcached >=2.2.0 required.');
+            throw new SkippedTestSuiteError('Extension memcached >=2.2.0 required.');
         }
         self::$client = AbstractAdapter::createConnection('memcached://'.getenv('MEMCACHED_HOST'), ['binary_protocol' => false]);
         self::$client->get('foo');
         $code = self::$client->getResultCode();
 
         if (\Memcached::RES_SUCCESS !== $code && \Memcached::RES_NOTFOUND !== $code) {
-            self::markTestSkipped('Memcached error: '.strtolower(self::$client->getResultMessage()));
+            throw new SkippedTestSuiteError('Memcached error: '.strtolower(self::$client->getResultMessage()));
         }
     }
 

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 
@@ -26,7 +27,7 @@ class PdoAdapterTest extends AdapterTestCase
     public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('pdo_sqlite')) {
-            self::markTestSkipped('Extension pdo_sqlite required.');
+            throw new SkippedTestSuiteError('Extension pdo_sqlite required.');
         }
 
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_cache');

--- a/src/Symfony/Component/Cache/Tests/Adapter/PdoDbalAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PdoDbalAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Adapter;
 
 use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\PdoAdapter;
 
@@ -27,7 +28,7 @@ class PdoDbalAdapterTest extends AdapterTestCase
     public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('pdo_sqlite')) {
-            self::markTestSkipped('Extension pdo_sqlite required.');
+            throw new SkippedTestSuiteError('Extension pdo_sqlite required.');
         }
 
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_cache');

--- a/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/PredisRedisClusterAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 
 /**
@@ -21,7 +22,7 @@ class PredisRedisClusterAdapterTest extends AbstractRedisAdapterTest
     public static function setUpBeforeClass(): void
     {
         if (!$hosts = getenv('REDIS_CLUSTER_HOSTS')) {
-            self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
+            throw new SkippedTestSuiteError('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
 
         self::$redis = RedisAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['class' => \Predis\Client::class, 'redis_cluster' => true, 'prefix' => 'prefix_']);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisAdapterSentinelTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
@@ -23,13 +24,13 @@ class RedisAdapterSentinelTest extends AbstractRedisAdapterTest
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(\Predis\Client::class)) {
-            self::markTestSkipped('The Predis\Client class is required.');
+            throw new SkippedTestSuiteError('The Predis\Client class is required.');
         }
         if (!$hosts = getenv('REDIS_SENTINEL_HOSTS')) {
-            self::markTestSkipped('REDIS_SENTINEL_HOSTS env var is not defined.');
+            throw new SkippedTestSuiteError('REDIS_SENTINEL_HOSTS env var is not defined.');
         }
         if (!$service = getenv('REDIS_SENTINEL_SERVICE')) {
-            self::markTestSkipped('REDIS_SENTINEL_SERVICE env var is not defined.');
+            throw new SkippedTestSuiteError('REDIS_SENTINEL_SERVICE env var is not defined.');
         }
 
         self::$redis = AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['redis_sentinel' => $service, 'prefix' => 'prefix_']);

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisArrayAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisArrayAdapterTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
+
 /**
  * @group integration
  */
@@ -20,7 +22,7 @@ class RedisArrayAdapterTest extends AbstractRedisAdapterTest
     {
         parent::setupBeforeClass();
         if (!class_exists(\RedisArray::class)) {
-            self::markTestSkipped('The RedisArray class is required.');
+            throw new SkippedTestSuiteError('The RedisArray class is required.');
         }
         self::$redis = new \RedisArray([getenv('REDIS_HOST')], ['lazy_connect' => true]);
         self::$redis->setOption(\Redis::OPT_PREFIX, 'prefix_');

--- a/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/RedisClusterAdapterTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Adapter;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
@@ -25,10 +26,10 @@ class RedisClusterAdapterTest extends AbstractRedisAdapterTest
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(\RedisCluster::class)) {
-            self::markTestSkipped('The RedisCluster class is required.');
+            throw new SkippedTestSuiteError('The RedisCluster class is required.');
         }
         if (!$hosts = getenv('REDIS_CLUSTER_HOSTS')) {
-            self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
+            throw new SkippedTestSuiteError('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
 
         self::$redis = AbstractAdapter::createConnection('redis:?host['.str_replace(' ', ']&host[', $hosts).']', ['lazy' => true, 'redis_cluster' => true]);

--- a/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/AbstractRedisCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\RedisCache;
 
@@ -35,12 +36,12 @@ abstract class AbstractRedisCacheTest extends CacheTestCase
     public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('redis')) {
-            self::markTestSkipped('Extension redis required.');
+            throw new SkippedTestSuiteError('Extension redis required.');
         }
         try {
             (new \Redis())->connect(getenv('REDIS_HOST'));
         } catch (\Exception $e) {
-            self::markTestSkipped($e->getMessage());
+            throw new SkippedTestSuiteError($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/MemcachedCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Adapter\AbstractAdapter;
 use Symfony\Component\Cache\Exception\CacheException;
@@ -33,14 +34,14 @@ class MemcachedCacheTest extends CacheTestCase
     public static function setUpBeforeClass(): void
     {
         if (!MemcachedCache::isSupported()) {
-            self::markTestSkipped('Extension memcached >=2.2.0 required.');
+            throw new SkippedTestSuiteError('Extension memcached >=2.2.0 required.');
         }
         self::$client = AbstractAdapter::createConnection('memcached://'.getenv('MEMCACHED_HOST'));
         self::$client->get('foo');
         $code = self::$client->getResultCode();
 
         if (\Memcached::RES_SUCCESS !== $code && \Memcached::RES_NOTFOUND !== $code) {
-            self::markTestSkipped('Memcached error: '.strtolower(self::$client->getResultMessage()));
+            throw new SkippedTestSuiteError('Memcached error: '.strtolower(self::$client->getResultMessage()));
         }
     }
 

--- a/src/Symfony/Component/Cache/Tests/Simple/PdoCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PdoCacheTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\PdoCache;
 use Symfony\Component\Cache\Tests\Adapter\PdoPruneableTrait;
@@ -28,7 +29,7 @@ class PdoCacheTest extends CacheTestCase
     public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('pdo_sqlite')) {
-            self::markTestSkipped('Extension pdo_sqlite required.');
+            throw new SkippedTestSuiteError('Extension pdo_sqlite required.');
         }
 
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_cache');

--- a/src/Symfony/Component/Cache/Tests/Simple/PdoDbalCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/PdoDbalCacheTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Cache\Tests\Simple;
 
 use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\SkippedTestSuiteError;
 use Psr\SimpleCache\CacheInterface;
 use Symfony\Component\Cache\Simple\PdoCache;
 use Symfony\Component\Cache\Tests\Adapter\PdoPruneableTrait;
@@ -29,7 +30,7 @@ class PdoDbalCacheTest extends CacheTestCase
     public static function setUpBeforeClass(): void
     {
         if (!\extension_loaded('pdo_sqlite')) {
-            self::markTestSkipped('Extension pdo_sqlite required.');
+            throw new SkippedTestSuiteError('Extension pdo_sqlite required.');
         }
 
         self::$dbFile = tempnam(sys_get_temp_dir(), 'sf_sqlite_cache');

--- a/src/Symfony/Component/Cache/Tests/Simple/RedisArrayCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/RedisArrayCacheTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
+
 /**
  * @group legacy
  * @group integration
@@ -21,7 +23,7 @@ class RedisArrayCacheTest extends AbstractRedisCacheTest
     {
         parent::setupBeforeClass();
         if (!class_exists(\RedisArray::class)) {
-            self::markTestSkipped('The RedisArray class is required.');
+            throw new SkippedTestSuiteError('The RedisArray class is required.');
         }
         self::$redis = new \RedisArray([getenv('REDIS_HOST')], ['lazy_connect' => true]);
     }

--- a/src/Symfony/Component/Cache/Tests/Simple/RedisClusterCacheTest.php
+++ b/src/Symfony/Component/Cache/Tests/Simple/RedisClusterCacheTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Cache\Tests\Simple;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
+
 /**
  * @group legacy
  * @group integration
@@ -20,10 +22,10 @@ class RedisClusterCacheTest extends AbstractRedisCacheTest
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(\RedisCluster::class)) {
-            self::markTestSkipped('The RedisCluster class is required.');
+            throw new SkippedTestSuiteError('The RedisCluster class is required.');
         }
         if (!$hosts = getenv('REDIS_CLUSTER_HOSTS')) {
-            self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
+            throw new SkippedTestSuiteError('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
 
         self::$redis = new \RedisCluster(null, explode(' ', $hosts));

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseFunctionalTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpFoundation\Tests;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use PHPUnit\Framework\TestCase;
 
 class ResponseFunctionalTest extends TestCase
@@ -24,7 +25,7 @@ class ResponseFunctionalTest extends TestCase
             2 => ['file', '/dev/null', 'w'],
         ];
         if (!self::$server = @proc_open('exec '.\PHP_BINARY.' -S localhost:8054', $spec, $pipes, __DIR__.'/Fixtures/response-functional')) {
-            self::markTestSkipped('PHP server unable to start.');
+            throw new SkippedTestSuiteError('PHP server unable to start.');
         }
         sleep(1);
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/AbstractSessionHandlerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use PHPUnit\Framework\TestCase;
 
 class AbstractSessionHandlerTest extends TestCase
@@ -24,7 +25,7 @@ class AbstractSessionHandlerTest extends TestCase
             2 => ['file', '/dev/null', 'w'],
         ];
         if (!self::$server = @proc_open('exec '.\PHP_BINARY.' -S localhost:8053', $spec, $pipes, __DIR__.'/Fixtures')) {
-            self::markTestSkipped('PHP server unable to start.');
+            throw new SkippedTestSuiteError('PHP server unable to start.');
         }
         sleep(1);
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisClusterSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisClusterSessionHandlerTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
+
 /**
  * @group integration
  */
@@ -19,11 +21,11 @@ class RedisClusterSessionHandlerTest extends AbstractRedisSessionHandlerTestCase
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(\RedisCluster::class)) {
-            self::markTestSkipped('The RedisCluster class is required.');
+            throw new SkippedTestSuiteError('The RedisCluster class is required.');
         }
 
         if (!$hosts = getenv('REDIS_CLUSTER_HOSTS')) {
-            self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
+            throw new SkippedTestSuiteError('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/MemcachedStoreTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Key;
 use Symfony\Component\Lock\PersistingStoreInterface;
@@ -34,7 +35,7 @@ class MemcachedStoreTest extends AbstractStoreTest
         $code = $memcached->getResultCode();
 
         if (\Memcached::RES_SUCCESS !== $code && \Memcached::RES_NOTFOUND !== $code) {
-            self::markTestSkipped('Unable to connect to the memcache host');
+            throw new SkippedTestSuiteError('Unable to connect to the memcache host');
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/PredisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/PredisStoreTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
+
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  * @group integration
@@ -23,7 +25,7 @@ class PredisStoreTest extends AbstractRedisStoreTest
         try {
             $redis->connect();
         } catch (\Exception $e) {
-            self::markTestSkipped($e->getMessage());
+            throw new SkippedTestSuiteError($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/RedisArrayStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisArrayStoreTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
+
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
@@ -22,12 +24,12 @@ class RedisArrayStoreTest extends AbstractRedisStoreTest
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(\RedisArray::class)) {
-            self::markTestSkipped('The RedisArray class is required.');
+            throw new SkippedTestSuiteError('The RedisArray class is required.');
         }
         try {
             (new \Redis())->connect(getenv('REDIS_HOST'));
         } catch (\Exception $e) {
-            self::markTestSkipped($e->getMessage());
+            throw new SkippedTestSuiteError($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/RedisClusterStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisClusterStoreTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
+
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
@@ -22,10 +24,10 @@ class RedisClusterStoreTest extends AbstractRedisStoreTest
     public static function setUpBeforeClass(): void
     {
         if (!class_exists(\RedisCluster::class)) {
-            self::markTestSkipped('The RedisCluster class is required.');
+            throw new SkippedTestSuiteError('The RedisCluster class is required.');
         }
         if (!getenv('REDIS_CLUSTER_HOSTS')) {
-            self::markTestSkipped('REDIS_CLUSTER_HOSTS env var is not defined.');
+            throw new SkippedTestSuiteError('REDIS_CLUSTER_HOSTS env var is not defined.');
         }
     }
 

--- a/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/RedisStoreTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Lock\Tests\Store;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use Symfony\Component\Lock\Exception\InvalidTtlException;
 use Symfony\Component\Lock\Store\RedisStore;
 
@@ -27,7 +28,7 @@ class RedisStoreTest extends AbstractRedisStoreTest
         try {
             (new \Redis())->connect(getenv('REDIS_HOST'));
         } catch (\Exception $e) {
-            self::markTestSkipped($e->getMessage());
+            throw new SkippedTestSuiteError($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\Tests\Transport\RedisExt;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\RedisExt\Connection;
@@ -28,12 +29,12 @@ class ConnectionTest extends TestCase
             $redis->get();
         } catch (TransportException $e) {
             if (0 === strpos($e->getMessage(), 'ERR unknown command \'X')) {
-                self::markTestSkipped('Redis server >= 5 is required');
+                throw new SkippedTestSuiteError('Redis server >= 5 is required');
             }
 
             throw $e;
         } catch (\RedisException $e) {
-            self::markTestSkipped($e->getMessage());
+            throw new SkippedTestSuiteError($e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Tests\RememberMe;
 
+use PHPUnit\Framework\SkippedTestSuiteError;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
@@ -35,7 +36,7 @@ class PersistentTokenBasedRememberMeServicesTest extends TestCase
         try {
             random_bytes(1);
         } catch (\Exception $e) {
-            self::markTestSkipped($e->getMessage());
+            throw new SkippedTestSuiteError($e->getMessage());
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Throwing a TestSkipped in a `setUpBeforeClass` si handled by PHP unit as a standard exception, leading to a generic exception  `Test skipped because of an error in hook method` (see https://github.com/symfony/symfony/pull/41380/checks?check_run_id=2645369759#step:14:165)

However phpunit is able to catch `SkippedTestSuiteError` in such situation.(https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/TestSuite.php#L438-L448)

This PR replaces `self::markTestSkipped` by `throw new SkippedTestSuiteError` (we don't have static method helper for this exception) in our `setUpBeforeClass` methods.