### PR TITLE
Improve usage of twig ternary

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
@@ -27,7 +27,7 @@
 {%- endblock button_row -%}
 
 {%- block hidden_row -%}
-    {%- set style = row_attr.style is defined ? (row_attr.style ~ (row_attr.style|trim|last != ';' ? '; ')) : '' -%}
+    {%- set style = row_attr.style is defined ? (row_attr.style ~ (row_attr.style|trim|last != ';' ? '; ')) -%}
     <tr{% with {attr: row_attr|merge({style: (style ~ ' display: none')|trim})} %}{{ block('attributes') }}{% endwith %}>
         <td colspan="2">
             {{- form_widget(form) -}}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -5,9 +5,9 @@
 {% block toolbar %}
     {% if collector.token %}
         {% set is_authenticated = collector.enabled and collector.authenticated  %}
-        {% set color_code = is_authenticated ? '' : 'yellow' %}
+        {% set color_code = not is_authenticated ? 'yellow' %}
     {% else %}
-        {% set color_code = collector.enabled ? 'red' : '' %}
+        {% set color_code = collector.enabled ? 'red' %}
     {% endif %}
 
     {% set icon %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -101,7 +101,7 @@
 {% endblock %}
 
 {% block menu %}
-    <span class="label label-status-{{ collector.symfonyState == 'eol' ? 'red' : collector.symfonyState in ['eom', 'dev'] ? 'yellow' : '' }}">
+    <span class="label label-status-{{ collector.symfonyState == 'eol' ? 'red' : collector.symfonyState in ['eom', 'dev'] ? 'yellow' }}">
         <span class="icon">{{ include('@WebProfiler/Icon/config.svg') }}</span>
         <strong>Configuration</strong>
     </span>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/form.html.twig
@@ -4,7 +4,7 @@
 
 {% block toolbar %}
     {% if collector.data.nb_errors > 0 or collector.data.forms|length %}
-        {% set status_color = collector.data.nb_errors ? 'red' : '' %}
+        {% set status_color = collector.data.nb_errors ? 'red' %}
         {% set icon %}
             {{ include('@WebProfiler/Icon/form.svg') }}
             <span class="sf-toolbar-value">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -201,11 +201,11 @@
 
         <tbody>
             {% for log in logs %}
-                {% set css_class = is_deprecation ? ''
-                    : log.priorityName in ['CRITICAL', 'ERROR', 'ALERT', 'EMERGENCY'] ? 'status-error'
+                {% set css_class = not is_deprecation
+                    ? log.priorityName in ['CRITICAL', 'ERROR', 'ALERT', 'EMERGENCY'] ? 'status-error'
                     : log.priorityName == 'WARNING' ? 'status-warning'
                 %}
-                <tr class="{{ css_class }}"{% if show_level %} data-filter-level="{{ log.priorityName|lower }}"{% endif %}{% if channel_is_defined %} data-filter-channel="{{ log.channel is not null ? log.channel : '' }}"{% endif %}>
+                <tr class="{{ css_class }}"{% if show_level %} data-filter-level="{{ log.priorityName|lower }}"{% endif %}{% if channel_is_defined %} data-filter-channel="{{ log.channel }}"{% endif %}>
                     <td class="font-normal text-small" nowrap>
                         {% if show_level %}
                             <span class="colored text-bold">{{ log.priorityName }}</span>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -67,7 +67,7 @@
 {% block menu %}
     {% set events = collector.events %}
 
-    <span class="label {{ events.messages|length ? '' : 'disabled' }}">
+    <span class="label {{ events.messages|empty ? 'disabled' }}">
         <span class="icon">{{ include('@WebProfiler/Icon/mailer.svg') }}</span>
 
         <strong>E-mails</strong>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/memory.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/memory.html.twig
@@ -2,7 +2,7 @@
 
 {% block toolbar %}
     {% set icon %}
-        {% set status_color = (collector.memory / 1024 / 1024) > 50 ? 'yellow' : '' %}
+        {% set status_color = (collector.memory / 1024 / 1024) > 50 ? 'yellow' %}
         {{ include('@WebProfiler/Icon/memory.svg') }}
         <span class="sf-toolbar-value">{{ '%.1f'|format(collector.memory / 1024 / 1024) }}</span>
         <span class="sf-toolbar-label">MiB</span>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -6,7 +6,7 @@
     {% set has_time_events = collector.events|length > 0 %}
     {% set total_time = has_time_events ? '%.0f'|format(collector.duration) : 'n/a' %}
     {% set initialization_time = collector.events|length ? '%.0f'|format(collector.inittime) : 'n/a' %}
-    {% set status_color = has_time_events and collector.duration > 1000 ? 'yellow' : '' %}
+    {% set status_color = has_time_events and collector.duration > 1000 ? 'yellow' %}
 
     {% set icon %}
         {{ include('@WebProfiler/Icon/time.svg') }}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/validator.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/validator.html.twig
@@ -2,7 +2,7 @@
 
 {% block toolbar %}
     {% if collector.violationsCount > 0 or collector.calls|length %}
-        {% set status_color = collector.violationsCount ? 'red' : '' %}
+        {% set status_color = collector.violationsCount ? 'red' %}
         {% set icon %}
             {{ include('@WebProfiler/Icon/validator.svg') }}
             <span class="sf-toolbar-value">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -123,7 +123,7 @@
                                 {%- endif -%}
                             {%- endset %}
                             {% if menu is not empty %}
-                                <li class="{{ name }} {{ name == panel ? 'selected' : '' }}">
+                                <li class="{{ name }} {{ name == panel ? 'selected' }}">
                                     <a href="{{ path('_profiler', { token: token, panel: name }) }}">{{ menu|raw }}</a>
                                 </li>
                             {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | none

Remove useless `else` condition when using twig ternary:

> `{{ foo ? 'yes' }}` is the same as `{{ foo ? 'yes' : '' }}`

See: https://twig.symfony.com/doc/3.x/templates.html#other-operators
