### PR TITLE
[Runtime] Possibility to define the env and/or debug key

### DIFF
--- a/src/Symfony/Component/Runtime/CHANGELOG.md
+++ b/src/Symfony/Component/Runtime/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * The component is not experimental anymore
+ * Add options "env_var_names" to `GenericRuntime` and `SymfonyRuntime`
 
 5.3.0
 -----

--- a/src/Symfony/Component/Runtime/Tests/phpt/.env
+++ b/src/Symfony/Component/Runtime/Tests/phpt/.env
@@ -1,1 +1,3 @@
 SOME_VAR=foo_bar
+ENV_MODE=foo
+DEBUG_MODE=0

--- a/src/Symfony/Component/Runtime/Tests/phpt/autoload.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/autoload.php
@@ -4,7 +4,7 @@ use Symfony\Component\Runtime\SymfonyRuntime;
 
 $_SERVER['APP_RUNTIME_OPTIONS'] = [
     'project_dir' => __DIR__,
-];
+] + ($_SERVER['APP_RUNTIME_OPTIONS'] ?? []);
 
 if (file_exists(dirname(__DIR__, 2).'/vendor/autoload.php')) {
     if (true === (require_once dirname(__DIR__, 2).'/vendor/autoload.php') || empty($_SERVER['SCRIPT_FILENAME'])) {

--- a/src/Symfony/Component/Runtime/Tests/phpt/runtime-options.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/runtime-options.php
@@ -1,0 +1,13 @@
+<?php
+
+$_SERVER['APP_RUNTIME_OPTIONS'] = [
+    'env_var_names' => [
+        'env_key' => 'ENV_MODE',
+        'debug_key' => 'DEBUG_MODE',
+    ],
+];
+require __DIR__.'/autoload.php';
+
+return function (array $context): void {
+    echo 'Env mode ', $context['ENV_MODE'], ', debug mode ', $context['DEBUG_MODE'];
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/runtime-options.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/runtime-options.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Options
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/runtime-options.php';
+
+?>
+--EXPECTF--
+Env mode foo, debug mode 0


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As the `Dotenv` class allows to choose the `envKey` and the `debugKey`, it could be interesting to be able to modify it also via the Runtime component.

Example : 
```
$_SERVER['APP_RUNTIME_OPTIONS'] = [
    'env_var_names' => [
        'env_key' => 'ENV_MODE',
        'debug_key' => 'DEBUG_MODE',
    ],
];
```