### PR TITLE
[Mime] Remove symfony/deprecation-contracts

### DIFF
--- a/src/Symfony/Component/Mime/composer.json
+++ b/src/Symfony/Component/Mime/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=8.0.2",
-        "symfony/deprecation-contracts": "^2.1",
         "symfony/polyfill-intl-idn": "^1.10",
         "symfony/polyfill-mbstring": "^1.0"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

As commented here https://github.com/symfony/symfony/pull/41298#discussion_r635621710 I removed `symfony/deprecation-contracts` as follow-up on #41364

If the removal of `symfony/deprecation-contracts` is not important, I am happy to close this PR.