### PR TITLE
Add return types to JsonSerializable implementations

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -224,9 +224,6 @@ class JsonResponseTest extends TestCase
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('This error is expected');
-        if (!interface_exists(\JsonSerializable::class, false)) {
-            $this->markTestSkipped('JsonSerializable is required.');
-        }
 
         $serializable = new JsonSerializableObject();
 
@@ -280,12 +277,10 @@ class JsonResponseTest extends TestCase
     }
 }
 
-if (interface_exists(\JsonSerializable::class, false)) {
-    class JsonSerializableObject implements \JsonSerializable
+class JsonSerializableObject implements \JsonSerializable
+{
+    public function jsonSerialize(): array
     {
-        public function jsonSerialize()
-        {
-            throw new \Exception('This error is expected');
-        }
+        throw new \Exception('This error is expected');
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/JsonSerializableDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/JsonSerializableDummy.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Fixtures;
 
 class JsonSerializableDummy implements \JsonSerializable
 {
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'foo' => 'a',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #41552
| License       | MIT
| Doc PR        | N/A

PHP 8.1 will trigger a deprecation warning if we implement `JsonSerializable` without a return type. I've added return types to the two mock implementations that were affected.