### PR TITLE
[Form] Add upgrade path for `empty_data` option in `TextType`

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -88,6 +88,7 @@ Form
  * Changed `$checkboxes` parameter type of the `CheckboxListMapper::mapFormsToData()` method from `iterable` to `\Traversable`.
  * Changed `$radios` parameter type of the `RadioListMapper::mapDataToForms()` method from `iterable` to `\Traversable`.
  * Changed `$radios` parameter type of the `RadioListMapper::mapFormsToData()` method from `iterable` to `\Traversable`.
+ * The default value of the `empty_data` option of the `TextType` has been changed to empty string.
 
 FrameworkBundle
 ---------------

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3HorizontalLayoutTest.php
@@ -30,7 +30,9 @@ abstract class AbstractBootstrap3HorizontalLayoutTest extends AbstractBootstrap3
 
     public function testLabelDoesNotRenderFieldAttributes()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), null, [
             'attr' => [
                 'class' => 'my&class',
@@ -47,7 +49,9 @@ abstract class AbstractBootstrap3HorizontalLayoutTest extends AbstractBootstrap3
 
     public function testLabelWithCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), null, [
             'label_attr' => [
                 'class' => 'my&class',
@@ -64,7 +68,9 @@ abstract class AbstractBootstrap3HorizontalLayoutTest extends AbstractBootstrap3
 
     public function testLabelWithCustomTextAndCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), 'Custom label', [
             'label_attr' => [
                 'class' => 'my&class',
@@ -83,6 +89,7 @@ abstract class AbstractBootstrap3HorizontalLayoutTest extends AbstractBootstrap3
     public function testLabelWithCustomTextAsOptionAndCustomAttributesPassedDirectly()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => 'Custom label',
         ]);
         $html = $this->renderLabel($form->createView(), null, [
@@ -103,6 +110,7 @@ abstract class AbstractBootstrap3HorizontalLayoutTest extends AbstractBootstrap3
     public function testLabelHtmlDefaultIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
         ]);
 
@@ -119,6 +127,7 @@ abstract class AbstractBootstrap3HorizontalLayoutTest extends AbstractBootstrap3
     public function testLabelHtmlIsTrue()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
             'label_html' => true,
         ]);

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap3LayoutTest.php
@@ -34,7 +34,9 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testLabelDoesNotRenderFieldAttributes()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), null, [
             'attr' => [
                 'class' => 'my&class',
@@ -51,7 +53,9 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testLabelWithCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), null, [
             'label_attr' => [
                 'class' => 'my&class',
@@ -68,7 +72,9 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testLabelWithCustomTextAndCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), 'Custom label', [
             'label_attr' => [
                 'class' => 'my&class',
@@ -87,6 +93,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testLabelWithCustomTextAsOptionAndCustomAttributesPassedDirectly()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => 'Custom label',
         ]);
         $html = $this->renderLabel($form->createView(), null, [
@@ -107,6 +114,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testLabelHtmlDefaultIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
         ]);
 
@@ -123,6 +131,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testLabelHtmlIsTrue()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
             'label_html' => true,
         ]);
@@ -140,6 +149,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testHelp()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help text test!',
         ]);
         $view = $form->createView();
@@ -157,6 +167,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testHelpAttr()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help text test!',
             'help_attr' => [
                 'class' => 'class-test',
@@ -177,6 +188,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testHelpHtmlDefaultIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
         ]);
 
@@ -204,6 +216,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testHelpHtmlIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
             'help_html' => false,
         ]);
@@ -232,6 +245,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testHelpHtmlIsTrue()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
             'help_html' => true,
         ]);
@@ -259,7 +273,9 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testErrors()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $form->addError(new FormError('[trans]Error 1[/trans]'));
         $form->addError(new FormError('[trans]Error 2[/trans]'));
         $view = $form->createView();
@@ -292,7 +308,9 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testOverrideWidgetBlock()
     {
         // see custom_widgets.html.twig
-        $form = $this->factory->createNamed('text_id', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('text_id', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderWidget($form->createView());
 
         $this->assertMatchesXpath($html,
@@ -1970,7 +1988,9 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testEmail()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType', 'foo&bar', [
+            'empty_data' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input
@@ -1986,6 +2006,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testEmailWithMaxLength()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType', 'foo&bar', [
+            'empty_data' => null,
             'attr' => ['maxlength' => 123],
         ]);
 
@@ -2017,6 +2038,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testDisabled()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'disabled' => true,
         ]);
 
@@ -2163,7 +2185,9 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testPassword()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', 'foo&bar', [
+            'empty_data' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input
@@ -2177,6 +2201,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testPasswordSubmittedWithNotAlwaysEmpty()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', null, [
+            'empty_data' => null,
             'always_empty' => false,
         ]);
         $form->submit('foo&bar');
@@ -2194,6 +2219,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testPasswordWithMaxLength()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', 'foo&bar', [
+            'empty_data' => null,
             'attr' => ['maxlength' => 123],
         ]);
 
@@ -2353,7 +2379,10 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testRange()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RangeType', 42, ['attr' => ['min' => 5]]);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RangeType', 42, [
+            'empty_data' => null,
+            'attr' => ['min' => 5],
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input
@@ -2368,7 +2397,10 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testRangeWithMinMaxValues()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RangeType', 42, ['attr' => ['min' => 5, 'max' => 57]]);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RangeType', 42, [
+            'empty_data' => null,
+            'attr' => ['min' => 5, 'max' => 57],
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input
@@ -2385,6 +2417,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testTextarea()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', 'foo&bar', [
+            'empty_data' => null,
             'attr' => ['pattern' => 'foo'],
         ]);
 
@@ -2400,7 +2433,9 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testText()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'foo&bar', [
+            'empty_data' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input
@@ -2416,6 +2451,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testTextWithMaxLength()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'foo&bar', [
+            'empty_data' => null,
             'attr' => ['maxlength' => 123],
         ]);
 
@@ -2432,7 +2468,9 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
 
     public function testSearch()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\SearchType', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\SearchType', 'foo&bar', [
+            'empty_data' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input
@@ -2646,7 +2684,10 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testUrlWithDefaultProtocol()
     {
         $url = 'http://www.example.com?foo1=bar1&foo2=bar2';
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, ['default_protocol' => 'http']);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, [
+            'empty_data' => null,
+            'default_protocol' => 'http',
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input
@@ -2662,7 +2703,10 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testUrlWithoutDefaultProtocol()
     {
         $url = 'http://www.example.com?foo1=bar1&foo2=bar2';
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, ['default_protocol' => null]);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, [
+            'empty_data' => null,
+            'default_protocol' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input
@@ -2740,6 +2784,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testWidgetAttributes()
     {
         $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', [
+            'empty_data' => null,
             'required' => true,
             'disabled' => true,
             'attr' => ['readonly' => true, 'maxlength' => 10, 'pattern' => '\d+', 'class' => 'foobar', 'data-foo' => 'bar'],
@@ -2754,6 +2799,7 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testWidgetAttributeNameRepeatedIfTrue()
     {
         $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', [
+            'empty_data' => null,
             'attr' => ['foo' => true],
         ]);
 
@@ -2791,7 +2837,9 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testTel()
     {
         $tel = '0102030405';
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TelType', $tel);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TelType', $tel, [
+            'empty_data' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input
@@ -2806,7 +2854,9 @@ abstract class AbstractBootstrap3LayoutTest extends AbstractLayoutTest
     public function testColor()
     {
         $color = '#0000ff';
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ColorType', $color);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ColorType', $color, [
+            'empty_data' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4HorizontalLayoutTest.php
@@ -22,7 +22,9 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
 {
     public function testRow()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $form->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
         $html = $this->renderRow($view);
@@ -62,7 +64,9 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
 
     public function testLabelDoesNotRenderFieldAttributes()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), null, [
             'attr' => [
                 'class' => 'my&class',
@@ -79,7 +83,9 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
 
     public function testLabelWithCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), null, [
             'label_attr' => [
                 'class' => 'my&class',
@@ -96,7 +102,9 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
 
     public function testLabelWithCustomTextAndCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), 'Custom label', [
             'label_attr' => [
                 'class' => 'my&class',
@@ -115,6 +123,7 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
     public function testLabelWithCustomTextAsOptionAndCustomAttributesPassedDirectly()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => 'Custom label',
         ]);
         $html = $this->renderLabel($form->createView(), null, [
@@ -135,6 +144,7 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
     public function testLabelHtmlDefaultIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
         ]);
 
@@ -151,6 +161,7 @@ abstract class AbstractBootstrap4HorizontalLayoutTest extends AbstractBootstrap4
     public function testLabelHtmlIsTrue()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
             'label_html' => true,
         ]);

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap4LayoutTest.php
@@ -32,7 +32,9 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 {
     public function testRow()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $form->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
         $html = $this->renderRow($view);
@@ -72,7 +74,9 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
     public function testLabelDoesNotRenderFieldAttributes()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), null, [
             'attr' => [
                 'class' => 'my&class',
@@ -89,7 +93,9 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
     public function testLabelWithCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), null, [
             'label_attr' => [
                 'class' => 'my&class',
@@ -106,7 +112,9 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
     public function testLabelWithCustomTextAndCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), 'Custom label', [
             'label_attr' => [
                 'class' => 'my&class',
@@ -125,6 +133,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
     public function testLabelWithCustomTextAsOptionAndCustomAttributesPassedDirectly()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'label' => 'Custom label',
         ]);
         $html = $this->renderLabel($form->createView(), null, [
@@ -145,6 +154,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
     public function testLabelHtmlDefaultIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
         ]);
 
@@ -161,6 +171,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
     public function testLabelHtmlIsTrue()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
             'label_html' => true,
         ]);
@@ -197,6 +208,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
     public function testHelp()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'help' => 'Help text test!',
         ]);
         $view = $form->createView();
@@ -214,6 +226,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
     public function testHelpAttr()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help text test!',
             'help_attr' => [
                 'class' => 'class-test',
@@ -234,6 +247,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
     public function testHelpHtmlDefaultIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
         ]);
 
@@ -261,6 +275,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
     public function testHelpHtmlIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
             'help_html' => false,
         ]);
@@ -289,6 +304,7 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
     public function testHelpHtmlIsTrue()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
             'help_html' => true,
         ]);
@@ -316,7 +332,9 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
     public function testErrors()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $form->addError(new FormError('[trans]Error 1[/trans]'));
         $form->addError(new FormError('[trans]Error 2[/trans]'));
         $view = $form->createView();
@@ -341,7 +359,9 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
     public function testErrorWithNoLabel()
     {
-        $form = $this->factory->createNamed('name', TextType::class, ['label' => false]);
+        $form = $this->factory->createNamed('name', TextType::class, ['label' => false], [
+            'empty_data' => null,
+        ]);
         $form->addError(new FormError('[trans]Error 1[/trans]'));
         $view = $form->createView();
         $html = $this->renderLabel($view);
@@ -1252,7 +1272,10 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
     public function testRange()
     {
-        $form = $this->factory->createNamed('name', RangeType::class, 42, ['attr' => ['min' => 5]]);
+        $form = $this->factory->createNamed('name', RangeType::class, 42, [
+            'empty_data' => null,
+            'attr' => ['min' => 5],
+        ]);
 
         $this->assertWidgetMatchesXpath(
             $form->createView(),
@@ -1269,7 +1292,10 @@ abstract class AbstractBootstrap4LayoutTest extends AbstractBootstrap3LayoutTest
 
     public function testRangeWithMinMaxValues()
     {
-        $form = $this->factory->createNamed('name', RangeType::class, 42, ['attr' => ['min' => 5, 'max' => 57]]);
+        $form = $this->factory->createNamed('name', RangeType::class, 42, [
+            'empty_data' => null,
+            'attr' => ['min' => 5, 'max' => 57],
+        ]);
 
         $this->assertWidgetMatchesXpath(
             $form->createView(),

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5HorizontalLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5HorizontalLayoutTest.php
@@ -28,7 +28,9 @@ abstract class AbstractBootstrap5HorizontalLayoutTest extends AbstractBootstrap5
 {
     public function testRow()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $form->addError(new FormError('[trans]Error![/trans]'));
         $html = $this->renderRow($form->createView());
 
@@ -55,7 +57,9 @@ abstract class AbstractBootstrap5HorizontalLayoutTest extends AbstractBootstrap5
 
     public function testRowWithCustomClass()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $form->addError(new FormError('[trans]Error![/trans]'));
         $html = $this->renderRow($form->createView(), [
             'row_attr' => [
@@ -101,7 +105,9 @@ abstract class AbstractBootstrap5HorizontalLayoutTest extends AbstractBootstrap5
 
     public function testLabelDoesNotRenderFieldAttributes()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), null, [
             'attr' => [
                 'class' => 'my&class',
@@ -118,7 +124,9 @@ abstract class AbstractBootstrap5HorizontalLayoutTest extends AbstractBootstrap5
 
     public function testLabelWithCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), null, [
             'label_attr' => [
                 'class' => 'my&class',
@@ -135,7 +143,9 @@ abstract class AbstractBootstrap5HorizontalLayoutTest extends AbstractBootstrap5
 
     public function testLabelWithCustomTextAndCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), 'Custom label', [
             'label_attr' => [
                 'class' => 'my&class',
@@ -154,6 +164,7 @@ abstract class AbstractBootstrap5HorizontalLayoutTest extends AbstractBootstrap5
     public function testLabelWithCustomTextAsOptionAndCustomAttributesPassedDirectly()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'label' => 'Custom label',
         ]);
         $html = $this->renderLabel($form->createView(), null, [
@@ -174,6 +185,7 @@ abstract class AbstractBootstrap5HorizontalLayoutTest extends AbstractBootstrap5
     public function testLabelHtmlDefaultIsFalse()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
         ]);
 
@@ -190,6 +202,7 @@ abstract class AbstractBootstrap5HorizontalLayoutTest extends AbstractBootstrap5
     public function testLabelHtmlIsTrue()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
             'label_html' => true,
         ]);
@@ -317,6 +330,7 @@ abstract class AbstractBootstrap5HorizontalLayoutTest extends AbstractBootstrap5
     public function testFloatingLabel()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'attr' => [
                 'placeholder' => 'name',
             ],

--- a/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/AbstractBootstrap5LayoutTest.php
@@ -40,7 +40,9 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
 {
     public function testRow()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $form->addError(new FormError('[trans]Error![/trans]'));
         $html = $this->renderRow($form->createView());
 
@@ -61,7 +63,9 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
 
     public function testRowWithCustomClass()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $form->addError(new FormError('[trans]Error![/trans]'));
         $html = $this->renderRow($form->createView(), [
             'row_attr' => [
@@ -86,7 +90,9 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
 
     public function testLabelDoesNotRenderFieldAttributes()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), null, [
             'attr' => [
                 'class' => 'my&class',
@@ -103,7 +109,9 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
 
     public function testLabelWithCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), null, [
             'label_attr' => [
                 'class' => 'my&class',
@@ -120,7 +128,9 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
 
     public function testLabelWithCustomTextAndCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), 'Custom label', [
             'label_attr' => [
                 'class' => 'my&class',
@@ -139,6 +149,7 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
     public function testLabelWithCustomTextAsOptionAndCustomAttributesPassedDirectly()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'label' => 'Custom label',
         ]);
         $html = $this->renderLabel($form->createView(), null, [
@@ -159,6 +170,7 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
     public function testLabelHtmlDefaultIsFalse()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
         ]);
 
@@ -175,6 +187,7 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
     public function testLabelHtmlIsTrue()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
             'label_html' => true,
         ]);
@@ -192,6 +205,7 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
     public function testHelp()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'help' => 'Help text test!',
         ]);
         $view = $form->createView();
@@ -209,6 +223,7 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
     public function testHelpAttr()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'help' => 'Help text test!',
             'help_attr' => [
                 'class' => 'class-test',
@@ -229,6 +244,7 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
     public function testHelpHtmlDefaultIsFalse()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
         ]);
 
@@ -256,6 +272,7 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
     public function testHelpHtmlIsFalse()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
             'help_html' => false,
         ]);
@@ -284,6 +301,7 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
     public function testHelpHtmlIsTrue()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
             'help_html' => true,
         ]);
@@ -309,7 +327,9 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
 
     public function testErrors()
     {
-        $form = $this->factory->createNamed('name', TextType::class);
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
+        ]);
         $form->addError(new FormError('[trans]Error 1[/trans]'));
         $form->addError(new FormError('[trans]Error 2[/trans]'));
         $html = $this->renderErrors($form->createView());
@@ -1526,7 +1546,10 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
 
     public function testRange()
     {
-        $form = $this->factory->createNamed('name', RangeType::class, 42, ['attr' => ['min' => 5]]);
+        $form = $this->factory->createNamed('name', RangeType::class, 42, [
+            'empty_data' => null,
+            'attr' => ['min' => 5],
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input
@@ -1541,7 +1564,10 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
 
     public function testRangeWithMinMaxValues()
     {
-        $form = $this->factory->createNamed('name', RangeType::class, 42, ['attr' => ['min' => 5, 'max' => 57]]);
+        $form = $this->factory->createNamed('name', RangeType::class, 42, [
+            'empty_data' => null,
+            'attr' => ['min' => 5, 'max' => 57],
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input
@@ -1558,7 +1584,9 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
     public function testColor()
     {
         $color = '#0000ff';
-        $form = $this->factory->createNamed('name', ColorType::class, $color);
+        $form = $this->factory->createNamed('name', ColorType::class, $color, [
+            'empty_data' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), ['attr' => ['class' => 'my&class']],
             '/input
@@ -1813,6 +1841,7 @@ abstract class AbstractBootstrap5LayoutTest extends AbstractBootstrap4LayoutTest
     public function testFloatingLabel()
     {
         $form = $this->factory->createNamed('name', TextType::class, null, [
+            'empty_data' => null,
             'attr' => [
                 'placeholder' => 'name',
             ],

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -59,7 +59,9 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
     public function testThemeBlockInheritanceUsingUse()
     {
         $view = $this->factory
-            ->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType')
+            ->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType', null, [
+                'empty_data' => null,
+            ])
             ->createView()
         ;
 
@@ -74,7 +76,9 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
     public function testThemeBlockInheritanceUsingExtend()
     {
         $view = $this->factory
-            ->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType')
+            ->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType', null, [
+                'empty_data' => null,
+            ])
             ->createView()
         ;
 
@@ -89,7 +93,9 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
     public function testThemeBlockInheritanceUsingDynamicExtend()
     {
         $view = $this->factory
-            ->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType')
+            ->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType', null, [
+                'empty_data' => null,
+            ])
             ->createView()
         ;
 
@@ -194,6 +200,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
     public function testHelpAttr()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help text test!',
             'help_attr' => [
                 'class' => 'class-test',
@@ -214,6 +221,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
     public function testHelpHtmlDefaultIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
         ]);
 
@@ -241,6 +249,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
     public function testHelpHtmlIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
             'help_html' => false,
         ]);
@@ -269,6 +278,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
     public function testHelpHtmlIsTrue()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
             'help_html' => true,
         ]);
@@ -297,6 +307,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
     public function testLabelHtmlDefaultIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
         ]);
 
@@ -313,6 +324,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
     public function testLabelHtmlIsTrue()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
             'label_html' => true,
         ]);

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionFieldHelpersTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionFieldHelpersTest.php
@@ -56,6 +56,7 @@ class FormExtensionFieldHelpersTest extends FormIntegrationTestCase
 
         $form = $this->factory->createNamedBuilder('register', FormType::class, $data)
             ->add('username', TextType::class, [
+                'empty_data' => null,
                 'label' => 'base.username',
                 'label_translation_parameters' => ['%label_brand%' => 'Symfony'],
                 'help' => 'base.username_help',

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionTableLayoutTest.php
@@ -80,6 +80,7 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
     public function testHelpAttr()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help text test!',
             'help_attr' => [
                 'class' => 'class-test',
@@ -100,6 +101,7 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
     public function testHelpHtmlDefaultIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
         ]);
 
@@ -127,6 +129,7 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
     public function testHelpHtmlIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
             'help_html' => false,
         ]);
@@ -155,6 +158,7 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
     public function testHelpHtmlIsTrue()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help <b>text</b> test!',
             'help_html' => true,
         ]);
