### PR TITLE
Add TesterTrait::assertCommandIsSuccessful() helper

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/XliffLintCommandTest.php
@@ -51,7 +51,7 @@ EOF;
             ['verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false]
         );
 
-        $this->assertEquals(0, $tester->getStatusCode(), 'Returns 0 in case of success');
+        $tester->assertCommandIsSuccessful('Returns 0 in case of success');
         $this->assertStringContainsString('[OK] All 0 XLIFF files contain valid syntax', trim($tester->getDisplay()));
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/YamlLintCommandTest.php
@@ -40,7 +40,7 @@ class YamlLintCommandTest extends TestCase
             ['verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false]
         );
 
-        $this->assertEquals(0, $tester->getStatusCode(), 'Returns 0 in case of success');
+        $tester->assertCommandIsSuccessful('Returns 0 in case of success');
         $this->assertStringContainsString('OK', trim($tester->getDisplay()));
     }
 
@@ -88,7 +88,7 @@ EOF;
             ['verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false]
         );
 
-        $this->assertEquals(0, $tester->getStatusCode(), 'Returns 0 in case of success');
+        $tester->assertCommandIsSuccessful('Returns 0 in case of success');
         $this->assertStringContainsString('[OK] All 0 YAML files contain valid syntax', trim($tester->getDisplay()));
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -147,7 +147,7 @@ class ApplicationTest extends TestCase
         $tester->run(['command' => 'fine']);
         $output = $tester->getDisplay();
 
-        $this->assertSame(0, $tester->getStatusCode());
+        $tester->assertCommandIsSuccessful();
         $this->assertStringContainsString('Some commands could not be registered:', $output);
         $this->assertStringContainsString('throwing', $output);
         $this->assertStringContainsString('fine', $output);
@@ -204,7 +204,7 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'list']);
 
-        $this->assertSame(0, $tester->getStatusCode());
+        $tester->assertCommandIsSuccessful();
         $display = explode('List commands', $tester->getDisplay());
 
         $this->assertStringContainsString(trim('[WARNING] Some commands could not be registered:'), trim($display[1]));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolClearCommandTest.php
@@ -33,7 +33,7 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
         $tester = $this->createCommandTester();
         $tester->execute(['pools' => ['cache.private_pool']], ['decorated' => false]);
 
-        $this->assertSame(0, $tester->getStatusCode(), 'cache:pool:clear exits with 0 in case of success');
+        $tester->assertCommandIsSuccessful('cache:pool:clear exits with 0 in case of success');
         $this->assertStringContainsString('Clearing cache pool: cache.private_pool', $tester->getDisplay());
         $this->assertStringContainsString('[OK] Cache was successfully cleared.', $tester->getDisplay());
     }
@@ -43,7 +43,7 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
         $tester = $this->createCommandTester();
         $tester->execute(['pools' => ['cache.public_pool']], ['decorated' => false]);
 
-        $this->assertSame(0, $tester->getStatusCode(), 'cache:pool:clear exits with 0 in case of success');
+        $tester->assertCommandIsSuccessful('cache:pool:clear exits with 0 in case of success');
         $this->assertStringContainsString('Clearing cache pool: cache.public_pool', $tester->getDisplay());
         $this->assertStringContainsString('[OK] Cache was successfully cleared.', $tester->getDisplay());
     }
@@ -53,7 +53,7 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
         $tester = $this->createCommandTester();
         $tester->execute(['pools' => ['cache.pool_with_clearer']], ['decorated' => false]);
 
-        $this->assertSame(0, $tester->getStatusCode(), 'cache:pool:clear exits with 0 in case of success');
+        $tester->assertCommandIsSuccessful('cache:pool:clear exits with 0 in case of success');
         $this->assertStringContainsString('Clearing cache pool: cache.pool_with_clearer', $tester->getDisplay());
         $this->assertStringContainsString('[OK] Cache was successfully cleared.', $tester->getDisplay());
     }
@@ -63,7 +63,7 @@ class CachePoolClearCommandTest extends AbstractWebTestCase
         $tester = $this->createCommandTester();
         $tester->execute(['pools' => ['cache.app_clearer']], ['decorated' => false]);
 
