### PR TITLE
[EventDispatcher] Correct the called event listener method case

### DIFF
--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -81,7 +81,7 @@ class RegisterListenersPass implements CompilerPassInterface
 
                 if (!isset($event['method'])) {
                     $event['method'] = 'on'.preg_replace_callback([
-                        '/(?<=\b)[a-z]/i',
+                        '/(?<=\b|_)[a-z]/i',
                         '/[^a-z0-9]/i',
                     ], function ($matches) { return strtoupper($matches[0]); }, $event['event']);
                     $event['method'] = preg_replace('/[^a-z0-9]/i', '', $event['method']);

--- a/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php
@@ -175,6 +175,7 @@ class RegisterListenersPassTest extends TestCase
         $container->register('foo', \stdClass::class)->addTag('kernel.event_listener', ['event' => 'foo.bar']);
         $container->register('bar', InvokableListenerService::class)->addTag('kernel.event_listener', ['event' => 'foo.bar']);
         $container->register('baz', InvokableListenerService::class)->addTag('kernel.event_listener', ['event' => 'event']);
+        $container->register('zar', \stdClass::class)->addTag('kernel.event_listener', ['event' => 'foo.bar_zar']);
         $container->register('event_dispatcher', \stdClass::class);
 
         $registerListenersPass = new RegisterListenersPass();
@@ -203,6 +204,14 @@ class RegisterListenersPassTest extends TestCase
                 [
                     'event',
                     [new ServiceClosureArgument(new Reference('baz')), 'onEvent'],
+                    0,
+                ],
+            ],
+            [
+                'addListener',
+                [
+                    'foo.bar_zar',
+                    [new ServiceClosureArgument(new Reference('zar')), 'onFooBarZar'],
                     0,
                 ],
             ],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | none
| Tickets       | none
| License       | MIT
| Doc PR        | none

when define an event listener,  if you don't specify a method, then the word case of the actual method maybe wrong, for example : 

```yaml
services:
  my_kernel_envent_listeners:
        class: App\EventListener\KernelListener
        tags:
            - { name: kernel.event_listener, event: kernel.controller_arguments }     
```
no `method` key at this tag, then actual method called is `onKernelControllerarguments`, actually it should be `onKernelControllerArguments`, the case of word 'arguments' should be upper.

ps: only event name that has dash(`_`) will be affected.

