### PR TITLE
PHPUnit on GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,201 +114,6 @@ jobs:
       #    sudo rm -rf .phpunit
       #    [ -d .phpunit.bak ] && mv .phpunit.bak .phpunit
 
-  nightly:
-    name: PHPUnit on PHP nightly
-    runs-on: Ubuntu-20.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          coverage: "none"
-          ini-values: "memory_limit=-1"
-          php-version: "8.1"
-
-      - name: Configure composer
-        run: |
-          COMPOSER_HOME="$(composer config home)"
-          ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
-          echo "COMPOSER_ROOT_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*').x-dev" >> $GITHUB_ENV
-
-      - name: Install dependencies
-        run: |
-          echo "::group::fake PHP version"
-          composer config platform.php 8.0.99
-          echo "::group::composer update"
-          composer update --no-progress --ansi
-          echo "::endgroup::"
-          echo "::group::install phpunit"
-          ./phpunit install
-          echo "::endgroup::"
-
-      - name: Run tests
-        run: |
-          _run_tests() {
-            ok=0
-            echo "::group::$1"
-
-            # Run the tests
-            ./phpunit --colors=always --exclude-group tty,benchmark,intl-data ./$1 2>&1 || ok=1
-
-            echo ""
-            echo "::endgroup::"
-
-            if [ $ok -ne 0 ]; then
-              echo "::error::$1 failed"
-            fi
-
-            # Make the tests always pass because we don't want the build to fail (yet).
-            return 0
-            #return $ok
-          }
-          export -f _run_tests
-
-          find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -print0 | xargs -0 -n1 dirname | sort | parallel _run_tests
-
-  high_deps:
-    name: PHPUnit (7.4, high deps)
-    runs-on: Ubuntu-20.04
-
-    env:
-      SYMFONY_DEPRECATIONS_HELPER: weak
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          coverage: "none"
-          ini-values: "memory_limit=-1"
-          php-version: "7.4"
-          extensions: amqp, apcu, igbinary, intl, mbstring, memcached, mongodb, redis
-          tools: flex
-
-      - name: Configure composer
-        run: |
-          SYMFONY_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*')
-          SYMFONY_REQUIRE=">=$SYMFONY_VERSION"
-          COMPOSER_HOME="$(composer config home)"
-          ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
-
-          echo COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev >> $GITHUB_ENV
-          echo SYMFONY_VERSION=$SYMFONY_VERSION >> $GITHUB_ENV
-          echo SYMFONY_REQUIRE="$SYMFONY_REQUIRE" >> $GITHUB_ENV
-
-      - name: Install PHPUnit
-        run: |
-          mkdir -p ./vendor/symfony
-          cd ./vendor/symfony
-          ln -s ../../src/Symfony/Bridge/PhpUnit phpunit-bridge
-          cd ../..
-          ./phpunit install
-          echo PHPUNIT=`pwd`/phpunit >> $GITHUB_ENV
-
-      - name: Run tests
-        run: |
-          _run_tests() {
-            ok=0
-            echo "::group::$1"
-
-            # Install dependencies
-            cd ./$1
-            composer update --no-progress --ansi 2>&1 || ok=1
-
-            if [ $ok -eq 0 ]; then
-              # Run the tests
-              $PHPUNIT --colors=always --exclude-group tty,benchmark,intl-data,legacy 2>&1 || ok=1
-            fi
-
-            echo ""
-            echo "::endgroup::"
-
-            if [ $ok -ne 0 ]; then
-              echo "::error::$1 failed"
-            fi
-
-            return $ok
-          }
-          export -f _run_tests
-
-          find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -print0 | xargs -0 -n1 dirname | sort | parallel _run_tests
-
-  low_deps:
-    name: PHPUnit (8.0, low deps)
-    runs-on: Ubuntu-20.04
-
-    env:
-      SYMFONY_DEPRECATIONS_HELPER: weak
-      SYMFONY_REQUIRE: ">=2.3"
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          coverage: "none"
-          ini-values: "memory_limit=-1"
-          php-version: "8.0"
-          # TODO: memcached is excluded because of compatibility issues with PHP 8
-          extensions: amqp, apcu, igbinary, intl, mbstring, :memcached, mongodb, redis
-          tools: flex
-
-      - name: Configure composer
-        run: |
-          SYMFONY_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*')
-          COMPOSER_HOME="$(composer config home)"
-          ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
-
-          echo COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev >> $GITHUB_ENV
-          echo SYMFONY_VERSION=$SYMFONY_VERSION >> $GITHUB_ENV
-
-      - name: Install PHPUnit
-        run: |
-          mkdir -p ./vendor/symfony
-          cd ./vendor/symfony
-          ln -s ../../src/Symfony/Bridge/PhpUnit phpunit-bridge
-          cd ../..
-          ./phpunit install
-          echo PHPUNIT=`pwd`/phpunit >> $GITHUB_ENV
-
-      - name: Run tests
-        run: |
-          _run_tests() {
-            ok=0
-            echo "::group::$1"
-
-            # Install dependencies
-            cd ./$1
-            composer update --no-progress --ansi --prefer-lowest --prefer-stable 2>&1  || ok=1
-
-            if [ $ok -ne 0 ]; then
-              echo "::error::$1 failed"
-              return $ok
-            fi
-
-            # Run the tests
-            $PHPUNIT --colors=always --exclude-group tty,benchmark,intl-data 2>&1 || ok=1
-
-            echo ""
-            echo "::endgroup::"
-
-            if [ $ok -ne 0 ]; then
-              echo "::error::$1 failed"
-            fi
-
-            return $ok
-          }
-          export -f _run_tests
-
-          find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -print0 | xargs -0 -n1 dirname | sort | parallel _run_tests
-
   phpunit:
     name: PHPUnit
     runs-on: Ubuntu-20.04
