### PR TITLE
[Uid] Fix fromString() with low base58 values

### DIFF
--- a/src/Symfony/Component/Uid/AbstractUid.php
+++ b/src/Symfony/Component/Uid/AbstractUid.php
@@ -43,7 +43,7 @@ abstract class AbstractUid implements \JsonSerializable
     abstract public function toBinary(): string;
 
     /**
-     * Returns the identifier as a base-58 case sensitive string.
+     * Returns the identifier as a base58 case sensitive string.
      */
     public function toBase58(): string
     {
@@ -51,7 +51,7 @@ abstract class AbstractUid implements \JsonSerializable
     }
 
     /**
-     * Returns the identifier as a base-32 case insensitive string.
+     * Returns the identifier as a base32 case insensitive string.
      */
     public function toBase32(): string
     {

--- a/src/Symfony/Component/Uid/Tests/UlidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UlidTest.php
@@ -124,4 +124,9 @@ class UlidTest extends TestCase
     {
         $this->assertInstanceOf(CustomUlid::class, CustomUlid::fromString((new CustomUlid())->toBinary()));
     }
+
+    public function testFromStringBase58Padding()
+    {
+        $this->assertInstanceOf(Ulid::class, Ulid::fromString('111111111u9QRyVM94rdmZ'));
+    }
 }

--- a/src/Symfony/Component/Uid/Tests/UuidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UuidTest.php
@@ -187,12 +187,22 @@ class UuidTest extends TestCase
         $this->assertSame([$a, $b, $c, $d], $uuids);
     }
 
-    public function testNilUuid()
+    /**
+     * @testWith    ["00000000-0000-0000-0000-000000000000"]
+     *              ["1111111111111111111111"]
+     *              ["00000000000000000000000000"]
+     */
+    public function testNilUuid(string $uuid)
     {
-        $uuid = Uuid::fromString('00000000-0000-0000-0000-000000000000');
+        $uuid = Uuid::fromString($uuid);
 
         $this->assertInstanceOf(NilUuid::class, $uuid);
         $this->assertSame('00000000-0000-0000-0000-000000000000', (string) $uuid);
+    }
+
+    public function testNewNilUuid()
+    {
+        $this->assertSame('00000000-0000-0000-0000-000000000000', (string) new NilUuid());
     }
 
     public function testFromStringOnExtendedClassReturnsStatic()
@@ -207,5 +217,10 @@ class UuidTest extends TestCase
         $this->assertSame(0.0, (new UuidV1('13814000-1dd2-11b2-a456-426655440000'))->getTime());
         $this->assertSame(-0.0000001, (new UuidV1('13813fff-1dd2-11b2-a456-426655440000'))->getTime());
         $this->assertSame(-12219292800.0, ((new UuidV1('00000000-0000-1000-a456-426655440000'))->getTime()));
+    }
+
+    public function testFromStringBase58Padding()
+    {
+        $this->assertInstanceOf(Uuid::class, Uuid::fromString('111111111u9QRyVM94rdmZ'));
     }
 }

--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -61,7 +61,7 @@ class Ulid extends AbstractUid
         if (36 === \strlen($ulid) && Uuid::isValid($ulid)) {
             $ulid = (new Uuid($ulid))->toBinary();
         } elseif (22 === \strlen($ulid) && 22 === strspn($ulid, BinaryUtil::BASE58[''])) {
-            $ulid = BinaryUtil::fromBase($ulid, BinaryUtil::BASE58);
+            $ulid = str_pad(BinaryUtil::fromBase($ulid, BinaryUtil::BASE58), 16, "\0", \STR_PAD_LEFT);
         }
 
         if (16 !== \strlen($ulid)) {

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -37,7 +37,7 @@ class Uuid extends AbstractUid
     public static function fromString(string $uuid): parent
     {
         if (22 === \strlen($uuid) && 22 === strspn($uuid, BinaryUtil::BASE58[''])) {
-            $uuid = BinaryUtil::fromBase($uuid, BinaryUtil::BASE58);
+            $uuid = str_pad(BinaryUtil::fromBase($uuid, BinaryUtil::BASE58), 16, "\0", \STR_PAD_LEFT);
         }
 
         if (16 === \strlen($uuid)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When converting base58 values to binary, we forgot to pad the result with null byte, so if the result is too "short", the code breaks.