### PR TITLE
[SecurityBundle] Create a smooth upgrade path for security factories

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -37,6 +37,21 @@ Messenger
 SecurityBundle
 --------------
 
+ * Deprecate `SecurityFactoryInterface` and `SecurityExtension::addSecurityListenerFactory()` in favor of
+   `AuthenticatorFactoryInterface` and `SecurityExtension::addAuthenticatorFactory()`
+ * Add `AuthenticatorFactoryInterface::getPriority()` which replaces `SecurityFactoryInterface::getPosition()`.
+   Previous positions are mapped to the following priorities:
+
+    | Position    | Constant                                              | Priority |
+    | ----------- | ----------------------------------------------------- | -------- |
+    | pre_auth    | `RemoteUserFactory::PRIORITY`/`X509Factory::PRIORITY` | -10      |
+    | form        | `FormLoginFactory::PRIORITY`                          | -30      |
+    | http        | `HttpBasicFactory::PRIORITY`                          | -50      |
+    | remember_me | `RememberMeFactory::PRIORITY`                         | -60      |
+    | anonymous   | n/a                                                   | -70      |
+
+ * Deprecate passing an array of arrays as 1st argument to `MainConfiguration`, pass a sorted flat array of
+   factories instead.
  * Deprecate the `always_authenticate_before_granting` option
 
 Security

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -355,6 +355,21 @@ Security
 SecurityBundle
 --------------
 
+ * Remove `SecurityFactoryInterface` and `SecurityExtension::addSecurityListenerFactory()` in favor of
+   `AuthenticatorFactoryInterface` and `SecurityExtension::addAuthenticatorFactory()`
+ * Add `AuthenticatorFactoryInterface::getPriority()` which replaces `SecurityFactoryInterface::getPosition()`.
+   Previous positions are mapped to the following priorities:
+
+    | Position    | Constant                                              | Priority |
+    | ----------- | ----------------------------------------------------- | -------- |
+    | pre_auth    | `RemoteUserFactory::PRIORITY`/`X509Factory::PRIORITY` | -10      |
+    | form        | `FormLoginFactory::PRIORITY`                          | -30      |
+    | http        | `HttpBasicFactory::PRIORITY`                          | -50      |
+    | remember_me | `RememberMeFactory::PRIORITY`                         | -60      |
+    | anonymous   | n/a                                                   | -70      |
+
+ * Remove passing an array of arrays as 1st argument to `MainConfiguration`, pass a sorted flat array of
+   factories instead.
  * Remove the `always_authenticate_before_granting` option
  * Remove the `UserPasswordEncoderCommand` class and the corresponding `user:encode-password` command,
    use `UserPasswordHashCommand` and `user:hash-password` instead

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,6 +4,11 @@ CHANGELOG
 5.4
 ---
 
+ * Deprecate `SecurityFactoryInterface` and `SecurityExtension::addSecurityListenerFactory()` in favor of
+   `AuthenticatorFactoryInterface` and `SecurityExtension::addAuthenticatorFactory()`
+ * Add `AuthenticatorFactoryInterface::getPriority()` which replaces `SecurityFactoryInterface::getPosition()`
+ * Deprecate passing an array of arrays as 1st argument to `MainConfiguration`, pass a sorted flat array of
+   factories instead.
  * Deprecate the `always_authenticate_before_granting` option
 
 5.3

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -12,6 +12,8 @@
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -31,8 +33,17 @@ class MainConfiguration implements ConfigurationInterface
     private $factories;
     private $userProviderFactories;
 
+    /**
+     * @param (SecurityFactoryInterface|AuthenticatorFactoryInterface)[] $factories
+     */
     public function __construct(array $factories, array $userProviderFactories)
     {
+        if (\is_array(current($factories))) {
+            trigger_deprecation('symfony/security-bundle', '5.4', 'Passing an array of arrays as 1st argument to "%s" is deprecated, pass a sorted array of factories instead.', __METHOD__);
+
+            $factories = array_merge(...array_values($factories));
+        }
+
         $this->factories = $factories;
         $this->userProviderFactories = $userProviderFactories;
     }
@@ -297,19 +308,17 @@ class MainConfiguration implements ConfigurationInterface
         ;
 
         $abstractFactoryKeys = [];