@@ -183,6 +187,7 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
     public function testLabelHtmlDefaultIsFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
         ]);
 
@@ -199,6 +204,7 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
     public function testLabelHtmlIsTrue()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => '<b>Bolded label</b>',
             'label_html' => true,
         ]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Form/UserLoginType.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/CsrfFormLoginBundle/Form/UserLoginType.php
@@ -39,8 +39,12 @@ class UserLoginType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('username', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('password', 'Symfony\Component\Form\Extension\Core\Type\PasswordType')
+            ->add('username', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('password', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', [
+                'empty_data' => null,
+            ])
             ->add('_target_path', 'Symfony\Component\Form\Extension\Core\Type\HiddenType')
         ;
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -139,16 +139,16 @@ class FormType extends BaseType
         };
 
         // Derive "empty_data" closure from "data_class" option
-        $emptyData = static function (Options $options): callable {
+        $emptyData = function (Options $options) {
             $class = $options['data_class'];
 
             if (null !== $class) {
-                return static function (FormInterface $form) use ($class): ?object {
+                return function (FormInterface $form) use ($class) {
                     return $form->isEmpty() && !$form->isRequired() ? null : new $class();
                 };
             }
 
-            return static function (FormInterface $form) {
+            return function (FormInterface $form) {
                 return $form->getConfig()->getCompound() ? [] : '';
             };
         };

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -29,7 +29,13 @@ use Symfony\Contracts\Translation\TranslatableInterface;
 class FormType extends BaseType
 {
     private DataMapper $dataMapper;
-    private static $emptyData = null;
+
+    /**
+     * @internal
+     *
+     * @deprecated Don't use this property. It will be removed in symfony/form 6.0
+     */
+    public static $emptyData = null;
 
     public function __construct(PropertyAccessorInterface $propertyAccessor = null)
     {
@@ -140,7 +146,7 @@ class FormType extends BaseType
         };
 
         // Derive "empty_data" closure from "data_class" option
-        if (self::$emptyData === null) {
+        if (null === self::$emptyData) {
             self::$emptyData = function (Options $options) {
                 $class = $options['data_class'];
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
@@ -28,8 +28,12 @@ class TextType extends AbstractType implements DataTransformerInterface
         if ('' === $options['empty_data']) {
             $builder->addViewTransformer($this);
         } elseif ($options['empty_data'] instanceof \Closure) {
-            // we assume that this is the default value from \Symfony\Component\Form\Extension\Core\Type\FormType::configureOptions()
-            trigger_deprecation('symfony/form', '5.4', 'The default value of "empty_data" option in "%s" will be changed to empty string. Declare "NULL" as value for "empty_data" if you still want use "NULL" as data.', __CLASS__);
+            $emptyData = new \ReflectionProperty(FormType::class, 'emptyData');
+            $emptyData->setAccessible(true);
+            // Closure in "empty_data" option is the default value from FormType::configureOptions()
+            if ($emptyData->getValue($builder->getForm()) === $options['empty_data']) {
+                trigger_deprecation('symfony/form', '5.4', 'The default value of "empty_data" option in "%s" will be changed to empty string. Declare "NULL" as value for "empty_data" if you still want use "NULL" as data.', __CLASS__);
+            }
         }
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
@@ -27,13 +27,9 @@ class TextType extends AbstractType implements DataTransformerInterface
         // See https://github.com/symfony/symfony/issues/5906#issuecomment-203189375
         if ('' === $options['empty_data']) {
             $builder->addViewTransformer($this);
-        } elseif ($options['empty_data'] instanceof \Closure) {
-            $emptyData = new \ReflectionProperty(FormType::class, 'emptyData');
-            $emptyData->setAccessible(true);
-            // Closure in "empty_data" option is the default value from FormType::configureOptions()
-            if ($emptyData->getValue($builder->getForm()) === $options['empty_data']) {
-                trigger_deprecation('symfony/form', '5.4', 'The default value of "empty_data" option in "%s" will be changed to empty string. Declare "NULL" as value for "empty_data" if you still want use "NULL" as data.', __CLASS__);
-            }
+        } elseif (FormType::$emptyData === $options['empty_data']) {
+            // "empty_data" option is the default value from FormType::configureOptions()
+            trigger_deprecation('symfony/form', '5.4', 'The default value of "empty_data" option in "%s" will be changed to empty string. Declare "NULL" as value for "empty_data" if you still want use "NULL" as data.', __CLASS__);
         }
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
@@ -27,6 +27,9 @@ class TextType extends AbstractType implements DataTransformerInterface
         // See https://github.com/symfony/symfony/issues/5906#issuecomment-203189375
         if ('' === $options['empty_data']) {
             $builder->addViewTransformer($this);
+        } elseif ($options['empty_data'] instanceof \Closure) {
+            // we assume that this is the default value from \Symfony\Component\Form\Extension\Core\Type\FormType::configureOptions()
+            trigger_deprecation('symfony/form', '5.4', 'The default value of "empty_data" option in "%s" will be changed to empty string. Declare "NULL" as value for "empty_data" if you still want use "NULL" as data.', __CLASS__);
         }
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
@@ -32,7 +32,7 @@ class TextType extends AbstractType implements DataTransformerInterface
 
             if (null !== $scope && FormType::class === $scope->getName()) {
                 // "empty_data" option is the default value from FormType::configureOptions()
-                trigger_deprecation('symfony/form', '5.4', 'The default value of "empty_data" option in "%s" will be changed to empty string. Declare "NULL" as value for "empty_data" if you still want use "NULL" as data.', __CLASS__);
+                trigger_deprecation('symfony/form', '6.1', 'The default value of "empty_data" option in "%s" will be changed to empty string. Declare "NULL" as value for "empty_data" if you still want use "NULL" as data.', __CLASS__);
             }
         }
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
@@ -27,7 +27,7 @@ class TextType extends AbstractType implements DataTransformerInterface
         // See https://github.com/symfony/symfony/issues/5906#issuecomment-203189375
         if ('' === $options['empty_data']) {
             $builder->addViewTransformer($this);
-        } elseif (is_callable($options['empty_data'])) {
+        } elseif ($options['empty_data'] instanceof \Closure) {
             $scope = (new \ReflectionFunction($options['empty_data']))->getClosureScopeClass();
 
             if (null !== $scope && FormType::class === $scope->getName()) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
@@ -27,9 +27,13 @@ class TextType extends AbstractType implements DataTransformerInterface
         // See https://github.com/symfony/symfony/issues/5906#issuecomment-203189375
         if ('' === $options['empty_data']) {
             $builder->addViewTransformer($this);
-        } elseif (FormType::$emptyData === $options['empty_data']) {
-            // "empty_data" option is the default value from FormType::configureOptions()
-            trigger_deprecation('symfony/form', '5.4', 'The default value of "empty_data" option in "%s" will be changed to empty string. Declare "NULL" as value for "empty_data" if you still want use "NULL" as data.', __CLASS__);
+        } elseif (is_callable($options['empty_data'])) {
+            $scope = (new \ReflectionFunction($options['empty_data']))->getClosureScopeClass();
+
+            if (null !== $scope && FormType::class === $scope->getName()) {
+                // "empty_data" option is the default value from FormType::configureOptions()
+                trigger_deprecation('symfony/form', '5.4', 'The default value of "empty_data" option in "%s" will be changed to empty string. Declare "NULL" as value for "empty_data" if you still want use "NULL" as data.', __CLASS__);
+            }
         }
     }
 

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -18,7 +18,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 {
     public function testRow()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $form->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
         $html = $this->renderRow($view);
@@ -38,7 +40,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRowOverrideVariables()
     {
-        $view = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType')->createView();
+        $view = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ])->createView();
         $html = $this->renderRow($view, [
             'attr' => ['class' => 'my&class'],
             'label' => 'foo&bar',
@@ -57,7 +61,14 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRepeatedRow()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, [
+            'first_options' => [
+                'empty_data' => null,
+            ],
+            'second_options' => [
+                'empty_data' => null,
+            ],
+        ]);
         $form->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
         $html = $this->renderRow($view);
@@ -101,10 +112,23 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testRest()
     {
         $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType')
-            ->add('field3', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('field4', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', [
+                'first_options' => [
+                    'empty_data' => null,
+                ],
+                'second_options' => [
+                    'empty_data' => null,
+                ],
+            ])
+            ->add('field3', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('field4', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm()
             ->createView();
 
@@ -142,12 +166,20 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testRestWithChildrenForms()
     {
         $child1 = $this->factory->createNamedBuilder('child1', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ]);
 
         $child2 = $this->factory->createNamedBuilder('child2', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ]);
 
         $view = $this->factory->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->add($child1)
@@ -200,8 +232,17 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testRestAndRepeatedWithRow()
     {
         $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('first', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('password', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType')
+            ->add('first', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('password', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', [
+                'first_options' => [
+                    'empty_data' => null,
+                ],
+                'second_options' => [
+                    'empty_data' => null,
+                ],
+            ])
             ->getForm()
             ->createView();
 
@@ -226,8 +267,17 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testRestAndRepeatedWithRowPerChild()
     {
         $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('first', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('password', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType')
+            ->add('first', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('password', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', [
+                'first_options' => [
+                    'empty_data' => null,
+                ],
+                'second_options' => [
+                    'empty_data' => null,
+                ],
+            ])
             ->getForm()
             ->createView();
 
@@ -254,8 +304,17 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testRestAndRepeatedWithWidgetPerChild()
     {
         $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('first', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('password', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType')
+            ->add('first', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('password', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', [
+                'first_options' => [
+                    'empty_data' => null,
+                ],
+                'second_options' => [
+                    'empty_data' => null,
+                ],
+            ])
             ->getForm()
             ->createView();
 
@@ -285,6 +344,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     {
         $form = $this->factory->createNamed('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', ['a', 'b'], [
             'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_options' => [
+                'empty_data' => null,
+            ],
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -325,6 +387,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     {
         $form = $this->factory->createNamed('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', [], [
             'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_options' => [
+                'empty_data' => null,
+            ],
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -341,7 +406,12 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
             'collection',
             'Symfony\Component\Form\Extension\Core\Type\CollectionType',
             ['a', 'b'],
-            ['entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType']
+            [
+                'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+                'entry_options' => [
+                    'empty_data' => null,
+                ],
+            ]
         );
 
         $form = $this->factory->createNamedBuilder('form', 'Symfony\Component\Form\Extension\Core\Type\FormType')
@@ -380,8 +450,12 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
         $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->setMethod('PUT')
             ->setAction('http://example.com')
-            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         // include ampersands everywhere to validate escaping
@@ -422,8 +496,12 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testFormWidget()
     {
         $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -479,7 +557,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
             ->add($this->factory
                 // No CSRF protection on nested forms
                 ->createNamedBuilder('child', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-                ->add($this->factory->createNamedBuilder('grandchild', 'Symfony\Component\Form\Extension\Core\Type\TextType'))
+                ->add($this->factory->createNamedBuilder('grandchild', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+                    'empty_data' => null,
+                ]))
             )
             ->getForm();
 
@@ -498,6 +578,12 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', 'foobar', [
             'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'first_options' => [
+                'empty_data' => null,
+            ],
+            'second_options' => [
+                'empty_data' => null,
+            ],
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -524,8 +610,15 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, [
             // the global required value cannot be overridden
-            'first_options' => ['label' => 'Test', 'required' => false],
-            'second_options' => ['label' => 'Test2'],
+            'first_options' => [
+                'label' => 'Test',
+                'required' => false,
+                'empty_data' => null,
+            ],
+            'second_options' => [
+                'label' => 'Test2',
+                'empty_data' => null,
+            ],
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -551,7 +644,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testSearchInputName()
     {
         $form = $this->factory->createNamedBuilder('full', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('name', 'Symfony\Component\Form\Extension\Core\Type\SearchType')
+            ->add('name', 'Symfony\Component\Form\Extension\Core\Type\SearchType', [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -571,7 +666,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testLabelHasNoId()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderRow($form->createView());
 
         $this->assertMatchesXpath($html,
@@ -587,6 +684,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testLabelIsNotRenderedWhenSetToFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => false,
         ]);
         $html = $this->renderRow($form->createView());
@@ -607,7 +705,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testThemeBlockInheritance($theme)
     {
         $view = $this->factory
-            ->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType')
+            ->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType', null, [
+                'empty_data' => null,
+            ])
             ->createView()
         ;
 
@@ -625,10 +725,14 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testThemeInheritance($parentTheme, $childTheme)
     {
         $child = $this->factory->createNamedBuilder('child', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('field', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+            ->add('field', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ]);
 
         $view = $this->factory->createNamedBuilder('parent', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('field', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->add($child)
             ->getForm()
             ->createView()
@@ -670,8 +774,11 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testCollectionRowWithCustomBlock()
     {
         $collection = ['one', 'two', 'three'];
-        $form = $this->factory->createNamedBuilder('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', $collection)
-            ->getForm();
+        $form = $this->factory->createNamedBuilder('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', $collection, [
+            'entry_options' => [
+                'empty_data' => null,
+            ],
+        ])->getForm();
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/div
@@ -863,8 +970,12 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testFormEndWithRest()
     {
         $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm()
             ->createView();
 
@@ -893,8 +1004,12 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testFormEndWithoutRest()
     {
         $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm()
             ->createView();
 
@@ -912,7 +1027,9 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
             'attr' => ['class' => 'foobar', 'data-foo' => 'bar'],
         ]);
 
-        $form->add('text', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form->add('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+            'empty_data' => null,
+        ]);
 
         $html = $this->renderWidget($form->createView());
 

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -146,7 +146,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testLabel()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $view = $form->createView();
         $this->renderWidget($view, ['label' => 'foo']);
         $html = $this->renderLabel($view);
@@ -162,6 +164,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testLabelWithoutTranslation()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'translation_domain' => false,
         ]);
 
@@ -191,6 +194,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testLabelWithCustomTextPassedAsOption()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => 'Custom label',
         ]);
         $html = $this->renderLabel($form->createView());
@@ -205,7 +209,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testLabelWithCustomTextPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), 'Custom label');
 
         $this->assertMatchesXpath($html,
@@ -219,6 +225,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testLabelWithCustomTextPassedAsOptionAndDirectly()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => 'Custom label',
         ]);
         $html = $this->renderLabel($form->createView(), 'Overridden label');
@@ -233,7 +240,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testLabelDoesNotRenderFieldAttributes()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), null, [
             'attr' => [
                 'class' => 'my&class',
@@ -250,7 +259,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testLabelWithCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), null, [
             'label_attr' => [
                 'class' => 'my&class',
@@ -267,7 +278,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testLabelWithCustomTextAndCustomAttributesPassedDirectly()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+            ]);
         $html = $this->renderLabel($form->createView(), 'Custom label', [
             'label_attr' => [
                 'class' => 'my&class',
@@ -287,6 +300,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testLabelWithCustomTextAsOptionAndCustomAttributesPassedDirectly()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => 'Custom label',
         ]);
         $html = $this->renderLabel($form->createView(), null, [
@@ -307,7 +321,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testLabelFormatName()
     {
         $form = $this->factory->createNamedBuilder('myform')
-            ->add('myfield', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('myfield', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm();
         $view = $form->get('myfield')->createView();
         $html = $this->renderLabel($view, null, ['label_format' => 'form.%name%']);
@@ -323,7 +339,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testLabelFormatId()
     {
         $form = $this->factory->createNamedBuilder('myform')
-            ->add('myfield', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('myfield', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm();
         $view = $form->get('myfield')->createView();
         $html = $this->renderLabel($view, null, ['label_format' => 'form.%id%']);
@@ -341,7 +359,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         $options = ['label_format' => 'form.%name%'];
 
         $form = $this->factory->createNamedBuilder('myform', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, $options)
-            ->add('myfield', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('myfield', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm();
         $view = $form->get('myfield')->createView();
         $html = $this->renderLabel($view);
@@ -359,7 +379,10 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         $options = ['label_format' => 'form.%name%'];
 
         $form = $this->factory->createNamedBuilder('myform', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, $options)
-            ->add('myfield', 'Symfony\Component\Form\Extension\Core\Type\TextType', ['label_format' => 'field.%name%'])
+            ->add('myfield', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+                'label_format' => 'field.%name%',
+            ])
             ->getForm();
         $view = $form->get('myfield')->createView();
         $html = $this->renderLabel($view);
@@ -428,6 +451,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testHelp()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help text test!',
         ]);
         $view = $form->createView();
@@ -444,7 +468,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testHelpNotSet()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $view = $form->createView();
         $html = $this->renderHelp($view);
 
@@ -454,6 +480,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testHelpSetLinkFromWidget()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'Help text test!',
         ]);
         $view = $form->createView();
@@ -471,7 +498,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testHelpNotSetNotLinkedFromWidget()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $view = $form->createView();
         $html = $this->renderRow($view);
 
@@ -487,7 +516,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testErrors()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $form->addError(new FormError('[trans]Error 1[/trans]'));
         $form->addError(new FormError('[trans]Error 2[/trans]'));
         $view = $form->createView();
@@ -507,7 +538,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testOverrideWidgetBlock()
     {
         // see custom_widgets.html.twig
-        $form = $this->factory->createNamed('text_id', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('text_id', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderWidget($form->createView());
 
         $this->assertMatchesXpath($html,
@@ -1718,7 +1751,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testEmail()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType', 'foo&bar', [
+            'empty_data' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
@@ -1733,6 +1768,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testEmailWithMaxLength()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\EmailType', 'foo&bar', [
+            'empty_data' => null,
             'attr' => ['maxlength' => 123],
         ]);
 
@@ -1773,6 +1809,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testDisabled()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'disabled' => true,
         ]);
 
@@ -1887,7 +1924,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testPassword()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', 'foo&bar', [
+            'empty_data' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
@@ -1900,6 +1939,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testPasswordSubmittedWithNotAlwaysEmpty()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', null, [
+            'empty_data' => null,
             'always_empty' => false,
         ]);
         $form->submit('foo&bar');
@@ -1916,6 +1956,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testPasswordWithMaxLength()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\PasswordType', 'foo&bar', [
+            'empty_data' => null,
             'attr' => ['maxlength' => 123],
         ]);
 
@@ -2016,7 +2057,10 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testRange()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RangeType', 42, ['attr' => ['min' => 5]]);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RangeType', 42, [
+            'empty_data' => null,
+            'attr' => ['min' => 5],
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
@@ -2030,7 +2074,10 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testRangeWithMinMaxValues()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RangeType', 42, ['attr' => ['min' => 5, 'max' => 57]]);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RangeType', 42, [
+            'empty_data' => null,
+            'attr' => ['min' => 5, 'max' => 57],
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
@@ -2046,6 +2093,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testTextarea()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', 'foo&bar', [
+            'empty_data' => null,
             'attr' => ['pattern' => 'foo'],
         ]);
 
@@ -2060,7 +2108,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testText()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'foo&bar', [
+            'empty_data' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
@@ -2075,6 +2125,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testTextWithMaxLength()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'foo&bar', [
+            'empty_data' => null,
             'attr' => ['maxlength' => 123],
         ]);
 
@@ -2090,7 +2141,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testSearch()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\SearchType', 'foo&bar');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\SearchType', 'foo&bar', [
+            'empty_data' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
@@ -2298,7 +2351,10 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testUrlWithDefaultProtocol()
     {
         $url = 'http://www.example.com?foo1=bar1&foo2=bar2';
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, ['default_protocol' => 'http']);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, [
+            'empty_data' => null,
+            'default_protocol' => 'http',
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
@@ -2313,7 +2369,10 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testUrlWithoutDefaultProtocol()
     {
         $url = 'http://www.example.com?foo1=bar1&foo2=bar2';
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, ['default_protocol' => null]);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\UrlType', $url, [
+            'empty_data' => null,
+            'default_protocol' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
@@ -2327,7 +2386,12 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testCollectionPrototype()
     {
         $form = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType', ['items' => ['one', 'two', 'three']])
-            ->add('items', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', ['allow_add' => true])
+            ->add('items', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', [
+                'entry_options' => [
+                    'empty_data' => null,
+                ],
+                'allow_add' => true,
+            ])
             ->getForm()
             ->createView();
 
@@ -2343,7 +2407,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testEmptyRootFormName()
     {
         $form = $this->factory->createNamedBuilder('', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         $this->assertMatchesXpath($this->renderWidget($form->createView()),
@@ -2472,6 +2538,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testWidgetAttributes()
     {
         $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', [
+            'empty_data' => null,
             'required' => true,
             'disabled' => true,
             'attr' => ['readonly' => true, 'maxlength' => 10, 'pattern' => '\d+', 'class' => 'foobar', 'data-foo' => 'bar'],
@@ -2486,6 +2553,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testWidgetAttributeNameRepeatedIfTrue()
     {
         $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', [
+            'empty_data' => null,
             'attr' => ['foo' => true],
         ]);
 
@@ -2498,6 +2566,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testWidgetAttributeHiddenIfFalse()
     {
         $form = $this->factory->createNamed('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', 'value', [
+            'empty_data' => null,
             'attr' => ['foo' => false],
         ]);
 
@@ -2544,7 +2613,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
     public function testTextareaWithWhitespaceOnlyContentRetainsValue()
     {
-        $form = $this->factory->createNamed('textarea', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', '  ');
+        $form = $this->factory->createNamed('textarea', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', '  ', [
+            'empty_data' => null,
+        ]);
 
         $html = $this->renderWidget($form->createView());
 
@@ -2554,7 +2625,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testTextareaWithWhitespaceOnlyContentRetainsValueWhenRenderingForm()
     {
         $form = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', ['textarea' => '  '])
-            ->add('textarea', 'Symfony\Component\Form\Extension\Core\Type\TextareaType')
+            ->add('textarea', 'Symfony\Component\Form\Extension\Core\Type\TextareaType', [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         $html = $this->renderForm($form->createView());
@@ -2577,8 +2650,14 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testTranslatedAttributes()
     {
         $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', ['attr' => ['title' => 'Foo']])
-            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType', ['attr' => ['placeholder' => 'Bar']])
+            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+                'attr' => ['title' => 'Foo'],
+            ])
+            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+                'attr' => ['placeholder' => 'Bar'],
+            ])
             ->getForm()
             ->createView();
 
@@ -2593,8 +2672,14 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType', null, [
                 'translation_domain' => false,
             ])
-            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', ['attr' => ['title' => 'Foo']])
-            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType', ['attr' => ['placeholder' => 'Bar']])
+            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+                'attr' => ['title' => 'Foo'],
+            ])
+            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+                'attr' => ['placeholder' => 'Bar'],
+            ])
             ->getForm()
             ->createView();
 
@@ -2607,7 +2692,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testTel()
     {
         $tel = '0102030405';
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TelType', $tel);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TelType', $tel, [
+            'empty_data' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
@@ -2621,7 +2708,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testColor()
     {
         $color = '#0000ff';
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ColorType', $color);
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\ColorType', $color, [
+            'empty_data' => null,
+        ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/input
@@ -2636,7 +2725,9 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     {
         $this->requiresFeatureSet(403);
 
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $html = $this->renderLabel($form->createView(), 'Address is %address%', [
             'label_translation_parameters' => [
                 '%address%' => 'Paris, rue de la Paix',
@@ -2656,6 +2747,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         $this->requiresFeatureSet(403);
 
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => 'for company %company%',
             'help_translation_parameters' => [
                 '%company%' => 'ACME Ltd.',
@@ -2674,6 +2766,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testLabelWithTranslatableMessage()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => new TranslatableMessage('foo'),
         ]);
         $html = $this->renderLabel($form->createView());
@@ -2689,6 +2782,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testHelpWithTranslatableMessage()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => new TranslatableMessage('foo'),
         ]);
         $html = $this->renderHelp($form->createView());
@@ -2728,6 +2822,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         $this->requiresFeatureSet(403);
 
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'attr' => [
                 'title' => 'Message to %company%',
                 'placeholder' => 'Enter a message to %company%',

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -2805,6 +2805,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         };
 
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'help' => $message,
         ]);
         $html = $this->renderHelp($form->createView());

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
@@ -330,7 +330,10 @@ abstract class AbstractRequestHandlerTest extends TestCase
         $this->serverParams->contentLength = $contentLength;
         $this->serverParams->postMaxSize = $iniMax;
 
-        $options = ['post_max_size_message' => 'Max {{ max }}!'];
+        $options = [
+            'empty_data' => null,
+            'post_max_size_message' => 'Max {{ max }}!',
+        ];
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, $options);
         $this->setRequestData('POST', [], []);
 

--- a/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
@@ -18,7 +18,9 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 {
     public function testRow()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
+        ]);
         $form->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
         $html = $this->renderRow($view);
@@ -43,6 +45,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     public function testLabelIsNotRenderedWhenSetToFalse()
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+            'empty_data' => null,
             'label' => false,
         ]);
         $html = $this->renderRow($form->createView());
@@ -61,7 +64,14 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testRepeatedRow()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, [
+            'first_options' => [
+                'empty_data' => null,
+            ],
+            'second_options' => [
+                'empty_data' => null,
+            ],
+        ]);
         $html = $this->renderRow($form->createView());
 
         $this->assertMatchesXpath($html,
@@ -91,7 +101,14 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testRepeatedRowWithErrors()
     {
-        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType');
+        $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', null, [
+            'first_options' => [
+                'empty_data' => null,
+            ],
+            'second_options' => [
+                'empty_data' => null,
+            ],
+        ]);
         $form->addError(new FormError('[trans]Error![/trans]'));
         $view = $form->createView();
         $html = $this->renderRow($view);
@@ -148,10 +165,23 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     public function testRest()
     {
         $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType')
-            ->add('field3', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('field4', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', [
+                'first_options' => [
+                    'empty_data' => null,
+                ],
+                'second_options' => [
+                    'empty_data' => null,
+                ],
+            ])
+            ->add('field3', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('field4', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm()
             ->createView();
 
@@ -196,6 +226,9 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     {
         $form = $this->factory->createNamed('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', ['a', 'b'], [
             'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_options' => [
+                'empty_data' => null,
+            ],
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -214,6 +247,9 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     {
         $form = $this->factory->createNamed('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', [], [
             'entry_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'entry_options' => [
+                'empty_data' => null,
+            ],
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -229,8 +265,12 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
         $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
             ->setMethod('PUT')
             ->setAction('http://example.com')
-            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm()
             ->createView();
 
@@ -279,8 +319,12 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     public function testFormWidget()
     {
         $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm()
             ->createView();
 
@@ -345,7 +389,9 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
             ->add($this->factory
                 // No CSRF protection on nested forms
                 ->createNamedBuilder('child', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-                ->add($this->factory->createNamedBuilder('grandchild', 'Symfony\Component\Form\Extension\Core\Type\TextType'))
+                ->add($this->factory->createNamedBuilder('grandchild', 'Symfony\Component\Form\Extension\Core\Type\TextType', null, [
+                    'empty_data' => null,
+                ]))
             )
             ->getForm();
 
@@ -367,6 +413,12 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', 'foobar', [
             'type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
+            'first_options' => [
+                'empty_data' => null,
+            ],
+            'second_options' => [
+                'empty_data' => null,
+            ],
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -401,8 +453,15 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     {
         $form = $this->factory->createNamed('name', 'Symfony\Component\Form\Extension\Core\Type\RepeatedType', 'foobar', [
             'type' => 'Symfony\Component\Form\Extension\Core\Type\PasswordType',
-            'first_options' => ['label' => 'Test', 'required' => false],
-            'second_options' => ['label' => 'Test2'],
+            'first_options' => [
+                'empty_data' => null,
+                'label' => 'Test',
+                'required' => false,
+            ],
+            'second_options' => [
+                'empty_data' => null,
+                'label' => 'Test2',
+            ],
         ]);
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
@@ -440,8 +499,11 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     public function testCollectionRowWithCustomBlock()
     {
         $collection = ['one', 'two', 'three'];
-        $form = $this->factory->createNamedBuilder('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', $collection)
-            ->getForm();
+        $form = $this->factory->createNamedBuilder('names', 'Symfony\Component\Form\Extension\Core\Type\CollectionType', $collection, [
+            'entry_options' => [
+                'empty_data' => null,
+            ],
+        ])->getForm();
 
         $this->assertWidgetMatchesXpath($form->createView(), [],
             '/table
@@ -457,8 +519,12 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     public function testFormEndWithRest()
     {
         $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm()
             ->createView();
 
@@ -495,8 +561,12 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     public function testFormEndWithoutRest()
     {
         $view = $this->factory->createNamedBuilder('name', 'Symfony\Component\Form\Extension\Core\Type\FormType')
-            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('field1', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
+            ->add('field2', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm()
             ->createView();
 
@@ -514,7 +584,9 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
             'attr' => ['class' => 'foobar', 'data-foo' => 'bar'],
         ]);
 
-        $form->add('text', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $form->add('text', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+            'empty_data' => null,
+        ]);
 
         $html = $this->renderWidget($form->createView());
 

--- a/src/Symfony/Component/Form/Tests/CompoundFormPerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormPerformanceTest.php
@@ -29,8 +29,12 @@ class CompoundFormPerformanceTest extends FormPerformanceTestCase
 
         for ($i = 0; $i < 40; ++$i) {
             $form = $this->factory->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType')
-                ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
-                ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+                ->add('firstName', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                    'empty_data' => null,
+                ])
+                ->add('lastName', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                    'empty_data' => null,
+                ])
                 ->add('color', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', [
                     'choices' => ['red' => 'Red', 'blue' => 'Blue'],
                     'required' => false,

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -205,7 +205,9 @@ class CompoundFormTest extends TestCase
 
     public function testAddUsingNameAndType()
     {
-        $this->form->add('foo', TextType::class);
+        $this->form->add('foo', TextType::class, [
+            'empty_data' => null,
+        ]);
 
         $this->assertTrue($this->form->has('foo'));
 
@@ -218,7 +220,9 @@ class CompoundFormTest extends TestCase
     public function testAddUsingIntegerNameAndType()
     {
         // in order to make casting unnecessary
-        $this->form->add(0, TextType::class);
+        $this->form->add(0, TextType::class, [
+            'empty_data' => null,
+        ]);
 
         $this->assertTrue($this->form->has(0));
 
@@ -230,7 +234,9 @@ class CompoundFormTest extends TestCase
 
     public function testAddWithoutType()
     {
-        $this->form->add('foo');
+        $this->form->add('foo', null, [
+            'empty_data' => null,
+        ]);
 
         $this->assertTrue($this->form->has('foo'));
 
@@ -247,7 +253,9 @@ class CompoundFormTest extends TestCase
             ->setDataMapper(new DataMapper())
             ->getForm();
 
-        $this->form->add('foo');
+        $this->form->add('foo', null, [
+            'empty_data' => null,
+        ]);
 
         $this->assertTrue($this->form->has('foo'));
 
@@ -264,7 +272,9 @@ class CompoundFormTest extends TestCase
             ->setDataMapper(new DataMapper())
             ->getForm();
 
-        $this->form->add('foo');
+        $this->form->add('foo', null, [
+            'empty_data' => null,
+        ]);
 
         $this->assertTrue($this->form->has('foo'));
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -59,7 +59,10 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [1 => 'string', 2 => 'string'];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener(TextType::class, ['attr' => ['maxlength' => 10]], false, false);
+        $listener = new ResizeFormListener(TextType::class, [
+            'empty_data' => null,
+            'attr' => ['maxlength' => 10],
+        ], false, false);
         $listener->preSetData($event);
 
         $this->assertFalse($this->form->has('0'));
@@ -80,7 +83,9 @@ class ResizeFormListenerTest extends TestCase
     {
         $data = null;
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener(TextType::class, [], false, false);
+        $listener = new ResizeFormListener(TextType::class, [
+            'empty_data' => null,
+        ], false, false);
         $listener->preSetData($event);
 
         $this->assertSame(0, $this->form->count());
@@ -92,7 +97,10 @@ class ResizeFormListenerTest extends TestCase
 
         $data = [0 => 'string', 1 => 'string'];
         $event = new FormEvent($this->form, $data);
-        $listener = new ResizeFormListener(TextType::class, ['attr' => ['maxlength' => 10]], true, false);
+        $listener = new ResizeFormListener(TextType::class, [
+            'empty_data' => null,
+            'attr' => ['maxlength' => 10],
+        ], true, false);
         $listener->preSubmit($event);
 
         $this->assertTrue($this->form->has('0'));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -186,7 +186,7 @@ abstract class BaseTypeTest extends TypeTestCase
             ])
             ->add('child', $this->getTestedType(), $this->getTestedTypeOptions() + [
                 'label_translation_parameters' => ['%override_param%' => 'child_value'],
-            ]))
+            ])
             ->getForm()
             ->createView();
 
@@ -203,7 +203,7 @@ abstract class BaseTypeTest extends TypeTestCase
             ])
             ->add('child', $this->getTestedType(), $this->getTestedTypeOptions() + [
                 'attr_translation_parameters' => ['%override_param%' => 'child_value'],
-            ]))
+            ])
             ->getForm()
             ->createView();
 
@@ -292,7 +292,7 @@ abstract class BaseTypeTest extends TypeTestCase
         return static::TESTED_TYPE;
     }
 
-    protected function getTestedTypeOptions()
+    protected function getTestedTypeOptions(): array
     {
         return static::TESTED_TYPE_OPTIONS;
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -22,17 +22,20 @@ abstract class BaseTypeTest extends TypeTestCase
     use VersionAwareTest;
 
     public const TESTED_TYPE = '';
+    public const TESTED_TYPE_OPTIONS = [];
 
     public function testPassDisabledAsOption()
     {
-        $form = $this->factory->create($this->getTestedType(), null, array_merge($this->getTestOptions(), ['disabled' => true]));
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
+            'disabled' => true,
+        ]);
 
         $this->assertTrue($form->isDisabled());
     }
 
     public function testPassIdAndNameToView()
     {
-        $view = $this->factory->createNamed('name', $this->getTestedType(), null, $this->getTestOptions())
+        $view = $this->factory->createNamed('name', $this->getTestedType(), null, $this->getTestedTypeOptions())
             ->createView();
 
         $this->assertEquals('name', $view->vars['id']);
@@ -42,7 +45,7 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testStripLeadingUnderscoresAndDigitsFromId()
     {
-        $view = $this->factory->createNamed('_09name', $this->getTestedType(), null, $this->getTestOptions())
+        $view = $this->factory->createNamed('_09name', $this->getTestedType(), null, $this->getTestedTypeOptions())
             ->createView();
 
         $this->assertEquals('name', $view->vars['id']);
@@ -53,7 +56,7 @@ abstract class BaseTypeTest extends TypeTestCase
     public function testPassIdAndNameToViewWithParent()
     {
         $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
-            ->add('child', $this->getTestedType(), $this->getTestOptions())
+            ->add('child', $this->getTestedType(), $this->getTestedTypeOptions())
             ->getForm()
             ->createView();
 
@@ -66,7 +69,7 @@ abstract class BaseTypeTest extends TypeTestCase
     {
         $builder = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
             ->add('child', FormTypeTest::TESTED_TYPE);
-        $builder->get('child')->add('grand_child', $this->getTestedType(), $this->getTestOptions());
+        $builder->get('child')->add('grand_child', $this->getTestedType(), $this->getTestedTypeOptions());
         $view = $builder->getForm()->createView();
 
         $this->assertEquals('parent_child_grand_child', $view['child']['grand_child']->vars['id']);
@@ -76,10 +79,9 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testPassTranslationDomainToView()
     {
-        $view = $this->factory->create($this->getTestedType(), null, array_merge($this->getTestOptions(), [
+        $view = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'translation_domain' => 'domain',
-        ]))
-            ->createView();
+        ])->createView();
 
         $this->assertSame('domain', $view->vars['translation_domain']);
     }
@@ -90,7 +92,7 @@ abstract class BaseTypeTest extends TypeTestCase
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'translation_domain' => 'domain',
             ])
-            ->add('child', $this->getTestedType(), $this->getTestOptions())
+            ->add('child', $this->getTestedType(), $this->getTestedTypeOptions())
             ->getForm()
             ->createView();
 
@@ -103,9 +105,9 @@ abstract class BaseTypeTest extends TypeTestCase
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'translation_domain' => 'parent_domain',
             ])
-            ->add('child', $this->getTestedType(), array_merge($this->getTestOptions(), [
+            ->add('child', $this->getTestedType(), $this->getTestedTypeOptions() + [
                 'translation_domain' => 'domain',
-            ]))
+            ])
             ->getForm()
             ->createView();
 
@@ -115,7 +117,7 @@ abstract class BaseTypeTest extends TypeTestCase
     public function testDefaultTranslationDomain()
     {
         $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
-            ->add('child', $this->getTestedType(), $this->getTestOptions())
+            ->add('child', $this->getTestedType(), $this->getTestedTypeOptions())
             ->getForm()
             ->createView();
 
@@ -126,10 +128,9 @@ abstract class BaseTypeTest extends TypeTestCase
     {
         $this->requiresFeatureSet(403);
 
-        $view = $this->factory->create($this->getTestedType(), null, array_merge($this->getTestOptions(), [
+        $view = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'label_translation_parameters' => ['%param%' => 'value'],
-        ]))
-            ->createView();
+        ])->createView();
 
         $this->assertSame(['%param%' => 'value'], $view->vars['label_translation_parameters']);
     }
@@ -138,10 +139,9 @@ abstract class BaseTypeTest extends TypeTestCase
     {
         $this->requiresFeatureSet(403);
 
-        $view = $this->factory->create($this->getTestedType(), null, array_merge($this->getTestOptions(), [
+        $view = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'attr_translation_parameters' => ['%param%' => 'value'],
-        ]))
-            ->createView();
+        ])->createView();
 
         $this->assertSame(['%param%' => 'value'], $view->vars['attr_translation_parameters']);
     }
@@ -154,7 +154,7 @@ abstract class BaseTypeTest extends TypeTestCase
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'label_translation_parameters' => ['%param%' => 'value'],
             ])
-            ->add('child', $this->getTestedType(), $this->getTestOptions())
+            ->add('child', $this->getTestedType(), $this->getTestedTypeOptions())
             ->getForm()
             ->createView();
 
@@ -169,7 +169,7 @@ abstract class BaseTypeTest extends TypeTestCase
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'attr_translation_parameters' => ['%param%' => 'value'],
             ])
-            ->add('child', $this->getTestedType(), $this->getTestOptions())
+            ->add('child', $this->getTestedType(), $this->getTestedTypeOptions())
             ->getForm()
             ->createView();
 
@@ -184,7 +184,7 @@ abstract class BaseTypeTest extends TypeTestCase
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'label_translation_parameters' => ['%parent_param%' => 'parent_value', '%override_param%' => 'parent_override_value'],
             ])
-            ->add('child', $this->getTestedType(), array_merge($this->getTestOptions(), [
+            ->add('child', $this->getTestedType(), $this->getTestedTypeOptions() + [
                 'label_translation_parameters' => ['%override_param%' => 'child_value'],
             ]))
             ->getForm()
@@ -201,7 +201,7 @@ abstract class BaseTypeTest extends TypeTestCase
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'attr_translation_parameters' => ['%parent_param%' => 'parent_value', '%override_param%' => 'parent_override_value'],
             ])
-            ->add('child', $this->getTestedType(), array_merge($this->getTestOptions(), [
+            ->add('child', $this->getTestedType(), $this->getTestedTypeOptions() + [
                 'attr_translation_parameters' => ['%override_param%' => 'child_value'],
             ]))
             ->getForm()
@@ -215,7 +215,7 @@ abstract class BaseTypeTest extends TypeTestCase
         $this->requiresFeatureSet(403);
 
         $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
-            ->add('child', $this->getTestedType(), $this->getTestOptions())
+            ->add('child', $this->getTestedType(), $this->getTestedTypeOptions())
             ->getForm()
             ->createView();
 
@@ -227,7 +227,7 @@ abstract class BaseTypeTest extends TypeTestCase
         $this->requiresFeatureSet(403);
 
         $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
-            ->add('child', $this->getTestedType(), $this->getTestOptions())
+            ->add('child', $this->getTestedType(), $this->getTestedTypeOptions())
             ->getForm()
             ->createView();
 
@@ -236,26 +236,28 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testPassLabelToView()
     {
-        $view = $this->factory->createNamed('__test___field', $this->getTestedType(), null, array_merge(
-            $this->getTestOptions(),
-            ['label' => 'My label']
-        ))
-            ->createView();
+        $view = $this->factory->createNamed(
+            '__test___field',
+            $this->getTestedType(),
+            null,
+            $this->getTestedTypeOptions() + [
+                'label' => 'My label',
+            ]
+        )->createView();
 
         $this->assertSame('My label', $view->vars['label']);
     }
 
     public function testPassMultipartFalseToView()
     {
-        $view = $this->factory->create($this->getTestedType(), null, $this->getTestOptions())
-            ->createView();
+        $view = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions())->createView();
 
         $this->assertFalse($view->vars['multipart']);
     }
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)
     {
-        $form = $this->factory->create($this->getTestedType(), null, $this->getTestOptions());
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions());
         $form->submit(null);
 
         $this->assertSame($expected, $form->getData());
@@ -265,7 +267,7 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testSubmitNullUsesDefaultEmptyData($emptyData = 'empty', $expectedData = null)
     {
-        $builder = $this->factory->createBuilder($this->getTestedType(), null, $this->getTestOptions());
+        $builder = $this->factory->createBuilder($this->getTestedType(), null, $this->getTestedTypeOptions());
 
         if ($builder->getCompound()) {
             $emptyData = [];
@@ -290,8 +292,8 @@ abstract class BaseTypeTest extends TypeTestCase
         return static::TESTED_TYPE;
     }
 
-    protected function getTestOptions(): array
+    protected function getTestedTypeOptions()
     {
-        return [];
+        return static::TESTED_TYPE_OPTIONS;
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
@@ -19,11 +19,13 @@ use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 class BirthdayTypeTest extends DateTypeTest
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\BirthdayType';
+    public const TESTED_TYPE_OPTIONS = [
+    ];
 
     public function testSetInvalidYearsOption()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'years' => 'bad value',
         ]);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BirthdayTypeTest.php
@@ -19,8 +19,7 @@ use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 class BirthdayTypeTest extends DateTypeTest
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\BirthdayType';
-    public const TESTED_TYPE_OPTIONS = [
-    ];
+    public const TESTED_TYPE_OPTIONS = [];
 
     public function testSetInvalidYearsOption()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -424,6 +424,7 @@ class CollectionTypeTest extends BaseTypeTest
             ],
             'prototype_options' => [
                 'help' => 'foo',
+                'empty_data' => null,
             ],
         ]);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -21,24 +21,26 @@ use Symfony\Component\Form\Tests\Fixtures\BlockPrefixedFooTextType;
 class CollectionTypeTest extends BaseTypeTest
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\CollectionType';
+    public const TESTED_TYPE_OPTIONS = [
+        'entry_type' => TextTypeTest::TESTED_TYPE,
+        'entry_options' => ['empty_data' => null],
+    ];
 
     public function testContainsNoChildByDefault()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'entry_type' => TextTypeTest::TESTED_TYPE,
-        ]);
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions());
 
         $this->assertCount(0, $form);
     }
 
     public function testSetDataAdjustsSize()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'entry_type' => TextTypeTest::TESTED_TYPE,
+        $form = $this->factory->create($this->getTestedType(), null, [
             'entry_options' => [
+                'empty_data' => null,
                 'attr' => ['maxlength' => 20],
             ],
-        ]);
+        ] + $this->getTestedTypeOptions());
         $form->setData(['foo@foo.com', 'foo@bar.com']);
 
         $this->assertInstanceOf(Form::class, $form[0]);
@@ -62,18 +64,14 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testThrowsExceptionIfObjectIsNotTraversable()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'entry_type' => TextTypeTest::TESTED_TYPE,
-        ]);
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions());
         $this->expectException(UnexpectedTypeException::class);
         $form->setData(new \stdClass());
     }
 
     public function testNotResizedIfSubmittedWithMissingData()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'entry_type' => TextTypeTest::TESTED_TYPE,
-        ]);
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions());
         $form->setData(['foo@foo.com', 'bar@bar.com']);
         $form->submit(['foo@bar.com']);
 
@@ -85,10 +83,9 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testResizedDownIfSubmittedWithMissingDataAndAllowDelete()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'entry_type' => TextTypeTest::TESTED_TYPE,
+        $form = $this->factory->create($this->getTestedType(), null, [
             'allow_delete' => true,
-        ]);
+        ] + $this->getTestedTypeOptions());
         $form->setData(['foo@foo.com', 'bar@bar.com']);
         $form->submit(['foo@foo.com']);
 
@@ -100,8 +97,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testResizedDownIfSubmittedWithEmptyDataAndDeleteEmpty()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'entry_type' => TextTypeTest::TESTED_TYPE,
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'allow_delete' => true,
             'delete_empty' => true,
         ]);
