### PR TITLE
[Security] Handle concurency in Csrf DoctrineTokenProvider

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -192,8 +192,15 @@ class DoctrineTokenProvider implements TokenProviderInterface, TokenVerifierInte
             return;
         }
 
-        $this->deleteTokenBySeries($tmpSeries);
-        $this->createNewToken(new PersistentToken($token->getClass(), $token->getUserIdentifier(), $tmpSeries, $token->getTokenValue(), $lastUsed));
+        $this->conn->beginTransaction();
+        try {
+            $this->deleteTokenBySeries($tmpSeries);
+            $this->createNewToken(new PersistentToken($token->getClass(), $token->getUserIdentifier(), $tmpSeries, $token->getTokenValue(), $lastUsed));
+
+            $this->conn->commit();
+        } catch (\Exception $e) {
+            $this->conn->rollBack();
+        }
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When the `PersistentRememberMeHandler` class process a `RememberMe` cookie older than 1 minute it can tells the `tokenVerifier` to update it. This method performs a `delete` then an `insert`. This could be an issue with concurrent requests leading to `UniqueConstraintViolationException`.

This PR wrap the delete/insert in a transaction to prevent this.