### PR TITLE
[FrameworkBundle] fix creating ContainerBuilder at warmup/CLI time

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
@@ -40,7 +40,11 @@ trait BuildDebugContainerTrait
         }
 
         if (!$kernel->isDebug() || !(new ConfigCache($kernel->getContainer()->getParameter('debug.container.dump'), true))->isFresh()) {
-            $buildContainer = \Closure::bind(function () { return $this->buildContainer(); }, $kernel, \get_class($kernel));
+            $buildContainer = \Closure::bind(function () {
+                $this->initializeBundles();
+
+                return $this->buildContainer();
+            }, $kernel, \get_class($kernel));
             $container = $buildContainer();
             $container->getCompilerPassConfig()->setRemovingPasses([]);
             $container->getCompilerPassConfig()->setAfterRemovingPasses([]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41011, #41128
| License       | MIT
| Doc PR        | -

In prod mode, because we hack the kernel to recreate a container builder at runtime for introspection needs, we end up with a broken object graph. Calling `$this->initializeBundles()` creates fresh bundle instances and that fixes the issue.

This could be merged on 5.2, but we don't need the fix on 5.2 because we never encountered the situation before adding the cache warmer for config builders.