@@ -117,7 +113,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testResizedDownWithDeleteEmptyCallable()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'entry_type' => AuthorType::class,
             'allow_delete' => true,
             'delete_empty' => function (Author $obj = null) {
@@ -136,7 +132,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testResizedDownIfSubmittedWithCompoundEmptyDataDeleteEmptyAndNoDataClass()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'entry_type' => AuthorType::class,
             // If the field is not required, no new Author will be created if the
             // form is completely empty
@@ -160,8 +156,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testDontAddEmptyDataIfDeleteEmpty()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'entry_type' => TextTypeTest::TESTED_TYPE,
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'allow_add' => true,
             'delete_empty' => true,
         ]);
@@ -177,8 +172,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testNoDeleteEmptyIfDeleteNotAllowed()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'entry_type' => TextTypeTest::TESTED_TYPE,
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'allow_delete' => false,
             'delete_empty' => true,
         ]);
@@ -192,7 +186,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testResizedDownIfSubmittedWithCompoundEmptyDataAndDeleteEmpty()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'entry_type' => 'Symfony\Component\Form\Tests\Fixtures\AuthorType',
             // If the field is not required, no new Author will be created if the
             // form is completely empty
@@ -215,7 +209,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testNotDeleteEmptyIfInvalid()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'entry_type' => ChoiceType::class,
             'entry_options' => [
                 'choices' => ['a', 'b'],
@@ -237,9 +231,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testNotResizedIfSubmittedWithExtraData()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'entry_type' => TextTypeTest::TESTED_TYPE,
-        ]);
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions());
         $form->setData(['foo@bar.com']);
         $form->submit(['foo@foo.com', 'bar@bar.com']);
 
