### PR TITLE
[Translation] [PoEditor] Fixed languages creation

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -313,9 +313,7 @@ final class LokaliseProvider implements ProviderInterface
         $responseContent = $response->toArray(false);
 
         if (\array_key_exists('languages', $responseContent)) {
-            return array_map(function ($language) {
-                return $language['lang_iso'];
-            }, $responseContent['languages']);
+            return array_column($responseContent['languages'], 'lang_iso');
         }
 
         return [];

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/PoEditorHttpClient.php
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/PoEditorHttpClient.php
@@ -24,7 +24,7 @@ final class PoEditorHttpClient implements HttpClientInterface
     {
         if (isset($options['poeditor_credentials'])) {
             if ('POST' === $method) {
-                $options['body'] = $options['poeditor_credentials'] + $options['body'];
+                $options['body'] = $options['poeditor_credentials'] + ($options['body'] ?? []);
             }
             unset($options['poeditor_credentials']);
         }

--- a/src/Symfony/Component/Translation/Bridge/PoEditor/Tests/PoEditorProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/PoEditor/Tests/PoEditorProviderTest.php
@@ -54,6 +54,39 @@ class PoEditorProviderTest extends ProviderTestCase
         ]));
 
         $responses = [
+            'getLanguages' => function (string $method, string $url, array $options = []): MockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertSame(http_build_query([
+                    'api_token' => 'API_KEY',
+                    'id' => 'PROJECT_ID',
+                ]), $options['body']);
+
+                return new MockResponse(json_encode([
+                    'response' => [
+                        'status' => 'success',
+                        'code' => '200',
+                        'message' => 'OK',
+                    ],
+                    'result' => [
+                        'languages' => [
+                            [
+                                'name' => 'English',
+                                'code' => 'en',
+                            ],
+                        ],
+                    ],
+                ]));
+            },
+            'createLanguages' => function (string $method, string $url, array $options = []) use ($successResponse): MockResponse {
+                $this->assertSame('POST', $method);
+                $this->assertSame(http_build_query([
+                    'api_token' => 'API_KEY',
+                    'id' => 'PROJECT_ID',
+                    'language' => 'fr',
+                ]), $options['body']);
+
+                return $successResponse;
+            },
             'addTerms' => function (string $method, string $url, array $options = []) use ($successResponse): MockResponse {
                 $this->assertSame('POST', $method);
                 $this->assertSame(http_build_query([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix partially https://github.com/symfony/symfony/issues/41374
| License       | MIT
| Doc PR        |

This PR fixes the first (at least for one locale) execution of `translation:push`, when Symfony locales do not exists in PoEditor, and should be created.

