### PR TITLE
[Form] better form doc types to support static analysis

### DIFF
--- a/src/Symfony/Component/Form/FormBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormBuilderInterface.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Form;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @extends \Traversable<string, self>
  */
 interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuilderInterface
 {
@@ -25,6 +27,7 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
      *
      * @param string|FormBuilderInterface $child
      * @param string|null                 $type
+     * @param array<string, mixed>        $options
      *
      * @return self
      */
@@ -33,8 +36,9 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
     /**
      * Creates a form builder.
      *
-     * @param string      $name The name of the form or the name of the property
-     * @param string|null $type The type of the form or null if name is a property
+     * @param string               $name    The name of the form or the name of the property
+     * @param string|null          $type    The type of the form or null if name is a property
+     * @param array<string, mixed> $options
      *
      * @return self
      */
@@ -72,7 +76,7 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
     /**
      * Returns the children.
      *
-     * @return array
+     * @return array<string, self>
      */
     public function all();
 

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -229,7 +229,7 @@ interface FormConfigInterface
     /**
      * Returns all options passed during the construction of the form.
      *
-     * @return array The passed options
+     * @return array<string, mixed> The passed options
      */
     public function getOptions();
 

--- a/src/Symfony/Component/Form/FormTypeInterface.php
+++ b/src/Symfony/Component/Form/FormTypeInterface.php
@@ -24,6 +24,8 @@ interface FormTypeInterface
      * This method is called for each type in the hierarchy starting from the
      * top most type. Type extensions can further modify the form.
      *
+     * @param array<string, mixed> $options
+     *
      * @see FormTypeExtensionInterface::buildForm()
      */
     public function buildForm(FormBuilderInterface $builder, array $options);
@@ -37,6 +39,8 @@ interface FormTypeInterface
      * A view of a form is built before the views of the child forms are built.
      * This means that you cannot access child views in this method. If you need
      * to do so, move your logic to {@link finishView()} instead.
+     *
+     * @param array<string, mixed> $options
      *
      * @see FormTypeExtensionInterface::buildView()
      */
@@ -52,6 +56,8 @@ interface FormTypeInterface
      * been built and finished and can be accessed. You should only implement
      * such logic in this method that actually accesses child views. For everything
      * else you are recommended to implement {@link buildView()} instead.
+     *
+     * @param array<string, mixed> $options
      *
      * @see FormTypeExtensionInterface::finishView()
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | 

otherwise phpstan will complain in custom FormTypes like

```
class RegistrationFormType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options): void
`````

that it does not know what the iterable $builder and $options are about.
