### PR TITLE
[Console] Both ansi and no-ansi return false by default

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -1040,7 +1040,7 @@ class Application implements ResetInterface
             new InputOption('--quiet', '-q', InputOption::VALUE_NONE, 'Do not output any message'),
             new InputOption('--verbose', '-v|vv|vvv', InputOption::VALUE_NONE, 'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'),
             new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Display this application version'),
-            new InputOption('--ansi', '', InputOption::VALUE_NEGATABLE, 'Force (or disable --no-ansi) ANSI output', false),
+            new InputOption('--ansi', '', InputOption::VALUE_NEGATABLE, 'Force (or disable --no-ansi) ANSI output', null),
             new InputOption('--no-interaction', '-n', InputOption::VALUE_NONE, 'Do not ask any interactive question'),
         ]);
     }

--- a/src/Symfony/Component/Console/Tests/Input/InputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputTest.php
@@ -57,8 +57,8 @@ class InputTest extends TestCase
         $this->assertTrue($input->getOption('no-name'));
 
         $input = new ArrayInput([], new InputDefinition([new InputOption('name', null, InputOption::VALUE_NEGATABLE)]));
-        $this->assertNull($input->getOption('name'));
-        $this->assertNull($input->getOption('no-name'));
+        $this->assertFalse($input->getOption('name'));
+        $this->assertFalse($input->getOption('no-name'));
     }
 
     public function testSetInvalidOption()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


In Symfony 5.2, both `getOption('ansi')` and  `getOption('no-ansi')` returned `false`.
Since the option is now negatable, we can not keep the same behavior, the value returned should be either `null`, `true/false` or `false/true`.

This PR returns `false` when a negatable option has a default value `null`.

I'm not 100% convinced by this, as we lost `null` behavior.... Maybe we should allow 5 differents values `null`, `true/false`, `false/true`, `true/true`, `false/false`