### PR TITLE
[Mailer] fix encoding of addresses using SmtpTransport

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/Smtp/SmtpTransportTest.php
@@ -114,6 +114,25 @@ class SmtpTransportTest extends TestCase
         $this->assertNotContains("\r\n.\r\n", $stream->getCommands());
         $this->assertTrue($stream->isClosed());
     }
+
+    public function testWriteEncodedRecipientAndSenderAddresses()
+    {
+        $stream = new DummyStream();
+
+        $transport = new SmtpTransport($stream);
+
+        $message = new Email();
+        $message->from('sender@exämple.org');
+        $message->addTo('recipient@exämple.org');
+        $message->addTo('recipient2@example.org');
+        $message->text('.');
+
+        $transport->send($message);
+
+        $this->assertContains("MAIL FROM:<sender@xn--exmple-cua.org>\r\n", $stream->getCommands());
+        $this->assertContains("RCPT TO:<recipient@xn--exmple-cua.org>\r\n", $stream->getCommands());
+        $this->assertContains("RCPT TO:<recipient2@example.org>\r\n", $stream->getCommands());
+    }
 }
 
 class DummyStream extends AbstractStream

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -194,9 +194,9 @@ class SmtpTransport extends AbstractTransport
 
         try {
             $envelope = $message->getEnvelope();
-            $this->doMailFromCommand($envelope->getSender()->getAddress());
+            $this->doMailFromCommand($envelope->getSender()->getEncodedAddress());
             foreach ($envelope->getRecipients() as $recipient) {
-                $this->doRcptToCommand($recipient->getAddress());
+                $this->doRcptToCommand($recipient->getEncodedAddress());
             }
 
             $this->executeCommand("DATA\r\n", [354]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  |no
| Deprecations? | no
| Tickets       | Fix #41651
| License       | MIT
| Doc PR        | -

This fixes https://github.com/symfony/symfony/issues/41651 by using the same IDN encoding logic that was also used on SwiftMailer.

also see https://github.com/swiftmailer/swiftmailer/blob/master/tests/unit/Swift/Transport/AbstractSmtpTest.php#L430