### PR TITLE
[Messenger] Fixed query string parsing

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/ConnectionTest.php
@@ -151,6 +151,16 @@ class ConnectionTest extends TestCase
         );
     }
 
+    public function testFromDsnWithSecretKeyQueryOptions()
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+
+        $this->assertEquals(
+            new Connection(['account' => '213', 'queue_name' => 'queue', 'buffer_size' => 1, 'wait_time' => 5, 'auto_setup' => false], new SqsClient(['region' => 'eu-west-1', 'accessKeyId' => null, 'accessKeySecret' => 'A+a+B+b'], null, $httpClient)),
+            Connection::fromDsn('sqs://default/213/queue?secret_key=A+a+B+b&buffer_size=1&wait_time=5&auto_setup=0', [], $httpClient)
+        );
+    }
+
     public function testFromDsnWithQueueNameOption()
     {
         $httpClient = $this->createMock(HttpClientInterface::class);

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -108,6 +108,10 @@ class Connection
             parse_str($parsedUrl['query'], $query);
         }
 
+        if (\array_key_exists('secret_key', $query)) {
+            $query['secret_key'] = str_replace(' ', '+', $query['secret_key']);
+        }
+
         // check for extra keys in options
         $optionsExtraKeys = array_diff(array_keys($options), array_keys(self::DEFAULT_OPTIONS));
         if (0 < \count($optionsExtraKeys)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  - 
| License       | MIT
| Doc PR        | -

Hi!
I love Symfony, it's a very useful framework. 

While using it, I found a bug and would like to make a pull request. 

The secret_key issued by Amazon SQS may contain a "+".

Before the fix, when you parse `A+a+A`, there was a problem that you cannot access Amazon SQS because of the unintended change as follows.
(This is the change that happens when using `parse_str()`.)

### Run parse_str()

#### before

```
A+a+A
```

#### after

```
A a A
```


In this pull request, we will fix it to use the exact secret_key by changing it to not use `parse_str()`.

