### PR TITLE
[Console] BUG: revert negatable ansi

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1040,7 +1040,8 @@ class Application implements ResetInterface
             new InputOption('--quiet', '-q', InputOption::VALUE_NONE, 'Do not output any message'),
             new InputOption('--verbose', '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
             new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Display this application version'),
-            new InputOption('--ansi', '', InputOption::VALUE_NEGATABLE, 'Force (or disable --no-ansi) ANSI output', false),
+            new InputOption('--ansi', '', InputOption::VALUE_NONE, 'Force ANSI output'),
+            new InputOption('--no-ansi', '', InputOption::VALUE_NONE, 'Disable ANSI output'),
             new InputOption('--no-interaction', '-n', InputOption::VALUE_NONE, 'Do not ask any interactive question'),
         ]);
     }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -503,12 +503,12 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'foos:bar1'], ['decorated' => false]);
         $this->assertSame('
-                                                          
-  There are no commands defined in the "foos" namespace.  
-                                                          
-  Did you mean this?                                      
-      foo                                                 
-                                                          
+
+  There are no commands defined in the "foos" namespace.
+
+  Did you mean this?
+      foo
+
 
 ', $tester->getDisplay(true));
     }
@@ -1277,8 +1277,7 @@ class ApplicationTest extends TestCase
         $this->assertTrue($inputDefinition->hasOption('verbose'));
         $this->assertTrue($inputDefinition->hasOption('version'));
         $this->assertTrue($inputDefinition->hasOption('ansi'));
-        $this->assertTrue($inputDefinition->hasNegation('no-ansi'));
-        $this->assertFalse($inputDefinition->hasOption('no-ansi'));
+        $this->assertTrue($inputDefinition->hasOption('no-ansi'));
         $this->assertTrue($inputDefinition->hasOption('no-interaction'));
     }
 

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -80,7 +80,8 @@ Options:
   -h, --help            Display help for the given command. When no command is given display help for the list command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
-      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
+      --ansi            Force ANSI output
+      --no-ansi         Disable ANSI output
   -n, --no-interaction  Do not ask any interactive question
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
@@ -79,7 +79,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Force (or disable --no-ansi) ANSI output",
+                        "description": "Force ANSI output",
                         "default": false
                     },
                     "no-ansi": {
@@ -88,7 +88,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Negate the \"--ansi\" option",
+                        "description": "Disable ANSI output",
                         "default": false
                     },
                     "no-interaction": {
@@ -182,7 +182,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Force (or disable --no-ansi) ANSI output",
+                        "description": "Force ANSI output",
                         "default": false
                     },
                     "no-ansi": {
@@ -191,7 +191,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Negate the \"--ansi\" option",
+                        "description": "Disable ANSI output",
                         "default": false
                     },
                     "no-interaction": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.md
@@ -95,14 +95,24 @@ Display this application version
 * Is negatable: no
 * Default: `false`
 
-#### `--ansi|--no-ansi`
+#### `--ansi`
 
-Force (or disable --no-ansi) ANSI output
+Force ANSI output
 
 * Accept value: no
 * Is value required: no
 * Is multiple: no
-* Is negatable: yes
+* Is negatable: no
+* Default: `false`
+
+#### `--no-ansi`
+
+Disable ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
 * Default: `false`
 
 #### `--no-interaction|-n`
@@ -222,14 +232,24 @@ Display this application version
 * Is negatable: no
 * Default: `false`
 
-#### `--ansi|--no-ansi`
+#### `--ansi`
 
-Force (or disable --no-ansi) ANSI output
+Force ANSI output
 
 * Accept value: no
 * Is value required: no
 * Is multiple: no
-* Is negatable: yes
+* Is negatable: no
+* Default: `false`
+
+#### `--no-ansi`
+
+Disable ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
 * Default: `false`
 
 #### `--no-interaction|-n`

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.txt
@@ -7,7 +7,8 @@ Console Tool
   <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
   <info>-q, --quiet</info>           Do not output any message
   <info>-V, --version</info>         Display this application version
-  <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
+  <info>    --ansi</info>            Force ANSI output
+  <info>    --no-ansi</info>         Disable ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question
   <info>-v|vv|vvv, --verbose</info>  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
