### PR TITLE
[Form] String is the preferred value type for TextType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
@@ -37,6 +37,7 @@ class TextType extends AbstractType implements DataTransformerInterface
     {
         $resolver->setDefaults([
             'compound' => false,
+            'empty_data' => '',
         ]);
     }
 
@@ -62,6 +63,6 @@ class TextType extends AbstractType implements DataTransformerInterface
      */
     public function reverseTransform($data)
     {
-        return null === $data ? '' : $data;
+        return $data ?? '';
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ColorTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ColorTypeTest.php
@@ -82,7 +82,7 @@ final class ColorTypeTest extends BaseTypeTest
         ];
     }
 
-    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    public function testSubmitNull($expected = '', $norm = '', $view = '')
     {
         parent::testSubmitNull($expected, $norm, '');
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
@@ -47,7 +47,7 @@ class PasswordTypeTest extends BaseTypeTest
         $this->assertSame(' pAs5w0rd ', $form->getData());
     }
 
-    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    public function testSubmitNull($expected = '', $norm = '', $view = '')
     {
         parent::testSubmitNull($expected, $norm, '');
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
@@ -15,7 +15,7 @@ class TextTypeTest extends BaseTypeTest
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\TextType';
 
-    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    public function testSubmitNull($expected = '', $norm = '', $view = '')
     {
         parent::testSubmitNull($expected, $norm, '');
     }
@@ -23,19 +23,19 @@ class TextTypeTest extends BaseTypeTest
     public function testSubmitNullReturnsNullWithEmptyDataAsString()
     {
         $form = $this->factory->create(static::TESTED_TYPE, 'name', [
-            'empty_data' => '',
+            'empty_data' => null,
         ]);
 
         $form->submit(null);
-        $this->assertSame('', $form->getData());
-        $this->assertSame('', $form->getNormData());
+        $this->assertNull($form->getData());
+        $this->assertNull($form->getNormData());
         $this->assertSame('', $form->getViewData());
     }
 
     public function provideZeros()
     {
         return [
-            [0, '0'],
+            [0, 0],
             ['0', '0'],
             ['00000', '00000'],
         ];

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
@@ -47,7 +47,7 @@ class UrlTypeTest extends TextTypeTest
 
         $form->submit('');
 
-        $this->assertNull($form->getData());
+        $this->assertSame('', $form->getData());
         $this->assertSame('', $form->getViewData());
     }
 
@@ -59,7 +59,7 @@ class UrlTypeTest extends TextTypeTest
 
         $form->submit(null);
 
-        $this->assertNull($form->getData());
+        $this->assertSame('', $form->getData());
         $this->assertSame('', $form->getViewData());
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #5906
| License       | MIT
| Doc PR        | symfony/symfony-docs#15404
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

I want to return to an old and very painful topic #5906. I wanted to revisit this topic before the release 4.0 and 5.0, but didn't find the time for this. Now, when everyone already has PHP 7 or 8, and the `strict_types=1` is the defect standard, it is probably time to abandon the hook when the text may not be a `string`.

We've been using hooks for many years, even before #18357. We want string values to always be strings. Under strict typing conditions, i consider using `NULL` as a value valid only in cases where the expected value is not a scalar type and cannot be correctly transformed from the submitted data. In such cases, we use custom transformers.

## Expected implementation

A very crude example.

```php
use Symfony\Component\Validator\Constraints as Assert;

final class RenameAuthor
{
    /**
     * @Assert\NotBlank
     * @Assert\Length(max=128)
     */
    public string $firstname = '';

    /**
     * @Assert\Length(max=128)
     */
    public string $lastname = '';

    /**
     * @Assert\Length(max=128)
     */
    public string $patronymic = '';
}
```

```php
use Symfony\Component\Form\AbstractType;
use Symfony\Component\Form\Extension\Core\Type\TextType;
use Symfony\Component\Form\FormBuilderInterface;
use Symfony\Component\OptionsResolver\OptionsResolver;

final class RenameAuthorFormType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options): void
    {
        $builder
            ->add('firstname', TextType::class)
            ->add('lastname', TextType::class, [
                'required' => false,
            ])
            ->add('patronymic', TextType::class, [
                'required' => false,
            ])
        ;
    }

    public function configureOptions(OptionsResolver $resolver): void
    {
        $resolver->setDefault('data_class', RenameAuthor::class);
    }
}
```

```php
class Questionnaire
{
    // ...

    public function renameAuthor(string $new_firstname, string $new_lastname, string $new_patronymic): void
    {
        $this->author_name = new AuthorName($new_firstname, $new_lastname, $new_patronymic);
    }
```

```php
$command = new RenameAuthor();

$form = $this->createForm(RenameAuthorFormType::class, $command)->handleRequest($request);

if ($form->isSubmitted() && $form->isValid()) {
    $questionnaire->renameAuthor($command->firstname, $command->lastname, $command->patronymic);

    // ...
}
```

## Actual implementation

Without hooks and specifying option `empty_data`.


```diff
use Symfony\Component\Validator\Constraints as Assert;

final class RenameAuthor
{
    /**
     * @Assert\NotBlank
     * @Assert\Length(max=128)
     */
-    public string $firstname = '';
+    private string $firstname = '';

    /**
     * @Assert\Length(max=128)
     */
-    public string $lastname = '';
+    private string $lastname = '';

    /**
     * @Assert\Length(max=128)
     */
-    public string $patronymic = '';
+    private string $patronymic = '';
+
+    public function getFirstname(): string
+    {
+        return $this->firstname;
+    }
+
+    public function setFirstname(?string $firstname): void
+    {
+        $this->firstname = $firstname ?? '';
+    }
+
+    public function getLastname(): string
+    {
+        return $this->lastname;
+    }
+
+    public function setLastname(?string $lastname): void
+    {
+        $this->lastname = $lastname ?? '';
+    }
+
+    public function getPatronymic(): string
+    {
+        return $this->patronymic;
+    }
+
+    public function setPatronymic(?string $patronymic): void
+    {
+        $this->patronymic = $patronymic ?? '';
+    }
}
```


```diff
$command = new RenameAuthor();

$form = $this->createForm(RenameAuthorFormType::class, $command)->handleRequest($request);

if ($form->isSubmitted() && $form->isValid()) {
-    $questionnaire->renameAuthor($command->firstname, $command->lastname, $command->patronymic);
+    $questionnaire->renameAuthor($command->getFirstname(), $command->getLastname(), $command->getPatronymic());

    // ...
}
```

## Implementation with empty_data option

It seems that specifying one option is not a problem. But you should always remember that the text may not be a `string`, and to typecast to a `string`, you need to specify option `empty_data` in each field, each form. There may be hundreds and thousands of such places per project, and the probability of errors increases with the growth of the project.

```diff
use Symfony\Component\Form\AbstractType;
use Symfony\Component\Form\Extension\Core\Type\TextType;
use Symfony\Component\Form\FormBuilderInterface;
use Symfony\Component\OptionsResolver\OptionsResolver;

final class RenameAuthorFormType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options): void
    {
        $builder
-            ->add('firstname', TextType::class)
+            ->add('firstname', TextType::class, [
+                'empty_data' => '',
+            ])
            ->add('lastname', TextType::class, [
+                'empty_data' => '',
                'required' => false,
            ])
            ->add('patronymic', TextType::class, [
+                'empty_data' => '',
                'required' => false,
            ])
        ;
    }

    public function configureOptions(OptionsResolver $resolver): void
    {
        $resolver->setDefault('data_class', RenameAuthor::class);
    }
}
```
