### PR TITLE
[VarExporter] Fix test on PHP 8.1

### DIFF
--- a/src/Symfony/Component/VarExporter/Tests/InstantiatorTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/InstantiatorTest.php
@@ -55,7 +55,10 @@ class InstantiatorTest extends TestCase
             "\0".__NAMESPACE__."\Foo\0priv" => 234,
         ];
 
-        $this->assertSame($expected, (array) Instantiator::instantiate(Bar::class, ['priv' => 123], [Foo::class => ['priv' => 234]]));
+        $actual = (array) Instantiator::instantiate(Bar::class, ['priv' => 123], [Foo::class => ['priv' => 234]]);
+        ksort($actual);
+
+        $this->assertSame($expected, $actual);
 
         $e = Instantiator::instantiate('Exception', ['foo' => 123, 'trace' => [234]]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #41552
| License       | MIT
| Doc PR        | N/A

On PHP 8.1, when dumping the properties of an object (either through serialization, `var_dump` or an array cast), those properties might appear in a different order than on PHP 8.0 and earlier.

Because of that, the test I'm fixing here fails. Since the order of the properties is not really important, I'm sorting the dumped array by key in order to get a stable order.