### PR TITLE
Add no-interaction for SYMFONY_PHPUNIT_REQUIRE on prophecy

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
+++ b/src/Symfony/Bridge/PhpUnit/bin/simple-phpunit.php
@@ -225,10 +225,10 @@ if (!file_exists("$PHPUNIT_DIR/$PHPUNIT_VERSION_DIR/phpunit") || $configurationH
     @copy("$PHPUNIT_VERSION_DIR/phpunit.xsd", 'phpunit.xsd');
     chdir("$PHPUNIT_VERSION_DIR");
     if ($SYMFONY_PHPUNIT_REMOVE) {
-        $passthruOrFail("$COMPOSER remove --no-update ".$SYMFONY_PHPUNIT_REMOVE);
+        $passthruOrFail("$COMPOSER remove --no-update --no-interaction ".$SYMFONY_PHPUNIT_REMOVE);
     }
     if ($SYMFONY_PHPUNIT_REQUIRE) {
-        $passthruOrFail("$COMPOSER require --no-update ".$SYMFONY_PHPUNIT_REQUIRE);
+        $passthruOrFail("$COMPOSER require --no-update --no-interaction ".$SYMFONY_PHPUNIT_REQUIRE);
     }
     if (5.1 <= $PHPUNIT_VERSION && $PHPUNIT_VERSION < 5.4) {
         $passthruOrFail("$COMPOSER require --no-update phpunit/phpunit-mock-objects \"~3.1.0\"");


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Add no-interaction for SYMFONY_PHPUNIT_REQUIRE on prophecy

Currently if you have for example the following configuration phpunit.xml.dist:

```xml
<server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
<server name="SYMFONY_PHPUNIT_REQUIRE" value="phpspec/prophecy-phpunit"/>
```

It will ask if you really wanted to add `phpspec/prophecy-phpunit` as requirement, or if you want to keep it as dev dependency. To avoid this question and just install the dependency as defined I would add here the no-interaction flag.

<img width="1113" alt="Bildschirmfoto 2021-07-12 um 20 27 26" src="https://user-images.githubusercontent.com/1698337/125337725-9ebc6380-e34f-11eb-8b86-200d4e757b91.png">

2 questions are currently asked when adding `phpspec/prophecy-phpunit`.