### PR TITLE
[Translation] Fix default value for locales in translation push|pull commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1360,24 +1360,28 @@ class FrameworkExtension extends Extension
             return;
         }
 
-        foreach ($config['providers'] as $name => $provider) {
-            if (!$config['enabled_locales'] && !$provider['locales']) {
-                throw new LogicException(sprintf('You must specify one of "framework.translator.enabled_locales" or "framework.translator.providers.%s.locales" in order to use translation providers.', $name));
+        $locales = $config['enabled_locales'] ?? [];
+
+        foreach ($config['providers'] as $provider) {
+            if ($provider['locales']) {
+                $locales += $provider['locales'];
             }
         }
 
+        $locales = array_unique($locales);
+
         $container->getDefinition('console.command.translation_pull')
             ->replaceArgument(4, array_merge($transPaths, [$config['default_path']]))
-            ->replaceArgument(5, $config['enabled_locales'])
+            ->replaceArgument(5, $locales)
         ;
 
         $container->getDefinition('console.command.translation_push')
             ->replaceArgument(2, array_merge($transPaths, [$config['default_path']]))
-            ->replaceArgument(3, $config['enabled_locales'])
+            ->replaceArgument(3, $locales)
         ;
 
         $container->getDefinition('translation.provider_collection_factory')
-            ->replaceArgument(1, $config['enabled_locales'])
+            ->replaceArgument(1, $locales)
         ;
 
         $container->getDefinition('translation.provider_collection')->setArgument(0, $config['providers']);

--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -94,13 +94,13 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $provider = $this->providers->get($input->getArgument('provider'));
+
         if (!$this->enabledLocales) {
-            throw new InvalidArgumentException('You must define "framework.translator.enabled_locales" or "framework.translator.providers.%s.locales" config key in order to work with translation providers.');
+            throw new InvalidArgumentException(sprintf('You must define "framework.translator.enabled_locales" or "framework.translator.providers.%s.locales" config key in order to work with translation providers.', parse_url($provider, \PHP_URL_SCHEME)));
         }
 
         $io = new SymfonyStyle($input, $output);
-
-        $provider = $this->providers->get($input->getArgument('provider'));
         $domains = $input->getOption('domains');
         $locales = $input->getOption('locales');
         $force = $input->getOption('force');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #41501 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | 

This PR ensures that `$locales` are always defined either `framework.translator.enabled_locales` or `framework.translator.providers.(loco|lokalise|crowdin).locales` is defined. Until now, the code expected `framework.translator.enabled_locales` to be defined, now if it's not, we merge all `framework.translator.providers.(loco|lokalise|crowdin).locales` values and pass them to `console.command.translation_pull` and `console.command.translation_push` definitions.