### PR TITLE
[Form] fix some type annotations

### DIFF
--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -371,8 +371,8 @@ class Button implements \IteratorAggregate, FormInterface
     /**
      * Submits data to the button.
      *
-     * @param string|null $submittedData Not used
-     * @param bool        $clearMissing  Not used
+     * @param array|string|null $submittedData Not used
+     * @param bool              $clearMissing  Not used
      *
      * @return $this
      *

--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -101,10 +101,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * This method should not be invoked.
-     *
-     * @param string $name
-     *
      * @throws BadMethodCallException
      */
     public function get($name)
@@ -115,10 +111,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * This method should not be invoked.
-     *
-     * @param string $name
-     *
      * @throws BadMethodCallException
      */
     public function remove($name)
@@ -128,8 +120,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
 
     /**
      * Unsupported method.
-     *
-     * @param string $name
      *
      * @return bool Always returns false
      */
@@ -161,12 +151,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * This method should not be invoked.
-     *
-     * @param string   $eventName
-     * @param callable $listener
-     * @param int      $priority
-     *
      * @throws BadMethodCallException
      */
     public function addEventListener($eventName, $listener, $priority = 0)
@@ -176,8 +160,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
 
     /**
      * Unsupported method.
-     *
-     * This method should not be invoked.
      *
      * @throws BadMethodCallException
      */
@@ -189,10 +171,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * This method should not be invoked.
-     *
-     * @param bool $forcePrepend
-     *
      * @throws BadMethodCallException
      */
     public function addViewTransformer(DataTransformerInterface $viewTransformer, $forcePrepend = false)
@@ -202,8 +180,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
 
     /**
      * Unsupported method.
-     *
-     * This method should not be invoked.
      *
      * @throws BadMethodCallException
      */
@@ -215,10 +191,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * This method should not be invoked.
-     *
-     * @param bool $forceAppend
-     *
      * @throws BadMethodCallException
      */
     public function addModelTransformer(DataTransformerInterface $modelTransformer, $forceAppend = false)
@@ -228,8 +200,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
 
     /**
      * Unsupported method.
-     *
-     * This method should not be invoked.
      *
      * @throws BadMethodCallException
      */
@@ -261,8 +231,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * This method should not be invoked.
-     *
      * @throws BadMethodCallException
      */
     public function setDataMapper(DataMapperInterface $dataMapper = null)
@@ -287,10 +255,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * This method should not be invoked.
-     *
-     * @param mixed $emptyData
-     *
      * @throws BadMethodCallException
      */
     public function setEmptyData($emptyData)
@@ -300,10 +264,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
 
     /**
      * Unsupported method.
-     *
-     * This method should not be invoked.
-     *
-     * @param bool $errorBubbling
      *
      * @throws BadMethodCallException
      */
@@ -315,10 +275,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * This method should not be invoked.
-     *
-     * @param bool $required
-     *
      * @throws BadMethodCallException
      */
     public function setRequired($required)
@@ -328,10 +284,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
 
     /**
      * Unsupported method.
-     *
-     * This method should not be invoked.
-     *
-     * @param null $propertyPath
      *
      * @throws BadMethodCallException
      */
@@ -343,10 +295,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * This method should not be invoked.
-     *
-     * @param bool $mapped
-     *
      * @throws BadMethodCallException
      */
     public function setMapped($mapped)
@@ -357,10 +305,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * This method should not be invoked.
-     *
-     * @param bool $byReference
-     *
      * @throws BadMethodCallException
      */
     public function setByReference($byReference)
@@ -370,10 +314,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
 
     /**
      * Unsupported method.
-     *
-     * This method should not be invoked.
-     *
-     * @param bool $compound
      *
      * @throws BadMethodCallException
      */
@@ -397,10 +337,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * This method should not be invoked.
-     *
-     * @param mixed $data
-     *
      * @throws BadMethodCallException
      */
     public function setData($data)
@@ -410,10 +346,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
 
     /**
      * Unsupported method.
-     *
-     * This method should not be invoked.
-     *
-     * @param bool $locked
      *
      * @throws BadMethodCallException
      */
