### PR TITLE
[Serializer][Validator] Add conflict with property-info < 5.3

### DIFF
--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -47,7 +47,7 @@
         "phpdocumentor/type-resolver": "<1.4.0",
         "symfony/dependency-injection": "<4.4",
         "symfony/property-access": "<4.4",
-        "symfony/property-info": "<4.4",
+        "symfony/property-info": "<5.3",
         "symfony/yaml": "<4.4"
     },
     "suggest": {

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -51,6 +51,7 @@
         "symfony/expression-language": "<5.1",
         "symfony/http-kernel": "<4.4",
         "symfony/intl": "<4.4",
+        "symfony/property-info": "<5.3",
         "symfony/translation": "<4.4",
         "symfony/yaml": "<4.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Both components uses the `getCollectionValueTypes` method from property-info that has been introduced in 5.3 in https://github.com/symfony/symfony/pull/39020

https://github.com/symfony/symfony/blob/3581145643f92dba52383c7978cfa3c03ab6c9c1/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php#L415

https://github.com/symfony/symfony/blob/3581145643f92dba52383c7978cfa3c03ab6c9c1/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php#L122

