### PR TITLE
[Routing][Serializer] Add possible missing imports of NamedArgumentConstructor

### DIFF
--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Routing\Annotation;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
+
 /**
  * Annotation class for @Route().
  *

--- a/src/Symfony/Component/Routing/Tests/Annotation/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/Annotation/RouteTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Tests\Annotation;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
@@ -87,6 +88,13 @@ class RouteTest extends TestCase
     {
         $route = $this->getMethodAnnotation($methodName, false);
         $this->assertEquals($route->$getter(), $expectedReturn);
+    }
+
+    public function testLoadFromDoctrineAnnotationInClassDocblock()
+    {
+        $annotations = (new AnnotationReader())->getClassAnnotations(new \ReflectionClass(Route::class));
+        $this->assertNotEmpty($annotations);
+        $this->assertInstanceOf(NamedArgumentConstructor::class, $annotations[1]);
     }
 
     public function getValidParameters(): iterable

--- a/src/Symfony/Component/Serializer/Annotation/Context.php
+++ b/src/Symfony/Component/Serializer/Annotation/Context.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Annotation;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
 /**

--- a/src/Symfony/Component/Serializer/Annotation/DiscriminatorMap.php
+++ b/src/Symfony/Component/Serializer/Annotation/DiscriminatorMap.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Annotation;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
 /**

--- a/src/Symfony/Component/Serializer/Annotation/Groups.php
+++ b/src/Symfony/Component/Serializer/Annotation/Groups.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Annotation;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
 /**

--- a/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
+++ b/src/Symfony/Component/Serializer/Annotation/MaxDepth.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Annotation;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
 /**

--- a/src/Symfony/Component/Serializer/Annotation/SerializedName.php
+++ b/src/Symfony/Component/Serializer/Annotation/SerializedName.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Annotation;
 
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | 

Hi.
This PR fixes possible missing imports of NamedArgumentConstructor (etc. added in https://github.com/symfony/symfony/pull/40266).

The main reason for this pull request and apply this changes is error caused by JMSSerializer as below:

```
Luxmed\Intranet\Exceptions\JMSSerializerException : [Semantical Error] The annotation "@NamedArgumentConstructor" in class Symfony\Component\Routing\Annotation\Route was never imported. Did you maybe forget to add a "use" statement for this annotation?
 /var/www/intranet/src/Service/JMSSerializerService.php:136
 /var/www/intranet/tests/DTO/SearchAnnotationDTOTest.php:197
 
 Caused by
 Doctrine\Common\Annotations\AnnotationException: [Semantical Error] The annotation "@NamedArgumentConstructor" in class Symfony\Component\Routing\Annotation\Route was never imported. Did you maybe forget to add a "use" statement for this annotation?
 
 /var/www/intranet/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationException.php:39
 /var/www/intranet/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php:803
 /var/www/intranet/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php:719
 /var/www/intranet/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/DocParser.php:376
 /var/www/intranet/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/AnnotationReader.php:146
 /var/www/intranet/vendor/doctrine/annotations/lib/Doctrine/Common/Annotations/CachedReader.php:64
 /var/www/intranet/vendor/jms/serializer/src/Metadata/Driver/AnnotationDriver.php:92
 /var/www/intranet/vendor/jms/metadata/src/Driver/DriverChain.php:32
 /var/www/intranet/vendor/jms/serializer/src/Metadata/Driver/TypedPropertiesDriver.php:63
 /var/www/intranet/vendor/jms/metadata/src/MetadataFactory.php:111
 /var/www/intranet/vendor/jms/serializer/src/GraphNavigator/SerializationGraphNavigator.php:218
 /var/www/intranet/vendor/jms/serializer/src/JsonSerializationVisitor.php:137
 /var/www/intranet/vendor/jms/serializer/src/GraphNavigator/SerializationGraphNavigator.php:260
 /var/www/intranet/vendor/jms/serializer/src/Serializer.php:252
 /var/www/intranet/vendor/jms/serializer/src/Serializer.php:163
 /var/www/intranet/src/Service/JMSSerializerService.php:134
 /var/www/intranet/tests/DTO/SearchAnnotationDTOTest.php:197
```