@@ -250,8 +242,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testResizedUpIfSubmittedWithExtraDataAndAllowAdd()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'entry_type' => TextTypeTest::TESTED_TYPE,
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'allow_add' => true,
         ]);
         $form->setData(['foo@bar.com']);
@@ -266,8 +257,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testAllowAddButNoPrototype()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'entry_type' => FormTypeTest::TESTED_TYPE,
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'allow_add' => true,
             'prototype' => false,
         ]);
@@ -277,21 +267,18 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testPrototypeMultipartPropagation()
     {
-        $form = $this->factory
-            ->create(static::TESTED_TYPE, null, [
-                'entry_type' => FileTypeTest::TESTED_TYPE,
-                'allow_add' => true,
-                'prototype' => true,
-            ])
-        ;
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'entry_type' => FileTypeTest::TESTED_TYPE,
+            'allow_add' => true,
+            'prototype' => true,
+        ]);
 
         $this->assertTrue($form->createView()->vars['multipart']);
     }
 
     public function testGetDataDoesNotContainsPrototypeNameBeforeDataAreSet()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, [], [
-            'entry_type' => FileTypeTest::TESTED_TYPE,
+        $form = $this->factory->create($this->getTestedType(), [], $this->getTestedTypeOptions() + [
             'prototype' => true,
             'allow_add' => true,
         ]);
@@ -302,8 +289,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testGetDataDoesNotContainsPrototypeNameAfterDataAreSet()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, [], [
-            'entry_type' => FileTypeTest::TESTED_TYPE,
+        $form = $this->factory->create($this->getTestedType(), [], $this->getTestedTypeOptions() + [
             'allow_add' => true,
             'prototype' => true,
         ]);
@@ -315,16 +301,14 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testPrototypeNameOption()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'entry_type' => FormTypeTest::TESTED_TYPE,
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'prototype' => true,
             'allow_add' => true,
         ]);
 
         $this->assertSame('__name__', $form->getConfig()->getAttribute('prototype')->getName(), '__name__ is the default');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'entry_type' => FormTypeTest::TESTED_TYPE,
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'prototype' => true,
             'allow_add' => true,
             'prototype_name' => '__test__',
@@ -335,8 +319,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testPrototypeDefaultLabel()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, [], [
-            'entry_type' => FileTypeTest::TESTED_TYPE,
+        $form = $this->factory->create($this->getTestedType(), [], $this->getTestedTypeOptions() + [
             'allow_add' => true,
             'prototype' => true,
             'prototype_name' => '__test__',
@@ -347,16 +330,16 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testPrototypeData()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, [], [
+        $form = $this->factory->create($this->getTestedType(), [], [
             'allow_add' => true,
             'prototype' => true,
             'prototype_data' => 'foo',
-            'entry_type' => TextTypeTest::TESTED_TYPE,
             'entry_options' => [
+                'empty_data' => null,
                 'data' => 'bar',
                 'label' => false,
             ],
-        ]);
+        ] + $this->getTestedTypeOptions());
 
         $this->assertSame('foo', $form->createView()->vars['prototype']->vars['value']);
         $this->assertFalse($form->createView()->vars['prototype']->vars['label']);
@@ -364,7 +347,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testPrototypeDefaultRequired()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, [], [
+        $form = $this->factory->create($this->getTestedType(), [], [
             'entry_type' => FileTypeTest::TESTED_TYPE,
             'allow_add' => true,
             'prototype' => true,
@@ -376,7 +359,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testPrototypeSetNotRequired()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, [], [
+        $form = $this->factory->create($this->getTestedType(), [], [
             'entry_type' => FileTypeTest::TESTED_TYPE,
             'allow_add' => true,
             'prototype' => true,
@@ -390,7 +373,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testPrototypeSetNotRequiredIfParentNotRequired()
     {
-        $child = $this->factory->create(static::TESTED_TYPE, [], [
+        $child = $this->factory->create($this->getTestedType(), [], [
             'entry_type' => FileTypeTest::TESTED_TYPE,
             'allow_add' => true,
             'prototype' => true,
@@ -409,7 +392,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testPrototypeNotOverrideRequiredByEntryOptionsInFavorOfParent()
     {
-        $child = $this->factory->create(static::TESTED_TYPE, [], [
+        $child = $this->factory->create($this->getTestedType(), [], [
             'entry_type' => FileTypeTest::TESTED_TYPE,
             'allow_add' => true,
             'prototype' => true,
@@ -449,7 +432,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testEntriesBlockPrefixes()
     {
-        $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, [''], [
+        $collectionView = $this->factory->createNamed('fields', $this->getTestedType(), [''], $this->getTestedTypeOptions() + [
             'allow_add' => true,
         ])
             ->createView()
@@ -469,9 +452,12 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testEntriesBlockPrefixesWithCustomBlockPrefix()
     {
-        $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, [''], [
+        $collectionView = $this->factory->createNamed('fields', $this->getTestedType(), [''], [
             'allow_add' => true,
-            'entry_options' => ['block_prefix' => 'field'],
+            'entry_options' => [
+                'empty_data' => null,
+                'block_prefix' => 'field',
+            ],
         ])
             ->createView()
         ;
@@ -491,7 +477,7 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testEntriesBlockPrefixesWithCustomBlockPrefixedType()
     {
-        $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, [''], [
+        $collectionView = $this->factory->createNamed('fields', $this->getTestedType(), [''], [
             'allow_add' => true,
             'entry_type' => BlockPrefixedFooTextType::class,
         ])
@@ -513,9 +499,12 @@ class CollectionTypeTest extends BaseTypeTest
 
     public function testPrototypeBlockPrefixesWithCustomBlockPrefix()
     {
-        $collectionView = $this->factory->createNamed('fields', static::TESTED_TYPE, [], [
+        $collectionView = $this->factory->createNamed('fields', $this->getTestedType(), [], [
             'allow_add' => true,
-            'entry_options' => ['block_prefix' => 'field'],
+            'entry_options' => [
+                'empty_data' => null,
+                'block_prefix' => 'field',
+            ],
         ])
             ->createView()
         ;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ColorTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ColorTypeTest.php
@@ -17,13 +17,16 @@ use Symfony\Component\Form\FormError;
 final class ColorTypeTest extends BaseTypeTest
 {
     public const TESTED_TYPE = ColorType::class;
+    public const TESTED_TYPE_OPTIONS = [
+        'empty_data' => null,
+    ];
 
     /**
      * @dataProvider validationShouldPassProvider
      */
     public function testValidationShouldPass(bool $html5, ?string $submittedValue)
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'html5' => $html5,
             'trim' => true,
         ]);
@@ -56,7 +59,7 @@ final class ColorTypeTest extends BaseTypeTest
      */
     public function testValidationShouldFail(string $expectedValueParameterValue, ?string $submittedValue, bool $trim = true)
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'html5' => true,
             'trim' => $trim,
         ]);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -721,8 +721,7 @@ class DateTimeTypeTest extends BaseTypeTest
             'Compound text field' => ['text', ['date' => ['year' => '2018', 'month' => '11', 'day' => '11'], 'time' => ['hour' => '21', 'minute' => '23']], $expectedData],
             'Compound choice field' => ['choice', ['date' => ['year' => '2018', 'month' => '11', 'day' => '11'], 'time' => ['hour' => '21', 'minute' => '23']], $expectedData],
             'Simple field lazy' => ['single_text', $lazyEmptyData, $expectedData],
-            // TODO uncomment after update to Symfony 6.0
-            // 'Compound text field lazy' => ['text', $lazyEmptyData, $expectedData],
+            'Compound text field lazy' => ['text', $lazyEmptyData, $expectedData],
             'Compound choice field lazy' => ['choice', $lazyEmptyData, $expectedData],
         ];
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -17,6 +17,9 @@ use Symfony\Component\Form\FormInterface;
 class DateTimeTypeTest extends BaseTypeTest
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\DateTimeType';
+    public const TESTED_TYPE_OPTIONS = [
+        'empty_data' => null,
+    ];
 
     private $defaultLocale;
 
@@ -34,7 +37,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitDateTime()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -62,7 +65,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitDateTimeImmutable()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -90,7 +93,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitString()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -116,7 +119,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitTimestamp()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'timestamp',
@@ -144,7 +147,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitWithoutMinutes()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -174,7 +177,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitWithSeconds()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -206,7 +209,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitDifferentTimezones()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Pacific/Tahiti',
             'date_widget' => 'choice',
@@ -238,7 +241,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitDifferentTimezonesDateTime()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Pacific/Tahiti',
             'widget' => 'single_text',
@@ -257,7 +260,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitDifferentTimezonesDateTimeImmutable()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Pacific/Tahiti',
             'widget' => 'single_text',
@@ -277,7 +280,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitStringSingleText()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -292,7 +295,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitStringSingleTextWithSeconds()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -308,7 +311,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitDifferentPattern()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'html5' => false,
             'date_format' => 'MM*yyyy*dd',
             'date_widget' => 'single_text',
@@ -330,12 +333,12 @@ class DateTimeTypeTest extends BaseTypeTest
     {
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
-        $this->assertInstanceOf(FormInterface::class, $this->factory->create(static::TESTED_TYPE, new \DateTime()));
+        $this->assertInstanceOf(FormInterface::class, $this->factory->create($this->getTestedType(), new \DateTime()));
     }
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
         ])
             ->createView();
@@ -345,7 +348,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'required' => false,
             'with_seconds' => true,
         ])
@@ -361,7 +364,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testPassNoPlaceholderToViewIfRequired()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'required' => true,
             'with_seconds' => true,
         ])
@@ -377,7 +380,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testPassPlaceholderAsString()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'placeholder' => 'Empty',
             'with_seconds' => true,
         ])
@@ -393,7 +396,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testPassPlaceholderAsArray()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'placeholder' => [
                 'year' => 'Empty year',
                 'month' => 'Empty month',
@@ -416,7 +419,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'required' => false,
             'placeholder' => [
                 'year' => 'Empty year',
@@ -438,7 +441,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'required' => true,
             'placeholder' => [
                 'year' => 'Empty year',
@@ -460,7 +463,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testPassHtml5TypeIfSingleTextAndHtml5Format()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
         ])
             ->createView();
@@ -470,7 +473,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testDontPassHtml5TypeIfHtml5NotAllowed()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
             'html5' => false,
         ])
@@ -481,7 +484,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testDontPassHtml5TypeIfNotSingleText()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'text',
         ])
             ->createView();
@@ -492,7 +495,7 @@ class DateTimeTypeTest extends BaseTypeTest
     public function testSingleTextWidgetWithSecondsShouldHaveRightStepAttribute()
     {
         $view = $this->factory
-            ->create(static::TESTED_TYPE, null, [
+            ->create($this->getTestedType(), null, [
                 'widget' => 'single_text',
                 'with_seconds' => true,
             ])
@@ -506,7 +509,7 @@ class DateTimeTypeTest extends BaseTypeTest
     public function testSingleTextWidgetWithSecondsShouldNotOverrideStepAttribute()
     {
         $view = $this->factory
-            ->create(static::TESTED_TYPE, null, [
+            ->create($this->getTestedType(), null, [
                 'widget' => 'single_text',
                 'with_seconds' => true,
                 'attr' => [
@@ -522,7 +525,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSingleTextWidgetWithCustomNonHtml5Format()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, new \DateTime('2019-02-13 19:12:13'), [
+        $form = $this->factory->create($this->getTestedType(), new \DateTime('2019-02-13 19:12:13'), [
             'widget' => 'single_text',
             'date_format' => \IntlDateFormatter::SHORT,
             'format' => null,
@@ -536,7 +539,7 @@ class DateTimeTypeTest extends BaseTypeTest
     public function testDateTypeChoiceErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create(static::TESTED_TYPE, null);
+        $form = $this->factory->create($this->getTestedType(), null);
 
         $form['date']->addError($error);
 
@@ -547,7 +550,7 @@ class DateTimeTypeTest extends BaseTypeTest
     public function testDateTypeSingleTextErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'date_widget' => 'single_text',
         ]);
 
@@ -560,7 +563,7 @@ class DateTimeTypeTest extends BaseTypeTest
     public function testTimeTypeChoiceErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create(static::TESTED_TYPE, null);
+        $form = $this->factory->create($this->getTestedType(), null);
 
         $form['time']->addError($error);
 
@@ -571,7 +574,7 @@ class DateTimeTypeTest extends BaseTypeTest
     public function testTimeTypeSingleTextErrorsBubbleUp()
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'time_widget' => 'single_text',
         ]);
 
@@ -583,7 +586,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testPassDefaultChoiceTranslationDomain()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'with_seconds' => true,
         ]);
 
@@ -599,7 +602,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testPassChoiceTranslationDomainAsString()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'choice_translation_domain' => 'messages',
             'with_seconds' => true,
         ]);
@@ -615,7 +618,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testPassChoiceTranslationDomainAsArray()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'choice_translation_domain' => [
                 'year' => 'foo',
                 'month' => 'test',
@@ -645,7 +648,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitNullWithText()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'text',
         ]);
         $form->submit(null);
@@ -661,7 +664,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitNullWithSingleText()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
         ]);
         $form->submit(null);
@@ -673,7 +676,7 @@ class DateTimeTypeTest extends BaseTypeTest
 
     public function testSubmitNullUsesDefaultEmptyData($emptyData = [], $expectedData = null)
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'empty_data' => $emptyData,
         ]);
         $form->submit(null);
@@ -692,7 +695,7 @@ class DateTimeTypeTest extends BaseTypeTest
      */
     public function testSubmitNullUsesDateEmptyData($widget, $emptyData, $expectedData)
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => $widget,
             'empty_data' => $emptyData,
         ]);
@@ -718,14 +721,15 @@ class DateTimeTypeTest extends BaseTypeTest
             'Compound text field' => ['text', ['date' => ['year' => '2018', 'month' => '11', 'day' => '11'], 'time' => ['hour' => '21', 'minute' => '23']], $expectedData],
             'Compound choice field' => ['choice', ['date' => ['year' => '2018', 'month' => '11', 'day' => '11'], 'time' => ['hour' => '21', 'minute' => '23']], $expectedData],
             'Simple field lazy' => ['single_text', $lazyEmptyData, $expectedData],
-            'Compound text field lazy' => ['text', $lazyEmptyData, $expectedData],
+            // TODO uncomment after update to Symfony 6.0
+            // 'Compound text field lazy' => ['text', $lazyEmptyData, $expectedData],
             'Compound choice field lazy' => ['choice', $lazyEmptyData, $expectedData],
         ];
     }
 
     public function testSubmitStringWithCustomInputFormat()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -1066,8 +1066,7 @@ class DateTypeTest extends BaseTypeTest
             'Compound text fields' => ['text', ['year' => '2018', 'month' => '11', 'day' => '11'], $expectedData],
             'Compound choice fields' => ['choice', ['year' => '2018', 'month' => '11', 'day' => '11'], $expectedData],
             'Simple field lazy' => ['single_text', $lazyEmptyData, $expectedData],
-            // TODO uncomment after update to Symfony 6.0
-            // 'Compound text fields lazy' => ['text', $lazyEmptyData, $expectedData],
+            'Compound text fields lazy' => ['text', $lazyEmptyData, $expectedData],
             'Compound choice fields lazy' => ['choice', $lazyEmptyData, $expectedData],
         ];
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -40,7 +40,7 @@ class DateTypeTest extends BaseTypeTest
     public function testInvalidWidgetOption()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'widget' => 'fake_widget',
         ]);
     }
@@ -48,14 +48,14 @@ class DateTypeTest extends BaseTypeTest
     public function testInvalidInputOption()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'input' => 'fake_input',
         ]);
     }
 
     public function testSubmitFromSingleTextDateTimeWithDefaultFormat()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'single_text',
