### PR TITLE
[Security] Deprecate `TokenInterface::isAuthenticated()`

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -30,3 +30,6 @@ Security
    behavior when using `enable_authenticator_manager: true`)
  * Deprecate not setting the 5th argument (`$exceptionOnNoToken`) of `AccessListener` to `false`
    (this is the default behavior when using `enable_authenticator_manager: true`)
+ * Deprecate `TokenInterface:isAuthenticated()` and `setAuthenticated()` methods without replacement.
+   Security tokens won't have an "authenticated" flag anymore, so they will always be considered authenticated
+ * Deprecate `DeauthenticatedEvent`, use `TokenDeauthenticatedEvent` instead

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -316,6 +316,9 @@ Security
    `UsernamePasswordFormAuthenticationListener`, `UsernamePasswordJsonAuthenticationListener` and `X509AuthenticationListener`
    from security-http, use the new authenticator system instead
  * Remove the Guard component, use the new authenticator system instead
+ * Remove `TokenInterface:isAuthenticated()` and `setAuthenticated()` methods without replacement.
+   Security tokens won't have an "authenticated" flag anymore, so they will always be considered authenticated
+ * Remove `DeauthenticatedEvent`, use `TokenDeauthenticatedEvent` instead
 
 SecurityBundle
 --------------

--- a/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
@@ -42,7 +42,7 @@ abstract class AbstractTokenProcessor
 
         if (null !== $token = $this->getToken()) {
             $record['extra'][$this->getKey()] = [
-                'authenticated' => $token->isAuthenticated(),
+                'authenticated' => $token->isAuthenticated(false), // @deprecated since Symfony 5.4, always true in 6.0
                 'roles' => $token->getRoleNames(),
             ];
 

--- a/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/TokenProcessorTest.php
@@ -39,7 +39,6 @@ class TokenProcessorTest extends TestCase
 
         $this->assertArrayHasKey('token', $record['extra']);
         $this->assertEquals($token->getUsername(), $record['extra']['token']['username']);
-        $this->assertEquals($token->isAuthenticated(), $record['extra']['token']['authenticated']);
         $this->assertEquals(['ROLE_USER'], $record['extra']['token']['roles']);
     }
 
@@ -59,7 +58,6 @@ class TokenProcessorTest extends TestCase
 
         $this->assertArrayHasKey('token', $record['extra']);
         $this->assertEquals($token->getUserIdentifier(), $record['extra']['token']['user_identifier']);
-        $this->assertEquals($token->isAuthenticated(), $record['extra']['token']['authenticated']);
         $this->assertEquals(['ROLE_USER'], $record['extra']['token']['roles']);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -123,7 +123,7 @@ class KernelBrowser extends HttpKernelBrowser
         }
 
         $token = new TestBrowserToken($user->getRoles(), $user, $firewallContext);
-        $token->setAuthenticated(true);
+        $token->setAuthenticated(true, false);
 
         $container = $this->getContainer();
         $container->get('security.untracked_token_storage')->setToken($token);

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -123,7 +123,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
 
             $this->data = [
                 'enabled' => true,
-                'authenticated' => $token->isAuthenticated(),
+                'authenticated' => $token->isAuthenticated(false),
                 'impersonated' => null !== $impersonatorUser,
                 'impersonator_user' => $impersonatorUser,
                 'impersonation_exit_path' => null,

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -99,7 +99,12 @@ abstract class AbstractToken implements TokenInterface
             throw new \InvalidArgumentException('$user must be an instanceof UserInterface, an object implementing a __toString method, or a primitive string.');
         }
 
