### PR TITLE
[Console] introduce `__toString` `method` annotation to `InputInterface`

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `TesterTrait::assertCommandIsSuccessful()` to test command
+ * Add `InputInterface::__toString()` method annotation. This will be replaced by the extension of the `Stringable` interface in 6.0.
 
 5.3
 ---

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -18,6 +18,8 @@ use Symfony\Component\Console\Exception\RuntimeException;
  * InputInterface is the interface implemented by all input classes.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @method string __toString()
  */
 interface InputInterface
 {

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -19,7 +19,8 @@ use Symfony\Component\Console\Exception\RuntimeException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @method string __toString()
+ * @method string __toString() Returns a stringified representation of the args passed to the command.
+ *                             InputArguments MUST be escaped as well as the InputOption values passed to the command.
  */
 interface InputInterface
 {

--- a/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
@@ -143,4 +143,9 @@ class NonStringInput extends Input
     public function parse()
     {
     }
+
+    public function __toString()
+    {
+        return '';
+    }
 }

--- a/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
+++ b/src/Symfony/Component/Console/Tests/EventListener/ErrorListenerTest.php
@@ -144,7 +144,7 @@ class NonStringInput extends Input
     {
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return '';
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #42042
| License       | MIT
| Doc PR        | none yet, please ping me if this will be necessary

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

As a preparation for 6.0, we are adding `__toString` as method declaration. This avoids having BC-breaks in upstream projects as suggested by [@wouterj](https://github.com/symfony/symfony/issues/42042#issuecomment-877409203).
In 6.0, the `Stringable` interface will be implemented instead.

Fixes #42042


If this feature will be accepted, I'm willing to create the PR for 6.0 which adds the `Stringable` interface. 👍🏼 
