### PR TITLE
[DoctrineBridge] Integrate doctrine/deprecations

### DIFF
--- a/src/Symfony/Bridge/Doctrine/bootstrap.php
+++ b/src/Symfony/Bridge/Doctrine/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Doctrine\Deprecations\Deprecation;
+
+if (class_exists(Deprecation::class)) {
+    Deprecation::enableWithTriggerError();
+}

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -63,6 +63,7 @@
         "doctrine/orm": ""
     },
     "autoload": {
+        "files": [ "bootstrap.php" ],
         "psr-4": { "Symfony\\Bridge\\Doctrine\\": "" },
         "exclude-from-classmap": [
             "/Tests/"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/doctrine/DoctrineBundle/issues/1300
| License       | MIT
| Doc PR        | -

This automatically enables deprecations triggered via doctrine/deprecations in standard symfony deprecations mode. Currently, symfony error-handler and phpunit-bridge are not aware of such deprecations with stock configuration of doctrine/deprecations. That might be a bug from user's POV. This patch fixes that.

We don't want this in a bundle, because all bundles using doctrine-bridge shouldn't have to reimplement this separately.