@@ -70,7 +70,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testSubmitFromSingleTextDateTimeWithCustomFormat()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'single_text',
@@ -92,7 +92,7 @@ class DateTypeTest extends BaseTypeTest
 
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'format' => \IntlDateFormatter::MEDIUM,
             'html5' => false,
             'model_timezone' => 'UTC',
@@ -114,7 +114,7 @@ class DateTypeTest extends BaseTypeTest
 
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'format' => \IntlDateFormatter::MEDIUM,
             'html5' => false,
             'model_timezone' => 'UTC',
@@ -137,7 +137,7 @@ class DateTypeTest extends BaseTypeTest
 
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'format' => \IntlDateFormatter::MEDIUM,
             'html5' => false,
             'model_timezone' => 'UTC',
@@ -159,7 +159,7 @@ class DateTypeTest extends BaseTypeTest
 
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'format' => \IntlDateFormatter::MEDIUM,
             'html5' => false,
             'model_timezone' => 'UTC',
@@ -183,7 +183,7 @@ class DateTypeTest extends BaseTypeTest
 
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'format' => \IntlDateFormatter::MEDIUM,
             'html5' => false,
             'model_timezone' => 'UTC',
@@ -217,7 +217,7 @@ class DateTypeTest extends BaseTypeTest
             'year' => '0',
         ];
 
-        $form = $this->factory->create(static::TESTED_TYPE, $input, [
+        $form = $this->factory->create($this->getTestedType(), $input, [
             'format' => \IntlDateFormatter::MEDIUM,
             'html5' => false,
             'model_timezone' => 'UTC',
@@ -232,7 +232,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testSubmitFromText()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'text',
@@ -254,7 +254,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testSubmitFromChoice()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -277,7 +277,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testSubmitFromChoiceEmpty()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -298,7 +298,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testSubmitFromInputDateTimeDifferentPattern()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -315,7 +315,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testSubmitFromInputStringDifferentPattern()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -332,7 +332,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testSubmitFromInputTimestampDifferentPattern()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -351,7 +351,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testSubmitFromInputRawDifferentPattern()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
@@ -377,7 +377,7 @@ class DateTypeTest extends BaseTypeTest
      */
     public function testDatePatternWithFormatOption($format, $pattern)
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'format' => $format,
         ])
             ->createView();
@@ -401,7 +401,7 @@ class DateTypeTest extends BaseTypeTest
     public function testThrowExceptionIfFormatIsNoPattern()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'format' => '0',
             'html5' => false,
             'widget' => 'single_text',
@@ -413,7 +413,7 @@ class DateTypeTest extends BaseTypeTest
     {
         $this->expectException(InvalidOptionsException::class);
         $this->expectExceptionMessage('The "format" option should contain the letters "y", "M" and "d". Its current value is "yy".');
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'months' => [6, 7],
             'format' => 'yy',
         ]);
@@ -423,7 +423,7 @@ class DateTypeTest extends BaseTypeTest
     {
         $this->expectException(InvalidOptionsException::class);
         $this->expectExceptionMessage('The "format" option should contain the letters "y", "M" or "d". Its current value is "wrong".');
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
             'format' => 'wrong',
             'html5' => false,
@@ -433,7 +433,7 @@ class DateTypeTest extends BaseTypeTest
     public function testThrowExceptionIfFormatIsNoConstant()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'format' => 105,
         ]);
     }
@@ -441,7 +441,7 @@ class DateTypeTest extends BaseTypeTest
     public function testThrowExceptionIfFormatIsInvalid()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'format' => [],
         ]);
     }
@@ -449,7 +449,7 @@ class DateTypeTest extends BaseTypeTest
     public function testThrowExceptionIfYearsIsInvalid()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'years' => 'bad value',
         ]);
     }
@@ -457,7 +457,7 @@ class DateTypeTest extends BaseTypeTest
     public function testThrowExceptionIfMonthsIsInvalid()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'months' => 'bad value',
         ]);
     }
@@ -465,7 +465,7 @@ class DateTypeTest extends BaseTypeTest
     public function testThrowExceptionIfDaysIsInvalid()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'days' => 'bad value',
         ]);
     }
@@ -477,7 +477,7 @@ class DateTypeTest extends BaseTypeTest
 
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'format' => \IntlDateFormatter::MEDIUM,
             'html5' => false,
             'model_timezone' => 'UTC',
@@ -500,7 +500,7 @@ class DateTypeTest extends BaseTypeTest
 
         \Locale::setDefault('de_DE');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'format' => \IntlDateFormatter::MEDIUM,
             'html5' => false,
             'model_timezone' => 'UTC',
@@ -521,7 +521,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testYearsOption()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'years' => [2010, 2011],
         ]);
 
@@ -536,7 +536,7 @@ class DateTypeTest extends BaseTypeTest
     public function testMonthsOption()
     {
         \Locale::setDefault('en');
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'months' => [6, 7],
             'format' => \IntlDateFormatter::SHORT,
         ]);
@@ -556,7 +556,7 @@ class DateTypeTest extends BaseTypeTest
 
         \Locale::setDefault('de_AT');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'months' => [1, 4],
             'format' => 'dd.MMM.yy',
         ]);
@@ -576,7 +576,7 @@ class DateTypeTest extends BaseTypeTest
 
         \Locale::setDefault('de_AT');
 
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'months' => [1, 4],
             'format' => 'dd.MMMM.yy',
         ])
@@ -595,7 +595,7 @@ class DateTypeTest extends BaseTypeTest
 
         \Locale::setDefault('de_AT');
 
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'months' => [1, 4],
             'format' => 'dd.MMMM.yy',
         ])
@@ -610,7 +610,7 @@ class DateTypeTest extends BaseTypeTest
     public function testIsDayWithinRangeReturnsTrueIfWithin()
     {
         \Locale::setDefault('en');
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'days' => [6, 7],
         ])
             ->createView();
@@ -623,7 +623,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testIsSynchronizedReturnsTrueIfChoiceAndCompletelyEmpty()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -640,7 +640,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testIsSynchronizedReturnsTrueIfChoiceAndCompletelyFilled()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, new \DateTime(), [
+        $form = $this->factory->create($this->getTestedType(), new \DateTime(), [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -657,7 +657,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testIsSynchronizedReturnsFalseIfChoiceAndDayEmpty()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'choice',
@@ -679,7 +679,7 @@ class DateTypeTest extends BaseTypeTest
 
         \Locale::setDefault('de_AT');
 
-        $view = $this->factory->create(static::TESTED_TYPE)
+        $view = $this->factory->create($this->getTestedType())
             ->createView();
 
         $this->assertSame('{{ day }}{{ month }}{{ year }}', $view->vars['date_pattern']);
@@ -692,7 +692,7 @@ class DateTypeTest extends BaseTypeTest
 
         \Locale::setDefault('de_AT');
 
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'format' => \IntlDateFormatter::LONG,
         ])
             ->createView();
@@ -702,7 +702,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testPassDatePatternToViewDifferentPattern()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'format' => 'MMyyyydd',
         ])
             ->createView();
@@ -712,7 +712,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testPassDatePatternToViewDifferentPatternWithSeparators()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'format' => 'MM*yyyy*dd',
         ])
             ->createView();
@@ -722,7 +722,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testDontPassDatePatternIfText()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
         ])
             ->createView();
@@ -737,7 +737,7 @@ class DateTypeTest extends BaseTypeTest
 
         \Locale::setDefault('es_ES');
 
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             // EEEE, d 'de' MMMM 'de' y
             'format' => \IntlDateFormatter::FULL,
         ])
@@ -748,7 +748,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testPassWidgetToView()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
         ])
             ->createView();
@@ -760,12 +760,12 @@ class DateTypeTest extends BaseTypeTest
     {
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
-        $this->assertInstanceOf(FormInterface::class, $this->factory->create(static::TESTED_TYPE, new \DateTime()));
+        $this->assertInstanceOf(FormInterface::class, $this->factory->create($this->getTestedType(), new \DateTime()));
     }
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
         ])
             ->createView();
@@ -775,7 +775,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'required' => false,
         ])
             ->createView();
@@ -787,7 +787,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testPassNoPlaceholderToViewIfRequired()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'required' => true,
         ])
             ->createView();
@@ -799,7 +799,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testPassPlaceholderAsString()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'placeholder' => 'Empty',
         ])
             ->createView();
@@ -811,7 +811,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testPassPlaceholderAsArray()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'placeholder' => [
                 'year' => 'Empty year',
                 'month' => 'Empty month',
@@ -827,7 +827,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'required' => false,
             'placeholder' => [
                 'year' => 'Empty year',
@@ -843,7 +843,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'required' => true,
             'placeholder' => [
                 'year' => 'Empty year',
@@ -859,7 +859,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testPassHtml5TypeIfSingleTextAndHtml5Format()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
         ])
             ->createView();
@@ -869,7 +869,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testDontPassHtml5TypeIfHtml5NotAllowed()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
             'html5' => false,
         ])
@@ -880,7 +880,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testDontPassHtml5TypeIfNotHtml5Format()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
             'format' => \IntlDateFormatter::MEDIUM,
             'html5' => false,
@@ -892,7 +892,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testDontPassHtml5TypeIfNotSingleText()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'text',
         ])
             ->createView();
@@ -914,7 +914,7 @@ class DateTypeTest extends BaseTypeTest
     public function testYearErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => $widget,
         ]);
         $form['year']->addError($error);
@@ -929,7 +929,7 @@ class DateTypeTest extends BaseTypeTest
     public function testMonthErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => $widget,
         ]);
         $form['month']->addError($error);
@@ -944,7 +944,7 @@ class DateTypeTest extends BaseTypeTest
     public function testDayErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => $widget,
         ]);
         $form['day']->addError($error);
@@ -955,7 +955,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testYears()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
             'years' => [1900, 2000, 2040],
         ])
             ->createView();
@@ -970,7 +970,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testPassDefaultChoiceTranslationDomain()
     {
-        $form = $this->factory->create(static::TESTED_TYPE);
+        $form = $this->factory->create($this->getTestedType());
 
         $view = $form->createView();
         $this->assertFalse($view['year']->vars['choice_translation_domain']);
@@ -980,7 +980,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testPassChoiceTranslationDomainAsString()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'choice_translation_domain' => 'messages',
         ]);
 
@@ -992,7 +992,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testPassChoiceTranslationDomainAsArray()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'choice_translation_domain' => [
                 'year' => 'foo',
                 'day' => 'test',
@@ -1012,7 +1012,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testSubmitNullWithSingleText()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
         ]);
         $form->submit(null);
@@ -1024,7 +1024,7 @@ class DateTypeTest extends BaseTypeTest
 
     public function testSubmitNullUsesDefaultEmptyData($emptyData = [], $expectedData = null)
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'empty_data' => $emptyData,
         ]);
         $form->submit(null);
@@ -1040,7 +1040,7 @@ class DateTypeTest extends BaseTypeTest
      */
     public function testSubmitNullUsesDateEmptyData($widget, $emptyData, $expectedData)
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => $widget,
             'empty_data' => $emptyData,
         ]);
@@ -1066,14 +1066,15 @@ class DateTypeTest extends BaseTypeTest
             'Compound text fields' => ['text', ['year' => '2018', 'month' => '11', 'day' => '11'], $expectedData],
             'Compound choice fields' => ['choice', ['year' => '2018', 'month' => '11', 'day' => '11'], $expectedData],
             'Simple field lazy' => ['single_text', $lazyEmptyData, $expectedData],
