### PR TITLE
[Console] Table vertical rendering

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.1
 ---
 
+ * Add support to display table vertically when calling setVertical()
  * Add method `__toString()` to `InputInterface`
  * Deprecate `Command::$defaultName` and `Command::$defaultDescription`, use the `AsCommand` attribute instead
  * Add suggested values for arguments and options in input definition, for input completion

--- a/src/Symfony/Component/Console/Tests/Helper/TableTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableTest.php
@@ -1579,4 +1579,374 @@ TABLE;
 
         $this->assertSame($expected, $this->getOutputContent($output));
     }
+
+    public function provideRenderVerticalTests(): \Traversable
+    {
+        $books = [
+            ['99921-58-10-7', 'Divine Comedy', 'Dante Alighieri', '9.95'],
+            ['9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens', '139.25'],
+        ];
+
+        yield 'With header for all' => [
+            <<<EOTXT
++------------------------------+
+|   ISBN: 99921-58-10-7        |
+|  Title: Divine Comedy        |
+| Author: Dante Alighieri      |
+|  Price: 9.95                 |
+|------------------------------|
+|   ISBN: 9971-5-0210-0        |
+|  Title: A Tale of Two Cities |
+| Author: Charles Dickens      |
+|  Price: 139.25               |
++------------------------------+
+
+EOTXT
+            ,
+            ['ISBN', 'Title', 'Author', 'Price'],
+            $books,
+        ];
+
+        yield 'With header for none' => [
+            <<<EOTXT
++----------------------+
+| 99921-58-10-7        |
+| Divine Comedy        |
+| Dante Alighieri      |
+| 9.95                 |
+|----------------------|
+| 9971-5-0210-0        |
+| A Tale of Two Cities |
+| Charles Dickens      |
+| 139.25               |
++----------------------+
+
+EOTXT
+            ,
+            [],
+            $books,
+        ];
+
+        yield 'With header for some' => [
+            <<<EOTXT
++------------------------------+
+|   ISBN: 99921-58-10-7        |
+|  Title: Divine Comedy        |
+| Author: Dante Alighieri      |
+|       : 9.95                 |
+|------------------------------|
+|   ISBN: 9971-5-0210-0        |
+|  Title: A Tale of Two Cities |
+| Author: Charles Dickens      |
+|       : 139.25               |
++------------------------------+
+
+EOTXT
+            ,
+            ['ISBN', 'Title', 'Author'],
+            $books,
+        ];
+
+        yield 'With row for some headers' => [
+            <<<EOTXT
++----------+
+| foo: one |
+| bar: two |
+| baz:     |
+|----------|
+| foo: 1   |
+| bar:     |
+| baz:     |
++----------+
+
+EOTXT
+            ,
+            ['foo', 'bar', 'baz'],
+            [
+                ['one', 'two'],
+                ['1'],
+            ],
+        ];
+
+        yield 'With TableSeparator' => [
+            <<<EOTXT
++-----------+
+| foo: one  |
+| bar: two  |
+| baz: tree |
+|-----------|
+| foo: 1    |
+| bar: 2    |
+| baz: 3    |
++-----------+
+
+EOTXT
+            ,
+            ['foo', 'bar', 'baz'],
+            [
+                ['one', 'two', 'tree'],
+                new TableSeparator(),
+                ['1', '2', '3'],
+            ],
+        ];
+
+        yield 'With breaking line' => [
+            <<<EOTXT
++-------------------------+
+|   ISBN: 99921-58-10-7   |
+|  Title: Divine Comedy   |
+| Author: Dante Alighieri |
+|  Price: 9.95            |
+|-------------------------|
+|   ISBN: 9971-5-0210-0   |
+|  Title: A Tale          |
+| of Two Cities           |
+| Author: Charles Dickens |
+|  Price: 139.25          |
++-------------------------+
+
+EOTXT
+            ,
+            ['ISBN', 'Title', 'Author', 'Price'],
+            [
+                ['99921-58-10-7', 'Divine Comedy', 'Dante Alighieri', '9.95'],
+                ['9971-5-0210-0', "A Tale\nof Two Cities", 'Charles Dickens', '139.25'],
+            ],
+        ];
+
+        yield 'With text tag' => [
+            <<<EOTXT
++------------------------------+
+|   ISBN: 99921-58-10-7        |
+|  Title: Divine Comedy        |
+| Author: Dante Alighieri      |
+|------------------------------|
+|   ISBN: 9971-5-0210-0        |
+|  Title: A Tale of Two Cities |
+| Author: Charles Dickens      |
++------------------------------+
+
+EOTXT
+            ,
+            ['ISBN', 'Title', 'Author'],
+            [
+                ['<info>99921-58-10-7</info>', '<error>Divine Comedy</error>', '<fg=blue;bg=white>Dante Alighieri</fg=blue;bg=white>'],
+                ['9971-5-0210-0', 'A Tale of Two Cities', '<info>Charles Dickens</>'],
+            ],
+        ];
+
+        yield 'With colspan' => [
+            <<<EOTXT
++---------------------------------------------------------------------------------------+
+|   ISBN: 99921-58-10-7                                                                 |
+|  Title: Divine Comedy                                                                 |
+| Author: Dante Alighieri                                                               |
+|---------------------------------------------------------------------------------------|
+| Cupiditate dicta atque porro, tempora exercitationem modi animi nulla nemo vel nihil! |
+|---------------------------------------------------------------------------------------|
+|   ISBN: 9971-5-0210-0                                                                 |
+|  Title: A Tale of Two Cities                                                          |
+| Author: Charles Dickens                                                               |
++---------------------------------------------------------------------------------------+
+
+EOTXT
+            ,
+            ['ISBN', 'Title', 'Author'],
+            [
+                ['99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'],
+                [new TableCell('Cupiditate dicta atque porro, tempora exercitationem modi animi nulla nemo vel nihil!', ['colspan' => 3])],
+                ['9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens'],
+            ],
+        ];
+
+        yield 'With colspans but no header' => [
+            <<<EOTXT
++--------------------------------------------------------------------------------+
+| Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor |
+|--------------------------------------------------------------------------------|
+| Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor |
+|--------------------------------------------------------------------------------|
+| Lorem ipsum dolor sit amet, consectetur                                        |
+| hello world                                                                    |
+|--------------------------------------------------------------------------------|
+| hello world                                                                    |
+| Lorem ipsum dolor sit amet, consectetur adipiscing elit                        |
+|--------------------------------------------------------------------------------|
+| hello                                                                          |
+| world                                                                          |
+| Lorem ipsum dolor sit amet, consectetur                                        |
+|--------------------------------------------------------------------------------|
+| Symfony                                                                        |
+| Test                                                                           |
+| Lorem ipsum dolor sit amet, consectetur                                        |
++--------------------------------------------------------------------------------+
+
+EOTXT
+            ,
+            [],
+            [
+                [new TableCell('Lorem ipsum dolor sit amet, <fg=white;bg=green>consectetur</> adipiscing elit, <fg=white;bg=red>sed</> do <fg=white;bg=red>eiusmod</> tempor', ['colspan' => 3])],
+                new TableSeparator(),
+                [new TableCell('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor', ['colspan' => 3])],
+                new TableSeparator(),
+                [new TableCell('Lorem ipsum <fg=white;bg=red>dolor</> sit amet, consectetur ', ['colspan' => 2]), 'hello world'],
+                new TableSeparator(),
+                ['hello <fg=white;bg=green>world</>', new TableCell('Lorem ipsum dolor sit amet, <fg=white;bg=green>consectetur</> adipiscing elit', ['colspan' => 2])],
+                new TableSeparator(),
+                ['hello ', new TableCell('world', ['colspan' => 1]), 'Lorem ipsum dolor sit amet, consectetur'],
+                new TableSeparator(),
+                ['Symfony ', new TableCell('Test', ['colspan' => 1]), 'Lorem <fg=white;bg=green>ipsum</> dolor sit amet, consectetur'],
+            ],
+        ];
+
+        yield 'Borderless style' => [
+            <<<EOTXT
+ ============================== 
+    ISBN: 99921-58-10-7         
+   Title: Divine Comedy         
+  Author: Dante Alighieri       
+   Price: 9.95                  
+ ============================== 
+    ISBN: 9971-5-0210-0         
+   Title: A Tale of Two Cities  
+  Author: Charles Dickens       
+   Price: 139.25                
+ ============================== 
+
+EOTXT
+            ,
+            ['ISBN', 'Title', 'Author', 'Price'],
+            $books,
+            'borderless',
+        ];
+
+        yield 'Compact style' => [
+            <<<EOTXT
+  ISBN: 99921-58-10-7        
+ Title: Divine Comedy        
+Author: Dante Alighieri      
+ Price: 9.95                 
+
+  ISBN: 9971-5-0210-0        
+ Title: A Tale of Two Cities 
+Author: Charles Dickens      
+ Price: 139.25               
+
+EOTXT
+            ,
+            ['ISBN', 'Title', 'Author', 'Price'],
+            $books,
+            'compact',
+        ];
+
+        yield 'symfony-style-guide style' => [
+            <<<EOTXT
+ ------------------------------ 
+    ISBN: 99921-58-10-7         
+   Title: Divine Comedy         
+  Author: Dante Alighieri       
+   Price: 9.95                  
+ ------------------------------ 
+    ISBN: 9971-5-0210-0         
+   Title: A Tale of Two Cities  
+  Author: Charles Dickens       
+   Price: 139.25                
+ ------------------------------ 
+
+EOTXT
+            ,
+            ['ISBN', 'Title', 'Author', 'Price'],
+            $books,
+            'symfony-style-guide',
+        ];
+
+        yield 'box style' => [
+            <<<EOTXT
+┌──────────────────────────────┐
+│   ISBN: 99921-58-10-7        │
+│  Title: Divine Comedy        │
+│ Author: Dante Alighieri      │
+│  Price: 9.95                 │
+│──────────────────────────────│
+│   ISBN: 9971-5-0210-0        │
+│  Title: A Tale of Two Cities │
+│ Author: Charles Dickens      │
+│  Price: 139.25               │
+└──────────────────────────────┘
+
+EOTXT
+            ,
+            ['ISBN', 'Title', 'Author', 'Price'],
+            $books,
+            'box',
+        ];
+
+        yield 'box-double style' => [
+            <<<EOTXT
+╔══════════════════════════════╗
+║   ISBN: 99921-58-10-7        ║
+║  Title: Divine Comedy        ║
+║ Author: Dante Alighieri      ║
+║  Price: 9.95                 ║
+║──────────────────────────────║
+║   ISBN: 9971-5-0210-0        ║
+║  Title: A Tale of Two Cities ║
+║ Author: Charles Dickens      ║
+║  Price: 139.25               ║
+╚══════════════════════════════╝
+
+EOTXT
+            ,
+            ['ISBN', 'Title', 'Author', 'Price'],
+            $books,
+            'box-double',
+        ];
+
+        yield 'With titles' => [
+            <<<EOTXT
++----------- Books ------------+
+|   ISBN: 99921-58-10-7        |
+|  Title: Divine Comedy        |
+| Author: Dante Alighieri      |
+|  Price: 9.95                 |
+|------------------------------|
+|   ISBN: 9971-5-0210-0        |
+|  Title: A Tale of Two Cities |
+| Author: Charles Dickens      |
+|  Price: 139.25               |
++---------- Page 1/2 ----------+
+
+EOTXT
+            ,
+            ['ISBN', 'Title', 'Author', 'Price'],
+            $books,
+            'default',
+            'Books',
+            'Page 1/2',
+        ];
+    }
+
+    /**
+     * @dataProvider provideRenderVerticalTests
+     */
+    public function testVerticalRender(string $expectedOutput, array $headers, array $rows, string $style = 'default', string $headerTitle = '', string $footerTitle = '')
+    {
+        $table = new Table($output = $this->getOutputStream());
+        $table
+            ->setHeaders($headers)
+            ->setRows($rows)
+            ->setVertical()
+            ->setStyle($style);
+
+        if (!empty($headerTitle)) {
+            $table->setHeaderTitle($headerTitle);
+        }
+        if (!empty($footerTitle)) {
+            $table->setFooterTitle($footerTitle);
+        }
+
+        $table->render();
+
+        $this->assertEquals($expectedOutput, $this->getOutputContent($output));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #41595
| License       | MIT
| Doc PR        | 

This PR adds a way to render Console Tables vertically. This is inspired by the way MySQL and PostgreSQL do with the '\G' command terminator.
For example, if we use this vertical rendering for the command `debug:validator`, the command would show something like:
```bash
App\Entity\Foo
-------------------

+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Property: bar                                                                                                                                                       |
|     Name: Symfony\Component\Validator\Constraints\Length                                                                                                            |
|   Groups: Default, Foo                                                                                                                                              |
|  Options: [                                                                                                                                                         |
|   "maxMessage" => "This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.",   |
|   "minMessage" => "This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.", |
|   "exactMessage" => "This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.",                                 |
|   "charsetMessage" => "This value does not match the expected {{ charset }} charset.",                                                                              |
|   "max" => 75,                                                                                                                                                      |
|   "min" => 2,                                                                                                                                                       |
|   "charset" => "UTF-8",                                                                                                                                             |
|   "normalizer" => null,                                                                                                                                             |
|   "allowEmptyString" => false,                                                                                                                                      |
|   "payload" => null                                                                                                                                                 |
| ]                                                                                                                                                                   |
|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| ...                                                                                                                                                                 |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+

```
Instead of : 
```bash
App\Entity\Foo
-------------------

+----------+------------------------------------------------+------------------------------------------------+----------------------------------------------------------------------------------+
| Property | Name                                           | Groups                                         | Options                                                                          |
+----------+------------------------------------------------+------------------------------------------------+----------------------------------------------------------------------------------+
| bar      | Symfony\Component\Validator\Constraints\Length | Default, Foo                                   | [                                                                                |
|          |                                                |                                                |   "maxMessage" => "This value                                                    |
|          |                                                |                                                | is too long. It should have {{ limit }} character or less.|This value is too lon |
|          |                                                |                                                | g. It should have {{ limit }} characters or less.",                              |
|          |                                                |                                                |   "minMessage" => "This value                                                    |
|          |                                                |                                                | is too short. It should have {{ limit }} character or more.|This value is too sh |
|          |                                                |                                                | ort. It should have {{ limit }} characters or more.",                            |
|          |                                                |                                                |   "exactMessage" => "This valu                                                   |
|          |                                                |                                                | e should have exactly {{ limit }} character.|This value should have exactly {{ l |
|          |                                                |                                                | imit }} characters.",                                                            |
|          |                                                |                                                |   "charsetMessage" => "This va                                                   |
|          |                                                |                                                | lue does not match the expected {{ charset }} charset.",                         |
|          |                                                |                                                |   "max" => 75,                                                                   |
|          |                                                |                                                |   "min" => 2,                                                                    |
|          |                                                |                                                |   "charset" => "UTF-8                                                   |
|          |                                                |                                                | 208m",                                                                           |
|          |                                                |                                                |   "normalizer" => null                                                   |
|          |                                                |                                                | ;208m,                                                                           |
|          |                                                |                                                |   "allowEmptyString" => false                                                   |
|          |                                                |                                                | [0;38;5;208m,                                                                    |
|          |                                                |                                                |   "payload" => null                                                   |
|          |                                                |                                                | 8m                                                                               |
|          |                                                |                                                | ]                                                                                |
...
+----------+------------------------------------------------+------------------------------------------------+----------------------------------------------------------------------------------+

```
Which is hard to read.