@@ -318,7 +123,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
       fail-fast: false
 
     steps:
@@ -330,6 +135,13 @@ jobs:
         # TODO: memcached is excluded because of compatibility issues with PHP 8
         run: echo "extensions='amqp, apcu, igbinary, intl, mbstring, :memcached, mongodb, redis'" >> $GITHUB_ENV
 
+      - name: Configure extensions
+        if: "${{ matrix.php == '8.1' }}"
+        # Test on PHP 8.1 with bundled extensions only and allow tests to fail for now.
+        run: |
+          echo "extensions='mbstring'" >> $GITHUB_ENV
+          echo "ALLOW_FAILURE=yes" >> $GITHUB_ENV
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -338,6 +150,10 @@ jobs:
           php-version: "${{ matrix.php }}"
           extensions: "${{ env.extensions }}"
           tools: flex
+
+      - name: Fake PHP version
+        if: "${{ matrix.php == '8.1' }}"
+        run: composer config platform.php 8.0.99
 
       - name: Configure composer
         run: |
@@ -368,6 +184,11 @@ jobs:
 
             if [ $ok -ne 0 ]; then
               echo "::error::$1 failed"
+            fi
+
+            if [ "$ALLOW_FAILURE" = "yes" ]; then
+              # Make the tests always pass because we don't want the build to fail (yet).
+              return 0
             fi
 
             return $ok

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,7 +154,9 @@ jobs:
 
             # Run the tests
             ./phpunit --colors=always --exclude-group tty,benchmark,intl-data ./$1 2>&1 || ok=1
-            echo "\n::endgroup::"
+
+            echo ""
+            echo "::endgroup::"
 
             if [ $ok -ne 0 ]; then
               echo "::error::$1 failed"
@@ -223,7 +225,8 @@ jobs:
               $PHPUNIT --colors=always --exclude-group tty,benchmark,intl-data,legacy 2>&1 || ok=1
             fi
 
-            echo "\n::endgroup::"
+            echo ""
+            echo "::endgroup::"
 
             if [ $ok -ne 0 ]; then
               echo "::error::$1 failed"
@@ -293,7 +296,8 @@ jobs:
             # Run the tests
             $PHPUNIT --colors=always --exclude-group tty,benchmark,intl-data 2>&1 || ok=1
 
-            echo "\n::endgroup::"
+            echo ""
+            echo "::endgroup::"
 
             if [ $ok -ne 0 ]; then
               echo "::error::$1 failed"
@@ -358,7 +362,9 @@ jobs:
 
             # Run the tests
             ./phpunit --colors=always --exclude-group tty,benchmark,intl-data ./$1 2>&1 || ok=1
-            echo "\n::endgroup::"
+
+            echo ""
+            echo "::endgroup::"
 
             if [ $ok -ne 0 ]; then
               echo "::error::$1 failed"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,7 @@ jobs:
 
     env:
       extensions: 'amqp, apcu, igbinary, intl, mbstring, memcached, mongodb, redis'
-      EXCLUDE_GROUPS: benchmark,intl-data,integration
+      EXCLUDE_GROUPS: benchmark,intl-data,tty,integration
 
     strategy:
       matrix:
@@ -223,6 +223,14 @@ jobs:
           export -f _run_tests
 
           find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -print0 | xargs -0 -n1 dirname | sort | parallel _run_tests
+
+      - name: Run TTY tests
+        run: |
+          ok=0
+          ./phpunit --colors=always --group tty src/Symfony/Component/Console 2>&1 || ok=1
+          ./phpunit --colors=always --group tty rc/Symfony/Bridge/Twig 2>&1 || ok=1
+
+          $ok || false
 
       - name: Run tests with SIGCHLD enabled PHP
         if: "${{ matrix.php == '7.1' }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -174,6 +174,9 @@ jobs:
     name: PHPUnit (7.4, high deps)
     runs-on: Ubuntu-20.04
 
