### PR TITLE
[Serializer] Pass context from serializer to property info

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -4,7 +4,8 @@ CHANGELOG
 6.2
 ---
 
-* Add support for constructor promoted properties to `Context` attribute
+ * Add support for constructor promoted properties to `Context` attribute
+ * Pass context from serializer to property info
 
 6.1
 ---

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyCompany.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyCompany.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class DummyCompany implements DummySubjectInterface
+{
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyProduct.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyProduct.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class DummyProduct implements DummySubjectInterface
+{
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummyReviewCreateDto.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummyReviewCreateDto.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+class DummyReviewCreateDto
+{
+    /**
+     * @var DummySubjectInterface
+     */
+    public $subject;
+
+    public $review;
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/DummySubjectInterface.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/DummySubjectInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+interface DummySubjectInterface
+{
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Use case:

There is a reusable Review model with interface. And then there are CompanyReview and ProductReview,
both uses the same model with implemented interface.

Now I'd like to provide also a single DTO which could typehint an interface and not the model implementation.
But as serializer doesn't pass the context to the property info, I cannot implement a custom property type
extractor which could give the right type based on my provided context.

To better understand see the new test.
