### PR TITLE
[Notifier] [Slack] Include additional errors to slack notifier error message

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackTransport.php
@@ -95,7 +95,9 @@ final class SlackTransport extends AbstractTransport
 
         $result = $response->toArray(false);
         if (!$result['ok']) {
-            throw new TransportException(sprintf('Unable to post the Slack message: "%s".', $result['error']), $response);
+            $errors = isset($result['errors']) ? ' ('.implode('|', $result['errors']).')' : '';
+
+            throw new TransportException(sprintf('Unable to post the Slack message: "%s"%s.', $result['error'], $errors), $response);
         }
 
         $sentMessage = new SentMessage($message, (string) $this);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Sometimes it is hard to debug why notification was rejected, so I am proposing to include error descriptions to the exception message.
