### PR TITLE
[SecurityBundle] [5.3] Closing tag typo

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/logout_delete_cookies.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/logout_delete_cookies.xml
@@ -18,5 +18,5 @@
                 </delete-cookies>
             </logout>
         </firewall>
-    </config>
+    </sec:config>
 </srv:container>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

Quick fix, On code review the closing tag doesnt match the opening tag

```xml
<sec:config> ... </config>
```