-            'Compound text fields lazy' => ['text', $lazyEmptyData, $expectedData],
+            // TODO uncomment after update to Symfony 6.0
+            // 'Compound text fields lazy' => ['text', $lazyEmptyData, $expectedData],
             'Compound choice fields lazy' => ['choice', $lazyEmptyData, $expectedData],
         ];
     }
 
     public function testSubmitStringWithCustomInputFormat()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'single_text',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/EnumTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/EnumTypeTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 class EnumTypeTest extends BaseTypeTest
 {
     public const TESTED_TYPE = EnumType::class;
+    public const TESTED_TYPE_OPTIONS = ['class' => Suit::class];
 
     public function testClassOptionIsRequired()
     {
@@ -119,7 +120,7 @@ class EnumTypeTest extends BaseTypeTest
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)
     {
-        $form = $this->factory->create($this->getTestedType(), null, $this->getTestOptions());
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions());
 
         $form->submit(null);
 
@@ -255,10 +256,5 @@ class EnumTypeTest extends BaseTypeTest
         $view = $form->createView();
 
         $this->assertSame('Yes', $view->children[0]->vars['label']);
-    }
-
-    protected function getTestOptions(): array
-    {
-        return ['class' => Suit::class];
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/EnumTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/EnumTypeTest.php
@@ -22,7 +22,9 @@ use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 class EnumTypeTest extends BaseTypeTest
 {
     public const TESTED_TYPE = EnumType::class;
-    public const TESTED_TYPE_OPTIONS = ['class' => Suit::class];
+    public const TESTED_TYPE_OPTIONS = [
+        'class' => Suit::class,
+    ];
 
     public function testClassOptionIsRequired()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -68,23 +68,23 @@ class FormTypeTest extends BaseTypeTest
 
     public function testCreateFormInstances()
     {
-        $this->assertInstanceOf(Form::class, $this->factory->create(static::TESTED_TYPE));
+        $this->assertInstanceOf(Form::class, $this->factory->create($this->getTestedType()));
     }
 
     public function testPassRequiredAsOption()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, ['required' => false]);
+        $form = $this->factory->create($this->getTestedType(), null, ['required' => false]);
 
         $this->assertFalse($form->isRequired());
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, ['required' => true]);
+        $form = $this->factory->create($this->getTestedType(), null, ['required' => true]);
 
         $this->assertTrue($form->isRequired());
     }
 
     public function testSubmittedDataIsTrimmedBeforeTransforming()
     {
-        $form = $this->factory->createBuilder(static::TESTED_TYPE)
+        $form = $this->factory->createBuilder($this->getTestedType())
             ->addViewTransformer(new FixedDataTransformer([
                 '' => '',
                 'reverse[a]' => 'a',
@@ -100,7 +100,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmittedDataIsNotTrimmedBeforeTransformingIfNoTrimming()
     {
-        $form = $this->factory->createBuilder(static::TESTED_TYPE, null, ['trim' => false])
+        $form = $this->factory->createBuilder($this->getTestedType(), null, ['trim' => false])
             ->addViewTransformer(new FixedDataTransformer([
                 '' => '',
                 'reverse[ a ]' => ' a ',
@@ -116,8 +116,8 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNonReadOnlyFormWithReadOnlyParentIsReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', static::TESTED_TYPE, null, ['attr' => ['readonly' => true]])
-            ->add('child', static::TESTED_TYPE)
+        $view = $this->factory->createNamedBuilder('parent', $this->getTestedType(), null, ['attr' => ['readonly' => true]])
+            ->add('child', $this->getTestedType())
             ->getForm()
             ->createView();
 
@@ -126,8 +126,8 @@ class FormTypeTest extends BaseTypeTest
 
     public function testReadOnlyFormWithNonReadOnlyParentIsReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', static::TESTED_TYPE)
-            ->add('child', static::TESTED_TYPE, ['attr' => ['readonly' => true]])
+        $view = $this->factory->createNamedBuilder('parent', $this->getTestedType())
+            ->add('child', $this->getTestedType(), ['attr' => ['readonly' => true]])
             ->getForm()
             ->createView();
 
@@ -136,8 +136,8 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNonReadOnlyFormWithNonReadOnlyParentIsNotReadOnly()
     {
-        $view = $this->factory->createNamedBuilder('parent', static::TESTED_TYPE)
-            ->add('child', static::TESTED_TYPE)
+        $view = $this->factory->createNamedBuilder('parent', $this->getTestedType())
+            ->add('child', $this->getTestedType())
             ->getForm()
             ->createView();
 
@@ -146,7 +146,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPassMaxLengthToView()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, ['attr' => ['maxlength' => 10]])
+        $view = $this->factory->create($this->getTestedType(), null, ['attr' => ['maxlength' => 10]])
             ->createView();
 
         $this->assertSame(10, $view->vars['attr']['maxlength']);
@@ -155,7 +155,7 @@ class FormTypeTest extends BaseTypeTest
     public function testDataClassMayBeNull()
     {
         $this->assertInstanceOf(
-            FormBuilderInterface::class, $this->factory->createBuilder(static::TESTED_TYPE, null, [
+            FormBuilderInterface::class, $this->factory->createBuilder($this->getTestedType(), null, [
             'data_class' => null,
         ]));
     }
@@ -163,7 +163,7 @@ class FormTypeTest extends BaseTypeTest
     public function testDataClassMayBeAbstractClass()
     {
         $this->assertInstanceOf(
-            FormBuilderInterface::class, $this->factory->createBuilder(static::TESTED_TYPE, null, [
+            FormBuilderInterface::class, $this->factory->createBuilder($this->getTestedType(), null, [
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\AbstractAuthor',
         ]));
     }
@@ -171,7 +171,7 @@ class FormTypeTest extends BaseTypeTest
     public function testDataClassMayBeInterface()
     {
         $this->assertInstanceOf(
-            FormBuilderInterface::class, $this->factory->createBuilder(static::TESTED_TYPE, null, [
+            FormBuilderInterface::class, $this->factory->createBuilder($this->getTestedType(), null, [
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\AuthorInterface',
         ]));
     }
@@ -179,7 +179,7 @@ class FormTypeTest extends BaseTypeTest
     public function testDataClassMustBeValidClassOrInterface()
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->factory->createBuilder(static::TESTED_TYPE, null, [
+        $this->factory->createBuilder($this->getTestedType(), null, [
             'data_class' => 'foobar',
         ]);
     }
@@ -191,12 +191,16 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitWithEmptyDataCreatesObjectIfClassAvailable()
     {
-        $form = $this->factory->createBuilder(static::TESTED_TYPE, null, [
+        $form = $this->factory->createBuilder($this->getTestedType(), null, [
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => false,
         ])
-            ->add('firstName', TextTypeTest::TESTED_TYPE)
-            ->add('lastName', TextTypeTest::TESTED_TYPE)
+            ->add('firstName', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
+            ])
+            ->add('lastName', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         $this->assertNull($form->getData());
@@ -214,13 +218,17 @@ class FormTypeTest extends BaseTypeTest
     public function testSubmitWithDefaultDataDontCreateObject()
     {
         $defaultAuthor = new Author();
-        $form = $this->factory->createBuilder(static::TESTED_TYPE, null, [
+        $form = $this->factory->createBuilder($this->getTestedType(), null, [
             // data class is inferred from the passed object
             'data' => $defaultAuthor,
             'required' => false,
         ])
-            ->add('firstName', TextTypeTest::TESTED_TYPE)
-            ->add('lastName', TextTypeTest::TESTED_TYPE)
+            ->add('firstName', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
+            ])
+            ->add('lastName', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         // partially empty
@@ -236,11 +244,13 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitWithEmptyDataCreatesArrayIfDataClassIsNull()
     {
-        $form = $this->factory->createBuilder(static::TESTED_TYPE, null, [
+        $form = $this->factory->createBuilder($this->getTestedType(), null, [
             'data_class' => null,
             'required' => false,
         ])
-            ->add('firstName', TextTypeTest::TESTED_TYPE)
+            ->add('firstName', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         $this->assertNull($form->getData());
@@ -252,12 +262,16 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitEmptyWithEmptyDataDontCreateObjectIfNotRequired()
     {
-        $form = $this->factory->createBuilder(static::TESTED_TYPE, null, [
+        $form = $this->factory->createBuilder($this->getTestedType(), null, [
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => false,
         ])
-            ->add('firstName', TextTypeTest::TESTED_TYPE)
-            ->add('lastName', TextTypeTest::TESTED_TYPE)
+            ->add('firstName', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
+            ])
+            ->add('lastName', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         $this->assertNull($form->getData());
@@ -269,12 +283,16 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitEmptyWithEmptyDataCreatesObjectIfRequired()
     {
-        $form = $this->factory->createBuilder(static::TESTED_TYPE, null, [
+        $form = $this->factory->createBuilder($this->getTestedType(), null, [
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'required' => true,
         ])
-            ->add('firstName', TextTypeTest::TESTED_TYPE)
-            ->add('lastName', TextTypeTest::TESTED_TYPE)
+            ->add('firstName', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
+            ])
+            ->add('lastName', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         $this->assertNull($form->getData());
@@ -289,8 +307,10 @@ class FormTypeTest extends BaseTypeTest
      */
     public function testSubmitWithEmptyDataStoresArrayIfNoClassAvailable()
     {
-        $form = $this->factory->createBuilder(static::TESTED_TYPE)
-            ->add('firstName', TextTypeTest::TESTED_TYPE)
+        $form = $this->factory->createBuilder($this->getTestedType())
+            ->add('firstName', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         $this->assertNull($form->getData());
@@ -302,7 +322,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testSubmitWithEmptyDataPassesEmptyStringToTransformerIfNotCompound()
     {
-        $form = $this->factory->createBuilder(static::TESTED_TYPE)
+        $form = $this->factory->createBuilder($this->getTestedType())
             ->addViewTransformer(new FixedDataTransformer([
                 // required for the initial, internal setData(null)
                 '' => 'null',
@@ -327,11 +347,13 @@ class FormTypeTest extends BaseTypeTest
     {
         $author = new Author();
 
-        $form = $this->factory->createBuilder(static::TESTED_TYPE, null, [
+        $form = $this->factory->createBuilder($this->getTestedType(), null, [
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'empty_data' => $author,
         ])
-            ->add('firstName', TextTypeTest::TESTED_TYPE)
+            ->add('firstName', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         $this->assertNull($form->getData());
@@ -346,18 +368,18 @@ class FormTypeTest extends BaseTypeTest
     public function testAttributesException()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, ['attr' => '']);
+        $this->factory->create($this->getTestedType(), null, ['attr' => '']);
     }
 
     public function testActionCannotBeNull()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, ['action' => null]);
+        $this->factory->create($this->getTestedType(), null, ['action' => null]);
     }
 
     public function testNameCanBeEmptyString()
     {
-        $form = $this->factory->createNamed('', static::TESTED_TYPE);
+        $form = $this->factory->createNamed('', $this->getTestedType());
 
         $this->assertEquals('', $form->getName());
     }
@@ -366,11 +388,13 @@ class FormTypeTest extends BaseTypeTest
     {
         $author = new FormTest_AuthorWithoutRefSetter(new Author());
 
-        $builder = $this->factory->createBuilder(static::TESTED_TYPE, $author);
-        $builder->add('reference', static::TESTED_TYPE, [
+        $builder = $this->factory->createBuilder($this->getTestedType(), $author);
+        $builder->add('reference', $this->getTestedType(), [
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
         ]);
-        $builder->get('reference')->add('firstName', TextTypeTest::TESTED_TYPE);
+        $builder->get('reference')->add('firstName', TextTypeTest::TESTED_TYPE, [
+            'empty_data' => null,
+        ]);
         $form = $builder->getForm();
 
         $form->submit([
@@ -389,11 +413,13 @@ class FormTypeTest extends BaseTypeTest
         $author = new FormTest_AuthorWithoutRefSetter(null);
         $newReference = new Author();
 
-        $builder = $this->factory->createBuilder(static::TESTED_TYPE, $author);
-        $builder->add('referenceCopy', static::TESTED_TYPE, [
+        $builder = $this->factory->createBuilder($this->getTestedType(), $author);
+        $builder->add('referenceCopy', $this->getTestedType(), [
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
         ]);
-        $builder->get('referenceCopy')->add('firstName', TextTypeTest::TESTED_TYPE);
+        $builder->get('referenceCopy')->add('firstName', TextTypeTest::TESTED_TYPE, [
+            'empty_data' => null,
+        ]);
         $form = $builder->getForm();
 
         $form['referenceCopy']->setData($newReference); // new author object
@@ -412,12 +438,14 @@ class FormTypeTest extends BaseTypeTest
     {
         $author = new FormTest_AuthorWithoutRefSetter(new Author());
 
-        $builder = $this->factory->createBuilder(static::TESTED_TYPE, $author);
-        $builder->add('referenceCopy', static::TESTED_TYPE, [
+        $builder = $this->factory->createBuilder($this->getTestedType(), $author);
+        $builder->add('referenceCopy', $this->getTestedType(), [
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
             'by_reference' => false,
         ]);
-        $builder->get('referenceCopy')->add('firstName', TextTypeTest::TESTED_TYPE);
+        $builder->get('referenceCopy')->add('firstName', TextTypeTest::TESTED_TYPE, [
+            'empty_data' => null,
+        ]);
         $form = $builder->getForm();
 
         $form->submit([
@@ -435,8 +463,8 @@ class FormTypeTest extends BaseTypeTest
     {
         $author = new FormTest_AuthorWithoutRefSetter('scalar');
 
-        $builder = $this->factory->createBuilder(static::TESTED_TYPE, $author);
-        $builder->add('referenceCopy', static::TESTED_TYPE);
+        $builder = $this->factory->createBuilder($this->getTestedType(), $author);
+        $builder->add('referenceCopy', $this->getTestedType());
         $builder->get('referenceCopy')->addViewTransformer(new CallbackTransformer(
             function () {},
             function ($value) { // reverseTransform
@@ -459,9 +487,9 @@ class FormTypeTest extends BaseTypeTest
         $ref2 = new Author();
         $author = ['referenceCopy' => $ref1];
 
-        $builder = $this->factory->createBuilder(static::TESTED_TYPE);
+        $builder = $this->factory->createBuilder($this->getTestedType());
         $builder->setData($author);
-        $builder->add('referenceCopy', static::TESTED_TYPE);
+        $builder->add('referenceCopy', $this->getTestedType());
         $builder->get('referenceCopy')->addViewTransformer(new CallbackTransformer(
             function () {},
             function ($value) use ($ref2) { // reverseTransform
@@ -481,9 +509,13 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPassMultipartTrueIfAnyChildIsMultipartToView()
     {
-        $view = $this->factory->createBuilder(static::TESTED_TYPE)
-            ->add('foo', TextTypeTest::TESTED_TYPE)
-            ->add('bar', FileTypeTest::TESTED_TYPE)
+        $view = $this->factory->createBuilder($this->getTestedType())
+            ->add('foo', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
+            ])
+            ->add('bar', FileTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
+            ])
             ->getForm()
             ->createView();
 
@@ -492,8 +524,8 @@ class FormTypeTest extends BaseTypeTest
 
     public function testViewIsNotRenderedByDefault()
     {
-        $view = $this->factory->createBuilder(static::TESTED_TYPE)
-            ->add('foo', static::TESTED_TYPE)
+        $view = $this->factory->createBuilder($this->getTestedType())
+            ->add('foo', $this->getTestedType())
             ->getForm()
             ->createView();
 
@@ -502,14 +534,14 @@ class FormTypeTest extends BaseTypeTest
 
     public function testErrorBubblingIfCompound()
     {
-        $form = $this->factory->create(static::TESTED_TYPE);
+        $form = $this->factory->create($this->getTestedType());
 
         $this->assertTrue($form->getConfig()->getErrorBubbling());
     }
 
     public function testNoErrorBubblingIfNotCompound()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'compound' => false,
         ]);
 
@@ -518,7 +550,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testOverrideErrorBubbling()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'compound' => false,
             'error_bubbling' => true,
         ]);
@@ -528,7 +560,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testErrorBubblingForCompoundFieldsIsDisabledByDefaultIfInheritDataIsEnabled()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'compound' => true,
             'inherit_data' => true,
         ]);
@@ -538,7 +570,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPropertyPath()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'property_path' => 'foo',
         ]);
 
@@ -548,7 +580,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPropertyPathNullImpliesDefault()
     {
-        $form = $this->factory->createNamed('name', static::TESTED_TYPE, null, [
+        $form = $this->factory->createNamed('name', $this->getTestedType(), null, [
             'property_path' => null,
         ]);
 
@@ -558,7 +590,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNotMapped()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'property_path' => 'foo',
             'mapped' => false,
         ]);
@@ -569,7 +601,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testViewValidNotSubmitted()
     {
-        $view = $this->factory->create(static::TESTED_TYPE)
+        $view = $this->factory->create($this->getTestedType())
             ->createView();
 
         $this->assertTrue($view->vars['valid']);
@@ -577,7 +609,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testViewNotValidSubmitted()
     {
-        $form = $this->factory->create(static::TESTED_TYPE);
+        $form = $this->factory->create($this->getTestedType());
         $form->submit([]);
         $form->addError(new FormError('An error'));
 
@@ -586,7 +618,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testViewSubmittedNotSubmitted()
     {
-        $view = $this->factory->create(static::TESTED_TYPE)
+        $view = $this->factory->create($this->getTestedType())
             ->createView();
 
         $this->assertFalse($view->vars['submitted']);
@@ -594,7 +626,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testViewSubmittedSubmitted()
     {
-        $form = $this->factory->create(static::TESTED_TYPE);
+        $form = $this->factory->create($this->getTestedType());
         $form->submit([]);
 
         $this->assertTrue($form->createView()->vars['submitted']);
@@ -602,7 +634,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testDataOptionSupersedesSetDataCalls()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'data' => 'default',
             'compound' => false,
         ]);
@@ -614,7 +646,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPassedDataSupersedesSetDataCalls()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, 'default', [
+        $form = $this->factory->create($this->getTestedType(), 'default', [
             'compound' => false,
         ]);
 
@@ -625,7 +657,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testDataOptionSupersedesSetDataCallsIfNull()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'data' => null,
             'compound' => false,
         ]);
@@ -637,7 +669,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testNormDataIsPassedToView()
     {
-        $view = $this->factory->createBuilder(static::TESTED_TYPE)
+        $view = $this->factory->createBuilder($this->getTestedType())
             ->addModelTransformer(new FixedDataTransformer([
                 'foo' => 'bar',
             ]))
@@ -662,7 +694,9 @@ class FormTypeTest extends BaseTypeTest
 
         $builder = $factory
             ->createBuilder(FormType::class, $money, ['invalid_message' => 'not the one to display'])
-            ->add('amount', TextType::class)
+            ->add('amount', TextType::class, [
+                'empty_data' => null,
+            ])
             ->add('currency', CurrencyType::class)
         ;
         $builder->setDataMapper(new MoneyDataMapper());
@@ -681,7 +715,7 @@ class FormTypeTest extends BaseTypeTest
     // https://github.com/symfony/symfony/issues/6862
     public function testPassZeroLabelToView()
     {
-        $view = $this->factory->create(static::TESTED_TYPE, null, [
+        $view = $this->factory->create($this->getTestedType(), null, [
                 'label' => '0',
             ])
             ->createView();
@@ -696,7 +730,7 @@ class FormTypeTest extends BaseTypeTest
 
     public function testPassBlockPrefixToViewWithParent()
     {
-        $view = $this->factory->createNamedBuilder('parent', static::TESTED_TYPE)
+        $view = $this->factory->createNamedBuilder('parent', $this->getTestedType())
             ->add('child', $this->getTestedType(), [
                 'block_prefix' => 'child',
             ])
@@ -840,12 +874,27 @@ class FormTypeTest extends BaseTypeTest
     public function testSortingViewChildrenBasedOnPriorityOption()
     {
         $view = $this->factory->createNamedBuilder('parent', self::TESTED_TYPE)
-            ->add('child1', null, ['priority' => -1])
-            ->add('child2')
-            ->add('child3', null, ['priority' => -1])
-            ->add('child4')
-            ->add('child5', null, ['priority' => 1])
-            ->add('child6')
+            ->add('child1', null, [
+                'empty_data' => null,
+                'priority' => -1,
+            ])
+            ->add('child2', null, [
+                'empty_data' => null,
+            ])
+            ->add('child3', null, [
+                'empty_data' => null,
+                'priority' => -1,
+            ])
+            ->add('child4', null, [
+                'empty_data' => null,
+            ])
+            ->add('child5', null, [
+                'empty_data' => null,
+                'priority' => 1,
+            ])
+            ->add('child6', null, [
+                'empty_data' => null,
+            ])
             ->getForm()
             ->createView();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
@@ -14,10 +14,13 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 class PasswordTypeTest extends BaseTypeTest
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\PasswordType';
+    public const TESTED_TYPE_OPTIONS = [
+        'empty_data' => null,
+    ];
 
     public function testEmptyIfNotSubmitted()
     {
-        $form = $this->factory->create(static::TESTED_TYPE);
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions());
         $form->setData('pAs5w0rd');
 
         $this->assertSame('', $form->createView()->vars['value']);
@@ -25,7 +28,7 @@ class PasswordTypeTest extends BaseTypeTest
 
     public function testEmptyIfSubmitted()
     {
-        $form = $this->factory->create(static::TESTED_TYPE);
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions());
         $form->submit('pAs5w0rd');
 
         $this->assertSame('', $form->createView()->vars['value']);
@@ -33,7 +36,9 @@ class PasswordTypeTest extends BaseTypeTest
 
     public function testNotEmptyIfSubmittedAndNotAlwaysEmpty()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, ['always_empty' => false]);
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
+            'always_empty' => false,
+        ]);
         $form->submit('pAs5w0rd');
 
         $this->assertSame('pAs5w0rd', $form->createView()->vars['value']);
@@ -41,7 +46,7 @@ class PasswordTypeTest extends BaseTypeTest
 
     public function testNotTrimmed()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null);
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions());
         $form->submit(' pAs5w0rd ');
 
         $this->assertSame(' pAs5w0rd ', $form->getData());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -18,6 +18,11 @@ use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 class RepeatedTypeTest extends BaseTypeTest
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\RepeatedType';
+    public const TESTED_TYPE_OPTIONS = [
+        'type' => TextTypeTest::TESTED_TYPE,
+        'first_options' => ['empty_data' => null],
+        'second_options' => ['empty_data' => null],
+    ];
 
     /**
      * @var Form
@@ -28,9 +33,7 @@ class RepeatedTypeTest extends BaseTypeTest
     {
         parent::setUp();
 
-        $this->form = $this->factory->create(static::TESTED_TYPE, null, [
-            'type' => TextTypeTest::TESTED_TYPE,
-        ]);
+        $this->form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions());
     }
 
     public function testSetData()
@@ -43,8 +46,7 @@ class RepeatedTypeTest extends BaseTypeTest
 
     public function testSetOptions()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'type' => TextTypeTest::TESTED_TYPE,
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'options' => ['label' => 'Global'],
         ]);
 
@@ -56,11 +58,18 @@ class RepeatedTypeTest extends BaseTypeTest
 
     public function testSetOptionsPerChild()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             // the global required value cannot be overridden
             'type' => TextTypeTest::TESTED_TYPE,
-            'first_options' => ['label' => 'Test', 'required' => false],
-            'second_options' => ['label' => 'Test2'],
+            'first_options' => [
+                'empty_data' => null,
+                'label' => 'Test',
+                'required' => false,
+            ],
+            'second_options' => [
+                'empty_data' => null,
+                'label' => 'Test2',
+            ],
         ]);
 
         $this->assertSame('Test', $form['first']->getConfig()->getOption('label'));
@@ -71,9 +80,8 @@ class RepeatedTypeTest extends BaseTypeTest
 
     public function testSetRequired()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'required' => false,
-            'type' => TextTypeTest::TESTED_TYPE,
         ]);
 
         $this->assertFalse($form['first']->isRequired());
@@ -85,8 +93,10 @@ class RepeatedTypeTest extends BaseTypeTest
         $form = $this->factory->create(NotMappedType::class);
         $this->assertFalse($form->getConfig()->getMapped());
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'type' => NotMappedType::class,
+            'first_options' => ['empty_data' => null],
+            'second_options' => ['empty_data' => null],
         ]);
 
         $this->assertTrue($form['first']->getConfig()->getMapped());
@@ -98,8 +108,7 @@ class RepeatedTypeTest extends BaseTypeTest
      */
     public function testNotMappedInnerIsOverridden($configurationKey)
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'type' => TextTypeTest::TESTED_TYPE,
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             $configurationKey => ['mapped' => false],
         ]);
 
@@ -118,8 +127,7 @@ class RepeatedTypeTest extends BaseTypeTest
     public function testSetInvalidOptions()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
-            'type' => TextTypeTest::TESTED_TYPE,
+        $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'options' => 'bad value',
         ]);
     }
@@ -127,7 +135,7 @@ class RepeatedTypeTest extends BaseTypeTest
     public function testSetInvalidFirstOptions()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'type' => TextTypeTest::TESTED_TYPE,
             'first_options' => 'bad value',
         ]);
@@ -136,7 +144,7 @@ class RepeatedTypeTest extends BaseTypeTest
     public function testSetInvalidSecondOptions()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'type' => TextTypeTest::TESTED_TYPE,
             'second_options' => 'bad value',
         ]);
@@ -144,7 +152,7 @@ class RepeatedTypeTest extends BaseTypeTest
 
     public function testSetErrorBubblingToTrue()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'error_bubbling' => true,
         ]);
 
@@ -155,7 +163,7 @@ class RepeatedTypeTest extends BaseTypeTest
 
     public function testSetErrorBubblingToFalse()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'error_bubbling' => false,
         ]);
 
@@ -166,11 +174,16 @@ class RepeatedTypeTest extends BaseTypeTest
 
     public function testSetErrorBubblingIndividually()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'error_bubbling' => true,
-            'options' => ['error_bubbling' => false],
-            'second_options' => ['error_bubbling' => true],
-        ]);
+            'options' => [
+                'error_bubbling' => false,
+            ],
+            'second_options' => [
+                'empty_data' => null,
+                'error_bubbling' => true,
+            ],
+        ] + $this->getTestedTypeOptions());
 
         $this->assertTrue($form->getConfig()->getOption('error_bubbling'));
         $this->assertFalse($form['first']->getConfig()->getOption('error_bubbling'));
@@ -179,11 +192,15 @@ class RepeatedTypeTest extends BaseTypeTest
 
     public function testSetOptionsPerChildAndOverwrite()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
-            'type' => TextTypeTest::TESTED_TYPE,
-            'options' => ['label' => 'Label'],
-            'second_options' => ['label' => 'Second label'],
-        ]);
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'options' => [
+                'label' => 'Label',
+            ],
+            'second_options' => [
+                'empty_data' => null,
+                'label' => 'Second label',
+            ],
+        ] + $this->getTestedTypeOptions());
 
         $this->assertSame('Label', $form['first']->getConfig()->getOption('label'));
         $this->assertSame('Second label', $form['second']->getConfig()->getOption('label'));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 class TextTypeTest extends BaseTypeTest
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\TextType';
+    public const TESTED_TYPE_OPTIONS = [
+        'empty_data' => null,
+    ];
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)
     {
@@ -22,7 +25,7 @@ class TextTypeTest extends BaseTypeTest
 
     public function testSubmitNullReturnsNullWithEmptyDataAsString()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, 'name', [
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
             'empty_data' => '',
         ]);
 
@@ -48,7 +51,7 @@ class TextTypeTest extends BaseTypeTest
      */
     public function testSetDataThroughParamsWithZero($data, $dataAsString)
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create(static::TESTED_TYPE, null, $this->getTestedTypeOptions() + [
             'data' => $data,
         ]);
         $view = $form->createView();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
@@ -35,6 +35,19 @@ class TextTypeTest extends BaseTypeTest
         $this->assertSame('', $form->getViewData());
     }
 
+    /**
+     * @group legacy
+     */
+    public function testDefaultEmptyDataCallback(): void
+    {
+        $form = $this->factory->create(static::TESTED_TYPE);
+
+        $form->submit(null);
+        $this->assertNull($form->getData());
+        $this->assertNull($form->getNormData());
+        $this->assertSame('', $form->getViewData());
+    }
+
     public function provideZeros()
     {
         return [

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
@@ -44,7 +44,7 @@ class TextTypeTest extends BaseTypeTest
      */
     public function testDefaultEmptyDataCallback()
     {
-        $this->expectDeprecation('Since symfony/form 5.4: The default value of "empty_data" option in "Symfony\Component\Form\Extension\Core\Type\TextType" will be changed to empty string. Declare "NULL" as value for "empty_data" if you still want use "NULL" as data.');
+        $this->expectDeprecation('Since symfony/form 6.1: The default value of "empty_data" option in "Symfony\Component\Form\Extension\Core\Type\TextType" will be changed to empty string. Declare "NULL" as value for "empty_data" if you still want use "NULL" as data.');
 
         $form = $this->factory->create(static::TESTED_TYPE);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
@@ -11,8 +11,12 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+
 class TextTypeTest extends BaseTypeTest
 {
+    use ExpectDeprecationTrait;
+
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\TextType';
     public const TESTED_TYPE_OPTIONS = [
         'empty_data' => null,
@@ -38,8 +42,10 @@ class TextTypeTest extends BaseTypeTest
     /**
      * @group legacy
      */
-    public function testDefaultEmptyDataCallback(): void
+    public function testDefaultEmptyDataCallback()
     {
+        $this->expectDeprecation('Since symfony/form 5.4: The default value of "empty_data" option in "Symfony\Component\Form\Extension\Core\Type\TextType" will be changed to empty string. Declare "NULL" as value for "empty_data" if you still want use "NULL" as data.');
+
         $form = $this->factory->create(static::TESTED_TYPE);
 
         $form->submit(null);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -1125,8 +1125,7 @@ class TimeTypeTest extends BaseTypeTest
             'Compound text field' => ['text', ['hour' => '21', 'minute' => '23'], $expectedData],
             'Compound choice field' => ['choice', ['hour' => '21', 'minute' => '23'], $expectedData],
             'Simple field lazy' => ['single_text', $lazyEmptyData, $expectedData],
-            // TODO uncomment after update to Symfony 6.0
-            // 'Compound text field lazy' => ['text', $lazyEmptyData, $expectedData],
+            'Compound text field lazy' => ['text', $lazyEmptyData, $expectedData],
             'Compound choice field lazy' => ['choice', $lazyEmptyData, $expectedData],
         ];
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -21,10 +21,13 @@ use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 class TimeTypeTest extends BaseTypeTest
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\TimeType';
+    public const TESTED_TYPE_OPTIONS = [
+        'empty_data' => null,
+    ];
 
     public function testSubmitDateTime()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -45,7 +48,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitDateTimeImmutable()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime_immutable',
@@ -67,7 +70,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitString()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -86,7 +89,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitStringWithCustomFormat()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, '11:33', [
+        $form = $this->factory->create($this->getTestedType(), '11:33', [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'widget' => 'single_text',
@@ -102,7 +105,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitTimestamp()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'timestamp',
@@ -123,7 +126,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitArray()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -142,7 +145,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitDatetimeSingleText()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -157,7 +160,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitDatetimeSingleTextWithoutMinutes()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -173,7 +176,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitArraySingleText()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -193,7 +196,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitArraySingleTextWithoutMinutes()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -213,7 +216,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitArraySingleTextWithSeconds()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'array',
@@ -235,7 +238,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitStringSingleText()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -250,7 +253,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitStringSingleTextWithoutMinutes()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -266,7 +269,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitWithSecondsAndBrowserOmissionSeconds()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -352,7 +355,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitDifferentTimezones()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'Europe/Berlin',
             'input' => 'datetime',
@@ -370,7 +373,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitDifferentTimezonesDuringDaylightSavingTime()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'Europe/Berlin',
             'input' => 'datetime',
@@ -388,7 +391,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitDifferentTimezonesDuringDaylightSavingTimeUsingSingleTextWidget()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'Europe/Berlin',
             'input' => 'datetime',
@@ -403,7 +406,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitWithoutSecondsAndBrowserAddingSeconds()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -419,7 +422,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitWithSecondsAndBrowserAddingMicroseconds()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -435,7 +438,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitWithoutSecondsAndBrowserAddingMicroseconds()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'string',
@@ -451,7 +454,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSetDataWithoutMinutes()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -465,7 +468,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSetDataWithSeconds()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'UTC',
             'input' => 'datetime',
@@ -479,7 +482,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSetDataDifferentTimezones()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Asia/Hong_Kong',
             'input' => 'string',
@@ -506,7 +509,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSetDataDifferentTimezonesDateTime()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'America/New_York',
             'view_timezone' => 'Asia/Hong_Kong',
             'input' => 'datetime',
@@ -534,7 +537,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSetDataDifferentTimezonesDuringDaylightSavingTime()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'Europe/Berlin',
             'input' => 'datetime',
@@ -552,7 +555,7 @@ class TimeTypeTest extends BaseTypeTest
         $this->expectException(LogicException::class);
         $this->expectExceptionMessage('Using different values for the "model_timezone" and "view_timezone" options without configuring a reference date is not supported.');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'Europe/Berlin',
             'input' => 'datetime',
@@ -566,7 +569,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testHoursOption()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'hours' => [6, 7],
         ]);
 
@@ -580,7 +583,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testIsMinuteWithinRangeReturnsTrueIfWithin()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'minutes' => [6, 7],
         ]);
 
@@ -594,7 +597,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testIsSecondWithinRangeReturnsTrueIfWithin()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'seconds' => [6, 7],
             'with_seconds' => true,
         ]);
@@ -611,7 +614,7 @@ class TimeTypeTest extends BaseTypeTest
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'choice',
         ]);
 
@@ -627,7 +630,7 @@ class TimeTypeTest extends BaseTypeTest
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'choice',
             'with_seconds' => true,
         ]);
@@ -645,7 +648,7 @@ class TimeTypeTest extends BaseTypeTest
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'choice',
         ]);
 
@@ -661,7 +664,7 @@ class TimeTypeTest extends BaseTypeTest
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'choice',
             'with_seconds' => true,
         ]);
@@ -679,7 +682,7 @@ class TimeTypeTest extends BaseTypeTest
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'choice',
             'with_seconds' => true,
         ]);
@@ -697,7 +700,7 @@ class TimeTypeTest extends BaseTypeTest
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'choice',
             'with_seconds' => true,
         ]);
@@ -715,7 +718,7 @@ class TimeTypeTest extends BaseTypeTest
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'choice',
             'with_seconds' => true,
         ]);
@@ -733,12 +736,12 @@ class TimeTypeTest extends BaseTypeTest
     {
         // Throws an exception if "data_class" option is not explicitly set
         // to null in the type
-        $this->assertInstanceOf(FormInterface::class, $this->factory->create(static::TESTED_TYPE, new \DateTime()));
+        $this->assertInstanceOf(FormInterface::class, $this->factory->create($this->getTestedType(), new \DateTime()));
     }
 
     public function testSingleTextWidgetShouldUseTheRightInputType()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
         ]);
 
@@ -748,7 +751,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSingleTextWidgetWithSecondsShouldHaveRightStepAttribute()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
             'with_seconds' => true,
         ]);
@@ -760,7 +763,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSingleTextWidgetWithSecondsShouldNotOverrideStepAttribute()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
             'with_seconds' => true,
             'attr' => [
@@ -775,7 +778,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testDontPassHtml5TypeIfHtml5NotAllowed()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => 'single_text',
             'html5' => false,
         ]);
@@ -786,7 +789,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testPassDefaultPlaceholderToViewIfNotRequired()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'required' => false,
             'with_seconds' => true,
         ]);
@@ -799,7 +802,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testPassNoPlaceholderToViewIfRequired()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'required' => true,
             'with_seconds' => true,
         ]);
@@ -812,7 +815,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testPassPlaceholderAsString()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'placeholder' => 'Empty',
             'with_seconds' => true,
         ]);
@@ -825,7 +828,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testPassPlaceholderAsArray()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'placeholder' => [
                 'hour' => 'Empty hour',
                 'minute' => 'Empty minute',
@@ -842,7 +845,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testPassPlaceholderAsPartialArrayAddEmptyIfNotRequired()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'required' => false,
             'placeholder' => [
                 'hour' => 'Empty hour',
@@ -859,7 +862,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testPassPlaceholderAsPartialArrayAddNullIfRequired()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'required' => true,
             'placeholder' => [
                 'hour' => 'Empty hour',
@@ -888,7 +891,7 @@ class TimeTypeTest extends BaseTypeTest
     public function testHourErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => $widget,
         ]);
         $form['hour']->addError($error);
@@ -903,7 +906,7 @@ class TimeTypeTest extends BaseTypeTest
     public function testMinuteErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => $widget,
         ]);
         $form['minute']->addError($error);
@@ -918,7 +921,7 @@ class TimeTypeTest extends BaseTypeTest
     public function testSecondErrorsBubbleUp($widget)
     {
         $error = new FormError('Invalid!');
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => $widget,
             'with_seconds' => true,
         ]);
@@ -931,7 +934,7 @@ class TimeTypeTest extends BaseTypeTest
     public function testInitializeWithSecondsAndWithoutMinutes()
     {
         $this->expectException(InvalidConfigurationException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'with_minutes' => false,
             'with_seconds' => true,
         ]);
@@ -940,7 +943,7 @@ class TimeTypeTest extends BaseTypeTest
     public function testThrowExceptionIfHoursIsInvalid()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'hours' => 'bad value',
         ]);
     }
