### PR TITLE
[Messenger] Fix opcache preload with alias classes - for 5.2

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpFactory.php
@@ -33,4 +33,7 @@ class AmqpFactory
         return new \AMQPExchange($channel);
     }
 }
-class_alias(AmqpFactory::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpFactory::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\AmqpExt\AmqpFactory::class, false)) {
+    class_alias(AmqpFactory::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpFactory::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceivedStamp.php
@@ -37,4 +37,7 @@ class AmqpReceivedStamp implements NonSendableStampInterface
         return $this->queueName;
     }
 }
-class_alias(AmqpReceivedStamp::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpReceivedStamp::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\AmqpExt\AmqpReceivedStamp::class, false)) {
+    class_alias(AmqpReceivedStamp::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpReceivedStamp::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpReceiver.php
@@ -136,4 +136,7 @@ class AmqpReceiver implements ReceiverInterface, MessageCountAwareInterface
         return $amqpReceivedStamp;
     }
 }
-class_alias(AmqpReceiver::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpReceiver::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\AmqpExt\AmqpReceiver::class, false)) {
+    class_alias(AmqpReceiver::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpReceiver::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpSender.php
@@ -75,4 +75,7 @@ class AmqpSender implements SenderInterface
         return $envelope;
     }
 }
-class_alias(AmqpSender::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpSender::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\AmqpExt\AmqpSender::class, false)) {
+    class_alias(AmqpSender::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpSender::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpStamp.php
@@ -74,4 +74,7 @@ final class AmqpStamp implements NonSendableStampInterface
         );
     }
 }
-class_alias(AmqpStamp::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpStamp::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\AmqpExt\AmqpStamp::class, false)) {
+    class_alias(AmqpStamp::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpStamp::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransport.php
@@ -92,4 +92,7 @@ class AmqpTransport implements TransportInterface, SetupableTransportInterface, 
         return $this->sender = new AmqpSender($this->connection, $this->serializer);
     }
 }
-class_alias(AmqpTransport::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpTransport::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\AmqpExt\AmqpTransport::class, false)) {
+    class_alias(AmqpTransport::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpTransport::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/AmqpTransportFactory.php
@@ -32,4 +32,7 @@ class AmqpTransportFactory implements TransportFactoryInterface
         return 0 === strpos($dsn, 'amqp://') || 0 === strpos($dsn, 'amqps://');
     }
 }
-class_alias(AmqpTransportFactory::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpTransportFactory::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\AmqpExt\AmqpTransportFactory::class, false)) {
+    class_alias(AmqpTransportFactory::class, \Symfony\Component\Messenger\Transport\AmqpExt\AmqpTransportFactory::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -588,4 +588,7 @@ class Connection
         return (null !== $amqpStamp ? $amqpStamp->getRoutingKey() : null) ?? $this->getDefaultPublishRoutingKey();
     }
 }
-class_alias(Connection::class, \Symfony\Component\Messenger\Transport\AmqpExt\Connection::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\AmqpExt\Connection::class, false)) {
+    class_alias(Connection::class, \Symfony\Component\Messenger\Transport\AmqpExt\Connection::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -445,4 +445,7 @@ class Connection implements ResetInterface
         }
     }
 }
-class_alias(Connection::class, \Symfony\Component\Messenger\Transport\Doctrine\Connection::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\Doctrine\Connection::class, false)) {
+    class_alias(Connection::class, \Symfony\Component\Messenger\Transport\Doctrine\Connection::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceivedStamp.php
@@ -30,4 +30,7 @@ class DoctrineReceivedStamp implements NonSendableStampInterface
         return $this->id;
     }
 }
-class_alias(DoctrineReceivedStamp::class, \Symfony\Component\Messenger\Transport\Doctrine\DoctrineReceivedStamp::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineReceivedStamp::class, false)) {
+    class_alias(DoctrineReceivedStamp::class, \Symfony\Component\Messenger\Transport\Doctrine\DoctrineReceivedStamp::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineReceiver.php
@@ -171,4 +171,7 @@ class DoctrineReceiver implements ReceiverInterface, MessageCountAwareInterface,
         );
     }
 }
-class_alias(DoctrineReceiver::class, \Symfony\Component\Messenger\Transport\Doctrine\DoctrineReceiver::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineReceiver::class, false)) {
+    class_alias(DoctrineReceiver::class, \Symfony\Component\Messenger\Transport\Doctrine\DoctrineReceiver::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineSender.php
@@ -55,4 +55,7 @@ class DoctrineSender implements SenderInterface
         return $envelope->with(new TransportMessageIdStamp($id));
     }
 }
-class_alias(DoctrineSender::class, \Symfony\Component\Messenger\Transport\Doctrine\DoctrineSender::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineSender::class, false)) {
+    class_alias(DoctrineSender::class, \Symfony\Component\Messenger\Transport\Doctrine\DoctrineSender::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
@@ -129,4 +129,7 @@ class DoctrineTransport implements TransportInterface, SetupableTransportInterfa
         return $this->sender = new DoctrineSender($this->connection, $this->serializer);
     }
 }
-class_alias(DoctrineTransport::class, \Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransport::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransport::class, false)) {
+    class_alias(DoctrineTransport::class, \Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransport::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransportFactory.php
@@ -62,4 +62,7 @@ class DoctrineTransportFactory implements TransportFactoryInterface
         return 0 === strpos($dsn, 'doctrine://');
     }
 }
-class_alias(DoctrineTransportFactory::class, \Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory::class, false)) {
+    class_alias(DoctrineTransportFactory::class, \Symfony\Component\Messenger\Transport\Doctrine\DoctrineTransportFactory::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -497,4 +497,7 @@ class Connection
         }
     }
 }
-class_alias(Connection::class, \Symfony\Component\Messenger\Transport\RedisExt\Connection::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\RedisExt\Connection::class, false)) {
+    class_alias(Connection::class, \Symfony\Component\Messenger\Transport\RedisExt\Connection::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceivedStamp.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceivedStamp.php
@@ -30,4 +30,7 @@ class RedisReceivedStamp implements NonSendableStampInterface
         return $this->id;
     }
 }
-class_alias(RedisReceivedStamp::class, \Symfony\Component\Messenger\Transport\RedisExt\RedisReceivedStamp::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\RedisExt\RedisReceivedStamp::class, false)) {
+    class_alias(RedisReceivedStamp::class, \Symfony\Component\Messenger\Transport\RedisExt\RedisReceivedStamp::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
@@ -86,4 +86,7 @@ class RedisReceiver implements ReceiverInterface
         return $redisReceivedStamp;
     }
 }
-class_alias(RedisReceiver::class, \Symfony\Component\Messenger\Transport\RedisExt\RedisReceiver::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\RedisExt\RedisReceiver::class, false)) {
+    class_alias(RedisReceiver::class, \Symfony\Component\Messenger\Transport\RedisExt\RedisReceiver::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisSender.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisSender.php
@@ -47,4 +47,7 @@ class RedisSender implements SenderInterface
         return $envelope;
     }
 }
-class_alias(RedisSender::class, \Symfony\Component\Messenger\Transport\RedisExt\RedisSender::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\RedisExt\RedisSender::class, false)) {
+    class_alias(RedisSender::class, \Symfony\Component\Messenger\Transport\RedisExt\RedisSender::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransport.php
@@ -84,4 +84,7 @@ class RedisTransport implements TransportInterface, SetupableTransportInterface
         return $this->sender = new RedisSender($this->connection, $this->serializer);
     }
 }
-class_alias(RedisTransport::class, \Symfony\Component\Messenger\Transport\RedisExt\RedisTransport::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\RedisExt\RedisTransport::class, false)) {
+    class_alias(RedisTransport::class, \Symfony\Component\Messenger\Transport\RedisExt\RedisTransport::class);
+}

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransportFactory.php
@@ -33,4 +33,7 @@ class RedisTransportFactory implements TransportFactoryInterface
         return 0 === strpos($dsn, 'redis://');
     }
 }
-class_alias(RedisTransportFactory::class, \Symfony\Component\Messenger\Transport\RedisExt\RedisTransportFactory::class);
+
+if (!class_exists(\Symfony\Component\Messenger\Transport\RedisExt\RedisTransportFactory::class, false)) {
+    class_alias(RedisTransportFactory::class, \Symfony\Component\Messenger\Transport\RedisExt\RedisTransportFactory::class);
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39961, fix #40752
| License       | MIT
| Doc PR        | -

Same fix than #41549 for 5.2 branch