### PR TITLE
[Mailer] [Sendgrid] Add template support

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 5.4
 ---
 
-* Add supporte for templates and dynamic template data
+* Add support for templates and dynamic template data
 
 4.4.0
 -----

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+* Add supporte for templates and dynamic template data
+
 4.4.0
 -----
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Mailer\Bridge\Sendgrid\Tests\Transport;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridApiTransport;
 use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -282,6 +283,26 @@ class SendgridApiTransportTest extends TestCase
             ->willReturn($response);
 
         $mailer = new SendgridApiTransport('foo', $httpClient);
+        $mailer->send($email);
+    }
+
+    public function testSendWithInvalidTemplateIdThrowsInvalidArgumentException()
+    {
+        $invalidTemplateId = 'd-abcd';
+
+        $email = new Email();
+        $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
+            ->to(new Address('bar@example.com', 'Mr. Recipient'))
+            ->bcc('baz@example.com')
+            ->text('content');
+
+        $email->getHeaders()->addTextHeader('X-Template-ID', $invalidTemplateId);
+
+        $mailer = new SendgridApiTransport('foo', $this->createMock(HttpClientInterface::class));
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Invalid TemplateID. Got: %s', $invalidTemplateId));
+
         $mailer->send($email);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -301,7 +301,7 @@ class SendgridApiTransportTest extends TestCase
         $mailer = new SendgridApiTransport('foo', $this->createMock(HttpClientInterface::class));
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(sprintf('Invalid TemplateID. Got: %s', $invalidTemplateId));
+        $this->expectExceptionMessage(sprintf('Invalid TemplateID. Got: "%s"', $invalidTemplateId));
 
         $mailer->send($email);
     }

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -225,7 +225,7 @@ class SendgridApiTransportTest extends TestCase
 
     public function testSendTemplateIdWithDynamicTemplateData()
     {
-        $templateId = 'd-d-0aac27809ad64ae98d5ebaf896ea8b33';
+        $templateId = 'd-0aac27809ad64ae98d5ebaf896ea8b33';
         $dynamicTemplateData = [
             'foo' => 'bar',
         ];

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -260,9 +260,9 @@ class SendgridApiTransportTest extends TestCase
                     'personalizations' => [
                         [
                             'to' => [[
-                                         'email' => 'bar@example.com',
-                                         'name' => 'Mr. Recipient',
-                                     ]],
+                                'email' => 'bar@example.com',
+                                'name' => 'Mr. Recipient',
+                            ]],
                             'subject' => null,
                             'dynamic_template_data' => $dynamicTemplateData,
                             'bcc' => [['email' => 'baz@example.com']],

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -116,7 +116,7 @@ class SendgridApiTransport extends AbstractApiTransport
                 $templateId = $header->getBodyAsString();
 
                 if (!preg_match('/^d\-[a-z0-9]{32}$/', $templateId)) {
-                    throw new InvalidArgumentException(sprintf('Invalid TemplateID. Got: %s', $templateId));
+                    throw new InvalidArgumentException(sprintf('Invalid TemplateID. Got: "%s".', $templateId));
                 }
 
                 $payload['template_id'] = $templateId;

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Mailer\Bridge\Sendgrid\Transport;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\InvalidArgumentException;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
@@ -112,7 +113,13 @@ class SendgridApiTransport extends AbstractApiTransport
             }
 
             if ('x-template-id' === $name) {
-                $payload['template_id'] = $header->getBodyAsString();
+                $templateId = $header->getBodyAsString();
+
+                if (!preg_match('/^d\-[a-z0-9]{32}$/', $templateId)) {
+                    throw new InvalidArgumentException(sprintf('Invalid TemplateID. Got: %s', $templateId));
+                }
+
+                $payload['template_id'] = $templateId;
 
                 continue;
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | ---
| License       | MIT
| Doc PR        | TODO

Documentation: https://sendgrid.com/docs/ui/sending-email/how-to-send-an-email-with-dynamic-transactional-templates/#send-a-transactional-email

You can now do the following:
```php
$email = new Email();
$email->addTo($'foo@bar.de');
$email->text('text');
$email->html('<html></html>');
$email->getHeaders()->addTextHeader('X-Template-ID', 'd-0aac27809ad64ae98d5ebaf896e58b33');
$email->getHeaders()->addTextHeader('X-Dynamic-Template-Data', json_encode(['price' => '42 €']));
```


I am however not sure about the `json_encode`/`json_decode` for handling an array, any proposal?
I also tried to use sth. like:
```php
$email->getHeader->addArrayHeader('X-Dynamic-Template-Data', ['price' => '42 €']);
```
but I am not sure about the spec and if I am allowed to add a new kind of header to the Mime component 🤔 

Note that you need to add sth. like:
```php
$email->text('text');
$email->html('<html></html>');
```

otherwise you will receive an exception:
<img width="515" alt="CleanShot 2021-06-15 at 13 49 46@2x" src="https://user-images.githubusercontent.com/995707/122047544-928cc700-cde0-11eb-9914-5e6b1fa343a6.png">
