### PR TITLE
[Uid] Prevent double validation in Uuid::fromString() with base32 values

### DIFF
--- a/src/Symfony/Component/Uid/Ulid.php
+++ b/src/Symfony/Component/Uid/Ulid.php
@@ -43,7 +43,7 @@ class Ulid extends AbstractUid
             throw new \InvalidArgumentException(sprintf('Invalid ULID: "%s".', $ulid));
         }
 
-        $this->uid = strtr($ulid, 'abcdefghjkmnpqrstvwxyz', 'ABCDEFGHJKMNPQRSTVWXYZ');
+        $this->uid = strtoupper($ulid);
     }
 
     public static function isValid(string $ulid): bool

--- a/src/Symfony/Component/Uid/Uuid.php
+++ b/src/Symfony/Component/Uid/Uuid.php
@@ -54,7 +54,9 @@ class Uuid extends AbstractUid
             $uuid = substr_replace($uuid, '-', 18, 0);
             $uuid = substr_replace($uuid, '-', 23, 0);
         } elseif (26 === \strlen($uuid) && Ulid::isValid($uuid)) {
-            $uuid = (new Ulid($uuid))->toRfc4122();
+            $ulid = new Ulid('00000000000000000000000000');
+            $ulid->uid = strtoupper($uuid);
+            $uuid = $ulid->toRfc4122();
         }
 
         if (__CLASS__ !== static::class || 36 !== \strlen($uuid)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Follow up to https://github.com/symfony/symfony/pull/41693, it should be a little bit faster if we don't validate twice, right?