### PR TITLE
[Messenger] [Redis] Make `auth` option works

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -169,6 +169,39 @@ class ConnectionTest extends TestCase
         Connection::fromDsn('redis://password@localhost/queue', [], $redis);
     }
 
+    public function testAuthFromOptions()
+    {
+        $redis = $this->createMock(\Redis::class);
+
+        $redis->expects($this->exactly(1))->method('auth')
+            ->with('password')
+            ->willReturn(true);
+
+        Connection::fromDsn('redis://localhost/queue', ['auth' => 'password'], $redis);
+    }
+
+    public function testAuthFromOptionsAndDsn()
+    {
+        $redis = $this->createMock(\Redis::class);
+
+        $redis->expects($this->exactly(1))->method('auth')
+            ->with('password2')
+            ->willReturn(true);
+
+        Connection::fromDsn('redis://password1@localhost/queue', ['auth' => 'password2'], $redis);
+    }
+
+    public function testAuthAsUserInDsn()
+    {
+        $redis = $this->createMock(\Redis::class);
+
+        $redis->expects($this->exactly(1))->method('auth')
+            ->with('password')
+            ->willReturn(true);
+
+        Connection::fromDsn('redis://password:localhost/queue', [], $redis);
+    }
+
     public function testNoAuthWithEmptyPassword()
     {
         $redis = $this->createMock(\Redis::class);

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -200,7 +200,7 @@ class Connection
             $connectionCredentials = [
                 'host' => $parsedUrl['host'] ?? '127.0.0.1',
                 'port' => $parsedUrl['port'] ?? 6379,
-                'auth' => $parsedUrl['pass'] ?? $parsedUrl['user'] ?? null,
+                'auth' => $redisOptions['auth'] ?? $parsedUrl['pass'] ?? $parsedUrl['user'] ?? null,
             ];
 
             $pathParts = explode('/', rtrim($parsedUrl['path'] ?? '', '/'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Considering this configuration:

```yaml
framework:
    messenger:
        transports:
            queue:
                dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
                options:
                    stream: 'cms'
                    delete_after_ack: false
                    auth: 'pa$$word'
                    serializer: !php/const Redis::SERIALIZER_JSON
```

It results to this error:

```
In Connection.php line 510:

  NOAUTH Authentication required.
```

Because the `auth` option was never read from the options, only from the parsed DSN.

This fix allows users to use `auth` option from the configuration.

I target 5.3, as 5.2 is going to be unmaintained at the end of July