### PR TITLE
[Console] Fix negated options not accessible

### DIFF
--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -146,6 +146,14 @@ abstract class Input implements InputInterface, StreamableInputInterface
      */
     public function getOption(string $name)
     {
+        if ($this->definition->hasNegation($name)) {
+            if (null === $value = $this->getOption($this->definition->negationToName($name))) {
+                return $value;
+            }
+
+            return !$value;
+        }
+
         if (!$this->definition->hasOption($name)) {
             throw new InvalidArgumentException(sprintf('The "%s" option does not exist.', $name));
         }
@@ -158,7 +166,11 @@ abstract class Input implements InputInterface, StreamableInputInterface
      */
     public function setOption(string $name, $value)
     {
-        if (!$this->definition->hasOption($name)) {
+        if ($this->definition->hasNegation($name)) {
+            $this->options[$this->definition->negationToName($name)] = !$value;
+
+            return;
+        } elseif (!$this->definition->hasOption($name)) {
             throw new InvalidArgumentException(sprintf('The "%s" option does not exist.', $name));
         }
 
@@ -170,7 +182,7 @@ abstract class Input implements InputInterface, StreamableInputInterface
      */
     public function hasOption(string $name)
     {
-        return $this->definition->hasOption($name);
+        return $this->definition->hasOption($name) || $this->definition->hasNegation($name);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Input/InputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputTest.php
@@ -45,6 +45,20 @@ class InputTest extends TestCase
         $input = new ArrayInput(['--name' => 'foo', '--bar' => null], new InputDefinition([new InputOption('name'), new InputOption('bar', '', InputOption::VALUE_OPTIONAL, '', 'default')]));
         $this->assertNull($input->getOption('bar'), '->getOption() returns null for options explicitly passed without value (or an empty value)');
         $this->assertEquals(['name' => 'foo', 'bar' => null], $input->getOptions(), '->getOptions() returns all option values');
+
+        $input = new ArrayInput(['--name' => null], new InputDefinition([new InputOption('name', null, InputOption::VALUE_NEGATABLE)]));
+        $this->assertTrue($input->hasOption('name'));
+        $this->assertTrue($input->hasOption('no-name'));
+        $this->assertTrue($input->getOption('name'));
+        $this->assertFalse($input->getOption('no-name'));
+
+        $input = new ArrayInput(['--no-name' => null], new InputDefinition([new InputOption('name', null, InputOption::VALUE_NEGATABLE)]));
+        $this->assertFalse($input->getOption('name'));
+        $this->assertTrue($input->getOption('no-name'));
+
+        $input = new ArrayInput([], new InputDefinition([new InputOption('name', null, InputOption::VALUE_NEGATABLE)]));
+        $this->assertNull($input->getOption('name'));
+        $this->assertNull($input->getOption('no-name'));
     }
 
     public function testSetInvalidOption()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41531
| License       | MIT
| Doc PR        | -

Removing the `--no-ansi` option to only let the negatable option `--ansi` breaks applications that expects calling `$input->getOption('no-ansi')`

This PR provides a fallback to return the negative value of the negatable options
