### PR TITLE
[DependencyInjection] fix `when@{env}` inside imported files

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -51,19 +51,19 @@ class XmlFileLoader extends FileLoader
 
         $this->container->fileExists($path);
 
-        $env = $this->env;
-        $this->env = null;
-        try {
-            $this->loadXml($xml, $path);
-        } finally {
-            $this->env = $env;
-        }
+        $this->loadXml($xml, $path);
 
         if ($this->env) {
             $xpath = new \DOMXPath($xml);
             $xpath->registerNamespace('container', self::NS);
             foreach ($xpath->query(sprintf('//container:when[@env="%s"]', $this->env)) ?: [] as $root) {
-                $this->loadXml($xml, $path, $root);
+                $env = $this->env;
+                $this->env = null;
+                try {
+                    $this->loadXml($xml, $path, $root);
+                } finally {
+                    $this->env = $env;
+                }
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -130,13 +130,7 @@ class YamlFileLoader extends FileLoader
             return;
         }
 
-        $env = $this->env;
-        $this->env = null;
-        try {
-            $this->loadContent($content, $path);
-        } finally {
-            $this->env = $env;
-        }
+        $this->loadContent($content, $path);
 
         // per-env configuration
         if ($this->env && isset($content['when@'.$this->env])) {
@@ -144,7 +138,13 @@ class YamlFileLoader extends FileLoader
                 throw new InvalidArgumentException(sprintf('The "when@%s" key should contain an array in "%s". Check your YAML syntax.', $this->env, $path));
             }
 
-            $this->loadContent($content['when@'.$this->env], $path);
+            $env = $this->env;
+            $this->env = null;
+            try {
+                $this->loadContent($content['when@'.$env], $path);
+            } finally {
+                $this->env = $env;
+            }
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services29.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services29.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+    <imports>
+        <import resource="services30.xml"/>
+    </imports>
+
+    <parameters>
+        <parameter key="root_parameter">default value</parameter>
+    </parameters>
+
+    <when env="dev">
+        <parameters>
+            <parameter key="root_parameter">value when on dev</parameter>
+        </parameters>
+    </when>
+
+    <when env="test">
+        <parameters>
+            <parameter key="root_parameter">value when on test</parameter>
+        </parameters>
+    </when>
+
+    <when env="prod">
+        <parameters>
+            <parameter key="root_parameter">value when on prod</parameter>
+        </parameters>
+    </when>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services30.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services30.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+    <parameters>
+        <parameter key="imported_parameter">default value</parameter>
+    </parameters>
+
+    <when env="dev">
+        <parameters>
+            <parameter key="imported_parameter">value when on dev</parameter>
+        </parameters>
+    </when>
+
+    <when env="test">
+        <parameters>
+            <parameter key="imported_parameter">value when on test</parameter>
+        </parameters>
+    </when>
+
+    <when env="prod">
+        <parameters>
+            <parameter key="imported_parameter">value when on prod</parameter>
+        </parameters>
+    </when>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services29.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services29.yml
@@ -1,0 +1,17 @@
+imports:
+    - { resource: services30.yml }
+
+parameters:
+    root_parameter: 'default value'
+
+when@dev:
+    parameters:
+        root_parameter: 'value when on dev'
+
+when@test:
+    parameters:
+        root_parameter: 'value when on test'
+
+when@prod:
+    parameters:
+        root_parameter: 'value when on prod'

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services30.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services30.yml
@@ -1,0 +1,14 @@
+parameters:
+    imported_parameter: 'default value'
+
+when@dev:
+    parameters:
+        imported_parameter: 'value when on dev'
+
+when@test:
+    parameters:
+        imported_parameter: 'value when on test'
+
+when@prod:
+    parameters:
+        imported_parameter: 'value when on prod'

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -231,6 +231,43 @@ class XmlFileLoaderTest extends TestCase
         }
     }
 
+    public function testLoadWithEnvironment()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'), 'dev');
+        $loader->load('services29.xml');
+
+        self::assertSame([
+            'imported_parameter' => 'value when on dev',
+            'root_parameter' => 'value when on dev',
+        ], $container->getParameterBag()->all());
+
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'), 'test');
+        $loader->load('services29.xml');
+
+        self::assertSame([
+            'imported_parameter' => 'value when on test',
+            'root_parameter' => 'value when on test',
+        ], $container->getParameterBag()->all());
+
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'), 'prod');
+        $loader->load('services29.xml');
+
+        self::assertSame([
+            'imported_parameter' => 'value when on prod',
+            'root_parameter' => 'value when on prod',
+        ], $container->getParameterBag()->all());
+
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'), 'other');
+        $loader->load('services29.xml');
+
+        self::assertSame([
+            'imported_parameter' => 'default value',
+            'root_parameter' => 'default value',
+        ], $container->getParameterBag()->all());
+    }
+
     public function testLoadAnonymousServices()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -172,6 +172,43 @@ class YamlFileLoaderTest extends TestCase
         }
     }
 
+    public function testLoadWithEnvironment()
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'), 'dev');
+        $loader->load('services29.yml');
+
+        self::assertSame([
+            'imported_parameter' => 'value when on dev',
+            'root_parameter' => 'value when on dev',
+        ], $container->getParameterBag()->all());
+
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'), 'test');
+        $loader->load('services29.yml');
+
+        self::assertSame([
+            'imported_parameter' => 'value when on test',
+            'root_parameter' => 'value when on test',
+        ], $container->getParameterBag()->all());
+
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'), 'prod');
+        $loader->load('services29.yml');
+
+        self::assertSame([
+            'imported_parameter' => 'value when on prod',
+            'root_parameter' => 'value when on prod',
+        ], $container->getParameterBag()->all());
+
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'), 'other');
+        $loader->load('services29.yml');
+
+        self::assertSame([
+            'imported_parameter' => 'default value',
+            'root_parameter' => 'default value',
+        ], $container->getParameterBag()->all());
+    }
+
     public function testLoadServices()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| Tickets       | Fix #41584
| License       | MIT

This PR enables users to use the `when@{environment}` in imported files. I found that the env was explicitly unset when loading the file (including its imports) which resulted in the environment not being set when processing the imports.

See https://github.com/nusje2000/symfony-41584-reproducer for a reproduction of the problem.