### PR TITLE
[HttpClient] throw exception when AsyncDecoratorTrait gets an already consumed response

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AsyncResponse.php
@@ -31,12 +31,15 @@ final class AsyncResponse implements ResponseInterface, StreamableInterface
 {
     use CommonResponseTrait;
 
+    private const FIRST_CHUNK_YIELDED = 1;
+    private const LAST_CHUNK_YIELDED = 2;
+
     private $client;
     private $response;
     private $info = ['canceled' => false];
     private $passthru;
     private $stream;
-    private $lastYielded = false;
+    private $yieldedState;
 
     /**
      * @param ?callable(ChunkInterface, AsyncContext): ?\Iterator $passthru
@@ -272,6 +275,14 @@ final class AsyncResponse implements ResponseInterface, StreamableInterface
                     continue;
                 }
 
+                if (null !== $chunk->getError()) {
+                    // no-op
+                } elseif ($chunk->isFirst()) {
+                    $r->yieldedState = self::FIRST_CHUNK_YIELDED;
+                } elseif (self::FIRST_CHUNK_YIELDED !== $r->yieldedState && null === $chunk->getInformationalStatus()) {
+                    throw new \LogicException(sprintf('Instance of "%s" is already consumed and cannot be managed by "%s". A decorated client should not call any of the response\'s methods in its "request()" method.', get_debug_type($response), $class ?? static::class));
+                }
+
                 foreach (self::passthru($r->client, $r, $chunk, $asyncMap) as $chunk) {
                     yield $r => $chunk;
                 }
@@ -282,9 +293,9 @@ final class AsyncResponse implements ResponseInterface, StreamableInterface
             }
 
             if (null === $chunk->getError() && $chunk->isLast()) {
-                $r->lastYielded = true;
+                $r->yieldedState = self::LAST_CHUNK_YIELDED;
             }
-            if (null === $chunk->getError() && !$r->lastYielded && $r->response === $response && null !== $r->client) {
+            if (null === $chunk->getError() && self::LAST_CHUNK_YIELDED !== $r->yieldedState && $r->response === $response && null !== $r->client) {
                 throw new \LogicException('A chunk passthru must yield an "isLast()" chunk before ending a stream.');
             }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40639
| License       | MIT
| Doc PR        | -