### PR TITLE
Remove `array_reverse` function in x-forwarded-for ip address list

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -2138,6 +2138,6 @@ class Request
         }
 
         // Now the IP chain contains only untrusted proxies and the client IP
-        return $clientIps ? array_reverse($clientIps) : [$firstTrustedIp];
+        return $clientIps ? $clientIps : [$firstTrustedIp];
     }
 }


### PR DESCRIPTION
Who suggest the "we should reverse x-forwarded-for ip addresses list" idea and who accepted this i don't know but this behavior is wrong. Client ip address is first one of x-forwarded-for ip address list and if there is a 1 or multiple gateway between client and server, gateway ip addresses are added last of array.

References:
- https://en.wikipedia.org/wiki/X-Forwarded-For
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For

| Q             | A
| ------------- | ---
| Branch?       | 5.4 for features / 4.4, 5.2 or 5.3 for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  |no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
