### PR TITLE
[Notifier] [Slack] Throw error if maximum block limit is reached for slack message options

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Notifier\Bridge\Slack;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackBlockInterface;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackDividerBlock;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
+use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Notification\Notification;
 
@@ -22,11 +23,17 @@ use Symfony\Component\Notifier\Notification\Notification;
  */
 final class SlackOptions implements MessageOptionsInterface
 {
+    private const MAX_BLOCKS = 50;
+
     private $options;
 
     public function __construct(array $options = [])
     {
         $this->options = $options;
+
+        if (\count($this->options['blocks'] ?? []) > self::MAX_BLOCKS) {
+            throw new LogicException(sprintf('Maximum number of "blocks" has been reached (%d).', self::MAX_BLOCKS));
+        }
     }
 
     public static function fromNotification(Notification $notification): self
@@ -97,6 +104,10 @@ final class SlackOptions implements MessageOptionsInterface
      */
     public function block(SlackBlockInterface $block): self
     {
+        if (\count($this->options['blocks'] ?? []) >= self::MAX_BLOCKS) {
+            throw new LogicException(sprintf('Maximum number of "blocks" has been reached (%d).', self::MAX_BLOCKS));
+        }
+
         $this->options['blocks'][] = $block->toArray();
 
         return $this;

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Tests/SlackOptionsTest.php
@@ -14,7 +14,9 @@ namespace Symfony\Component\Notifier\Bridge\Slack\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Notifier\Bridge\Slack\Block\SlackDividerBlock;
+use Symfony\Component\Notifier\Bridge\Slack\Block\SlackSectionBlock;
 use Symfony\Component\Notifier\Bridge\Slack\SlackOptions;
+use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Notification\Notification;
 
 /**
@@ -186,5 +188,43 @@ final class SlackOptionsTest extends TestCase
             ],
             (new Notification($subject))->emoji($emoji)->content($content),
         ];
+    }
+
+    public function testConstructWithMaximumBlocks()
+    {
+        $options = new SlackOptions(['blocks' => array_map(static function () { return ['type' => 'divider']; }, range(0, 49))]);
+
+        $this->assertCount(50, $options->toArray()['blocks']);
+    }
+
+    public function testConstructThrowsWithTooManyBlocks()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Maximum number of "blocks" has been reached (50).');
+
+        new SlackOptions(['blocks' => array_map(static function () { return ['type' => 'divider']; }, range(0, 50))]);
+    }
+
+    public function testAddMaximumBlocks()
+    {
+        $options = new SlackOptions();
+        for ($i = 0; $i < 50; ++$i) {
+            $options->block(new SlackSectionBlock());
+        }
+
+        $this->assertCount(50, $options->toArray()['blocks']);
+    }
+
+    public function testThrowsWhenBlocksLimitReached()
+    {
+        $options = new SlackOptions();
+        for ($i = 0; $i < 50; ++$i) {
+            $options->block(new SlackSectionBlock());
+        }
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Maximum number of "blocks" has been reached (50).');
+
+        $options->block(new SlackSectionBlock());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/42090#discussion_r669033094
| License       | MIT
| Doc PR        | N/A

As requested to improve DX :)
