### PR TITLE
HttpClientInterface - fix @method withOptions

### DIFF
--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\HttpClient\Test\HttpClientTestCase;
  *
  * @see HttpClientTestCase for a reference test suite
  *
- * @method static withOptions(array $options) Returns a new instance of the client with new default options
+ * @method static HttpClientInterface withOptions(array $options) Returns a new instance of the client with new default options
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2 & 5.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


My project have a custom HttpClient witch implement HttpClientInterface.
Since update symfony/http-client from 5.2.4 to 5.2.9, i have a direct deprecated message which look like this:
```
Class "App\Core\Bridge\HttpClient\RetryHttpClient" should implement method "Symfony\Contracts\HttpClient\HttpClientInterface::withOptions()": withOptions(array $options) Returns a new instance of the client with new default options.
```
but even I added the wanted method like this:
```
/**
 * @param array<mixed> $options
 */
public static function withOptions(array $options): self
{
    return new self($options['client'], $options['logger'], $options['retries']);
}
```
I steel got the error.
I dig into vendor/symfony/error-handler/DebugClassLoader.php class to see how it work and on this code (line 440-456):
```
if ($refl->isInterface() && false !== strpos($doc, 'method') && preg_match_all('#\n \* @method\s+(static\s+)?+([\w\|&\[\]\\\]+\s+)?(\w+(?:\s*\([^\)]*\))?)+(.+?([[:punct:]]\s*)?)?(?=\r?\n \*(?: @|/$|\r?\n))#', $doc, $notice, \PREG_SET_ORDER)) {
    foreach ($notice as $method) {
        $static = '' !== $method[1] && !empty($method[2]);
        $name = $method[3];
        $description = $method[4] ?? null;
        if (false === strpos($name, '(')) {
            $name .= '()';
        }
        if (null !== $description) {
            $description = trim($description);
            if (!isset($method[5])) {
                $description .= '.';
            }
        }
        self::$method[$class][] = [$class, $name, $static, $description];
    }
}
```
it seem to have $static = true, it need $method[2] witch I think represent the return type not empty

This fix is a quick one to get $static = true and it seem better to precise the return type, but maybe the intention of not precise it was for old php version ? if it's the case, maybe it will be better to improve DebugClassLoader to handle @method static without typehint return ?