### PR TITLE
[DependencyInjection] Fix TaggedLocator attribute without indexAttribute argument

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -218,7 +218,7 @@ class AutowirePass extends AbstractRecursivePass
 
                     if (TaggedLocator::class === $attribute->getName()) {
                         $attribute = $attribute->newInstance();
-                        $arguments[$index] = new ServiceLocatorArgument(new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute));
+                        $arguments[$index] = new ServiceLocatorArgument(new TaggedIteratorArgument($attribute->tag, $attribute->indexAttribute, null, true));
                         break;
                     }
                 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\IteratorConsumer;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\LocatorConsumer;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\LocatorConsumerConsumer;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\LocatorConsumerFactory;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\LocatorConsumerWithoutIndex;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedService1;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedService2;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TaggedService3;
@@ -401,6 +402,35 @@ class IntegrationTest extends TestCase
         $locator = $s->getLocator();
         self::assertSame($container->get(BarTagClass::class), $locator->get('bar_tab_class_with_defaultmethod'));
         self::assertSame($container->get(FooTagClass::class), $locator->get('foo'));
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testTaggedLocatorConfiguredViaAttributeWithoutIndex()
+    {
+        $container = new ContainerBuilder();
+        $container->register(BarTagClass::class)
+            ->setPublic(true)
+            ->addTag('foo_bar')
+        ;
+        $container->register(FooTagClass::class)
+            ->setPublic(true)
+            ->addTag('foo_bar')
+        ;
+        $container->register(LocatorConsumerWithoutIndex::class)
+            ->setAutowired(true)
+            ->setPublic(true)
+        ;
+
+        $container->compile();
+
+        /** @var LocatorConsumerWithoutIndex $s */
+        $s = $container->get(LocatorConsumerWithoutIndex::class);
+
+        $locator = $s->getLocator();
+        self::assertSame($container->get(BarTagClass::class), $locator->get(BarTagClass::class));
+        self::assertSame($container->get(FooTagClass::class), $locator->get(FooTagClass::class));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/LocatorConsumerWithoutIndex.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/LocatorConsumerWithoutIndex.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\TaggedLocator;
+
+final class LocatorConsumerWithoutIndex
+{
+    public function __construct(
+        #[TaggedLocator('foo_bar')]
+        private ContainerInterface $locator,
+    ) {
+    }
+
+    public function getLocator(): ContainerInterface
+    {
+        return $this->locator;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The new TaggedLocator attribute does not index services correctly without the `indexAttribute` argument

## Example
```php
public function __construct(
    #[TaggedLocator('app.tag')]
    ServiceLocator $serviceLocator
) {
    // ...
}
```

### Expected
```php
$serviceLocator->getProvidedServices();
// [
//    "App\Service1" => "..."
//    "App\Service2" => "..."
// ]

$serviceLocator->has(App\Service1::class);
// true

$serviceLocator->get(App\Service1::class);
// Instance of App\Service1
```

### Actual
```php
$services = $serviceLocator->getProvidedServices();
// [
//    0 => [...]
//    1 => [...]
// ]

$serviceLocator->has(App\Service1::class);
// false

$serviceLocator->get(App\Service1::class);
// Exception
```

Same issue with ContainerInterface instead of ServiceLocator

## Proposed solution
This fix allows services to be indexed by their fully qualified name instead of a numeric index if `indexAttribute` argument is not provided.

The solution is oriented towards the implemenation in the YamlFileLoader (Symfony\Component\DependencyInjection\Loader\YamlFileLoader). The YamlFileLoader fulfills the expected behaviour above:

```php
// Symfony\Component\DependencyInjection\Loader\YamlFileLoader

// Line 850
$forLocator = 'tagged_locator' === $value->getTag();

// ...

// Line 857
$argument = new TaggedIteratorArgument($argument['tag'], $argument['index_by'] ?? null, $argument['default_index_method'] ?? null, $forLocator, $argument['default_priority_method'] ?? null);
```
