### PR TITLE
[Mime] Fix CSV file mime type guess test for PHP 8.1

### DIFF
--- a/src/Symfony/Component/Mime/Tests/MimeTypesTest.php
+++ b/src/Symfony/Component/Mime/Tests/MimeTypesTest.php
@@ -75,7 +75,12 @@ class MimeTypesTest extends AbstractMimeTypeGuesserTest
     }
 
     /**
-     * PHP 8 detects .csv files as "application/csv" while PHP 7 returns "text/plain".
+     * PHP 8 detects .csv files as "application/csv" (or "text/csv", depending
+     * on your system) while PHP 7 returns "text/plain".
+     *
+     * "text/csv" is described by RFC 7111.
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc7111
      *
      * @requires PHP 8
      */
@@ -84,7 +89,7 @@ class MimeTypesTest extends AbstractMimeTypeGuesserTest
         $mt = new MimeTypes();
 
         $mime = $mt->guessMimeType(__DIR__.'/Fixtures/mimetypes/abc.csv');
-        $this->assertSame('application/csv', $mime);
+        $this->assertContains($mime, ['application/csv', 'text/csv']);
         $this->assertSame(['csv'], $mt->getExtensions($mime));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Part of #41552 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A

I had the same result as @derrabus on my computer: `application/csv`. The CI returns `text/csv`. These two seem possible, although `text/csv` is described in [RFC 7111](https://datatracker.ietf.org/doc/html/rfc7111#page-3).

(Oops little typo in title, thanks Alexander for the fix :pray: )