### PR TITLE
[HttpKernel] Fixes file_get_content in HttpCache's Store for PHP7.4+

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -349,7 +349,7 @@ class Store implements StoreInterface
     {
         $path = $this->getPath($key);
 
-        return file_exists($path) && false !== ($contents = file_get_contents($path)) ? $contents : null;
+        return file_exists($path) && false !== ($contents = @file_get_contents($path)) ? $contents : null;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

While trying to get 6.0 branch tests green, I encountered an error on multiple HttpKernel tests.
After investigating, it comes from the file_get_contents in the load method of the Store class from HttpCache. For obscure reasons, some calls are in errors and the content can't be read for "permission denied".
This is happening only on PHP 7.4.0+ (and that explains why the tests are green on the branch 5.4 as it runs php 7.2), adding the `@` error suppressor fixes this.