-        if (null === $this->user) {
+        // @deprecated since Symfony 5.4, remove the whole block if/elseif/else block in 6.0
+        if (1 < \func_num_args() && !func_get_arg(1)) {
+            // ContextListener checks if the user has changed on its own and calls `setAuthenticated()` subsequently,
+            // avoid doing the same checks twice
+            $changed = false;
+        } elseif (null === $this->user) {
             $changed = false;
         } elseif ($this->user instanceof UserInterface) {
             if (!$user instanceof UserInterface) {
@@ -113,8 +118,9 @@ abstract class AbstractToken implements TokenInterface
             $changed = (string) $this->user !== (string) $user;
         }
 
+        // @deprecated since Symfony 5.4
         if ($changed) {
-            $this->setAuthenticated(false);
+            $this->setAuthenticated(false, false);
         }
 
         $this->user = $user;
@@ -122,9 +128,15 @@ abstract class AbstractToken implements TokenInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @deprecated since Symfony 5.4
      */
     public function isAuthenticated()
     {
+        if (1 > \func_num_args() || func_get_arg(0)) {
+            trigger_deprecation('symfony/security-core', '5.4', 'Method "%s()" is deprecated. In version 6.0, security tokens won\'t have an "authenticated" flag anymore and will always be considered authenticated.', __METHOD__);
+        }
+
         return $this->authenticated;
     }
 
@@ -133,6 +145,10 @@ abstract class AbstractToken implements TokenInterface
      */
     public function setAuthenticated(bool $authenticated)
     {
+        if (2 > \func_num_args() || func_get_arg(1)) {
+            trigger_deprecation('symfony/security-core', '5.4', 'Method "%s()" is deprecated. In version 6.0, security tokens won\'t have an "authenticated" state anymore and will always be considered as authenticated.', __METHOD__);
+        }
+
         $this->authenticated = $authenticated;
     }
 
@@ -275,6 +291,9 @@ abstract class AbstractToken implements TokenInterface
         $this->__unserialize(\is_array($serialized) ? $serialized : unserialize($serialized));
     }
 
+    /**
+     * @deprecated since Symfony 5.4
+     */
     private function hasUserChanged(UserInterface $user): bool
     {
         if (!($this->user instanceof UserInterface)) {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
@@ -33,7 +33,8 @@ class AnonymousToken extends AbstractToken
 
         $this->secret = $secret;
         $this->setUser($user);
-        $this->setAuthenticated(true);
+        // @deprecated since Symfony 5.4
+        $this->setAuthenticated(true, false);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
@@ -53,11 +53,21 @@ class NullToken implements TokenInterface
         return '';
     }
 
+    /**
+     * @deprecated since Symfony 5.4
+     */
     public function isAuthenticated()
     {
+        if (0 === \func_num_args() || func_get_arg(0)) {
+            trigger_deprecation('symfony/security-core', '5.4', 'Method "%s()" is deprecated. In version 6.0, security tokens won\'t have an "authenticated" flag anymore and will always be considered authenticated.', __METHOD__);
+        }
+
         return true;
     }
 
+    /**
+     * @deprecated since Symfony 5.4
+     */
     public function setAuthenticated(bool $isAuthenticated)
     {
         throw new \BadMethodCallException('Cannot change authentication state of NullToken.');

--- a/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/PreAuthenticatedToken.php
@@ -41,7 +41,7 @@ class PreAuthenticatedToken extends AbstractToken
         $this->firewallName = $firewallName;
 
         if ($roles) {
-            $this->setAuthenticated(true);
+            $this->setAuthenticated(true, false);
         }
     }
 

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -44,7 +44,7 @@ class RememberMeToken extends AbstractToken
         $this->secret = $secret;
 
         $this->setUser($user);
-        parent::setAuthenticated(true);
+        parent::setAuthenticated(true, false);
     }
 
     /**
@@ -56,7 +56,7 @@ class RememberMeToken extends AbstractToken
             throw new \LogicException('You cannot set this token to authenticated after creation.');
         }
 
-        parent::setAuthenticated(false);
+        parent::setAuthenticated(false, false);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -71,11 +71,15 @@ interface TokenInterface extends \Serializable
      * Returns whether the user is authenticated or not.
      *
      * @return bool true if the token has been authenticated, false otherwise
+     *
+     * @deprecated since Symfony 5.4. In 6.0, security tokens will always be considered authenticated
      */
     public function isAuthenticated();
 
     /**
      * Sets the authenticated flag.
+     *
+     * @deprecated since Symfony 5.4. In 6.0, security tokens will always be considered authenticated
      */
     public function setAuthenticated(bool $isAuthenticated);
 

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -42,7 +42,7 @@ class UsernamePasswordToken extends AbstractToken
         $this->credentials = $credentials;
         $this->firewallName = $firewallName;
 
-        parent::setAuthenticated(\count($roles) > 0);
+        parent::setAuthenticated(\count($roles) > 0, false);
     }
 
     /**
@@ -54,7 +54,7 @@ class UsernamePasswordToken extends AbstractToken
             throw new \LogicException('Cannot set this token to trusted after instantiation.');
         }
 
-        parent::setAuthenticated(false);
+        parent::setAuthenticated(false, false);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
@@ -62,7 +62,12 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
 
             $token = new NullToken();
         } else {
-            if ($this->alwaysAuthenticate || !$token->isAuthenticated()) {
+            $authenticated = true;
+            // @deprecated since Symfony 5.4
+            if ($this->alwaysAuthenticate || !$authenticated = $token->isAuthenticated(false)) {
+                if (!($authenticated ?? true)) {
+                    trigger_deprecation('symfony/core', '5.4', 'Returning false from "%s()" is deprecated and won\'t have any effect in Symfony 6.0 as security tokens will always be considered authenticated.');
+                }
                 $this->tokenStorage->setToken($token = $this->authenticationManager->authenticate($token));
             }
         }

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Deprecate setting the 4th argument (`$alwaysAuthenticate`) to `true` and not setting the
    5th argument (`$exceptionOnNoToken`) to `false` of `AuthorizationChecker`
+ * Deprecate methods `TokenInterface::isAuthenticated()` and `setAuthenticated`,
+   tokens will always be considered authenticated in 6.0
 
 5.3
 ---

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AbstractTokenTest.php
@@ -41,6 +41,7 @@ class AbstractTokenTest extends TestCase
 
             public function getRoles()
             {
+                return [];
             }
 
             public function getPassword()
@@ -104,6 +105,9 @@ class AbstractTokenTest extends TestCase
         $this->assertEquals(['ROLE_FOO'], $token->getRoleNames());
     }
 
+    /**
+     * @group legacy
+     */
     public function testAuthenticatedFlag()
     {
         $token = new ConcreteToken();
@@ -158,6 +162,7 @@ class AbstractTokenTest extends TestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getUserChanges
      */
     public function testSetUserSetsAuthenticatedToFalseWhenUserChanges($firstUser, $secondUser)
@@ -190,6 +195,7 @@ class AbstractTokenTest extends TestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getUsers
      */
     public function testSetUserDoesNotSetAuthenticatedToFalseWhenUserDoesNotChange($user)
@@ -205,6 +211,9 @@ class AbstractTokenTest extends TestCase
         $this->assertTrue($token->isAuthenticated());
     }
 