+    env:
+      SYMFONY_DEPRECATIONS_HELPER: weak
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -207,7 +210,6 @@ jobs:
           cd ../..
           ./phpunit install
           echo PHPUNIT=`pwd`/phpunit >> $GITHUB_ENV
-          echo SYMFONY_DEPRECATIONS_HELPER=weak >> $GITHUB_ENV
 
       - name: Run tests
         run: |
@@ -226,6 +228,76 @@ jobs:
 
             # Run the tests
             $PHPUNIT --colors=always --exclude-group tty,benchmark,intl-data,legacy 2>&1 || ok=1
+            echo ::endgroup::
+
+            if [ $ok -ne 0 ]; then
+              echo "::error::$1 failed"
+            fi
+
+            # Make the tests always pass because we don't want the build to fail (yet).
+            return $ok
+          }
+          export -f _run_tests
+
+          find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -print0 | xargs -0 -n1 dirname | sort | parallel _run_tests
+
+  low_deps:
+    name: PHPUnit (8.0, low deps)
+    runs-on: Ubuntu-20.04
+
+    env:
+      SYMFONY_DEPRECATIONS_HELPER: weak
+      SYMFONY_REQUIRE: ">=2.3"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: "none"
+          ini-values: "memory_limit=-1"
+          php-version: "8.0"
+          extensions: amqp, apcu, igbinary, intl, mbstring, memcached, mongodb, redis
+          tools: flex
+
+      - name: Configure composer
+        run: |
+          SYMFONY_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*')
+          COMPOSER_HOME="$(composer config home)"
+          composer self-update
+          ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
+
+          echo COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev >> $GITHUB_ENV
+          echo SYMFONY_VERSION=$SYMFONY_VERSION >> $GITHUB_ENV
+
+      - name: Install PHPUnit
+        run: |
+          mkdir -p ./vendor/symfony
+          cd ./vendor/symfony
+          ln -s ../../src/Symfony/Bridge/PhpUnit phpunit-bridge
+          cd ../..
+          ./phpunit install
+          echo PHPUNIT=`pwd`/phpunit >> $GITHUB_ENV
+
+      - name: Run tests
+        run: |
+          _run_tests() {
+            ok=0
+            echo "::group::$1"
+
+            # Install dependencies
+            cd ./$1
+            composer update --no-progress --ansi --prefer-lowest --prefer-stable 2>&1  || ok=1
+
+            if [ $ok -ne 0 ]; then
+              echo "::error::$1 failed"
+              return $ok
+            fi
+
+            # Run the tests
+            $PHPUNIT --colors=always --exclude-group tty,benchmark,intl-data 2>&1 || ok=1
             echo ::endgroup::
 
             if [ $ok -ne 0 ]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -310,3 +310,61 @@ jobs:
           export -f _run_tests
 
           find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -print0 | xargs -0 -n1 dirname | sort | parallel _run_tests
+
+  phpunit:
+    name: PHPUnit
+    runs-on: Ubuntu-20.04
+
+    strategy:
+      matrix:
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: "none"
+          ini-values: "memory_limit=-1"
+          php-version: "${{ matrix.php }}"
+          extensions: amqp, apcu, igbinary, intl, mbstring, memcached, mongodb, redis
+          tools: flex
+
+      - name: Configure composer
+        run: |
+          COMPOSER_HOME="$(composer config home)"
+          composer self-update
+          ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
+          echo "COMPOSER_ROOT_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*').x-dev" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: |
+          echo "::group::composer update"
+          composer update --no-progress --ansi
+          echo "::endgroup::"
+          echo "::group::install phpunit"
+          ./phpunit install
+          echo "::endgroup::"
+
+      - name: Run tests
+        run: |
+          _run_tests() {
+            ok=0
+            echo "::group::$1"
+
+            # Run the tests
+            ./phpunit --colors=always --exclude-group tty,benchmark,intl-data ./$1 2>&1 || ok=1
+            echo ::endgroup::
+
+            if [ $ok -ne 0 ]; then
+              echo "::error::$1 failed"
+            fi
+
+            return $ok
+          }
+          export -f _run_tests
+
+          find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -print0 | xargs -0 -n1 dirname | sort | parallel _run_tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -177,7 +177,7 @@ jobs:
             echo "::group::$1"
 
             # Run the tests
-            ./phpunit --colors=always --exclude-group tty,benchmark,intl-data ./$1 2>&1 || ok=1
+            ./phpunit --colors=always --exclude-group tty,benchmark,intl-data,integration ./$1 2>&1 || ok=1
 
             echo ""
             echo "::endgroup::"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,7 +229,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          wget https://github.com/derrabus/php-pcntl-binaries/raw/main/php-7.1.3-pcntl-sigchild.tar.bz2
+          wget -q https://github.com/derrabus/php-pcntl-binaries/raw/main/php-7.1.3-pcntl-sigchild.tar.bz2
           tar -xjf php-7.1.3-pcntl-sigchild.tar.bz2
           cd ..
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,6 @@ jobs:
       - name: Configure composer
         run: |
           COMPOSER_HOME="$(composer config home)"
-          composer self-update
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
           echo "COMPOSER_ROOT_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*').x-dev" >> $GITHUB_ENV
 
@@ -133,7 +132,6 @@ jobs:
       - name: Configure composer
         run: |
           COMPOSER_HOME="$(composer config home)"
-          composer self-update
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
           echo "COMPOSER_ROOT_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*').x-dev" >> $GITHUB_ENV
 
@@ -195,7 +193,6 @@ jobs:
           SYMFONY_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*')
           SYMFONY_REQUIRE=">=$SYMFONY_VERSION"
           COMPOSER_HOME="$(composer config home)"
-          composer self-update
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
 
           echo COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev >> $GITHUB_ENV
@@ -219,15 +216,14 @@ jobs:
 
             # Install dependencies
             cd ./$1
-            composer update --no-progress --ansi 2>&1  || ok=1
+            composer update --no-progress --ansi 2>&1 || ok=1
 
-            if [ $ok -ne 0 ]; then
-              echo "::error::$1 failed"
-              return $ok
+            if [ $ok -eq 0 ]; then
+              # Run the tests
+              $PHPUNIT --colors=always --exclude-group tty,benchmark,intl-data,legacy 2>&1 || ok=1
             fi
 
-            # Run the tests
-            $PHPUNIT --colors=always --exclude-group tty,benchmark,intl-data,legacy 2>&1 || ok=1
+            echo
             echo ::endgroup::
 
             if [ $ok -ne 0 ]; then
@@ -266,7 +262,6 @@ jobs:
         run: |
           SYMFONY_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*')
           COMPOSER_HOME="$(composer config home)"
-          composer self-update
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
 
           echo COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev >> $GITHUB_ENV
@@ -336,7 +331,6 @@ jobs:
       - name: Configure composer
         run: |
           COMPOSER_HOME="$(composer config home)"
-          composer self-update
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
           echo "COMPOSER_ROOT_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*').x-dev" >> $GITHUB_ENV
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,7 +127,7 @@ jobs:
     runs-on: Ubuntu-20.04
 
     env:
-      extensions: 'amqp, apcu, igbinary, intl, mbstring, memcached, mongodb, redis'
+      extensions: amqp,apcu,igbinary,intl,mbstring,memcached,mongodb,redis
       EXCLUDE_GROUPS: benchmark,intl-data,tty,integration
 
     strategy:
@@ -142,13 +142,13 @@ jobs:
       - name: Configure extensions
         if: "${{ matrix.php == '8.0' }}"
         # TODO: memcached is excluded because of compatibility issues with PHP 8
-        run: echo "extensions='amqp, apcu, igbinary, intl, mbstring, :memcached, mongodb, redis'" >> $GITHUB_ENV
+        run: echo "extensions=amqp,apcu,igbinary,intl,mbstring,:memcached,mongodb,redis" >> $GITHUB_ENV
 
       - name: Configure extensions
         if: "${{ matrix.php == '8.1' }}"
         # Test on PHP 8.1 with bundled extensions only and allow tests to fail for now.
         run: |
-          echo "extensions='mbstring'" >> $GITHUB_ENV
+          echo "extensions=mbstring" >> $GITHUB_ENV
           echo "ALLOW_FAILURE=yes" >> $GITHUB_ENV
 
       - name: Setup PHP

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,7 +154,7 @@ jobs:
 
             # Run the tests
             ./phpunit --colors=always --exclude-group tty,benchmark,intl-data ./$1 2>&1 || ok=1
-            echo ::endgroup::
+            echo "\n::endgroup::"
 
             if [ $ok -ne 0 ]; then
               echo "::error::$1 failed"
@@ -223,14 +223,12 @@ jobs:
               $PHPUNIT --colors=always --exclude-group tty,benchmark,intl-data,legacy 2>&1 || ok=1
             fi
 
-            echo
-            echo ::endgroup::
+            echo "\n::endgroup::"
 
             if [ $ok -ne 0 ]; then
               echo "::error::$1 failed"
             fi
 
-            # Make the tests always pass because we don't want the build to fail (yet).
             return $ok
           }
           export -f _run_tests