-        foreach ($factories as $factoriesAtPosition) {
-            foreach ($factoriesAtPosition as $factory) {
-                $name = str_replace('-', '_', $factory->getKey());
-                $factoryNode = $firewallNodeBuilder->arrayNode($name)
-                    ->canBeUnset()
-                ;
+        foreach ($factories as $factory) {
+            $name = str_replace('-', '_', $factory->getKey());
+            $factoryNode = $firewallNodeBuilder->arrayNode($name)
+                ->canBeUnset()
+            ;
 
-                if ($factory instanceof AbstractFactory) {
-                    $abstractFactoryKeys[] = $name;
-                }
-
-                $factory->addConfiguration($factoryNode);
+            if ($factory instanceof AbstractFactory) {
+                $abstractFactoryKeys[] = $name;
             }
+
+            $factory->addConfiguration($factoryNode);
         }
 
         // check for unreachable check paths

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AnonymousFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AnonymousFactory.php
@@ -52,6 +52,11 @@ class AnonymousFactory implements SecurityFactoryInterface, AuthenticatorFactory
         throw new InvalidConfigurationException(sprintf('The authenticator manager no longer has "anonymous" security. Please remove this option under the "%s" firewall'.($config['lazy'] ? ' and add "lazy: true"' : '').'.', $firewallName));
     }
 
+    public function getPriority()
+    {
+        return -60;
+    }
+
     public function getPosition()
     {
         return 'anonymous';

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AuthenticatorFactoryInterface.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AuthenticatorFactoryInterface.php
@@ -11,9 +11,12 @@
 
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory;
 
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
+ * @method int getPriority() defines the position at which the authenticator is called
+ *
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
 interface AuthenticatorFactoryInterface
@@ -24,4 +27,14 @@ interface AuthenticatorFactoryInterface
      * @return string|string[] The authenticator service ID(s) to be used by the firewall
      */
     public function createAuthenticator(ContainerBuilder $container, string $firewallName, array $config, string $userProviderId);
+
+    /**
+     * Defines the configuration key used to reference the authenticator
+     * in the firewall configuration.
+     *
+     * @return string
+     */
+    public function getKey();
+
+    public function addConfiguration(NodeDefinition $builder);
 }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/CustomAuthenticatorFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/CustomAuthenticatorFactory.php
@@ -27,6 +27,11 @@ class CustomAuthenticatorFactory implements AuthenticatorFactoryInterface, Secur
         throw new \LogicException('Custom authenticators are not supported when "security.enable_authenticator_manager" is not set to true.');
     }
 
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
     public function getPosition(): string
     {
         return 'pre_auth';

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
@@ -27,6 +27,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class FormLoginFactory extends AbstractFactory implements AuthenticatorFactoryInterface
 {
+    public const PRIORITY = -30;
+
     public function __construct()
     {
         $this->addOption('username_parameter', '_username');
@@ -35,6 +37,11 @@ class FormLoginFactory extends AbstractFactory implements AuthenticatorFactoryIn
         $this->addOption('csrf_token_id', 'authenticate');
         $this->addOption('enable_csrf', false);
         $this->addOption('post_only', true);
+    }
+
+    public function getPriority(): int
+    {
+        return self::PRIORITY;
     }
 
     public function getPosition()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/GuardAuthenticationFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/GuardAuthenticationFactory.php
@@ -34,6 +34,11 @@ class GuardAuthenticationFactory implements SecurityFactoryInterface, Authentica
         return 'pre_auth';
     }
 
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
     public function getKey()
     {
         return 'guard';

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
@@ -25,6 +25,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class HttpBasicFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface
 {
+    public const PRIORITY = -50;
+
     public function create(ContainerBuilder $container, string $id, array $config, string $userProvider, ?string $defaultEntryPoint)
     {
         $provider = 'security.authentication.provider.dao.'.$id;
@@ -64,6 +66,11 @@ class HttpBasicFactory implements SecurityFactoryInterface, AuthenticatorFactory
             ->replaceArgument(1, new Reference($userProviderId));
 
         return $authenticatorId;
+    }
+
+    public function getPriority(): int
+    {
+        return self::PRIORITY;
     }
 
     public function getPosition()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/JsonLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/JsonLoginFactory.php
@@ -24,12 +24,19 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class JsonLoginFactory extends AbstractFactory implements AuthenticatorFactoryInterface
 {
+    public const PRIORITY = -40;
+
     public function __construct()
     {
         $this->addOption('username_path', 'username');
         $this->addOption('password_path', 'password');
         $this->defaultFailureHandlerOptions = [];
         $this->defaultSuccessHandlerOptions = [];
+    }
+
+    public function getPriority(): int
+    {
+        return self::PRIORITY;
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginLinkFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginLinkFactory.php
@@ -27,6 +27,8 @@ use Symfony\Component\Security\Http\LoginLink\LoginLinkHandler;
  */
 class LoginLinkFactory extends AbstractFactory implements AuthenticatorFactoryInterface
 {
+    public const PRIORITY = -20;
+
     public function addConfiguration(NodeDefinition $node)
     {
         /** @var NodeBuilder $builder */
@@ -145,6 +147,11 @@ class LoginLinkFactory extends AbstractFactory implements AuthenticatorFactoryIn
             ]);
 
         return $authenticatorId;
+    }
+
+    public function getPriority(): int
+    {
+        return self::PRIORITY;
     }
 
     public function getPosition()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/LoginThrottlingFactory.php
@@ -34,6 +34,12 @@ class LoginThrottlingFactory implements AuthenticatorFactoryInterface, SecurityF
         throw new \LogicException('Login throttling is not supported when "security.enable_authenticator_manager" is not set to true.');
     }
 
+    public function getPriority(): int
+    {
+        // this factory doesn't register any authenticators, this priority doesn't matter
+        return 0;
+    }
+
     public function getPosition(): string
     {
         // this factory doesn't register any authenticators, this position doesn't matter

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -21,6 +21,7 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpFoundation\Cookie;
@@ -30,8 +31,10 @@ use Symfony\Component\Security\Http\EventListener\RememberMeLogoutListener;
 /**
  * @internal
  */
-class RememberMeFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface
+class RememberMeFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface, PrependExtensionInterface
 {
+    public const PRIORITY = -50;
+
     protected $options = [
         'name' => 'REMEMBERME',
         'lifetime' => 31536000,
@@ -179,6 +182,14 @@ class RememberMeFactory implements SecurityFactoryInterface, AuthenticatorFactor
     public function getPosition()
     {
         return 'remember_me';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPriority(): int
+    {
+        return self::PRIORITY;
     }
 
     public function getKey()
@@ -330,5 +341,28 @@ class RememberMeFactory implements SecurityFactoryInterface, AuthenticatorFactor
             ->addArgument('rememberme-'.$firewallName.'-stale-');
 
         return new Reference($tokenVerifierId, ContainerInterface::NULL_ON_INVALID_REFERENCE);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        $rememberMeSecureDefault = false;
+        $rememberMeSameSiteDefault = null;
+
+        if (!isset($container->getExtensions()['framework'])) {
+            return;
+        }
+
+        foreach ($container->getExtensionConfig('framework') as $config) {
+            if (isset($config['session']) && \is_array($config['session'])) {
+                $rememberMeSecureDefault = $config['session']['cookie_secure'] ?? $rememberMeSecureDefault;
+                $rememberMeSameSiteDefault = \array_key_exists('cookie_samesite', $config['session']) ? $config['session']['cookie_samesite'] : $rememberMeSameSiteDefault;
+            }
+        }
+
+        $this->options['secure'] = $rememberMeSecureDefault;
+        $this->options['samesite'] = $rememberMeSameSiteDefault;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RemoteUserFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RemoteUserFactory.php
@@ -26,6 +26,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RemoteUserFactory implements SecurityFactoryInterface, AuthenticatorFactoryInterface
 {
+    public const PRIORITY = -10;
+
     public function create(ContainerBuilder $container, string $id, array $config, string $userProvider, ?string $defaultEntryPoint)
     {
         $providerId = 'security.authentication.provider.pre_authenticated.'.$id;
@@ -56,6 +58,11 @@ class RemoteUserFactory implements SecurityFactoryInterface, AuthenticatorFactor
         ;
 
         return $authenticatorId;
+    }
+
+    public function getPriority(): int
+    {
+        return self::PRIORITY;
     }
 
     public function getPosition()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SecurityFactoryInterface.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/SecurityFactoryInterface.php
@@ -18,6 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * SecurityFactoryInterface is the interface for all security authentication listener.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @deprecated since Symfony 5.3, use AuthenticatorFactoryInterface instead.
  */
 interface SecurityFactoryInterface
 {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/X509Factory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/X509Factory.php
@@ -25,6 +25,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class X509Factory implements SecurityFactoryInterface, AuthenticatorFactoryInterface
 {
+    public const PRIORITY = -10;
+
     public function create(ContainerBuilder $container, string $id, array $config, string $userProvider, ?string $defaultEntryPoint)
     {
         $providerId = 'security.authentication.provider.pre_authenticated.'.$id;
@@ -58,6 +60,11 @@ class X509Factory implements SecurityFactoryInterface, AuthenticatorFactoryInter
         ;
 
         return $authenticatorId;
+    }
+
+    public function getPriority(): int
+    {
+        return self::PRIORITY;
     }
 
     public function getPosition()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
 use Symfony\Bridge\Twig\Extension\LogoutUrlExtension;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FirewallListenerFactoryInterface;
-use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\RememberMeFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
 use Symfony\Bundle\SecurityBundle\Security\LegacyLogoutHandlerListener;
@@ -58,42 +57,20 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
     private $requestMatchers = [];
     private $expressions = [];
     private $contextListeners = [];
-    private $listenerPositions = ['pre_auth', 'form', 'http', 'remember_me', 'anonymous'];
+    /** @var array<array{0: int, 1: AuthenticatorFactoryInterface|SecurityFactoryInterface}> */
     private $factories = [];
+    /** @var (AuthenticatorFactoryInterface|SecurityFactoryInterface)[] */
+    private $sortedFactories = [];
     private $userProviderFactories = [];
     private $statelessFirewallKeys = [];
 
     private $authenticatorManagerEnabled = false;
 
-    public function __construct()
-    {
-        foreach ($this->listenerPositions as $position) {
-            $this->factories[$position] = [];
-        }
-    }
-
     public function prepend(ContainerBuilder $container)
     {
-        $rememberMeSecureDefault = false;
-        $rememberMeSameSiteDefault = null;
-
-        if (!isset($container->getExtensions()['framework'])) {
-            return;
-        }
-        foreach ($container->getExtensionConfig('framework') as $config) {
-            if (isset($config['session']) && \is_array($config['session'])) {
-                $rememberMeSecureDefault = $config['session']['cookie_secure'] ?? $rememberMeSecureDefault;
-                $rememberMeSameSiteDefault = \array_key_exists('cookie_samesite', $config['session']) ? $config['session']['cookie_samesite'] : $rememberMeSameSiteDefault;
-            }
-        }
-        foreach ($this->listenerPositions as $position) {
-            foreach ($this->factories[$position] as $factory) {
-                if ($factory instanceof RememberMeFactory) {
-                    \Closure::bind(function () use ($rememberMeSecureDefault, $rememberMeSameSiteDefault) {
-                        $this->options['secure'] = $rememberMeSecureDefault;
-                        $this->options['samesite'] = $rememberMeSameSiteDefault;
-                    }, $factory, $factory)();
-                }
+        foreach ($this->getSortedFactories() as $factory) {
+            if ($factory instanceof PrependExtensionInterface) {
+                $factory->prepend($container);
             }
         }
     }
@@ -556,12 +533,10 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
         $container->setAlias('security.user_checker.'.$id, new Alias($firewall['user_checker'], false));
 
-        foreach ($this->factories as $position) {
-            foreach ($position as $factory) {
-                $key = str_replace('-', '_', $factory->getKey());
-                if (\array_key_exists($key, $firewall)) {
-                    $listenerKeys[] = $key;
-                }
+        foreach ($this->getSortedFactories() as $factory) {
+            $key = str_replace('-', '_', $factory->getKey());
+            if (\array_key_exists($key, $firewall)) {
+                $listenerKeys[] = $key;
             }
         }
 
@@ -594,44 +569,42 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $hasListeners = false;
         $entryPoints = [];
 
-        foreach ($this->listenerPositions as $position) {
-            foreach ($this->factories[$position] as $factory) {
-                $key = str_replace('-', '_', $factory->getKey());
+        foreach ($this->getSortedFactories() as $factory) {
+            $key = str_replace('-', '_', $factory->getKey());
 
-                if (isset($firewall[$key])) {
-                    $userProvider = $this->getUserProvider($container, $id, $firewall, $key, $defaultProvider, $providerIds, $contextListenerId);
+            if (isset($firewall[$key])) {
+                $userProvider = $this->getUserProvider($container, $id, $firewall, $key, $defaultProvider, $providerIds, $contextListenerId);
 
-                    if ($this->authenticatorManagerEnabled) {
-                        if (!$factory instanceof AuthenticatorFactoryInterface) {
-                            throw new InvalidConfigurationException(sprintf('Cannot configure AuthenticatorManager as "%s" authentication does not support it, set "security.enable_authenticator_manager" to `false`.', $key));
-                        }
+                if ($this->authenticatorManagerEnabled) {
+                    if (!$factory instanceof AuthenticatorFactoryInterface) {
+                        throw new InvalidConfigurationException(sprintf('Cannot configure AuthenticatorManager as "%s" authentication does not support it, set "security.enable_authenticator_manager" to `false`.', $key));
+                    }
 
-                        $authenticators = $factory->createAuthenticator($container, $id, $firewall[$key], $userProvider);
-                        if (\is_array($authenticators)) {
-                            foreach ($authenticators as $authenticator) {
-                                $authenticationProviders[] = $authenticator;
-                                $entryPoints[] = $authenticator;
-                            }
-                        } else {
-                            $authenticationProviders[] = $authenticators;
-                            $entryPoints[$key] = $authenticators;
+                    $authenticators = $factory->createAuthenticator($container, $id, $firewall[$key], $userProvider);
+                    if (\is_array($authenticators)) {
+                        foreach ($authenticators as $authenticator) {
+                            $authenticationProviders[] = $authenticator;
+                            $entryPoints[] = $authenticator;
                         }
                     } else {
-                        [$provider, $listenerId, $defaultEntryPoint] = $factory->create($container, $id, $firewall[$key], $userProvider, $defaultEntryPoint);
-
-                        $listeners[] = new Reference($listenerId);
-                        $authenticationProviders[] = $provider;
+                        $authenticationProviders[] = $authenticators;
+                        $entryPoints[$key] = $authenticators;
                     }
+                } else {
+                    [$provider, $listenerId, $defaultEntryPoint] = $factory->create($container, $id, $firewall[$key], $userProvider, $defaultEntryPoint);
 
-                    if ($factory instanceof FirewallListenerFactoryInterface) {
-                        $firewallListenerIds = $factory->createListeners($container, $id, $firewall[$key]);
-                        foreach ($firewallListenerIds as $firewallListenerId) {
-                            $listeners[] = new Reference($firewallListenerId);
-                        }
-                    }
-
-                    $hasListeners = true;
+                    $listeners[] = new Reference($listenerId);
+                    $authenticationProviders[] = $provider;
                 }
+
+                if ($factory instanceof FirewallListenerFactoryInterface) {
+                    $firewallListenerIds = $factory->createListeners($container, $id, $firewall[$key]);
+                    foreach ($firewallListenerIds as $firewallListenerId) {
+                        $listeners[] = new Reference($firewallListenerId);
+                    }
+                }
+
+                $hasListeners = true;
             }
         }
 
@@ -1062,9 +1035,27 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         return $this->requestMatchers[$id] = new Reference($id);
     }
 
+    /**
+     * @deprecated since 5.4, use "addAuthenticatorFactory()" instead
+     */
     public function addSecurityListenerFactory(SecurityFactoryInterface $factory)
     {
-        $this->factories[$factory->getPosition()][] = $factory;
+        trigger_deprecation('symfony/security-bundle', '5.4', 'Method "%s()" is deprecated, use "addAuthenticatorFactory()" instead.', __METHOD__);
+
+        $this->factories[] = [[
+            'pre_auth' => -10,
+            'form' => -30,
+            'http' => -40,
+            'remember_me' => -50,
+            'anonymous' => -60,
+        ][$factory->getPosition()], $factory];
+        $this->sortedFactories = [];
+    }
+
+    public function addAuthenticatorFactory(AuthenticatorFactoryInterface $factory)
+    {
+        $this->factories[] = [method_exists($factory, 'getPriority') ? $factory->getPriority() : 0, $factory];
+        $this->sortedFactories = [];
     }
 
     public function addUserProviderFactory(UserProviderFactoryInterface $factory)
@@ -1088,7 +1079,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
         // first assemble the factories
-        return new MainConfiguration($this->factories, $this->userProviderFactories);
+        return new MainConfiguration($this->getSortedFactories(), $this->userProviderFactories);
     }
 
     private function isValidIps($ips): bool
@@ -1134,5 +1125,26 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         }
 
         return false;
+    }
+
+    /**
+     * @return (AuthenticatorFactoryInterface|SecurityFactoryInterface)[]
+     */
+    private function getSortedFactories(): array
+    {
+        if (!$this->sortedFactories) {
+            $factories = [];
+            foreach ($this->factories as $i => $factory) {
+                $factories[] = array_merge($factory, [$i]);
+            }
+
+            usort($factories, function ($a, $b) {
+                return $b[0] <=> $a[0] ?: $a[2] <=> $b[2];
+            });
+
+            $this->sortedFactories = array_column($factories, 1);
+        }
+
+        return $this->sortedFactories;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -38,6 +38,7 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\RemoteUse
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\X509Factory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\InMemoryFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\LdapFactory;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\DependencyInjection\AddEventAliasesPass;
@@ -56,21 +57,22 @@ class SecurityBundle extends Bundle
     {
         parent::build($container);
 
+        /** @var SecurityExtension $extension */
         $extension = $container->getExtension('security');
-        $extension->addSecurityListenerFactory(new FormLoginFactory());
-        $extension->addSecurityListenerFactory(new FormLoginLdapFactory());
-        $extension->addSecurityListenerFactory(new JsonLoginFactory());
-        $extension->addSecurityListenerFactory(new JsonLoginLdapFactory());
-        $extension->addSecurityListenerFactory(new HttpBasicFactory());
-        $extension->addSecurityListenerFactory(new HttpBasicLdapFactory());
-        $extension->addSecurityListenerFactory(new RememberMeFactory());
-        $extension->addSecurityListenerFactory(new X509Factory());
-        $extension->addSecurityListenerFactory(new RemoteUserFactory());
-        $extension->addSecurityListenerFactory(new GuardAuthenticationFactory());
-        $extension->addSecurityListenerFactory(new AnonymousFactory());
-        $extension->addSecurityListenerFactory(new CustomAuthenticatorFactory());
-        $extension->addSecurityListenerFactory(new LoginThrottlingFactory());
-        $extension->addSecurityListenerFactory(new LoginLinkFactory());
+        $extension->addAuthenticatorFactory(new FormLoginFactory());
+        $extension->addAuthenticatorFactory(new FormLoginLdapFactory());
+        $extension->addAuthenticatorFactory(new JsonLoginFactory());
+        $extension->addAuthenticatorFactory(new JsonLoginLdapFactory());
+        $extension->addAuthenticatorFactory(new HttpBasicFactory());
+        $extension->addAuthenticatorFactory(new HttpBasicLdapFactory());
+        $extension->addAuthenticatorFactory(new RememberMeFactory());
+        $extension->addAuthenticatorFactory(new X509Factory());
+        $extension->addAuthenticatorFactory(new RemoteUserFactory());
+        $extension->addAuthenticatorFactory(new GuardAuthenticationFactory());
+        $extension->addAuthenticatorFactory(new AnonymousFactory());
+        $extension->addAuthenticatorFactory(new CustomAuthenticatorFactory());
+        $extension->addAuthenticatorFactory(new LoginThrottlingFactory());
+        $extension->addAuthenticatorFactory(new LoginLinkFactory());
 
         $extension->addUserProviderFactory(new InMemoryFactory());
         $extension->addUserProviderFactory(new LdapFactory());

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -12,12 +12,16 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\MainConfiguration;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 
 class MainConfigurationTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * The minimal, required config needed to not have any required validation
      * issues.
@@ -112,5 +116,28 @@ class MainConfigurationTest extends TestCase
         $processedConfig = $processor->processConfiguration($configuration, [$config]);
 
         $this->assertEquals('app.henk_checker', $processedConfig['firewalls']['stub']['user_checker']);
+    }
+
+    public function testFirewalls()
+    {
+        $factory = $this->createMock(AuthenticatorFactoryInterface::class);
+        $factory->expects($this->once())->method('addConfiguration');
+
+        $configuration = new MainConfiguration(['stub' => $factory], []);
+        $configuration->getConfigTreeBuilder();
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyFirewalls()
+    {
+        $factory = $this->createMock(AuthenticatorFactoryInterface::class);
+        $factory->expects($this->once())->method('addConfiguration');
+
+        $this->expectDeprecation('Since symfony/security-bundle 5.4: Passing an array of arrays as 1st argument to "Symfony\Bundle\SecurityBundle\DependencyInjection\MainConfiguration::__construct" is deprecated, pass a sorted array of factories instead.');
+
+        $configuration = new MainConfiguration(['http_basic' => ['stub' => $factory]], []);
+        $configuration->getConfigTreeBuilder();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Ref https://github.com/symfony/symfony/pull/41613#discussion_r647334554
| License       | MIT
| Doc PR        | -

This change allows removing `SecurityFactoryInterface` in Symfony 6.

I've also changed the discrete ordering using "listener positions" to the much more common continuous ordering using priorities. I feel like priorities are much more self-explanatory.