### PR TITLE
[EventDispatcher] Add types to private properties

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/TraceableEventDispatcher.php
@@ -32,20 +32,18 @@ class TraceableEventDispatcher implements EventDispatcherInterface, ResetInterfa
     protected $logger;
     protected $stopwatch;
 
-    private $callStack;
-    private $dispatcher;
-    private $wrappedListeners;
-    private $orphanedEvents;
-    private $requestStack;
-    private $currentRequestHash = '';
+    private ?\SplObjectStorage $callStack = null;
+    private EventDispatcherInterface $dispatcher;
+    private array $wrappedListeners = [];
+    private array $orphanedEvents = [];
+    private ?RequestStack $requestStack;
+    private string $currentRequestHash = '';
 
     public function __construct(EventDispatcherInterface $dispatcher, Stopwatch $stopwatch, LoggerInterface $logger = null, RequestStack $requestStack = null)
     {
         $this->dispatcher = $dispatcher;
         $this->stopwatch = $stopwatch;
         $this->logger = $logger;
-        $this->wrappedListeners = [];
-        $this->orphanedEvents = [];
         $this->requestStack = $requestStack;
     }
 

--- a/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
+++ b/src/Symfony/Component/EventDispatcher/Debug/WrappedListener.php
@@ -21,17 +21,17 @@ use Symfony\Component\VarDumper\Caster\ClassStub;
  */
 final class WrappedListener
 {
-    private $listener;
-    private $optimizedListener;
-    private $name;
-    private $called;
-    private $stoppedPropagation;
-    private $stopwatch;
-    private $dispatcher;
-    private $pretty;
-    private $stub;
-    private $priority;
-    private static $hasClassStub;
+    private string|array|object $listener;
+    private ?\Closure $optimizedListener;
+    private string $name;
+    private bool $called = false;
+    private bool $stoppedPropagation = false;
+    private Stopwatch $stopwatch;
+    private ?EventDispatcherInterface $dispatcher;
+    private string $pretty;
+    private ClassStub|string $stub;
+    private ?int $priority = null;
+    private static bool $hasClassStub;
 
     public function __construct(callable|array $listener, ?string $name, Stopwatch $stopwatch, EventDispatcherInterface $dispatcher = null)
     {
@@ -39,8 +39,6 @@ final class WrappedListener
         $this->optimizedListener = $listener instanceof \Closure ? $listener : (\is_callable($listener) ? \Closure::fromCallable($listener) : null);
         $this->stopwatch = $stopwatch;
         $this->dispatcher = $dispatcher;
-        $this->called = false;
-        $this->stoppedPropagation = false;
 
         if (\is_array($listener)) {
             $this->name = \is_object($listener[0]) ? get_debug_type($listener[0]) : $listener[0];
@@ -66,12 +64,10 @@ final class WrappedListener
             $this->name = $name;
         }
 
-        if (null === self::$hasClassStub) {
-            self::$hasClassStub = class_exists(ClassStub::class);
-        }
+        self::$hasClassStub ??= class_exists(ClassStub::class);
     }
 
-    public function getWrappedListener()
+    public function getWrappedListener(): callable|array
     {
         return $this->listener;
     }
@@ -93,9 +89,7 @@ final class WrappedListener
 
     public function getInfo(string $eventName): array
     {
-        if (null === $this->stub) {
-            $this->stub = self::$hasClassStub ? new ClassStub($this->pretty.'()', $this->listener) : $this->pretty.'()';
-        }
+        $this->stub ??= self::$hasClassStub ? new ClassStub($this->pretty.'()', $this->listener) : $this->pretty.'()';
 
         return [
             'event' => $eventName,

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/AddEventAliasesPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/AddEventAliasesPass.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class AddEventAliasesPass implements CompilerPassInterface
 {
-    private $eventAliases;
+    private array $eventAliases;
 
     public function __construct(array $eventAliases)
     {

--- a/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
+++ b/src/Symfony/Component/EventDispatcher/DependencyInjection/RegisterListenersPass.php
@@ -25,10 +25,10 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 class RegisterListenersPass implements CompilerPassInterface
 {
-    private $hotPathEvents = [];
-    private $hotPathTagName = 'container.hot_path';
-    private $noPreloadEvents = [];
-    private $noPreloadTagName = 'container.no_preload';
+    private array $hotPathEvents = [];
+    private string $hotPathTagName = 'container.hot_path';
+    private array $noPreloadEvents = [];
+    private string $noPreloadTagName = 'container.no_preload';
 
     /**
      * @return $this

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -31,9 +31,9 @@ use Symfony\Component\EventDispatcher\Debug\WrappedListener;
  */
 class EventDispatcher implements EventDispatcherInterface
 {
-    private $listeners = [];
-    private $sorted = [];
-    private $optimized;
+    private array $listeners = [];
+    private array $sorted = [];
+    private array $optimized;
 
     public function __construct()
     {
@@ -49,7 +49,7 @@ class EventDispatcher implements EventDispatcherInterface
     {
         $eventName = $eventName ?? \get_class($event);
 
-        if (null !== $this->optimized) {
+        if (isset($this->optimized)) {
             $listeners = $this->optimized[$eventName] ?? (empty($this->listeners[$eventName]) ? [] : $this->optimizeListeners($eventName));
         } else {
             $listeners = $this->getListeners($eventName);

--- a/src/Symfony/Component/EventDispatcher/ImmutableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ImmutableEventDispatcher.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\EventDispatcher;
  */
 class ImmutableEventDispatcher implements EventDispatcherInterface
 {
-    private $dispatcher;
+    private EventDispatcherInterface $dispatcher;
 
     public function __construct(EventDispatcherInterface $dispatcher)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

In Symfony 6, we would be able to use typed properties. This is why I gave it a try and migrated all private properties of my favorite component to evaluate how the path might look like and what we have to watch out for.

Why only private properties? Well because adding types here is mostly safe. If I add a type to a protected/public property, I might break existing code that overrides that property.

One important thing we have to watch out for is the uninitialized state that a typed property has until we assign a value to it for the first time. As long as that property is in that state, reading it will trigger an error. However, calling `isset()` is safe and access to those properties can be safeguarded with `??` and `??=`.

An untyped property would implicitly be initialized with `null` and our existing code often relies on that behavior.

Another pitfall is the `callable` pseudo-type: PHP does not allow us to assign it to a property. I've used `string|array|object` instead, but I'm open for better ideas.

I used PhpStorm for most of the work, but I needed to adjust the code afterwards. I've searched the code (except the `Tests` folder) for for `private $`, opened each file and let PhpStorm infer all property types. Findings:

* If PhpStorm inferred a type, it was the correct one.
* PhpStorm is bad at detecting the nullability of a property.
* PhpStorm won't help you deal with uninitialized properties and it won't add a `= null` initializer.

The manual work was mainly look at all the places where a property is accessed and check if an implicit `null` initialization was expected or if `null` is assigned directly to the property. My goal here was to avoid making a property nullable if possible.

I sometimes moved an initialization with a constant value from the constructor to the property declaration to make the initialization more obvious. I think we can backport that if we want to keep the diff small.

What do you think? Shall we go with types properties?