@@ -294,13 +292,13 @@ jobs:
 
             # Run the tests
             $PHPUNIT --colors=always --exclude-group tty,benchmark,intl-data 2>&1 || ok=1
-            echo ::endgroup::
+
+            echo "\n::endgroup::"
 
             if [ $ok -ne 0 ]; then
               echo "::error::$1 failed"
             fi
 
-            # Make the tests always pass because we don't want the build to fail (yet).
             return $ok
           }
           export -f _run_tests
@@ -360,7 +358,7 @@ jobs:
 
             # Run the tests
             ./phpunit --colors=always --exclude-group tty,benchmark,intl-data ./$1 2>&1 || ok=1
-            echo ::endgroup::
+            echo "\n::endgroup::"
 
             if [ $ok -ne 0 ]; then
               echo "::error::$1 failed"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -222,3 +222,14 @@ jobs:
           export -f _run_tests
 
           find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -print0 | xargs -0 -n1 dirname | sort | parallel _run_tests
+
+      - name: Run tests with SIGCHLD enabled PHP
+        if: "${{ matrix.php == '7.1' }}"
+        run: |
+          mkdir build
+          cd build
+          wget https://github.com/derrabus/php-pcntl-binaries/raw/main/php-7.1.3-pcntl-sigchild.tar.bz2
+          tar -xjf php-7.1.3-pcntl-sigchild.tar.bz2
+          cd ..
+
+          ./build/php/bin/php ./phpunit --colors=always src/Symfony/Component/Process

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -255,7 +255,8 @@ jobs:
           coverage: "none"
           ini-values: "memory_limit=-1"
           php-version: "8.0"
