### PR TITLE
[Runtime] fix overriding --env|-e with single-command apps

### DIFF
--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -131,6 +131,7 @@ class SymfonyRuntime extends GenericRuntime
             }
 
             $console->setDefaultCommand($application->getName(), true);
+            $console->getDefinition()->addOptions($application->getDefinition()->getOptions());
 
             return $this->getRunner($console);
         }

--- a/src/Symfony/Component/Runtime/Tests/phpt/command.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/command.php
@@ -2,14 +2,15 @@
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 require __DIR__.'/autoload.php';
 
 return function (Command $command, InputInterface $input, OutputInterface $output, array $context) {
-    $command->setCode(function () use ($output, $context) {
-        $output->write('OK Command '.$context['SOME_VAR']);
-    });
+    $command->addOption('hello', 'e', InputOption::VALUE_REQUIRED, 'How should I greet?', 'OK');
 
-    return $command;
+    return $command->setCode(function () use ($input, $output, $context) {
+        $output->write($input->getOption('hello').' Command '.$context['SOME_VAR']);
+    });
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41658
| License       | MIT
| Doc PR        | -