### PR TITLE
[HttpFoundation] fix 'Request::create' on IIS

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -420,12 +420,12 @@ class Request
 
         $server['REQUEST_URI'] = $components['path'].('' !== $queryString ? '?'.$queryString : '');
         $server['QUERY_STRING'] = $queryString;
-        
+
         if (isset($server['IIS_WasUrlRewritten']) && '1' == $server['IIS_WasUrlRewritten']
             && isset($server['UNENCODED_URL']) && !empty($server['UNENCODED_URL'])) {
             $server['UNENCODED_URL'] = $server['REQUEST_URI'];
         }
-        
+
         return self::createRequestFromFactory($query, $request, [], $cookies, $files, $server, $content);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -420,7 +420,11 @@ class Request
 
         $server['REQUEST_URI'] = $components['path'].('' !== $queryString ? '?'.$queryString : '');
         $server['QUERY_STRING'] = $queryString;
-
+        
+        if(isset($server['IIS_WasUrlRewritten']) && '1' == $server['IIS_WasUrlRewritten']
+            && isset($server['UNENCODED_URL']) && !empty($server['UNENCODED_URL'])){
+            $server['UNENCODED_URL'] = $server['REQUEST_URI'];
+        }
         return self::createRequestFromFactory($query, $request, [], $cookies, $files, $server, $content);
     }
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -421,10 +421,11 @@ class Request
         $server['REQUEST_URI'] = $components['path'].('' !== $queryString ? '?'.$queryString : '');
         $server['QUERY_STRING'] = $queryString;
         
-        if(isset($server['IIS_WasUrlRewritten']) && '1' == $server['IIS_WasUrlRewritten']
-            && isset($server['UNENCODED_URL']) && !empty($server['UNENCODED_URL'])){
+        if (isset($server['IIS_WasUrlRewritten']) && '1' == $server['IIS_WasUrlRewritten']
+            && isset($server['UNENCODED_URL']) && !empty($server['UNENCODED_URL'])) {
             $server['UNENCODED_URL'] = $server['REQUEST_URI'];
         }
+        
         return self::createRequestFromFactory($query, $request, [], $cookies, $files, $server, $content);
     }
 


### PR DESCRIPTION
Request::create('/demo/bob', 'GET', [], $_COOKIE, [], $_SERVER)
When the web server is IIS,  this method will set value of $_SERVER['REQUEST_URI'] to '/demo/bob', but keep $_SERVER['UNENCODED_URL'] unchanged.
But mehod 'prepareRequestUri' will check the value of $_SERVER['UNENCODED_URL'] and will use the value of origin request.

| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT