### PR TITLE
[Console] SymfonyStyle - add string type to confirm() $question by co…

### DIFF
--- a/src/Symfony/Component/Console/Style/SymfonyStyle.php
+++ b/src/Symfony/Component/Console/Style/SymfonyStyle.php
@@ -288,7 +288,7 @@ class SymfonyStyle extends OutputStyle
     /**
      * {@inheritdoc}
      */
-    public function confirm($question, $default = true)
+    public function confirm(string $question, bool $default = true)
     {
         return $this->askQuestion(new ConfirmationQuestion($question, $default));
     }


### PR DESCRIPTION
PR retargeted from Symfony 5.4: https://github.com/symfony/symfony/pull/41983

Inspired by & follow up to https://github.com/symfony/symfony/pull/41946 by @nicolas-grekas 

<br>

This type is always string, see contract https://github.com/symfony/symfony/blob/5010ebdad90e9e0889e6a66ff9ad7b290bd00bae/src/Symfony/Component/Console/Style/StyleInterface.php#L102

Also `ConfirmationQuestion` requires `string` strict type bellow

Probably forgotten during adding types everywhere in  https://github.com/symfony/symfony/pull/32318

| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT


