### PR TITLE
[FrameworkBundle] Add commented base64 version of secrets' keys

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Secrets/SodiumVault.php
@@ -200,9 +200,10 @@ class SodiumVault extends AbstractVault implements EnvVarLoaderInterface
 
     private function export(string $file, string $data): void
     {
+        $b64 = 'decrypt.private' === $file ? '// SYMFONY_DECRYPTION_SECRET='.base64_encode($data)."\n" : '';
         $name = basename($this->pathPrefix.$file);
         $data = str_replace('%', '\x', rawurlencode($data));
-        $data = sprintf("<?php // %s on %s\n\nreturn \"%s\";\n", $name, date('r'), $data);
+        $data = sprintf("<?php // %s on %s\n\n%sreturn \"%s\";\n", $name, date('r'), $b64, $data);
 
         $this->createSecretsDir();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I'm proposing this minor DX improvement: adding the base64-encoded version of secrets' keys in their source file.
Here is an example output. L3 is the new one.
```php
<?php // dev.decrypt.private on Tue, 22 Jun 2021 15:30:09 +0200
  
// SYMFONY_DECRYPTION_SECRET=GpvL44UBcwxbXrJHc2dHK+zFVssHsQk04hyzXBjBum81lNFTuHIVldehxdgdDJ/anfrTD4eYN3Wn5H7BW2a1Kg==
return "\x1A\x9B\xCB\xE3\x85\x01s\x0C\x5B\x5E\xB2GsgG\x2B\xEC\xC5V\xCB\x07\xB1\x094\xE2\x1C\xB3\x5C\x18\xC1\xBAo5\x94\xD1S\xB8r\x15\x95\xD7\xA1\xC5\xD8\x1D\x0C\x9F\xDA\x9D\xFA\xD3\x0F\x87\x987u\xA7\xE4~\xC1\x5Bf\xB5\x2A";
```

Should make it a bit easier to populate the SYMFONY_DECRYPTION_SECRET env var by enabling copy/pasting.