### PR TITLE
[FrameworkBundle] Introduced new method for getting bundles config path

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate the `AdapterInterface` autowiring alias, use `CacheItemPoolInterface` instead
  * Deprecate the public `profiler` service to private
  * Deprecate `get()`, `has()`, `getDoctrine()`, and `dispatchMessage()` in `AbstractController`, use method/constructor injection instead
+ * Add `MicroKernelTrait::getBundlesPath` method to get bundles config path
 
 5.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Kernel/MicroKernelTrait.php
@@ -88,7 +88,7 @@ trait MicroKernelTrait
      */
     public function registerBundles(): iterable
     {
-        $contents = require $this->getProjectDir().'/config/bundles.php';
+        $contents = require $this->getBundlesPath();
         foreach ($contents as $class => $envs) {
             if ($envs[$this->environment] ?? $envs['all'] ?? false) {
                 yield new $class();
@@ -124,7 +124,7 @@ trait MicroKernelTrait
             $kernelDefinition->addTag('routing.route_loader');
 
             $container->addObjectResource($this);
-            $container->fileExists($this->getProjectDir().'/config/bundles.php');
+            $container->fileExists($this->getBundlesPath());
 
             try {
                 $configureContainer = new \ReflectionMethod($this, 'configureContainer');
@@ -202,5 +202,13 @@ trait MicroKernelTrait
         }
 
         return $collection;
+    }
+
+    /**
+     * Gets the path to the bundles configuration file.
+     */
+    private function getBundlesPath(): string
+    {
+        return $this->getProjectDir().'/config/bundles.php';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#15423

At the moment bundles path duplicated in MicroKernelTrait: in `registerBundles` and `registerContainerConfiguration` methods. This leads to need to override the both methods if bundles config stored by custom path (e.g. when multiple kernels used).

The new method allows override the only itself when custom path is used.