### PR TITLE
[Serializer][Validator] Fix not null return from "getCollectionValueTypes"

### DIFF
--- a/src/Symfony/Component/PropertyInfo/Type.php
+++ b/src/Symfony/Component/PropertyInfo/Type.php
@@ -179,16 +179,7 @@ class Type
     {
         trigger_deprecation('symfony/property-info', '5.3', 'The "%s()" method is deprecated, use "getCollectionValueTypes()" instead.', __METHOD__);
 
-        $type = $this->getCollectionValueTypes();
-        if (0 === \count($type)) {
-            return null;
-        }
-
-        if (\is_array($type)) {
-            [$type] = $type;
-        }
-
-        return $type;
+        return $this->getCollectionValueTypes()[0] ?? null;
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -473,13 +473,13 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 if (null !== $collectionKeyType = $type->getCollectionKeyTypes()) {
                     [$context['key_type']] = $collectionKeyType;
                 }
-            } elseif ($type->isCollection() && null !== ($collectionValueType = $type->getCollectionValueTypes()) && \count($collectionValueType) > 0 && Type::BUILTIN_TYPE_ARRAY === $collectionValueType[0]->getBuiltinType()) {
+            } elseif ($type->isCollection() && \count($collectionValueType = $type->getCollectionValueTypes()) > 0 && Type::BUILTIN_TYPE_ARRAY === $collectionValueType[0]->getBuiltinType()) {
                 // get inner type for any nested array
                 [$innerType] = $collectionValueType;
 
                 // note that it will break for any other builtinType
                 $dimensions = '[]';
-                while (null !== $innerType->getCollectionValueTypes() && Type::BUILTIN_TYPE_ARRAY === $innerType->getBuiltinType()) {
+                while (\count($innerType->getCollectionValueTypes()) > 0 && Type::BUILTIN_TYPE_ARRAY === $innerType->getBuiltinType()) {
                     $dimensions .= '[]';
                     [$innerType] = $innerType->getCollectionValueTypes();
                 }

--- a/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php
@@ -119,7 +119,7 @@ final class PropertyInfoLoader implements LoaderInterface
             }
             if (!$hasTypeConstraint) {
                 if (1 === \count($builtinTypes)) {
-                    if ($types[0]->isCollection() && (null !== $collectionValueType = $types[0]->getCollectionValueTypes())) {
+                    if ($types[0]->isCollection() && \count($collectionValueType = $types[0]->getCollectionValueTypes()) > 0) {
                         [$collectionValueType] = $collectionValueType;
                         $this->handleAllConstraint($property, $allConstraint, $collectionValueType, $metadata);
                     }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/PropertyInfoLoaderEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/PropertyInfoLoaderEntity.php
@@ -23,6 +23,7 @@ class PropertyInfoLoaderEntity
     public $scalar;
     public $object;
     public $collection;
+    public $collectionOfUnknown;
 
     /**
      * @Assert\Type(type="int")

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/PropertyInfoLoaderTest.php
@@ -44,6 +44,7 @@ class PropertyInfoLoaderTest extends TestCase
                 'scalar',
                 'object',
                 'collection',
+                'collectionOfUnknown',
                 'alreadyMappedType',
                 'alreadyMappedNotNull',
                 'alreadyMappedNotBlank',
@@ -61,6 +62,7 @@ class PropertyInfoLoaderTest extends TestCase
                 [new Type(Type::BUILTIN_TYPE_STRING, true), new Type(Type::BUILTIN_TYPE_INT), new Type(Type::BUILTIN_TYPE_BOOL)],
                 [new Type(Type::BUILTIN_TYPE_OBJECT, true, Entity::class)],
                 [new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true, null, new Type(Type::BUILTIN_TYPE_OBJECT, false, Entity::class))],
+                [new Type(Type::BUILTIN_TYPE_ARRAY, true, null, true)],
                 [new Type(Type::BUILTIN_TYPE_FLOAT, true)], // The existing constraint is float
                 [new Type(Type::BUILTIN_TYPE_STRING, true)],
                 [new Type(Type::BUILTIN_TYPE_STRING, true)],
@@ -72,6 +74,7 @@ class PropertyInfoLoaderTest extends TestCase
         $propertyInfoStub
             ->method('isWritable')
             ->will($this->onConsecutiveCalls(
+                true,
                 true,
                 true,
                 true,
@@ -134,6 +137,13 @@ class PropertyInfoLoaderTest extends TestCase
         $this->assertInstanceOf(NotNull::class, $collectionConstraints[0]->constraints[0]);
         $this->assertInstanceOf(TypeConstraint::class, $collectionConstraints[0]->constraints[1]);
         $this->assertSame(Entity::class, $collectionConstraints[0]->constraints[1]->type);
+
+        $collectionOfUnknownMetadata = $classMetadata->getPropertyMetadata('collectionOfUnknown');
+        $this->assertCount(1, $collectionOfUnknownMetadata);
+        $collectionOfUnknownConstraints = $collectionOfUnknownMetadata[0]->getConstraints();
+        $this->assertCount(1, $collectionOfUnknownConstraints);
+        $this->assertInstanceOf(TypeConstraint::class, $collectionOfUnknownConstraints[0]);
+        $this->assertSame('array', $collectionOfUnknownConstraints[0]->type);
 
         $alreadyMappedTypeMetadata = $classMetadata->getPropertyMetadata('alreadyMappedType');
         $this->assertCount(1, $alreadyMappedTypeMetadata);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


Currently experimenting `An exception has been thrown during the rendering of a template ("Notice: Undefined offset: 0").`

When a property is an array and PropertyInfo is not able to guess the type of CollectionValue