### PR TITLE
Handle 'hidden' param from AsCommand attribute

### DIFF
--- a/src/Symfony/Component/Console/Attribute/AsCommand.php
+++ b/src/Symfony/Component/Console/Attribute/AsCommand.php
@@ -21,7 +21,7 @@ class AsCommand
         public string $name,
         public ?string $description = null,
         array $aliases = [],
-        bool $hidden = false,
+        public bool $hidden = false,
     ) {
         if (!$hidden && !$aliases) {
             return;

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -513,7 +513,12 @@ class Command
      */
     public function isHidden()
     {
-        return $this->hidden;
+        $isHidden = false;
+        if (\PHP_VERSION_ID >= 80000 && $attribute = (new \ReflectionClass($this))->getAttributes(AsCommand::class)) {
+            $isHidden = $attribute[0]->newInstance()->hidden;
+        }
+
+        return $this->hidden || $isHidden;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -414,6 +414,8 @@ class CommandTest extends TestCase
     {
         $this->assertSame('|foo|f', Php8Command::getDefaultName());
         $this->assertSame('desc', Php8Command::getDefaultDescription());
+
+        $this->assertSame(true, (new Php8Command())->isHidden());
     }
 }
 

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -415,7 +415,7 @@ class CommandTest extends TestCase
         $this->assertSame('|foo|f', Php8Command::getDefaultName());
         $this->assertSame('desc', Php8Command::getDefaultDescription());
 
-        $this->assertSame(true, (new Php8Command())->isHidden());
+        $this->assertTrue((new Php8Command())->isHidden());
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 


The recently introduced `AsCommand` attribute works like a charm (as much as the whole 5.3 release :ok_hand:). Thanks a lot for that!

Though, it seems that the `hidden` property has been forgotten, whether one set it or not the command only checks the `$this->hidden` value set from the `configure()` method.


For example:
```php
#[AsCommand(
    name: 'app:do:something',
    description: 'Will do something very cool.',
    aliases: [],
    hidden: true
)]
class DoSomethingCommand extends Command
```

When I run ```bash bin/console list app``` I get
```bash
Available commands for the "app" namespace:
  app:do:something  Do something very cool.
```

I implemented a fix inspired by the `$name`/`$description` properties.