### PR TITLE
[PhpUnitBridge] Fix deprecation handler with PHPUnit 10

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\PhpUnit;
 
 use PHPUnit\Framework\TestResult;
+use PHPUnit\Util\Error\Handler;
 use PHPUnit\Util\ErrorHandler;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler\Configuration;
 use Symfony\Bridge\PhpUnit\DeprecationErrorHandler\Deprecation;
@@ -51,7 +52,7 @@ class DeprecationErrorHandler
     ];
 
     private static $isRegistered = false;
-    private static $isAtLeastPhpUnit83;
+    private static $errorHandler;
 
     /**
      * Registers and configures the deprecation handler.
@@ -335,16 +336,23 @@ class DeprecationErrorHandler
 
     private static function getPhpUnitErrorHandler()
     {
-        if (!isset(self::$isAtLeastPhpUnit83)) {
-            self::$isAtLeastPhpUnit83 = class_exists(ErrorHandler::class) && method_exists(ErrorHandler::class, '__invoke');
+        if (!$eh = self::$errorHandler) {
+            if (class_exists(Handler::class)) {
+                $eh = self::$errorHandler = Handler::class;
+            } elseif (method_exists(ErrorHandler::class, '__invoke')) {
+                $eh = self::$errorHandler = ErrorHandler::class;
+            } else {
+                return self::$errorHandler = 'PHPUnit\Util\ErrorHandler::handleError';
+            }
         }
-        if (!self::$isAtLeastPhpUnit83) {
-            return 'PHPUnit\Util\ErrorHandler::handleError';
+
+        if ('PHPUnit\Util\ErrorHandler::handleError' === $eh) {
+            return $eh;
         }
 
         foreach (debug_backtrace(\DEBUG_BACKTRACE_PROVIDE_OBJECT | \DEBUG_BACKTRACE_IGNORE_ARGS) as $frame) {
             if (isset($frame['object']) && $frame['object'] instanceof TestResult) {
-                return new ErrorHandler(
+                return new $eh(
                     $frame['object']->getConvertDeprecationsToExceptions(),
                     $frame['object']->getConvertErrorsToExceptions(),
                     $frame['object']->getConvertNoticesToExceptions(),

--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -13,6 +13,8 @@ namespace Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
+use PHPUnit\Metadata\Api\Groups;
+use PHPUnit\Util\Error\Handler;
 use PHPUnit\Util\Test;
 use Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerFor;
 use Symfony\Component\Debug\DebugClassLoader as LegacyDebugClassLoader;
@@ -192,12 +194,13 @@ class Deprecation
         }
 
         $method = $this->originatingMethod();
+        $groups = class_exists(Groups::class) ? [new Groups(), 'groups'] : [Test::class, 'getGroups'];
 
         return 0 === strpos($method, 'testLegacy')
             || 0 === strpos($method, 'provideLegacy')
             || 0 === strpos($method, 'getLegacy')
             || strpos($this->originClass, '\Legacy')
-            || \in_array('legacy', Test::getGroups($this->originClass, $method), true);
+            || \in_array('legacy', $groups($this->originClass, $method), true);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41580
| License       | MIT
| Doc PR        | 
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

With PHPUnit 10, a lot of classes and methods were refactored. This PR adds the support of PHPUnit 10 into the deprecation handler.