### PR TITLE
[Cache] Remove internal from RedisProxy

### DIFF
--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Make `LockRegistry` use semaphores when possible
  * Deprecate `DoctrineProvider` because this class has been added to the `doctrine/cache` package
+ * Remove `@internal` from `RedisProxy`
 
 5.3
 ---

--- a/src/Symfony/Component/Cache/Traits/RedisProxy.php
+++ b/src/Symfony/Component/Cache/Traits/RedisProxy.php
@@ -13,8 +13,6 @@ namespace Symfony\Component\Cache\Traits;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
- *
- * @internal
  */
 class RedisProxy
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

we use RedisAdapter::createConnection to get a lazy redis client, aka `Symfony\Component\Cache\Traits\RedisProxy`

As such this symbol is currently leaking in our service layer, but it's internal :(

Let's remove it.