### PR TITLE
Release v5.3.1

### DIFF
--- a/CHANGELOG-5.3.md
+++ b/CHANGELOG-5.3.md
@@ -7,6 +7,14 @@ in 5.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v5.3.0...v5.3.1
 
+* 5.3.1 (2021-06-02)
+
+ * bug #41463 [Serializer][Validator] Fix not null return from "getCollectionValueTypes" (jderusse)
+ * bug #41493 [Security] Readd deprecated methods to the interfaces (wouterj)
+ * bug #41495 [HttpFoundation] Add ReturnTypeWillChange to SessionHandlers (nikic)
+ * bug #41485 [HttpKernel] fix ArgumentMetadataFactory messes up controller arguments with attributes (sgehrig)
+ * bug #41461 Fix Symfony 5.3 end of maintenance date (jmsche)
+
 * 5.3.0 (2021-05-31)
 
  * bug #41458 [FrameworkBundle] fix ConfigBuilderCacheWarmer (nicolas-grekas)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -75,12 +75,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     private static $freshCache = [];
 
-    public const VERSION = '5.3.1-DEV';
+    public const VERSION = '5.3.1';
     public const VERSION_ID = 50301;
     public const MAJOR_VERSION = 5;
     public const MINOR_VERSION = 3;
     public const RELEASE_VERSION = 1;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '01/2022';
     public const END_OF_LIFE = '01/2022';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v5.3.0...v5.3.1)

 * bug #41463 [Serializer][Validator] Fix not null return from "getCollectionValueTypes" (@jderusse)
 * bug #41493 [Security] Readd deprecated methods to the interfaces (@wouterj)
 * bug #41495 [HttpFoundation] Add ReturnTypeWillChange to SessionHandlers (@nikic)
 * bug #41485 [HttpKernel] fix ArgumentMetadataFactory messes up controller arguments with attributes (@sgehrig)
 * bug #41461 Fix Symfony 5.3 end of maintenance date (@jmsche)
