### PR TITLE
remove duplicate test

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -101,11 +101,6 @@ class LoginLinkHandlerTest extends TestCase
 
         yield [
             new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash'),
-            ['emailProperty' => 'ryan@symfonycasts.com', 'passwordProperty' => 'pwhash'],
-        ];
-
-        yield [
-            new TestLoginLinkHandlerUser('weaverryan', 'ryan@symfonycasts.com', 'pwhash'),
             ['lastAuthenticatedAt' => ''],
         ];
 


### PR DESCRIPTION
Q | A
-- | --
Branch? | 5.x
Bug fix? | no
New feature? | yes
Deprecations? | no
License | MIT

The removed test is a duplication of Line 98 and introduced by https://github.com/symfony/symfony/pull/40153
I would prefer to conserve the test and edit value but the values are harcoded in the test
