### PR TITLE
Add a Special Case for Translating Choices in en_US_POSIX

### DIFF
--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -43,7 +43,7 @@ class PluralizationRules
             $locale = 'xbr';
         }
 
-        if (\strlen($locale) > 3) {
+        if ('en_US_POSIX' !== $locale && \strlen($locale) > 3) {
             $locale = substr($locale, 0, -\strlen(strrchr($locale, '_')));
         }
 
@@ -88,6 +88,7 @@ class PluralizationRules
             case 'de':
             case 'el':
             case 'en':
+            case 'en_US_POSIX':
             case 'eo':
             case 'es':
             case 'et':

--- a/src/Symfony/Contracts/Translation/Test/TranslatorTest.php
+++ b/src/Symfony/Contracts/Translation/Test/TranslatorTest.php
@@ -80,6 +80,17 @@ class TranslatorTest extends TestCase
         $this->assertEquals($expected, $translator->trans($id, ['%count%' => $number]));
     }
 
+    /**
+     * @dataProvider getTransChoiceTests
+     */
+    public function testTransChoiceWithEnUsPosix($expected, $id, $number)
+    {
+        $translator = $this->getTranslator();
+        $translator->setLocale('en_US_POSIX');
+
+        $this->assertEquals($expected, $translator->trans($id, ['%count%' => $number]));
+    }
+
     public function testGetSetLocale()
     {
         $translator = $this->getTranslator();
@@ -296,7 +307,7 @@ class TranslatorTest extends TestCase
     {
         return [
             ['1', ['ay', 'bo', 'cgg', 'dz', 'id', 'ja', 'jbo', 'ka', 'kk', 'km', 'ko', 'ky']],
-            ['2', ['nl', 'fr', 'en', 'de', 'de_GE', 'hy', 'hy_AM']],
+            ['2', ['nl', 'fr', 'en', 'de', 'de_GE', 'hy', 'hy_AM', 'en_US_POSIX']],
             ['3', ['be', 'bs', 'cs', 'hr']],
             ['4', ['cy', 'mt', 'sl']],
             ['6', ['ar']],

--- a/src/Symfony/Contracts/Translation/TranslatorTrait.php
+++ b/src/Symfony/Contracts/Translation/TranslatorTrait.php
@@ -140,7 +140,7 @@ EOF;
     {
         $number = abs($number);
 
-        switch ('pt_BR' !== $locale && \strlen($locale) > 3 ? substr($locale, 0, strrpos($locale, '_')) : $locale) {
+        switch ('pt_BR' !== $locale && 'en_US_POSIX' !== $locale && \strlen($locale) > 3 ? substr($locale, 0, strrpos($locale, '_')) : $locale) {
             case 'af':
             case 'bn':
             case 'bg':
@@ -149,6 +149,7 @@ EOF;
             case 'de':
             case 'el':
             case 'en':
+            case 'en_US_POSIX':
             case 'eo':
             case 'es':
             case 'et':


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix https://github.com/symfony/symfony/issues/42036 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a <!-- required for new features -->

This adds a special case similar to `pt_BR` for handling `en_US_POSIX`
which is set as the default locale on some operating systems.

~Two tests here might be over the top, not sure.~

Not over the top! One of them caught the same issue in the translation component itself :tada:
