### PR TITLE
[Security] Fix opcache preload with alias classes - for 5.3

### DIFF
--- a/src/Symfony/Component/Security/Core/Exception/UserNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UserNotFoundException.php
@@ -93,4 +93,7 @@ class UserNotFoundException extends AuthenticationException
         parent::__unserialize($parentData);
     }
 }
-class_alias(UserNotFoundException::class, UsernameNotFoundException::class);
+
+if (!class_exists(UsernameNotFoundException::class, false)) {
+    class_alias(UserNotFoundException::class, UsernameNotFoundException::class);
+}

--- a/src/Symfony/Component/Security/Core/User/InMemoryUserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUserChecker.php
@@ -67,4 +67,7 @@ class InMemoryUserChecker implements UserCheckerInterface
         }
     }
 }
-class_alias(InMemoryUserChecker::class, UserChecker::class);
+
+if (!class_exists(UserChecker::class, false)) {
+    class_alias(InMemoryUserChecker::class, UserChecker::class);
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39961, fix #40752
| License       | MIT
| Doc PR        | -

Same fix than #41549, #41550 for 5.3 branch