### PR TITLE
[Cache] Adding missing class name in deprecation notice

### DIFF
--- a/src/Symfony/Component/Cache/DoctrineProvider.php
+++ b/src/Symfony/Component/Cache/DoctrineProvider.php
@@ -26,7 +26,7 @@ class DoctrineProvider extends CacheProvider implements PruneableInterface, Rese
 
     public function __construct(CacheItemPoolInterface $pool)
     {
-        trigger_deprecation('symfony/cache', '5.4', '"%s" is deprecated, use "Doctrine\Common\Cache\Psr6\DoctrineProvider" instead.');
+        trigger_deprecation('symfony/cache', '5.4', '"%s" is deprecated, use "Doctrine\Common\Cache\Psr6\DoctrineProvider" instead.', __CLASS__);
 
         $this->pool = $pool;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | not needed

Hi!

Just a missing placeholder for the `%s` - noticed in the symfony/ux test suite.

Cheers!