### PR TITLE
[Notifier] Add warning if transport factory was not added for new bridge

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1874,13 +1874,18 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertFalse($container->hasDefinition('texter'));
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testIfNotifierTransportsAreKnownByFrameworkExtension()
     {
         $container = $this->createContainerFromFile('notifier');
 
         foreach ((new Finder())->in(\dirname(__DIR__, 4).'/Component/Notifier/Bridge')->directories()->depth(0)->exclude('Mercure') as $bridgeDirectory) {
             $transportFactoryName = strtolower($bridgeDirectory->getFilename());
-            $this->assertTrue($container->hasDefinition('notifier.transport_factory.'.$transportFactoryName), sprintf('Did you forget to add the TransportFactory: "%s" to the $classToServices array in the FrameworkBundleExtension?', $bridgeDirectory->getFilename()));
+            if (!$container->hasDefinition('notifier.transport_factory.'.$transportFactoryName)) {
+                $this->addWarning(sprintf('The TransportFactory service "%s" is missing. Please don\'t forget to add the TransportFactory: "%s" to the $classToServices array in the FrameworkBundleExtension.', 'notifier.transport_factory.'.$transportFactoryName, $bridgeDirectory->getFilename()));
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->

In #40845 we added a test to make sure the framework integration for a new notifier bridge is configured correctly. But in #41375 we realised that a failing test will prevent us from merging a new bridge were we don't have a subtree split repository yet.

A possible solution could be to just show a warning instead of letting the test fail which I would like to propose here.
