### PR TITLE
Revert CI workaround for masterminds/html5

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,7 +41,6 @@ jobs:
         run: |
           echo "extensions=mbstring" >> $GITHUB_ENV
           composer config platform.php 8.0.99
-          composer require --dev --no-update masterminds/html5:~2.7.5@dev
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Masterminds/html5-php#209
| License       | MIT
| Doc PR        | N/A

The branches of `masterminds/html5` have been fixed, so we can revert our workaround.