### PR TITLE
[HttpKernel] Fix controller arguments attributes accumulation

### DIFF
--- a/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
+++ b/src/Symfony/Component/HttpKernel/ControllerMetadata/ArgumentMetadataFactory.php
@@ -34,6 +34,8 @@ final class ArgumentMetadataFactory implements ArgumentMetadataFactoryInterface
         }
 
         foreach ($reflection->getParameters() as $param) {
+            $attributes = [];
+
             if (\PHP_VERSION_ID >= 80000) {
                 foreach ($param->getAttributes() as $reflectionAttribute) {
                     if (class_exists($reflectionAttribute->getName())) {

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
@@ -37,7 +37,7 @@ class ArgumentMetadataFactoryTest extends TestCase
     {
         $arguments = $this->factory->createArgumentMetadata([$this, 'signature1']);
 
-        $this->assertEquals([
+        self::assertEquals([
             new ArgumentMetadata('foo', self::class, false, false, null),
             new ArgumentMetadata('bar', 'array', false, false, null),
             new ArgumentMetadata('baz', 'callable', false, false, null),
@@ -48,7 +48,7 @@ class ArgumentMetadataFactoryTest extends TestCase
     {
         $arguments = $this->factory->createArgumentMetadata([$this, 'signature2']);
 
-        $this->assertEquals([
+        self::assertEquals([
             new ArgumentMetadata('foo', self::class, false, true, null, true),
             new ArgumentMetadata('bar', FakeClassThatDoesNotExist::class, false, true, null, true),
             new ArgumentMetadata('baz', 'Fake\ImportedAndFake', false, true, null, true),
@@ -59,7 +59,7 @@ class ArgumentMetadataFactoryTest extends TestCase
     {
         $arguments = $this->factory->createArgumentMetadata([$this, 'signature3']);
 
-        $this->assertEquals([
+        self::assertEquals([
             new ArgumentMetadata('bar', FakeClassThatDoesNotExist::class, false, false, null),
             new ArgumentMetadata('baz', 'Fake\ImportedAndFake', false, false, null),
         ], $arguments);
@@ -69,7 +69,7 @@ class ArgumentMetadataFactoryTest extends TestCase
     {
         $arguments = $this->factory->createArgumentMetadata([$this, 'signature4']);
 
-        $this->assertEquals([
+        self::assertEquals([
             new ArgumentMetadata('foo', null, false, true, 'default'),
             new ArgumentMetadata('bar', null, false, true, 500),
             new ArgumentMetadata('baz', null, false, true, []),
@@ -80,7 +80,7 @@ class ArgumentMetadataFactoryTest extends TestCase
     {
         $arguments = $this->factory->createArgumentMetadata([$this, 'signature5']);
 
-        $this->assertEquals([
+        self::assertEquals([
             new ArgumentMetadata('foo', 'array', false, true, null, true),
             new ArgumentMetadata('bar', null, false, true, null, true),
         ], $arguments);
@@ -90,7 +90,7 @@ class ArgumentMetadataFactoryTest extends TestCase
     {
         $arguments = $this->factory->createArgumentMetadata([new VariadicController(), 'action']);
 
-        $this->assertEquals([
+        self::assertEquals([
             new ArgumentMetadata('foo', null, false, false, null),
             new ArgumentMetadata('bar', null, true, false, null),
         ], $arguments);
@@ -100,7 +100,7 @@ class ArgumentMetadataFactoryTest extends TestCase
     {
         $arguments = $this->factory->createArgumentMetadata([new BasicTypesController(), 'action']);
 
-        $this->assertEquals([
+        self::assertEquals([
             new ArgumentMetadata('foo', 'string', false, false, null),
             new ArgumentMetadata('bar', 'int', false, false, null),
             new ArgumentMetadata('baz', 'float', false, false, null),
@@ -111,7 +111,7 @@ class ArgumentMetadataFactoryTest extends TestCase
     {
         $arguments = $this->factory->createArgumentMetadata([new NullableController(), 'action']);
 
-        $this->assertEquals([
+        self::assertEquals([
             new ArgumentMetadata('foo', 'string', false, false, null, true),
             new ArgumentMetadata('bar', \stdClass::class, false, false, null, true),
             new ArgumentMetadata('baz', 'string', false, true, 'value', true),
@@ -126,7 +126,7 @@ class ArgumentMetadataFactoryTest extends TestCase
     {
         $arguments = $this->factory->createArgumentMetadata([new AttributeController(), 'action']);
 
-        $this->assertEquals([
+        self::assertEquals([
             new ArgumentMetadata('baz', 'string', false, false, null, false, [new Foo('bar')]),
         ], $arguments);
     }
@@ -136,8 +136,8 @@ class ArgumentMetadataFactoryTest extends TestCase
      */
     public function testMultipleAttributes()
     {
-        $this->factory->createArgumentMetadata([new AttributeController(), 'multiAttributeArg']);
-        $this->assertCount(1, $this->factory->createArgumentMetadata([new AttributeController(), 'multiAttributeArg'])[0]->getAttributes());
+        $arguments = $this->factory->createArgumentMetadata([new AttributeController(), 'multiAttributeArg']);
+        self::assertCount(1, $arguments[0]->getAttributes());
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
@@ -140,6 +140,16 @@ class ArgumentMetadataFactoryTest extends TestCase
         $this->assertCount(1, $this->factory->createArgumentMetadata([new AttributeController(), 'multiAttributeArg'])[0]->getAttributes());
     }
 
+    /**
+     * @requires PHP 8
+     */
+    public function testMultipleArguments()
+    {
+        $arguments = $this->factory->createArgumentMetadata([new AttributeController(), 'multipleArguments']);
+        self::assertCount(1, $arguments[0]->getAttributes());
+        self::assertCount(0, $arguments[1]->getAttributes());
+    }
+
     private function signature1(self $foo, array $bar, callable $baz)
     {
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/AttributeController.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/Controller/AttributeController.php
@@ -20,4 +20,7 @@ class AttributeController
 
     public function multiAttributeArg(#[Foo('bar'), Undefined('bar')] string $baz) {
     }
+
+    public function multipleArguments(#[Foo('bar')] string $first, string $second) {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

When argument attributes are specified, they are not cleared for the next argument in the list. Bug only occurs in 5.3.

Along the way, tidied up the ArgumentMetadataFactory tests a little.