-        $this->assertSame(0, $tester->getStatusCode(), 'cache:pool:clear exits with 0 in case of success');
+        $tester->assertCommandIsSuccessful('cache:pool:clear exits with 0 in case of success');
         $this->assertStringContainsString('Calling cache clearer: cache.app_clearer', $tester->getDisplay());
         $this->assertStringContainsString('[OK] Cache was successfully cleared.', $tester->getDisplay());
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolListCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/CachePoolListCommandTest.php
@@ -30,7 +30,7 @@ class CachePoolListCommandTest extends AbstractWebTestCase
         $tester = $this->createCommandTester(['cache.app', 'cache.system']);
         $tester->execute([]);
 
-        $this->assertSame(0, $tester->getStatusCode(), 'cache:pool:list exits with 0 in case of success');
+        $tester->assertCommandIsSuccessful('cache:pool:list exits with 0 in case of success');
         $this->assertStringContainsString('cache.app', $tester->getDisplay());
         $this->assertStringContainsString('cache.system', $tester->getDisplay());
     }
@@ -40,7 +40,7 @@ class CachePoolListCommandTest extends AbstractWebTestCase
         $tester = $this->createCommandTester([]);
         $tester->execute([]);
 
-        $this->assertSame(0, $tester->getStatusCode(), 'cache:pool:list exits with 0 in case of success');
+        $tester->assertCommandIsSuccessful('cache:pool:list exits with 0 in case of success');
     }
 
     private function createCommandTester(array $poolNames)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ContainerDebugCommandTest.php
@@ -161,7 +161,7 @@ TXT
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'debug:container', '--deprecations' => true]);
 
-        $this->assertSame(0, $tester->getStatusCode());
+        $tester->assertCommandIsSuccessful();
         $this->assertStringContainsString('Symfony\Bundle\FrameworkBundle\Controller\Controller', $tester->getDisplay());
         $this->assertStringContainsString('/home/hamza/projet/contrib/sf/vendor/symfony/framework-bundle/Controller/Controller.php', $tester->getDisplay());
     }
@@ -181,7 +181,7 @@ TXT
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'debug:container', '--deprecations' => true]);
 
-        $this->assertSame(0, $tester->getStatusCode());
+        $tester->assertCommandIsSuccessful();
         $this->assertStringContainsString('[OK] There are no deprecations in the logs!', $tester->getDisplay());
     }
 
@@ -199,7 +199,7 @@ TXT
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'debug:container', '--deprecations' => true]);
 
-        $this->assertSame(0, $tester->getStatusCode());
+        $tester->assertCommandIsSuccessful();
         $this->assertStringContainsString('[WARNING] The deprecation file does not exist', $tester->getDisplay());
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -38,7 +38,7 @@
         "doctrine/persistence": "^1.3|^2.0",
         "symfony/asset": "^5.3|^6.0",
         "symfony/browser-kit": "^5.4|^6.0",
-        "symfony/console": "^5.2|^6.0",
+        "symfony/console": "^5.4|^6.0",
         "symfony/css-selector": "^4.4|^5.0|^6.0",
         "symfony/dom-crawler": "^4.4|^5.0|^6.0",
         "symfony/dotenv": "^5.1|^6.0",

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Add `TesterTrait::assertCommandIsSuccessful()` to test command
+
 5.3
 ---
 