@@ -948,7 +951,7 @@ class TimeTypeTest extends BaseTypeTest
     public function testThrowExceptionIfMinutesIsInvalid()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'minutes' => 'bad value',
         ]);
     }
@@ -956,7 +959,7 @@ class TimeTypeTest extends BaseTypeTest
     public function testThrowExceptionIfSecondsIsInvalid()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'seconds' => 'bad value',
         ]);
     }
@@ -964,7 +967,7 @@ class TimeTypeTest extends BaseTypeTest
     public function testReferenceDateTimezoneMustMatchModelTimezone()
     {
         $this->expectException(InvalidConfigurationException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'Europe/Berlin',
             'reference_date' => new \DateTimeImmutable('now', new \DateTimeZone('Europe/Berlin')),
@@ -973,7 +976,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testModelTimezoneDefaultToReferenceDateTimezoneIfProvided()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'view_timezone' => 'Europe/Berlin',
             'reference_date' => new \DateTimeImmutable('now', new \DateTimeZone('Europe/Berlin')),
         ]);
@@ -983,7 +986,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testViewTimezoneDefaultsToModelTimezoneIfProvided()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'Europe/Berlin',
         ]);
 
@@ -992,7 +995,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testPassDefaultChoiceTranslationDomain()
     {
-        $form = $this->factory->create(static::TESTED_TYPE);
+        $form = $this->factory->create($this->getTestedType());
 
         $view = $form->createView();
         $this->assertFalse($view['hour']->vars['choice_translation_domain']);
@@ -1001,7 +1004,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testPassChoiceTranslationDomainAsString()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'choice_translation_domain' => 'messages',
             'with_seconds' => true,
         ]);
@@ -1014,7 +1017,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testPassChoiceTranslationDomainAsArray()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'choice_translation_domain' => [
                 'hour' => 'foo',
                 'second' => 'test',
@@ -1037,7 +1040,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testSubmitNullUsesDefaultEmptyData($emptyData = [], $expectedData = null)
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'empty_data' => $emptyData,
         ]);
         $form->submit(null);
@@ -1050,7 +1053,7 @@ class TimeTypeTest extends BaseTypeTest
 
     public function testArrayTimeWithReferenceDoesNotUseReferenceTimeOnZero()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'model_timezone' => 'UTC',
             'view_timezone' => 'Europe/Berlin',
             'reference_date' => new \DateTimeImmutable('01-01-2021 12:34:56', new \DateTimeZone('UTC')),
@@ -1096,7 +1099,7 @@ class TimeTypeTest extends BaseTypeTest
      */
     public function testSubmitNullUsesDateEmptyData($widget, $emptyData, $expectedData)
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'widget' => $widget,
             'empty_data' => $emptyData,
         ]);
@@ -1122,7 +1125,8 @@ class TimeTypeTest extends BaseTypeTest
             'Compound text field' => ['text', ['hour' => '21', 'minute' => '23'], $expectedData],
             'Compound choice field' => ['choice', ['hour' => '21', 'minute' => '23'], $expectedData],
             'Simple field lazy' => ['single_text', $lazyEmptyData, $expectedData],
-            'Compound text field lazy' => ['text', $lazyEmptyData, $expectedData],
+            // TODO uncomment after update to Symfony 6.0
+            // 'Compound text field lazy' => ['text', $lazyEmptyData, $expectedData],
             'Compound choice field lazy' => ['choice', $lazyEmptyData, $expectedData],
         ];
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
@@ -16,10 +16,13 @@ use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 class UrlTypeTest extends TextTypeTest
 {
     public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\UrlType';
+    public const TESTED_TYPE_OPTIONS = [
+        'empty_data' => null,
+    ];
 
     public function testSubmitAddsDefaultProtocolIfNoneIsIncluded()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, 'name');
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions());
 
         $form->submit('www.domain.com');
 
@@ -29,7 +32,7 @@ class UrlTypeTest extends TextTypeTest
 
     public function testSubmitAddsNoDefaultProtocolIfAlreadyIncluded()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'default_protocol' => 'http',
         ]);
 
@@ -41,7 +44,7 @@ class UrlTypeTest extends TextTypeTest
 
     public function testSubmitAddsNoDefaultProtocolIfEmpty()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'default_protocol' => 'http',
         ]);
 
@@ -53,7 +56,7 @@ class UrlTypeTest extends TextTypeTest
 
     public function testSubmitAddsNoDefaultProtocolIfNull()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'default_protocol' => 'http',
         ]);
 
@@ -65,7 +68,7 @@ class UrlTypeTest extends TextTypeTest
 
     public function testSubmitAddsNoDefaultProtocolIfSetToNull()
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'default_protocol' => null,
         ]);
 
@@ -78,14 +81,14 @@ class UrlTypeTest extends TextTypeTest
     public function testThrowExceptionIfDefaultProtocolIsInvalid()
     {
         $this->expectException(InvalidOptionsException::class);
-        $this->factory->create(static::TESTED_TYPE, null, [
+        $this->factory->create($this->getTestedType(), null, $this->getTestedTypeOptions() + [
             'default_protocol' => [],
         ]);
     }
 
     public function testSubmitNullUsesDefaultEmptyData($emptyData = 'empty', $expectedData = 'http://empty')
     {
-        $form = $this->factory->create(static::TESTED_TYPE, null, [
+        $form = $this->factory->create($this->getTestedType(), null, [
             'empty_data' => $emptyData,
         ]);
         $form->submit(null);

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -27,7 +27,9 @@ class FormTypeCsrfExtensionTest_ChildType extends AbstractType
     {
         // The form needs a child in order to trigger CSRF protection by
         // default
-        $builder->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $builder->add('name', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+            'empty_data' => null,
+        ]);
     }
 }
 
@@ -186,7 +188,9 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
                 'csrf_token_id' => 'TOKEN_ID',
                 'compound' => true,
             ])
-            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         $form->submit([
@@ -217,7 +221,9 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
                 'csrf_token_manager' => $this->tokenManager,
                 'compound' => true,
             ])
-            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         $form->submit([
@@ -248,7 +254,9 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
                 'csrf_token_manager' => $this->tokenManager,
                 'compound' => true,
             ])
-            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         $form->submit([
@@ -275,7 +283,9 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
                 'csrf_token_id' => 'TOKEN_ID',
                 'compound' => true,
             ])
-            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+            ->add('child', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+                'empty_data' => null,
+            ])
             ->getForm();
 
         $form->submit([

--- a/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/DataCollector/FormDataCollectorTest.php
@@ -590,6 +590,9 @@ class FormDataCollectorTest extends TestCase
         $form = $this->factory->createNamedBuilder('root', FormType::class, ['items' => null])
             ->add('items', CollectionType::class, [
                 'entry_type' => TextType::class,
+                'entry_options' => [
+                    'empty_data' => null,
+                ],
                 'allow_add' => true,
                 // data is locked and modelData (null) is different to the
                 // configured data, so modifications of the configured data

--- a/src/Symfony/Component/Form/Tests/Extension/HtmlSanitizer/Type/TextTypeHtmlSanitizerExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/HtmlSanitizer/Type/TextTypeHtmlSanitizerExtensionTest.php
@@ -45,7 +45,10 @@ class TextTypeHtmlSanitizerExtensionTest extends TypeTestCase
     public function testSanitizer()
     {
         $form = $this->factory->createBuilder(FormType::class, ['data' => null])
-            ->add('data', TextType::class, ['sanitize_html' => true])
+            ->add('data', TextType::class, [
+                'empty_data' => null,
+                'sanitize_html' => true,
+            ])
             ->getForm()
         ;
         $form->submit(['data' => 'foobar']);
@@ -53,7 +56,11 @@ class TextTypeHtmlSanitizerExtensionTest extends TypeTestCase
         $this->assertSame(['data' => 'foo'], $form->getData());
 
         $form = $this->factory->createBuilder(FormType::class, ['data' => null])
-            ->add('data', TextType::class, ['sanitize_html' => true, 'sanitizer' => 'bar'])
+            ->add('data', TextType::class, [
+                'empty_data' => null,
+                'sanitize_html' => true,
+                'sanitizer' => 'bar',
+            ])
             ->getForm()
         ;
         $form->submit(['data' => 'foobar']);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorFunctionalTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorFunctionalTest.php
@@ -86,9 +86,10 @@ class FormValidatorFunctionalTest extends TestCase
     public function testNonCompositeConstraintValidatedOnce()
     {
         $form = $this->formFactory->create(TextType::class, null, [
-                'constraints' => [new NotBlank(['groups' => ['foo', 'bar']])],
-                'validation_groups' => ['foo', 'bar'],
-            ]);
+            'empty_data' => null,
+            'constraints' => [new NotBlank(['groups' => ['foo', 'bar']])],
+            'validation_groups' => ['foo', 'bar'],
+        ]);
         $form->submit('');
 
         $violations = $this->validator->validate($form);
@@ -113,8 +114,12 @@ class FormValidatorFunctionalTest extends TestCase
             ],
             'validation_groups' => ['field1', 'field2'],
         ]);
-        $form->add('field1');
-        $form->add('field2');
+        $form->add('field1', null, [
+            'empty_data' => null,
+        ]);
+        $form->add('field2', null, [
+            'empty_data' => null,
+        ]);
         $form->submit([
             'field1' => '',
             'field2' => '',
@@ -144,8 +149,12 @@ class FormValidatorFunctionalTest extends TestCase
             ],
             'validation_groups' => new GroupSequence(['field1', 'field2']),
         ]);