-          extensions: amqp, apcu, igbinary, intl, mbstring, memcached, mongodb, redis
+          # TODO: memcached is excluded because of compatibility issues with PHP 8
+          extensions: amqp, apcu, igbinary, intl, mbstring, :memcached, mongodb, redis
           tools: flex
 
       - name: Configure composer
@@ -310,6 +311,9 @@ jobs:
     name: PHPUnit
     runs-on: Ubuntu-20.04
 
+    env:
+      extensions: 'amqp, apcu, igbinary, intl, mbstring, memcached, mongodb, redis'
+
     strategy:
       matrix:
         php: ['7.1', '7.2', '7.3', '7.4', '8.0']
@@ -319,13 +323,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Configure extensions
+        if: "${{ matrix.php == '8.0' }}"
+        # TODO: memcached is excluded because of compatibility issues with PHP 8
+        run: echo "extensions='amqp, apcu, igbinary, intl, mbstring, :memcached, mongodb, redis'" >> $GITHUB_ENV
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           coverage: "none"
           ini-values: "memory_limit=-1"
           php-version: "${{ matrix.php }}"
-          extensions: amqp, apcu, igbinary, intl, mbstring, memcached, mongodb, redis
+          extensions: "${{ env.extensions }}"
           tools: flex
 
       - name: Configure composer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,7 +128,7 @@ jobs:
 
     env:
       extensions: 'amqp, apcu, igbinary, intl, mbstring, memcached, mongodb, redis'
-      EXCLUDE_GROUPS: tty,benchmark,intl-data,integration
+      EXCLUDE_GROUPS: benchmark,intl-data,integration
 
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,14 +224,6 @@ jobs:
 
           find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -print0 | xargs -0 -n1 dirname | sort | parallel _run_tests
 
-      - name: Run TTY tests
-        run: |
-          ok=0
-          ./phpunit --colors=always --group tty src/Symfony/Component/Console 2>&1 || ok=1
-          ./phpunit --colors=always --group tty rc/Symfony/Bridge/Twig 2>&1 || ok=1
-
-          $ok || false
-
       - name: Run tests with SIGCHLD enabled PHP
         if: "${{ matrix.php == '7.1' }}"
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -169,3 +169,72 @@ jobs:
           export -f _run_tests
 
           find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -print0 | xargs -0 -n1 dirname | sort | parallel _run_tests
