### PR TITLE
[Messenger] remove legacy code paths

### DIFF
--- a/src/Symfony/Component/Messenger/Envelope.php
+++ b/src/Symfony/Component/Messenger/Envelope.php
@@ -73,7 +73,7 @@ final class Envelope
     {
         $cloned = clone $this;
 
-        unset($cloned->stamps[$this->resolveAlias($stampFqcn)]);
+        unset($cloned->stamps[$stampFqcn]);
 
         return $cloned;
     }
@@ -84,7 +84,6 @@ final class Envelope
     public function withoutStampsOfType(string $type): self
     {
         $cloned = clone $this;
-        $type = $this->resolveAlias($type);
 
         foreach ($cloned->stamps as $class => $stamps) {
             if ($class === $type || is_subclass_of($class, $type)) {
@@ -97,7 +96,7 @@ final class Envelope
 
     public function last(string $stampFqcn): ?StampInterface
     {
-        return isset($this->stamps[$stampFqcn = $this->resolveAlias($stampFqcn)]) ? end($this->stamps[$stampFqcn]) : null;
+        return isset($this->stamps[$stampFqcn = $stampFqcn]) ? end($this->stamps[$stampFqcn]) : null;
     }
 
     /**
@@ -106,7 +105,7 @@ final class Envelope
     public function all(string $stampFqcn = null): array
     {
         if (null !== $stampFqcn) {
-            return $this->stamps[$this->resolveAlias($stampFqcn)] ?? [];
+            return $this->stamps[$stampFqcn] ?? [];
         }
 
         return $this->stamps;
@@ -118,15 +117,5 @@ final class Envelope
     public function getMessage(): object
     {
         return $this->message;
-    }
-
-    /**
-     * BC to be removed in 6.0.
-     */
-    private function resolveAlias(string $fqcn): string
-    {
-        static $resolved;
-
-        return $resolved[$fqcn] ?? ($resolved[$fqcn] = (new \ReflectionClass($fqcn))->getName());
     }
 }

--- a/src/Symfony/Component/Messenger/Middleware/RejectRedeliveredMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/RejectRedeliveredMessageMiddleware.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Messenger\Middleware;
 use Symfony\Component\Messenger\Bridge\Amqp\Transport\AmqpReceivedStamp;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\RejectRedeliveredMessageException;
-use Symfony\Component\Messenger\Transport\AmqpExt\AmqpReceivedStamp as LegacyAmqpReceivedStamp;
 
 /**
  * Middleware that throws a RejectRedeliveredMessageException when a message is detected that has been redelivered by AMQP.
@@ -36,12 +35,6 @@ class RejectRedeliveredMessageMiddleware implements MiddlewareInterface
     {
         $amqpReceivedStamp = $envelope->last(AmqpReceivedStamp::class);
         if ($amqpReceivedStamp instanceof AmqpReceivedStamp && $amqpReceivedStamp->getAmqpEnvelope()->isRedelivery()) {
-            throw new RejectRedeliveredMessageException('Redelivered message from AMQP detected that will be rejected and trigger the retry logic.');
-        }
-
-        // Legacy code to support symfony/messenger < 5.1
-        $amqpReceivedStamp = $envelope->last(LegacyAmqpReceivedStamp::class);
-        if ($amqpReceivedStamp instanceof LegacyAmqpReceivedStamp && $amqpReceivedStamp->getAmqpEnvelope()->isRedelivery()) {
             throw new RejectRedeliveredMessageException('Redelivered message from AMQP detected that will be rejected and trigger the retry logic.');
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Should make tests green. (and missed in https://github.com/symfony/symfony/pull/41319)