### PR TITLE
[HttpClient] Add default base_uri to MockHttpClient

### DIFF
--- a/src/Symfony/Component/HttpClient/MockHttpClient.php
+++ b/src/Symfony/Component/HttpClient/MockHttpClient.php
@@ -34,7 +34,7 @@ class MockHttpClient implements HttpClientInterface
     /**
      * @param callable|callable[]|ResponseInterface|ResponseInterface[]|iterable|null $responseFactory
      */
-    public function __construct($responseFactory = null, string $baseUri = null)
+    public function __construct($responseFactory = null, ?string $baseUri = 'https://example.com')
     {
         if ($responseFactory instanceof ResponseInterface) {
             $responseFactory = [$responseFactory];

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -27,7 +27,7 @@ class MockHttpClientTest extends HttpClientTestCase
      */
     public function testMocking($factory, array $expectedResponses)
     {
-        $client = new MockHttpClient($factory, 'https://example.com/');
+        $client = new MockHttpClient($factory);
         $this->assertSame(0, $client->getRequestsCount());
 
         $urls = ['/foo', '/bar'];
@@ -126,7 +126,7 @@ class MockHttpClientTest extends HttpClientTestCase
      */
     public function testTransportExceptionThrowsIfPerformedMoreRequestsThanConfigured($factory)
     {
-        $client = new MockHttpClient($factory, 'https://example.com/');
+        $client = new MockHttpClient($factory);
 
         $client->request('POST', '/foo');
         $client->request('POST', '/foo');

--- a/src/Symfony/Component/HttpClient/Tests/ScopingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/ScopingHttpClientTest.php
@@ -91,7 +91,7 @@ class ScopingHttpClientTest extends TestCase
 
     public function testForBaseUri()
     {
-        $client = ScopingHttpClient::forBaseUri(new MockHttpClient(), 'http://example.com/foo');
+        $client = ScopingHttpClient::forBaseUri(new MockHttpClient(null, null), 'http://example.com/foo');
 
         $response = $client->request('GET', '/bar');
         $this->assertSame('http://example.com/foo', implode('', $response->getRequestOptions()['base_uri']));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Not really a new feature, but still not a bugfix. This provides better DX IMHO.