### PR TITLE
[HttpClient] Remove obsolete handling of curl resources

### DIFF
--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -331,7 +331,7 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             throw new \TypeError(sprintf('"%s()" expects parameter 1 to be an iterable of CurlResponse objects, "%s" given.', __METHOD__, get_debug_type($responses)));
         }
 
-        if (\is_resource($this->multi->handle) || $this->multi->handle instanceof \CurlMultiHandle) {
+        if ($this->multi->handle instanceof \CurlMultiHandle) {
             $active = 0;
             while (\CURLM_CALL_MULTI_PERFORM === curl_multi_exec($this->multi->handle, $active));
         }

--- a/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
+++ b/src/Symfony/Component/HttpClient/Internal/CurlClientState.php
@@ -22,7 +22,7 @@ use Psr\Log\LoggerInterface;
  */
 final class CurlClientState extends ClientState
 {
-    /** @var \CurlMultiHandle|resource */
+    /** @var \CurlMultiHandle */
     public $handle;
     /** @var PushedResponse[] */
     public $pushedResponses = [];
@@ -52,7 +52,7 @@ final class CurlClientState extends ClientState
         $this->dnsCache->evictions = $this->dnsCache->evictions ?: $this->dnsCache->removals;
         $this->dnsCache->removals = $this->dnsCache->hostnames = [];
 
-        if (\is_resource($this->handle) || $this->handle instanceof \CurlMultiHandle) {
+        if ($this->handle instanceof \CurlMultiHandle) {
             if (\defined('CURLMOPT_PUSHFUNCTION')) {
                 curl_multi_setopt($this->handle, \CURLMOPT_PUSHFUNCTION, null);
             }
@@ -62,7 +62,7 @@ final class CurlClientState extends ClientState
         }
 
         foreach ($this->openHandles as [$ch]) {
-            if (\is_resource($ch) || $ch instanceof \CurlHandle) {
+            if ($ch instanceof \CurlHandle) {
                 curl_setopt($ch, \CURLOPT_VERBOSE, false);
             }
         }

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -37,15 +37,13 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
     private $debugBuffer;
 
     /**
-     * @param \CurlHandle|resource|string $ch
-     *
      * @internal
      */
-    public function __construct(CurlClientState $multi, $ch, array $options = null, LoggerInterface $logger = null, string $method = 'GET', callable $resolveRedirect = null, int $curlVersion = null)
+    public function __construct(CurlClientState $multi, \CurlHandle|string $ch, array $options = null, LoggerInterface $logger = null, string $method = 'GET', callable $resolveRedirect = null, int $curlVersion = null)
     {
         $this->multi = $multi;
 
-        if (\is_resource($ch) || $ch instanceof \CurlHandle) {
+        if ($ch instanceof \CurlHandle) {
             $this->handle = $ch;
             $this->debugBuffer = fopen('php://temp', 'w+');
             if (0x074000 === $curlVersion) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

On PHP 8, the cURL extension does not operate on resources anymore. Instead, handles are now instances of `CurlHandle` or `CurlMultiHandle`. Because of that, we can remove code related to cURL handles being resources on 6.0.