--- a/src/Symfony/Component/Console/Tester/Constraint/CommandIsSuccessful.php
+++ b/src/Symfony/Component/Console/Tester/Constraint/CommandIsSuccessful.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tester\Constraint;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use Symfony\Component\Console\Command\Command;
+
+final class CommandIsSuccessful extends Constraint
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function toString(): string
+    {
+        return 'is successful';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function matches($other): bool
+    {
+        return Command::SUCCESS === $other;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function failureDescription($other): string
+    {
+        return 'the command '.$this->toString();
+    }
+}

--- a/src/Symfony/Component/Console/Tester/TesterTrait.php
+++ b/src/Symfony/Component/Console/Tester/TesterTrait.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Component\Console\Tester;
 
+use PHPUnit\Framework\Assert;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Tester\Constraint\CommandIsSuccessful;
 
 /**
  * @author Amrouche Hamza <hamza.simperfit@gmail.com>
@@ -108,6 +110,11 @@ trait TesterTrait
         }
 
         return $this->statusCode;
+    }
+
+    public function assertCommandIsSuccessful(string $message = ''): void
+    {
+        Assert::assertThat($this->statusCode, new CommandIsSuccessful(), $message);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
@@ -82,13 +82,13 @@ class ApplicationTesterTest extends TestCase
         $tester->setInputs(['I1', 'I2', 'I3']);
         $tester->run(['command' => 'foo']);
 
-        $this->assertSame(0, $tester->getStatusCode());
+        $tester->assertCommandIsSuccessful();
         $this->assertEquals('Q1Q2Q3', $tester->getDisplay(true));
     }
 
     public function testGetStatusCode()
     {
-        $this->assertSame(0, $this->tester->getStatusCode(), '->getStatusCode() returns the status code');
+        $this->tester->assertCommandIsSuccessful('->getStatusCode() returns the status code');
     }
 
     public function testErrorOutput()

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -79,7 +79,7 @@ class CommandTesterTest extends TestCase
 
     public function testGetStatusCode()
     {
-        $this->assertSame(0, $this->tester->getStatusCode(), '->getStatusCode() returns the status code');
+        $this->tester->assertCommandIsSuccessful('->getStatusCode() returns the status code');
     }
 
     public function testGetStatusCodeWithoutCallingExecuteBefore()
@@ -129,7 +129,7 @@ class CommandTesterTest extends TestCase
         $tester->setInputs(['Bobby', 'Fine', 'France']);
         $tester->execute([]);
 
-        $this->assertEquals(0, $tester->getStatusCode());
+        $tester->assertCommandIsSuccessful();
         $this->assertEquals(implode('', $questions), $tester->getDisplay(true));
     }
 
@@ -154,7 +154,7 @@ class CommandTesterTest extends TestCase
         $tester->setInputs(['', '', '']);
         $tester->execute([]);
 
-        $this->assertEquals(0, $tester->getStatusCode());
+        $tester->assertCommandIsSuccessful();
         $this->assertEquals(implode('', $questions), $tester->getDisplay(true));
     }
 
@@ -227,7 +227,7 @@ class CommandTesterTest extends TestCase
         $tester->setInputs(['Bobby', 'Fine', 'France']);
         $tester->execute([]);
 
-        $this->assertEquals(0, $tester->getStatusCode());
+        $tester->assertCommandIsSuccessful();
     }
 
     public function testErrorOutput()

--- a/src/Symfony/Component/Console/Tests/Tester/Constraint/CommandIsSuccessfulTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/Constraint/CommandIsSuccessfulTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Tester\Constraint;
+
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestFailure;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\Constraint\CommandIsSuccessful;
+
+final class CommandIsSuccessfulTest extends TestCase
+{
+    public function testConstraint()
+    {
+        $constraint = new CommandIsSuccessful();
+
+        $this->assertTrue($constraint->evaluate(Command::SUCCESS, '', true));
+        $this->assertFalse($constraint->evaluate(Command::FAILURE, '', true));
+        $this->assertFalse($constraint->evaluate(Command::INVALID, '', true));
+
+        try {
+            $constraint->evaluate(Command::FAILURE);
+        } catch (ExpectationFailedException $e) {
+            $this->assertStringContainsString('Failed asserting that the command is successful.', TestFailure::exceptionToString($e));
+
+            return;
+        }
+
+        $this->fail();
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -71,7 +71,7 @@ TXT
         $tester = $this->createCommandTester();
         $tester->execute(['class' => 'DateTime'], ['decorated' => false, 'interactive' => false]);
 
-        $this->assertEquals(0, $tester->getStatusCode(), 'Returns 0 in case of success');
+        $tester->assertCommandIsSuccessful('Returns 0 in case of success');
         $this->assertStringContainsString('Symfony\Component\Form\Extension\Core\Type\DateTimeType (Block prefix: "datetime")', $tester->getDisplay());
     }
 
@@ -123,7 +123,7 @@ TXT;
         $tester->setInputs([0]);
         $tester->execute(['class' => 'AmbiguousType'], ['decorated' => false, 'interactive' => true]);
 
-        $this->assertEquals(0, $tester->getStatusCode(), 'Returns 0 in case of success');
+        $tester->assertCommandIsSuccessful('Returns 0 in case of success');
         $output = $tester->getDisplay(true);
         $this->assertStringMatchesFormat(<<<TXT
 

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -33,7 +33,7 @@
         "symfony/dependency-injection": "^4.4|^5.0|^6.0",
         "symfony/expression-language": "^4.4|^5.0|^6.0",
         "symfony/config": "^4.4|^5.0|^6.0",
-        "symfony/console": "^4.4|^5.0|^6.0",
+        "symfony/console": "^5.4|^6.0",
         "symfony/http-foundation": "^4.4|^5.0|^6.0",
         "symfony/http-kernel": "^4.4|^5.0|^6.0",
         "symfony/intl": "^4.4|^5.0|^6.0",

--- a/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/ConsumeMessagesCommandTest.php
@@ -63,7 +63,7 @@ class ConsumeMessagesCommandTest extends TestCase
             '--limit' => 1,
         ]);
 
-        $this->assertSame(0, $tester->getStatusCode());
+        $tester->assertCommandIsSuccessful();
         $this->assertStringContainsString('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
     }
 
@@ -96,7 +96,7 @@ class ConsumeMessagesCommandTest extends TestCase
             '--limit' => 1,
         ]);
 
-        $this->assertSame(0, $tester->getStatusCode());
+        $tester->assertCommandIsSuccessful();
         $this->assertStringContainsString('[OK] Consuming messages from transports "dummy-receiver"', $tester->getDisplay());
     }
 }

--- a/src/Symfony/Component/Messenger/composer.json
+++ b/src/Symfony/Component/Messenger/composer.json
@@ -26,7 +26,7 @@
     },
     "require-dev": {
         "psr/cache": "^1.0|^2.0|^3.0",
-        "symfony/console": "^4.4|^5.0|^6.0",
+        "symfony/console": "^5.4|^6.0",
         "symfony/dependency-injection": "^4.4|^5.0|^6.0",
         "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
         "symfony/http-kernel": "^4.4|^5.0|^6.0",

--- a/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
@@ -36,7 +36,7 @@ class XliffLintCommandTest extends TestCase
             ['verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false]
         );
 
-        $this->assertEquals(0, $tester->getStatusCode(), 'Returns 0 in case of success');
+        $tester->assertCommandIsSuccessful('Returns 0 in case of success');
         $this->assertStringContainsString('OK', trim($tester->getDisplay()));
     }
 
@@ -51,7 +51,7 @@ class XliffLintCommandTest extends TestCase
             ['verbosity' => OutputInterface::VERBOSITY_VERBOSE, 'decorated' => false]
         );
 
-        $this->assertEquals(0, $tester->getStatusCode(), 'Returns 0 in case of success');
+        $tester->assertCommandIsSuccessful('Returns 0 in case of success');
         $this->assertStringContainsString('OK', trim($tester->getDisplay()));
     }
 
@@ -101,7 +101,7 @@ class XliffLintCommandTest extends TestCase
 
         $tester->execute(['filename' => $filename], ['decorated' => false]);
 
-        $this->assertEquals(0, $tester->getStatusCode());
+        $tester->assertCommandIsSuccessful();
         $this->assertStringContainsString('[OK] All 1 XLIFF files contain valid syntax.', trim($tester->getDisplay()));
     }
 
@@ -112,7 +112,7 @@ class XliffLintCommandTest extends TestCase
 
         $tester->execute(['filename' => $filename], ['decorated' => false]);
 
-        $this->assertSame(0, $tester->getStatusCode());
+        $tester->assertCommandIsSuccessful();
         $this->assertStringContainsString('[OK] All 1 XLIFF files contain valid syntax.', trim($tester->getDisplay()));
     }
 

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "symfony/config": "^4.4|^5.0|^6.0",
-        "symfony/console": "^4.4|^5.0|^6.0",
+        "symfony/console": "^5.4|^6.0",
         "symfony/dependency-injection": "^5.0|^6.0",
         "symfony/http-kernel": "^5.0|^6.0",
         "symfony/intl": "^4.4|^5.0|^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


This PR introduces a new helper TesterTrait::assertCommandIsSuccessful() that aims to help testing the result of a command.
This is inspired by [BrowserKitAssertionsTrait::assertResponseIsSuccessful](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php#L31)