### PR TITLE
[HttpFoundation] Use directly `has` object method into `get` object method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -87,7 +87,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      */
     public function get(string $key, $default = null)
     {
-        return \array_key_exists($key, $this->parameters) ? $this->parameters[$key] : $default;
+        return $this->has($key) ? $this->parameters[$key] : $default;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

Use directly has object method into get object method

