### PR TITLE
[Security] Make it possible to inherit MessageDigestPasswordHasher

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Hasher/MessageDigestPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/MessageDigestPasswordHasher.php
@@ -83,7 +83,7 @@ class MessageDigestPasswordHasher implements LegacyPasswordHasherInterface
         return false;
     }
 
-    private function mergePasswordAndSalt(string $password, ?string $salt): string
+    protected function mergePasswordAndSalt(string $password, ?string $salt): string
     {
         if (!$salt) {
             return $password;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

Symfony 5.3 breaks existing installations that inherit MessageDigestPasswordEncoder (MessageDigestPasswordHasher) because the mergePasswordAndSalt method is private and thus cannot be overwritten.