### PR TITLE
[DoctrineMessenger] use auto_setup in schemaListener

### DIFF
--- a/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaSubscriber.php
+++ b/src/Symfony/Bridge/Doctrine/SchemaListener/MessengerTransportDoctrineSchemaSubscriber.php
@@ -46,6 +46,10 @@ final class MessengerTransportDoctrineSchemaSubscriber implements EventSubscribe
                 continue;
             }
 
+            if (!$transport->useAutoSetup()) {
+                continue;
+            }
+
             $transport->configureSchema($event->getSchema(), $dbalConnection);
         }
     }
@@ -61,6 +65,10 @@ final class MessengerTransportDoctrineSchemaSubscriber implements EventSubscribe
 
         foreach ($this->transports as $transport) {
             if (!$transport instanceof DoctrineTransport) {
+                continue;
+            }
+
+            if (!$transport->useAutoSetup()) {
                 continue;
             }
 

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -311,6 +311,11 @@ class Connection implements ResetInterface
         return [];
     }
 
+    public function useAutoSetup(): bool
+    {
+        return $this->autoSetup;
+    }
+
     private function createAvailableMessagesQueryBuilder(): QueryBuilder
     {
         $now = new \DateTime();

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/DoctrineTransport.php
@@ -119,6 +119,11 @@ class DoctrineTransport implements TransportInterface, SetupableTransportInterfa
         return $this->connection->getExtraSetupSqlForTable($createdTable);
     }
 
+    public function useAutoSetup(): bool
+    {
+        return $this->connection->useAutoSetup();
+    }
+
     private function getReceiver(): DoctrineReceiver
     {
         return $this->receiver = new DoctrineReceiver($this->connection, $this->serializer);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38398
| License       | MIT

Uses the `auto_setup` option of the doctrine transport to determine if changes to the schema should be made by the `SchemaListener`.