### PR TITLE
[HttpClient] Check if curl_multi_exec is supported

### DIFF
--- a/src/Symfony/Component/HttpClient/HttpClient.php
+++ b/src/Symfony/Component/HttpClient/HttpClient.php
@@ -49,7 +49,7 @@ final class HttpClient
             }
         }
 
-        if (\extension_loaded('curl')) {
+        if (\extension_loaded('curl') && \function_exists('curl_multi_exec')) {
             if ('\\' !== \DIRECTORY_SEPARATOR || isset($defaultOptions['cafile']) || isset($defaultOptions['capath']) || ini_get('curl.cainfo') || ini_get('openssl.cafile') || ini_get('openssl.capath')) {
                 return new CurlHttpClient($defaultOptions, $maxHostConnections, $maxPendingPushes);
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Check if curl_multi_exec is supported

if it isn't active, just return an object of type NativeHttpClient. 
