### PR TITLE
Set minimum required version for framework-bundle to 5.3

### DIFF
--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -40,7 +40,7 @@
     },
     "conflict": {
         "symfony/event-dispatcher": "<4.4",
-        "symfony/framework-bundle": "<4.4",
+        "symfony/framework-bundle": "<5.3",
         "symfony/http-kernel": "<4.4"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

When trying to update `symfony/messenger` to 5.3 while still using `symfony/framework-bundle` 4.4 I've got this error:

```
The service "console.command.messenger_failed_messages_retry" has a dependency on a non-existent service "messenger.failure_transports.default".
```

<details><summary>Full Stack trace:</summary>
<p>

```
Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException:
The service "console.command.messenger_failed_messages_retry" has a dependency on a non-existent service "messenger.failure_transports.default".

  at /usr/app/vendor/symfony/dependency-injection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php:86
  at Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass->processValue()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/AbstractRecursivePass.php:82)
  at Symfony\Component\DependencyInjection\Compiler\AbstractRecursivePass->processValue()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php:49)
  at Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass->processValue()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/AbstractRecursivePass.php:87)
  at Symfony\Component\DependencyInjection\Compiler\AbstractRecursivePass->processValue()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php:49)
  at Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass->processValue()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/AbstractRecursivePass.php:82)
  at Symfony\Component\DependencyInjection\Compiler\AbstractRecursivePass->processValue()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php:49)
  at Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass->processValue()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/AbstractRecursivePass.php:82)
  at Symfony\Component\DependencyInjection\Compiler\AbstractRecursivePass->processValue()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php:49)
  at Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass->processValue()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/AbstractRecursivePass.php:91)
  at Symfony\Component\DependencyInjection\Compiler\AbstractRecursivePass->processValue()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php:49)
  at Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass->processValue()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/AbstractRecursivePass.php:82)
  at Symfony\Component\DependencyInjection\Compiler\AbstractRecursivePass->processValue()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php:49)
  at Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass->processValue()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/AbstractRecursivePass.php:46)
  at Symfony\Component\DependencyInjection\Compiler\AbstractRecursivePass->process()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php:40)
  at Symfony\Component\DependencyInjection\Compiler\CheckExceptionOnInvalidReferenceBehaviorPass->process()
     (/usr/app/vendor/symfony/dependency-injection/Compiler/Compiler.php:94)
  at Symfony\Component\DependencyInjection\Compiler\Compiler->compile()
     (/usr/app/vendor/symfony/dependency-injection/ContainerBuilder.php:762)
  at Symfony\Component\DependencyInjection\ContainerBuilder->compile()
     (/usr/app/vendor/symfony/http-kernel/Kernel.php:596)
  at Symfony\Component\HttpKernel\Kernel->initializeContainer()
     (/usr/app/vendor/symfony/http-kernel/Kernel.php:136)
  at Symfony\Component\HttpKernel\Kernel->boot()
     (/usr/app/vendor/symfony/http-kernel/Kernel.php:196)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (/usr/app/public/index.php:30)                
```

</p>
</details>

Here you can see the issue reproduced: https://github.com/Runroom/archetype-symfony/pull/1913

This is caused by this PR: https://github.com/symfony/symfony/pull/38468

This is the piece of code from `framework-bundle`: https://github.com/symfony/symfony/blob/5.3/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1969-L1976

This is the usage of that service on `messenger`:
https://github.com/symfony/symfony/blob/5.3/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php#L260-L264

It adds some logic to the framework bundle to declare a new alias: `messenger.failure_transports.default` which is used on a `CompilerPass` on the messenger component. This service is not present on 4.4 of the `symfony/framework-bundle`.

Maybe there is another option to deal with this cases, but I wasn't sure.
