### PR TITLE
[Security] Add an upgrade note about the removal of Serializable

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -158,6 +158,11 @@ Security
    in `PreAuthenticatedToken`, `RememberMeToken`, `SwitchUserToken`, `UsernamePasswordToken`,
    `DefaultAuthenticationSuccessHandler`.
  * Removed the `AbstractRememberMeServices::$providerKey` property in favor of `AbstractRememberMeServices::$firewallName`
+ * Authentication tokens do not implement the deprecated `Serializable`
+   interface anymore. The consequence is that tokens that were serialized (e.g.
+   into the session) with PHP 7.3 or below cannot be unserialized anymore. It is
+   recommended to roll out a Symfony 5 application with PHP 7.4 or later first
+   before upgrading it to Symfony 6.
 
 TwigBundle
 ----------


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Jumping from Symfony 5 on PHP 7.2/7.3 to Symfony 6 on PHP 8 directly will fry your sessions. I've added a note that PHP should be upgraded first. I believe that most apps will take that path anyway, so this shouldn't be much of a footgun. 🤞🏻 