### PR TITLE
[DependencyInjection] Allow `Target` attribute to be used with constructor property promotion

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Attribute/Target.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Target.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-#[\Attribute(\Attribute::TARGET_PARAMETER|\Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_PARAMETER | \Attribute::TARGET_PROPERTY)]
 final class Target
 {
     /**
@@ -31,7 +31,7 @@ final class Target
         $this->name = lcfirst(str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $name))));
     }
 
-    public static function parseName(\ReflectionParameter|\ReflectionProperty $reflector): string
+    public static function parseName(\ReflectionParameter | \ReflectionProperty $reflector): string
     {
         if (80000 > \PHP_VERSION_ID || !$target = $reflector->getAttributes(self::class)[0] ?? null) {
             return $reflector->name;

--- a/src/Symfony/Component/DependencyInjection/Attribute/Target.php
+++ b/src/Symfony/Component/DependencyInjection/Attribute/Target.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-#[\Attribute(\Attribute::TARGET_PARAMETER)]
+#[\Attribute(\Attribute::TARGET_PARAMETER|\Attribute::TARGET_PROPERTY)]
 final class Target
 {
     /**
@@ -31,22 +31,22 @@ final class Target
         $this->name = lcfirst(str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $name))));
     }
 
-    public static function parseName(\ReflectionParameter $parameter): string
+    public static function parseName(\ReflectionParameter|\ReflectionProperty $reflector): string
     {
-        if (80000 > \PHP_VERSION_ID || !$target = $parameter->getAttributes(self::class)[0] ?? null) {
-            return $parameter->name;
+        if (80000 > \PHP_VERSION_ID || !$target = $reflector->getAttributes(self::class)[0] ?? null) {
+            return $reflector->name;
         }
 
         $name = $target->newInstance()->name;
 
         if (!preg_match('/^[a-zA-Z_\x7f-\xff]/', $name)) {
-            if (($function = $parameter->getDeclaringFunction()) instanceof \ReflectionMethod) {
+            if (($function = $reflector->getDeclaringFunction()) instanceof \ReflectionMethod) {
                 $function = $function->class.'::'.$function->name;
             } else {
                 $function = $function->name;
             }
 
-            throw new InvalidArgumentException(sprintf('Invalid #[Target] name "%s" on parameter "$%s" of "%s()": the first character must be a letter.', $name, $parameter->name, $function));
+            throw new InvalidArgumentException(sprintf('Invalid #[Target] name "%s" on parameter "$%s" of "%s()": the first character must be a letter.', $name, $reflector->name, $function));
         }
 
         return $name;

--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Allow `#[Target]` to be used with constructor property promotion
+
 5.3
 ---
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/AutowirePassTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\includes\FooVariadic;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\includes\MultipleArgumentsOptionalScalarNotReallyOptional;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\WithTarget;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\WithTargetOnPromotedProperty;
 use Symfony\Component\DependencyInjection\TypedReference;
 use Symfony\Contracts\Service\Attribute\Required;
 
@@ -1081,6 +1082,23 @@ class AutowirePassTest extends TestCase
         $container->register(BarInterface::class, BarInterface::class);
         $container->register(BarInterface::class.' $imageStorage', BarInterface::class);
         $container->register('with_target', WithTarget::class)
+            ->setAutowired(true);
+
+        (new AutowirePass())->process($container);
+
+        $this->assertSame(BarInterface::class.' $imageStorage', (string) $container->getDefinition('with_target')->getArgument(0));
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testArgumentWithTargetOnPromotedProperty()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(BarInterface::class, BarInterface::class);
+        $container->register(BarInterface::class.' $imageStorage', BarInterface::class);
+        $container->register('with_target', WithTargetOnPromotedProperty::class)
             ->setAutowired(true);
 
         (new AutowirePass())->process($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ResolveBindingsPassTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\DependencyInjection\Tests\Fixtures\CaseSensitiveClass;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\NamedArgumentsDummy;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\ParentNotExists;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\WithTarget;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\WithTargetOnPromotedProperty;
 use Symfony\Component\DependencyInjection\TypedReference;
 
 require_once __DIR__.'/../Fixtures/includes/autowiring_classes.php';
@@ -197,6 +198,21 @@ class ResolveBindingsPassTest extends TestCase
         $container = new ContainerBuilder();
 
         $container->register('with_target', WithTarget::class)
+            ->setBindings([BarInterface::class.' $imageStorage' => new Reference('bar')]);
+
+        (new ResolveBindingsPass())->process($container);
+
+        $this->assertSame('bar', (string) $container->getDefinition('with_target')->getArgument(0));
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testBindWithTargetOnPromotedProperty()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('with_target', WithTargetOnPromotedProperty::class)
             ->setBindings([BarInterface::class.' $imageStorage' => new Reference('bar')]);
 
         (new ResolveBindingsPass())->process($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/WithTargetOnPromotedProperty.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/WithTargetOnPromotedProperty.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Component\DependencyInjection\Attribute\Target;
+
+class WithTargetOnPromotedProperty
+{
+    public function __construct(
+        #[Target('image.storage')]
+        private BarInterface $bar
+    ) {
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      |no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 


This makes it possible to do this:
```php
class GitHubDownloader
{
    public function __construct(#[Target('githubApi')] private HttpClientInterface $httpClient)
    {
    }
}
```