### PR TITLE
Add missing translations for Swedish

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.sv.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.sv.xlf
@@ -70,6 +70,14 @@
                 <source>Invalid or expired login link.</source>
                 <target>Ogiltig eller utgången inloggningslänk.</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+                <target>För många misslyckade inloggningsförsök, försök igen om %minutes% minut.</target>
+            </trans-unit>
+            <trans-unit id="20">
+                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+                <target>För många misslyckade inloggningsförsök, försök igen om %minutes% minuter.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41483
| License       | MIT

Add missing Swedish translations to Security component.