### PR TITLE
[Yaml] Double-quote strings with single quote marks

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+6.1
+---
+
+ * In cases where it will likely improve readability, strings containing single quotes will be double-quoted.
+
 5.4
 ---
 

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -177,6 +177,14 @@ class Inline
             case Escaper::requiresDoubleQuoting($value):
                 return Escaper::escapeWithDoubleQuotes($value);
             case Escaper::requiresSingleQuoting($value):
+                $singleQuoted = Escaper::escapeWithSingleQuotes($value);
+                if (!str_contains($value, "'")) {
+                    return $singleQuoted;
+                }
+                // Attempt double-quoting the string instead to see if it's more efficient.
+                $doubleQuoted = Escaper::escapeWithDoubleQuotes($value);
+
+                return \strlen($doubleQuoted) < \strlen($singleQuoted) ? $doubleQuoted : $singleQuoted;
             case Parser::preg_match('{^[0-9]+[_0-9]*$}', $value):
             case Parser::preg_match(self::getHexRegex(), $value):
             case Parser::preg_match(self::getTimestampRegex(), $value):

--- a/src/Symfony/Component/Yaml/Tests/DumperTest.php
+++ b/src/Symfony/Component/Yaml/Tests/DumperTest.php
@@ -60,7 +60,7 @@ class DumperTest extends TestCase
         $expected = <<<'EOF'
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+"foo'bar": {  }
 bar:
        - 1
        - foo
@@ -107,7 +107,7 @@ EOF;
     public function testInlineLevel()
     {
         $expected = <<<'EOF'
-{ '': bar, foo: '#bar', 'foo''bar': {  }, bar: [1, foo], foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } } }
+{ '': bar, foo: '#bar', "foo'bar": {  }, bar: [1, foo], foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } } }
 EOF;
         $this->assertEquals($expected, $this->dumper->dump($this->array, -10), '->dump() takes an inline level argument');
         $this->assertEquals($expected, $this->dumper->dump($this->array, 0), '->dump() takes an inline level argument');
@@ -115,7 +115,7 @@ EOF;
         $expected = <<<'EOF'
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+"foo'bar": {  }
 bar: [1, foo]
 foobar: { foo: bar, bar: [1, foo], foobar: { foo: bar, bar: [1, foo] } }
 
@@ -125,7 +125,7 @@ EOF;
         $expected = <<<'EOF'
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+"foo'bar": {  }
 bar:
     - 1
     - foo
@@ -140,7 +140,7 @@ EOF;
         $expected = <<<'EOF'
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+"foo'bar": {  }
 bar:
     - 1
     - foo
@@ -159,7 +159,7 @@ EOF;
         $expected = <<<'EOF'
 '': bar
 foo: '#bar'
-'foo''bar': {  }
+"foo'bar": {  }
 bar:
     - 1
     - foo

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -473,6 +473,10 @@ class InlineTest extends TestCase
             ["'foo # bar'", 'foo # bar'],
             ["'#cfcfcf'", '#cfcfcf'],
 
+            ["\"isn't it a nice single quote\"", "isn't it a nice single quote"],
+            ['\'this is "double quoted"\'', 'this is "double quoted"'],
+            ["\"one double, four single quotes: \\\"''''\"", 'one double, four single quotes: "\'\'\'\''],
+            ['\'four double, one single quote: """"\'\'\'', 'four double, one single quote: """"\''],
             ["'a \"string\" with ''quoted strings inside'''", 'a "string" with \'quoted strings inside\''],
 
             ["'-dash'", '-dash'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #41687
| License       | MIT
| Doc PR        | It's a tiny change, is it really required?

This changes the behavior of the `Dumper` to double-quote strings containing single quote marks when it's likely to improve readability (measured by the length of the quoted string). See the linked ticket for the detailed motivation behind this.