### PR TITLE
* validators.(ru|lt).xlf - wrong trans-unit ids

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
@@ -131,24 +131,24 @@
                 <target>Ši reikšmė turi būti skaičius.</target>
             </trans-unit>
             <trans-unit id="36">
-                <source>This value is not a valid country.</source>
-                <target>Ši reikšmė nėra tinkama šalis.</target>
-            </trans-unit>
-            <trans-unit id="37">
                 <source>This file is not a valid image.</source>
                 <target>Byla nėra paveikslėlis.</target>
             </trans-unit>
-            <trans-unit id="38">
+            <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
                 <target>Ši reikšmė nėra tinkamas IP adresas.</target>
             </trans-unit>
-            <trans-unit id="39">
+            <trans-unit id="38">
                 <source>This value is not a valid language.</source>
                 <target>Ši reikšmė nėra tinkama kalba.</target>
             </trans-unit>
-            <trans-unit id="40">
+            <trans-unit id="39">
                 <source>This value is not a valid locale.</source>
                 <target>Ši reikšmė nėra tinkama lokalė.</target>
+            </trans-unit>
+            <trans-unit id="40">
+                <source>This value is not a valid country.</source>
+                <target>Ši reikšmė nėra tinkama šalis.</target>
             </trans-unit>
             <trans-unit id="41">
                 <source>This value is already used.</source>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
@@ -131,24 +131,24 @@
                 <target>Значение должно быть числом.</target>
             </trans-unit>
             <trans-unit id="36">
-                <source>This value is not a valid country.</source>
-                <target>Значение не является допустимой страной.</target>
-            </trans-unit>
-            <trans-unit id="37">
                 <source>This file is not a valid image.</source>
                 <target>Файл не является допустимым форматом изображения.</target>
             </trans-unit>
-            <trans-unit id="38">
+            <trans-unit id="37">
                 <source>This is not a valid IP address.</source>
                 <target>Значение не является допустимым IP адресом.</target>
             </trans-unit>
-            <trans-unit id="39">
+            <trans-unit id="38">
                 <source>This value is not a valid language.</source>
                 <target>Значение не является допустимым языком.</target>
             </trans-unit>
-            <trans-unit id="40">
+            <trans-unit id="39">
                 <source>This value is not a valid locale.</source>
                 <target>Значение не является допустимой локалью.</target>
+            </trans-unit>
+            <trans-unit id="40">
+                <source>This value is not a valid country.</source>
+                <target>Значение не является допустимой страной.</target>
             </trans-unit>
             <trans-unit id="41">
                 <source>This value is already used.</source>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/41867
| License       | MIT

Hi, it is not a big issue, but validators.en.xlf vs validators.ru.xlf indexes not matched.