### PR TITLE
[Validator] Add support of nested attributes

### DIFF
--- a/.github/patch-types.php
+++ b/.github/patch-types.php
@@ -34,6 +34,7 @@ foreach ($loader->getClassMap() as $class => $file) {
         case false !== strpos($file, '/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ParentDummy.php'):
         case false !== strpos($file, '/src/Symfony/Component/Runtime/Internal/ComposerPlugin.php'):
         case false !== strpos($file, '/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ObjectOuter.php'):
+        case false !== strpos($file, '/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/Entity.php'):
         case false !== strpos($file, '/src/Symfony/Component/VarDumper/Tests/Fixtures/NotLoadableClass.php'):
         case false !== strpos($file, '/src/Symfony/Component/VarDumper/Tests/Fixtures/ReflectionIntersectionTypeFixture.php'):
             continue 2;

--- a/src/Symfony/Component/Validator/Constraints/All.php
+++ b/src/Symfony/Component/Validator/Constraints/All.php
@@ -17,9 +17,15 @@ namespace Symfony\Component\Validator\Constraints;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class All extends Composite
 {
     public $constraints = [];
+
+    public function __construct($constraints = null, array $groups = null, $payload = null)
+    {
+        parent::__construct($constraints ?? [], $groups, $payload);
+    }
 
     public function getDefaultOption()
     {

--- a/src/Symfony/Component/Validator/Constraints/AtLeastOneOf.php
+++ b/src/Symfony/Component/Validator/Constraints/AtLeastOneOf.php
@@ -17,6 +17,7 @@ namespace Symfony\Component\Validator\Constraints;
  *
  * @author Przemysław Bogusz <przemyslaw.bogusz@tubotax.pl>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class AtLeastOneOf extends Composite
 {
     public const AT_LEAST_ONE_OF_ERROR = 'f27e6d6c-261a-4056-b391-6673a623531c';
@@ -29,6 +30,15 @@ class AtLeastOneOf extends Composite
     public $message = 'This value should satisfy at least one of the following constraints:';
     public $messageCollection = 'Each element of this collection should satisfy its own set of constraints.';
     public $includeInternalMessages = true;
+
+    public function __construct($constraints = null, array $groups = null, $payload = null, string $message = null, string $messageCollection = null, bool $includeInternalMessages = null)
+    {
+        parent::__construct($constraints ?? [], $groups, $payload);
+
+        $this->message = $message ?? $this->message;
+        $this->messageCollection = $messageCollection ?? $this->messageCollection;
+        $this->includeInternalMessages = $includeInternalMessages ?? $this->includeInternalMessages;
+    }
 
     public function getDefaultOption()
     {

--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -19,6 +19,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Collection extends Composite
 {
     public const MISSING_FIELD_ERROR = '2fa2158c-2a7f-484b-98aa-975522539ff8';
@@ -38,15 +39,20 @@ class Collection extends Composite
     /**
      * {@inheritdoc}
      */
-    public function __construct($options = null)
+    public function __construct($fields = null, array $groups = null, $payload = null, bool $allowExtraFields = null, bool $allowMissingFields = null, string $extraFieldsMessage = null, string $missingFieldsMessage = null)
     {
-        // no known options set? $options is the fields array
-        if (\is_array($options)
-            && !array_intersect(array_keys($options), ['groups', 'fields', 'allowExtraFields', 'allowMissingFields', 'extraFieldsMessage', 'missingFieldsMessage'])) {
-            $options = ['fields' => $options];
+        // no known options set? $fields is the fields array
+        if (\is_array($fields)
+            && !array_intersect(array_keys($fields), ['groups', 'fields', 'allowExtraFields', 'allowMissingFields', 'extraFieldsMessage', 'missingFieldsMessage'])) {
+            $fields = ['fields' => $fields];
         }
 
-        parent::__construct($options);
+        parent::__construct($fields, $groups, $payload);
+
+        $this->allowExtraFields = $allowExtraFields ?? $this->allowExtraFields;
+        $this->allowMissingFields = $allowMissingFields ?? $this->allowMissingFields;
+        $this->extraFieldsMessage = $extraFieldsMessage ?? $this->extraFieldsMessage;
+        $this->missingFieldsMessage = $missingFieldsMessage ?? $this->missingFieldsMessage;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/Composite.php
+++ b/src/Symfony/Component/Validator/Constraints/Composite.php
@@ -51,9 +51,9 @@ abstract class Composite extends Constraint
      * cached. When constraints are loaded from the cache, no more group
      * checks need to be done.
      */
-    public function __construct($options = null)
+    public function __construct($options = null, array $groups = null, $payload = null)
     {
-        parent::__construct($options);
+        parent::__construct($options, $groups, $payload);
 
         $this->initializeNestedConstraints();
 

--- a/src/Symfony/Component/Validator/Constraints/Sequentially.php
+++ b/src/Symfony/Component/Validator/Constraints/Sequentially.php
@@ -20,9 +20,15 @@ namespace Symfony\Component\Validator\Constraints;
  *
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Sequentially extends Composite
 {
     public $constraints = [];
+
+    public function __construct($constraints = null, array $groups = null, $payload = null)
+    {
+        parent::__construct($constraints ?? [], $groups, $payload);
+    }
 
     public function getDefaultOption()
     {

--- a/src/Symfony/Component/Validator/Tests/Fixtures/Attribute/Entity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/Attribute/Entity.php
@@ -29,9 +29,13 @@ class Entity extends EntityParent implements EntityInterfaceB
      * @Assert\All(constraints={@Assert\NotNull, @Assert\Range(min=3)})
      * @Assert\Collection(fields={
      *   "foo" = {@Assert\NotNull, @Assert\Range(min=3)},
-     *   "bar" = @Assert\Range(min=5)
-     * })
+     *   "bar" = @Assert\Range(min=5),
+     *   "baz" = @Assert\Required({@Assert\Email()}),
+     *   "qux" = @Assert\Optional({@Assert\NotBlank()})
+     * }, allowExtraFields=true)
      * @Assert\Choice(choices={"A", "B"}, message="Must be one of %choices%")
+     * @Assert\AtLeastOneOf({@Assert\NotNull, @Assert\Range(min=3)}, message="foo", includeInternalMessages=false)
+     * @Assert\Sequentially({@Assert\NotBlank, @Assert\Range(min=5)})
      */
     #[
         Assert\NotNull,

--- a/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/Entity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/Entity.php
@@ -9,42 +9,65 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Validator\Tests\Fixtures\Annotation;
+namespace Symfony\Component\Validator\Tests\Fixtures\NestedAttribute;
 
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Tests\Fixtures\Attribute\EntityParent;
 use Symfony\Component\Validator\Tests\Fixtures\EntityInterfaceB;
+use Symfony\Component\Validator\Tests\Fixtures\CallbackClass;
+use Symfony\Component\Validator\Tests\Fixtures\ConstraintA;
 
-/**
- * @Symfony\Component\Validator\Tests\Fixtures\ConstraintA
- * @Assert\GroupSequence({"Foo", "Entity"})
- * @Assert\Callback({"Symfony\Component\Validator\Tests\Fixtures\CallbackClass", "callback"})
- */
+#[
+    ConstraintA,
+    Assert\GroupSequence(['Foo', 'Entity']),
+    Assert\Callback([CallbackClass::class, 'callback']),
+]
 class Entity extends EntityParent implements EntityInterfaceB
 {
-    /**
-     * @Assert\NotNull
-     * @Assert\Range(min=3)
-     * @Assert\All({@Assert\NotNull, @Assert\Range(min=3)}),
-     * @Assert\All(constraints={@Assert\NotNull, @Assert\Range(min=3)})
-     * @Assert\Collection(fields={
-     *   "foo" = {@Assert\NotNull, @Assert\Range(min=3)},
-     *   "bar" = @Assert\Range(min=5),
-     *   "baz" = @Assert\Required({@Assert\Email()}),
-     *   "qux" = @Assert\Optional({@Assert\NotBlank()})
-     * }, allowExtraFields=true)
-     * @Assert\Choice(choices={"A", "B"}, message="Must be one of %choices%")
-     * @Assert\AtLeastOneOf({@Assert\NotNull, @Assert\Range(min=3)}, message="foo", includeInternalMessages=false)
-     * @Assert\Sequentially({@Assert\NotBlank, @Assert\Range(min=5)})
-     */
+    #[
+        Assert\NotNull,
+        Assert\Range(min: 3),
+        Assert\All([
+            new Assert\NotNull(),
+            new Assert\Range(min: 3),
+        ]),
+        Assert\All(
+            constraints: [
+                new Assert\NotNull(),
+                new Assert\Range(min: 3),
+            ],
+        ),
+        Assert\Collection(
+            fields: [
+                'foo' => [
+                    new Assert\NotNull(),
+                    new Assert\Range(min: 3),
+                ],
+                'bar' => new Assert\Range(min: 5),
+                'baz' => new Assert\Required([new Assert\Email()]),
+                'qux' => new Assert\Optional([new Assert\NotBlank()]),
+            ],
+            allowExtraFields: true
+        ),
+        Assert\Choice(choices: ['A', 'B'], message: 'Must be one of %choices%'),
+        Assert\AtLeastOneOf(
+            constraints: [
+                new Assert\NotNull(),
+                new Assert\Range(min: 3),
+            ],
+            message: 'foo',
+            includeInternalMessages: false,
+        ),
+        Assert\Sequentially([
+            new Assert\NotBlank(),
+            new Assert\Range(min: 5),
+        ]),
+    ]
     public $firstName;
-    /**
-     * @Assert\Valid
-     */
+    #[Assert\Valid]
     public $childA;
-    /**
-     * @Assert\Valid
-     */
+    #[Assert\Valid]
     public $childB;
     protected $lastName;
     public $reference;
@@ -73,9 +96,7 @@ class Entity extends EntityParent implements EntityInterfaceB
         $this->lastName = $lastName;
     }
 
-    /**
-     * @Assert\NotNull
-     */
+    #[Assert\NotNull]
     public function getLastName()
     {
         return $this->lastName;
@@ -85,17 +106,13 @@ class Entity extends EntityParent implements EntityInterfaceB
     {
     }
 
-    /**
-     * @Assert\IsTrue
-     */
+    #[Assert\IsTrue]
     public function isValid()
     {
         return 'valid';
     }
 
-    /**
-     * @Assert\IsTrue
-     */
+    #[Assert\IsTrue]
     public function hasPermissions()
     {
         return 'permissions';
@@ -106,16 +123,12 @@ class Entity extends EntityParent implements EntityInterfaceB
         return 'Overridden data';
     }
 
-    /**
-     * @Assert\Callback(payload="foo")
-     */
+    #[Assert\Callback(payload: 'foo')]
     public function validateMe(ExecutionContextInterface $context)
     {
     }
 
-    /**
-     * @Assert\Callback
-     */
+    #[Assert\Callback]
     public static function validateMeStatic($object, ExecutionContextInterface $context)
     {
     }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/EntityParent.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/EntityParent.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures\NestedAttribute;
+
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Tests\Fixtures\EntityInterfaceA;
+
+class EntityParent implements EntityInterfaceA
+{
+    protected $firstName;
+    private $internal;
+    private $data = 'Data';
+    private $child;
+
+    #[NotNull]
+    protected $other;
+
+    public function getData()
+    {
+        return 'Data';
+    }
+
+    public function getChild()
+    {
+        return $this->child;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/GroupSequenceProviderEntity.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/NestedAttribute/GroupSequenceProviderEntity.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Fixtures\NestedAttribute;
+
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\GroupSequenceProviderInterface;
+
+#[Assert\GroupSequenceProvider]
+class GroupSequenceProviderEntity implements GroupSequenceProviderInterface
+{
+    public $firstName;
+    public $lastName;
+
+    protected $sequence = [];
+
+    public function __construct($sequence)
+    {
+        $this->sequence = $sequence;
+    }
+
+    public function getGroupSequence()
+    {
+        return $this->sequence;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -14,12 +14,18 @@ namespace Symfony\Component\Validator\Tests\Mapping\Loader;
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraints\All;
+use Symfony\Component\Validator\Constraints\AtLeastOneOf;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\Collection;
+use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\IsTrue;
+use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Optional;
 use Symfony\Component\Validator\Constraints\Range;
+use Symfony\Component\Validator\Constraints\Required;
+use Symfony\Component\Validator\Constraints\Sequentially;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
@@ -65,13 +71,23 @@ class AnnotationLoaderTest extends TestCase
         $expected->addPropertyConstraint('firstName', new Range(['min' => 3]));
         $expected->addPropertyConstraint('firstName', new All([new NotNull(), new Range(['min' => 3])]));
         $expected->addPropertyConstraint('firstName', new All(['constraints' => [new NotNull(), new Range(['min' => 3])]]));
-        $expected->addPropertyConstraint('firstName', new Collection(['fields' => [
+        $expected->addPropertyConstraint('firstName', new Collection([
             'foo' => [new NotNull(), new Range(['min' => 3])],
             'bar' => new Range(['min' => 5]),
-        ]]));
+            'baz' => new Required([new Email()]),
+            'qux' => new Optional([new NotBlank()]),
+        ], null, null, true));
         $expected->addPropertyConstraint('firstName', new Choice([
             'message' => 'Must be one of %choices%',
             'choices' => ['A', 'B'],
+        ]));
+        $expected->addPropertyConstraint('firstName', new AtLeastOneOf([
+            new NotNull(),
+            new Range(['min' => 3]),
+        ], null, null, 'foo', null, false));
+        $expected->addPropertyConstraint('firstName', new Sequentially([
+            new NotBlank(),
+            new Range(['min' => 5]),
         ]));
         $expected->addPropertyConstraint('childA', new Valid());
         $expected->addPropertyConstraint('childB', new Valid());
@@ -141,13 +157,23 @@ class AnnotationLoaderTest extends TestCase
         $expected->addPropertyConstraint('firstName', new Range(['min' => 3]));
         $expected->addPropertyConstraint('firstName', new All([new NotNull(), new Range(['min' => 3])]));
         $expected->addPropertyConstraint('firstName', new All(['constraints' => [new NotNull(), new Range(['min' => 3])]]));
-        $expected->addPropertyConstraint('firstName', new Collection(['fields' => [
+        $expected->addPropertyConstraint('firstName', new Collection([
             'foo' => [new NotNull(), new Range(['min' => 3])],
             'bar' => new Range(['min' => 5]),
-        ]]));
+            'baz' => new Required([new Email()]),
+            'qux' => new Optional([new NotBlank()]),
+        ], null, null, true));
         $expected->addPropertyConstraint('firstName', new Choice([
             'message' => 'Must be one of %choices%',
             'choices' => ['A', 'B'],
+        ]));
+        $expected->addPropertyConstraint('firstName', new AtLeastOneOf([
+            new NotNull(),
+            new Range(['min' => 3]),
+        ], null, null, 'foo', null, false));
+        $expected->addPropertyConstraint('firstName', new Sequentially([
+            new NotBlank(),
+            new Range(['min' => 5]),
         ]));
         $expected->addPropertyConstraint('childA', new Valid());
         $expected->addPropertyConstraint('childB', new Valid());
@@ -184,6 +210,10 @@ class AnnotationLoaderTest extends TestCase
 
         if (\PHP_VERSION_ID >= 80000) {
             yield 'attributes' => ['Symfony\Component\Validator\Tests\Fixtures\Attribute'];
+        }
+
+        if (\PHP_VERSION_ID >= 80100) {
+            yield 'nested_attributes' => ['Symfony\Component\Validator\Tests\Fixtures\NestedAttribute'];
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #38503
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/15541

Although the RFC (https://wiki.php.net/rfc/new_in_initializers) is in the voting phase (until 14 July), it is already well on its way to passing.

Based on @nikic's development (https://github.com/php/php-src/pull/7153), this makes the development of support possible. It will obviously take a little while before this pull request is merged.

If this pull request is OK for you, I'll get to work on writing the existing documentation for the attribute validation constraints.

![Capture d’écran du 2021-07-05 17-11-23](https://user-images.githubusercontent.com/2144837/124491886-0d2f7d80-ddb4-11eb-8147-493bdc6c48ac.png)

Not sure about the Symfony version to target, as `AtLeastOneOf` has been introduced in 5.1. Although, I couldn't find attributes validation documentation for 4.4.