### PR TITLE
[FrameworkBundle] Fix broken mock

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerTraitTest.php
@@ -503,7 +503,11 @@ abstract class ControllerTraitTest extends TestCase
 
     public function testCreateForm()
     {
-        $form = new Form($this->createMock(FormConfigInterface::class));
+        $config = $this->createMock(FormConfigInterface::class);
+        $config->method('getInheritData')->willReturn(false);
+        $config->method('getName')->willReturn('');
+
+        $form = new Form($config);
 
         $formFactory = $this->createMock(FormFactoryInterface::class);
         $formFactory->expects($this->once())->method('create')->willReturn($form);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Backport from #42109. The mocked implementations of `getInheritData()` and `getName()` will currently return `null` which is something the real implementation would never do.