### PR TITLE
[Security] Fix invalid cookie when migrating to new Security

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/RememberMeDetails.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/RememberMeDetails.php
@@ -40,6 +40,9 @@ class RememberMeDetails
         if (false === $cookieParts[1] = base64_decode($cookieParts[1], true)) {
             throw new AuthenticationException('The user identifier contains a character from outside the base64 alphabet.');
         }
+        if (4 !== \count($cookieParts)) {
+            throw new AuthenticationException('The cookie contains invalid data.');
+        }
 
         return new static(...$cookieParts);
     }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/RememberMeAuthenticatorTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Http\Authenticator\RememberMeAuthenticator;
 use Symfony\Component\Security\Http\RememberMe\RememberMeDetails;
@@ -79,5 +80,13 @@ class RememberMeAuthenticatorTest extends TestCase
         $this->expectException(\LogicException::class);
 
         $this->authenticator->authenticate(Request::create('/'));
+    }
+
+    public function testAuthenticateWithoutOldToken()
+    {
+        $this->expectException(AuthenticationException::class);
+
+        $request = Request::create('/', 'GET', [], ['_remember_me_cookie' => base64_encode('foo:bar')]);
+        $this->authenticator->authenticate($request);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In the new Security System, the method `RememberMeDetails::fromRawCookie` expects to get a cookie made of 4 parts.
This is not the case when the cookie has been generated by a `PersistentTokenBasedRememberMeServices`.

This is an issue when migrating an application to the new Security System, old cookie lead to 500 errors.

This PR fix the issue by throwing gracefully a `AuthenticationException`. Handled by the authenticator.