### PR TITLE
Pin masterminds/html5 to the master branch for PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,6 +141,8 @@ jobs:
         run: |
           echo "::group::fake PHP version"
           composer config platform.php 8.0.99
+          echo "::group::Adjust dependencies"
+          composer require --dev --no-update masterminds/html5:~2.7.5@dev
           echo "::group::composer update"
           composer update --no-progress --ansi
           echo "::endgroup::"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Our tests on PHP 8.1 require the changes I've made in Masterminds/html5-php#207. Unfortunately, Composer will not pick a version with those changes because of the reasons described in Masterminds/html5-php#209. This PR adds a small workaround to the PHP 8.1 job which I'll happily revert as soon as Masterminds/html5-php#209 is resolved.