### PR TITLE
[Notifier] [Smsapi] fixed checking whether message is sent

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/Tests/SmsapiTransportTest.php
@@ -11,7 +11,10 @@
 
 namespace Symfony\Component\Notifier\Bridge\Smsapi\Tests;
 
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\Notifier\Bridge\Smsapi\SmsapiTransport;
+use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
@@ -43,5 +46,41 @@ final class SmsapiTransportTest extends TransportTestCase
     {
         yield [new ChatMessage('Hello!')];
         yield [$this->createMock(MessageInterface::class)];
+    }
+
+    public function createClient(int $statusCode, string $content): HttpClientInterface
+    {
+        return new MockHttpClient(new MockResponse($content, ['http_code' => $statusCode]));
+    }
+
+    public function responseProvider(): iterable
+    {
+        $responses = [
+            ['status' => 200, 'content' => '{"error":101,"message":"Authorization failed"}', 'errorMessage' => 'Unable to send the SMS: "Authorization failed".'],
+            ['status' => 500, 'content' => '{}', 'errorMessage' => 'Unable to send the SMS: "unknown error".'],
+            ['status' => 500, 'content' => '{"error":null,"message":"Unknown"}', 'errorMessage' => 'Unable to send the SMS: "Unknown".'],
+            ['status' => 500, 'content' => '{"error":null,"message":null}', 'errorMessage' => 'Unable to send the SMS: "unknown error".'],
+            ['status' => 500, 'content' => 'Internal error', 'errorMessage' => 'Could not decode body to an array.'],
+            ['status' => 200, 'content' => 'Internal error', 'errorMessage' => 'Could not decode body to an array.'],
+        ];
+
+        foreach ($responses as $response) {
+            yield [$response['status'], $response['content'], $response['errorMessage']];
+        }
+    }
+
+    /**
+     * @dataProvider responseProvider
+     */
+    public function testThrowExceptionWhenMessageWasNotSent(int $statusCode, string $content, string $errorMessage)
+    {
+        $client = $this->createClient($statusCode, $content);
+        $transport = $this->createTransport($client);
+        $message = new SmsMessage('0611223344', 'Hello!');
+
+        $this->expectException(TransportException::class);
+        $this->expectExceptionMessage($errorMessage);
+
+        $transport->send($message);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | -
| License       | MIT
| Doc PR        | -

SmsAPI always return 200 status code even if we enter incorrect token.
The content is: `{"error":101,"message":"Authorization failed"}`.