@@ -425,8 +357,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * This method should not be invoked.
-     *
      * @throws BadMethodCallException
      */
     public function setFormFactory(FormFactoryInterface $formFactory)
@@ -437,8 +367,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * @param string $action
-     *
      * @throws BadMethodCallException
      */
     public function setAction($action)
@@ -448,8 +376,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
 
     /**
      * Unsupported method.
-     *
-     * @param string $method
      *
      * @throws BadMethodCallException
      */
@@ -471,8 +397,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     /**
      * Unsupported method.
      *
-     * @param bool $initialize
-     *
      * @return $this
      *
      * @throws BadMethodCallException
@@ -488,8 +412,6 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
 
     /**
      * Unsupported method.
-     *
-     * @param bool $inheritData
      *
      * @throws BadMethodCallException
      */

--- a/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
+++ b/src/Symfony/Component/Form/ChoiceList/Factory/PropertyAccessDecorator.php
@@ -18,6 +18,7 @@ use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\PropertyAccess\PropertyPathInterface;
 
 /**
  * Adds property path support to a choice list factory.
@@ -59,11 +60,9 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
     /**
      * {@inheritdoc}
      *
-     * @param iterable                          $choices The choices
-     * @param callable|string|PropertyPath|null $value   The callable or path for
-     *                                                   generating the choice values
+     * @param mixed $value
      *
-     * @return ChoiceListInterface The choice list
+     * @return ChoiceListInterface
      */
     public function createListFromChoices($choices, $value = null)
     {
@@ -71,7 +70,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             $value = new PropertyPath($value);
         }
 
