### PR TITLE
Prepare PasswordUpgraderInterface implementations for 6.0 signature

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -133,10 +133,14 @@ class EntityUserProvider implements UserProviderInterface, PasswordUpgraderInter
      *
      * @final
      */
-    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
+    public function upgradePassword($user, string $newHashedPassword): void
     {
         if (!$user instanceof PasswordAuthenticatedUserInterface) {
             trigger_deprecation('symfony/doctrine-bridge', '5.3', 'The "%s::upgradePassword()" method expects an instance of "%s" as first argument, the "%s" class should implement it.', PasswordUpgraderInterface::class, PasswordAuthenticatedUserInterface::class, get_debug_type($user));
+
+            if (!$user instanceof UserInterface) {
+                throw new \TypeError(sprintf('The "%s::upgradePassword()" method expects an instance of "%s" as first argument, "%s" given.', PasswordAuthenticatedUserInterface::class, get_debug_type($user)));
+            }
         }
 
         $class = $this->getClass();
@@ -146,7 +150,7 @@ class EntityUserProvider implements UserProviderInterface, PasswordUpgraderInter
 
         $repository = $this->getRepository();
         if ($repository instanceof PasswordUpgraderInterface) {
-            $repository->upgradePassword($user, $newEncodedPassword);
+            $repository->upgradePassword($user, $newHashedPassword);
         }
     }
 

--- a/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
+++ b/src/Symfony/Component/Ldap/Security/LdapUserProvider.php
@@ -132,7 +132,7 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
      *
      * @final
      */
-    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
+    public function upgradePassword($user, string $newHashedPassword): void
     {
         if (!$user instanceof LdapUser) {
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', get_debug_type($user)));
@@ -143,9 +143,9 @@ class LdapUserProvider implements UserProviderInterface, PasswordUpgraderInterfa
         }
 
         try {
-            $user->getEntry()->setAttribute($this->passwordAttribute, [$newEncodedPassword]);
+            $user->getEntry()->setAttribute($this->passwordAttribute, [$newHashedPassword]);
             $this->ldap->getEntryManager()->update($user->getEntry());
-            $user->setPassword($newEncodedPassword);
+            $user->setPassword($newHashedPassword);
         } catch (ExceptionInterface $e) {
             // ignore failed password upgrades
         }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Provider/DaoAuthenticationProviderTest.php
@@ -384,7 +384,7 @@ class TestUser implements UserInterface
 }
 interface PasswordUpgraderProvider extends UserProviderInterface, PasswordUpgraderInterface
 {
-    public function upgradePassword(UserInterface $user, string $newHashedPassword): void;
+    public function upgradePassword($user, string $newHashedPassword): void;
 
     public function loadUserByIdentifier(string $identifier): UserInterface;
 }

--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -130,16 +130,20 @@ class ChainUserProvider implements UserProviderInterface, PasswordUpgraderInterf
      *
      * {@inheritdoc}
      */
-    public function upgradePassword($user, string $newEncodedPassword): void
+    public function upgradePassword($user, string $newHashedPassword): void
     {
         if (!$user instanceof PasswordAuthenticatedUserInterface) {
             trigger_deprecation('symfony/security-core', '5.3', 'The "%s::upgradePassword()" method expects an instance of "%s" as first argument, the "%s" class should implement it.', PasswordUpgraderInterface::class, PasswordAuthenticatedUserInterface::class, get_debug_type($user));
+
+            if (!$user instanceof UserInterface) {
+                throw new \TypeError(sprintf('The "%s::upgradePassword()" method expects an instance of "%s" as first argument, "%s" given.', PasswordAuthenticatedUserInterface::class, get_debug_type($user)));
+            }
         }
 
         foreach ($this->providers as $provider) {
             if ($provider instanceof PasswordUpgraderInterface) {
                 try {
-                    $provider->upgradePassword($user, $newEncodedPassword);
+                    $provider->upgradePassword($user, $newHashedPassword);
                 } catch (UnsupportedUserException $e) {
                     // ignore: password upgrades are opportunistic
                 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Fixtures/PasswordUpgraderProvider.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Fixtures/PasswordUpgraderProvider.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class PasswordUpgraderProvider extends InMemoryUserProvider implements PasswordUpgraderInterface
 {
-    public function upgradePassword(UserInterface $user, string $newEncodedPassword): void
+    public function upgradePassword($user, string $newHashedPassword): void
     {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Makes implementations compatible with both 5.x and 6.x to make #41982 green.
