### PR TITLE
[FrameworkBundle] Remove redundant cache service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1555,7 +1555,7 @@ class FrameworkExtension extends Extension
             $container->setDefinition('annotations.cached_reader', $container->getDefinition('annotations.psr_cached_reader'));
 
             if ('php_array' === $config['cache']) {
-                $cacheService = 'annotations.psr_cache';
+                $cacheService = 'annotations.cache_adapter';
 
                 // Enable warmer only if PHP array is used for cache
                 $definition = $container->findDefinition('annotations.cache_warmer');

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
@@ -68,10 +68,11 @@ return static function (ContainerConfigurator $container) {
                 param('kernel.cache_dir').'/annotations.php',
                 service('cache.annotations'),
             ])
+            ->tag('container.hot_path')
 
         ->set('annotations.cache', DoctrineProvider::class)
             ->args([
-                service('annotations.cache_adapter')
+                service('annotations.cache_adapter'),
             ])
             ->tag('container.hot_path')
 
@@ -86,13 +87,6 @@ return static function (ContainerConfigurator $container) {
                     inline_service(ArrayAdapter::class),
                     abstract_arg('Debug-Flag'),
                 ])
-            ->set('annotations.psr_cache', PhpArrayAdapter::class)
-                ->factory([PhpArrayAdapter::class, 'create'])
-                ->args([
-                    param('kernel.cache_dir').'/annotations.php',
-                    service('cache.annotations'),
-                ])
-                ->tag('container.hot_path')
         ;
     }
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Follows #40444 and #41230.

@Nyholm and I have fixed the same problem on different branches. Merging both efforts, we've created two cache services that are supposed to serve the same purpose. This PR suggests to remove one of them.