### PR TITLE
[HttpFoundation] fix FileBag under PHP 8.1

### DIFF
--- a/src/Symfony/Component/HttpFoundation/FileBag.php
+++ b/src/Symfony/Component/HttpFoundation/FileBag.php
@@ -113,6 +113,8 @@ class FileBag extends ParameterBag
      */
     protected function fixPhpFilesArray($data)
     {
+        // Remove extra key added by PHP 8.1.
+        unset($data['full_path']);
         $keys = array_keys($data);
         sort($keys);
 

--- a/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/FileBagTest.php
@@ -45,6 +45,23 @@ class FileBagTest extends TestCase
         $this->assertEquals($file, $bag->get('file'));
     }
 
+    public function testShouldConvertsUploadedFilesPhp81()
+    {
+        $tmpFile = $this->createTempFile();
+        $file = new UploadedFile($tmpFile, basename($tmpFile), 'text/plain');
+
+        $bag = new FileBag(['file' => [
+            'name' => basename($tmpFile),
+            'full_path' => basename($tmpFile),
+            'type' => 'text/plain',
+            'tmp_name' => $tmpFile,
+            'error' => 0,
+            'size' => null,
+        ]]);
+
+        $this->assertEquals($file, $bag->get('file'));
+    }
+
     public function testShouldSetEmptyUploadedFilesToNull()
     {
         $bag = new FileBag(['file' => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no<!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

See https://php.watch/versions/8.1/$_FILES-full-path - in \Symfony\Component\HttpFoundation\FileBag::convertFileInformation() we check against a list of hardcoded keys. This logic breaks in PHP 8.1 because of the new key.