### PR TITLE
[CssSelector] [WIP] Support of :has pseudo selector

### DIFF
--- a/src/Symfony/Component/CssSelector/Node/HasNode.php
+++ b/src/Symfony/Component/CssSelector/Node/HasNode.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Symfony\Component\CssSelector\Node;
+
+class HasNode extends AbstractNode
+{
+    private $selector;
+    private $subSelector;
+
+    public function __construct(NodeInterface $selector, NodeInterface $subSelector)
+    {
+        $this->selector = $selector;
+        $this->subSelector = $subSelector;
+    }
+
+    public function getSelector(): NodeInterface
+    {
+        return $this->selector;
+    }
+
+    public function getSubSelector(): NodeInterface
+    {
+        return $this->subSelector;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSpecificity(): Specificity
+    {
+        return $this->selector->getSpecificity()->plus($this->subSelector->getSpecificity());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        return sprintf('%s[%s:has(%s)]', $this->getNodeName(), $this->selector, $this->subSelector);
+    }
+}

--- a/src/Symfony/Component/CssSelector/Tests/Node/HasNodeTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Node/HasNodeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\CssSelector\Tests\Node;
+
+use Symfony\Component\CssSelector\Node\ClassNode;
+use Symfony\Component\CssSelector\Node\ElementNode;
+use Symfony\Component\CssSelector\Node\HasNode;
+
+class HasNodeTest extends AbstractNodeTest
+{
+    public function getToStringConversionTestData()
+    {
+        return [
+            [new HasNode(new ElementNode(), new ClassNode(new ElementNode(), 'class')), 'Has[Element[*]:has(Class[Element[*].class])]'],
+        ];
+    }
+
+    public function getSpecificityValueTestData()
+    {
+        return [
+            [new HasNode(new ElementNode(), new ClassNode(new ElementNode(), 'class')), 10],
+        ];
+    }
+}

--- a/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/ParserTest.php
@@ -138,6 +138,8 @@ class ParserTest extends TestCase
             ['div:not(div.foo)', ['Negation[Element[div]:not(Class[Element[div].foo])]']],
             ['td ~ th', ['CombinedSelector[Element[td] ~ Element[th]]']],
             ['.foo[data-bar][data-baz=0]', ["Attribute[Attribute[Class[Element[*].foo][data-bar]][data-baz = '0']]"]],
+            ['*:has(div)', ['Has[Element[*]:has(Element[div])]']],
+//            ['section:not(:has(h1, h2, h3, h4, h5, h6))', ['']],
         ];
     }
 
@@ -168,6 +170,7 @@ class ParserTest extends TestCase
             [':lang(fr', SyntaxErrorException::unexpectedToken('an argument', new Token(Token::TYPE_FILE_END, '', 8))->getMessage()],
             [':contains("foo', SyntaxErrorException::unclosedString(10)->getMessage()],
             ['foo!', SyntaxErrorException::unexpectedToken('selector', new Token(Token::TYPE_DELIMITER, '!', 3))->getMessage()],
+            ['div:has(div', SyntaxErrorException::unexpectedToken('")"', new Token(Token::TYPE_FILE_END, '', 11))->getMessage()],
         ];
     }
 

--- a/src/Symfony/Component/CssSelector/Tests/XPath/Fixtures/ids.html
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/Fixtures/ids.html
@@ -20,6 +20,7 @@ c"></li>
    <li id="sixth-li"></li>
    <li id="seventh-li">  </li>
  </ol>
+ <ol class="second-ol"></ol>
  <p id="paragraph">
    <b id="p-b">hi</b> <em id="p-em">there</em>
    <b id="p-b2">guy</b>

--- a/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/XPath/TranslatorTest.php
@@ -219,6 +219,7 @@ HTML
             ['e + f', "e/following-sibling::*[(name() = 'f') and (position() = 1)]"],
             ['e ~ f', 'e/following-sibling::f'],
             ['div#container p', "div[@id = 'container']/descendant-or-self::*/p"],
+            ['e:has(div)', "e['div']"]
         ];
     }
 
@@ -353,6 +354,7 @@ HTML
             [':not(*)', []],
             ['a:not([href])', ['name-anchor']],
             ['ol :Not(li[class])', ['first-li', 'second-li', 'li-div', 'fifth-li', 'sixth-li', 'seventh-li']],
+            ['ol:has(li)', ['first-ol']],
             // HTML-specific
             [':link', ['link-href', 'tag-anchor', 'nofollow-anchor', 'area-href']],
             [':visited', []],

--- a/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/NodeExtension.php
@@ -74,6 +74,7 @@ class NodeExtension extends AbstractExtension
             'Class' => [$this, 'translateClass'],
             'Hash' => [$this, 'translateHash'],
             'Element' => [$this, 'translateElement'],
+            'Has' => [$this, 'translateHas'],
         ];
     }
 
@@ -98,6 +99,15 @@ class NodeExtension extends AbstractExtension
         }
 
         return $xpath->addCondition('0');
+    }
+
+    public function translateHas(Node\HasNode $node, Translator $translator): XPathExpr
+    {
+        $xpath = $translator->nodeToXPath($node->getSelector());
+        $subXpath = $translator->nodeToXPath($node->getSubSelector());
+//        $subXpath->addNameTest();
+
+        return new XPathExpr('', $xpath, $subXpath);
     }
 
     public function translateFunction(Node\FunctionNode $node, Translator $translator): XPathExpr


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #40179
| License       | MIT
| Doc PR        | TODO
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

> ⚠️ This is the first time I have putted my hands in the CssSelector component and I don't exactly know how it works. Thank you for your understanding 😄 
---
Support of the [`:has` pseudo class](https://drafts.csswg.org/selectors-4/#has-pseudo):
```php
$crawler->filter('.foo:has(.bar)');
```