### PR TITLE
[Form] Fix ChoiceType to effectively set and use translator

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -45,7 +45,7 @@ class CoreExtension extends AbstractExtension
             new Type\FormType($this->propertyAccessor),
             new Type\BirthdayType(),
             new Type\CheckboxType(),
-            new Type\ChoiceType($this->choiceListFactory),
+            new Type\ChoiceType($this->choiceListFactory, $this->translator),
             new Type\CollectionType(),
             new Type\CountryType(),
             new Type\DateIntervalType(),

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -62,6 +62,11 @@ class ChoiceType extends AbstractType
             )
         );
 
+        if (null !== $translator && !$translator instanceof TranslatorInterface) {
+            throw new \TypeError(sprintf('Argument 2 passed to "%s()" must be han instance of "%s", "%s" given.', __METHOD__, TranslatorInterface::class, \is_object($translator) ? \get_class($translator) : \gettype($translator)));
+        }
+        $this->translator = $translator;
+
         // BC, to be removed in 6.0
         if ($this->choiceListFactory instanceof CachingFactoryDecorator) {
             return;
@@ -72,11 +77,6 @@ class ChoiceType extends AbstractType
         if ($ref->getNumberOfParameters() < 3) {
             trigger_deprecation('symfony/form', '5.1', 'Not defining a third parameter "callable|null $filter" in "%s::%s()" is deprecated.', $ref->class, $ref->name);
         }
-
-        if (null !== $translator && !$translator instanceof TranslatorInterface) {
-            throw new \TypeError(sprintf('Argument 2 passed to "%s()" must be han instance of "%s", "%s" given.', __METHOD__, TranslatorInterface::class, \is_object($translator) ? \get_class($translator) : \gettype($translator)));
-        }
-        $this->translator = $translator;
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTranslationTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTranslationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\Type;
+
+use Symfony\Component\Form\Extension\Core\CoreExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class ChoiceTypeTranslationTest extends TypeTestCase
+{
+    public const TESTED_TYPE = 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
+
+    private $choices = [
+        'Bernhard' => 'a',
+        'Fabien' => 'b',
+        'Kris' => 'c',
+        'Jon' => 'd',
+        'Roman' => 'e',
+    ];
+
+    protected function getExtensions()
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->expects($this->any())->method('trans')
+            ->willReturnCallback(function ($key, $params) {
+                return strtr(sprintf('Translation of: %s', $key), $params);
+            }
+        );
+
+        return array_merge(parent::getExtensions(), [new CoreExtension(null, null, $translator)]);
+    }
+
+    public function testInvalidMessageAwarenessForMultiple()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'multiple' => true,
+            'expanded' => false,
+            'choices' => $this->choices,
+            'invalid_message' => 'You are not able to use value "{{ value }}"',
+        ]);
+
+        $form->submit(['My invalid choice']);
+        $this->assertEquals(
+            "ERROR: Translation of: You are not able to use value \"My invalid choice\"\n",
+            (string) $form->getErrors(true)
+        );
+    }
+
+    public function testInvalidMessageAwarenessForMultipleWithoutScalarOrArrayViewData()
+    {
+        $form = $this->factory->create(static::TESTED_TYPE, null, [
+            'multiple' => true,
+            'expanded' => false,
+            'choices' => $this->choices,
+            'invalid_message' => 'You are not able to use value "{{ value }}"',
+        ]);
+
+        $form->submit(new \stdClass());
+        $this->assertEquals(
+            "ERROR: Translation of: You are not able to use value \"stdClass\"\n",
+            (string) $form->getErrors(true)
+        );
+    }
+}


### PR DESCRIPTION
[Component][Form][ChoiceType] constructor line order changed to set translator before early return; 

[Component][Form][CoreExtension] a second argument $translator has been added for instantiation of [Component][Form][ChoiceType] 

| Q             | A
| ------------- | ---
| Branch?       |  5.2 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41497
| License       | MIT
| Doc PR        | -

[Component][Form][ChoiceType] The bug probably came to life after a merge of two commits from different branches: 5.1 and 4.4. The commit in branch 5.1 contained a conditional early return related with the choiceListFactory:
```php
if ($this->choiceListFactory instanceof CachingFactoryDecorator) {
    return;
}
```
The code from the branch 4.4 was there to set the translator, but it wasn't effective when the constructor early returned in the line above. 
```php
$this->translator = $translator;
```

The fix was to switch [Component][Form][ChoiceType] constructor lines related with the translator above the early return related with choiceListFactory.

As a second parameter $translator has been added to the [Component][Form][ChoiceType] constructor, the translator needs to be injected by the CoreExtension so that ChoiceType could set and use it. This is why a second argument is added now in [Component][Form][CoreExtension] loadTypes for Type\ChoiceType:
```php
new Type\ChoiceType($this->choiceListFactory, $this->translator),
```

