### PR TITLE
[DependencyInjection] Fix binding "iterable $foo" when using the PHP-DSL

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveBindingsPass.php
@@ -134,7 +134,7 @@ class ResolveBindingsPass extends AbstractRecursivePass
             }
 
             if (null !== $bindingValue && !$bindingValue instanceof Reference && !$bindingValue instanceof Definition && !$bindingValue instanceof TaggedIteratorArgument && !$bindingValue instanceof ServiceLocatorArgument) {
-                throw new InvalidArgumentException(sprintf('Invalid value for binding key "%s" for service "%s": expected null, "%s", "%s", "%s" or ServiceLocatorArgument, "%s" given.', $key, $this->currentId, Reference::class, Definition::class, TaggedIteratorArgument::class, \gettype($bindingValue)));
+                throw new InvalidArgumentException(sprintf('Invalid value for binding key "%s" for service "%s": expected "%s", "%s", "%s", "%s" or null, "%s" given.', $key, $this->currentId, Reference::class, Definition::class, TaggedIteratorArgument::class, ServiceLocatorArgument::class, \gettype($bindingValue)));
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/BindTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/BindTrait.php
@@ -34,7 +34,7 @@ trait BindTrait
     final public function bind(string $nameOrFqcn, $valueOrRef): self
     {
         $valueOrRef = static::processValue($valueOrRef, true);
-        if (!preg_match('/^(?:(?:array|bool|float|int|string)[ \t]*+)?\$/', $nameOrFqcn) && !$valueOrRef instanceof Reference) {
+        if (!preg_match('/^(?:(?:array|bool|float|int|string|iterable)[ \t]*+)?\$/', $nameOrFqcn) && !$valueOrRef instanceof Reference) {
             throw new InvalidArgumentException(sprintf('Invalid binding for service "%s": named arguments must start with a "$", and FQCN must map to references. Neither applies to binding "%s".', $this->id, $nameOrFqcn));
         }
         $bindings = $this->definition->getBindings();

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Foo.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/Foo.php
@@ -4,7 +4,7 @@ namespace Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype;
 
 class Foo implements FooInterface, Sub\BarInterface
 {
-    public function __construct($bar = null)
+    public function __construct($bar = null, iterable $foo)
     {
     }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/defaults.expected.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/defaults.expected.yml
@@ -15,13 +15,14 @@ services:
             - { name: t, a: b }
         autowire: true
         autoconfigure: true
-        arguments: ['@bar']
+        arguments: ['@bar', !tagged_iterator foo]
     bar:
         class: Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\Foo
         public: true
         tags:
             - { name: t, a: b }
         autowire: true
+        arguments: [null, !tagged_iterator foo]
         calls:
             - [setFoo, ['@bar']]
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/defaults.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/config/defaults.php
@@ -14,6 +14,7 @@ return function (ContainerConfigurator $c) {
         ->autowire()
         ->tag('t', ['a' => 'b'])
         ->bind(Foo::class, ref('bar'))
+        ->bind('iterable $foo', tagged_iterator('foo'))
         ->public();
 
     $s->set(Foo::class)->args([ref('bar')])->public();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41689
| License       | MIT
| Doc PR        | -