### PR TITLE
[Messenger] fix BC for FrameworkBundle 4.4 with a non-existence alias being used

### DIFF
--- a/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
+++ b/src/Symfony/Component/Messenger/DependencyInjection/MessengerPass.php
@@ -260,7 +260,11 @@ class MessengerPass implements CompilerPassInterface
             $commandDefinition = $container->getDefinition('console.command.messenger_failed_messages_retry');
             $globalReceiverName = $commandDefinition->getArgument(0);
             if (null !== $globalReceiverName) {
-                $failureTransportsMap[$commandDefinition->getArgument(0)] = new Reference('messenger.failure_transports.default');
+                if ($container->hasAlias('messenger.failure_transports.default')) {
+                    $failureTransportsMap[$globalReceiverName] = new Reference('messenger.failure_transports.default');
+                } else {
+                    $failureTransportsMap[$globalReceiverName] = new Reference('messenger.transport.'.$globalReceiverName);
+                }
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/symfony/symfony/pull/41545 ... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT


When trying to update symfony/messenger to 5.3 while still using symfony/framework-bundle 4.4 there is an error:

The service "console.command.messenger_failed_messages_retry" has a dependency on a non-existent service "messenger.failure_transports.default".

This is because in Symfony Messenger 5.3, on the PR https://github.com/symfony/symfony/pull/38468 to support multiple failure transports we have created an alias, that is only available on the FrameworkBundle 5.3.

This fix will use an already existence alias. 

Sample project to test this behavior: https://github.com/monteiro/PR-41553-symfony