-        if ($value instanceof PropertyPath) {
+        if ($value instanceof PropertyPathInterface) {
             $accessor = $this->propertyAccessor;
             $value = function ($choice) use ($accessor, $value) {
                 // The callable may be invoked with a non-object/array value
@@ -88,10 +87,9 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
     /**
      * {@inheritdoc}
      *
-     * @param callable|string|PropertyPath|null $value The callable or path for
-     *                                                 generating the choice values
+     * @param mixed $value
      *
-     * @return ChoiceListInterface The choice list
+     * @return ChoiceListInterface
      */
     public function createListFromLoader(ChoiceLoaderInterface $loader, $value = null)
     {
@@ -99,7 +97,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             $value = new PropertyPath($value);
         }
 
-        if ($value instanceof PropertyPath) {
+        if ($value instanceof PropertyPathInterface) {
             $accessor = $this->propertyAccessor;
             $value = function ($choice) use ($accessor, $value) {
                 // The callable may be invoked with a non-object/array value
@@ -116,13 +114,13 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
     /**
      * {@inheritdoc}
      *
-     * @param array|callable|string|PropertyPath|null $preferredChoices The preferred choices
-     * @param callable|string|PropertyPath|null       $label            The callable or path generating the choice labels
-     * @param callable|string|PropertyPath|null       $index            The callable or path generating the view indices
-     * @param callable|string|PropertyPath|null       $groupBy          The callable or path generating the group names
-     * @param array|callable|string|PropertyPath|null $attr             The callable or path generating the HTML attributes
+     * @param mixed $preferredChoices
+     * @param mixed $label
+     * @param mixed $index
+     * @param mixed $groupBy
+     * @param mixed $attr
      *
-     * @return ChoiceListView The choice list view
+     * @return ChoiceListView
      */
     public function createView(ChoiceListInterface $list, $preferredChoices = null, $label = null, $index = null, $groupBy = null, $attr = null)
     {
@@ -132,7 +130,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             $label = new PropertyPath($label);
         }
 
-        if ($label instanceof PropertyPath) {
+        if ($label instanceof PropertyPathInterface) {
             $label = function ($choice) use ($accessor, $label) {
                 return $accessor->getValue($choice, $label);
             };
@@ -142,7 +140,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             $preferredChoices = new PropertyPath($preferredChoices);
         }
 
-        if ($preferredChoices instanceof PropertyPath) {
+        if ($preferredChoices instanceof PropertyPathInterface) {
             $preferredChoices = function ($choice) use ($accessor, $preferredChoices) {
                 try {
                     return $accessor->getValue($choice, $preferredChoices);
@@ -157,7 +155,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             $index = new PropertyPath($index);
         }
 
-        if ($index instanceof PropertyPath) {
+        if ($index instanceof PropertyPathInterface) {
             $index = function ($choice) use ($accessor, $index) {
                 return $accessor->getValue($choice, $index);
             };
@@ -167,7 +165,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             $groupBy = new PropertyPath($groupBy);
         }
 
-        if ($groupBy instanceof PropertyPath) {
+        if ($groupBy instanceof PropertyPathInterface) {
             $groupBy = function ($choice) use ($accessor, $groupBy) {
                 try {
                     return $accessor->getValue($choice, $groupBy);
@@ -182,7 +180,7 @@ class PropertyAccessDecorator implements ChoiceListFactoryInterface
             $attr = new PropertyPath($attr);
         }
 
-        if ($attr instanceof PropertyPath) {
+        if ($attr instanceof PropertyPathInterface) {
             $attr = function ($choice) use ($accessor, $attr) {
                 return $accessor->getValue($choice, $attr);
             };

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -260,8 +260,16 @@ class FormValidator extends ConstraintValidator
 
     private static function getConstraintsInGroups($constraints, $group)
     {
-        return array_filter($constraints, static function (Constraint $constraint) use ($group) {
-            return \in_array($group, $constraint->groups, true);
+        $groups = (array) $group;
+
+        return array_filter($constraints, static function (Constraint $constraint) use ($groups) {
+            foreach ($groups as $group) {
+                if (\in_array($group, $constraint->groups, true)) {
+                    return true;
+                }
+            }
+
+            return false;
         });
     }
 }

--- a/src/Symfony/Component/Form/SubmitButton.php
+++ b/src/Symfony/Component/Form/SubmitButton.php
@@ -34,8 +34,8 @@ class SubmitButton extends Button implements ClickableInterface
     /**
      * Submits data to the button.
      *
-     * @param string|null $submittedData The data
-     * @param bool        $clearMissing  Not used
+     * @param array|string|null $submittedData The data
+     * @param bool              $clearMissing  Not used
      *
      * @return $this
      *

--- a/src/Symfony/Component/Form/Util/OptionsResolverWrapper.php
+++ b/src/Symfony/Component/Form/Util/OptionsResolverWrapper.php
@@ -67,6 +67,8 @@ class OptionsResolverWrapper extends OptionsResolver
     }
 
     /**
+     * @param string|array $allowedTypes
+     *
      * @return $this
      */
     public function setAllowedTypes($option, $allowedTypes): self
@@ -81,6 +83,8 @@ class OptionsResolverWrapper extends OptionsResolver
     }
 
     /**
+     * @param string|array $allowedTypes
+     *
      * @return $this
      */
     public function addAllowedTypes($option, $allowedTypes): self

--- a/src/Symfony/Component/Validator/Constraints/GroupSequence.php
+++ b/src/Symfony/Component/Validator/Constraints/GroupSequence.php
@@ -56,7 +56,7 @@ class GroupSequence
     /**
      * The groups in the sequence.
      *
-     * @var string[]|string[][]|GroupSequence[]
+     * @var array<string|string[]|GroupSequence>
      */
     public $groups;
 
@@ -79,7 +79,7 @@ class GroupSequence
     /**
      * Creates a new group sequence.
      *
-     * @param string[] $groups The groups in the sequence
+     * @param array<string|string[]|GroupSequence> $groups The groups in the sequence
      */
     public function __construct(array $groups)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Backported from #41998

The change in `FormValidator` is likely a bug fix, but it could be an incomplete one.
`testFieldsValidateInSequenceWithNestedGroupsArray` triggers a call to `getConstraintsInGroups` with an array.

I'd appreciate if @HeahDude, @xabbuh, or anyone with a better knowledge of Form could have a look please.