### PR TITLE
[Serializer] Add option to skip uninitialized typed properties

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/SkipUninitializedValuesTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/SkipUninitializedValuesTestTrait.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
+
+use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Test AbstractObjectNormalizer::SKIP_UNINITIALIZED_VALUES.
+ */
+trait SkipUninitializedValuesTestTrait
+{
+    abstract protected function getNormalizerForSkipUninitializedValues(): NormalizerInterface;
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testSkipUninitializedValues()
+    {
+        $object = new TypedPropertiesObject();
+
+        $normalizer = $this->getNormalizerForSkipUninitializedValues();
+        $result = $normalizer->normalize($object, null, ['skip_uninitialized_values' => true, 'groups' => ['foo']]);
+        $this->assertSame(['initialized' => 'value'], $result);
+    }
+
+    /**
+     * @requires PHP 7.4
+     */
+    public function testWithoutSkipUninitializedValues()
+    {
+        $object = new TypedPropertiesObject();
+
+        $normalizer = $this->getNormalizerForSkipUninitializedValues();
+        $this->expectException(UninitializedPropertyException::class);
+        $normalizer->normalize($object, null, ['groups' => ['foo']]);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/TypedPropertiesObject.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/TypedPropertiesObject.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+
+class TypedPropertiesObject
+{
+    /**
+     * @Groups({"foo"})
+     */
+    public string $unInitialized;
+
+    /**
+     * @Groups({"foo"})
+     */
+    public string $initialized = 'value';
+
+    /**
+     * @Groups({"bar"})
+     */
+    public string $initialized2 = 'value';
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -49,6 +49,7 @@ use Symfony\Component\Serializer\Tests\Normalizer\Features\MaxDepthTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\ObjectDummy;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\ObjectToPopulateTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\SkipNullValuesTestTrait;
+use Symfony\Component\Serializer\Tests\Normalizer\Features\SkipUninitializedValuesTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\TypeEnforcementTestTrait;
 
 /**
@@ -66,6 +67,7 @@ class ObjectNormalizerTest extends TestCase
     use MaxDepthTestTrait;
     use ObjectToPopulateTestTrait;
     use SkipNullValuesTestTrait;
+    use SkipUninitializedValuesTestTrait;
     use TypeEnforcementTestTrait;
 
     /**
@@ -532,6 +534,15 @@ class ObjectNormalizerTest extends TestCase
     protected function getNormalizerForSkipNullValues(): ObjectNormalizer
     {
         return new ObjectNormalizer();
+    }
+
+    // skip uninitialized
+
+    protected function getNormalizerForSkipUninitializedValues(): ObjectNormalizer
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+
+        return new ObjectNormalizer($classMetadataFactory);
     }
 
     // type enforcement

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -33,7 +33,7 @@
         "symfony/http-foundation": "^4.4|^5.0|^6.0",
         "symfony/http-kernel": "^4.4|^5.0|^6.0",
         "symfony/mime": "^4.4|^5.0|^6.0",
-        "symfony/property-access": "^4.4.9|^5.0.9|^6.0",
+        "symfony/property-access": "^5.1|^6.0",
         "symfony/property-info": "^5.3|^6.0",
         "symfony/uid": "^5.1|^6.0",
         "symfony/validator": "^4.4|^5.0|^6.0",
@@ -46,7 +46,7 @@
         "phpdocumentor/reflection-docblock": "<3.2.2",
         "phpdocumentor/type-resolver": "<1.4.0",
         "symfony/dependency-injection": "<4.4",
-        "symfony/property-access": "<4.4",
+        "symfony/property-access": "<5.1",
         "symfony/property-info": "<5.3",
         "symfony/yaml": "<4.4"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #40578
| License       | MIT

Adds the ability to skip uninitialized values from Serializer. This is useful when using typed properties in 7.4 and those without default values should not be included in the result.
This works correctly when we're not using serializer groups, but when using the groups - it breaks badly, so it's also kind of a fix in addition to feature.
