### PR TITLE
[Mime] Removes tests for code that has been deleted

### DIFF
--- a/src/Symfony/Component/Mime/Tests/AddressTest.php
+++ b/src/Symfony/Component/Mime/Tests/AddressTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Mime\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mime\Address;
-use Symfony\Component\Mime\Exception\InvalidArgumentException;
 
 class AddressTest extends TestCase
 {

--- a/src/Symfony/Component/Mime/Tests/AddressTest.php
+++ b/src/Symfony/Component/Mime/Tests/AddressTest.php
@@ -92,29 +92,6 @@ class AddressTest extends TestCase
         return [[''], [' '], [" \r\n "]];
     }
 
-    /**
-     * @dataProvider fromStringProvider
-     * @group legacy
-     */
-    public function testFromString($string, $displayName, $addrSpec)
-    {
-        $address = Address::create($string);
-        $this->assertEquals($displayName, $address->getName());
-        $this->assertEquals($addrSpec, $address->getAddress());
-        $fromToStringAddress = Address::create($address->toString());
-        $this->assertEquals($displayName, $fromToStringAddress->getName());
-        $this->assertEquals($addrSpec, $fromToStringAddress->getAddress());
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testFromStringFailure()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        Address::create('Jane Doe <example@example.com');
-    }
-
     public function fromStringProvider()
     {
         return [

--- a/src/Symfony/Component/Mime/Tests/AddressTest.php
+++ b/src/Symfony/Component/Mime/Tests/AddressTest.php
@@ -98,10 +98,10 @@ class AddressTest extends TestCase
      */
     public function testFromString($string, $displayName, $addrSpec)
     {
-        $address = Address::fromString($string);
+        $address = Address::create($string);
         $this->assertEquals($displayName, $address->getName());
         $this->assertEquals($addrSpec, $address->getAddress());
-        $fromToStringAddress = Address::fromString($address->toString());
+        $fromToStringAddress = Address::create($address->toString());
         $this->assertEquals($displayName, $fromToStringAddress->getName());
         $this->assertEquals($addrSpec, $fromToStringAddress->getAddress());
     }
@@ -112,7 +112,7 @@ class AddressTest extends TestCase
     public function testFromStringFailure()
     {
         $this->expectException(InvalidArgumentException::class);
-        Address::fromString('Jane Doe <example@example.com');
+        Address::create('Jane Doe <example@example.com');
     }
 
     public function fromStringProvider()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | Not a new feature

This PR fixes tests on the MIME component after a deprecated method was removed on the 6.0 branch by the PR https://github.com/symfony/symfony/pull/41364
