### PR TITLE
[Security] Readd deprecated methods to the interfaces

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/User/UserLoaderInterface.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/UserLoaderInterface.php
@@ -29,4 +29,10 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 interface UserLoaderInterface
 {
+    /**
+     * @return UserInterface|null
+     *
+     * @deprecated since Symfony 5.3, use loadUserByIdentifier() instead
+     */
+    public function loadUserByUsername(string $username);
 }

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentTokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentTokenInterface.php
@@ -48,4 +48,11 @@ interface PersistentTokenInterface
      * @return \DateTime
      */
     public function getLastUsed();
+
+    /**
+     * @return string
+     *
+     * @deprecated since Symfony 5.3, use getUserIdentifier() instead
+     */
+    public function getUsername();
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -130,4 +130,11 @@ interface TokenInterface extends \Serializable
      * Restores the object state from an array given by __serialize().
      */
     public function __unserialize(array $data): void;
+
+    /**
+     * @return string
+     *
+     * @deprecated since Symfony 5.3, use getUserIdentifier() instead
+     */
+    public function getUsername();
 }

--- a/src/Symfony/Component/Security/Core/User/UserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserInterface.php
@@ -78,4 +78,11 @@ interface UserInterface
      * the plain-text password is stored on this object.
      */
     public function eraseCredentials();
+
+    /**
+     * @return string
+     *
+     * @deprecated since Symfony 5.3, use getUserIdentifier() instead
+     */
+    public function getUsername();
 }

--- a/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
@@ -57,4 +57,13 @@ interface UserProviderInterface
      * @return bool
      */
     public function supportsClass(string $class);
+
+    /**
+     * @return UserInterface
+     *
+     * @throws UserNotFoundException
+     *
+     * @deprecated since Symfony 5.3, use loadUserByIdentifier() instead
+     */
+    public function loadUserByUsername(string $username);
 }

--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -211,6 +211,11 @@ class TestLoginLinkHandlerUserProvider implements UserProviderInterface
         $this->users[$user->getUserIdentifier()] = $user;
     }
 
+    public function loadUserByUsername($username): TestLoginLinkHandlerUser
+    {
+        return $this->loadUserByIdentifier($username);
+    }
+
     public function loadUserByIdentifier(string $userIdentifier): TestLoginLinkHandlerUser
     {
         if (!isset($this->users[$userIdentifier])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41470
| License       | MIT
| Doc PR        | n/a

Readd the deprecated methods to the interface, to make sure third party packages <5.3 work with objects created using the 5.3+ interfaces.

I've tested in a project and the deprecation is not triggered when implementing the method, only when calling. So this should still allow applications to be deprecation free in 5.4.