### PR TITLE
[HttpKernel] Fix Symfony 5.3 end of maintenance date

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -82,7 +82,7 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     public const RELEASE_VERSION = 1;
     public const EXTRA_VERSION = 'DEV';
 
-    public const END_OF_MAINTENANCE = '05/2021';
+    public const END_OF_MAINTENANCE = '01/2022';
     public const END_OF_LIFE = '01/2022';
 
     public function __construct(string $environment, bool $debug)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes?
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Hi,

I think the end of maintenance date was somehow forgotten during the 5.3.0 release process, so the profiler indicates this version is not maintained anymore, hence this PR :)