### PR TITLE
add ability to style doubles and integers independently

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.4
 ---
 
+ * Add ability to style integer and double values independently
  * Add casters for Symfony's UUIDs and ULIDs
 
 5.2.0

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -139,10 +139,19 @@ class CliDumper extends AbstractDumper
 
             case 'integer':
                 $style = 'num';
+
+                if (isset($this->styles['integer'])) {
+                    $style = 'integer';
+                }
+
                 break;
 
             case 'double':
                 $style = 'num';
+
+                if (isset($this->styles['float'])) {
+                    $style = 'float';
+                }
 
                 switch (true) {
                     case \INF === $value:  $value = 'INF'; break;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #39393
| License       | MIT

This PR introduces new `integer` and `float` keywords, so that clients of the VarDumper component can style both types of variables independently.

Example of the feature in action:
![example](https://i.imgur.com/w8Ka4sv.png)

Original RFC: #39393 