### PR TITLE
[HttpKernel] fix ArgumentMetadataFactory messes up controller arguments with attributes

### DIFF
--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
@@ -34,6 +34,7 @@ final class ArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
         }
 
         foreach ($reflection->getParameters() as $param) {
+            $attributes = [];
             if (\PHP_VERSION_ID >= 80000) {
                 foreach ($param->getAttributes() as $reflectionAttribute) {
                     if (class_exists($reflectionAttribute->getName())) {
@@ -42,7 +43,7 @@ final class ArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
                 }
             }
 
-            $arguments[] = new ArgumentMetadata($param->getName(), $this->getType($param, $reflection), $param->isVariadic(), $param->isDefaultValueAvailable(), $param->isDefaultValueAvailable() ? $param->getDefaultValue() : null, $param->allowsNull(), $attributes ?? []);
+            $arguments[] = new ArgumentMetadata($param->getName(), $this->getType($param, $reflection), $param->isVariadic(), $param->isDefaultValueAvailable(), $param->isDefaultValueAvailable() ? $param->getDefaultValue() : null, $param->allowsNull(), $attributes);
         }
 
         return $arguments;

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
@@ -140,6 +140,18 @@ class ArgumentMetadataFactoryTest extends TestCase
         $this->assertCount(1, $this->factory->createArgumentMetadata([new AttributeController(), 'multiAttributeArg'])[0]->getAttributes());
     }
 
+    /**
+     * @requires PHP 8
+     */
+    public function testIssue41478()
+    {
+        $arguments = $this->factory->createArgumentMetadata([new AttributeController(), 'issue41478']);
+        $this->assertEquals([
+            new ArgumentMetadata('baz', 'string', false, false, null, false, [new Foo('bar')]),
+            new ArgumentMetadata('bat', 'string', false, false, null, false, []),
+        ], $arguments);
+    }
+
     private function signature1(self $foo, array $bar, callable $baz)
     {
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/AttributeController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/AttributeController.php
@@ -20,4 +20,7 @@ class AttributeController
 
     public function multiAttributeArg(#[Foo('bar'), Undefined('bar')] string $baz) {
     }
+
+    public function issue41478(#[Foo('bar')] string $baz, string $bat) {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes/no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41478
| License       | MIT
| Doc PR        | n/a

fixes issue #41478 by resetting the $attributes array per controller argument 

also adds test to ensure correct metadata in cases where controller arguments without attributes follow arguments with attributes