### PR TITLE
[Console] Revert "bug #41952  fix handling positional arguments"

### DIFF
--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -106,7 +106,7 @@ abstract class Input implements InputInterface, StreamableInputInterface
      */
     public function getArgument($name)
     {
-        if (!$this->definition->hasArgument($name)) {
+        if (!$this->definition->hasArgument((string) $name)) {
             throw new InvalidArgumentException(sprintf('The "%s" argument does not exist.', $name));
         }
 
@@ -118,7 +118,7 @@ abstract class Input implements InputInterface, StreamableInputInterface
      */
     public function setArgument($name, $value)
     {
-        if (!$this->definition->hasArgument($name)) {
+        if (!$this->definition->hasArgument((string) $name)) {
             throw new InvalidArgumentException(sprintf('The "%s" argument does not exist.', $name));
         }
 
@@ -130,7 +130,7 @@ abstract class Input implements InputInterface, StreamableInputInterface
      */
     public function hasArgument($name)
     {
-        return $this->definition->hasArgument($name);
+        return $this->definition->hasArgument((string) $name);
     }
 
     /**

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -110,8 +110,6 @@ abstract class Input implements InputInterface, StreamableInputInterface
             throw new InvalidArgumentException(sprintf('The "%s" argument does not exist.', $name));
         }
 
-        $name = \is_int($name) ? key(\array_slice($this->definition->getArguments(), $name, 1, true)) : $name;
-
         return $this->arguments[$name] ?? $this->definition->getArgument($name)->getDefault();
     }
 
@@ -123,8 +121,6 @@ abstract class Input implements InputInterface, StreamableInputInterface
         if (!$this->definition->hasArgument($name)) {
             throw new InvalidArgumentException(sprintf('The "%s" argument does not exist.', $name));
         }
-
-        $name = \is_int($name) ? key(\array_slice($this->definition->getArguments(), $name, 1, true)) : $name;
 
         $this->arguments[$name] = $value;
     }

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -83,7 +83,7 @@ interface InputInterface
     /**
      * Returns the argument value for a given argument name.
      *
-     * @param string|int $name The InputArgument name or position
+     * @param string $name The argument name
      *
      * @return mixed
      *
@@ -94,8 +94,8 @@ interface InputInterface
     /**
      * Sets an argument value by name.
      *
-     * @param string|int $name  The InputArgument name or position
-     * @param mixed      $value The argument value
+     * @param string $name  The argument name
+     * @param mixed  $value The argument value
      *
      * @throws InvalidArgumentException When argument given doesn't exist
      */

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -104,7 +104,7 @@ interface InputInterface
     /**
      * Returns true if an InputArgument object exists by name or position.
      *
-     * @param string|int $name The InputArgument name or position
+     * @param string $name The InputArgument name or position
      *
      * @return bool true if the InputArgument object exists, false otherwise
      */

--- a/src/Symfony/Component/Console/Tests/Input/InputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputTest.php
@@ -75,11 +75,6 @@ class InputTest extends TestCase
         $input = new ArrayInput(['name' => 'foo'], new InputDefinition([new InputArgument('name'), new InputArgument('bar', InputArgument::OPTIONAL, '', 'default')]));
         $this->assertEquals('default', $input->getArgument('bar'), '->getArgument() returns the default value for optional arguments');
         $this->assertEquals(['name' => 'foo', 'bar' => 'default'], $input->getArguments(), '->getArguments() returns all argument values, even optional ones');
-
-        $input = new ArrayInput(['arg1' => 'foo'], new InputDefinition([new InputArgument('arg1'), new InputArgument('arg2')]));
-        $input->setArgument(1, 'bar');
-        $this->assertEquals('bar', $input->getArgument(1));
-        $this->assertEquals(['arg1' => 'foo', 'arg2' => 'bar'], $input->getArguments());
     }
 
     public function testSetInvalidArgument()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Reverts #41952 as it breaks tests on 5.3 due to an implicit string cast:
We added the `string` typehint to the `$name` argument in 5.x, removing it now to allow for `string|int` would be a BC break which I don't think is worth it.