### PR TITLE
[WebProfilerBundle] Fix some deprecation

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base.html.twig
@@ -17,14 +17,14 @@
         <script>
             if (null === localStorage.getItem('symfony/profiler/theme') || 'theme-auto' === localStorage.getItem('symfony/profiler/theme')) {
                 document.body.classList.add((matchMedia('(prefers-color-scheme: dark)').matches ? 'theme-dark' : 'theme-light'));
+                // needed to respond dynamically to OS changes without having to refresh the page
+                window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+                    document.body.classList.remove('theme-light', 'theme-dark');
+                    document.body.classList.add(e.matches ? 'theme-dark' : 'theme-light');
+                });
             } else {
                 document.body.classList.add(localStorage.getItem('symfony/profiler/theme'));
             }
-            // needed to respond dynamically to OS changes without having to refresh the page
-            window.matchMedia('(prefers-color-scheme: dark)').addListener(function (e) {
-                document.body.classList.remove(e.matches ? 'theme-light' : 'theme-dark');
-                document.body.classList.add(e.matches ? 'theme-dark' : 'theme-light');
-            });
 
             document.body.classList.add(localStorage.getItem('symfony/profiler/width') || 'width-normal');
         </script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The `addListener()` method is deprecated (see https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener). We should use `addEventListener()` (https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/onchange).