### PR TITLE
[SecurityBundle] Hide security toolbar if no firewall matched

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -3,85 +3,87 @@
 {% block page_title 'Security' %}
 
 {% block toolbar %}
-    {% if collector.token %}
-        {% set is_authenticated = collector.enabled and collector.authenticated  %}
-        {% set color_code = is_authenticated ? '' : 'yellow' %}
-    {% elseif collector.enabled %}
-        {% set color_code = collector.authenticatorManagerEnabled ? 'yellow' : 'red' %}
-    {% else %}
-        {% set color_code = '' %}
-    {% endif %}
-
-    {% set icon %}
-        {{ include('@Security/Collector/icon.svg') }}
-        <span class="sf-toolbar-value">{{ collector.user|default('n/a') }}</span>
-    {% endset %}
-
-    {% set text %}
-        {% if collector.impersonated %}
-            <div class="sf-toolbar-info-group">
-                <div class="sf-toolbar-info-piece">
-                    <b>Impersonator</b>
-                    <span>{{ collector.impersonatorUser }}</span>
-                </div>
-            </div>
+    {% if not collector.firewall %}
+        {% if collector.token %}
+            {% set is_authenticated = collector.enabled and collector.authenticated  %}
+            {% set color_code = is_authenticated ? '' : 'yellow' %}
+        {% elseif collector.enabled %}
+            {% set color_code = collector.authenticatorManagerEnabled ? 'yellow' : 'red' %}
+        {% else %}
+            {% set color_code = '' %}
         {% endif %}
 
-        <div class="sf-toolbar-info-group">
-            {% if collector.enabled %}
-                {% if collector.token %}
-                    <div class="sf-toolbar-info-piece">
-                        <b>Logged in as</b>
-                        <span>{{ collector.user }}</span>
-                    </div>
+        {% set icon %}
+            {{ include('@Security/Collector/icon.svg') }}
+            <span class="sf-toolbar-value">{{ collector.user|default('n/a') }}</span>
+        {% endset %}
 
+        {% set text %}
+            {% if collector.impersonated %}
+                <div class="sf-toolbar-info-group">
                     <div class="sf-toolbar-info-piece">
-                        <b>Authenticated</b>
-                        <span class="sf-toolbar-status sf-toolbar-status-{{ is_authenticated ? 'green' : 'yellow' }}">{{ is_authenticated ? 'Yes' : 'No' }}</span>
+                        <b>Impersonator</b>
+                        <span>{{ collector.impersonatorUser }}</span>
                     </div>
-
-                    <div class="sf-toolbar-info-piece">
-                        <b>Token class</b>
-                        <span>{{ collector.tokenClass|abbr_class }}</span>
-                    </div>
-                {% else %}
-                    <div class="sf-toolbar-info-piece">
-                        <b>Authenticated</b>
-                        <span class="sf-toolbar-status sf-toolbar-status-yellow">No</span>
-                    </div>
-                {% endif %}
-
-                {% if collector.firewall %}
-                    <div class="sf-toolbar-info-piece">
-                        <b>Firewall name</b>
-                        <span>{{ collector.firewall.name }}</span>
-                    </div>
-                {% endif %}
-
-                {% if collector.token and collector.logoutUrl %}
-                    <div class="sf-toolbar-info-piece">
-                        <b>Actions</b>
-                        <span>
-                            <a href="{{ collector.logoutUrl }}">Logout</a>
-                            {% if collector.impersonated and collector.impersonationExitPath %}
-                                | <a href="{{ collector.impersonationExitPath }}">Exit impersonation</a>
-                            {% endif %}
-                        </span>
-                    </div>
-                {% endif %}
-            {% else %}
-                <div class="sf-toolbar-info-piece">
-                    <span>The security is disabled.</span>
                 </div>
             {% endif %}
-        </div>
-    {% endset %}
 
-    {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url, status: color_code }) }}
+            <div class="sf-toolbar-info-group">
+                {% if collector.enabled %}
+                    {% if collector.token %}
+                        <div class="sf-toolbar-info-piece">
+                            <b>Logged in as</b>
+                            <span>{{ collector.user }}</span>
+                        </div>
+
+                        <div class="sf-toolbar-info-piece">
+                            <b>Authenticated</b>
+                            <span class="sf-toolbar-status sf-toolbar-status-{{ is_authenticated ? 'green' : 'yellow' }}">{{ is_authenticated ? 'Yes' : 'No' }}</span>
+                        </div>
+
+                        <div class="sf-toolbar-info-piece">
+                            <b>Token class</b>
+                            <span>{{ collector.tokenClass|abbr_class }}</span>
+                        </div>
+                    {% else %}
+                        <div class="sf-toolbar-info-piece">
+                            <b>Authenticated</b>
+                            <span class="sf-toolbar-status sf-toolbar-status-yellow">No</span>
+                        </div>
+                    {% endif %}
+
+                    {% if collector.firewall %}
+                        <div class="sf-toolbar-info-piece">
+                            <b>Firewall name</b>
+                            <span>{{ collector.firewall.name }}</span>
+                        </div>
+                    {% endif %}
+
+                    {% if collector.token and collector.logoutUrl %}
+                        <div class="sf-toolbar-info-piece">
+                            <b>Actions</b>
+                            <span>
+                                <a href="{{ collector.logoutUrl }}">Logout</a>
+                                {% if collector.impersonated and collector.impersonationExitPath %}
+                                    | <a href="{{ collector.impersonationExitPath }}">Exit impersonation</a>
+                                {% endif %}
+                            </span>
+                        </div>
+                    {% endif %}
+                {% else %}
+                    <div class="sf-toolbar-info-piece">
+                        <span>The security is disabled.</span>
+                    </div>
+                {% endif %}
+            </div>
+        {% endset %}
+
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url, status: color_code }) }}
+    {% endif %}
 {% endblock %}
 
 {% block menu %}
-    <span class="label {{ not collector.enabled or not collector.token ? 'disabled' }}">
+    <span class="label {{ not collector.firewall or not collector.token ? 'disabled' }}">
         <span class="icon">{{ include('@Security/Collector/icon.svg') }}</span>
         <strong>Security</strong>
     </span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/pull/41242#issuecomment-863909552
| License       | MIT
| Doc PR        | -

As reported by @pavol-tk, we currently show a red Security block in the toolbar if no firewall matched. I think we should instead leave the block out of the toolbar, just like we do with all other elements if there is no data for that request.

cc @javiereguiluz as you're the best in these UX like decisions :)