### PR TITLE
[Security] fix #41891 Save hashed tokenValue in RememberMe cookie

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -89,13 +89,12 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         // if a token was regenerated less than a minute ago, there is no need to regenerate it
         // if multiple concurrent requests reauthenticate a user we do not want to update the token several times
         if ($persistentToken->getLastUsed()->getTimestamp() + 60 < time()) {
-            $tokenValue = base64_encode(random_bytes(64));
-            $tokenValueHash = $this->generateHash($tokenValue);
+            $tokenValue = $this->generateHash(base64_encode(random_bytes(64)));
             $tokenLastUsed = new \DateTime();
             if ($this->tokenVerifier) {
-                $this->tokenVerifier->updateExistingToken($persistentToken, $tokenValueHash, $tokenLastUsed);
+                $this->tokenVerifier->updateExistingToken($persistentToken, $tokenValue, $tokenLastUsed);
             }
-            $this->tokenProvider->updateToken($series, $tokenValueHash, $tokenLastUsed);
+            $this->tokenProvider->updateToken($series, $tokenValue, $tokenLastUsed);
         }
 
         $this->createCookie($rememberMeDetails->withValue($series.':'.$tokenValue));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #41891 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT

The hashed tokenValue is expected in the RememberMe cookie. This was not the case when this branch was executed.
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
