### PR TITLE
[Finder] Fix iterator return types

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/RecursiveDirectoryIterator.php
@@ -58,6 +58,7 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
      *
      * @return SplFileInfo File information
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         // the logic here avoids redoing the same work in all iterations
@@ -82,6 +83,7 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
      *
      * @throws AccessDeniedException
      */
+    #[\ReturnTypeWillChange]
     public function getChildren()
     {
         try {
@@ -109,7 +111,10 @@ class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
 
     /**
      * Do nothing for non rewindable stream.
+     *
+     * @return void
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         if (false === $this->isRewindable()) {

--- a/src/Symfony/Component/Finder/Tests/Iterator/FileTypeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FileTypeFilterIteratorTest.php
@@ -65,17 +65,17 @@ class FileTypeFilterIteratorTest extends RealIteratorTestCase
 
 class InnerTypeIterator extends \ArrayIterator
 {
-    public function current()
+    public function current(): \SplFileInfo
     {
         return new \SplFileInfo(parent::current());
     }
 
-    public function isFile()
+    public function isFile(): bool
     {
         return $this->current()->isFile();
     }
 
-    public function isDir()
+    public function isDir(): bool
     {
         return $this->current()->isDir();
     }

--- a/src/Symfony/Component/Finder/Tests/Iterator/FilenameFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FilenameFilterIteratorTest.php
@@ -42,7 +42,7 @@ class FilenameFilterIteratorTest extends IteratorTestCase
 
 class InnerNameIterator extends \ArrayIterator
 {
-    public function current()
+    public function current(): \SplFileInfo
     {
         return new \SplFileInfo(parent::current());
     }

--- a/src/Symfony/Component/Finder/Tests/Iterator/MockSplFileInfo.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/MockSplFileInfo.php
@@ -48,7 +48,7 @@ class MockSplFileInfo extends \SplFileInfo
         }
     }
 
-    public function isFile()
+    public function isFile(): bool
     {
         if (null === $this->type) {
             return false !== strpos($this->getFilename(), 'file');
@@ -57,7 +57,7 @@ class MockSplFileInfo extends \SplFileInfo
         return self::TYPE_FILE === $this->type;
     }
 
-    public function isDir()
+    public function isDir(): bool
     {
         if (null === $this->type) {
             return false !== strpos($this->getFilename(), 'directory');
@@ -66,13 +66,9 @@ class MockSplFileInfo extends \SplFileInfo
         return self::TYPE_DIRECTORY === $this->type;
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
-        if (null === $this->mode) {
-            return preg_match('/r\+/', $this->getFilename());
-        }
-
-        return preg_match('/r\+/', $this->mode);
+        return (bool) preg_match('/r\+/', $this->mode ?? $this->getFilename());
     }
 
     public function getContents()

--- a/src/Symfony/Component/Finder/Tests/Iterator/SizeRangeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SizeRangeFilterIteratorTest.php
@@ -48,22 +48,22 @@ class SizeRangeFilterIteratorTest extends RealIteratorTestCase
 
 class InnerSizeIterator extends \ArrayIterator
 {
-    public function current()
+    public function current(): \SplFileInfo
     {
         return new \SplFileInfo(parent::current());
     }
 
-    public function getFilename()
+    public function getFilename(): string
     {
         return parent::current();
     }
 
-    public function isFile()
+    public function isFile(): bool
     {
         return $this->current()->isFile();
     }
 
-    public function getSize()
+    public function getSize(): int
     {
         return $this->current()->getSize();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #41552
| License       | MIT
| Doc PR        | N/A

This PR fixes deprecation warnings on PHP 8.1 related to missing return types of iterator implementations.