@@ -7,13 +7,13 @@
       </usages>
       <description>Display help for a command</description>
       <help>The &lt;info&gt;help&lt;/info&gt; command displays help for a given command:
- 
+
    &lt;info&gt;app/console help list&lt;/info&gt;
- 
+
  You can also output the help in other formats by using the &lt;comment&gt;--format&lt;/comment&gt; option:
- 
+
    &lt;info&gt;app/console help --format=xml list&lt;/info&gt;
- 
+
  To display the list of available commands, please use the &lt;info&gt;list&lt;/info&gt; command.</help>
       <arguments>
         <argument name="command_name" is_required="0" is_array="0">
@@ -46,10 +46,10 @@
           <description>Display this application version</description>
         </option>
         <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Force (or disable --no-ansi) ANSI output</description>
+          <description>Force ANSI output</description>
         </option>
         <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Negate the "--ansi" option</description>
+          <description>Disable ANSI output</description>
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
@@ -62,19 +62,19 @@
       </usages>
       <description>List commands</description>
       <help>The &lt;info&gt;list&lt;/info&gt; command lists all commands:
- 
+
    &lt;info&gt;app/console list&lt;/info&gt;
- 
+
  You can also display the commands for a specific namespace:
- 
+
    &lt;info&gt;app/console list test&lt;/info&gt;
- 
+
  You can also output the information in other formats by using the &lt;comment&gt;--format&lt;/comment&gt; option:
- 
+
    &lt;info&gt;app/console list --format=xml&lt;/info&gt;
- 
+
  It's also possible to get raw list of commands (useful for embedding command runner):
- 
+
    &lt;info&gt;app/console list --raw&lt;/info&gt;</help>
       <arguments>
         <argument name="namespace" is_required="0" is_array="0">
@@ -108,10 +108,10 @@
           <description>Display this application version</description>
         </option>
         <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Force (or disable --no-ansi) ANSI output</description>
+          <description>Force ANSI output</description>
         </option>
         <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Negate the "--ansi" option</description>
+          <description>Disable ANSI output</description>
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -83,7 +83,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Force (or disable --no-ansi) ANSI output",
+                        "description": "Force ANSI output",
                         "default": false
                     },
                     "no-ansi": {
@@ -92,7 +92,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Negate the \"--ansi\" option",
+                        "description": "Disable ANSI output",
                         "default": false
                     },
                     "no-interaction": {
@@ -186,7 +186,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Force (or disable --no-ansi) ANSI output",
+                        "description": "Force ANSI output",
                         "default": false
                     },
                     "no-ansi": {
@@ -195,7 +195,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Negate the \"--ansi\" option",
+                        "description": "Disable ANSI output",
                         "default": false
                     },
                     "no-interaction": {
@@ -274,7 +274,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Force (or disable --no-ansi) ANSI output",
+                        "description": "Force ANSI output",
                         "default": false
                     },
                     "no-ansi": {
@@ -283,7 +283,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Negate the \"--ansi\" option",
+                        "description": "Disable ANSI output",
                         "default": false
                     },
                     "no-interaction": {
@@ -370,7 +370,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Force (or disable --no-ansi) ANSI output",
+                        "description": "Force ANSI output",
                         "default": false
                     },
                     "no-ansi": {
@@ -379,7 +379,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Negate the \"--ansi\" option",
+                        "description": "Disable ANSI output",
                         "default": false
                     },
                     "no-interaction": {
@@ -447,7 +447,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Force (or disable --no-ansi) ANSI output",
+                        "description": "Force ANSI output",
                         "default": false
                     },
                     "no-ansi": {
@@ -456,7 +456,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Negate the \"--ansi\" option",
+                        "description": "Disable ANSI output",
                         "default": false
                     },
                     "no-interaction": {
@@ -526,7 +526,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Force (or disable --no-ansi) ANSI output",
+                        "description": "Force ANSI output",
                         "default": false
                     },
                     "no-ansi": {
@@ -535,7 +535,7 @@
                         "accept_value": false,
                         "is_value_required": false,
                         "is_multiple": false,
-                        "description": "Negate the \"--ansi\" option",
+                        "description": "Disable ANSI output",
                         "default": false
                     },
                     "no-interaction": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.md
