### PR TITLE
[EventDispatcher] Declare return type of `getSubscribedEvents()`

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
@@ -43,7 +43,7 @@ interface EventSubscriberInterface
      * The code must not depend on runtime state as it will only be called at compile time.
      * All logic depending on runtime state must be put into the individual methods handling the events.
      *
-     * @return array The event names to listen to
+     * @return array<string, mixed> The event names to listen to
      */
     public static function getSubscribedEvents();
 }


### PR DESCRIPTION
Fixes 

Method getSubscribedEvents() return type has no value type specified in iterable type array.  
💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | kinda
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix 
| License       | MIT
| Doc PR        | 

