### PR TITLE
Add helper in tests to deal with session and csrf

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/CsrfHelperTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/CsrfHelperTrait.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\Security\Csrf\CsrfToken;
+
+/**
+ * Provides methods to deal with CSRF tokens in a stateless container.
+ */
+trait CsrfHelperTrait
+{
+    use SessionHelperTrait;
+
+    private function getCsrfToken(KernelBrowser $client, string $tokenId): CsrfToken
+    {
+        return $this->callInRequestContext($client, function () use ($tokenId) {
+            return static::getContainer()->get('security.csrf.token_manager')->getToken($tokenId);
+        });
+    }
+
+    private function removeCsrfToken(KernelBrowser $client, string $tokenId): CsrfToken
+    {
+        return $this->callInRequestContext($client, function () use ($tokenId) {
+            return static::getContainer()->get('security.csrf.token_manager')->removeToken($tokenId);
+        });
+    }
+
+    private function isCsrfTokenValid(KernelBrowser $client, CsrfToken $token): bool
+    {
+        return $this->callInRequestContext($client, function () use ($token) {
+            return static::getContainer()->get('security.csrf.token_manager')->isTokenValid($token);
+        });
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Test/SessionHelperTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/SessionHelperTrait.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Provides method to deal with sessions in a stateless container.
+ */
+trait SessionHelperTrait
+{
+    private function callInRequestContext(KernelBrowser $client, callable $callable)
+    {
+        /** @var EventDispatcherInterface $eventDispatcher */
+        $eventDispatcher = static::getContainer()->get(EventDispatcherInterface::class);
+        $return = null;
+        $wrappedCallable = function (RequestEvent $event) use (&$callable, &$return) {
+            try {
+                $return = $callable();
+            } finally {
+                $event->setResponse(new Response(''));
+                $event->stopPropagation();
+            }
+        };
+
+        $eventDispatcher->addListener(KernelEvents::REQUEST, $wrappedCallable);
+        try {
+            $client->request('GET', '/'.uniqid('', true));
+
+            return $return;
+        } finally {
+            $eventDispatcher->removeListener(KernelEvents::REQUEST, $wrappedCallable);
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | TODO


Since we remove the session from the container (effective in 6.0), implementing tests that need a session could be hard, because a request have to be started (see #41757 and #41046 for CSRF)

This PR adds helper to ease starting a session to extract and read session.

usage:
```php
$client = self::createClient();
$token = $this->getCsrfToken($client, 'id');
```
```php
$client = self::createClient();
$session = $this->callInRequestContext($client, function () {
  return static::getContainer()->get('request_stack')->getSession();
}
```

Note: We use a similar code in our SecurityBundle test suite.
