### PR TITLE
[FrameworkBundle] Make AbstractDataCollector extend DataCollector to reduce boilerplate

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DataCollector/AbstractDataCollector.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DataCollector/AbstractDataCollector.php
@@ -11,16 +11,13 @@
 
 namespace Symfony\Bundle\FrameworkBundle\DataCollector;
 
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+
 /**
  * @author Laurent VOULLEMIER <laurent.voullemier@gmail.com>
  */
-abstract class AbstractDataCollector implements TemplateAwareDataCollectorInterface
+abstract class AbstractDataCollector extends DataCollector implements TemplateAwareDataCollectorInterface
 {
-    /**
-     * @var array
-     */
-    protected $data = [];
-
     public function getName(): string
     {
         return static::class;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  |  no
| Deprecations? | no
| Tickets       | Partially fixes #41577 (part 1)
| License       | MIT

This PR makes `AbstractDataCollector` extend the base `DataCollector` in order to make it even easier to create the data collectors. Currently, developers must implement `__sleep()`, `__wakeup()`, `cloneVar()` etc on their own if they want to use `AbstractDataCollector` instead of the good old `DataCollector` which makes the "boilerplate" even bigger than just adding the `getName()`, `reset()` and `getTemplate()`, making this class less useful than the old one.
