### PR TITLE
[Notifier] [Bridge] Remove hidden dependency on HttpFoundation for SmsBiurasTransport

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/SmsBiuras/SmsBiurasTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/SmsBiuras/SmsBiurasTransport.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\SmsBiuras;
 
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
@@ -90,7 +89,7 @@ final class SmsBiurasTransport extends AbstractTransport
             ],
         ]);
 
-        if (Response::HTTP_OK !== $response->getStatusCode()) {
+        if (200 !== $response->getStatusCode()) {
             throw new TransportException('Unable to send the SMS.', $response);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

[SmsBiurasTransport](https://github.com/symfony/symfony/blob/5.3/src/Symfony/Component/Notifier/Bridge/SmsBiuras/SmsBiurasTransport.php#L93) has a hidden dependency on HttpFoundation. Similar to this pull request https://github.com/symfony/symfony/pull/40766 but one more class to be fixed
