### PR TITLE
[DoctrineBridge] add `DoctrineLoader`, which extracts information from Doctrine ORM

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Serializer/DoctrineLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Serializer/DoctrineLoader.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Bridge\Doctrine\Serializer;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Serializer\Mapping\AttributeMetadata;
+use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
+use Symfony\Component\Serializer\Mapping\Loader\LoaderInterface;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+
+/**
+ * Sets DateTimeNormalizer::FORMAT_KEY to ISO 8601 (Y-m-d) for dates, (H:i:s) for time.
+ */
+class DoctrineLoader implements LoaderInterface
+{
+    private $doctrine;
+    private $dateFormat;
+    private $timeFormat;
+
+    public function __construct(ManagerRegistry $doctrine, string $dateFormat = 'Y-m-d', string $timeFormat = 'H:i:s')
+    {
+        $this->doctrine = $doctrine;
+        $this->dateFormat = $dateFormat;
+        $this->timeFormat = $timeFormat;
+    }
+
+    public function loadClassMetadata(ClassMetadataInterface $classMetadata): bool
+    {
+        $reflectionClass = $classMetadata->getReflectionClass();
+        $entityManager = $this->doctrine->getManagerForClass($reflectionClass->getName());
+
+        if (null === $entityManager) {
+            return false;
+        }
+
+        $doctrineMetadata = $entityManager->getClassMetadata($reflectionClass->getName());
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+
+        foreach ($reflectionClass->getProperties() as $property) {
+            if (!$doctrineMetadata->hasField($property->name)) {
+                continue;
+            }
+
+            $context = $this->getContext($doctrineMetadata->getTypeOfField($property->name));
+
+            if (null !== $context) {
+                $attributeMetadata = $attributesMetadata[$property->name] ?? new AttributeMetadata($property->name);
+                $classMetadata->addAttributeMetadata($attributeMetadata);
+
+                $attributeMetadata->setNormalizationContextForGroups($context);
+                $attributeMetadata->setDenormalizationContextForGroups($context);
+            }
+        }
+
+        return true;
+    }
+
+    private function getContext(string $type): ?array
+    {
+        switch ($type) {
+            case Types::DATE_IMMUTABLE:
+            case Types::DATE_MUTABLE:
+                return [
+                    DateTimeNormalizer::FORMAT_KEY => $this->dateFormat,
+                ];
+            case Types::TIME_IMMUTABLE:
+            case Types::TIME_MUTABLE:
+                return [
+                    DateTimeNormalizer::FORMAT_KEY => $this->timeFormat,
+                ];
+            default:
+                return null;
+        }
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DoctrineSerializerLoaderEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/DoctrineSerializerLoaderEntity.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity()
+ */
+class DoctrineSerializerLoaderEntity
+{
+    /**
+     * @ORM\Id()
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue()
+     */
+    public $id;
+
+    /**
+     * @ORM\Column(type="date")
+     */
+    public $dateMutable;
+
+    /**
+     * @ORM\Column(type="date_immutable")
+     */
+    public $dateImmutable;
+
+    /**
+     * @ORM\Column(type="time")
+     */
+    private $timeMutable;
+
+    /**
+     * @ORM\Column(type="time_immutable")
+     */
+    private $timeImmutable;
+}

--- a/src/Symfony/Bridge/Doctrine/Tests/Serializer/DoctrineLoaderTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Serializer/DoctrineLoaderTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Bridge\Doctrine\Tests\Serializer;
+
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\Doctrine\Serializer\DoctrineLoader;
+use Symfony\Bridge\Doctrine\Tests\DoctrineTestHelper;
+use Symfony\Bridge\Doctrine\Tests\Fixtures\DoctrineSerializerLoaderEntity;
+use Symfony\Component\Serializer\Mapping\ClassMetadata;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
+
+class DoctrineLoaderTest extends TestCase
+{
+    public function datesProvider(): iterable
+    {
+        yield ['dateImmutable', 'Y-m-d'];
+        yield ['dateMutable', 'Y-m-d'];
+        yield ['timeImmutable', 'H:i:s'];
+        yield ['timeMutable', 'H:i:s'];
+    }
+
+    /**
+     * @dataProvider datesProvider
+     */
+    public function testDates(string $field, string $expectedFormat)
+    {
+        $entityManager = DoctrineTestHelper::createTestEntityManager();
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry
+            ->expects(self::any())
+            ->method('getManagerForClass')
+            ->with(DoctrineSerializerLoaderEntity::class)
+            ->willReturn($entityManager);
+
+        $loader = new DoctrineLoader($registry);
+
+        $classMetadata = new ClassMetadata(DoctrineSerializerLoaderEntity::class);
+        $loader->loadClassMetadata($classMetadata);
+
+        self::assertSame(
+            $expectedFormat,
+            $classMetadata->getAttributesMetadata()[$field]->getNormalizationContexts(
+            )['*'][DateTimeNormalizer::FORMAT_KEY]
+        );
+        self::assertSame(
+            $expectedFormat,
+            $classMetadata->getAttributesMetadata()[$field]->getDenormalizationContexts(
+            )['*'][DateTimeNormalizer::FORMAT_KEY]
+        );
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -43,6 +43,7 @@
         "symfony/uid": "^5.1|^6.0",
         "symfony/validator": "^5.2|^6.0",
         "symfony/translation": "^4.4|^5.0|^6.0",
+        "symfony/serializer": "^4.4|^5.0|^6.0",
         "symfony/var-dumper": "^4.4|^5.0|^6.0",
         "doctrine/annotations": "^1.10.4",
         "doctrine/collections": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #41227
| License       | MIT
| Doc PR        | 

Needs help from someone to make this configurable in FrameworkBundle. (Opt-in probably, and desired format for date and time).

Just noticed the Static analysis failure - but return value from method seems useless, cause it's not used anywhere - and because of that, I'm unsure what should be returned ?

https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactory.php#L50

