### PR TITLE
[Validator] Add the errorPath option to the Expression constraint

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for `ConstraintViolationList::createFromMessage()`
+ * Add the `errorPath` option to the `Expression` constraint
 
 5.3
 ---

--- a/src/Symfony/Component/Validator/Constraints/Expression.php
+++ b/src/Symfony/Component/Validator/Constraints/Expression.php
@@ -47,9 +47,9 @@ class Expression extends Constraint
         string $message = null,
         array $values = null,
         array $groups = null,
-        string $errorPath = null,
         $payload = null,
-        array $options = []
+        array $options = [],
+        string $errorPath = null
     ) {
         if (!class_exists(ExpressionLanguage::class)) {
             throw new LogicException(sprintf('The "symfony/expression-language" component is required to use the "%s" constraint.', __CLASS__));

--- a/src/Symfony/Component/Validator/Constraints/Expression.php
+++ b/src/Symfony/Component/Validator/Constraints/Expression.php
@@ -35,6 +35,7 @@ class Expression extends Constraint
     public $message = 'This value is not valid.';
     public $expression;
     public $values = [];
+    public $errorPath;
 
     /**
      * {@inheritdoc}
@@ -46,6 +47,7 @@ class Expression extends Constraint
         string $message = null,
         array $values = null,
         array $groups = null,
+        string $errorPath = null,
         $payload = null,
         array $options = []
     ) {
@@ -65,6 +67,7 @@ class Expression extends Constraint
 
         $this->message = $message ?? $this->message;
         $this->values = $values ?? $this->values;
+        $this->errorPath = $errorPath ?? $this->errorPath;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionValidator.php
@@ -44,6 +44,7 @@ class ExpressionValidator extends ConstraintValidator
 
         if (!$this->getExpressionLanguage()->evaluate($constraint->expression, $variables)) {
             $this->context->buildViolation($constraint->message)
+                ->atPath((string) $constraint->errorPath)
                 ->setParameter('{{ value }}', $this->formatValue($value, self::OBJECT_TO_STRING))
                 ->setCode(Expression::EXPRESSION_FAILED_ERROR)
                 ->addViolation();

--- a/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ExpressionValidatorTest.php
@@ -123,6 +123,29 @@ class ExpressionValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
+    public function testFailingExpressionAtObjectLevelWithErrorPath()
+    {
+        $constraint = new Expression([
+            'expression' => 'this.data == 1',
+            'message' => 'myMessage',
+            'errorPath' => '__root__',
+        ]);
+
+        $object = new ToString();
+        $object->data = '2';
+
+        $this->setObject($object);
+        $this->setPropertyPath('');
+
+        $this->validator->validate($object, $constraint);
+
+        $this->buildViolation('myMessage')
+            ->atPath('__root__')
+            ->setParameter('{{ value }}', 'toString')
+            ->setCode(Expression::EXPRESSION_FAILED_ERROR)
+            ->assertRaised();
+    }
+
     public function testSucceedingExpressionAtPropertyLevel()
     {
         $constraint = new Expression('value == this.data');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | @todo

PR adds the `errorPath` option to the Expression constraint. 
This option can be useful for cases when Expression constraint is applied on the Class Level and we need to define the error path. 
Current behavior put an empty string to the `propertyPath`.

It works in the same way like in the `Unique` constraint.