### PR TITLE
[Routing] Fix support for stringable parameters

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -298,7 +298,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
             if ($v instanceof \stdClass) {
                 $v = (array) $v;
                 array_walk_recursive($v, $caster);
-            } elseif (\is_object($v) && method_exists($v, '__toString')) {
+            } elseif (\is_object($v) && !get_object_vars($v) && method_exists($v, '__toString')) {
                 $v = (string) $v;
             }
         });

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -298,7 +298,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
             if ($v instanceof \stdClass) {
                 $v = (array) $v;
                 array_walk_recursive($v, $caster);
-            } elseif (\is_object($v)) {
+            } elseif (\is_object($v) && method_exists($v, '__toString')) {
                 $v = (string) $v;
             }
         });

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -294,6 +294,15 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
             return $a == $b ? 0 : 1;
         });
 
+        array_walk_recursive($extra, $caster = static function (&$v) use (&$caster) {
+            if ($v instanceof \stdClass) {
+                $v = (array) $v;
+                array_walk_recursive($v, $caster);
+            } elseif (null !== $v) {
+                $v = (string) $v;
+            }
+        });
+
         // extract fragment
         $fragment = $defaults['_fragment'] ?? '';
 

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -298,7 +298,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
             if ($v instanceof \stdClass) {
                 $v = (array) $v;
                 array_walk_recursive($v, $caster);
-            } elseif (null !== $v) {
+            } elseif (\is_object($v)) {
                 $v = (string) $v;
             }
         });

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -112,7 +112,7 @@ class UrlGeneratorTest extends TestCase
         $routes = $this->getRoutes('test', new Route('/testing'));
         $url = $this->getGenerator($routes)->generate('test', [$parameter => $value], UrlGeneratorInterface::ABSOLUTE_PATH);
 
