### PR TITLE
[PasswordHasher] UserPasswordHasher only calls getSalt when method exists

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasher.php
@@ -43,9 +43,16 @@ class UserPasswordHasher implements UserPasswordHasherInterface
             trigger_deprecation('symfony/password-hasher', '5.3', 'The "%s()" method expects a "%s" instance as first argument. Not implementing it in class "%s" is deprecated.', __METHOD__, PasswordAuthenticatedUserInterface::class, get_debug_type($user));
         }
 
-        $salt = $user->getSalt();
-        if ($salt && !$user instanceof LegacyPasswordAuthenticatedUserInterface) {
-            trigger_deprecation('symfony/password-hasher', '5.3', 'Returning a string from "getSalt()" without implementing the "%s" interface is deprecated, the "%s" class should implement it.', LegacyPasswordAuthenticatedUserInterface::class, get_debug_type($user));
+        $salt = null;
+
+        if ($user instanceof LegacyPasswordAuthenticatedUserInterface) {
+            $salt = $user->getSalt();
+        } elseif ($user instanceof UserInterface) {
+            $salt = $user->getSalt();
+
+            if (null !== $salt) {
+                trigger_deprecation('symfony/password-hasher', '5.3', 'Returning a string from "getSalt()" without implementing the "%s" interface is deprecated, the "%s" class should implement it.', LegacyPasswordAuthenticatedUserInterface::class, get_debug_type($user));
+            }
         }
 
         $hasher = $this->hasherFactory->getPasswordHasher($user);
@@ -65,9 +72,16 @@ class UserPasswordHasher implements UserPasswordHasherInterface
             trigger_deprecation('symfony/password-hasher', '5.3', 'The "%s()" method expects a "%s" instance as first argument. Not implementing it in class "%s" is deprecated.', __METHOD__, PasswordAuthenticatedUserInterface::class, get_debug_type($user));
         }
 
-        $salt = $user->getSalt();
-        if ($salt && !$user instanceof LegacyPasswordAuthenticatedUserInterface) {
-            trigger_deprecation('symfony/password-hasher', '5.3', 'Returning a string from "getSalt()" without implementing the "%s" interface is deprecated, the "%s" class should implement it.', LegacyPasswordAuthenticatedUserInterface::class, get_debug_type($user));
+        $salt = null;
+
+        if ($user instanceof LegacyPasswordAuthenticatedUserInterface) {
+            $salt = $user->getSalt();
+        } elseif ($user instanceof UserInterface) {
+            $salt = $user->getSalt();
+
+            if (null !== $salt) {
+                trigger_deprecation('symfony/password-hasher', '5.3', 'Returning a string from "getSalt()" without implementing the "%s" interface is deprecated, the "%s" class should implement it.', LegacyPasswordAuthenticatedUserInterface::class, get_debug_type($user));
+            }
         }
 
         if (null === $user->getPassword()) {

--- a/src/Symfony/Component/PasswordHasher/Tests/Fixtures/TestLegacyPasswordAuthenticatedUser.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Fixtures/TestLegacyPasswordAuthenticatedUser.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Symfony\Component\PasswordHasher\Tests\Fixtures;
+
+use Symfony\Component\Security\Core\User\LegacyPasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+final class TestLegacyPasswordAuthenticatedUser implements LegacyPasswordAuthenticatedUserInterface, UserInterface
+{
+    private $username;
+    private $password;
+    private $salt;
+    private $roles;
+
+    public function __construct(string $username, ?string $password = null, ?string $salt = null, array $roles = [])
+    {
+        $this->roles = $roles;
+        $this->salt = $salt;
+        $this->password = $password;
+        $this->username = $username;
+    }
+
+    public function getSalt(): ?string
+    {
+        return $this->salt;
+    }
+
+    public function getPassword(): ?string
+    {
+        return $this->password;
+    }
+
+    public function getRoles()
+    {
+        return $this->roles;
+    }
+
+    public function eraseCredentials()
+    {
+        // Do nothing
+        return;
+    }
+
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    public function getUserIdentifier()
+    {
+        return $this->username;
+    }
+}

--- a/src/Symfony/Component/PasswordHasher/Tests/Fixtures/TestPasswordAuthenticatedUser.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Fixtures/TestPasswordAuthenticatedUser.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symfony\Component\PasswordHasher\Tests\Fixtures;
+
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+
+final class TestPasswordAuthenticatedUser implements PasswordAuthenticatedUserInterface
+{
+    private $password;
+
+    public function __construct(?string $password = null)
+    {
+        $this->password = $password;
+    }
+
+    public function getPassword(): ?string
+    {
+        return $this->password;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41753
| License       | MIT

