### PR TITLE
[Messenger] Fix broken mock

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Tests/Transport/AmazonSqsTransportTest.php
@@ -177,6 +177,20 @@ class AmazonSqsTransportTest extends TestCase
 
     private function createHttpException(): HttpException
     {
-        return new ServerException($this->createMock(ResponseInterface::class));
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getInfo')->willReturnCallback(static function (?string $type = null) {
+            $info = [
+                'http_code' => 500,
+                'url' => 'https://symfony.com',
+            ];
+
+            if (null === $type) {
+                return $info;
+            }
+
+            return $info[$type] ?? null;
+        });
+
+        return new ServerException($response);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #41552
| License       | MIT
| Doc PR        | N/A

In reality, `$response->getInfo('http_code')` will always yield an integer, but the mock created in `AmazonSqsTransportTest` will return `null`. This causes trouble on PHP 8.1 because the status code is eventually passed as `$code` to an exception constructor that does not allow `null` values anymore.