### PR TITLE
[PhpUnitBridge] Avoid triggering the autoloader in Deprecation::isLegacy()

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -14,11 +14,12 @@ namespace Symfony\Bridge\PhpUnit\DeprecationErrorHandler;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Metadata\Api\Groups;
-use PHPUnit\Util\Error\Handler;
 use PHPUnit\Util\Test;
 use Symfony\Bridge\PhpUnit\Legacy\SymfonyTestsListenerFor;
 use Symfony\Component\Debug\DebugClassLoader as LegacyDebugClassLoader;
 use Symfony\Component\ErrorHandler\DebugClassLoader;
+
+class_exists(Groups::class);
 
 /**
  * @internal
@@ -194,7 +195,7 @@ class Deprecation
         }
 
         $method = $this->originatingMethod();
-        $groups = class_exists(Groups::class) ? [new Groups(), 'groups'] : [Test::class, 'getGroups'];
+        $groups = class_exists(Groups::class, false) ? [new Groups(), 'groups'] : [Test::class, 'getGroups'];
 
         return 0 === strpos($method, 'testLegacy')
             || 0 === strpos($method, 'provideLegacy')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The low-deps tests are currently failing because Deprecation::isLegacy() keeps triggering the autoloader and might even do so while `DebugClassLoader` considers a failed autoload attempt as an error.