### PR TITLE
Fix Url Validator false positives

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -26,7 +26,7 @@ class UrlValidator extends ConstraintValidator
             (%s)://                                 # protocol
             (((?:[\_\.\pL\pN-]|%%[0-9A-Fa-f]{2})+:)?((?:[\_\.\pL\pN-]|%%[0-9A-Fa-f]{2})+)@)?  # basic auth
             (
-                ([\pL\pN\pS\-\_\.])+(\.?([\pL\pN]|xn\-\-[\pL\pN-]+)+\.?) # a domain name
+                ([\pL\pN\pS]+\.?[\pL\pN\pS\-\_]+)+(\.?([\pL\pN]|xn\-\-[\pL\pN-]+)+\.?) # a domain name
                     |                                                 # or
                 \d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}                    # an IP address
                     |                                                 # or

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -105,6 +105,7 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
         return [
             ['http://a.pl'],
             ['http://www.example.com'],
+            ['http://tt.example.com'],
             ['http://www.example.com.'],
             ['http://www.example.museum'],
             ['https://example.com/'],
@@ -265,6 +266,10 @@ class UrlValidatorTest extends ConstraintValidatorTestCase
             ['http://example.com/exploit.html?hel lo'],
             ['http://example.com/exploit.html?not_a%hex'],
             ['http://'],
+            ['http://www..com'],
+            ['http://www..example.com'],
+            ['http://wwww.example..com'],
+            ['http://.www.example.com'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/41683
| License       | MIT

This PR tries to fix false positive issues with a couple of variants of domain names which Url validator thinks that they are valid

Url Validator returns false positive result on cases:
- http://www.example..com
- http://www..example.com
- http://www..com
- http://.www.example.com