@@ -108,14 +108,24 @@ Display this application version
 * Is negatable: no
 * Default: `false`
 
-#### `--ansi|--no-ansi`
+#### `--ansi`
 
-Force (or disable --no-ansi) ANSI output
+Force ANSI output
 
 * Accept value: no
 * Is value required: no
 * Is multiple: no
-* Is negatable: yes
+* Is negatable: no
+* Default: `false`
+
+#### `--no-ansi`
+
+Disable ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
 * Default: `false`
 
 #### `--no-interaction|-n`
@@ -235,14 +245,24 @@ Display this application version
 * Is negatable: no
 * Default: `false`
 
-#### `--ansi|--no-ansi`
+#### `--ansi`
 
-Force (or disable --no-ansi) ANSI output
+Force ANSI output
 
 * Accept value: no
 * Is value required: no
 * Is multiple: no
-* Is negatable: yes
+* Is negatable: no
+* Default: `false`
+
+#### `--no-ansi`
+
+Disable ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
 * Default: `false`
 
 #### `--no-interaction|-n`
@@ -310,14 +330,24 @@ Display this application version
 * Is negatable: no
 * Default: `false`
 
-#### `--ansi|--no-ansi`
+#### `--ansi`
 
-Force (or disable --no-ansi) ANSI output
+Force ANSI output
 
 * Accept value: no
 * Is value required: no
 * Is multiple: no
-* Is negatable: yes
+* Is negatable: no
+* Default: `false`
+
+#### `--no-ansi`
+
+Disable ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
 * Default: `false`
 
 #### `--no-interaction|-n`
@@ -401,14 +431,24 @@ Display this application version
 * Is negatable: no
 * Default: `false`
 
-#### `--ansi|--no-ansi`
+#### `--ansi`
 
-Force (or disable --no-ansi) ANSI output
+Force ANSI output
 
 * Accept value: no
 * Is value required: no
 * Is multiple: no
-* Is negatable: yes
+* Is negatable: no
+* Default: `false`
+
+#### `--no-ansi`
+
+Disable ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
 * Default: `false`
 
 #### `--no-interaction|-n`
@@ -473,14 +513,24 @@ Display this application version
 * Is negatable: no
 * Default: `false`
 
-#### `--ansi|--no-ansi`
+#### `--ansi`
 
-Force (or disable --no-ansi) ANSI output
+Force ANSI output
 
 * Accept value: no
 * Is value required: no
 * Is multiple: no
-* Is negatable: yes
+* Is negatable: no
+* Default: `false`
+
+#### `--no-ansi`
+
+Disable ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
 * Default: `false`
 
 #### `--no-interaction|-n`

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.txt
@@ -7,7 +7,8 @@ My Symfony application <info>v1.0</info>
   <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
   <info>-q, --quiet</info>           Do not output any message
   <info>-V, --version</info>         Display this application version
-  <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
+  <info>    --ansi</info>            Force ANSI output
+  <info>    --no-ansi</info>         Disable ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question
   <info>-v|vv|vvv, --verbose</info>  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -7,13 +7,13 @@
       </usages>
       <description>Display help for a command</description>
       <help>The &lt;info&gt;help&lt;/info&gt; command displays help for a given command:
- 
+
    &lt;info&gt;app/console help list&lt;/info&gt;
- 
+
  You can also output the help in other formats by using the &lt;comment&gt;--format&lt;/comment&gt; option:
- 
+
    &lt;info&gt;app/console help --format=xml list&lt;/info&gt;
- 
+
  To display the list of available commands, please use the &lt;info&gt;list&lt;/info&gt; command.</help>
       <arguments>
         <argument name="command_name" is_required="0" is_array="0">
@@ -46,10 +46,10 @@
           <description>Display this application version</description>
         </option>
         <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Force (or disable --no-ansi) ANSI output</description>
+          <description>Force ANSI output</description>
         </option>
         <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Negate the "--ansi" option</description>
+          <description>Disable ANSI output</description>
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
@@ -62,19 +62,19 @@
       </usages>
       <description>List commands</description>
       <help>The &lt;info&gt;list&lt;/info&gt; command lists all commands:
- 
+
    &lt;info&gt;app/console list&lt;/info&gt;