+
+  high_deps:
+    name: PHPUnit (7.4, high deps)
+    runs-on: Ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          coverage: "none"
+          ini-values: "memory_limit=-1"
+          php-version: "7.4"
+          extensions: amqp, apcu, igbinary, intl, mbstring, memcached, mongodb, redis
+          tools: flex
+
+      - name: Configure composer
+        run: |
+          SYMFONY_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*')
+          SYMFONY_REQUIRE=">=$SYMFONY_VERSION"
+          COMPOSER_HOME="$(composer config home)"
+          composer self-update
+          ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
+
+          echo COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev >> $GITHUB_ENV
+          echo SYMFONY_VERSION=$SYMFONY_VERSION >> $GITHUB_ENV
+          echo SYMFONY_REQUIRE="$SYMFONY_REQUIRE" >> $GITHUB_ENV
+
+      - name: Install PHPUnit
+        run: |
+          mkdir -p ./vendor/symfony
+          cd ./vendor/symfony
+          ln -s ../../src/Symfony/Bridge/PhpUnit phpunit-bridge
+          cd ../..
+          ./phpunit install
+          echo PHPUNIT=`pwd`/phpunit >> $GITHUB_ENV
+          echo SYMFONY_DEPRECATIONS_HELPER=weak >> $GITHUB_ENV
+
+      - name: Run tests
+        run: |
+          _run_tests() {
+            ok=0
+            echo "::group::$1"
+
+            # Install dependencies
+            cd ./$1
+            composer update --no-progress --ansi 2>&1  || ok=1
+
+            if [ $ok -ne 0 ]; then
+              echo "::error::$1 failed"
+              return $ok
+            fi
+
+            # Run the tests
+            $PHPUNIT --colors=always --exclude-group tty,benchmark,intl-data,legacy 2>&1 || ok=1
+            echo ::endgroup::
+
+            if [ $ok -ne 0 ]; then
+              echo "::error::$1 failed"
+            fi
+
+            # Make the tests always pass because we don't want the build to fail (yet).
+            return $ok
+          }
+          export -f _run_tests
+
+          find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -print0 | xargs -0 -n1 dirname | sort | parallel _run_tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,11 +77,19 @@ jobs:
           entrypoint: /bin/bash
           args: -c "(/opt/bitnami/openldap/bin/ldapwhoami -h localhost:3389 -D cn=admin,dc=symfony,dc=com -w symfony||sleep 5) && /opt/bitnami/openldap/bin/ldapadd -h ldap:3389 -D cn=admin,dc=symfony,dc=com -w symfony -f src/Symfony/Component/Ldap/Tests/Fixtures/data/fixtures.ldif && /opt/bitnami/openldap/bin/ldapdelete -h ldap:3389 -D cn=admin,dc=symfony,dc=com -w symfony cn=a,ou=users,dc=symfony,dc=com"
 
+      - name: Detect Symfony version
+        id: symfony-versions
+        run: |
+          echo "::set-output name=symfony-major-version::$(grep "const MAJOR_VERSION =" ./src/Symfony/Component/HttpKernel/Kernel.php | egrep -o '[0-9]+')"
+          echo "::set-output name=symfony-minor-version::$(grep "const MINOR_VERSION =" ./src/Symfony/Component/HttpKernel/Kernel.php | egrep -o '[0-9]+')"
+          echo "::set-output name=symfony-version::$(grep "const MAJOR_VERSION =" ./src/Symfony/Component/HttpKernel/Kernel.php | egrep -o '[0-9]+').$(grep "const MINOR_VERSION =" ./src/Symfony/Component/HttpKernel/Kernel.php | egrep -o '[0-9]+')"
+
       - name: Configure composer
         run: |
           COMPOSER_HOME="$(composer config home)"
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
-          echo "COMPOSER_ROOT_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*').x-dev" >> $GITHUB_ENV
+
+          echo "COMPOSER_ROOT_VERSION=${{ steps.symfony-versions.outputs.symfony-version }}.x-dev" >> $GITHUB_ENV
 
       - name: Install dependencies
         run: |
@@ -156,11 +164,19 @@ jobs:
         if: "${{ matrix.php == '8.1' }}"
         run: composer config platform.php 8.0.99
 
+      - name: Detect Symfony version
+        id: symfony-versions
+        run: |
+          echo "::set-output name=symfony-major-version::$(grep "const MAJOR_VERSION =" ./src/Symfony/Component/HttpKernel/Kernel.php | egrep -o '[0-9]+')"
+          echo "::set-output name=symfony-minor-version::$(grep "const MINOR_VERSION =" ./src/Symfony/Component/HttpKernel/Kernel.php | egrep -o '[0-9]+')"
+          echo "::set-output name=symfony-version::$(grep "const MAJOR_VERSION =" ./src/Symfony/Component/HttpKernel/Kernel.php | egrep -o '[0-9]+').$(grep "const MINOR_VERSION =" ./src/Symfony/Component/HttpKernel/Kernel.php | egrep -o '[0-9]+')"
+
       - name: Configure composer
         run: |
           COMPOSER_HOME="$(composer config home)"
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
-          echo "COMPOSER_ROOT_VERSION=$(grep -m1 SYMFONY_VERSION .travis.yml | grep -o '[0-9.x]*').x-dev" >> $GITHUB_ENV
+
+          echo "COMPOSER_ROOT_VERSION=${{ steps.symfony-versions.outputs.symfony-version }}.x-dev" >> $GITHUB_ENV
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,7 +155,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: "none"
-          ini-values: date.timezone=Europe/Paris,memory_limit=-1,default_socket_timeout=10,session.gc_probability=0
+          ini-values: date.timezone=Europe/Paris,memory_limit=-1,default_socket_timeout=10,session.gc_probability=0,apc.enable_cli=1
           php-version: "${{ matrix.php }}"
           extensions: "${{ env.extensions }}"
           tools: flex

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -176,7 +176,8 @@ jobs:
           COMPOSER_HOME="$(composer config home)"
           ([ -d "$COMPOSER_HOME" ] || mkdir "$COMPOSER_HOME") && cp .github/composer-config.json "$COMPOSER_HOME/config.json"
 
