### PR TITLE
[Security] Add a method in the security helper to ease programmatic logout

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate the `Symfony\Component\Security\Core\Security` service alias, use `Symfony\Bundle\SecurityBundle\Security\Security` instead
  * Add `Security::getFirewallConfig()` to help to get the firewall configuration associated to the Request
  * Add `Security::login()` to login programmatically
+ * Add `Security::logout()` to logout programmatically
 
 6.1
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -376,6 +376,13 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $container->register($firewallEventDispatcherId, EventDispatcher::class)
             ->addTag('event_dispatcher.dispatcher', ['name' => $firewallEventDispatcherId]);
 
+        $eventDispatcherLocator = $container->getDefinition('security.firewall.event_dispatcher_locator');
+        $eventDispatcherLocator
+            ->replaceArgument(0, array_merge($eventDispatcherLocator->getArgument(0), [
+                $id => new ServiceClosureArgument(new Reference($firewallEventDispatcherId)),
+            ]))
+        ;
+
         // Register listeners
         $listeners = [];
         $listenerKeys = [];

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -455,6 +455,8 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                     false === $firewall['stateless'] && isset($firewall['context']) ? $firewall['context'] : null,
                 ])
             ;
+
+            $config->replaceArgument(12, $firewall['logout']);
         }
 
         // Determine default entry point

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -86,6 +86,7 @@ return static function (ContainerConfigurator $container) {
                     'request_stack' => service('request_stack'),
                     'security.firewall.map' => service('security.firewall.map'),
                     'security.user_checker' => service('security.user_checker'),
+                    'security.firewall.event_dispatcher_locator' => service('security.firewall.event_dispatcher_locator'),
                 ]),
                 abstract_arg('authenticators'),
             ])

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -87,6 +87,7 @@ return static function (ContainerConfigurator $container) {
                     'security.firewall.map' => service('security.firewall.map'),
                     'security.user_checker' => service('security.user_checker'),
                     'security.firewall.event_dispatcher_locator' => service('security.firewall.event_dispatcher_locator'),
+                    'security.csrf.token_manager' => service('security.csrf.token_manager')->ignoreOnInvalid(),
                 ]),
                 abstract_arg('authenticators'),
             ])
@@ -207,6 +208,7 @@ return static function (ContainerConfigurator $container) {
                 null,
                 [], // listeners
                 null, // switch_user
+                null, // logout
             ])
 
         ->set('security.logout_url_generator', LogoutUrlGenerator::class)

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Security\Http\AccessMap;
 use Symfony\Component\Security\Http\Authentication\CustomAuthenticationFailureHandler;
 use Symfony\Component\Security\Http\Authentication\CustomAuthenticationSuccessHandler;
@@ -160,5 +161,8 @@ return static function (ContainerConfigurator $container) {
                 service('security.access_map'),
             ])
             ->tag('monolog.logger', ['channel' => 'security'])
