### PR TITLE
[Validator] Ignore validation of ExpressionLanguageSyntax against empty string

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntaxValidator.php
@@ -39,6 +39,10 @@ class ExpressionLanguageSyntaxValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, ExpressionLanguageSyntax::class);
         }
 
+        if (null === $expression || '' === $expression) {
+            return;
+        }
+
         if (!\is_string($expression)) {
             throw new UnexpectedValueException($expression, 'string');
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionLanguageSyntaxValidatorTest.php
@@ -42,6 +42,21 @@ class ExpressionLanguageSyntaxValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
+    public function testExpressionEmpty()
+    {
+        $this->validator->validate(null, new ExpressionLanguageSyntax([
+            'message' => 'myMessage',
+        ]));
+
+        $this->assertNoViolation();
+
+        $this->validator->validate('', new ExpressionLanguageSyntax([
+            'message' => 'myMessage',
+        ]));
+
+        $this->assertNoViolation();
+    }
+
     public function testExpressionWithAllowedVariableName()
     {
         $this->validator->validate('a + 1', new ExpressionLanguageSyntax([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I have the following object
```php
class Foo
{
  #[Assert\ExpressionLanguageSyntax(allowedVariables: ['x', 'y'])]
  public ?string $exp = null;
}
```

When `exp` is null, the validator yield an `UnexpectedValueException` because null is not a string.

A workaround would be to wrap the constrain in a `AtLeastOneOf`. 

```php
class Foo
{
    /**
     * @Assert\AtLeastOneOf({
     *     @Assert\Blank(),
     *     @Assert\ExpressionLanguageSyntax(allowedVariables={"x", "y"}),
     * })
     */
    public ?string $exp = null;
}
```

But it's not nice:
- it does not work with php8 attributes
- the error message displayed to the user is now wrap into "This value should satisfy at least one of the following constraints ... "

This PR ignore validation when the input is null or empty (as we do for many other validators (datetime, bic, ...))