### PR TITLE
[WebProfilerBundle] Improved the light/dark theme switching

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base.html.twig
@@ -15,10 +15,18 @@
     </head>
     <body>
         <script>
-            document.body.classList.add(
-                localStorage.getItem('symfony/profiler/theme') || (matchMedia('(prefers-color-scheme: dark)').matches ? 'theme-dark' : 'theme-light'),
-                localStorage.getItem('symfony/profiler/width') || 'width-normal'
-            );
+            if (null === localStorage.getItem('symfony/profiler/theme') || 'theme-auto' === localStorage.getItem('symfony/profiler/theme')) {
+                document.body.classList.add((matchMedia('(prefers-color-scheme: dark)').matches ? 'theme-dark' : 'theme-light'));
+            } else {
+                document.body.classList.add(localStorage.getItem('symfony/profiler/theme'));
+            }
+            // needed to respond dynamically to OS changes without having to refresh the page
+            window.matchMedia('(prefers-color-scheme: dark)').addListener(function (e) {
+                document.body.classList.remove(e.matches ? 'theme-light' : 'theme-dark');
+                document.body.classList.add(e.matches ? 'theme-dark' : 'theme-light');
+            });
+
+            document.body.classList.add(localStorage.getItem('symfony/profiler/width') || 'width-normal');
         </script>
 
         {% block body '' %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/settings.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/settings.html.twig
@@ -116,21 +116,25 @@
         <div class="modal-content">
             <h4>Theme</h4>
 
+            <input class="config-option" type="radio" name="theme" value="auto" id="settings-theme-auto">
+            <label for="settings-theme-auto">Auto</label>
+            <p class="form-help"><strong>Default theme</strong>. It switches between Light and Dark automatically to match the operating system theme.</p>
+
             <input class="config-option" type="radio" name="theme" value="light" id="settings-theme-light">
             <label for="settings-theme-light">Light</label>
-            <p class="form-help">Default theme. Improves readability.</p>
+            <p class="form-help">Provides greatest readability, but requires a well-lit environment.</p>
 
             <input class="config-option" type="radio" name="theme" value="dark" id="settings-theme-dark">
             <label for="settings-theme-dark">Dark</label>
-            <p class="form-help">Reduces eye fatigue. Ideal for low light conditions.</p>
+            <p class="form-help">Reduces eye fatigue. Ideal for low light environments.</p>
 
             <h4>Page Width</h4>
 
-            <input class="config-option" type="radio" name="width" value="light" id="settings-width-normal">
+            <input class="config-option" type="radio" name="width" value="normal" id="settings-width-normal">
             <label for="settings-width-normal">Normal</label>
             <p class="form-help">Fixed page width. Improves readability.</p>
 
-            <input class="config-option" type="radio" name="width" value="dark" id="settings-width-full">
+            <input class="config-option" type="radio" name="width" value="full" id="settings-width-full">
             <label for="settings-width-full">Full-page</label>
             <p class="form-help">Dynamic page width. As wide as the browser window.</p>
         </div>
@@ -139,27 +143,38 @@
 
 <script>
 (function() {
-    let configOptions = document.querySelectorAll('.config-option');
-    let oppositeValues = { 'light': 'dark', 'dark': 'light', 'normal': 'full', 'full': 'normal' };
+    const configOptions = document.querySelectorAll('.config-option');
+    const allSettingValues = ['theme-auto', 'theme-ligh', 'theme-dark', 'width-normal', 'width-full'];
     [...configOptions].forEach(option => {
-        option.addEventListener('click', function (event) {
-            let optionParts = option.id.split('-');
-            let optionName = optionParts[1];
-            let optionValue = optionParts[2];
+        option.addEventListener('change', function (event) {
+            const optionName = option.name;
+            const optionValue = option.value;
+            const settingName = 'symfony/profiler/' + optionName;
+            const settingValue = optionName + '-' + optionValue;
 
-            document.body.classList.remove(optionName + '-' + oppositeValues[optionValue]);
-            document.body.classList.add(optionName + '-' + optionValue);
-            localStorage.setItem('symfony/profiler/' + optionName, optionName + '-' + optionValue);
+            localStorage.setItem(settingName, settingValue);
+
+            document.body.classList.forEach((cssClass) => {
+                if (cssClass.startsWith(optionName)) {
+                    document.body.classList.remove(cssClass);
+                }
+            });
+
+            if ('theme-auto' === settingValue) {
+                document.body.classList.add((matchMedia('(prefers-color-scheme: dark)').matches ? 'theme-dark' : 'theme-light'));
+            } else {
+                document.body.classList.add(settingValue);
+            }
         });
     });
 
-    let openModalButton = document.getElementById('open-settings');
-    let modalWindow = document.getElementById('profiler-settings');
-    let closeModalButton = document.getElementsByClassName('close-modal')[0];
-    let modalWrapper = document.getElementsByClassName('modal-wrap')[0]
+    const openModalButton = document.getElementById('open-settings');
+    const modalWindow = document.getElementById('profiler-settings');
+    const closeModalButton = document.getElementsByClassName('close-modal')[0];
+    const modalWrapper = document.getElementsByClassName('modal-wrap')[0]
 
     openModalButton.addEventListener('click', function(event) {
-        document.getElementById('settings-' + (localStorage.getItem('symfony/profiler/theme') || 'theme-light')).checked = 'checked';
+        document.getElementById('settings-' + (localStorage.getItem('symfony/profiler/theme') || 'theme-auto')).checked = 'checked';
         document.getElementById('settings-' + (localStorage.getItem('symfony/profiler/width') || 'width-normal')).checked = 'checked';
 
         modalWindow.classList.toggle('visible');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

~Note: I think this is a bug fix ... but maybe you prefer to consider it a new feature.~

-----

The current Symfony Profiler works like this:

* If you don't set the theme, it selects it automatically form light/dark to match your OS
* But you can also select "light" or "dark" explicitly

The problem is that when you choose a theme explicitly, the "auto" theme is no longer available. You need to delete the local storage of your browser.

This PR makes it explicit the "auto theme" already available in the Profiler. That way, you can set "light", "dark" or "auto" explicitly:

![Captura de pantalla 2021-05-28 a las 11 01 21](https://user-images.githubusercontent.com/73419/119959213-130b9500-bfa4-11eb-80b8-8adb089bbbda.png)

It also changes the "theme listener" to respond instantly to OS changes, without having to refresh the page.
