### PR TITLE
[HttpKernel] Add session cookie handling in cli context

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -325,7 +325,7 @@ class FrameworkExtension extends Extension
             $this->sessionConfigEnabled = true;
             $this->registerSessionConfiguration($config['session'], $container, $loader);
             if (!empty($config['test'])) {
-                $container->getDefinition('test.session.listener')->setArgument(1, '%session.storage.options%');
+                $container->getDefinition('test.session.listener')->setArgument(2, '%session.storage.options%');
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
@@ -153,8 +153,10 @@ return static function (ContainerConfigurator $container) {
                     'session_collector' => service('data_collector.request.session_collector')->ignoreOnInvalid(),
                 ]),
                 param('kernel.debug'),
+                param('session.storage.options'),
             ])
             ->tag('kernel.event_subscriber')
+            ->tag('kernel.reset', ['method' => 'reset'])
 
         // for BC
         ->alias('session.storage.filesystem', 'session.storage.mock_file')

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.php
@@ -16,7 +16,7 @@ use Symfony\Bundle\FrameworkBundle\Test\TestContainer;
 use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\BrowserKit\History;
 use Symfony\Component\DependencyInjection\ServiceLocator;
-use Symfony\Component\HttpKernel\EventListener\TestSessionListener;
+use Symfony\Component\HttpKernel\EventListener\SessionListener;
 
 return static function (ContainerConfigurator $container) {
     $container->parameters()->set('test.client.parameters', []);
@@ -35,11 +35,13 @@ return static function (ContainerConfigurator $container) {
         ->set('test.client.history', History::class)->share(false)
         ->set('test.client.cookiejar', CookieJar::class)->share(false)
 
-        ->set('test.session.listener', TestSessionListener::class)
+        ->set('test.session.listener', SessionListener::class)
             ->args([
                 service_locator([
                     'session' => service('.session.do-not-use')->ignoreOnInvalid(),
                 ]),
+                param('kernel.debug'),
+                param('session.storage.options'),
             ])
             ->tag('kernel.event_subscriber')
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -186,7 +186,7 @@ class Request
     protected $format;
 
     /**
-     * @var SessionInterface|callable
+     * @var SessionInterface|callable(): SessionInterface
      */
     protected $session;
 
@@ -775,6 +775,8 @@ class Request
 
     /**
      * @internal
+     *
+     * @param callable(): SessionInterface $factory
      */
     public function setSessionFactory(callable $factory)
     {

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -13,13 +13,16 @@ namespace Symfony\Component\HttpKernel\EventListener;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\SessionUtils;
 use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Exception\UnexpectedSessionUsageException;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * Sets the session onto the request on the "kernel.request" event and saves
@@ -36,7 +39,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  *
  * @internal
  */
-abstract class AbstractSessionListener implements EventSubscriberInterface
+abstract class AbstractSessionListener implements EventSubscriberInterface, ResetInterface
 {
     public const NO_AUTO_CACHE_CONTROL_HEADER = 'Symfony-Session-NoAutoCacheControl';
 
@@ -44,10 +47,16 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
     private $sessionUsageStack = [];
     private $debug;
 
-    public function __construct(ContainerInterface $container = null, bool $debug = false)
+    /**
+     * @var array<string, mixed>
+     */
+    private $sessionOptions;
+
+    public function __construct(ContainerInterface $container = null, bool $debug = false, array $sessionOptions = [])
     {
         $this->container = $container;
         $this->debug = $debug;
+        $this->sessionOptions = $sessionOptions;
     }
 
     public function onKernelRequest(RequestEvent $event)
@@ -60,7 +69,22 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
         if (!$request->hasSession()) {
             // This variable prevents calling `$this->getSession()` twice in case the Request (and the below factory) is cloned
             $sess = null;
-            $request->setSessionFactory(function () use (&$sess) { return $sess ?? $sess = $this->getSession(); });
+            $request->setSessionFactory(function () use (&$sess, $request) {
+                if (!$sess) {
+                    $sess = $this->getSession();
+                }
+
+                /*
+                 * For supporting sessions in php runtime with runners like roadrunner or swoole the session
+                 * cookie need read from the cookie bag and set on the session storage.
+                 */
+                if ($sess && !$sess->isStarted()) {
+                    $sessionId = $request->cookies->get($sess->getName(), '');
+                    $sess->setId($sessionId);
+                }
+
+                return $sess;
+            });
         }
 
         $session = $this->container && $this->container->has('initialized_session') ? $this->container->get('initialized_session') : null;
@@ -109,6 +133,54 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
              * it is saved will just restart it.
              */
             $session->save();
+
+            /*
+             * For supporting sessions in php runtime with runners like roadrunner or swoole the session
+             * cookie need to be written on the response object and should not be written by PHP itself.
+             */
+            $sessionName = $session->getName();
+            $sessionId = $session->getId();
+            $sessionCookiePath = $this->sessionOptions['cookie_path'] ?? '/';
+            $sessionCookieDomain = $this->sessionOptions['cookie_domain'] ?? null;
+            $sessionCookieSecure = $this->sessionOptions['cookie_secure'] ?? false;
+            $sessionCookieHttpOnly = $this->sessionOptions['cookie_httponly'] ?? true;
+            $sessionCookieSameSite = $this->sessionOptions['cookie_samesite'] ?? Cookie::SAMESITE_LAX;
+
+            SessionUtils::popSessionCookie($sessionName, $sessionCookiePath);
+
+            $request = $event->getRequest();
+            $requestSessionCookieId = $request->cookies->get($sessionName);
+
+            if ($requestSessionCookieId && $session->isEmpty()) {
+                $response->headers->clearCookie(
+                    $sessionName,
+                    $sessionCookiePath,
+                    $sessionCookieDomain,
+                    $sessionCookieSecure,
+                    $sessionCookieHttpOnly,
+                    $sessionCookieSameSite
+                );
+            } elseif ($sessionId !== $requestSessionCookieId) {
+                $expire = 0;
+                $lifetime = $this->sessionOptions['cookie_lifetime'] ?? null;
+                if ($lifetime) {
+                    $expire = time() + $lifetime;
+                }
+
+                $response->headers->setCookie(
+                    Cookie::create(
+                        $sessionName,
+                        $sessionId,
+                        $expire,
+                        $sessionCookiePath,
+                        $sessionCookieDomain,
+                        $sessionCookieSecure,
+                        $sessionCookieHttpOnly,
+                        false,
+                        $sessionCookieSameSite
+                    )
+                );
+            }
         }
 
         if ($session instanceof Session ? $session->getUsageIndex() === end($this->sessionUsageStack) : !$session->isStarted()) {
@@ -186,6 +258,20 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
             KernelEvents::RESPONSE => ['onKernelResponse', -1000],
             KernelEvents::FINISH_REQUEST => ['onFinishRequest'],
         ];
+    }
+
+    public function reset(): void
+    {
+        if (\PHP_SESSION_ACTIVE === session_status()) {
+            session_abort();
+        }
+
+        session_unset();
+        $_SESSION = [];
+
+        if (!headers_sent()) { // session id can only be reset when no headers were so we check for headers_sent first
+            session_id('');
+        }
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
@@ -28,6 +28,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * @author Fabien Potencier <fabien@symfony.com>
  *
  * @internal
+ *
+ * @deprecated the TestSessionListener use the default SessionListener instead
  */
 abstract class AbstractTestSessionListener implements EventSubscriberInterface
 {
@@ -37,6 +39,8 @@ abstract class AbstractTestSessionListener implements EventSubscriberInterface
     public function __construct(array $sessionOptions = [])
     {
         $this->sessionOptions = $sessionOptions;
+
+        trigger_deprecation('symfony/http-kernel', '5.4', 'The %s is deprecated use the %s instead.', __CLASS__, AbstractSessionListener::class);
     }
 
     public function onKernelRequest(RequestEvent $event)

--- a/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SessionListener.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\EventListener;
 
-use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -29,11 +28,6 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
  */
 class SessionListener extends AbstractSessionListener
 {
-    public function __construct(ContainerInterface $container, bool $debug = false)
-    {
-        parent::__construct($container, $debug);
-    }
-
     public function onKernelRequest(RequestEvent $event)
     {
         parent::onKernelRequest($event);

--- a/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
@@ -20,6 +20,8 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  *
  * @final
+ *
+ * @deprecated the TestSessionListener use the default SessionListener instead
  */
 class TestSessionListener extends AbstractTestSessionListener
 {

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  * Tests SessionListener.
  *
  * @author Bulat Shakirzyanov <mallluhuct@gmail.com>
+ * @group legacy
  */
 class TestSessionListenerTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #42890
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Currently the session cookie is never set on the `request` object. In a normal webserver setup this is not needed as a session is in php-fpm or apache fastcgi written by php itself when the response is outputted in: https://github.com/symfony/symfony/blob/744b901750c1cc09e85bcb2ebdf0505449a1158f/src/Symfony/Component/HttpFoundation/Response.php#L393

When use a runner like `Roadrunner` the `session` cookie is never set on the `Request` object, as this kind of appserver never really outputs something and is running in the `cli` context.

Actually there is no way from outside to know if `$session->save()` was called or not because when the code in `Roadrunner` executes the session is actually written and so closed here: https://github.com/symfony/symfony/blob/744b901750c1cc09e85bcb2ebdf0505449a1158f/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php#L279.

The best way so to fix this issue is that in CLI context symfony writes the session cookie on the `Response` object when the session is really saved.

This fixes issues which we have in the current roadrunner implementation of php runtime:
  - [x] https://github.com/php-runtime/roadrunner-symfony-nyholm/blob/58665237ef2bff08a1ebf269e64abbf8cd09fbd7/src/Runner.php#L89
  - [x] https://github.com/php-runtime/roadrunner-symfony-nyholm/blob/58665237ef2bff08a1ebf269e64abbf8cd09fbd7/src/Runner.php#L81

Beside Roadrunner there is also Swoole implementation which would require the same here: https://github.com/php-runtime/runtime/issues/60

With this changes the Runners can be simplified a lot: https://github.com/php-runtime/runtime/pull/62/files#

## TODO

Reset session variables after successfully response. The following code currently lives also in the runtime implementation but is requires also by all runners and so we should find a place where we put it:

```
                if (PHP_SESSION_ACTIVE === session_status()) {
                    session_abort();
                }
                // reset all session variables to initialize state
                $_SESSION = [];
session_id(''); // in this case session_start() will generate us a new session_id()
```

EDIT: Added this now to the `AbstractSessionListener` service via `ResetInterface`.