### PR TITLE
[Security] Fix special char used to create cache key

### DIFF
--- a/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/CacheTokenVerifierTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/RememberMe/CacheTokenVerifierTest.php
@@ -21,22 +21,22 @@ class CacheTokenVerifierTest extends TestCase
     public function testVerifyCurrentToken()
     {
         $verifier = new CacheTokenVerifier(new ArrayAdapter());
-        $token = new PersistentToken('class', 'user', 'series1', 'value', new \DateTime());
+        $token = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTime());
         $this->assertTrue($verifier->verifyToken($token, 'value'));
     }
 
     public function testVerifyFailsInvalidToken()
     {
         $verifier = new CacheTokenVerifier(new ArrayAdapter());
-        $token = new PersistentToken('class', 'user', 'series1', 'value', new \DateTime());
+        $token = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTime());
         $this->assertFalse($verifier->verifyToken($token, 'wrong-value'));
     }
 
     public function testVerifyOutdatedToken()
     {
         $verifier = new CacheTokenVerifier(new ArrayAdapter());
-        $outdatedToken = new PersistentToken('class', 'user', 'series1', 'value', new \DateTime());
-        $newToken = new PersistentToken('class', 'user', 'series1', 'newvalue', new \DateTime());
+        $outdatedToken = new PersistentToken('class', 'user', 'series1@special:chars=/', 'value', new \DateTime());
+        $newToken = new PersistentToken('class', 'user', 'series1@special:chars=/', 'newvalue', new \DateTime());
         $verifier->updateExistingToken($outdatedToken, 'newvalue', new \DateTime());
         $this->assertTrue($verifier->verifyToken($newToken, 'value'));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The remember Me token's `series` property might contains special chars: because it has been generated with `$series = base64_encode(random_bytes(64));`.

When using this identifier to create cache items, users get Exception `Cache key "foo+bar/baz==" contains reserved characters "{}()/\@:".`

This PR sanitize the property before using it as cache key
