### PR TITLE
Missing translations for Chinese (zh_CN) #41814

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.zh_CN.xlf
@@ -368,7 +368,7 @@
             </trans-unit>
             <trans-unit id="95">
                 <source>This value is not a valid hostname.</source>
-                <target>该数值不是有效的主机名称。</target>
+                <target>该值不是有效的主机名称。</target>
             </trans-unit>
             <trans-unit id="96">
                 <source>The number of elements in this collection should be a multiple of {{ compared_value }}.</source>
@@ -376,7 +376,7 @@
             </trans-unit>
             <trans-unit id="97">
                 <source>This value should satisfy at least one of the following constraints:</source>
-                <target>该数值需符合以下其中一个约束：</target>
+                <target>该值需符合以下其中一个约束：</target>
             </trans-unit>
             <trans-unit id="98">
                 <source>Each element of this collection should satisfy its own set of constraints.</source>
@@ -384,7 +384,11 @@
             </trans-unit>
             <trans-unit id="99">
                 <source>This value is not a valid International Securities Identification Number (ISIN).</source>
-                <target>该数值不是有效的国际证券识别码 （ISIN）。</target>
+                <target>该值不是有效的国际证券识别码 （ISIN）。</target>
+            </trans-unit>
+            <trans-unit id="100">
+                <source>This value should be a valid expression.</source>
+                <target>该值需为一个有效的表达式。</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41814
| License       | MIT
| Doc PR        | none

1. change "数值" to "值" in some tokens.("数值" in Chinese means an numeric value, but some tokens not declare it's value is a number);
2. add the id=100 translation.