### PR TITLE
[PropertyInfo] Support for intersection types

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -17,4 +17,13 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+
+    <issueHandlers>
+        <UndefinedClass>
+            <errorLevel type="suppress">
+                <!-- Class has been added in PHP 8.1 -->
+                <referencedClass name="ReflectionIntersectionType"/>
+            </errorLevel>
+        </UndefinedClass>
+    </issueHandlers>
 </psalm>

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -333,8 +333,8 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
         $types = [];
         $nullable = $reflectionType->allowsNull();
 
-        foreach ($reflectionType instanceof \ReflectionUnionType ? $reflectionType->getTypes() : [$reflectionType] as $type) {
-            $phpTypeOrClass = $reflectionType instanceof \ReflectionNamedType ? $reflectionType->getName() : (string) $type;
+        foreach (($reflectionType instanceof \ReflectionUnionType || $reflectionType instanceof \ReflectionIntersectionType) ? $reflectionType->getTypes() : [$reflectionType] as $type) {
+            $phpTypeOrClass = $type->getName();
             if ('null' === $phpTypeOrClass || 'mixed' === $phpTypeOrClass || 'never' === $phpTypeOrClass) {
                 continue;
             }

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -256,11 +256,20 @@ class ReflectionExtractorTest extends TestCase
     }
 
     /**
+     * @dataProvider php81TypesProvider
      * @requires PHP 8.1
      */
-    public function testExtractPhp81Type()
+    public function testExtractPhp81Type($property, array $type = null)
     {
-        $this->assertNull($this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Php81Dummy', 'nothing', []));
+        $this->assertEquals($type, $this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Php81Dummy', $property, []));
+    }
+
+    public function php81TypesProvider()
+    {
+        return [
+            ['nothing', null],
+            ['collection', [new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Traversable'), new Type(Type::BUILTIN_TYPE_OBJECT, false, 'Countable')]],
+        ];
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php81Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php81Dummy.php
@@ -8,4 +8,8 @@ class Php81Dummy
     {
         throw new \Exception('Oops');
     }
+
+    public function getCollection(): \Traversable&\Countable
+    {
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #41552
| License       | MIT
| Doc PR        | N/A

I was a bit unsure how to fix this one. PropertyInfo does not know about the concept of intersection types yet. With this PR, the component will behave exactly the same for an intersection type as for a union: You will get an array of all atomic types.