### PR TITLE
[Filesystem] Workaround cannot dumpFile into "protected" folders on Windows

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -678,10 +678,6 @@ class Filesystem
             $this->mkdir($dir);
         }
 
-        if (!is_writable($dir)) {
-            throw new IOException(sprintf('Unable to write to the "%s" directory.', $dir), 0, null, $dir);
-        }
-
         // Will create a temp file with 0600 access rights
         // when the filesystem supports chmod.
         $tmpFile = $this->tempnam($dir, basename($filename));
@@ -719,10 +715,6 @@ class Filesystem
 
         if (!is_dir($dir)) {
             $this->mkdir($dir);
-        }
-
-        if (!is_writable($dir)) {
-            throw new IOException(sprintf('Unable to write to the "%s" directory.', $dir), 0, null, $dir);
         }
 
         if (false === @file_put_contents($filename, $content, \FILE_APPEND)) {

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1751,6 +1751,27 @@ class FilesystemTest extends FilesystemTestCase
         $this->assertFilePermissions(767, $targetFilePath);
     }
 
+    public function testDumpToProtectedDirectory()
+    {
+        if (\DIRECTORY_SEPARATOR !== '\\') {
+            $this->markTestSkipped('This test is specific to Windows.');
+        }
+
+        if (($userProfilePath = getenv('USERPROFILE')) === false || !is_dir($userProfilePath)) {
+            throw new \RuntimeException('Failed to retrieve user profile path.');
+        }
+
+        $targetPath = implode(\DIRECTORY_SEPARATOR, [$userProfilePath, 'Downloads', '__test_file.ext']);
+
+        try {
+            $this->assertFileDoesNotExist($targetPath);
+            $this->filesystem->dumpFile($targetPath, 'foobar');
+            $this->assertFileExists($targetPath);
+        } finally {
+            $this->filesystem->remove($targetPath);
+        }
+    }
+
     /**
      * Normalize the given path (transform each forward slash into a real directory separator).
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39496
| License       | MIT
| Doc PR        | 

