### PR TITLE
[Notifier] Add FakeSMS Logger transport

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -2502,7 +2502,8 @@ class FrameworkExtension extends Extension
 
         if (ContainerBuilder::willBeAvailable('symfony/fake-sms-notifier', FakeSmsTransportFactory::class, ['symfony/framework-bundle', 'symfony/notifier', 'symfony/mailer'])) {
             $container->getDefinition($classToServices[FakeSmsTransportFactory::class])
-                ->replaceArgument('$mailer', new Reference('mailer'));
+                ->replaceArgument('$mailer', new Reference('mailer'))
+                ->replaceArgument('$logger', new Reference('logger'));
         }
 
         if (isset($config['admin_recipients'])) {

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Add the ``FakeSmsLoggerTransport``
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsLoggerTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/FakeSmsLoggerTransport.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\FakeSms;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Antoine Makdessi <amakdessi@me.com>
+ */
+final class FakeSmsLoggerTransport extends AbstractTransport
+{
+    protected const HOST = 'default';
+
+    private $logger;
+
+    public function __construct(LoggerInterface $logger, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    {
+        $this->logger = $logger;
+
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('fakesms+logger://%s', $this->getEndpoint());
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof SmsMessage;
+    }
+
+    /**
+     * @param MessageInterface|SmsMessage $message
+     */
+    protected function doSend(MessageInterface $message): SentMessage
+    {
+        if (!$this->supports($message)) {
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
+        }
+
+        $this->logger->info(sprintf('New SMS on phone number: %s', $message->getPhone()));
+
+        return new SentMessage($message, (string) $this);
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/README.md
@@ -1,9 +1,9 @@
 Fake SMS Notifier
 =================
 
-Provides Fake SMS (as email during development) integration for Symfony Notifier.
+Provides Fake SMS (as email or log during development) integration for Symfony Notifier.
 
-#### DSN example
+#### DSN example for email
 
 ```
 FAKE_SMS_DSN=fakesms+email://default?to=TO&from=FROM
@@ -14,8 +14,15 @@ where:
  - `FROM` is email who send SMS during development
 
 To use a custom mailer transport:
+
 ```
 FAKE_SMS_DSN=fakesms+email://mailchimp?to=TO&from=FROM
+```
+
+#### DSN example for logger
+
+```
+FAKE_SMS_DSN=fakesms+logger://default
 ```
 
 Resources

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsLoggerTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsLoggerTransportTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\FakeSms\Tests;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Notifier\Bridge\FakeSms\FakeSmsLoggerTransport;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class FakeSmsLoggerTransportTest extends TransportTestCase
+{
+    public function createTransport(HttpClientInterface $client = null, LoggerInterface $logger = null): TransportInterface
+    {
+        $transport = (new FakeSmsLoggerTransport($logger ?? $this->createMock(LoggerInterface::class), $client ?? $this->createMock(HttpClientInterface::class)));
+
+        return $transport;
+    }
+
+    public function toStringProvider(): iterable
+    {
+        yield ['fakesms+logger://default', $this->createTransport()];
+    }
+
+    public function supportedMessagesProvider(): iterable
+    {
+        yield [new SmsMessage('0611223344', 'Hello!')];
+        yield [new SmsMessage('+33611223344', 'Hello!')];
+    }
+
+    public function unsupportedMessagesProvider(): iterable
+    {
+        yield [new ChatMessage('Hello!')];
+        yield [$this->createMock(MessageInterface::class)];
+    }
+
+    public function testSendWithDefaultTransport()
+    {
+        $message = new SmsMessage($phone = '0611223344', 'Hello!');
+
+        $logger = new TestLogger();
+
+        $transport = $this->createTransport(null, $logger);
+
+        $transport->send($message);
+
+        $logs = $logger->logs;
+        $this->assertNotEmpty($logs);
+
+        $log = $logs[0];
+        $this->assertSame(sprintf('New SMS on phone number: %s', $phone), $log['message']);
+        $this->assertSame('info', $log['level']);
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/FakeSmsTransportFactoryTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\FakeSms\Tests;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Notifier\Bridge\FakeSms\FakeSmsTransportFactory;
 use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
@@ -23,7 +24,7 @@ final class FakeSmsTransportFactoryTest extends TransportFactoryTestCase
      */
     public function createFactory(): TransportFactoryInterface
     {
-        return new FakeSmsTransportFactory($this->createMock(MailerInterface::class));
+        return new FakeSmsTransportFactory($this->createMock(MailerInterface::class), $this->createMock(LoggerInterface::class));
     }
 
     public function createProvider(): iterable
@@ -36,6 +37,11 @@ final class FakeSmsTransportFactoryTest extends TransportFactoryTestCase
         yield [
             'fakesms+email://mailchimp?to=recipient@email.net&from=sender@email.net',
             'fakesms+email://mailchimp?to=recipient@email.net&from=sender@email.net',
+        ];
+
+        yield [
+            'fakesms+logger://default',
+            'fakesms+logger://default',
         ];
     }
 

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/TestLogger.php
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/Tests/TestLogger.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\FakeSms\Tests;
+
+use Psr\Log\AbstractLogger;
+
+final class TestLogger extends AbstractLogger
+{
+    public $logs = [];
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->logs[] = [
+            'level' => $level,
+            'message' => $message,
+            'context' => $context,
+        ];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/FakeSms/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/FakeSms/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "symfony/fake-sms-notifier",
     "type": "symfony-bridge",
-    "description": "Fake SMS (as email during development) Notifier Bridge.",
+    "description": "Fake SMS (as email or log during development) Notifier Bridge.",
     "keywords": ["sms", "development", "email", "notifier", "symfony"],
     "homepage": "https://symfony.com",
     "license": "MIT",
@@ -9,6 +9,11 @@
         {
             "name": "James Hemery",
             "homepage": "https://github.com/JamesHemery"
+        },
+        {
+            "name": "Antoine Makdessi",
+            "email": "amakdessi@me.com",
+            "homepage": "http://antoine.makdessi.free.fr"
         },
         {
             "name": "Symfony Community",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Sub part of #40625
| License       | MIT
| Doc PR        | WIP

Friendly ping @OskarStark 

As commented [here](https://github.com/symfony/symfony/issues/40625#issuecomment-880452693) I use mainly the sms transport, thus wanted to work on the fake sms. This PR adds the `logger`.

For the part `an optional channel`, how can we get to here? dymanically retreiving the proper logger based on the dsn config?