- 
+
  You can also display the commands for a specific namespace:
- 
+
    &lt;info&gt;app/console list test&lt;/info&gt;
- 
+
  You can also output the information in other formats by using the &lt;comment&gt;--format&lt;/comment&gt; option:
- 
+
    &lt;info&gt;app/console list --format=xml&lt;/info&gt;
- 
+
  It's also possible to get raw list of commands (useful for embedding command runner):
- 
+
    &lt;info&gt;app/console list --raw&lt;/info&gt;</help>
       <arguments>
         <argument name="namespace" is_required="0" is_array="0">
@@ -108,10 +108,10 @@
           <description>Display this application version</description>
         </option>
         <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Force (or disable --no-ansi) ANSI output</description>
+          <description>Force ANSI output</description>
         </option>
         <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Negate the "--ansi" option</description>
+          <description>Disable ANSI output</description>
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
@@ -141,10 +141,10 @@
           <description>Display this application version</description>
         </option>
         <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Force (or disable --no-ansi) ANSI output</description>
+          <description>Force ANSI output</description>
         </option>
         <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Negate the "--ansi" option</description>
+          <description>Disable ANSI output</description>
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
@@ -182,10 +182,10 @@
           <description>Display this application version</description>
         </option>
         <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Force (or disable --no-ansi) ANSI output</description>
+          <description>Force ANSI output</description>
         </option>
         <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Negate the "--ansi" option</description>
+          <description>Disable ANSI output</description>
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
@@ -213,10 +213,10 @@
           <description>Display this application version</description>
         </option>
         <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Force (or disable --no-ansi) ANSI output</description>
+          <description>Force ANSI output</description>
         </option>
         <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Negate the "--ansi" option</description>
+          <description>Disable ANSI output</description>
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>
@@ -246,10 +246,10 @@
           <description>Display this application version</description>
         </option>
         <option name="--ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Force (or disable --no-ansi) ANSI output</description>
+          <description>Force ANSI output</description>
         </option>
         <option name="--no-ansi" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
-          <description>Negate the "--ansi" option</description>
+          <description>Disable ANSI output</description>
         </option>
         <option name="--no-interaction" shortcut="-n" accept_value="0" is_value_required="0" is_multiple="0">
           <description>Do not ask any interactive question</description>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_filtered_namespace.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_filtered_namespace.txt
@@ -7,7 +7,8 @@ My Symfony application <info>v1.0</info>
   <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
   <info>-q, --quiet</info>           Do not output any message
   <info>-V, --version</info>         Display this application version
-  <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
+  <info>    --ansi</info>            Force ANSI output
+  <info>    --no-ansi</info>         Disable ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question
   <info>-v|vv|vvv, --verbose</info>  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.md
@@ -99,14 +99,24 @@ Display this application version
 * Is negatable: no
 * Default: `false`
 
-#### `--ansi|--no-ansi`
+#### `--ansi`
 
-Force (or disable --no-ansi) ANSI output
+Force ANSI output
 
 * Accept value: no
 * Is value required: no
 * Is multiple: no
-* Is negatable: yes
+* Is negatable: no
+* Default: `false`
+
+#### `--no-ansi`
+
+Disable ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
 * Default: `false`
 
 #### `--no-interaction|-n`
@@ -226,14 +236,24 @@ Display this application version
 * Is negatable: no
 * Default: `false`
 
-#### `--ansi|--no-ansi`
+#### `--ansi`
 
-Force (or disable --no-ansi) ANSI output
+Force ANSI output
 
 * Accept value: no
 * Is value required: no
 * Is multiple: no
-* Is negatable: yes
+* Is negatable: no
+* Default: `false`
+
+#### `--no-ansi`
+
+Disable ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
 * Default: `false`
 
 #### `--no-interaction|-n`
@@ -317,14 +337,24 @@ Display this application version
 * Is negatable: no
 * Default: `false`
 
-#### `--ansi|--no-ansi`
+#### `--ansi`
 
-Force (or disable --no-ansi) ANSI output
+Force ANSI output
 
 * Accept value: no
 * Is value required: no
 * Is multiple: no
