### PR TITLE
[Lock] fix derivating semaphore from key

### DIFF
--- a/src/Symfony/Component/Lock/Store/SemaphoreStore.php
+++ b/src/Symfony/Component/Lock/Store/SemaphoreStore.php
@@ -63,7 +63,7 @@ class SemaphoreStore implements StoreInterface, BlockingStoreInterface
             return;
         }
 
-        $keyId = crc32($key);
+        $keyId = unpack('i', md5($key, true))[1];
         $resource = sem_get($keyId);
         $acquired = @sem_acquire($resource, !$blocking);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

A crc32 is a 32bits number.
This new code uses a 64bits number on x64.
This reduces the risk of collision (that could cause a deadlock) by a huge amount.
