### PR TITLE
[HttpKernel] Provide migration path for TestSessionListener

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -5,3 +5,8 @@ FrameworkBundle
 ---------------
 
  * Deprecate the `AdapterInterface` autowiring alias, use `CacheItemPoolInterface` instead
+
+HttpKernel
+----------
+
+ * Deprecate `AbstractTestSessionListener::getSession` inject a session in the request instead

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.php
@@ -38,7 +38,6 @@ return static function (ContainerConfigurator $container) {
         ->set('test.session.listener', TestSessionListener::class)
             ->args([
                 service_locator([
-                    'session_factory' => service('session.factory')->ignoreOnInvalid(),
                     'session' => service('.session.do-not-use')->ignoreOnInvalid(),
                 ]),
             ])

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Deprecate `AbstractTestSessionListener::getSession` inject a session in the request instead
+
 5.3
 ---
 

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
@@ -46,7 +46,9 @@ abstract class AbstractTestSessionListener implements EventSubscriberInterface
         }
 
         // bootstrap the session
-        if (!$session = $this->getSession()) {
+        if ($event->getRequest()->hasSession()) {
+            $session = $event->getRequest()->getSession();
+        } elseif (!$session = $this->getSession()) {
             return;
         }
 
@@ -100,13 +102,15 @@ abstract class AbstractTestSessionListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::REQUEST => ['onKernelRequest', 192],
+            KernelEvents::REQUEST => ['onKernelRequest', 127], // AFTER SessionListener
             KernelEvents::RESPONSE => ['onKernelResponse', -128],
         ];
     }
 
     /**
      * Gets the session object.
+     *
+     * @deprecated since Symfony 5.4, will be removed in 6.0.
      *
      * @return SessionInterface|null A SessionInterface instance or null if no session is available
      */

--- a/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/TestSessionListener.php
@@ -31,14 +31,15 @@ class TestSessionListener extends AbstractTestSessionListener
         parent::__construct($sessionOptions);
     }
 
+    /**
+     * @deprecated since Symfony 5.4, will be removed in 6.0.
+     */
     protected function getSession(): ?SessionInterface
     {
+        trigger_deprecation('symfony/http-kernel', '5.4', '"%s" is deprecated and will be removed in 6.0, inject a session in the request instead.', __METHOD__);
+
         if ($this->container->has('session')) {
             return $this->container->get('session');
-        }
-
-        if ($this->container->has('session_factory')) {
-            return $this->container->get('session_factory')->createSession();
         }
 
         return null;

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/TestSessionListenerTest.php
@@ -19,7 +19,6 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\AbstractTestSessionListener;
-use Symfony\Component\HttpKernel\EventListener\SessionListener;
 use Symfony\Component\HttpKernel\EventListener\TestSessionListener;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -99,6 +98,7 @@ class TestSessionListenerTest extends TestCase
 
         $kernel = $this->createMock(HttpKernelInterface::class);
         $request = Request::create('/', 'GET', [], ['MOCKSESSID' => '123']);
+        $request->setSession($this->getSession());
         $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
         $this->listener->onKernelRequest($event);
 
@@ -118,6 +118,7 @@ class TestSessionListenerTest extends TestCase
 
         $kernel = $this->createMock(HttpKernelInterface::class);
         $request = Request::create('/', 'GET', [], ['MOCKSESSID' => '123']);
+        $request->setSession($this->getSession());
         $event = new RequestEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST);
         $this->listener->onKernelRequest($event);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When working on #41321 I realized that #41343 was wrong for `TestSessionListener`.
Injecting the factory in both SessionListener AND TestSessionListener would generate 2 distinguished session instances which is the opposite of the expected behavior: TestSessionListener needs the session used by the request to set the right sessionId in the cookie.

This PR fallback to `request->getSession()` when there is no session injected in the container (ie: FrameworkBundlke:6)