### PR TITLE
[FrameworkBundle] fix KernelBrowser::loginUser with a stateless firewall

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -122,7 +122,15 @@ class KernelBrowser extends HttpKernelBrowser
 
         $token = new TestBrowserToken($user->getRoles(), $user, $firewallContext);
         $token->setAuthenticated(true);
-        $session = $this->getContainer()->get('session');
+
+        $container = $this->getContainer();
+        $container->get('security.token_storage')->setToken($token);
+
+        if (!$container->has('session')) {
+            return $this;
+        }
+
+        $session = $container->get('session');
         $session->set('_security_'.$firewallContext, serialize($token));
         $session->save();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SecurityTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SecurityTest.php
@@ -38,6 +38,7 @@ class SecurityTest extends AbstractWebTestCase
         yield ['the-username', ['ROLE_FOO'], null];
         yield ['the-username', ['ROLE_FOO'], 'main'];
         yield ['other-username', ['ROLE_FOO'], 'custom'];
+        yield ['stateless-username', ['ROLE_FOO'], 'stateless'];
 
         yield ['the-username', ['ROLE_FOO'], null];
         yield ['no-role-username', [], null];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/config.yml
@@ -12,6 +12,10 @@ security:
             memory:
                 users:
                     other-username: { password: the-password, roles: ['ROLE_FOO'] }
+        stateless:
+            memory:
+                users:
+                    stateless-username: { password: the-password, roles: ['ROLE_FOO'] }
 
     firewalls:
         main:
@@ -24,3 +28,8 @@ security:
             form_login:
                 check_path: /custom/login/check
             provider: custom
+        stateless:
+            pattern: ^/stateless
+            stateless: true
+            http_basic: ~
+            provider: stateless

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Security/routing.yml
@@ -5,3 +5,7 @@ security_profile:
 security_custom_profile:
     path:     /custom/user_profile
     defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\SecurityController::profileAction }
+
+security_stateless_profile:
+    path:     /stateless/user_profile
+    defaults: { _controller: Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller\SecurityController::profileAction }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo?

Currently, `KernelBrowser::loginUser()` doesn't work with stateless firewalls (Basic HTTP, JWT etc) and fails if the session is disabled (which is frequent when creating web APIs, and when using stateless firewalls). This PR fixes the problem.