### PR TITLE
Support `statusCode` default param when loading template directly via route

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * Add `configureContainer()`, `configureRoutes()`, `getConfigDir()` and `getBundlesPath()` to `MicroKernelTrait`
  * Add support for configuring log level, and status code by exception class
  * Bind the `default_context` parameter onto serializer's encoders and normalizers
+ * Add support for `statusCode` default parameter when loading a template directly from route using the `Symfony\Bundle\FrameworkBundle\Controller\TemplateController` controller
 
 5.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -33,19 +33,20 @@ class TemplateController
     /**
      * Renders a template.
      *
-     * @param string    $template  The template name
-     * @param int|null  $maxAge    Max age for client caching
-     * @param int|null  $sharedAge Max age for shared (proxy) caching
-     * @param bool|null $private   Whether or not caching should apply for client caches only
-     * @param array     $context   The context (arguments) of the template
+     * @param string    $template   The template name
+     * @param int|null  $maxAge     Max age for client caching
+     * @param int|null  $sharedAge  Max age for shared (proxy) caching
+     * @param bool|null $private    Whether or not caching should apply for client caches only
+     * @param array     $context    The context (arguments) of the template
+     * @param int       $statusCode The HTTP status code to return with the response. Defaults to 200
      */
-    public function templateAction(string $template, int $maxAge = null, int $sharedAge = null, bool $private = null, array $context = []): Response
+    public function templateAction(string $template, int $maxAge = null, int $sharedAge = null, bool $private = null, array $context = [], int $statusCode = 200): Response
     {
         if (null === $this->twig) {
             throw new \LogicException('You cannot use the TemplateController if the Twig Bundle is not available.');
         }
 
-        $response = new Response($this->twig->render($template, $context));
+        $response = new Response($this->twig->render($template, $context), $statusCode);
 
         if ($maxAge) {
             $response->setMaxAge($maxAge);
@@ -64,8 +65,8 @@ class TemplateController
         return $response;
     }
 
-    public function __invoke(string $template, int $maxAge = null, int $sharedAge = null, bool $private = null, array $context = []): Response
+    public function __invoke(string $template, int $maxAge = null, int $sharedAge = null, bool $private = null, array $context = [], int $statusCode = 200): Response
     {
-        return $this->templateAction($template, $maxAge, $sharedAge, $private, $context);
+        return $this->templateAction($template, $maxAge, $sharedAge, $private, $context, $statusCode);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/TemplateControllerTest.php
@@ -59,4 +59,19 @@ class TemplateControllerTest extends TestCase
         $this->assertEquals($expected, $controller->templateAction($templateName, null, null, null, $context)->getContent());
         $this->assertEquals($expected, $controller($templateName, null, null, null, $context)->getContent());
     }
+
+    public function testStatusCode()
+    {
+        $templateName = 'template_controller.html.twig';
+        $statusCode = 201;
+
+        $loader = new ArrayLoader();
+        $loader->setTemplate($templateName, '<h1>{{param}}</h1>');
+
+        $twig = new Environment($loader);
+        $controller = new TemplateController($twig);
+
+        $this->assertSame(201, $controller->templateAction($templateName, null, null, null, [], $statusCode)->getStatusCode());
+        $this->assertSame(200, $controller->templateAction($templateName)->getStatusCode());
+    }
 }


### PR DESCRIPTION
_This is my first PR to Symfony, so please be patient as I get to grips with the 'admin' process of getting everything exactly how you want it!_

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | symfony/symfony-docs#15376

### TODO

- [x] submit changes to the documentation and update this PR with a link

### Summary

Added support for `statusCode` default parameter when loading a template directly from route via the `Symfony\Bundle\FrameworkBundle\Controller\TemplateController` controller (like [this](https://symfony.com/doc/current/templates.html#templates-render-from-route)). This will continue to default to a 200 code, but can be changed by updating your route - for instance something like this:

```
test_route:
  path: /test_route
  controller:    Symfony\Bundle\FrameworkBundle\Controller\TemplateController
  defaults:
    # the path of the template to render
    template:  'test.html.twig'
    # the status code to include in the response headers
    statusCode: 201
```
This could be useful for when you want to render a template without adding any extra business logic in a controller, but don't want to return a 200 response.
