### PR TITLE
[Process] Fix incorrect parameter type

### DIFF
--- a/src/Symfony/Component/Process/Pipes/WindowsPipes.php
+++ b/src/Symfony/Component/Process/Pipes/WindowsPipes.php
@@ -71,7 +71,7 @@ class WindowsPipes extends AbstractPipes
                     }
                     $this->lockHandles[$pipe] = $h;
 
-                    if (!fclose(fopen($file, 'w')) || !$h = fopen($file, 'r')) {
+                    if (!($h = fopen($file, 'w')) || !fclose($h) || !$h = fopen($file, 'r')) {
                         flock($this->lockHandles[$pipe], \LOCK_UN);
                         fclose($this->lockHandles[$pipe]);
                         unset($this->lockHandles[$pipe]);


### PR DESCRIPTION
In the affected line of code, fclose() should ONLY be passed a parameter of type resource, but fopen() can return a value of type bool (if the fopen() fails). This results in a fatal error under PHP 8: Fatal error: Uncaught TypeError: fclose(): Argument #1 ($stream) must be of type resource, bool given.

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

