### PR TITLE
[Form] Document null support in NumberToLocalizedStringTransformer

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformer.php
@@ -45,7 +45,7 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
     /**
      * Transforms a normalized format into a localized money string.
      *
-     * @param int|float $value Normalized number
+     * @param int|float|null $value Normalized number
      *
      * @return string Localized money string
      *
@@ -69,7 +69,7 @@ class MoneyToLocalizedStringTransformer extends NumberToLocalizedStringTransform
      *
      * @param string $value Localized money string
      *
-     * @return int|float Normalized number
+     * @return int|float|null Normalized number
      *
      * @throws TransformationFailedException if the given value is not a string
      *                                       or if the value can not be transformed

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -98,7 +98,7 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
     /**
      * Transforms a number type into localized number.
      *
-     * @param int|float $value Number value
+     * @param int|float|null $value Number value
      *
      * @return string Localized value
      *
@@ -133,7 +133,7 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
      *
      * @param string $value The localized value
      *
-     * @return int|float The numeric value
+     * @return int|float|null The numeric value
      *
      * @throws TransformationFailedException if the given value is not a string
      *                                       or if the value can not be transformed


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`Symfony\Component\Form\Extension\Core\DataTransformer\NumberToLocalizedStringTransformer` explicitly checks for and returns nulls but these aren't documented in the class' doc blocks, which causes static analysis tools to report a false positive when checking for these null values elsewhere.  This adds the missing null types to the doc blocks.