-        $this->assertSame(sprintf('/app.php/testing?%s', $expectedQueryString), $url);
+        $this->assertSame(sprintf('/app.php/testing%s', $expectedQueryString), $url);
     }
 
     /**
@@ -123,7 +123,7 @@ class UrlGeneratorTest extends TestCase
         $routes = $this->getRoutes('test', new Route('/testing'));
         $url = $this->getGenerator($routes)->generate('test', [$parameter => $value], UrlGeneratorInterface::ABSOLUTE_URL);
 
-        $this->assertSame(sprintf('http://localhost/app.php/testing?%s', $expectedQueryString), $url);
+        $this->assertSame(sprintf('http://localhost/app.php/testing%s', $expectedQueryString), $url);
     }
 
     public function valuesProvider(): array
@@ -135,22 +135,16 @@ class UrlGeneratorTest extends TestCase
         $nestedStdClass->nested = $stdClass;
 
         return [
-            'string' => ['foo=bar', 'foo', 'bar'],
-            'boolean-false' => ['foo=0', 'foo', false],
-            'boolean-true' => ['foo=1', 'foo', true],
-            'object implementing __toString()' => ['foo=bar', 'foo', new StringableObject()],
-            'object implementing __toString() in nested array' => ['foo%5Bbaz%5D=bar', 'foo', ['baz' => new StringableObject()]],
-            'stdClass' => ['foo%5Bbaz%5D=bar', 'foo', $stdClass],
-            'stdClass in nested stdClass' => ['foo%5Bnested%5D%5Bbaz%5D=bar', 'foo', $nestedStdClass],
+            'null' => ['', 'foo', null],
+            'string' => ['?foo=bar', 'foo', 'bar'],
+            'boolean-false' => ['?foo=0', 'foo', false],
+            'boolean-true' => ['?foo=1', 'foo', true],
+            'object implementing __toString()' => ['?foo=bar', 'foo', new StringableObject()],
+            'object implementing __toString() in nested array' => ['?foo%5Bbaz%5D=bar', 'foo', ['baz' => new StringableObject()]],
+            'stdClass' => ['foo%5Bbaz%5D=bar', '?foo', $stdClass],
+            'stdClass in nested stdClass' => ['?foo%5Bnested%5D%5Bbaz%5D=bar', 'foo', $nestedStdClass],
+            'not stringable object' => ['', 'foo', new NotStringableObject()],
         ];
-    }
-
-    public function testUrlWithNullExtraParameters()
-    {
-        $routes = $this->getRoutes('test', new Route('/testing'));
-        $url = $this->getGenerator($routes)->generate('test', ['foo' => null], UrlGeneratorInterface::ABSOLUTE_URL);
-
-        $this->assertEquals('http://localhost/app.php/testing', $url);
     }
 
     public function testUrlWithExtraParametersFromGlobals()
@@ -924,4 +918,8 @@ class StringableObject
     {
         return 'bar';
     }
+}
+
+class NotStringableObject
+{
 }

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -140,10 +140,13 @@ class UrlGeneratorTest extends TestCase
             'boolean-false' => ['?foo=0', 'foo', false],
             'boolean-true' => ['?foo=1', 'foo', true],
             'object implementing __toString()' => ['?foo=bar', 'foo', new StringableObject()],
+            'object implementing __toString() but has public property' => ['?foo%5Bfoo%5D=property', 'foo', new StringableObjectWithPublicProperty()],
             'object implementing __toString() in nested array' => ['?foo%5Bbaz%5D=bar', 'foo', ['baz' => new StringableObject()]],
-            'stdClass' => ['foo%5Bbaz%5D=bar', '?foo', $stdClass],
+            'object implementing __toString() in nested array but has public property' => ['?foo%5Bbaz%5D%5Bfoo%5D=property', 'foo', ['baz' => new StringableObjectWithPublicProperty()]],
+            'stdClass' => ['?foo%5Bbaz%5D=bar', 'foo', $stdClass],
             'stdClass in nested stdClass' => ['?foo%5Bnested%5D%5Bbaz%5D=bar', 'foo', $nestedStdClass],
-            'not stringable object' => ['', 'foo', new NotStringableObject()],
+            'non stringable object' => ['', 'foo', new NonStringableObject()],
+            'non stringable object but has public property' => ['?foo%5Bfoo%5D=property', 'foo', new NonStringableObjectWithPublicProperty()],
         ];
     }
 
@@ -920,6 +923,21 @@ class StringableObject
     }
 }
 
-class NotStringableObject
+class StringableObjectWithPublicProperty
 {
+    public $foo = 'property';
+
+    public function __toString()
+    {
+        return 'bar';
+    }
+}
+
+class NonStringableObject
+{
+}
+
+class NonStringableObjectWithPublicProperty
+{
+    public $foo = 'property';
 }

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -128,6 +128,46 @@ class UrlGeneratorTest extends TestCase
         $this->assertEquals('http://localhost/app.php/testing', $url);
     }
 
+    public function testRelativeUrlWithStringableObjectParameter()
+    {
+        $stringableObject = new StringableObject();
+
+        $routes = $this->getRoutes('test', new Route('/testing/{foo}'));
+        $url = $this->getGenerator($routes)->generate('test', ['foo' => $stringableObject], UrlGeneratorInterface::ABSOLUTE_PATH);
+
+        $this->assertSame('/app.php/testing/bar', $url);
+    }
+
+    public function testRelativeUrlWithStringableObjectExtraParameter()
+    {
+        $stringableObject = new StringableObject();
+
+        $routes = $this->getRoutes('test', new Route('/testing'));
+        $url = $this->getGenerator($routes)->generate('test', ['stringable' => $stringableObject], UrlGeneratorInterface::ABSOLUTE_PATH);
+
+        $this->assertSame('/app.php/testing?stringable=bar', $url);
+    }
+
+    public function testAbsoluteUrlWithStringableObjectExtraParameter()
+    {
+        $stringableObject = new StringableObject();
+
+        $routes = $this->getRoutes('test', new Route('/testing'));
+        $url = $this->getGenerator($routes)->generate('test', ['stringable' => $stringableObject], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        $this->assertSame('http://localhost/app.php/testing?stringable=bar', $url);
+    }
+
+    public function testAbsoluteUrlWithStringableObjectExtraParameterInArray()
+    {
+        $stringableObject = new StringableObject();
+
+        $routes = $this->getRoutes('test', new Route('/testing'));
+        $url = $this->getGenerator($routes)->generate('test', ['key' => ['stringable' => $stringableObject]], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        $this->assertSame('http://localhost/app.php/testing?key%5Bstringable%5D=bar', $url);
+    }
+
     public function testUrlWithExtraParametersFromGlobals()
     {
         $routes = $this->getRoutes('test', new Route('/testing'));
@@ -890,5 +930,13 @@ class UrlGeneratorTest extends TestCase
         $routes->add($name, $route);
 
         return $routes;
+    }
+}
+
+class StringableObject
+{
+    public function __toString()
+    {
+        return 'bar';
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #26992
| License       | MIT
| Doc PR        | ---

In my project I added a `Ulid` as query parameter and it was not added and no exception was thrown, so it was simply missing.

I added a test case, and it is failing as expected:
<img width="868" alt="CleanShot 2021-07-11 at 13 05 50@2x" src="https://user-images.githubusercontent.com/995707/125192555-c5dc3d80-e248-11eb-8290-37863d65163b.png">

I am also not sure about the behaviour we want, but not adding the parameter without any notice is not a good DX in my opinion. Can you please leave your thoughts how to proceed? We can also add support for `\Stringable` in general? Thanks 

cc @fancyweb @nicolas-grekas @linaori @garak 

## Conclusion
It looks, like `http_build_query` does no casting!