+
+        ->set('security.firewall.event_dispatcher_locator', ServiceLocator::class)
+            ->args([[]])
     ;
 };

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
@@ -16,33 +16,21 @@ namespace Symfony\Bundle\SecurityBundle\Security;
  */
 final class FirewallConfig
 {
-    private string $name;
-    private string $userChecker;
-    private ?string $requestMatcher;
-    private bool $securityEnabled;
-    private bool $stateless;
-    private ?string $provider;
-    private ?string $context;
-    private ?string $entryPoint;
-    private ?string $accessDeniedHandler;
-    private ?string $accessDeniedUrl;
-    private array $authenticators;
-    private ?array $switchUser;
-
-    public function __construct(string $name, string $userChecker, string $requestMatcher = null, bool $securityEnabled = true, bool $stateless = false, string $provider = null, string $context = null, string $entryPoint = null, string $accessDeniedHandler = null, string $accessDeniedUrl = null, array $authenticators = [], array $switchUser = null)
-    {
-        $this->name = $name;
-        $this->userChecker = $userChecker;
-        $this->requestMatcher = $requestMatcher;
-        $this->securityEnabled = $securityEnabled;
-        $this->stateless = $stateless;
-        $this->provider = $provider;
-        $this->context = $context;
-        $this->entryPoint = $entryPoint;
-        $this->accessDeniedHandler = $accessDeniedHandler;
-        $this->accessDeniedUrl = $accessDeniedUrl;
-        $this->authenticators = $authenticators;
-        $this->switchUser = $switchUser;
+    public function __construct(
+        private readonly string $name,
+        private readonly string $userChecker,
+        private readonly ?string $requestMatcher = null,
+        private readonly bool $securityEnabled = true,
+        private readonly bool $stateless = false,
+        private readonly ?string $provider = null,
+        private readonly ?string $context = null,
+        private readonly ?string $entryPoint = null,
+        private readonly ?string $accessDeniedHandler = null,
+        private readonly ?string $accessDeniedUrl = null,
+        private readonly array $authenticators = [],
+        private readonly ?array $switchUser = null,
+        private readonly ?array $logout = null
+    ) {
     }
 
     public function getName(): string
@@ -110,5 +98,10 @@ final class FirewallConfig
     public function getSwitchUser(): ?array
     {
         return $this->switchUser;
+    }
+
+    public function getLogout(): ?array
+    {
+        return $this->logout;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -141,6 +141,7 @@ abstract class CompleteConfigurationTest extends TestCase
                 '',
                 [],
                 null,
+                null,
             ],
             [
                 'secure',
@@ -165,6 +166,14 @@ abstract class CompleteConfigurationTest extends TestCase
                     'parameter' => '_switch_user',
                     'role' => 'ROLE_ALLOWED_TO_SWITCH',
                 ],
+                [
+                    'csrf_parameter' => '_csrf_token',
+                    'csrf_token_id' => 'logout',
+                    'path' => '/logout',
+                    'target' => '/',
+                    'invalidate_session' => true,
+                    'delete_cookies' => [],
+                ],
             ],
             [
                 'host',
@@ -181,6 +190,7 @@ abstract class CompleteConfigurationTest extends TestCase
                     'http_basic',
                 ],
                 null,
+                null,
             ],
             [
                 'with_user_checker',
@@ -196,6 +206,7 @@ abstract class CompleteConfigurationTest extends TestCase
                 [
                     'http_basic',
                 ],
+                null,
                 null,
             ],
         ], $configs);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/framework.yml }
 
 services:
-    # alias the service so we can access it in the tests
     functional_test.security.helper:
         alias: security.helper
         public: true
@@ -11,7 +10,7 @@ services:
         alias: security.token_storage
         public: true
 
-    Symfony\Bundle\SecurityBundle\Tests\Functional\WelcomeController:
+    Symfony\Bundle\SecurityBundle\Tests\Functional\ForceLoginController:
         arguments: ['@security.helper']
         public: true
 
@@ -19,22 +18,31 @@ services:
         arguments: ['@security.helper']
         public: true
 
+    Symfony\Bundle\SecurityBundle\Tests\Functional\LoggedInController:
+        arguments: ['@security.helper']
+        public: true
+
     Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator: ~
 
 security:
     enable_authenticator_manager: true
+
     providers:
-        in_memory:
+        main:
             memory:
-                users: []
+                users:
+                    chalasr: { password: the-password, roles: ['ROLE_FOO'] }
+                    no-role-username: { password: the-password, roles: [] }
 
     firewalls:
-        default:
-            json_login:
-                username_path: user.login
-                password_path: user.password
+        main:
+            pattern: ^/main
+            form_login:
+                check_path: /main/login/check
             custom_authenticators:
                 - 'Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator'
+            provider: main
 
     access_control:
-        - { path: ^/foo, roles: PUBLIC_ACCESS }
+        - { path: '^/main/login/check$', roles: IS_AUTHENTICATED_FULLY }
+        - { path: '^/main/logged-in$', roles: IS_AUTHENTICATED_FULLY }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config.yml
@@ -15,6 +15,10 @@ services:
         arguments: ['@security.helper']
         public: true
 
+    Symfony\Bundle\SecurityBundle\Tests\Functional\LogoutController:
+        arguments: ['@security.helper']
+        public: true
+
     Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator: ~
 
 security:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config_logout_csrf.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config_logout_csrf.yml
@@ -2,7 +2,6 @@ imports:
     - { resource: ./../config/framework.yml }
 
 services:
-    # alias the service so we can access it in the tests
     functional_test.security.helper:
         alias: security.helper
         public: true
@@ -11,32 +10,39 @@ services:
         alias: security.token_storage
         public: true
 
