### PR TITLE
[Messenger] prevent reflection usages when classes do not exist

### DIFF
--- a/src/Symfony/Component/Messenger/Envelope.php
+++ b/src/Symfony/Component/Messenger/Envelope.php
@@ -127,6 +127,6 @@ final class Envelope
     {
         static $resolved;
 
-        return $resolved[$fqcn] ?? ($resolved[$fqcn] = (new \ReflectionClass($fqcn))->getName());
+        return $resolved[$fqcn] ?? ($resolved[$fqcn] = class_exists($fqcn) ? (new \ReflectionClass($fqcn))->getName() : $fqcn);
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/EnvelopeTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EnvelopeTest.php
@@ -55,6 +55,13 @@ class EnvelopeTest extends TestCase
         $this->assertCount(1, $envelope->all(DelayStamp::class));
     }
 
+    public function testWithoutAllWithNonExistentStampClass()
+    {
+        $envelope = new Envelope(new DummyMessage('dummy'));
+
+        $this->assertInstanceOf(Envelope::class, $envelope->withoutAll(NonExistentStamp::class));
+    }
+
     public function testWithoutStampsOfType()
     {
         $envelope = new Envelope(new DummyMessage('dummy'), [
@@ -77,6 +84,13 @@ class EnvelopeTest extends TestCase
         $this->assertEmpty($envelope5->all());
     }
 
+    public function testWithoutStampsOfTypeWithNonExistentStampClass()
+    {
+        $envelope = new Envelope(new DummyMessage('dummy'));
+
+        $this->assertInstanceOf(Envelope::class, $envelope->withoutStampsOfType(NonExistentStamp::class));
+    }
+
     public function testLast()
     {
         $receivedStamp = new ReceivedStamp('transport');
@@ -84,6 +98,13 @@ class EnvelopeTest extends TestCase
 
         $this->assertSame($receivedStamp, $envelope->last(ReceivedStamp::class));
         $this->assertNull($envelope->last(ValidationStamp::class));
+    }
+
+    public function testLastWithNonExistentStampClass()
+    {
+        $envelope = new Envelope(new DummyMessage('dummy'));
+
+        $this->assertNull($envelope->last(NonExistentStamp::class));
     }
 
     public function testAll()
@@ -98,6 +119,13 @@ class EnvelopeTest extends TestCase
         $this->assertSame($receivedStamp, $stamps[ReceivedStamp::class][0]);
         $this->assertArrayHasKey(ValidationStamp::class, $stamps);
         $this->assertSame($validationStamp, $stamps[ValidationStamp::class][0]);
+    }
+
+    public function testAllWithNonExistentStampClass()
+    {
+        $envelope = new Envelope(new DummyMessage('dummy'));
+
+        $this->assertSame([], $envelope->all(NonExistentStamp::class));
     }
 
     public function testWrapWithMessage()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41748
| License       | MIT
| Doc PR        | 