-          echo "COMPOSER_ROOT_VERSION=${{ steps.symfony-versions.outputs.symfony-version }}.x-dev" >> $GITHUB_ENV
+          echo 'COMPOSER_ROOT_VERSION=${{ steps.symfony-versions.outputs.symfony-version }}.x-dev' >> $GITHUB_ENV
+          echo 'SYMFONY_REQUIRE=>=${{ steps.symfony-versions.outputs.symfony-version }}' >> $GITHUB_ENV
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,7 +155,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           coverage: "none"
-          ini-values: "memory_limit=-1"
+          ini-values: date.timezone=Europe/Paris,memory_limit=-1,default_socket_timeout=10,session.gc_probability=0
           php-version: "${{ matrix.php }}"
           extensions: "${{ env.extensions }}"
           tools: flex

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,6 +120,7 @@ jobs:
 
     env:
       extensions: 'amqp, apcu, igbinary, intl, mbstring, memcached, mongodb, redis'
+      EXCLUDE_GROUPS: tty,benchmark,intl-data,integration
 
     strategy:
       matrix:
@@ -170,6 +171,15 @@ jobs:
           ./phpunit install
           echo "::endgroup::"
 
+      - name: Patch return types
+        if: "${{ matrix.php == '8.0' }}"
+        run: |
+          sed -i 's/"\*\*\/Tests\/"//' composer.json
+          composer install --optimize-autoloader
+          SYMFONY_PATCH_TYPE_DECLARATIONS=force=1 php .github/patch-types.php
+          SYMFONY_PATCH_TYPE_DECLARATIONS=force=1 php .github/patch-types.php # ensure the script is idempotent
+          echo EXCLUDE_GROUPS="$EXCLUDE_GROUPS,legacy" >> $GITHUB_ENV
+
       - name: Run tests
         run: |
           _run_tests() {
@@ -177,7 +187,7 @@ jobs:
             echo "::group::$1"
 
             # Run the tests
-            ./phpunit --colors=always --exclude-group tty,benchmark,intl-data,integration ./$1 2>&1 || ok=1
+            ./phpunit --colors=always --exclude-group $EXCLUDE_GROUPS ./$1 2>&1 || ok=1
 
             echo ""
             echo "::endgroup::"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ env:
 
 matrix:
     include:
-        - php: 7.1
-          env: php_extra="7.2 7.3 8.0"
         - php: 7.4
           env: deps=high
         - php: 8.0
@@ -110,21 +108,12 @@ before_install:
       export -f tpecl
 
     - |
-      # Install sigchild-enabled PHP to test the Process component on the lowest PHP matrix line
-      if [[ ! $deps && $TRAVIS_PHP_VERSION = ${MIN_PHP%.*} && ! -d php-$MIN_PHP/sapi ]]; then
-          wget http://php.net/get/php-$MIN_PHP.tar.bz2/from/this/mirror -O - | tar -xj &&
-          (cd php-$MIN_PHP && ./configure --enable-sigchild --enable-pcntl && make -j2)
-      fi
-
-    - |
       # php.ini configuration
       (
-          for PHP in $TRAVIS_PHP_VERSION $php_extra; do
-              ([[ $PHP != 7.4 ]] && phpenv global $PHP 2>/dev/null) || (cd / && wget https://storage.googleapis.com/travis-ci-language-archives/php/binaries/ubuntu/18.04/x86_64/php-$PHP.tar.bz2 -O - | tar -xj) &
-          done
+          ([[ $TRAVIS_PHP_VERSION != 7.4 ]] && phpenv global $TRAVIS_PHP_VERSION 2>/dev/null) || (cd / && wget https://storage.googleapis.com/travis-ci-language-archives/php/binaries/ubuntu/18.04/x86_64/php-$TRAVIS_PHP_VERSION.tar.bz2 -O - | tar -xj) &
           wait
       )
-      for PHP in $TRAVIS_PHP_VERSION $php_extra; do
+      for PHP in $TRAVIS_PHP_VERSION; do
           INI=~/.phpenv/versions/$PHP/etc/conf.d/travis.ini
           echo date.timezone = Europe/Paris >> $INI
           echo memory_limit = -1 >> $INI
@@ -140,7 +129,7 @@ before_install:
 
     - |
       # Install extra PHP extensions
-      for PHP in $TRAVIS_PHP_VERSION $php_extra; do
+      for PHP in $TRAVIS_PHP_VERSION; do
           export PHP=$PHP
           phpenv global $PHP
           INI=~/.phpenv/versions/$PHP/etc/conf.d/travis.ini
@@ -204,12 +193,6 @@ install:
       fi
 
     - |
-      # Skip the phpunit-bridge on bugfix-branches when $deps is empty
-      if [[ ! $deps && $SYMFONY_VERSION != $SYMFONY_FEATURE_BRANCH ]]; then
-          export COMPONENTS=$(find src/Symfony -mindepth 2 -type f -name phpunit.xml.dist -not -wholename '*/Bridge/PhpUnit/*' -printf '%h\n' | sort)
-      fi
-
-    - |
       # Install symfony/flex
       if [[ $deps = low ]]; then
           export SYMFONY_REQUIRE='>=2.3'
@@ -223,7 +206,7 @@ install:
       [[ $deps = high && $SYMFONY_VERSION = *.4 ]] && export LEGACY=,legacy
 
       export COMPOSER_ROOT_VERSION=$SYMFONY_VERSION.x-dev
-      if [[ $deps ]]; then mv composer.json.phpunit composer.json; fi
+      mv composer.json.phpunit composer.json
 
     - |
       # phpinfo
@@ -234,7 +217,7 @@ install:
       }
       export -f phpinfo
 
-      for PHP in $TRAVIS_PHP_VERSION $php_extra; do
+      for PHP in $TRAVIS_PHP_VERSION; do
           tfold phpinfo phpinfo $PHP
       done
 
@@ -249,7 +232,7 @@ install:
           fi
           phpenv global $PHP
           rm vendor/composer/package-versions-deprecated -Rf
-          ([[ $deps ]] && cd src/Symfony/Component/HttpFoundation; cp composer.json composer.bak; composer require --dev --no-update mongodb/mongodb)
+          cd src/Symfony/Component/HttpFoundation; cp composer.json composer.bak; composer require --dev --no-update mongodb/mongodb
           tfold 'composer update' $COMPOSER_UP
           tfold 'phpunit install' ./phpunit install
           if [[ $deps = high ]]; then
@@ -274,28 +257,9 @@ install:
               [[ ! $X ]] || (exit 1)
           elif [[ $deps = low ]]; then
               echo "$COMPONENTS" | parallel --gnu "tfold {} 'cd {} && $COMPOSER_UP --prefer-lowest --prefer-stable && $PHPUNIT_X'"
-          else
-              if [[ $PHP = 8.0* ]]; then
-                  # add return types before running the test suite
-                  sed -i 's/"\*\*\/Tests\/"//' composer.json
-                  composer install --optimize-autoloader
-                  SYMFONY_PATCH_TYPE_DECLARATIONS=force=1 php .github/patch-types.php
-                  SYMFONY_PATCH_TYPE_DECLARATIONS=force=1 php .github/patch-types.php # ensure the script is idempotent
-                  PHPUNIT_X="$PHPUNIT_X,legacy"
-              fi
-
-              echo "$COMPONENTS" | parallel --gnu "tfold {} $PHPUNIT_X {}"
-
-              tfold src/Symfony/Component/Console.tty $PHPUNIT src/Symfony/Component/Console --group tty
-              tfold src/Symfony/Bridge/Twig.tty $PHPUNIT src/Symfony/Bridge/Twig --group tty
-
-              if [[ $PHP = ${MIN_PHP%.*} ]]; then
-                  export PHP=$MIN_PHP
-                  tfold src/Symfony/Component/Process.sigchild SYMFONY_DEPRECATIONS_HELPER=weak php-$MIN_PHP/sapi/cli/php ./phpunit --colors=always src/Symfony/Component/Process/
-              fi
           fi
       }
       export -f run_tests
 
 script:
-    echo $TRAVIS_PHP_VERSION $php_extra | xargs -n1 bash -c '(</dev/tty run_tests $0)' || false
+    run_tests $TRAVIS_PHP_VERSION

--- a/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
+++ b/src/Symfony/Component/VarExporter/Tests/VarExporterTest.php
@@ -67,10 +67,13 @@ class VarExporterTest extends TestCase
 
         yield [$a];
 
-        $a = [null, $h];
-        $a[0] = &$a;
+        // This test segfaults on the final PHP 7.2 release
+        if (\PHP_VERSION_ID !== 70234) {
+            $a = [null, $h];
+            $a[0] = &$a;
 
-        yield [$a];
+            yield [$a];
+        }
     }
 
     /**
@@ -163,10 +166,13 @@ class VarExporterTest extends TestCase
 
         yield ['hard-references', $value];
 
-        $value = [];
-        $value[0] = &$value;
+        // This test segfaults on the final PHP 7.2 release
+        if (\PHP_VERSION_ID !== 70234) {
+            $value = [];
+            $value[0] = &$value;
 
-        yield ['hard-references-recursive', $value];
+            yield ['hard-references-recursive', $value];
+        }
 
         static $value = [123];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR adds PHPUnit jobs for all supported PHP versions to our GitHub Actions workflow. These jobs can replace the first of our three Travis CI jobs (AKA the "php_extra" one). The idea is to have a more integrated CI experience for contributors and to be prepared for future Travis outages.