### PR TITLE
[FrameworkBundle] Move ServiceSessionFactory in FrameworkBundle

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\FrameworkBundle\Session\DeprecatedSessionFactory;
+use Symfony\Bundle\FrameworkBundle\Session\ServiceSessionFactory;
 use Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
@@ -31,7 +32,6 @@ use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorageFactory;
 use Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Storage\PhpBridgeSessionStorageFactory;
-use Symfony\Component\HttpFoundation\Session\Storage\ServiceSessionFactory;
 use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
 use Symfony\Component\HttpKernel\EventListener\SessionListener;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Session/ServiceSessionFactory.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Session/ServiceSessionFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Session;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
+use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageFactoryInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal to be removed in Symfony 6
+ */
+final class ServiceSessionFactory implements SessionStorageFactoryInterface
+{
+    private $storage;
+
+    public function __construct(SessionStorageInterface $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    public function createStorage(?Request $request): SessionStorageInterface
+    {
+        if ($this->storage instanceof NativeSessionStorage && $request && $request->isSecure()) {
+            $this->storage->setOptions(['cookie_secure' => true]);
+        }
+
+        return $this->storage;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


The class `ServiceSessionFactory` from `symfony/http-fundation` is used by `symfony/framework-bundle: 5.x`.

We can not remove the class in 6.0 (in https://github.com/symfony/symfony/pull/41321) because `symfony/http-fundation: 6.0` can be used by `symfony/framework-bundle: 5.x` and needs this class.

This PR move this `@internal` class in FwB, in order to provide a migration path 