### PR TITLE
[FrameworkBundle] distinguish system and app cache dirs

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1041,7 +1041,7 @@ class Configuration implements ConfigurationInterface
                             ->info('System related cache pools configuration')
                             ->defaultValue('cache.adapter.system')
                         ->end()
-                        ->scalarNode('directory')->defaultValue('%kernel.cache_dir%/pools')->end()
+                        ->scalarNode('directory')->defaultValue('%kernel.cache_dir%/pools/app')->end()
                         ->scalarNode('default_doctrine_provider')->end()
                         ->scalarNode('default_psr6_provider')->end()
                         ->scalarNode('default_redis_provider')->defaultValue('redis://localhost')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
@@ -77,7 +77,7 @@ return static function (ContainerConfigurator $container) {
                 '', // namespace
                 0, // default lifetime
                 abstract_arg('version'),
-                sprintf('%s/pools', param('kernel.cache_dir')),
+                sprintf('%s/pools/system', param('kernel.cache_dir')),
                 service('logger')->ignoreOnInvalid(),
             ])
             ->tag('cache.pool', ['clearer' => 'cache.system_clearer', 'reset' => 'reset'])
@@ -114,7 +114,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 '', // namespace
                 0, // default lifetime
-                sprintf('%s/pools', param('kernel.cache_dir')),
+                sprintf('%s/pools/app', param('kernel.cache_dir')),
                 service('cache.default_marshaller')->ignoreOnInvalid(),
             ])
             ->call('setLogger', [service('logger')->ignoreOnInvalid()])

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -494,7 +494,7 @@ class ConfigurationTest extends TestCase
                 'pools' => [],
                 'app' => 'cache.adapter.filesystem',
                 'system' => 'cache.adapter.system',
-                'directory' => '%kernel.cache_dir%/pools',
+                'directory' => '%kernel.cache_dir%/pools/app',
                 'default_redis_provider' => 'redis://localhost',
                 'default_memcached_provider' => 'memcached://localhost',
                 'default_pdo_provider' => ContainerBuilder::willBeAvailable('doctrine/dbal', Connection::class, ['symfony/framework-bundle']) ? 'database_connection' : null,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 

The "app" (in contrast to the "system") cache is meant to persist between deploys to not lose cached items on each deployment.
This is also explicitly mentioned in https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/5.3/config/packages/cache.yaml#L6-L7
> The "app" cache stores to the filesystem by default. The data in this cache should persist between deploys.

If you don't have another cache backend like redis available and must use the filesystem, there is currently no easy way to distinguish the system and app cache. They are all just hashed dirs in the pools dir. So there is no way to identify the app cache and share it between deployments as it is meant to be.
This PR solves this by configuring different dirs for app and system caches:
- var/cache/prod/pools/app/
- var/cache/prod/pools/system/

Now you can persist the `var/cache/prod/pools/app/` directory between deployments, e.g. by configuring the dir as [deployer shared_dirs](https://deployer.org/docs/configuration.html#shared_dirs)