+    /**
+     * @group legacy
+     */
     public function testIsUserChangedWhenSerializing()
     {
         $token = new ConcreteToken(['ROLE_ADMIN']);

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AnonymousTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/AnonymousTokenTest.php
@@ -18,11 +18,17 @@ class AnonymousTokenTest extends TestCase
 {
     public function testConstructor()
     {
-        $token = new AnonymousToken('foo', 'bar');
-        $this->assertTrue($token->isAuthenticated());
-
         $token = new AnonymousToken('foo', 'bar', ['ROLE_FOO']);
         $this->assertEquals(['ROLE_FOO'], $token->getRoleNames());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testIsAuthenticated()
+    {
+        $token = new AnonymousToken('foo', 'bar');
+        $this->assertTrue($token->isAuthenticated());
     }
 
     public function testGetKey()

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/PreAuthenticatedTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/PreAuthenticatedTokenTest.php
@@ -18,11 +18,7 @@ class PreAuthenticatedTokenTest extends TestCase
 {
     public function testConstructor()
     {
-        $token = new PreAuthenticatedToken('foo', 'bar', 'key');
-        $this->assertFalse($token->isAuthenticated());
-
         $token = new PreAuthenticatedToken('foo', 'bar', 'key', ['ROLE_FOO']);
-        $this->assertTrue($token->isAuthenticated());
         $this->assertEquals(['ROLE_FOO'], $token->getRoleNames());
         $this->assertEquals('key', $token->getFirewallName());
     }
@@ -44,5 +40,14 @@ class PreAuthenticatedTokenTest extends TestCase
         $token = new PreAuthenticatedToken('foo', 'bar', 'key');
         $token->eraseCredentials();
         $this->assertEquals('', $token->getCredentials());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testIsAuthenticated()
+    {
+        $token = new PreAuthenticatedToken('foo', 'bar', 'key');
+        $this->assertFalse($token->isAuthenticated());
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/RememberMeTokenTest.php
@@ -26,6 +26,15 @@ class RememberMeTokenTest extends TestCase
         $this->assertEquals('foo', $token->getSecret());
         $this->assertEquals(['ROLE_FOO'], $token->getRoleNames());
         $this->assertSame($user, $token->getUser());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testIsAuthenticated()
+    {
+        $user = $this->getUser();
+        $token = new RememberMeToken($user, 'fookey', 'foo');
         $this->assertTrue($token->isAuthenticated());
     }
 

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/SwitchUserTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/SwitchUserTokenTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Tests\Authentication\Token\Fixtures\CustomUser;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class SwitchUserTokenTest extends TestCase
@@ -42,6 +43,9 @@ class SwitchUserTokenTest extends TestCase
         $this->assertEquals(['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH'], $unserializedOriginalToken->getRoleNames());
     }
 
+    /**
+     * @group legacy
+     */
     public function testSetUserDoesNotDeauthenticate()
     {
         $impersonated = new class() implements UserInterface {
@@ -75,7 +79,7 @@ class SwitchUserTokenTest extends TestCase
             }
         };
 
-        $originalToken = new UsernamePasswordToken('impersonator', 'foo', 'provider-key', ['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH']);
+        $originalToken = new UsernamePasswordToken(new InMemoryUser('impersonator', '', ['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH']), 'foo', 'provider-key', ['ROLE_ADMIN', 'ROLE_ALLOWED_TO_SWITCH']);
         $token = new SwitchUserToken($impersonated, 'bar', 'provider-key', ['ROLE_USER', 'ROLE_PREVIOUS_ADMIN'], $originalToken);
         $token->setUser($impersonated);
         $this->assertTrue($token->isAuthenticated());

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/UsernamePasswordTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/UsernamePasswordTokenTest.php
@@ -18,15 +18,26 @@ class UsernamePasswordTokenTest extends TestCase
 {
     public function testConstructor()
     {
+        $token = new UsernamePasswordToken('foo', 'bar', 'key', ['ROLE_FOO']);
+        $this->assertEquals(['ROLE_FOO'], $token->getRoleNames());
+        $this->assertEquals('key', $token->getFirewallName());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testIsAuthenticated()
+    {
         $token = new UsernamePasswordToken('foo', 'bar', 'key');
         $this->assertFalse($token->isAuthenticated());
 
         $token = new UsernamePasswordToken('foo', 'bar', 'key', ['ROLE_FOO']);
-        $this->assertEquals(['ROLE_FOO'], $token->getRoleNames());
         $this->assertTrue($token->isAuthenticated());
-        $this->assertEquals('key', $token->getFirewallName());
     }
 
+    /**
+     * @group legacy
+     */
     public function testSetAuthenticatedToTrue()
     {
         $this->expectException(\LogicException::class);
@@ -34,6 +45,9 @@ class UsernamePasswordTokenTest extends TestCase
         $token->setAuthenticated(true);
     }
 
+    /**
+     * @group legacy
+     */
     public function testSetAuthenticatedToFalse()
     {
         $token = new UsernamePasswordToken('foo', 'bar', 'key');

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -42,6 +42,9 @@ class AuthorizationCheckerTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
     public function testVoteAuthenticatesTokenIfNecessary()
     {
         $token = new UsernamePasswordToken('username', 'password', 'provider');

--- a/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Guard/Provider/GuardAuthenticationProvider.php
@@ -93,7 +93,7 @@ class GuardAuthenticationProvider implements AuthenticationProviderInterface
 
             // this should never happen - but technically, the token is
             // authenticated... so it could just be returned
-            if ($token->isAuthenticated()) {
+            if ($token->isAuthenticated(false)) {
                 return $token;
             }
 

--- a/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
+++ b/src/Symfony/Component/Security/Guard/Token/PostAuthenticationGuardToken.php
@@ -49,7 +49,7 @@ class PostAuthenticationGuardToken extends AbstractToken implements GuardTokenIn
 
         // this token is meant to be used after authentication success, so it is always authenticated
         // you could set it as non authenticated later if you need to
-        $this->setAuthenticated(true);
+        $this->setAuthenticated(true, false);
     }
 
     /**

--- a/src/Symfony/Component/Security/Guard/Token/PreAuthenticationGuardToken.php
+++ b/src/Symfony/Component/Security/Guard/Token/PreAuthenticationGuardToken.php
@@ -42,7 +42,7 @@ class PreAuthenticationGuardToken extends AbstractToken implements GuardTokenInt
 
         parent::__construct([]);
 
-        // never authenticated
+        // @deprecated since Symfony 5.4
         parent::setAuthenticated(false);
     }
 
@@ -62,6 +62,9 @@ class PreAuthenticationGuardToken extends AbstractToken implements GuardTokenInt
         return $this->credentials;
     }
 
+    /**
+     * @deprecated since Symfony 5.4
+     */
     public function setAuthenticated(bool $authenticated)
     {
         throw new \LogicException('The PreAuthenticationGuardToken is *never* authenticated.');

--- a/src/Symfony/Component/Security/Http/Authenticator/Token/PostAuthenticationToken.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Token/PostAuthenticationToken.php
@@ -34,9 +34,9 @@ class PostAuthenticationToken extends AbstractToken
         $this->setUser($user);
         $this->firewallName = $firewallName;
 
+        // @deprecated since Symfony 5.4
         // this token is meant to be used after authentication success, so it is always authenticated
-        // you could set it as non authenticated later if you need to
-        $this->setAuthenticated(true);
+        $this->setAuthenticated(true, false);
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Deprecate not setting the 5th argument (`$exceptionOnNoToken`) of `AccessListener` to `false`
+ * Deprecate `DeauthenticatedEvent`, use `TokenDeauthenticatedEvent` instead
 
 5.3
 ---

--- a/src/Symfony/Component/Security/Http/Event/DeauthenticatedEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/DeauthenticatedEvent.php
@@ -22,25 +22,35 @@ use Symfony\Contracts\EventDispatcher\Event;
  * a session is deauthenticated.
  *
  * @author Hamza Amrouche <hamza.simperfit@gmail.com>
+ *
+ * @deprecated since Symfony 5.4, use TokenDeauthenticatedEvent instead
  */
 final class DeauthenticatedEvent extends Event
 {
     private $originalToken;
     private $refreshedToken;
 
-    public function __construct(TokenInterface $originalToken, TokenInterface $refreshedToken)
+    public function __construct(TokenInterface $originalToken, TokenInterface $refreshedToken, bool $triggerDeprecation = true)
     {
+        if ($triggerDeprecation) {
+            @trigger_deprecation('symfony/security-http', '5.4', 'Class "%s" is deprecated, use "%s" instead.', __CLASS__, TokenDeauthenticatedEvent::class);
+        }
+
         $this->originalToken = $originalToken;
         $this->refreshedToken = $refreshedToken;
     }
 
     public function getRefreshedToken(): TokenInterface
     {
+        @trigger_deprecation('symfony/security-http', '5.4', 'Class "%s" is deprecated, use "%s" instead.', __CLASS__, TokenDeauthenticatedEvent::class);
+
         return $this->refreshedToken;
     }
 
     public function getOriginalToken(): TokenInterface
     {
+        @trigger_deprecation('symfony/security-http', '5.4', 'Class "%s" is deprecated, use "%s" instead.', __CLASS__, TokenDeauthenticatedEvent::class);
+
         return $this->originalToken;
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -95,7 +95,9 @@ class AccessListener extends AbstractListener
             $token = new NullToken();
         }
 
-        if (!$token->isAuthenticated()) {
+        // @deprecated since Symfony 5.4
+        if (!$token->isAuthenticated(false)) {
+            trigger_deprecation('symfony/core', '5.4', 'Returning false from "%s()" is deprecated and won\'t have any effect in Symfony 6.0 as security tokens will always be considered authenticated.');
             $token = $this->authManager->authenticate($token);
             $this->tokenStorage->setToken($token);
         }

--- a/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
@@ -78,7 +78,7 @@ class BasicAuthenticationListener extends AbstractListener
 
         if (null !== $token = $this->tokenStorage->getToken()) {
             // @deprecated since 5.3, change to $token->getUserIdentifier() in 6.0
-            if ($token instanceof UsernamePasswordToken && $token->isAuthenticated() && (method_exists($token, 'getUserIdentifier') ? $token->getUserIdentifier() : $token->getUsername()) === $username) {
+            if ($token instanceof UsernamePasswordToken && $token->isAuthenticated(false) && (method_exists($token, 'getUserIdentifier') ? $token->getUserIdentifier() : $token->getUsername()) === $username) {
                 return;
             }
         }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -45,12 +46,16 @@ class AccessListenerTest extends TestCase
             ->willReturn([['foo' => 'bar'], null])
         ;
 
-        $token = $this->createMock(TokenInterface::class);
-        $token
-            ->expects($this->any())
-            ->method('isAuthenticated')
-            ->willReturn(true)
-        ;
+        $token = new class extends AbstractToken {
+            public function isAuthenticated(): bool
+            {
+                return true;
+            }
+
+            public function getCredentials()
+            {
+            }
+        };
 
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
         $tokenStorage
@@ -79,6 +84,9 @@ class AccessListenerTest extends TestCase
         $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
 
+    /**
+     * @group legacy
+     */
     public function testHandleWhenTheTokenIsNotAuthenticated()
     {
         $request = new Request();

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -305,6 +305,9 @@ class ContextListenerTest extends TestCase
         $this->assertSame($refreshedUser, $tokenStorage->getToken()->getUser());
     }
 
+    /**
+     * @group legacy
+     */
     public function testDeauthenticatedEvent()
     {
         $tokenStorage = new TokenStorage();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | todo

From https://github.com/symfony/symfony/pull/41613#discussion_r650550141

> all unauthenticated token use-cases have been replaced with passports (and the removal of anonymous). This means that if you have a token, it should always be authenticated.