### PR TITLE
[Translation] Translate translatable parameters

### DIFF
--- a/src/Symfony/Component/Translation/Tests/TranslatableTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatableTest.php
@@ -21,11 +21,11 @@ class TranslatableTest extends TestCase
     /**
      * @dataProvider getTransTests
      */
-    public function testTrans($expected, $translatable, $translation, $locale)
+    public function testTrans(string $expected, TranslatableMessage $translatable, array $translation, string $locale)
     {
         $translator = new Translator('en');
         $translator->addLoader('array', new ArrayLoader());
-        $translator->addResource('array', [$translatable->getMessage() => $translation], $locale, $translatable->getDomain());
+        $translator->addResource('array', $translation, $locale, $translatable->getDomain());
 
         $this->assertSame($expected, $translatable->trans($translator, $locale));
     }
@@ -50,8 +50,16 @@ class TranslatableTest extends TestCase
     public function getTransTests()
     {
         return [
-            ['Symfony est super !', new TranslatableMessage('Symfony is great!', [], ''), 'Symfony est super !', 'fr'],
-            ['Symfony est awesome !', new TranslatableMessage('Symfony is %what%!', ['%what%' => 'awesome'], ''), 'Symfony est %what% !', 'fr'],
+            ['Symfony est super !', new TranslatableMessage('Symfony is great!', [], ''), [
+                'Symfony is great!' => 'Symfony est super !',
+            ], 'fr'],
+            ['Symfony est awesome !', new TranslatableMessage('Symfony is %what%!', ['%what%' => 'awesome'], ''), [
+                'Symfony is %what%!' => 'Symfony est %what% !',
+            ], 'fr'],
+            ['Symfony est superbe !', new TranslatableMessage('Symfony is %what%!', ['%what%' => new TranslatableMessage('awesome', [], '')], ''), [
+                'Symfony is %what%!' => 'Symfony est %what% !',
+                'awesome' => 'superbe',
+            ], 'fr'],
         ];
     }
 

--- a/src/Symfony/Component/Translation/TranslatableMessage.php
+++ b/src/Symfony/Component/Translation/TranslatableMessage.php
@@ -52,6 +52,11 @@ class TranslatableMessage implements TranslatableInterface
 
     public function trans(TranslatorInterface $translator, string $locale = null): string
     {
-        return $translator->trans($this->getMessage(), $this->getParameters(), $this->getDomain(), $locale);
+        return $translator->trans($this->getMessage(), array_map(
+            static function ($parameter) use ($translator, $locale) {
+                return $parameter instanceof TranslatableInterface ? $parameter->trans($translator, $locale) : $parameter;
+            },
+            $this->getParameters()
+        ), $this->getDomain(), $locale);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no (I guess it's a feature)
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Considering unit test expectation showing `Symfony est awesome !` there is something quite not so awesome in the fact that "awesome" is not translated. As it looks like we're trying to make a french sentence, it sounds to me that what we actually expect is to have the whole sentence translated including the parameters if they are themselves translatable.

So with the following code:
```php
$message = new TranslatableMessage('Symfony is %what%!', ['%what%' => new TranslatableMessage('awesome')]);
echo $message->trans($translator, 'fr');
```
And with all translations properly provided to the `$translator`, I expect:
```
Symfony est superbe !
```

Currently, we get:
```
Symfony est awesome !
```