### PR TITLE
[PasswordHasher] Use sodium as "best" hasher if with algorithm=auto

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/PasswordHasherFactory.php
@@ -116,7 +116,7 @@ class PasswordHasherFactory implements PasswordHasherFactoryInterface
         if ('auto' === $config['algorithm']) {
             // "plaintext" is not listed as any leaked hashes could then be used to authenticate directly
             if (SodiumPasswordHasher::isSupported()) {
-                $algorithms = ['native', 'sodium', 'pbkdf2'];
+                $algorithms = ['sodium', 'native', 'pbkdf2'];
             } else {
                 $algorithms = ['native', 'pbkdf2'];
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

According to [the docs](https://symfony.com/doc/current/reference/configuration/security.html#using-the-auto-password-hasher), setting `password_hashers.xxx.algorithm=auto` should prefer Sodium to native (bcrypt) if available: 

> it tries to use Sodium by default and falls back to the bcrypt password hashing function if not possible. 

But this is not what's actually happening. New passwords are hashed with bcrypt (`$2y$`) instead of Argon2ID (`$argon2id$`). The `MigratingPasswordHasher` gets an instance of `NativePasswordHasher` instead of `SodiumPasswordHasher` as first parameter (`$bestHasher`). 

I think this is a simple mixup and the fix seems easy enough. 

But I haven't found a good way to write a test for it: 
* I can't get the "best hasher" out of the `MigratingPasswordHasher`to run an assertion on it
* `PasswordHasherFactory::getHasherConfigFromAlgorithm` is private, otherwise I could simply test its output

I'm open for ideas. Or can we merge the fix without a test?