### PR TITLE
[HttpFoundation] allow savePath of NativeFileSessionHandler to be null

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/SessionHandlerFactory.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/SessionHandlerFactory.php
@@ -48,7 +48,9 @@ class SessionHandlerFactory
             case !\is_string($connection):
                 throw new \InvalidArgumentException(sprintf('Unsupported Connection: "%s".', \get_class($connection)));
             case 0 === strpos($connection, 'file://'):
-                return new StrictSessionHandler(new NativeFileSessionHandler(substr($connection, 7)));
+                $savePath = substr($connection, 7);
+
+                return new StrictSessionHandler(new NativeFileSessionHandler('' === $savePath ? null : $savePath));
 
             case 0 === strpos($connection, 'redis:'):
             case 0 === strpos($connection, 'rediss:'):

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/SessionHandlerFactoryTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/SessionHandlerFactoryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\SessionHandlerFactory;
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\StrictSessionHandler;
+
+/**
+ * Test class for SessionHandlerFactory.
+ *
+ * @author Simon <simon.chrzanowski@quentic.com>
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class SessionHandlerFactoryTest extends TestCase
+{
+    /**
+     * @dataProvider provideConnectionDSN
+     */
+    public function testCreateHandler(string $connectionDSN, string $expectedPath, string $expectedHandlerType)
+    {
+        $handler = SessionHandlerFactory::createHandler($connectionDSN);
+
+        $this->assertInstanceOf($expectedHandlerType, $handler);
+        $this->assertEquals($expectedPath, ini_get('session.save_path'));
+    }
+
+    public function provideConnectionDSN(): array
+    {
+        $base = sys_get_temp_dir();
+
+        return [
+            'native file handler using save_path from php.ini' => ['connectionDSN' => 'file://', 'expectedPath' => ini_get('session.save_path'), 'expectedHandlerType' => StrictSessionHandler::class],
+            'native file handler using provided save_path' => ['connectionDSN' => 'file://'.$base.'/session/storage', 'expectedPath' => $base.'/session/storage', 'expectedHandlerType' => StrictSessionHandler::class],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no 
| Tickets       | Fix #41669
| License       | MIT

By introducing the great Symfony\Component\HttpFoundation\Session\Storage\Handler\SessionHandlerFactory it is possible to configure session handler via DSN. But if I want to use the NativeFileSessionHandler to use configured session.save_path of php.ini, it doesn't work as expected because the $savePath constructor param is an empty string (and not NULL) by using "file://" as DSN.


