### PR TITLE
[Notifier] Remove conflict rules for bridges

### DIFF
--- a/src/Symfony/Component/Notifier/composer.json
+++ b/src/Symfony/Component/Notifier/composer.json
@@ -25,27 +25,8 @@
         "symfony/messenger": "^5.4|^6.0"
     },
     "conflict": {
-        "symfony/http-kernel": "<5.4",
-        "symfony/discord-notifier": "<5.4",
-        "symfony/esendex-notifier": "<5.4",
         "symfony/event-dispatcher": "<5.4",
-        "symfony/firebase-notifier": "<5.4",
-        "symfony/free-mobile-notifier": "<5.4",
-        "symfony/google-chat-notifier": "<5.4",
-        "symfony/infobip-notifier": "<5.4",
-        "symfony/linked-in-notifier": "<5.4",
-        "symfony/mattermost-notifier": "<5.4",
-        "symfony/mobyt-notifier": "<5.4",
-        "symfony/nexmo-notifier": "<5.4",
-        "symfony/ovh-cloud-notifier": "<5.4",
-        "symfony/rocket-chat-notifier": "<5.4",
-        "symfony/sendinblue-notifier": "<5.4",
-        "symfony/sinch-notifier": "<5.4",
-        "symfony/slack-notifier": "<5.4",
-        "symfony/smsapi-notifier": "<5.4",
-        "symfony/telegram-notifier": "<5.4",
-        "symfony/twilio-notifier": "<5.4",
-        "symfony/zulip-notifier": "<5.4"
+        "symfony/http-kernel": "<5.4"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

While Notifier was experimental, we used conflict rules to make sure that we don't install an incompatible combination of the Notifier component + a bridge. The component is not experimental anymore and on 6.x it will follow semver. I believe that the conflict rules are obsolete now.