### PR TITLE
ParameterBag: Expanded method "has"

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * made `Request::getSession()` throw if the session has not been set before
  * removed `Response::HTTP_RESERVED_FOR_WEBDAV_ADVANCED_COLLECTIONS_EXPIRED_PROPOSAL`
  * passing a null url when instantiating a `RedirectResponse` is not allowed
+ * added expansion of the method `has` for `ParameterBag`
 
 4.4.0
 -----

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -91,9 +91,17 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @return bool true if the parameter exists, false otherwise
      */
-    public function has(string $key)
+    public function has(...$keys): bool
     {
-        return \array_key_exists($key, $this->parameters);
+        foreach ($keys as $key) {
+            if (\array_key_exists($key, $this->parameters)) {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -94,7 +94,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
     public function has(...$keys): bool
     {
         foreach ($keys as $key) {
-            if (\array_key_exists($key, $this->parameters)) {
+            if (\array_key_exists((string) $key, $this->parameters)) {
                 continue;
             }
 

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -140,7 +140,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
     public function getDigits(string $key, string $default = '')
     {
         // we need to remove - and + because they're allowed in the filter
-        return str_replace(['-', '+'], '', $this->filter($key, $default, FILTER_SANITIZE_NUMBER_INT));
+        return str_replace(['-', '+'], '', $this->filter($key, $default, \FILTER_SANITIZE_NUMBER_INT));
     }
 
     /**
@@ -160,7 +160,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      */
     public function getBoolean(string $key, bool $default = false)
     {
-        return $this->filter($key, $default, FILTER_VALIDATE_BOOLEAN);
+        return $this->filter($key, $default, \FILTER_VALIDATE_BOOLEAN);
     }
 
     /**
@@ -174,7 +174,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @return mixed
      */
-    public function filter(string $key, $default = null, int $filter = FILTER_DEFAULT, $options = [])
+    public function filter(string $key, $default = null, int $filter = \FILTER_DEFAULT, $options = [])
     {
         $value = $this->get($key, $default);
 
@@ -185,7 +185,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
 
         // Add a convenience check for arrays.
         if (\is_array($value) && !isset($options['flags'])) {
-            $options['flags'] = FILTER_REQUIRE_ARRAY;
+            $options['flags'] = \FILTER_REQUIRE_ARRAY;
         }
 
         return filter_var($value, $filter, $options);

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -138,22 +138,22 @@ class ParameterBagTest extends TestCase
 
         $this->assertEmpty($bag->filter('nokey'), '->filter() should return empty by default if no key is found');
 
-        $this->assertEquals('0123', $bag->filter('digits', '', FILTER_SANITIZE_NUMBER_INT), '->filter() gets a value of parameter as integer filtering out invalid characters');
+        $this->assertEquals('0123', $bag->filter('digits', '', \FILTER_SANITIZE_NUMBER_INT), '->filter() gets a value of parameter as integer filtering out invalid characters');
 
-        $this->assertEquals('example@example.com', $bag->filter('email', '', FILTER_VALIDATE_EMAIL), '->filter() gets a value of parameter as email');
+        $this->assertEquals('example@example.com', $bag->filter('email', '', \FILTER_VALIDATE_EMAIL), '->filter() gets a value of parameter as email');
 
-        $this->assertEquals('http://example.com/foo', $bag->filter('url', '', FILTER_VALIDATE_URL, ['flags' => FILTER_FLAG_PATH_REQUIRED]), '->filter() gets a value of parameter as URL with a path');
+        $this->assertEquals('http://example.com/foo', $bag->filter('url', '', \FILTER_VALIDATE_URL, ['flags' => \FILTER_FLAG_PATH_REQUIRED]), '->filter() gets a value of parameter as URL with a path');
 
         // This test is repeated for code-coverage
-        $this->assertEquals('http://example.com/foo', $bag->filter('url', '', FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED), '->filter() gets a value of parameter as URL with a path');
+        $this->assertEquals('http://example.com/foo', $bag->filter('url', '', \FILTER_VALIDATE_URL, \FILTER_FLAG_PATH_REQUIRED), '->filter() gets a value of parameter as URL with a path');
 
-        $this->assertFalse($bag->filter('dec', '', FILTER_VALIDATE_INT, [
-            'flags' => FILTER_FLAG_ALLOW_HEX,
+        $this->assertFalse($bag->filter('dec', '', \FILTER_VALIDATE_INT, [
+            'flags' => \FILTER_FLAG_ALLOW_HEX,
             'options' => ['min_range' => 1, 'max_range' => 0xff],
         ]), '->filter() gets a value of parameter as integer between boundaries');
 
-        $this->assertFalse($bag->filter('hex', '', FILTER_VALIDATE_INT, [
-            'flags' => FILTER_FLAG_ALLOW_HEX,
+        $this->assertFalse($bag->filter('hex', '', \FILTER_VALIDATE_INT, [
+            'flags' => \FILTER_FLAG_ALLOW_HEX,
             'options' => ['min_range' => 1, 'max_range' => 0xff],
         ]), '->filter() gets a value of parameter as integer between boundaries');
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -87,9 +87,9 @@ class ParameterBagTest extends TestCase
 
     public function testHas()
     {
-        $bag = new ParameterBag(['foo' => 'bar']);
+        $bag = new ParameterBag(['foo' => 'bar', 'hello' => 'world']);
 
-        $this->assertTrue($bag->has('foo'), '->has() returns true if a parameter is defined');
+        $this->assertTrue($bag->has('foo', 'hello'), '->has() returns true if a parameters is defined');
         $this->assertFalse($bag->has('unknown'), '->has() return false if a parameter is not defined');
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1 for features / 4.4, 5.2 or 5.3 for bug fixes <!-- see below -->
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Added expansion of the method `has` for `ParameterBag` from:
```php
->has('foo');
```
to:
```php
->has('foo', 'bar'); // Return `true` if all parameters exists
```

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
