### PR TITLE
Fix ctype_digit deprecation

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -161,8 +161,8 @@ class Inline
                 return 'true';
             case false === $value:
                 return 'false';
-            case ctype_digit($value):
-                return \is_string($value) ? "'$value'" : (int) $value;
+            case \is_int($value):
+                return $value;
             case is_numeric($value) && false === strpos($value, "\f") && false === strpos($value, "\n") && false === strpos($value, "\r") && false === strpos($value, "\t") && false === strpos($value, "\v"):
                 $locale = setlocale(\LC_NUMERIC, 0);
                 if (false !== $locale) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Running the Yaml unit tests on PHP 8.1 built: Jul 12 2021 00:22:13 results in the following PHP Notices:
```
Testing /Users/alex/dev/symfony/src/Symfony/Component/Yaml/Tests
...............................................................  63 / 689 (  9%)
............................................................... 126 / 689 ( 18%)
............................................................... 189 / 689 ( 27%)
............................................................... 252 / 689 ( 36%)
............................................................... 315 / 689 ( 45%)
............................................................... 378 / 689 ( 54%)
............................................................... 441 / 689 ( 64%)
............................................................... 504 / 689 ( 73%)
............................................................... 567 / 689 ( 82%)
............................................................... 630 / 689 ( 91%)
...........................................................     689 / 689 (100%)

Time: 00:00.336, Memory: 20.00 MB

OK (689 tests, 984 assertions)

Unsilenced deprecation notices (131)

  109x: ctype_digit(): Argument of type int will be interpreted as string in the future
    53x in DumperTest::testSpecifications from Symfony\Component\Yaml\Tests
    21x in DumperTest::testInlineLevel from Symfony\Component\Yaml\Tests
    16x in InlineTest::testDump from Symfony\Component\Yaml\Tests
    7x in DumperTest::testDumpingArrayObjectInstancesWithNumericKeysInlined from Symfony\Component\Yaml\Tests
    7x in DumperTest::testDumpingArrayObjectInstancesWithNumericKeysRespectsInlineLevel from Symfony\Component\Yaml\Tests
    3x in DumperTest::testIndentationInConstructor from Symfony\Component\Yaml\Tests
    1x in DumperTest::testObjectSupportEnabled from Symfony\Component\Yaml\Tests
    1x in DumperTest::testObjectSupportDisabledButNoExceptions from Symfony\Component\Yaml\Tests

  22x: ctype_digit(): Argument of type float will be interpreted as string in the future
    15x in DumperTest::testSpecifications from Symfony\Component\Yaml\Tests
    6x in InlineTest::testDump from Symfony\Component\Yaml\Tests
    1x in InlineTest::testDumpNumericValueWithLocale from Symfony\Component\Yaml\Tests
```
