### PR TITLE
[Runtime] Add dotenv_overload option to SymfonyRuntime to tell Dotenv to override existing vars

### DIFF
--- a/src/Symfony/Component/Runtime/Tests/phpt/autoload.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/autoload.php
@@ -2,7 +2,8 @@
 
 use Symfony\Component\Runtime\SymfonyRuntime;
 
-$_SERVER['APP_RUNTIME_OPTIONS'] = [
+$_SERVER['APP_RUNTIME_OPTIONS'] = $_SERVER['APP_RUNTIME_OPTIONS'] ?? [];
+$_SERVER['APP_RUNTIME_OPTIONS'] += [
     'project_dir' => __DIR__,
 ];
 

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload.php
@@ -1,0 +1,15 @@
+<?php
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+$_SERVER['SOME_VAR'] = 'ccc';
+$_SERVER['APP_RUNTIME_OPTIONS'] = [
+    'dotenv_overload' => true,
+];
+
+require __DIR__.'/autoload.php';
+
+return function (Request $request, array $context) {
+    return new Response('OK Request '.$context['SOME_VAR']);
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test Dotenv overload
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/dotenv_overload.php';
+
+?>
+--EXPECTF--
+OK Request foo_bar


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Proposing this as bug fix because it's retro compatible and it looks like it was "forgotten".

My use case is that I have projects with:
```php
// ...
$dotenv = new Dotenv();
$dotenv->bootEnv($fullDotEnvPath = dirname(__DIR__).'/.env');
$dotenv->overload($fullDotEnvPath);
//...
```
I think it's not currently possible to migrate this behavior to the new Runtime component.

After:
```php
// ...
$_SERVER['APP_RUNTIME_OPTIONS'] = [
    'dotenv_overload' => true,
];
// ...
```