### PR TITLE
[FrameworkBundle] Always dump the container as XML

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/BuildDebugContainerTrait.php
@@ -38,8 +38,10 @@ trait BuildDebugContainerTrait
         if ($this->containerBuilder) {
             return $this->containerBuilder;
         }
+        $container = $kernel->getContainer();
+        $containerDump = $container->hasParameter('debug.container.dump') ? $container->getParameter('debug.container.dump') : null;
 
-        if (!$kernel->isDebug() || !(new ConfigCache($kernel->getContainer()->getParameter('debug.container.dump'), true))->isFresh()) {
+        if (null === $containerDump || !(new ConfigCache($containerDump, $kernel->isDebug()))->isFresh()) {
             $buildContainer = \Closure::bind(function () {
                 $this->initializeBundles();
 
@@ -50,7 +52,7 @@ trait BuildDebugContainerTrait
             $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
             $container->compile();
         } else {
-            (new XmlFileLoader($container = new ContainerBuilder(), new FileLocator()))->load($kernel->getContainer()->getParameter('debug.container.dump'));
+            (new XmlFileLoader($container = new ContainerBuilder(), new FileLocator()))->load($containerDump);
             $locatorPass = new ServiceLocatorTagPass();
             $locatorPass->process($container);
         }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -938,9 +938,7 @@ class FrameworkExtension extends Extension
 
         $debug = $container->getParameter('kernel.debug');
 
-        if ($debug) {
-            $container->setParameter('debug.container.dump', '%kernel.build_dir%/%kernel.container_class%.xml');
-        }
+        $container->setParameter('debug.container.dump', '%kernel.build_dir%/%kernel.container_class%.xml');
 
         if ($debug && class_exists(Stopwatch::class)) {
             $loader->load('debug.php');

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -160,11 +160,11 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new RegisterReverseContainerPass(false), PassConfig::TYPE_AFTER_REMOVING);
         $container->addCompilerPass(new RemoveUnusedSessionMarshallingHandlerPass());
         $container->addCompilerPass(new SessionPass());
+        $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_BEFORE_REMOVING, -255);
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new AddDebugLogProcessorPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 2);
             $container->addCompilerPass(new UnusedTagsPass(), PassConfig::TYPE_AFTER_REMOVING);
-            $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_BEFORE_REMOVING, -255);
             $container->addCompilerPass(new CacheCollectorPass(), PassConfig::TYPE_BEFORE_REMOVING);
         }
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -382,6 +382,7 @@ class SecurityExtensionTest extends TestCase
         $container->registerExtension(new FrameworkExtension());
         $container->setParameter('kernel.bundles_metadata', []);
         $container->setParameter('kernel.project_dir', __DIR__);
+        $container->setParameter('kernel.build_dir', __DIR__);
         $container->setParameter('kernel.cache_dir', __DIR__);
         $container->setParameter('kernel.container_class', 'FooContainer');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Dumping the container as XML in prod too prevents compiling it twice on `cache:warmup`, when eg `ConfigBuilderCacheWarmer` runs, or when `debug:container` or `debug:router` run.