### PR TITLE
[Security] Prevent `FormLoginAuthenticator` from responding to requests that should be handled by `JsonLoginAuthenticator`

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -37,6 +37,7 @@ CHANGELOG
  * Deprecate the `security.authentication.provider.*` services, use the new authenticator system instead
  * Deprecate the `security.authentication.listener.*` services, use the new authenticator system instead
  * Deprecate the Guard component integration, use the new authenticator system instead
+ * Add `form_login.form_only` option
 
 5.2.0
 -----

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
@@ -37,6 +37,7 @@ class FormLoginFactory extends AbstractFactory implements AuthenticatorFactoryIn
         $this->addOption('csrf_token_id', 'authenticate');
         $this->addOption('enable_csrf', false);
         $this->addOption('post_only', true);
+        $this->addOption('form_only', false);
     }
 
     public function getPriority(): int

--- a/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
@@ -60,6 +60,7 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
             'password_parameter' => '_password',
             'check_path' => '/login_check',
             'post_only' => true,
+            'form_only' => false,
             'enable_csrf' => false,
             'csrf_parameter' => '_csrf_token',
             'csrf_token_id' => 'authenticate',
@@ -74,7 +75,8 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
     public function supports(Request $request): bool
     {
         return ($this->options['post_only'] ? $request->isMethod('POST') : true)
-            && $this->httpUtils->checkRequestPath($request, $this->options['check_path']);
+            && $this->httpUtils->checkRequestPath($request, $this->options['check_path'])
+            && ($this->options['form_only'] ? 'form' === $request->getContentType() : true);
     }
 
     public function authenticate(Request $request): Passport

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/FormLoginAuthenticatorTest.php
@@ -156,6 +156,27 @@ class FormLoginAuthenticatorTest extends TestCase
         $this->assertEquals('s$cr$t', $badge->getAndErasePlaintextPassword());
     }
 
+    /**
+     * @dataProvider provideContentTypes()
+     */
+    public function testSupportsFormOnly(string $contentType, bool $shouldSupport)
+    {
+        $request = new Request();
+        $request->headers->set('CONTENT_TYPE', $contentType);
+        $request->server->set('REQUEST_URI', '/login_check');
+        $request->setMethod('POST');
+
+        $this->setUpAuthenticator(['form_only' => true]);
+
+        $this->assertSame($shouldSupport, $this->authenticator->supports($request));
+    }
+
+    public function provideContentTypes()
+    {
+        yield ['application/json', false];
+        yield ['application/x-www-form-urlencoded', true];
+    }
+
     private function setUpAuthenticator(array $options = [])
     {
         $this->authenticator = new FormLoginAuthenticator(new HttpUtils(), $this->userProvider, $this->successHandler, $this->failureHandler, $options);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | No
| New feature?  | No
| Deprecations? | No
| Tickets       | Fix #41959
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Prevent FormLoginAuthenticator from responding to requests that should be handled by JsonLoginAuthenticator
