### PR TITLE
[Security] Restore extension point in MessageDigestPasswordEncoder

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Core\Encoder;
 
 use Symfony\Component\PasswordHasher\Hasher\MessageDigestPasswordHasher;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
 trigger_deprecation('symfony/security-core', '5.3', 'The "%s" class is deprecated, use "%s" instead.', MessageDigestPasswordEncoder::class, MessageDigestPasswordHasher::class);
 
@@ -24,7 +25,10 @@ trigger_deprecation('symfony/security-core', '5.3', 'The "%s" class is deprecate
  */
 class MessageDigestPasswordEncoder extends BasePasswordEncoder
 {
-    use LegacyEncoderTrait;
+    private $algorithm;
+    private $encodeHashAsBase64;
+    private $iterations = 1;
+    private $encodedLength = -1;
 
     /**
      * @param string $algorithm          The digest algorithm to use
@@ -33,6 +37,51 @@ class MessageDigestPasswordEncoder extends BasePasswordEncoder
      */
     public function __construct(string $algorithm = 'sha512', bool $encodeHashAsBase64 = true, int $iterations = 5000)
     {
-        $this->hasher = new MessageDigestPasswordHasher($algorithm, $encodeHashAsBase64, $iterations);
+        $this->algorithm = $algorithm;
+        $this->encodeHashAsBase64 = $encodeHashAsBase64;
+
+        try {
+            $this->encodedLength = \strlen($this->encodePassword('', 'salt'));
+        } catch (\LogicException $e) {
+            // ignore algorithm not supported
+        }
+
+        $this->iterations = $iterations;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function encodePassword(string $raw, ?string $salt)
+    {
+        if ($this->isPasswordTooLong($raw)) {
+            throw new BadCredentialsException('Invalid password.');
+        }
+
+        if (!\in_array($this->algorithm, hash_algos(), true)) {
+            throw new \LogicException(sprintf('The algorithm "%s" is not supported.', $this->algorithm));
+        }
+
+        $salted = $this->mergePasswordAndSalt($raw, $salt);
+        $digest = hash($this->algorithm, $salted, true);
+
+        // "stretch" hash
+        for ($i = 1; $i < $this->iterations; ++$i) {
+            $digest = hash($this->algorithm, $digest.$salted, true);
+        }
+
+        return $this->encodeHashAsBase64 ? base64_encode($digest) : bin2hex($digest);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPasswordValid(string $encoded, string $raw, ?string $salt)
+    {
+        if (\strlen($encoded) !== $this->encodedLength || false !== strpos($encoded, '$')) {
+            return false;
+        }
+
+        return !$this->isPasswordTooLong($raw) && $this->comparePasswords($encoded, $this->encodePassword($raw, $salt));
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/Fixtures/MyMessageDigestPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/Fixtures/MyMessageDigestPasswordEncoder.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Tests\Encoder\Fixtures;
+
+use Symfony\Component\Security\Core\Encoder\MessageDigestPasswordEncoder;
+
+final class MyMessageDigestPasswordEncoder extends MessageDigestPasswordEncoder
+{
+    public function __construct()
+    {
+        parent::__construct('sha512', true, 1);
+    }
+
+    protected function mergePasswordAndSalt(string $password, ?string $salt): string
+    {
+        return json_encode(['password' => $password, 'salt' => $salt]);
+    }
+
+    protected function demergePasswordAndSalt(string $mergedPasswordSalt): array
+    {
+        ['password' => $password, 'salt' => $salt] = json_decode($mergedPasswordSalt, true);
+
+        return [$password, $salt];
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Encoder/MessageDigestPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Encoder/MessageDigestPasswordEncoderTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Core\Tests\Encoder;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Encoder\MessageDigestPasswordEncoder;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\Tests\Encoder\Fixtures\MyMessageDigestPasswordEncoder;
 
 /**
  * @group legacy
@@ -59,5 +60,14 @@ class MessageDigestPasswordEncoderTest extends TestCase
         $encoder = new MessageDigestPasswordEncoder();
 
         $this->assertFalse($encoder->isPasswordValid('encoded', str_repeat('a', 5000), 'salt'));
+    }
+
+    public function testCustomEncoder()
+    {
+        $encoder = new MyMessageDigestPasswordEncoder();
+        $encodedPassword = $encoder->encodePassword('p4ssw0rd', 's417');
+
+        $this->assertSame(base64_encode(hash('sha512', '{"password":"p4ssw0rd","salt":"s417"}', true)), $encodedPassword);
+        $this->assertTrue($encoder->isPasswordValid($encodedPassword, 'p4ssw0rd', 's417'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/41696#issuecomment-860824922
| License       | MIT
| Doc PR        | N/A

Until Symfony 5.2, it was possible to extend `MessageDigestPasswordEncoder` and override the way password and salt are merged. This broke with #39802. I've restored the old logic and added a test case to cover that scenario.