### PR TITLE
Fix SessionTokenStorage reuse with Request

### DIFF
--- a/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/SessionTokenStorageTest.php
+++ b/src/Symfony/Component/Security/Csrf/Tests/TokenStorage/SessionTokenStorageTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Csrf\Tests\TokenStorage;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -24,6 +25,8 @@ use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
  */
 class SessionTokenStorageTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     private const SESSION_NAMESPACE = 'foobar';
 
     /**
@@ -158,5 +161,51 @@ class SessionTokenStorageTest extends TestCase
 
         $this->assertTrue($this->session->has('foo'));
         $this->assertSame('baz', $this->session->get('foo'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testMockSessionIsCreatedWhenMissing()
+    {
+        $this->expectDeprecation('Since symfony/security-csrf 5.3: Using the "Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage" without a session has no effect and is deprecated. It will throw a "Symfony\Component\HttpFoundation\Exception\SessionNotFoundException" in Symfony 6.0');
+
+        $this->storage->setToken('token_id', 'TOKEN');
+
+        $requestStack = new RequestStack();
+        $storage = new SessionTokenStorage($requestStack, self::SESSION_NAMESPACE);
+
+        $this->assertFalse($storage->hasToken('foo'));
+        $storage->setToken('foo', 'bar');
+        $this->assertTrue($storage->hasToken('foo'));
+        $this->assertSame('bar', $storage->getToken('foo'));
+
+        $session = new Session(new MockArraySessionStorage());
+        $request = new Request();
+        $request->setSession($session);
+        $requestStack->push($request);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testMockSessionIsReusedEvenWhenRequestHasSession()
+    {
+        $this->expectDeprecation('Since symfony/security-csrf 5.3: Using the "Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage" without a session has no effect and is deprecated. It will throw a "Symfony\Component\HttpFoundation\Exception\SessionNotFoundException" in Symfony 6.0');
+
+        $this->storage->setToken('token_id', 'TOKEN');
+
+        $requestStack = new RequestStack();
+        $storage = new SessionTokenStorage($requestStack, self::SESSION_NAMESPACE);
+
+        $storage->setToken('foo', 'bar');
+        $this->assertSame('bar', $storage->getToken('foo'));
+
+        $session = new Session(new MockArraySessionStorage());
+        $request = new Request();
+        $request->setSession($session);
+        $requestStack->push($request);
+
+        $this->assertSame('bar', $storage->getToken('foo'));
     }
 }

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorage.php
@@ -34,7 +34,7 @@ class SessionTokenStorage implements ClearableTokenStorageInterface
     private $requestStack;
     private $namespace;
     /**
-     * Tp be remove in Symfony 6.0
+     * To be removed in Symfony 6.0.
      */
     private $session;
 
@@ -130,7 +130,7 @@ class SessionTokenStorage implements ClearableTokenStorageInterface
     private function getSession(): SessionInterface
     {
         try {
-            return $this->requestStack->getSession();
+            return $this->session ?? $this->requestStack->getSession();
         } catch (SessionNotFoundException $e) {
             trigger_deprecation('symfony/security-csrf', '5.3', 'Using the "%s" without a session has no effect and is deprecated. It will throw a "%s" in Symfony 6.0', __CLASS__, SessionNotFoundException::class);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41757
| License       | MIT
| Doc PR        | -


When the CsrfTokenManager is used BEFORE a request is sent, the `SessionTokenStorage` creates a fake session to stores the token.
But if the Storage is, then, called with a real request, the fake session is not used anymore. This is an issue for people using CSRF tests in tests. Asm they are not able to use the `security.csrf.token_manager` service.