### PR TITLE
[Validator] Fix tests by making constraint options dumps order consistent

### DIFF
--- a/src/Symfony/Component/Validator/Command/DebugCommand.php
+++ b/src/Symfony/Component/Validator/Command/DebugCommand.php
@@ -165,6 +165,8 @@ EOF
             $options[$propertyName] = $constraint->$propertyName;
         }
 
+        ksort($options);
+
         return $options;
     }
 

--- a/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Validator/Tests/Command/DebugCommandTest.php
@@ -72,8 +72,8 @@ Symfony\Component\Validator\Tests\Dummy\DummyClassOne
 | Property      | Name                                             | Groups  | Options                                                    |
 +---------------+--------------------------------------------------+---------+------------------------------------------------------------+
 | firstArgument | Symfony\Component\Validator\Constraints\NotBlank | Default | [                                                          |
-|               |                                                  |         |   "message" => "This value should not be blank.",          |
 |               |                                                  |         |   "allowNull" => false,                                    |
+|               |                                                  |         |   "message" => "This value should not be blank.",          |
 |               |                                                  |         |   "normalizer" => null,                                    |
 |               |                                                  |         |   "payload" => null                                        |
 |               |                                                  |         | ]                                                          |
@@ -133,8 +133,8 @@ Symfony\Component\Validator\Tests\Dummy\DummyClassOne
 | Property      | Name                                             | Groups  | Options                                                    |
 +---------------+--------------------------------------------------+---------+------------------------------------------------------------+
 | firstArgument | Symfony\Component\Validator\Constraints\NotBlank | Default | [                                                          |
-|               |                                                  |         |   "message" => "This value should not be blank.",          |
 |               |                                                  |         |   "allowNull" => false,                                    |
+|               |                                                  |         |   "message" => "This value should not be blank.",          |
 |               |                                                  |         |   "normalizer" => null,                                    |
 |               |                                                  |         |   "payload" => null                                        |
 |               |                                                  |         | ]                                                          |
@@ -153,8 +153,8 @@ Symfony\Component\Validator\Tests\Dummy\DummyClassTwo
 | Property      | Name                                             | Groups  | Options                                                    |
 +---------------+--------------------------------------------------+---------+------------------------------------------------------------+
 | firstArgument | Symfony\Component\Validator\Constraints\NotBlank | Default | [                                                          |
-|               |                                                  |         |   "message" => "This value should not be blank.",          |
 |               |                                                  |         |   "allowNull" => false,                                    |
+|               |                                                  |         |   "message" => "This value should not be blank.",          |
 |               |                                                  |         |   "normalizer" => null,                                    |
 |               |                                                  |         |   "payload" => null                                        |
 |               |                                                  |         | ]                                                          |


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #41552
| License       | MIT
| Doc PR        | N/A