### PR TITLE
[DependencyInjection] Support psr/container v2 in contracts

### DIFF
--- a/src/Symfony/Contracts/Service/ServiceLocatorTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceLocatorTrait.php
@@ -40,10 +40,8 @@ trait ServiceLocatorTrait
 
     /**
      * {@inheritdoc}
-     *
-     * @return bool
      */
-    public function has(string $id)
+    public function has(string $id): bool
     {
         return isset($this->factories[$id]);
     }

--- a/src/Symfony/Contracts/Service/composer.json
+++ b/src/Symfony/Contracts/Service/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "psr/container": "^1.1"
+        "psr/container": "^1.1|^2.0"
     },
     "conflict": {
         "ext-psr": "<1.1|>=2"

--- a/src/Symfony/Contracts/composer.json
+++ b/src/Symfony/Contracts/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "psr/cache": "^1.0|^2.0|^3.0",
-        "psr/container": "^1.1",
+        "psr/container": "^1.1|^2.0",
         "psr/event-dispatcher": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | --
| License       | MIT
| Doc PR        | --

This adds support for `psr/container` 2.x in `contracts` (and more specifically `service-contracts`. After digging through dependencies, I found this (which is required via `console`) as the last remaining place in my code that required the 1.x line.