### PR TITLE
Use PHP_OS_FAMILY if possible

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -139,7 +139,7 @@ jobs:
         if: "${{ matrix.php == '8.0' && ! matrix.mode }}"
         run: |
           sed -i 's/"\*\*\/Tests\/"//' composer.json
-          composer install --optimize-autoloader
+          composer install -q --optimize-autoloader
           SYMFONY_PATCH_TYPE_DECLARATIONS=force=1 php .github/patch-types.php
           SYMFONY_PATCH_TYPE_DECLARATIONS=force=1 php .github/patch-types.php # ensure the script is idempotent
           echo PHPUNIT="$PHPUNIT,legacy" >> $GITHUB_ENV

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/Descriptor/AbstractDescriptorTest.php
@@ -209,7 +209,7 @@ abstract class AbstractDescriptorTest extends TestCase
     }
 
     /** @dataProvider getClassDescriptionTestData */
-    public function testGetClassDecription($object, $expectedDescription)
+    public function testGetClassDescription($object, $expectedDescription)
     {
         $this->assertEquals($expectedDescription, $this->getDescriptor()->getClassDescription($object));
     }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.css.twig
@@ -1,5 +1,5 @@
 .container {
-    max-width: auto;
+    max-width: none;
     margin: 0;
     padding: 0;
 }
@@ -28,5 +28,5 @@
 }
 
 .exception-message-wrapper .container {
-    min-height: auto;
+    min-height: unset;
 }

