### PR TITLE
[Security] Fix invalid RememberMe value after update

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -98,7 +98,7 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
             $this->tokenProvider->updateToken($series, $tokenValueHash, $tokenLastUsed);
         }
 
-        $this->createCookie($rememberMeDetails->withValue($tokenValue));
+        $this->createCookie($rememberMeDetails->withValue($series.':'.$tokenValue));
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -92,8 +92,14 @@ class PersistentRememberMeHandlerTest extends TestCase
 
         /** @var Cookie $cookie */
         $cookie = $this->request->attributes->get(ResponseListener::COOKIE_ATTR_NAME);
-        $this->assertNotEquals($rememberMeDetails->toString(), $cookie->getValue());
-        $this->assertMatchesRegularExpression('{'.str_replace('\\', '\\\\', base64_decode($rememberMeDetails->withValue('[a-zA-Z0-9/+]+')->toString())).'}', base64_decode($cookie->getValue()));
+        $rememberParts = explode(':', base64_decode($rememberMeDetails->toString()), 4);
+        $cookieParts = explode(':', base64_decode($cookie->getValue()), 4);
+
+        $this->assertSame($rememberParts[0], $cookieParts[0]); // class
+        $this->assertSame($rememberParts[1], $cookieParts[1]); // identifier
+        $this->assertSame($rememberParts[2], $cookieParts[2]); // expire
+        $this->assertNotSame($rememberParts[3], $cookieParts[3]); // value
+        $this->assertSame(explode(':', $rememberParts[3])[0], explode(':', $cookieParts[3])[0]); // series
     }
 
     public function testConsumeRememberMeCookieInvalidToken()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


When refreshing the rememberMe cookie value, the `series` part where lost, leading to an invalid RememberMe cookie the next time we want to use it.