### PR TITLE
[Messenger] Pass envelope to message handler as second __invoke parameter

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: Ubuntu-20.04
 
     env:
-      extensions: amqp,apcu,igbinary,intl,mbstring,memcached,mongodb,redis
+      extensions: amqp,apcu,igbinary,intl,mbstring,memcached,mongodb,redis-5.3.4
 
     strategy:
       matrix:

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -78,7 +78,7 @@ class ConnectionTest extends TestCase
         $redis->expects($this->once())
             ->method('connect')
             ->with('tls://127.0.0.1', 6379)
-            ->willReturn(null);
+            ->willReturn(true);
 
         Connection::fromDsn('redis://127.0.0.1?tls=1', [], $redis);
     }
@@ -92,7 +92,7 @@ class ConnectionTest extends TestCase
         $redis->expects($this->once())
             ->method('connect')
             ->with('tls://127.0.0.1', 6379)
-            ->willReturn(null);
+            ->willReturn(true);
 
         Connection::fromDsn('redis://127.0.0.1', ['tls' => true], $redis);
     }
@@ -103,7 +103,7 @@ class ConnectionTest extends TestCase
         $redis->expects($this->once())
             ->method('connect')
             ->with('tls://127.0.0.1', 6379)
-            ->willReturn(null);
+            ->willReturn(true);
 
         Connection::fromDsn('rediss://127.0.0.1?delete_after_ack=true', [], $redis);
     }
@@ -315,7 +315,7 @@ class ConnectionTest extends TestCase
 
         $redis->expects($this->exactly(1))->method('xadd')
             ->with('queue', '*', ['message' => '{"body":"1","headers":[]}'], 20000, true)
-            ->willReturn(1);
+            ->willReturn('1');
 
         $connection = Connection::fromDsn('redis://localhost/queue?stream_max_entries=20000', ['delete_after_ack' => true], $redis);
         $connection->add('1', []);
@@ -365,7 +365,7 @@ class ConnectionTest extends TestCase
     {
         $redis = $this->createMock(\Redis::class);
 
-        $redis->expects($this->once())->method('xadd')->willReturn(0);
+        $redis->expects($this->once())->method('xadd')->willReturn('0');
         $redis->expects($this->once())->method('xack')->willReturn(0);
 
         $redis->method('getLastError')->willReturnOnConsecutiveCalls('xadd error', 'xack error');

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `StopWorkerExceptionInterface` and its implementation `StopWorkerException` to stop the worker.
  * Add support for resetting container services after each messenger message.
+ * Add message envelope to handler `__invoke()` calls
 
 5.3
 ---

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -60,7 +60,7 @@ class HandleMessageMiddleware implements MiddlewareInterface
 
             try {
                 $handler = $handlerDescriptor->getHandler();
-                $handledStamp = HandledStamp::fromDescriptor($handlerDescriptor, $handler($message));
+                $handledStamp = HandledStamp::fromDescriptor($handlerDescriptor, $handler($message, $envelope));
                 $envelope = $envelope->with($handledStamp);
                 $this->logger->info('Message {class} handled by {handler}', $context + ['handler' => $handledStamp->getHandlerName()]);
             } catch (\Throwable $e) {

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -40,6 +40,22 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
         $middleware->handle($envelope, $this->getStackMock());
     }
 
+    public function testHandlerWithEnvelopeInConstructor()
+    {
+        $message = new DummyMessage('Hey');
+        $envelope = new Envelope($message);
+
+        $handler = $this->createPartialMock(HandleMessageMiddlewareTestCallable::class, ['__invoke']);
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [$handler],
+        ]));
+
+        $handler->expects($this->once())->method('__invoke')->with($message, $envelope);
+
+        $middleware->handle($envelope, $this->getStackMock());
+    }
+
     /**
      * @dataProvider itAddsHandledStampsProvider
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

When calling message handlers `__invoke()` method, pass in the envelope as a second parameter. This ensures we're backwards compatible (doesn't break existing handlers) but any which might want to use the envelope can do so.

My use case for this is a trace ID we want to use for tracking requests across events with AMQP:

- HTTP request contains `X-Trace-Id`, controller receives this and dispatches a message with an `x-trace-id` AMQP header
- worker collects message, hands off to handler
- handler does some work and then dispatches another message but it should preserve the `x-trace-id` header