### PR TITLE
Avoid broken action URL in text notification mail

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Email/zurb_2/notification/body.txt.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Email/zurb_2/notification/body.txt.twig
@@ -8,7 +8,7 @@
 
 {% block action %}
 {% if action_url %}
-{{ action_url }}: {{ action_text }}
+{{ action_text }}: {{ action_url }}
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Some mail clients make URLs clickable automatically which leads to broken URLs due to the appended ":" (colon)

Fix this by moving the action text before the action URL.
