### PR TITLE
[SecurityBundle] Fix call to deprecated getUsername() in tests

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AuthenticatorBundle/SecurityController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/AuthenticatorBundle/SecurityController.php
@@ -23,6 +23,6 @@ class SecurityController extends AbstractController
 
     public function profileAction()
     {
-        return new Response('Welcome '.$this->getUser()->getUsername().'!');
+        return new Response('Welcome '.$this->getUser()->getUserIdentifier().'!');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -
