### PR TITLE
Use `mb_strlen` instead of `strlen`.

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Hasher/CheckPasswordLengthTrait.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/CheckPasswordLengthTrait.php
@@ -20,6 +20,6 @@ trait CheckPasswordLengthTrait
 {
     private function isPasswordTooLong(string $password): bool
     {
-        return PasswordHasherInterface::MAX_PASSWORD_LENGTH < \mb_strlen($password, '8bit');
+        return PasswordHasherInterface::MAX_PASSWORD_LENGTH < mb_strlen($password, '8bit');
     }
 }

--- a/src/Symfony/Component/PasswordHasher/Hasher/CheckPasswordLengthTrait.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/CheckPasswordLengthTrait.php
@@ -20,6 +20,6 @@ trait CheckPasswordLengthTrait
 {
     private function isPasswordTooLong(string $password): bool
     {
-        return PasswordHasherInterface::MAX_PASSWORD_LENGTH < \strlen($password);
+        return PasswordHasherInterface::MAX_PASSWORD_LENGTH < \mb_strlen($password, '8bit');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?       | no
| New feature?  | no
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Using `mb_strlen` would be safer.