-        $form->add('field1');
-        $form->add('field2');
+        $form->add('field1', null, [
+            'empty_data' => null,
+        ]);
+        $form->add('field2', null, [
+            'empty_data' => null,
+        ]);
 
         $form->submit([
             'field1' => '',
@@ -165,9 +174,11 @@ class FormValidatorFunctionalTest extends TestCase
             'validation_groups' => new GroupSequence(['group1', 'group2']),
         ])
             ->add('foo', TextType::class, [
+                'empty_data' => null,
                 'constraints' => [new Length(['min' => 10, 'groups' => ['group1']])],
             ])
             ->add('bar', TextType::class, [
+                'empty_data' => null,
                 'constraints' => [new NotBlank(['groups' => ['group2']])],
             ])
         ;
@@ -186,12 +197,15 @@ class FormValidatorFunctionalTest extends TestCase
             'validation_groups' => new GroupSequence([['group1', 'group2'], 'group3']),
         ])
             ->add('foo', TextType::class, [
+                'empty_data' => null,
                 'constraints' => [new Length(['min' => 10, 'groups' => ['group1']])],
             ])
             ->add('bar', TextType::class, [
+                'empty_data' => null,
                 'constraints' => [new Length(['min' => 10, 'groups' => ['group2']])],
             ])
             ->add('baz', TextType::class, [
+                'empty_data' => null,
                 'constraints' => [new NotBlank(['groups' => ['group3']])],
             ])
         ;
@@ -211,6 +225,7 @@ class FormValidatorFunctionalTest extends TestCase
             'validation_groups' => new GroupSequence(['group1', 'group2']),
         ])
             ->add('foo', TextType::class, [
+                'empty_data' => null,
                 'constraints' => [
                     new NotBlank([
                         'groups' => ['group1'],
@@ -237,8 +252,11 @@ class FormValidatorFunctionalTest extends TestCase
         $form = $this->formFactory->create(FormType::class, null, [
             'validation_groups' => new GroupSequence(['group1', 'group2']),
         ])
-            ->add('bar')
+            ->add('bar', null, [
+                'empty_data' => null,
+            ])
             ->add('foo', TextType::class, [
+                'empty_data' => null,
                 'constraints' => [
                     new NotBlank([
                         'groups' => ['group1'],
@@ -266,10 +284,12 @@ class FormValidatorFunctionalTest extends TestCase
             'validation_groups' => ['group1', 'group2'],
         ])
             ->add('field1', null, [
+                'empty_data' => null,
                 'constraints' => [new NotBlank(['groups' => 'group1'])],
                 'property_path' => '[foo]',
             ])
             ->add('field2', null, [
+                'empty_data' => null,
                 'constraints' => [new NotBlank(['groups' => 'group2'])],
                 'property_path' => '[bar]',
             ])
@@ -357,10 +377,12 @@ class FormValidatorFunctionalTest extends TestCase
             'validation_groups' => new GroupSequence(['group1', 'group2']),
         ])
             ->add('field1', null, [
+                'empty_data' => null,
                 'constraints' => [new NotBlank(['groups' => 'group1'])],
                 'property_path' => '[foo]',
             ])
             ->add('field2', null, [
+                'empty_data' => null,
                 'constraints' => [new NotBlank(['groups' => 'group2'])],
                 'property_path' => '[bar]',
             ])
@@ -382,11 +404,14 @@ class FormValidatorFunctionalTest extends TestCase
     {
         $form = $this->formFactory->create(FormType::class)
             ->add('field1', null, [
+                'empty_data' => null,
                 'constraints' => [new Expression([
                     'expression' => '!this.getParent().get("field2").getData()',
                 ])],
             ])
-            ->add('field2')
+            ->add('field2', null, [
+                'empty_data' => null,
+            ])
         ;
 
         $form->submit([
@@ -405,12 +430,15 @@ class FormValidatorFunctionalTest extends TestCase
             'validation_groups' => new GroupSequence(['group1']),
         ])
             ->add('field1', null, [
+                'empty_data' => null,
                 'constraints' => [new Expression([
                     'expression' => '!this.getParent().get("field2").getData()',
                     'groups' => ['group1'],
                 ])],
             ])
-            ->add('field2')
+            ->add('field2', null, [
+                'empty_data' => null,
+            ])
         ;
 
         $form->submit([
@@ -448,8 +476,12 @@ class FormValidatorFunctionalTest extends TestCase
     public function testDoNotAddInvalidMessageIfChildFormIsAlreadyNotSynchronized()
     {
         $formBuilder = $this->formFactory->createBuilder()
-            ->add('field1')
-            ->add('field2')
+            ->add('field1', null, [
+                'empty_data' => null,
+            ])
+            ->add('field2', null, [
+                'empty_data' => null,
+            ])
             ->addModelTransformer(new CallbackTransformer(
                 function () {
                 },
@@ -497,8 +529,11 @@ class FooType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('bar')
+            ->add('bar', null, [
+                'empty_data' => null,
+            ])
             ->add('baz', null, [
+                'empty_data' => null,
                 'constraints' => [new NotBlank()],
             ])
         ;
@@ -531,7 +566,9 @@ class ReviewType extends AbstractType
             ->add('rating', IntegerType::class, [
                 'constraints' => [new Valid()],
             ])
-            ->add('title')
+            ->add('title', null, [
+                'empty_data' => null,
+            ])
             ->add('author', CustomerType::class, [
                 'constraints' => [new Valid()],
             ])
@@ -559,7 +596,9 @@ class CustomerType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('email')
+            ->add('email', null, [
+                'empty_data' => null,
+            ])
         ;
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorFunctionalTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorFunctionalTest.php
@@ -347,7 +347,9 @@ class FormValidatorFunctionalTest extends TestCase
         $form = $this->formFactory->create(FormType::class, null, [
             'data_class' => Review::class,
         ])
-            ->add('title')
+            ->add('title', null, [
+                'empty_data' => null,
+            ])
             ->add('customers', CollectionType::class, [
                 'mapped' => false,
                 'entry_type' => CustomerType::class,

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/ColorTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/ColorTypeValidatorExtensionTest.php
@@ -20,7 +20,9 @@ class ColorTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
     protected function createForm(array $options = [])
     {
-        return $this->factory->create(ColorType::class, null, $options);
+        return $this->factory->create(ColorType::class, null, [
+            'empty_data' => null,
+        ] + $options);
     }
 
     public function testInvalidMessage()

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/EmailTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/EmailTypeValidatorExtensionTest.php
@@ -20,7 +20,9 @@ class EmailTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
     protected function createForm(array $options = [])
     {
-        return $this->factory->create(EmailType::class, null, $options);
+        return $this->factory->create(EmailType::class, null, [
+            'empty_data' => null,
+        ] + $options);
     }
 
     public function testInvalidMessage()

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -80,6 +80,7 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
             ->getFormFactory()
             ->create(FormTypeTest::TESTED_TYPE, null, ['validation_groups' => new GroupSequence(['First', 'Second'])])
             ->add('field', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
                 'constraints' => [
                     new Length(['min' => 10, 'groups' => ['First']]),
                     new NotBlank(['groups' => ['Second']]),
@@ -125,13 +126,17 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
             ->addExtension(new ValidatorExtension($validator))
             ->getFormFactory()
             ->create(FormTypeTest::TESTED_TYPE, new Author(), ['validation_groups' => new GroupSequence(['First', 'Second'])])
-            ->add('firstName', TextTypeTest::TESTED_TYPE)
+            ->add('firstName', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
+            ])
             ->add('lastName', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
                 'constraints' => [
                     new Length(['min' => 10, 'groups' => ['First']]),
                 ],
             ])
             ->add('australian', TextTypeTest::TESTED_TYPE, [
+                'empty_data' => null,
                 'constraints' => [
                     new NotBlank(['groups' => ['Second']]),
                 ],

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/PasswordTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/PasswordTypeValidatorExtensionTest.php
@@ -20,7 +20,9 @@ class PasswordTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
     protected function createForm(array $options = [])
     {
-        return $this->factory->create(PasswordType::class, null, $options);
+        return $this->factory->create(PasswordType::class, null, [
+            'empty_data' => null,
+        ] + $options);
     }
 
     public function testInvalidMessage()

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RangeTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RangeTypeValidatorExtensionTest.php
@@ -20,7 +20,9 @@ class RangeTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
     protected function createForm(array $options = [])
     {
-        return $this->factory->create(RangeType::class, null, $options);
+        return $this->factory->create(RangeType::class, null, [
+            'empty_data' => null,
+        ] + $options);
     }
 
     public function testInvalidMessage()

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RepeatedTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/RepeatedTypeValidatorExtensionTest.php
@@ -20,7 +20,10 @@ class RepeatedTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
     protected function createForm(array $options = [])
     {
-        return $this->factory->create(RepeatedType::class, null, $options);
+        return $this->factory->create(RepeatedType::class, null, [
+            'first_options' => ['empty_data' => null],
+            'second_options' => ['empty_data' => null],
+        ] + $options);
     }
 
     public function testInvalidMessage()

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SearchTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SearchTypeValidatorExtensionTest.php
@@ -20,7 +20,9 @@ class SearchTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
     protected function createForm(array $options = [])
     {
-        return $this->factory->create(SearchType::class, null, $options);
+        return $this->factory->create(SearchType::class, null, [
+            'empty_data' => null,
+        ] + $options);
     }
 
     public function testInvalidMessage()

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TelTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TelTypeValidatorExtensionTest.php
@@ -20,7 +20,9 @@ class TelTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
     protected function createForm(array $options = [])
     {
-        return $this->factory->create(TelType::class, null, $options);
+        return $this->factory->create(TelType::class, null, [
+            'empty_data' => null,
+        ] + $options);
     }
 
     public function testInvalidMessage()

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UrlTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/UrlTypeValidatorExtensionTest.php
@@ -20,7 +20,9 @@ class UrlTypeValidatorExtensionTest extends BaseValidatorExtensionTest
 
     protected function createForm(array $options = [])
     {
-        return $this->factory->create(UrlType::class, null, $options);
+        return $this->factory->create(UrlType::class, null, [
+            'empty_data' => null,
+        ] + $options);
     }
 
     public function testInvalidMessage()

--- a/src/Symfony/Component/Form/Tests/Fixtures/AlternatingRowType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/AlternatingRowType.php
@@ -16,7 +16,9 @@ class AlternatingRowType extends AbstractType
             $type = 0 === $form->getName() % 2
                 ? 'Symfony\Component\Form\Extension\Core\Type\TextType'
                 : 'Symfony\Component\Form\Extension\Core\Type\TextareaType';
-            $form->add('title', $type);
+            $form->add('title', $type, [
+                'empty_data' => null,
+            ]);
         });
     }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/AuthorType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/AuthorType.php
@@ -11,8 +11,12 @@ class AuthorType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('firstName')
-            ->add('lastName')
+            ->add('firstName', null, [
+                'empty_data' => null,
+            ])
+            ->add('lastName', null, [
+                'empty_data' => null,
+            ])
         ;
     }
 

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -56,21 +56,28 @@ class FormBuilderTest extends TestCase
 
     public function testAddIsFluent()
     {
-        $builder = $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType', ['bar' => 'baz']);
+        $builder = $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+            'empty_data' => null,
+            'bar' => 'baz',
+        ]);
         $this->assertSame($builder, $this->builder);
     }
 
     public function testAdd()
     {
         $this->assertFalse($this->builder->has('foo'));
-        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+            'empty_data' => null,
+        ]);
         $this->assertTrue($this->builder->has('foo'));
     }
 
     public function testAddIntegerName()
     {
         $this->assertFalse($this->builder->has(0));
-        $this->builder->add(0, 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $this->builder->add(0, 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+            'empty_data' => null,
+        ]);
         $this->assertTrue($this->builder->has(0));
     }
 
@@ -79,7 +86,9 @@ class FormBuilderTest extends TestCase
         $this->assertCount(0, $this->builder->all());
         $this->assertFalse($this->builder->has('foo'));
 
-        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+            'empty_data' => null,
+        ]);
         $children = $this->builder->all();
 
         $this->assertTrue($this->builder->has('foo'));
@@ -92,9 +101,13 @@ class FormBuilderTest extends TestCase
      */
     public function testMaintainOrderOfLazyAndExplicitChildren()
     {
-        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+            'empty_data' => null,
+        ]);
         $this->builder->add(new FormBuilder('bar', null, new EventDispatcher(), $this->factory));
-        $this->builder->add('baz', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $this->builder->add('baz', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+            'empty_data' => null,
+        ]);
 
         $children = $this->builder->all();
 
@@ -103,7 +116,9 @@ class FormBuilderTest extends TestCase
 
     public function testRemove()
     {
-        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+            'empty_data' => null,
+        ]);
         $this->builder->remove('foo');
         $this->assertFalse($this->builder->has('foo'));
     }
@@ -117,7 +132,9 @@ class FormBuilderTest extends TestCase
     // https://github.com/symfony/symfony/pull/4826
     public function testRemoveAndGetForm()
     {
-        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+            'empty_data' => null,
+        ]);
         $this->builder->remove('foo');
         $form = $this->builder->getForm();
         $this->assertInstanceOf(Form::class, $form);

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -142,7 +142,9 @@ class FormBuilderTest extends TestCase
 
     public function testCreateNoTypeNo()
     {
-        $builder = $this->builder->create('foo');
+        $builder = $this->builder->create('foo', null, [
+            'empty_data' => null,
+        ]);
 
         $this->assertInstanceOf(TextType::class, $builder->getType()->getInnerType());
     }
@@ -165,7 +167,9 @@ class FormBuilderTest extends TestCase
 
     public function testGetExplicitType()
     {
-        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType');
+        $this->builder->add('foo', 'Symfony\Component\Form\Extension\Core\Type\TextType', [
+            'empty_data' => null,
+        ]);
         $builder = $this->builder->get('foo');
 
         $this->assertNotSame($builder, $this->builder);
@@ -174,7 +178,9 @@ class FormBuilderTest extends TestCase
     public function testGetGuessedType()
     {
         $rootFormBuilder = new FormBuilder('name', 'stdClass', new EventDispatcher(), $this->factory);
-        $rootFormBuilder->add('foo');
+        $rootFormBuilder->add('foo', null, [
+            'empty_data' => null,
+        ]);
         $fooBuilder = $rootFormBuilder->get('foo');
 
         $this->assertNotSame($fooBuilder, $rootFormBuilder);

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -102,7 +102,9 @@ class FormFactoryTest extends TestCase
 
     public function testCreateBuilderForPropertyWithoutTypeGuesser()
     {
-        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName');
+        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName', null, [
+            'empty_data' => null,
+        ]);
 
         $this->assertSame('firstName', $builder->getName());
     }
@@ -112,7 +114,9 @@ class FormFactoryTest extends TestCase
         $this->guesser1->configureTypeGuess(TextType::class, ['attr' => ['maxlength' => 10]], Guess::MEDIUM_CONFIDENCE);
         $this->guesser2->configureTypeGuess(PasswordType::class, ['attr' => ['maxlength' => 7]], Guess::HIGH_CONFIDENCE);
 
-        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName');
+        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName', null, [
+            'empty_data' => null,
+        ]);
 
         $this->assertSame('firstName', $builder->getName());
         $this->assertSame(['maxlength' => 7], $builder->getOption('attr'));
@@ -121,7 +125,9 @@ class FormFactoryTest extends TestCase
 
     public function testCreateBuilderCreatesTextFormIfNoGuess()
     {
-        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName');
+        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName', null, [
+            'empty_data' => null,
+        ]);
 
         $this->assertSame('firstName', $builder->getName());
         $this->assertInstanceOf(TextType::class, $builder->getType()->getInnerType());
@@ -131,7 +137,10 @@ class FormFactoryTest extends TestCase
     {
         $this->guesser1->configureTypeGuess(TextType::class, ['attr' => ['class' => 'foo', 'maxlength' => 10]], Guess::MEDIUM_CONFIDENCE);
 
-        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName', null, ['attr' => ['maxlength' => 11]]);
+        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName', null, [
+            'empty_data' => null,
+            'attr' => ['maxlength' => 11],
+        ]);
 
         $this->assertSame('firstName', $builder->getName());
         $this->assertSame(['class' => 'foo', 'maxlength' => 11], $builder->getOption('attr'));
@@ -143,7 +152,9 @@ class FormFactoryTest extends TestCase
         $this->guesser1->configureMaxLengthGuess(15, Guess::MEDIUM_CONFIDENCE);
         $this->guesser2->configureMaxLengthGuess(20, Guess::HIGH_CONFIDENCE);
 
-        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName');
+        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName', null, [
+            'empty_data' => null,
+        ]);
 
         $this->assertSame('firstName', $builder->getName());
         $this->assertSame(['maxlength' => 20], $builder->getOption('attr'));
@@ -155,7 +166,10 @@ class FormFactoryTest extends TestCase
         $this->guesser1->configureMaxLengthGuess(20, Guess::HIGH_CONFIDENCE);
         $this->guesser2->configurePatternGuess('.{5,}', Guess::HIGH_CONFIDENCE);
 
-        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName', null, ['attr' => ['class' => 'tinymce']]);
+        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName', null, [
+            'empty_data' => null,
+            'attr' => ['class' => 'tinymce']
+        ]);
 
         $this->assertSame('firstName', $builder->getName());
         $this->assertSame(['maxlength' => 20, 'pattern' => '.{5,}', 'class' => 'tinymce'], $builder->getOption('attr'));
@@ -167,7 +181,9 @@ class FormFactoryTest extends TestCase
         $this->guesser1->configureRequiredGuess(true, Guess::MEDIUM_CONFIDENCE);
         $this->guesser2->configureRequiredGuess(false, Guess::HIGH_CONFIDENCE);
 
-        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName');
+        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName', null, [
+            'empty_data' => null,
+        ]);
 
         $this->assertSame('firstName', $builder->getName());
         $this->assertFalse($builder->getOption('required'));
@@ -179,7 +195,9 @@ class FormFactoryTest extends TestCase
         $this->guesser1->configurePatternGuess('[a-z]', Guess::MEDIUM_CONFIDENCE);
         $this->guesser2->configurePatternGuess('[a-zA-Z]', Guess::HIGH_CONFIDENCE);
 
-        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName');
+        $builder = $this->factory->createBuilderForProperty('Application\Author', 'firstName', null, [
+            'empty_data' => null,
+        ]);
 
         $this->assertSame('firstName', $builder->getName());
         $this->assertSame(['pattern' => '[a-zA-Z]'], $builder->getOption('attr'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| License       | MIT
| Doc PR        | symfony/symfony-docs#15404
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

Upgrade path for #41514