### PR TITLE
[Console] fix type annotations on InputInterface

### DIFF
--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -83,7 +83,7 @@ interface InputInterface
     /**
      * Returns the argument value for a given argument name.
      *
-     * @param string $name The argument name
+     * @param string|int $name The InputArgument name or position
      *
      * @return mixed
      *
@@ -94,8 +94,8 @@ interface InputInterface
     /**
      * Sets an argument value by name.
      *
-     * @param string $name  The argument name
-     * @param mixed  $value The argument value
+     * @param string|int $name  The InputArgument name or position
+     * @param mixed      $value The argument value
      *
      * @throws InvalidArgumentException When argument given doesn't exist
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`hasArgument` already accepts `string|int`.
Makes sense?