--- a/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/SymfonyQuestionHelper.php
@@ -100,7 +100,7 @@ class SymfonyQuestionHelper extends QuestionHelper
 
     private function getEofShortcut(): string
     {
-        if (false !== strpos(\PHP_OS, 'WIN')) {
+        if ('Windows' === \PHP_OS_FAMILY) {
             return '<comment>Ctrl+Z</comment> then <comment>Enter</comment>';
         }
 

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -1018,14 +1018,14 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         $bar->setRedrawFrequency(4); // disable step based redraws
         $bar->start();
 
-        $bar->setProgress(1); // No treshold hit, no redraw
+        $bar->setProgress(1); // No threshold hit, no redraw
         $bar->maxSecondsBetweenRedraws(2);
         sleep(1);
         $bar->setProgress(2); // Still no redraw because it takes 2 seconds for a redraw
         sleep(1);
         $bar->setProgress(3); // 1+1 = 2 -> redraw finally
         $bar->setProgress(4); // step based redraw freq hit, redraw even without sleep
-        $bar->setProgress(5); // No treshold hit, no redraw
+        $bar->setProgress(5); // No threshold hit, no redraw
         $bar->maxSecondsBetweenRedraws(3);
         sleep(2);
         $bar->setProgress(6); // No redraw even though 2 seconds passed. Throttling has priority
@@ -1056,7 +1056,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         $bar->setProgress(3); // 1 second passed but we changed threshold, should not draw
         sleep(1);
         $bar->setProgress(4); // 1+1 seconds = 2 seconds passed which conforms threshold, draw
-        $bar->setProgress(5); // No treshold hit, no redraw
+        $bar->setProgress(5); // No threshold hit, no redraw
 
         rewind($output->getStream());
         $this->assertEquals(

--- a/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/SymfonyQuestionHelperTest.php
@@ -218,7 +218,7 @@ EOT
     {
         $expected = 'Write an essay (press Ctrl+D to continue)';
 
-        if (false !== strpos(\PHP_OS, 'WIN')) {
+        if ('Windows' === \PHP_OS_FAMILY) {
             $expected = 'Write an essay (press Ctrl+Z then Enter to continue)';
         }
 

--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -208,7 +208,7 @@ class DebugClassLoader
             } elseif (substr($test, -\strlen($file)) === $file) {
                 // filesystem is case insensitive and realpath() normalizes the case of characters
                 self::$caseCheck = 1;
-            } elseif (false !== stripos(\PHP_OS, 'darwin')) {
+            } elseif ('Darwin' === \PHP_OS_FAMILY) {
                 // on MacOSX, HFS+ is case insensitive but realpath() doesn't normalize the case of characters
                 self::$caseCheck = 2;
             } else {

--- a/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageForRetryListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageForRetryListenerTest.php
@@ -99,12 +99,12 @@ class SendFailedMessageForRetryListenerTest extends TestCase
         $senderLocator = $this->createMock(ContainerInterface::class);
         $senderLocator->expects($this->once())->method('has')->willReturn(true);
         $senderLocator->expects($this->once())->method('get')->willReturn($sender);
-        $retryStategy = $this->createMock(RetryStrategyInterface::class);
-        $retryStategy->expects($this->once())->method('isRetryable')->willReturn(true);
-        $retryStategy->expects($this->once())->method('getWaitingTime')->willReturn(1000);
+        $retryStrategy = $this->createMock(RetryStrategyInterface::class);
+        $retryStrategy->expects($this->once())->method('isRetryable')->willReturn(true);
+        $retryStrategy->expects($this->once())->method('getWaitingTime')->willReturn(1000);
         $retryStrategyLocator = $this->createMock(ContainerInterface::class);
         $retryStrategyLocator->expects($this->once())->method('has')->willReturn(true);
-        $retryStrategyLocator->expects($this->once())->method('get')->willReturn($retryStategy);
+        $retryStrategyLocator->expects($this->once())->method('get')->willReturn($retryStrategy);
 
         $listener = new SendFailedMessageForRetryListener($senderLocator, $retryStrategyLocator);
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/AmqpExt/ConnectionTest.php
@@ -480,7 +480,7 @@ class ConnectionTest extends TestCase
         $connection->publish('body', ['Foo' => 'X'], 0, new AmqpStamp(null, \AMQP_NOPARAM, ['headers' => ['Bar' => 'Y']]));
     }
 
-    public function testAmqpStampDelireryModeIsUsed()
+    public function testAmqpStampDeliveryModeIsUsed()
     {
         $factory = new TestAmqpFactory(
             $this->createMock(\AMQPConnection::class),

--- a/src/Symfony/Component/Translation/PluralizationRules.php
+++ b/src/Symfony/Component/Translation/PluralizationRules.php
@@ -43,7 +43,7 @@ class PluralizationRules
             $locale = 'xbr';
         }
 
-        if (\strlen($locale) > 3) {
+        if ('en_US_POSIX' !== $locale && \strlen($locale) > 3) {
             $locale = substr($locale, 0, -\strlen(strrchr($locale, '_')));
         }
 
@@ -88,6 +88,7 @@ class PluralizationRules
             case 'de':
             case 'el':
             case 'en':
+            case 'en_US_POSIX':
             case 'eo':
             case 'es':
             case 'et':

--- a/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Validator/RecursiveValidatorTest.php
@@ -1905,7 +1905,7 @@ class RecursiveValidatorTest extends TestCase
         $this->assertSame($constraint, $violations[0]->getConstraint());
     }
 
-    public function testCollectionConstraitViolationHasCorrectContext()
+    public function testCollectionConstraintViolationHasCorrectContext()
     {
         $data = [
             'foo' => 'fooValue',

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -711,7 +711,7 @@ class Inline
         $nextOffset += strspn($value, ' ', $nextOffset);
 
         if ('' === $tag && (!isset($value[$nextOffset]) || \in_array($value[$nextOffset], [']', '}', ','], true))) {
-            throw new ParseException(sprintf('Using the unquoted scalar value "!" is not supported. You must quote it.', $value), self::$parsedLineNumber + 1, $value, self::$parsedFilename);
+            throw new ParseException('Using the unquoted scalar value "!" is not supported. You must quote it.', self::$parsedLineNumber + 1, $value, self::$parsedFilename);
         }
 
         // Is followed by a scalar and is a built-in tag

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -161,8 +161,8 @@ class Inline
                 return 'true';
             case false === $value:
                 return 'false';
-            case ctype_digit($value):
-                return \is_string($value) ? "'$value'" : (int) $value;
+            case \is_int($value):
+                return $value;
             case is_numeric($value) && false === strpos($value, "\f") && false === strpos($value, "\n") && false === strpos($value, "\r") && false === strpos($value, "\t") && false === strpos($value, "\v"):
                 $locale = setlocale(\LC_NUMERIC, 0);
                 if (false !== $locale) {

--- a/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
@@ -42,7 +42,10 @@ class ParentTestService
     {
     }
 
-    public function setContainer(ContainerInterface $container): ContainerInterface
+    /**
+     * @return ContainerInterface
+     */
+    public function setContainer(ContainerInterface $container)
     {
         return $container;
     }

--- a/src/Symfony/Contracts/Translation/Test/TranslatorTest.php
+++ b/src/Symfony/Contracts/Translation/Test/TranslatorTest.php
@@ -80,6 +80,17 @@ class TranslatorTest extends TestCase
         $this->assertEquals($expected, $translator->trans($id, ['%count%' => $number]));
     }
 
+    /**
+     * @dataProvider getTransChoiceTests
+     */
+    public function testTransChoiceWithEnUsPosix($expected, $id, $number)
+    {
+        $translator = $this->getTranslator();
+        $translator->setLocale('en_US_POSIX');
+
+        $this->assertEquals($expected, $translator->trans($id, ['%count%' => $number]));
+    }
+
     public function testGetSetLocale()
     {
         $translator = $this->getTranslator();
@@ -296,7 +307,7 @@ class TranslatorTest extends TestCase
     {
         return [
             ['1', ['ay', 'bo', 'cgg', 'dz', 'id', 'ja', 'jbo', 'ka', 'kk', 'km', 'ko', 'ky']],
-            ['2', ['nl', 'fr', 'en', 'de', 'de_GE', 'hy', 'hy_AM']],
+            ['2', ['nl', 'fr', 'en', 'de', 'de_GE', 'hy', 'hy_AM', 'en_US_POSIX']],
             ['3', ['be', 'bs', 'cs', 'hr']],
             ['4', ['cy', 'mt', 'sl']],
             ['6', ['ar']],

--- a/src/Symfony/Contracts/Translation/TranslatorTrait.php
+++ b/src/Symfony/Contracts/Translation/TranslatorTrait.php
@@ -140,7 +140,7 @@ EOF;
     {
         $number = abs($number);
 
-        switch ('pt_BR' !== $locale && \strlen($locale) > 3 ? substr($locale, 0, strrpos($locale, '_')) : $locale) {
+        switch ('pt_BR' !== $locale && 'en_US_POSIX' !== $locale && \strlen($locale) > 3 ? substr($locale, 0, strrpos($locale, '_')) : $locale) {
             case 'af':
             case 'bn':
             case 'bg':
@@ -149,6 +149,7 @@ EOF;
             case 'de':
             case 'el':
             case 'en':
+            case 'en_US_POSIX':
             case 'eo':
             case 'es':
             case 'et':


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This constant was introduced in PHP 7.2: https://www.php.net/manual/en/reserved.constants.php#constant.php-os-family

~This is not a bug, so if you decide to merge, it should be in 5.4 branch I guess.~