### PR TITLE
[Ldap] Fixing the behaviour of getting LDAP Attributes

### DIFF
--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -78,7 +78,7 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
             $this->ldap->bind($this->searchDn, $this->searchPassword);
             $identifier = $this->ldap->escape($identifier, '', LdapInterface::ESCAPE_FILTER);
             $query = str_replace(['{username}', '{user_identifier}'], $identifier, $this->defaultSearch);
-            $search = $this->ldap->query($this->baseDn, $query);
+            $search = $this->ldap->query($this->baseDn, $query, ['filter' => 0 == \count($this->extraFields) ? '*' : $this->extraFields]);
         } catch (ConnectionException $e) {
             $e = new UserNotFoundException(sprintf('User "%s" not found.', $identifier), 0, $e);
             $e->setUserIdentifier($identifier);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo?

Some of the attributes in LDAP are not shipped via `filter = *`, they have to be requested. Example the `memberOf` attribute using the OpenLDAP docker demo `rroemhild/docker-test-openldap`. The `memberOf` attribute is an overlay and only available on request.

ldapsearch example without requesting `memberOf`:

```bash
$ ldapsearch -H ldap://localhost:10389 -b dc=planetexpress,dc=com -D "cn=admin,dc=planetexpress,dc=com" -w GoodNewsEveryone "(&(objectClass=inetOrgPerson)(uid=fry))"

dn: cn=Philip J. Fry,ou=people,dc=planetexpress,dc=com
objectClass: inetOrgPerson
objectClass: organizationalPerson
objectClass: person
objectClass: top
cn: Philip J. Fry
sn: Fry
description: Human
displayName: Fry
employeeType: Delivery boy
givenName: Philip
jpegPhoto:: ....
mail: fry@planetexpress.com
ou: Delivering Crew
uid: fry
userPassword:: ....
```

ldapsearch example with requesting `memberOf`:

```bash
ldapsearch -H ldap://localhost:10389 -b dc=planetexpress,dc=com -D "cn=admin,dc=planetexpress,dc=com" -w GoodNewsEveryone "(&(objectClass=inetOrgPerson)(uid=fry))" "*" "memberOf"

dn: cn=Philip J. Fry,ou=people,dc=planetexpress,dc=com
objectClass: inetOrgPerson
objectClass: organizationalPerson
objectClass: person
objectClass: top
cn: Philip J. Fry
sn: Fry
description: Human
displayName: Fry
employeeType: Delivery boy
givenName: Philip
jpegPhoto:: ....
mail: fry@planetexpress.com
ou: Delivering Crew
uid: fry
userPassword:: ....
memberOf: cn=ship_crew,ou=people,dc=planetexpress,dc=com
```
