### PR TITLE
[Security] make the getter usable if no user identifier is set

### DIFF
--- a/src/Symfony/Component/Security/Core/Exception/UserNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UserNotFoundException.php
@@ -32,7 +32,7 @@ class UserNotFoundException extends AuthenticationException
     /**
      * Get the user identifier (e.g. username or e-mailaddress).
      */
-    public function getUserIdentifier(): string
+    public function getUserIdentifier(): ?string
     {
         return $this->identifier;
     }

--- a/src/Symfony/Component/Security/Core/Tests/Exception/UserNotFoundExceptionTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Exception/UserNotFoundExceptionTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Security\Core\Tests\Exception;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 
 class UserNotFoundExceptionTest extends TestCase
 {
@@ -23,6 +23,23 @@ class UserNotFoundExceptionTest extends TestCase
         $this->assertEquals(['{{ username }}' => null, '{{ user_identifier }}' => null], $exception->getMessageData());
         $exception->setUserIdentifier('username');
         $this->assertEquals(['{{ username }}' => 'username', '{{ user_identifier }}' => 'username'], $exception->getMessageData());
+    }
+
+    public function testUserIdentifierIsNotSetByDefault()
+    {
+        $exception = new UserNotFoundException();
+
+        $this->assertNull($exception->getUserIdentifier());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testUsernameIsNotSetByDefault()
+    {
+        $exception = new UserNotFoundException();
+
+        $this->assertNull($exception->getUsername());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41697
| License       | MIT
| Doc PR        | 