### PR TITLE
Stop using service "session" in our tests

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/RequestTrackerBundle/DependencyInjection/RequestTrackerExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/RequestTrackerBundle/DependencyInjection/RequestTrackerExtension.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\RequestTrackerBundle\DependencyInjection;
+
+use Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\RequestTrackerBundle\EventSubscriber\RequestTrackerSubscriber;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+final class RequestTrackerExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $container->register('request_tracker_subscriber', RequestTrackerSubscriber::class)
+            ->setPublic(true)
+            ->addTag('kernel.event_subscriber');
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/RequestTrackerBundle/EventSubscriber/RequestTrackerSubscriber.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/RequestTrackerBundle/EventSubscriber/RequestTrackerSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\RequestTrackerBundle\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+
+final class RequestTrackerSubscriber implements EventSubscriberInterface
+{
+    /** @var ?Request */
+    private $lastRequest;
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            RequestEvent::class => 'onRequest',
+        ];
+    }
+
+    public function onRequest(RequestEvent $event)
+    {
+        $this->lastRequest = $event->getRequest();
+    }
+
+    public function getLastRequest(): ?Request
+    {
+        return $this->lastRequest;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/RequestTrackerBundle/RequestTrackerBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/RequestTrackerBundle/RequestTrackerBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\RequestTrackerBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+final class RequestTrackerBundle extends Bundle
+{
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SecurityRoutingIntegrationTest.php
@@ -136,7 +136,7 @@ class SecurityRoutingIntegrationTest extends AbstractWebTestCase
 
         $this->assertEquals(200, $client->getResponse()->getStatusCode(), (string) $client->getResponse());
         $this->assertTrue($client->getResponse()->headers->getCacheControlDirective('public'));
-        $this->assertSame(0, self::getContainer()->get('session')->getUsageIndex());
+        $this->assertSame(0, self::getContainer()->get('request_tracker_subscriber')->getLastRequest()->getSession()->getUsageIndex());
     }
 
     /**
@@ -274,7 +274,7 @@ class SecurityRoutingIntegrationTest extends AbstractWebTestCase
 
         $this->assertEquals(200, $client->getResponse()->getStatusCode(), (string) $client->getResponse());
         $this->assertTrue($client->getResponse()->headers->getCacheControlDirective('public'));
-        $this->assertSame(0, self::getContainer()->get('session')->getUsageIndex());
+        $this->assertSame(0, self::getContainer()->get('request_tracker_subscriber')->getLastRequest()->getSession()->getUsageIndex());
     }
 
     private function assertAllowed($client, $path)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/bundles.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/bundles.php
@@ -12,6 +12,7 @@
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\FormLoginBundle;
+use Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\RequestTrackerBundle\RequestTrackerBundle;
 use Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\TestBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
 
@@ -20,5 +21,6 @@ return [
     new SecurityBundle(),
     new TwigBundle(),
     new FormLoginBundle(),
+    new RequestTrackerBundle(),
     new TestBundle(),
 ];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This PR makes tests suite compatible with `symfony/framework-bundle:6.0` without `session` service