### PR TITLE
[Security] Implement fluent interface on RememberMeBadge::disable()

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/RememberMeBadge.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/RememberMeBadge.php
@@ -47,10 +47,14 @@ class RememberMeBadge implements BadgeInterface
      *
      * The default is disabled, this can be called to suppress creation
      * after it was enabled.
+     *
+     * @return $this
      */
-    public function disable(): void
+    public function disable(): self
     {
         $this->enabled = false;
+
+        return $this;
     }
 
     public function isEnabled(): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

I was a bit puzzled when a I saw that `RememberMeBadge::enable()` implements a fluent interface while its counterpart `disable()` does not. This PR fixes this inconsistency.

The class is flagged as `@final`, so this change should not violate the BC promise.