### PR TITLE
[Notifier] Escape `.` char for Telegram transport

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/TelegramTransport.php
@@ -79,8 +79,9 @@ final class TelegramTransport extends AbstractTransport
 
         $options['text'] = $message->getSubject();
 
-        if (!isset($options['parse_mode'])) {
+        if (!isset($options['parse_mode']) || TelegramOptions::PARSE_MODE_MARKDOWN_V2 === $options['parse_mode']) {
             $options['parse_mode'] = TelegramOptions::PARSE_MODE_MARKDOWN_V2;
+            $options['text'] = str_replace('.', '\.', $message->getSubject());
         }
 
         $response = $this->client->request('POST', $endpoint, [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Hello, 

The MarkdownV2 parse mode of Telegram has the '.' char as a reserved char when sending a message.
It should be escaped but only on this mode because it is not reserved on the others.

Link to the original report in the documentation : https://github.com/symfony/symfony-docs/pull/15420

I tried writing a test but couldn't reproduce the error, it does work on a small project however.

This is my first PR on Sf, hope I did it correctly.

Cheers