-* Is negatable: yes
+* Is negatable: no
+* Default: `false`
+
+#### `--no-ansi`
+
+Disable ANSI output
+
+* Accept value: no
+* Is value required: no
+* Is multiple: no
+* Is negatable: no
 * Default: `false`
 
 #### `--no-interaction|-n`

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_mbstring.txt
@@ -7,7 +7,8 @@ MbString åpplicätion
   <info>-h, --help</info>            Display help for the given command. When no command is given display help for the <info>list</info> command
   <info>-q, --quiet</info>           Do not output any message
   <info>-V, --version</info>         Display this application version
-  <info>    --ansi|--no-ansi</info>  Force (or disable --no-ansi) ANSI output
+  <info>    --ansi</info>            Force ANSI output
+  <info>    --no-ansi</info>         Disable ANSI output
   <info>-n, --no-interaction</info>  Do not ask any interactive question
   <info>-v|vv|vvv, --verbose</info>  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run1.txt
@@ -7,7 +7,8 @@ Options:
   -h, --help            Display help for the given command. When no command is given display help for the list command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
-      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
+      --ansi            Force ANSI output
+      --no-ansi         Disable ANSI output
   -n, --no-interaction  Do not ask any interactive question
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
@@ -14,23 +14,24 @@ Options:
   -h, --help            Display help for the given command. When no command is given display help for the list command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
-      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
+      --ansi            Force ANSI output
+      --no-ansi         Disable ANSI output
   -n, --no-interaction  Do not ask any interactive question
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 Help:
   The list command lists all commands:
-  
+
     app/console list
-  
+
   You can also display the commands for a specific namespace:
-  
+
     app/console list test
-  
+
   You can also output the information in other formats by using the --format option:
-  
+
     app/console list --format=xml
-  
+
   It's also possible to get raw list of commands (useful for embedding command runner):
-  
+
     app/console list --raw

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run3.txt
@@ -14,23 +14,24 @@ Options:
   -h, --help            Display help for the given command. When no command is given display help for the list command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
-      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
+      --ansi            Force ANSI output
+      --no-ansi         Disable ANSI output
   -n, --no-interaction  Do not ask any interactive question
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 Help:
   The list command lists all commands:
-  
+
     app/console list
-  
+
   You can also display the commands for a specific namespace:
-  
+
     app/console list test
-  
+
   You can also output the information in other formats by using the --format option:
-  
+
     app/console list --format=xml
-  
+
   It's also possible to get raw list of commands (useful for embedding command runner):
-  
+
     app/console list --raw

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run5.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run5.txt
@@ -13,17 +13,18 @@ Options:
   -h, --help            Display help for the given command. When no command is given display help for the list command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
-      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
+      --ansi            Force ANSI output
+      --no-ansi         Disable ANSI output
   -n, --no-interaction  Do not ask any interactive question
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
 
 Help:
   The help command displays help for a given command:
-  
+
     app/console help list
-  
+
   You can also output the help in other formats by using the --format option:
-  
+
     app/console help --format=xml list
-  
+
   To display the list of available commands, please use the list command.

--- a/src/Symfony/Component/Console/Tests/phpt/single_application/help_name.phpt
+++ b/src/Symfony/Component/Console/Tests/phpt/single_application/help_name.phpt
@@ -31,6 +31,7 @@ Options:
   -h, --help            Display help for the given command. When no command is given display help for the %s command
   -q, --quiet           Do not output any message
   -V, --version         Display this application version
-      --ansi|--no-ansi  Force (or disable --no-ansi) ANSI output
+      --ansi            Force ANSI output
+      --no-ansi         Disable ANSI output
   -n, --no-interaction  Do not ask any interactive question
   -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

When I create a command and configure it with the addOption 'no-ansi', the current 5.3 is throwing an exception.

The reason behind it is, that it is configure as negatable. When it is adding it check if the no-ansi is exists. Then it throws an exception.
In the 5.2 situation it then checked if the options equals. If not throw an exception.

https://github.com/symfony/console/blob/5.3/Input/InputDefinition.php#L255 part where the check is coming for the negatable and throws an exception.
https://github.com/symfony/console/blob/5.3/Input/InputDefinition.php#L233 The equals check where in the past the error was prevented.

Reverting the option to two values, seems like the right solution.