### PR TITLE
[Messenger] Fixed BC layer for RedeliveryStamp

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/RedeliveryStamp.php
@@ -24,15 +24,27 @@ final class RedeliveryStamp implements StampInterface
     private $exceptionMessage;
     private $flattenException;
 
-    public function __construct(int $retryCount, string $exceptionMessage = null, FlattenException $flattenException = null, \DateTimeInterface $redeliveredAt = null)
+    /**
+     * @param \DateTimeInterface|null $exceptionMessage
+     */
+    public function __construct(int $retryCount, $exceptionMessage = null, FlattenException $flattenException = null, \DateTimeInterface $redeliveredAt = null)
     {
         $this->retryCount = $retryCount;
         $this->redeliveredAt = $redeliveredAt ?? new \DateTimeImmutable();
-
-        if (null !== $exceptionMessage) {
-            trigger_deprecation('symfony/messenger', '5.2', sprintf('Using the "$exceptionMessage" parameter in the "%s" class is deprecated, use the "%s" class instead.', self::class, ErrorDetailsStamp::class));
+        if (null !== $redeliveredAt) {
+            trigger_deprecation('symfony/messenger', '5.2', sprintf('Using the "$redeliveredAt" as 4th argument of the "%s::__construct()" is deprecated, pass "$redeliveredAt" as second argument instead.', self::class));
         }
-        $this->exceptionMessage = $exceptionMessage;
+
+        if ($exceptionMessage instanceof \DateTimeInterface) {
+            // In Symfony 6.0, the second argument will be $redeliveredAt
+            $this->redeliveredAt = $exceptionMessage;
+            if (null !== $redeliveredAt) {
+                throw new \LogicException('It is deprecated to specify a redeliveredAt as 4th argument. The correct way is to specify redeliveredAt as the second argument. Using both is not allowed.');
+            }
+        } elseif (null !== $exceptionMessage) {
+            trigger_deprecation('symfony/messenger', '5.2', sprintf('Using the "$exceptionMessage" parameter in the "%s" class is deprecated, use the "%s" class instead.', self::class, ErrorDetailsStamp::class));
+            $this->exceptionMessage = $exceptionMessage;
+        }
 
         if (null !== $flattenException) {
             trigger_deprecation('symfony/messenger', '5.2', sprintf('Using the "$flattenException" parameter in the "%s" class is deprecated, use the "%s" class instead.', self::class, ErrorDetailsStamp::class));

--- a/src/Symfony/Component/Messenger/Tests/Stamp/RedeliveryStampTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Stamp/RedeliveryStampTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\Messenger\Tests\Stamp;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 
 class RedeliveryStampTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testGetters()
     {
         $stamp = new RedeliveryStamp(10);
@@ -25,7 +28,36 @@ class RedeliveryStampTest extends TestCase
 
     public function testSerialization()
     {
-        $stamp = new RedeliveryStamp(10, null, null, \DateTimeImmutable::createFromFormat(\DateTimeInterface::ISO8601, '2005-08-15T15:52:01+0000'));
+        $stamp = new RedeliveryStamp(10, \DateTimeImmutable::createFromFormat(\DateTimeInterface::ISO8601, '2005-08-15T15:52:01+0000'));
         $this->assertSame('2005-08-15T15:52:01+0000', $stamp->getRedeliveredAt()->format(\DateTimeInterface::ISO8601));
+    }
+
+    public function testRedeliveryAt()
+    {
+        $redeliveredAt = new \DateTimeImmutable('+2minutes');
+        $stamp = new RedeliveryStamp(10, $redeliveredAt);
+        $this->assertSame($redeliveredAt, $stamp->getRedeliveredAt());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyRedeliveryAt()
+    {
+        $this->expectDeprecation('Since symfony/messenger 5.2: Using the "$redeliveredAt" as 4th argument of the "Symfony\Component\Messenger\Stamp\RedeliveryStamp::__construct()" is deprecated, pass "$redeliveredAt" as second argument instead.');
+        $redeliveredAt = new \DateTimeImmutable('+2minutes');
+        $stamp = new RedeliveryStamp(10, null, null, $redeliveredAt);
+        $this->assertSame($redeliveredAt, $stamp->getRedeliveredAt());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testPassingBothLegacyAndCurrentRedeliveryAt()
+    {
+        $this->expectDeprecation('Since symfony/messenger 5.2: Using the "$redeliveredAt" as 4th argument of the "Symfony\Component\Messenger\Stamp\RedeliveryStamp::__construct()" is deprecated, pass "$redeliveredAt" as second argument instead.');
+        $redeliveredAt = new \DateTimeImmutable('+2minutes');
+        $this->expectException(\LogicException::class);
+        new RedeliveryStamp(10, $redeliveredAt, null, $redeliveredAt);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Related to https://github.com/symfony/symfony/pull/41319#discussion_r640725265
| License       | MIT
| Doc PR        | n/a

In Symfony 6, the second argument to RedeliveryStamp's constructor will be a DateTimeInterface. We should already allow people to instantiate this object with the Symfony 6 way. 
