### PR TITLE
[Serializer] Fix call to `expectExceptionMessage()`

### DIFF
--- a/src/Symfony/Component/Serializer/Tests/Normalizer/UidNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/UidNormalizerTest.php
@@ -162,7 +162,7 @@ class UidNormalizerTest extends TestCase
     public function testNormalizeWithNormalizationFormatNotValid()
     {
         $this->expectException(LogicException::class);
-        $this->expectDeprecationMessage('The "ccc" format is not valid.');
+        $this->expectExceptionMessage('The "ccc" format is not valid.');
 
         $this->normalizer->normalize(new Ulid(), null, [
             'uid_normalization_format' => 'ccc',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Follows #39675