### PR TITLE
[PasswordHasher] Prevent PHP fatal error when using auto algorithm

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
@@ -116,9 +116,13 @@ class PasswordHasherFactory implements PasswordHasherFactoryInterface
         if ('auto' === $config['algorithm']) {
             // "plaintext" is not listed as any leaked hashes could then be used to authenticate directly
             if (SodiumPasswordHasher::isSupported()) {
-                $algorithms = ['native', 'sodium', 'pbkdf2', $config['hash_algorithm']];
+                $algorithms = ['native', 'sodium', 'pbkdf2'];
             } else {
-                $algorithms = ['native', 'pbkdf2', $config['hash_algorithm']];
+                $algorithms = ['native', 'pbkdf2'];
+            }
+
+            if ($config['hash_algorithm'] ?? '') {
+                $algorithms[] = $config['hash_algorithm'];
             }
 
             $hasherChain = [];

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/PasswordHasherFactoryTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/PasswordHasherFactoryTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherAwareInterface;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactory;
 use Symfony\Component\PasswordHasher\Hasher\SodiumPasswordHasher;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 use Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -83,6 +84,16 @@ class PasswordHasherFactoryTest extends TestCase
         $hasher = $factory->getPasswordHasher(SomeChildUser::class);
         $expectedHasher = new MessageDigestPasswordHasher('sha1');
         $this->assertEquals($expectedHasher->hash('foo', ''), $hasher->hash('foo', ''));
+    }
+
+    public function testGetHasherConfiguredWithAuto()
+    {
+        $factory = new PasswordHasherFactory([
+            'auto' => ['algorithm' => 'auto'],
+        ]);
+
+        $hasher = $factory->getPasswordHasher('auto');
+        $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
     }
 
     public function testGetNamedHasherForHasherAware()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #41571
| License       | MIT
| Doc PR        | N/A

Fixes a PHP fatal error that occurs when using the auto algorithm of the PasswordHasher in a standalone project.