### PR TITLE
[Messenger] Remove TLS related options when not using TLS

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/ConnectionTest.php
@@ -748,6 +748,27 @@ class ConnectionTest extends TestCase
         $connection = Connection::fromDsn('amqp://localhost?confirm_timeout=0.5', [], $factory);
         $connection->publish('body');
     }
+
+    public function testItCanBeConstructedWithTLSOptionsAndNonTLSDsn()
+    {
+        $this->assertEquals(
+            new Connection([
+                'host' => 'localhost',
+                'port' => 5672,
+                'vhost' => '/',
+            ], [
+                'name' => self::DEFAULT_EXCHANGE_NAME,
+            ], [
+                self::DEFAULT_EXCHANGE_NAME => [],
+            ]),
+            Connection::fromDsn('amqp://', [
+                'cacert' => 'foobar',
+                'cert' => 'foobar',
+                'key' => 'foobar',
+                'verify' => false,
+            ])
+        );
+    }
 }
 
 class TestAmqpFactory extends AmqpFactory

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -219,6 +219,10 @@ class Connection
             return $queueOptions;
         }, $queuesOptions);
 
+        if (!$useAmqps) {
+            unset($amqpOptions['cacert'], $amqpOptions['cert'], $amqpOptions['key'], $amqpOptions['verify']);
+        }
+
         if ($useAmqps && !self::hasCaCertConfigured($amqpOptions)) {
             throw new InvalidArgumentException('No CA certificate has been provided. Set "amqp.cacert" in your php.ini or pass the "cacert" parameter in the DSN to use SSL. Alternatively, you can use amqp:// to use without SSL.');
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | not really
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Remove TLS related options when not using TLS to connect to a broker.

The goal is to be able to use the same configuration for both `amqp://` & `amqps://` DSN.

Currently, when using a configuration containing a `cacert` key with a non-TLS DSN will throw a `AMQPConnectionException` (Socket error: could not connect to host.)

Configuration example:
```yaml
framework:
    messenger:
        transports:
            async:
              dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
              options:
                cacert: '%kernel.project_dir%/amqp_cacert.pem'
```