### PR TITLE
Fix: when@env with services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/when-env-services.yaml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/when-env-services.yaml
@@ -1,0 +1,13 @@
+when@some-env:
+    services:
+        foo_service:
+            class: FooClass
+
+when@some-other-env:
+    services:
+        foo_service:
+            class: BarClass
+
+services:
+    foo_service:
+        class: BazClass

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -1035,12 +1035,21 @@ class YamlFileLoaderTest extends TestCase
         $this->assertEquals($expected, $container->get('stack_e'));
     }
 
-    public function testWhenEnv()
+    public function testWhenEnvWithParameters()
     {
         $container = new ContainerBuilder();
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'), 'some-env');
         $loader->load('when-env.yaml');
 
         $this->assertSame(['foo' => 234, 'bar' => 345], $container->getParameterBag()->all());
+    }
+
+    public function testWhenEnvWithServices()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'), 'some-env');
+        $loader->load('when-env-services.yaml');
+        $services = $container->getDefinitions();
+        $this->assertEquals('FooClass', $services['foo_service']->getClass());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

In the [blogpost](https://symfony.com/blog/new-in-symfony-5-3-configure-multiple-environments-in-a-single-file) we mention, that the following code is working:
```yaml
# config/services.yaml

when@dev:
    services:
        App\SomeServiceForDev: ~
```

In my project i get the following error message:
> The configuration key "services" is unsupported for definition "when@prod" in "/Users/oskar.stark/dev//config/services.yaml". Allowed configuration keys are "alias", "parent", "class", "shared", "synthetic", "lazy", "public", "abstract", "deprecated", "factory", "file", "arguments", "properties", "configurator", "calls", "tags", "decorates", "decoration_inner_name", "decoration_priority", "decoration_on_invalid", "autowire", "autoconfigure", "bind" in /Users/oskar.stark/dev//config/services.yaml (which is being imported from "/Users/oskar.stark/dev/src/Kernel.php").

This PR adds another testphase for the `services` key.