-    Symfony\Bundle\SecurityBundle\Tests\Functional\WelcomeController:
+    Symfony\Bundle\SecurityBundle\Tests\Functional\ForceLoginController:
         arguments: ['@security.helper']
         public: true
 
     Symfony\Bundle\SecurityBundle\Tests\Functional\LogoutController:
-        arguments: ['@security.helper', '@security.csrf.token_manager']
+        arguments: ['@security.helper']
+        public: true
+
+    Symfony\Bundle\SecurityBundle\Tests\Functional\LoggedInController:
+        arguments: ['@security.helper']
         public: true
 
     Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator: ~
 
 security:
     enable_authenticator_manager: true
+
     providers:
-        in_memory:
+        main:
             memory:
-                users: []
+                users:
+                    chalasr: { password: the-password, roles: ['ROLE_FOO'] }
+                    no-role-username: { password: the-password, roles: [] }
 
     firewalls:
-        default:
-            json_login:
-                username_path: user.login
-                password_path: user.password
-            logout:
-                path: /regular-logout
+        main:
+            pattern: ^/main
+            form_login:
+                check_path: /main/login/check
             custom_authenticators:
                 - 'Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator'
+            provider: main
 
     access_control:
-        - { path: ^/foo, roles: PUBLIC_ACCESS }
+        - { path: '^/main/logged-in$', roles: IS_AUTHENTICATED_FULLY }
+        - { path: '^/main/force-logout$', roles: IS_AUTHENTICATED_FULLY }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config_logout_csrf.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/config_logout_csrf.yml
@@ -1,0 +1,42 @@
+imports:
+    - { resource: ./../config/framework.yml }
+
+services:
+    # alias the service so we can access it in the tests
+    functional_test.security.helper:
+        alias: security.helper
+        public: true
+
+    functional.test.security.token_storage:
+        alias: security.token_storage
+        public: true
+
+    Symfony\Bundle\SecurityBundle\Tests\Functional\WelcomeController:
+        arguments: ['@security.helper']
+        public: true
+
+    Symfony\Bundle\SecurityBundle\Tests\Functional\LogoutController:
+        arguments: ['@security.helper', '@security.csrf.token_manager']
+        public: true
+
+    Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator: ~
+
+security:
+    enable_authenticator_manager: true
+    providers:
+        in_memory:
+            memory:
+                users: []
+
+    firewalls:
+        default:
+            json_login:
+                username_path: user.login
+                password_path: user.password
+            logout:
+                path: /regular-logout
+            custom_authenticators:
+                - 'Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator'
+
+    access_control:
+        - { path: ^/foo, roles: PUBLIC_ACCESS }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/routing.yml
@@ -2,6 +2,6 @@ welcome:
     path: /welcome
     controller: Symfony\Bundle\SecurityBundle\Tests\Functional\WelcomeController::welcome
 
-logout:
-    path: /auto-logout
+force-logout:
+    path: /force-logout
     controller: Symfony\Bundle\SecurityBundle\Tests\Functional\LogoutController::logout

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/routing.yml
@@ -1,3 +1,7 @@
 welcome:
     path: /welcome
-    defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\WelcomeController::welcome }
+    controller: Symfony\Bundle\SecurityBundle\Tests\Functional\WelcomeController::welcome
+
+logout:
+    path: /auto-logout
+    controller: Symfony\Bundle\SecurityBundle\Tests\Functional\LogoutController::logout

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/SecurityHelper/routing.yml
@@ -1,7 +1,11 @@
-welcome:
-    path: /welcome
-    controller: Symfony\Bundle\SecurityBundle\Tests\Functional\WelcomeController::welcome
+force-login:
+    path: /main/force-login
+    controller: Symfony\Bundle\SecurityBundle\Tests\Functional\ForceLoginController::welcome
+
+logged-in:
+    path: /main/logged-in
+    controller: Symfony\Bundle\SecurityBundle\Tests\Functional\LoggedInController
 
 force-logout:
-    path: /force-logout
+    path: /main/force-logout
     controller: Symfony\Bundle\SecurityBundle\Tests\Functional\LogoutController::logout


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.x
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #40663
| License       | MIT
| Doc PR        | 

This PR aims to ease the programmatic login using the Security helper, to fix (#40663).

A simple method has been added to the Security helper. 

Thanks !