### PR TITLE
[PasswordHasher] Remove PasswordHasherAwareInterface type from UserPasswordHasherInterface API

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasher.php
@@ -32,7 +32,7 @@ class UserPasswordHasher implements UserPasswordHasherInterface
     }
 
     /**
-     * @param PasswordAuthenticatedUserInterface|PasswordHasherAwareInterface $user
+     * @param PasswordAuthenticatedUserInterface $user
      */
     public function hashPassword($user, string $plainPassword): string
     {
@@ -54,7 +54,7 @@ class UserPasswordHasher implements UserPasswordHasherInterface
     }
 
     /**
-     * @param PasswordAuthenticatedUserInterface|PasswordHasherAwareInterface $user
+     * @param PasswordAuthenticatedUserInterface $user
      */
     public function isPasswordValid($user, string $plainPassword): bool
     {
@@ -80,7 +80,7 @@ class UserPasswordHasher implements UserPasswordHasherInterface
     }
 
     /**
-     * @param PasswordAuthenticatedUserInterface|PasswordHasherAwareInterface $user
+     * @param PasswordAuthenticatedUserInterface $user
      */
     public function needsRehash($user): bool
     {

--- a/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasherInterface.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasherInterface.php
@@ -18,9 +18,9 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
  *
  * @author Ariel Ferrandini <arielferrandini@gmail.com>
  *
- * @method string hashPassword(PasswordAuthenticatedUserInterface|PasswordHasherAwareInterface $user, string $plainPassword)    Hashes the plain password for the given user.
- * @method bool   isPasswordValid(PasswordAuthenticatedUserInterface|PasswordHasherAwareInterface $user, string $plainPassword) Checks if the plaintext password matches the user's password.
- * @method bool   needsRehash(PasswordAuthenticatedUserInterface|PasswordHasherAwareInterface $user)                            Checks if an encoded password would benefit from rehashing.
+ * @method string hashPassword(PasswordAuthenticatedUserInterface $user, string $plainPassword)    Hashes the plain password for the given user.
+ * @method bool   isPasswordValid(PasswordAuthenticatedUserInterface $user, string $plainPassword) Checks if the plaintext password matches the user's password.
+ * @method bool   needsRehash(PasswordAuthenticatedUserInterface $user)                            Checks if an encoded password would benefit from rehashing.
  */
 interface UserPasswordHasherInterface
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | no (not yet released)
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As spotted by @stof in https://github.com/symfony/symfony/pull/41640#discussion_r650006561, the methods of this interface should not handle user classes/instances that are not implementing `PasswordAuthenticatedUserInterface`.
This reverts that part from https://github.com/symfony/symfony/pull/41678 (not released yet).