### PR TITLE
[Workflow] qa: add missing type-hints to workflow `Transition`

### DIFF
--- a/src/Symfony/Component/Workflow/Transition.php
+++ b/src/Symfony/Component/Workflow/Transition.php
@@ -32,16 +32,25 @@ class Transition
         $this->tos = (array) $tos;
     }
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return $this->name;
     }
 
+    /**
+     * @return string[]
+     */
     public function getFroms()
     {
         return $this->froms;
     }
 
+    /**
+     * @return string[]
+     */
     public function getTos()
     {
         return $this->tos;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | not really
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

Hey there, I am using the `Workflow` component and realized that `Transition` lacks method type-hints. I've added a PHPDoc to reflect the return types.

If this is considered a bug fix, I can rebase against 5.3. If anything else is missing, please let me know.