### PR TITLE
Relax requirement on symfony/runtime

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,7 @@
         "symfony/polyfill-php73": "^1.11",
         "symfony/polyfill-php80": "^1.15",
         "symfony/polyfill-php81": "^1.22",
-        "symfony/polyfill-uuid": "^1.15",
-        "symfony/runtime": "self.version"
+        "symfony/polyfill-uuid": "^1.15"
     },
     "replace": {
         "symfony/asset": "self.version",
@@ -144,6 +143,7 @@
         "egulias/email-validator": "^2.1.10|^3.1",
         "symfony/mercure-bundle": "^0.3",
         "symfony/phpunit-bridge": "^5.2",
+        "symfony/runtime": "self.version",
         "symfony/security-acl": "~2.8|~3.0",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "twig/cssinliner-extra": "^2.12|^3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

It looks like we have an issue with runtime:

```
rio ~/rio/server/backend composer out
[...]
symfony/symfony           v5.3.0  v5.3.1 The Symfony PHP framework
```

```
rio ~/rio/server/backend composer why-not symfony/symfony:v5.3.1
symfony/symfony         v5.3.1      requires          symfony/runtime (self.version)             
jolicode/redirectionio  dev-master  does not require  symfony/runtime (but v5.3.0 is installed)
```

So symfony/symfony require symfony/runtime with "self.version"
But symfony/runtime 5.3.1 does not exist

=> so symfony/symfony 5.3.1 is not installable