### PR TITLE
[Uid] Add NilUlid

### DIFF
--- a/src/Symfony/Component/Uid/CHANGELOG.md
+++ b/src/Symfony/Component/Uid/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Add `NilUlid`
+
 5.3
 ---
 

--- a/src/Symfony/Component/Uid/NilUlid.php
+++ b/src/Symfony/Component/Uid/NilUlid.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Uid;
+
+class NilUlid extends Ulid
+{
+    public function __construct()
+    {
+        $this->uid = parent::NIL;
+    }
+}

--- a/src/Symfony/Component/Uid/Tests/UlidTest.php
+++ b/src/Symfony/Component/Uid/Tests/UlidTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Uid\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\NilUlid;
 use Symfony\Component\Uid\Tests\Fixtures\CustomUlid;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\UuidV4;
@@ -241,5 +242,23 @@ class UlidTest extends TestCase
     public function testFromStringBase58Padding()
     {
         $this->assertInstanceOf(Ulid::class, Ulid::fromString('111111111u9QRyVM94rdmZ'));
+    }
+
+    /**
+     * @testWith    ["00000000-0000-0000-0000-000000000000"]
+     *              ["1111111111111111111111"]
+     *              ["00000000000000000000000000"]
+     */
+    public function testNilUlid(string $ulid)
+    {
+        $ulid = Ulid::fromString($ulid);
+
+        $this->assertInstanceOf(NilUlid::class, $ulid);
+        $this->assertSame('00000000000000000000000000', (string) $ulid);
+    }
+
+    public function testNewNilUlid()
+    {
+        $this->assertSame('00000000000000000000000000', (string) new NilUlid());
     }
 }

--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\Uid;
  */
 class Ulid extends AbstractUid
 {
-    private const NIL = '00000000000000000000000000';
+    protected const NIL = '00000000000000000000000000';
 
     private static $time = '';
     private static $rand = [];
@@ -71,6 +71,10 @@ class Ulid extends AbstractUid
         }
 
         if (16 !== \strlen($ulid)) {
+            if (self::NIL === $ulid) {
+                return new NilUlid();
+            }
+
             return new static($ulid);
         }
 
@@ -84,6 +88,10 @@ class Ulid extends AbstractUid
             base_convert(substr($ulid, 22, 5), 16, 32),
             base_convert(substr($ulid, 27, 5), 16, 32)
         );
+
+        if (self::NIL === $ulid) {
+            return new NilUlid();
+        }
 
         $u = new static(self::NIL);
         $u->uid = strtr($ulid, 'abcdefghijklmnopqrstuv', 'ABCDEFGHJKMNPQRSTVWXYZ');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`NilUlid` is not really official but I think it would be useful. The goal is to be able to do `new NilUlid();` instead of `new Ulid('00000000000000000000000000');` and therefore to detect it more easily (like for the `NilUuid`). Currently I'm creating the class manually. My use case is using it as a placeholder.