### PR TITLE
[Security] Fix setUsername() deprecation message

### DIFF
--- a/src/Symfony/Component/Security/Core/Exception/UserNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UserNotFoundException.php
@@ -62,7 +62,7 @@ class UserNotFoundException extends AuthenticationException
      */
     public function setUsername(string $username)
     {
-        trigger_deprecation('symfony/security-core', '5.3', 'Method "%s()" is deprecated, use getUserIdentifier() instead.', __METHOD__);
+        trigger_deprecation('symfony/security-core', '5.3', 'Method "%s()" is deprecated, use setUserIdentifier() instead.', __METHOD__);
 
         $this->identifier = $username;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The deprecation message for `UserNotFoundException:: setUsername()` is directing to `getUserIdentifier()` instead of `setUserIdentifier()`.