### PR TITLE
[Console] Allow dupplicate negative option

### DIFF
--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -231,7 +231,7 @@ class InputDefinition
         if (isset($this->options[$option->getName()]) && !$option->equals($this->options[$option->getName()])) {
             throw new LogicException(sprintf('An option named "%s" already exists.', $option->getName()));
         }
-        if (isset($this->negations[$option->getName()])) {
+        if (isset($this->negations[$option->getName()]) && !$option->equals($this->options[$this->negations[$option->getName()]])) {
             throw new LogicException(sprintf('An option named "%s" already exists.', $option->getName()));
         }
 
@@ -252,7 +252,7 @@ class InputDefinition
 
         if ($option->isNegatable()) {
             $negatedName = 'no-'.$option->getName();
-            if (isset($this->options[$negatedName])) {
+            if (isset($this->options[$negatedName]) && !$option->equals($this->options[$negatedName])) {
                 throw new LogicException(sprintf('An option named "%s" already exists.', $negatedName));
             }
             $this->negations[$negatedName] = $option->getName();

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -219,13 +219,36 @@ class InputOption
      */
     public function equals(self $option)
     {
-        return $option->getName() === $this->getName()
+        if ($option->getName() === $this->getName()
             && $option->getShortcut() === $this->getShortcut()
             && $option->getDefault() === $this->getDefault()
-            && $option->isNegatable() === $this->isNegatable()
             && $option->isArray() === $this->isArray()
             && $option->isValueRequired() === $this->isValueRequired()
             && $option->isValueOptional() === $this->isValueOptional()
-        ;
+        ) {
+            return true;
+        }
+
+        if (!($option->isNegatable() xor $this->isNegatable())) {
+            return false;
+        }
+
+        if ($option->isNegatable()) {
+            $n = $option;
+            $p = $this;
+        } else {
+            $p = $option;
+            $n = $this;
+        }
+
+        return (
+            (
+                $n->getName() === $p->getName()
+                && $n->getShortcut() === $p->getShortcut()
+            ) || (
+                'no-'.$n->getName() === $p->getName()
+                && null === $p->getShortcut()
+            )
+        ) && !$p->acceptValue();
     }
 }

--- a/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
@@ -244,22 +244,20 @@ class InputDefinitionTest extends TestCase
 
     public function testAddDuplicateNegatedOption()
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('An option named "no-foo" already exists.');
-
         $definition = new InputDefinition();
         $definition->addOption(new InputOption('no-foo'));
         $definition->addOption(new InputOption('foo', null, InputOption::VALUE_NEGATABLE));
+
+        $this->expectNotToPerformAssertions();
     }
 
     public function testAddDuplicateNegatedReverseOption()
     {
-        $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('An option named "no-foo" already exists.');
-
         $definition = new InputDefinition();
         $definition->addOption(new InputOption('foo', null, InputOption::VALUE_NEGATABLE));
         $definition->addOption(new InputOption('no-foo'));
+
+        $this->expectNotToPerformAssertions();
     }
 
     public function testAddDuplicateShortcutOption()

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -193,5 +193,18 @@ class InputOptionTest extends TestCase
         $option = new InputOption('foo', 'f', null, 'Some description');
         $option2 = new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL, 'Some description');
         $this->assertFalse($option->equals($option2));
+
+        $option = new InputOption('foo', null, InputOption::VALUE_NEGATABLE, 'Some description');
+        $option2 = new InputOption('no-foo', null, null, 'Alternative description');
+        $this->assertTrue($option->equals($option2));
+        $this->assertTrue($option2->equals($option));
+
+        $option = new InputOption('foo', null, InputOption::VALUE_NEGATABLE, 'Some description');
+        $option2 = new InputOption('foo', null, null, 'Alternative description');
+        $this->assertTrue($option->equals($option2));
+
+        $option = new InputOption('foo', null, InputOption::VALUE_NEGATABLE, 'Some description');
+        $option2 = new InputOption('bar', null, null, 'Alternative description');
+        $this->assertFalse($option->equals($option2));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | -

Alternative to #41723 that allow overriding negatable option with opposite option