### PR TITLE
[Security] Fixed 'security.command.debug_firewall' not found

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -529,8 +529,10 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
             $listeners[] = new Reference('security.firewall.authenticator.'.$id);
 
             // Add authenticators to the debug:firewall command
-            $debugCommand = $container->getDefinition('security.command.debug_firewall');
-            $debugCommand->replaceArgument(3, array_merge($debugCommand->getArgument(3), [$id => $authenticators]));
+            if ($container->hasDefinition('security.command.debug_firewall')) {
+                $debugCommand = $container->getDefinition('security.command.debug_firewall');
+                $debugCommand->replaceArgument(3, array_merge($debugCommand->getArgument(3), [$id => $authenticators]));
+            }
         }
 
         $config->replaceArgument(7, $configuredEntryPoint ?: $defaultEntryPoint);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

When working on a bundle that depends on some `symfony/security-bundle`, I found this. 
Basically, we assume that service `security.command.debug_firewall` is always defined. For most application this service is defined as it is defined if `symfony/console` is installed. This is why we never caught the bug before. 

But I do run into issues when I run the tests for my bundle. 
