### PR TITLE
[SecurityBundle] Link UserProviderListener to correct firewall dispatcher

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -339,6 +339,8 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
         $config->replaceArgument(4, $firewall['stateless']);
 
+        $firewallEventDispatcherId = 'security.event_dispatcher.'.$id;
+
         // Provider id (must be configured explicitly per firewall/authenticator if more than one provider is set)
         $defaultProvider = null;
         if (isset($firewall['provider'])) {
@@ -349,7 +351,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
             if ($this->authenticatorManagerEnabled) {
                 $container->setDefinition('security.listener.'.$id.'.user_provider', new ChildDefinition('security.listener.user_provider.abstract'))
-                    ->addTag('kernel.event_listener', ['event' => CheckPassportEvent::class, 'priority' => 2048, 'method' => 'checkPassport'])
+                    ->addTag('kernel.event_listener', ['dispatcher' => $firewallEventDispatcherId, 'event' => CheckPassportEvent::class, 'priority' => 2048, 'method' => 'checkPassport'])
                     ->replaceArgument(0, new Reference($defaultProvider));
             }
         } elseif (1 === \count($providerIds)) {
@@ -359,7 +361,6 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $config->replaceArgument(5, $defaultProvider);
 
         // Register Firewall-specific event dispatcher
-        $firewallEventDispatcherId = 'security.event_dispatcher.'.$id;
         $container->register($firewallEventDispatcherId, EventDispatcher::class);
 
         // Register listeners

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticatorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AuthenticatorTest.php
@@ -63,4 +63,28 @@ class AuthenticatorTest extends AbstractWebTestCase
         yield ['jane@example.org', true];
         yield ['john@example.org', false];
     }
+
+    /**
+     * @dataProvider provideEmailsWithFirewalls
+     */
+    public function testLoginUsersWithMultipleFirewalls(string $username, string $firewallContext)
+    {
+        $client = $this->createClient(['test_case' => 'Authenticator', 'root_config' => 'multiple_firewall_user_provider.yml']);
+        $client->request('GET', '/main/login/check');
+
+        $client->request('POST', '/'.$firewallContext.'/login/check', [
+            '_username' => $username,
+            '_password' => 'test',
+        ]);
+        $this->assertResponseRedirects('/'.$firewallContext.'/user_profile');
+
+        $client->request('GET', '/'.$firewallContext.'/user_profile');
+        $this->assertEquals('Welcome '.$username.'!', $client->getResponse()->getContent());
+    }
+
+    public function provideEmailsWithFirewalls()
+    {
+        yield ['jane@example.org', 'main'];
+        yield ['john@example.org', 'custom'];
+    }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AuthenticatorBundle/LoginFormAuthenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AuthenticatorBundle/LoginFormAuthenticator.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Http\Authenticator\AbstractLoginFormAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
+use Symfony\Component\Security\Http\Util\TargetPathTrait;
+
+class LoginFormAuthenticator extends AbstractLoginFormAuthenticator
+{
+    use TargetPathTrait;
+
+    /** @var UrlGeneratorInterface */
+    private $urlGenerator;
+
+    public function __construct(UrlGeneratorInterface $urlGenerator)
+    {
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function authenticate(Request $request): PassportInterface
+    {
+        $username = $request->request->get('_username', '');
+
+        $request->getSession()->set(Security::LAST_USERNAME, $username);
+
+        return new Passport(
+            new UserBadge($username),
+            new PasswordCredentials($request->request->get('_password', '')),
+            []
+        );
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $firewallName): ?Response
+    {
+        return new RedirectResponse($this->urlGenerator->generate('security_'.$firewallName.'_profile'));
+    }
+
+    protected function getLoginUrl(Request $request): string
+    {
+        return strpos($request->getUri(), 'main') ?
+            $this->urlGenerator->generate('security_main_login') :
+            $this->urlGenerator->generate('security_custom_login')
+        ;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AuthenticatorBundle/SecurityController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AuthenticatorBundle/SecurityController.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityController extends AbstractController
+{
+    public function checkAction()
+    {
+        return new Response('OK');
+    }
+
+    public function profileAction()
+    {
+        return new Response('Welcome '.$this->getUser()->getUsername().'!');
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/config.yml
@@ -14,4 +14,12 @@ services:
         calls:
             - ['setContainer', ['@Psr\Container\ContainerInterface']]
         tags: [container.service_subscriber]
+    Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\SecurityController:
+        public: true
+        calls:
+            - ['setContainer', ['@Psr\Container\ContainerInterface']]
+        tags: [container.service_subscriber]
     Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ApiAuthenticator: ~
+    Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\LoginFormAuthenticator:
+        public: true
+        arguments: ['@router']

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/multiple_firewall_user_provider.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/multiple_firewall_user_provider.yml
@@ -1,0 +1,14 @@
+imports:
+- { resource: ./config.yml }
+- { resource: ./security.yml }
+
+security:
+    firewalls:
+        main:
+            pattern: ^/main
+            provider: in_memory
+            custom_authenticator: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\LoginFormAuthenticator
+        custom:
+            pattern: ^/custom
+            provider: in_memory2
+            custom_authenticator: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\LoginFormAuthenticator

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/routing.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/Authenticator/routing.yml
@@ -2,3 +2,19 @@ profile:
     path: /profile
     defaults:
         _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\ProfileController
+
+security_main_login:
+    path:     /main/login/check
+    defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\SecurityController::checkAction }
+
+security_custom_login:
+    path:     /custom/login/check
+    defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\SecurityController::checkAction }
+
+security_main_profile:
+    path:     /main/user_profile
+    defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\SecurityController::profileAction }
+
+security_custom_profile:
+    path:     /custom/user_profile
+    defaults: { _controller: Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\AuthenticatorBundle\SecurityController::profileAction }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix #40158 , Fix #41474
| License       | MIT
| Doc PR        | /

When using the new AuthenticationManager, an incorrect UserProvider could be attached to the UserBadge when having multiple providers defined in `security.yaml`.

The `UserProviderListener` was tagged to the global event dispatcher instead of the dispatcher for the specific firewall.
