### PR TITLE
Add phpdoc for constraint

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/All.php
+++ b/src/Symfony/Component/Validator/Constraints/All.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Constraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
@@ -19,6 +21,9 @@ namespace Symfony\Component\Validator\Constraints;
  */
 class All extends Composite
 {
+    /**
+     * @var Constraint[]
+     */
     public $constraints = [];
 
     public function getDefaultOption()

--- a/src/Symfony/Component/Validator/Constraints/AtLeastOneOf.php
+++ b/src/Symfony/Component/Validator/Constraints/AtLeastOneOf.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Constraint;
+
 /**
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
@@ -25,9 +27,24 @@ class AtLeastOneOf extends Composite
         self::AT_LEAST_ONE_OF_ERROR => 'AT_LEAST_ONE_OF_ERROR',
     ];
 
+    /**
+     * @var Constraint[]
+     */
     public $constraints = [];
+
+    /**
+     * @var string
+     */
     public $message = 'This value should satisfy at least one of the following constraints:';
+
+    /**
+     * @var string
+     */
     public $messageCollection = 'Each element of this collection should satisfy its own set of constraints.';
+
+    /**
+     * @var bool
+     */
     public $includeInternalMessages = true;
 
     public function getDefaultOption()

--- a/src/Symfony/Component/Validator/Constraints/Bic.php
+++ b/src/Symfony/Component/Validator/Constraints/Bic.php
@@ -42,9 +42,24 @@ class Bic extends Constraint
         self::INVALID_CASE_ERROR => 'INVALID_CASE_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This is not a valid Business Identifier Code (BIC).';
+
+    /**
+     * @var string
+     */
     public $ibanMessage = 'This Business Identifier Code (BIC) is not associated with IBAN {{ iban }}.';
+
+    /**
+     * @var string|null
+     */
     public $iban;
+
+    /**
+     * @var string|PropertyPathInterface|null
+     */
     public $ibanPropertyPath;
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/Blank.php
+++ b/src/Symfony/Component/Validator/Constraints/Blank.php
@@ -28,6 +28,9 @@ class Blank extends Constraint
         self::NOT_BLANK_ERROR => 'NOT_BLANK_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be blank.';
 
     public function __construct(array $options = null, string $message = null, array $groups = null, $payload = null)

--- a/src/Symfony/Component/Validator/Constraints/CardScheme.php
+++ b/src/Symfony/Component/Validator/Constraints/CardScheme.php
@@ -46,7 +46,14 @@ class CardScheme extends Constraint
         self::INVALID_FORMAT_ERROR => 'INVALID_FORMAT_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'Unsupported card type or invalid card number.';
+
+    /**
+     * @var string|string[]
+     */
     public $schemes;
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/Choice.php
+++ b/src/Symfony/Component/Validator/Constraints/Choice.php
@@ -32,15 +32,54 @@ class Choice extends Constraint
         self::TOO_MANY_ERROR => 'TOO_MANY_ERROR',
     ];
 
+    /**
+     * @var array|null
+     */
     public $choices;
+
+    /**
+     * @var string|callable|null
+     */
     public $callback;
+
+    /**
+     * @var bool
+     */
     public $multiple = false;
+
+    /**
+     * @var bool
+     */
     public $strict = true;
+
+    /**
+     * @var int|null
+     */
     public $min;
+
+    /**
+     * @var int|null
+     */
     public $max;
+
+    /**
+     * @var string
+     */
     public $message = 'The value you selected is not a valid choice.';
+
+    /**
+     * @var string
+     */
     public $multipleMessage = 'One or more of the given values is invalid.';
+
+    /**
+     * @var string
+     */
     public $minMessage = 'You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.';
+
+    /**
+     * @var string
+     */
     public $maxMessage = 'You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.';
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -29,10 +29,29 @@ class Collection extends Composite
         self::NO_SUCH_FIELD_ERROR => 'NO_SUCH_FIELD_ERROR',
     ];
 
+    /**
+     * @var array
+     */
     public $fields = [];
+
+    /**
+     * @var bool
+     */
     public $allowExtraFields = false;
+
+    /**
+     * @var bool
+     */
     public $allowMissingFields = false;
+
+    /**
+     * @var string
+     */
     public $extraFieldsMessage = 'This field was not expected.';
+
+    /**
+     * @var string
+     */
     public $missingFieldsMessage = 'This field is missing.';
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/Count.php
+++ b/src/Symfony/Component/Validator/Constraints/Count.php
@@ -33,12 +33,39 @@ class Count extends Constraint
         self::NOT_DIVISIBLE_BY_ERROR => 'NOT_DIVISIBLE_BY_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $minMessage = 'This collection should contain {{ limit }} element or more.|This collection should contain {{ limit }} elements or more.';
+
+    /**
+     * @var string
+     */
     public $maxMessage = 'This collection should contain {{ limit }} element or less.|This collection should contain {{ limit }} elements or less.';
+
+    /**
+     * @var string
+     */
     public $exactMessage = 'This collection should contain exactly {{ limit }} element.|This collection should contain exactly {{ limit }} elements.';
+
+    /**
+     * @var string
+     */
     public $divisibleByMessage = 'The number of elements in this collection should be a multiple of {{ compared_value }}.';
+
+    /**
+     * @var int|null
+     */
     public $min;
+
+    /**
+     * @var int|null
+     */
     public $max;
+
+    /**
+     * @var int|null
+     */
     public $divisibleBy;
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/Country.php
+++ b/src/Symfony/Component/Validator/Constraints/Country.php
@@ -30,7 +30,14 @@ class Country extends Constraint
         self::NO_SUCH_COUNTRY_ERROR => 'NO_SUCH_COUNTRY_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value is not a valid country.';
+
+    /**
+     * @var bool
+     */
     public $alpha3 = false;
 
     public function __construct(

--- a/src/Symfony/Component/Validator/Constraints/Currency.php
+++ b/src/Symfony/Component/Validator/Constraints/Currency.php
@@ -31,6 +31,9 @@ class Currency extends Constraint
         self::NO_SUCH_CURRENCY_ERROR => 'NO_SUCH_CURRENCY_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value is not a valid currency.';
 
     public function __construct(array $options = null, string $message = null, array $groups = null, $payload = null)

--- a/src/Symfony/Component/Validator/Constraints/Date.php
+++ b/src/Symfony/Component/Validator/Constraints/Date.php
@@ -30,6 +30,9 @@ class Date extends Constraint
         self::INVALID_DATE_ERROR => 'INVALID_DATE_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value is not a valid date.';
 
     public function __construct(array $options = null, string $message = null, array $groups = null, $payload = null)

--- a/src/Symfony/Component/Validator/Constraints/DateTime.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTime.php
@@ -32,7 +32,14 @@ class DateTime extends Constraint
         self::INVALID_TIME_ERROR => 'INVALID_TIME_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $format = 'Y-m-d H:i:s';
+
+    /**
+     * @var string
+     */
     public $message = 'This value is not a valid datetime.';
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/DivisibleBy.php
+++ b/src/Symfony/Component/Validator/Constraints/DivisibleBy.php
@@ -26,5 +26,8 @@ class DivisibleBy extends AbstractComparison
         self::NOT_DIVISIBLE_BY => 'NOT_DIVISIBLE_BY',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be a multiple of {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -46,8 +46,19 @@ class Email extends Constraint
         self::VALIDATION_MODE_LOOSE,
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value is not a valid email address.';
+
+    /**
+     * @var string
+     */
     public $mode;
+
+    /**
+     * @var callable
+     */
     public $normalizer;
 
     public function __construct(

--- a/src/Symfony/Component/Validator/Constraints/EqualTo.php
+++ b/src/Symfony/Component/Validator/Constraints/EqualTo.php
@@ -27,5 +27,8 @@ class EqualTo extends AbstractComparison
         self::NOT_EQUAL_ERROR => 'NOT_EQUAL_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be equal to {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/Expression.php
+++ b/src/Symfony/Component/Validator/Constraints/Expression.php
@@ -32,8 +32,19 @@ class Expression extends Constraint
         self::EXPRESSION_FAILED_ERROR => 'EXPRESSION_FAILED_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value is not valid.';
+
+    /**
+     * @var string|ExpressionObject
+     */
     public $expression;
+
+    /**
+     * @var array
+     */
     public $values = [];
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntax.php
+++ b/src/Symfony/Component/Validator/Constraints/ExpressionLanguageSyntax.php
@@ -28,8 +28,19 @@ class ExpressionLanguageSyntax extends Constraint
         self::EXPRESSION_LANGUAGE_SYNTAX_ERROR => 'EXPRESSION_LANGUAGE_SYNTAX_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be a valid expression.';
+
+    /**
+     * @var string
+     */
     public $service;
+
+    /**
+     * @var array
+     */
     public $allowedVariables;
 
     public function __construct(array $options = null, string $message = null, string $service = null, array $allowedVariables = null, array $groups = null, $payload = null)

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -41,21 +41,79 @@ class File extends Constraint
         self::INVALID_MIME_TYPE_ERROR => 'INVALID_MIME_TYPE_ERROR',
     ];
 
+    /**
+     * @var bool|null
+     */
     public $binaryFormat;
+
+    /**
+     * @var string|string[]
+     */
     public $mimeTypes = [];
+
+    /**
+     * @var string
+     */
     public $notFoundMessage = 'The file could not be found.';
+
+    /**
+     * @var string
+     */
     public $notReadableMessage = 'The file is not readable.';
+
+    /**
+     * @var string
+     */
     public $maxSizeMessage = 'The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.';
+
+    /**
+     * @var string
+     */
     public $mimeTypesMessage = 'The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.';
+
+    /**
+     * @var string
+     */
     public $disallowEmptyMessage = 'An empty file is not allowed.';
 
+    /**
+     * @var string
+     */
     public $uploadIniSizeErrorMessage = 'The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.';
+
+    /**
+     * @var string
+     */
     public $uploadFormSizeErrorMessage = 'The file is too large.';
+
+    /**
+     * @var string
+     */
     public $uploadPartialErrorMessage = 'The file was only partially uploaded.';
+
+    /**
+     * @var string
+     */
     public $uploadNoFileErrorMessage = 'No file was uploaded.';
+
+    /**
+     * @var string
+     */
     public $uploadNoTmpDirErrorMessage = 'No temporary folder was configured in php.ini.';
+
+    /**
+     * @var string
+     */
     public $uploadCantWriteErrorMessage = 'Cannot write temporary file to disk.';
+
+    /**
+     * @var string
+     */
     public $uploadExtensionErrorMessage = 'A PHP extension caused the upload to fail.';
+
+    /**
+     * @var string
+     */
     public $uploadErrorMessage = 'The file could not be uploaded.';
 
     protected $maxSize;

--- a/src/Symfony/Component/Validator/Constraints/GreaterThan.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThan.php
@@ -27,5 +27,8 @@ class GreaterThan extends AbstractComparison
         self::TOO_LOW_ERROR => 'TOO_LOW_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be greater than {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqual.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqual.php
@@ -27,5 +27,8 @@ class GreaterThanOrEqual extends AbstractComparison
         self::TOO_LOW_ERROR => 'TOO_LOW_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be greater than or equal to {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/Hostname.php
+++ b/src/Symfony/Component/Validator/Constraints/Hostname.php
@@ -28,7 +28,14 @@ class Hostname extends Constraint
         self::INVALID_HOSTNAME_ERROR => 'INVALID_HOSTNAME_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value is not a valid hostname.';
+
+    /**
+     * @var bool
+     */
     public $requireTld = true;
 
     public function __construct(

--- a/src/Symfony/Component/Validator/Constraints/Iban.php
+++ b/src/Symfony/Component/Validator/Constraints/Iban.php
@@ -38,6 +38,9 @@ class Iban extends Constraint
         self::NOT_SUPPORTED_COUNTRY_CODE_ERROR => 'NOT_SUPPORTED_COUNTRY_CODE_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This is not a valid International Bank Account Number (IBAN).';
 
     public function __construct(array $options = null, string $message = null, array $groups = null, $payload = null)

--- a/src/Symfony/Component/Validator/Constraints/IdenticalTo.php
+++ b/src/Symfony/Component/Validator/Constraints/IdenticalTo.php
@@ -27,5 +27,8 @@ class IdenticalTo extends AbstractComparison
         self::NOT_IDENTICAL_ERROR => 'NOT_IDENTICAL_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be identical to {{ compared_value_type }} {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/Image.php
+++ b/src/Symfony/Component/Validator/Constraints/Image.php
@@ -58,34 +58,140 @@ class Image extends File
         self::CORRUPTED_IMAGE_ERROR => 'CORRUPTED_IMAGE_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $mimeTypes = 'image/*';
+
+    /**
+     * @var int
+     */
     public $minWidth;
+
+    /**
+     * @var int
+     */
     public $maxWidth;
+
+    /**
+     * @var int
+     */
     public $maxHeight;
+
+    /**
+     * @var int
+     */
     public $minHeight;
+
+    /**
+     * @var float|int
+     */
     public $maxRatio;
+
+    /**
+     * @var float|int
+     */
     public $minRatio;
+
+    /**
+     * @var float|int
+     */
     public $minPixels;
+
+    /**
+     * @var float|int
+     */
     public $maxPixels;
+
+    /**
+     * @var bool
+     */
     public $allowSquare = true;
+
+    /**
+     * @var bool
+     */
     public $allowLandscape = true;
+
+    /**
+     * @var bool
+     */
     public $allowPortrait = true;
+
+    /**
+     * @var bool
+     */
     public $detectCorrupted = false;
 
     // The constant for a wrong MIME type is taken from the parent class.
+    /**
+     * @var string
+     */
     public $mimeTypesMessage = 'This file is not a valid image.';
+
+    /**
+     * @var string
+     */
     public $sizeNotDetectedMessage = 'The size of the image could not be detected.';
+
+    /**
+     * @var string
+     */
     public $maxWidthMessage = 'The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px.';
+
+    /**
+     * @var string
+     */
     public $minWidthMessage = 'The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.';
+
+    /**
+     * @var string
+     */
     public $maxHeightMessage = 'The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.';
+
+    /**
+     * @var string
+     */
     public $minHeightMessage = 'The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.';
+
+    /**
+     * @var string
+     */
     public $minPixelsMessage = 'The image has too few pixels ({{ pixels }} pixels). Minimum amount expected is {{ min_pixels }} pixels.';
+
+    /**
+     * @var string
+     */
     public $maxPixelsMessage = 'The image has too many pixels ({{ pixels }} pixels). Maximum amount expected is {{ max_pixels }} pixels.';
+
+    /**
+     * @var string
+     */
     public $maxRatioMessage = 'The image ratio is too big ({{ ratio }}). Allowed maximum ratio is {{ max_ratio }}.';
+
+    /**
+     * @var string
+     */
     public $minRatioMessage = 'The image ratio is too small ({{ ratio }}). Minimum ratio expected is {{ min_ratio }}.';
+
+    /**
+     * @var string
+     */
     public $allowSquareMessage = 'The image is square ({{ width }}x{{ height }}px). Square images are not allowed.';
+
+    /**
+     * @var string
+     */
     public $allowLandscapeMessage = 'The image is landscape oriented ({{ width }}x{{ height }}px). Landscape oriented images are not allowed.';
+
+    /**
+     * @var string
+     */
     public $allowPortraitMessage = 'The image is portrait oriented ({{ width }}x{{ height }}px). Portrait oriented images are not allowed.';
+
+    /**
+     * @var string
+     */
     public $corruptedMessage = 'The image file is corrupted.';
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/Ip.php
+++ b/src/Symfony/Component/Validator/Constraints/Ip.php
@@ -70,10 +70,19 @@ class Ip extends Constraint
         self::INVALID_IP_ERROR => 'INVALID_IP_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $version = self::V4;
 
+    /**
+     * @var string
+     */
     public $message = 'This is not a valid IP address.';
 
+    /**
+     * @var callable
+     */
     public $normalizer;
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/IsFalse.php
+++ b/src/Symfony/Component/Validator/Constraints/IsFalse.php
@@ -28,6 +28,9 @@ class IsFalse extends Constraint
         self::NOT_FALSE_ERROR => 'NOT_FALSE_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be false.';
 
     public function __construct(array $options = null, string $message = null, array $groups = null, $payload = null)

--- a/src/Symfony/Component/Validator/Constraints/IsNull.php
+++ b/src/Symfony/Component/Validator/Constraints/IsNull.php
@@ -28,6 +28,9 @@ class IsNull extends Constraint
         self::NOT_NULL_ERROR => 'NOT_NULL_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be null.';
 
     public function __construct(array $options = null, string $message = null, array $groups = null, $payload = null)

--- a/src/Symfony/Component/Validator/Constraints/IsTrue.php
+++ b/src/Symfony/Component/Validator/Constraints/IsTrue.php
@@ -28,6 +28,9 @@ class IsTrue extends Constraint
         self::NOT_TRUE_ERROR => 'NOT_TRUE_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be true.';
 
     public function __construct(array $options = null, string $message = null, array $groups = null, $payload = null)

--- a/src/Symfony/Component/Validator/Constraints/Isbn.php
+++ b/src/Symfony/Component/Validator/Constraints/Isbn.php
@@ -41,10 +41,29 @@ class Isbn extends Constraint
         self::TYPE_NOT_RECOGNIZED_ERROR => 'TYPE_NOT_RECOGNIZED_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $isbn10Message = 'This value is not a valid ISBN-10.';
+
+    /**
+     * @var string
+     */
     public $isbn13Message = 'This value is not a valid ISBN-13.';
+
+    /**
+     * @var string
+     */
     public $bothIsbnMessage = 'This value is neither a valid ISBN-10 nor a valid ISBN-13.';
+
+    /**
+     * @var string|null
+     */
     public $type;
+
+    /**
+     * @var string|null
+     */
     public $message;
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/Isin.php
+++ b/src/Symfony/Component/Validator/Constraints/Isin.php
@@ -35,6 +35,9 @@ class Isin extends Constraint
         self::INVALID_CHECKSUM_ERROR => 'INVALID_CHECKSUM_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value is not a valid International Securities Identification Number (ISIN).';
 
     public function __construct(array $options = null, string $message = null, array $groups = null, $payload = null)

--- a/src/Symfony/Component/Validator/Constraints/Issn.php
+++ b/src/Symfony/Component/Validator/Constraints/Issn.php
@@ -39,8 +39,19 @@ class Issn extends Constraint
         self::CHECKSUM_FAILED_ERROR => 'CHECKSUM_FAILED_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value is not a valid ISSN.';
+
+    /**
+     * @var bool
+     */
     public $caseSensitive = false;
+
+    /**
+     * @var bool
+     */
     public $requireHyphen = false;
 
     public function __construct(

--- a/src/Symfony/Component/Validator/Constraints/Json.php
+++ b/src/Symfony/Component/Validator/Constraints/Json.php
@@ -28,6 +28,9 @@ class Json extends Constraint
         self::INVALID_JSON_ERROR => 'INVALID_JSON_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be valid JSON.';
 
     public function __construct(array $options = null, string $message = null, array $groups = null, $payload = null)

--- a/src/Symfony/Component/Validator/Constraints/Language.php
+++ b/src/Symfony/Component/Validator/Constraints/Language.php
@@ -30,7 +30,14 @@ class Language extends Constraint
         self::NO_SUCH_LANGUAGE_ERROR => 'NO_SUCH_LANGUAGE_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value is not a valid language.';
+
+    /**
+     * @var bool
+     */
     public $alpha3 = false;
 
     public function __construct(

--- a/src/Symfony/Component/Validator/Constraints/Length.php
+++ b/src/Symfony/Component/Validator/Constraints/Length.php
@@ -34,14 +34,49 @@ class Length extends Constraint
         self::INVALID_CHARACTERS_ERROR => 'INVALID_CHARACTERS_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $maxMessage = 'This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.';
+
+    /**
+     * @var string
+     */
     public $minMessage = 'This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.';
+
+    /**
+     * @var string
+     */
     public $exactMessage = 'This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.';
+
+    /**
+     * @var string
+     */
     public $charsetMessage = 'This value does not match the expected {{ charset }} charset.';
+
+    /**
+     * @var int|null
+     */
     public $max;
+
+    /**
+     * @var int|null
+     */
     public $min;
+
+    /**
+     * @var string
+     */
     public $charset = 'UTF-8';
+
+    /**
+     * @var callable|null
+     */
     public $normalizer;
+
+    /**
+     * @var bool
+     */
     public $allowEmptyString = false;
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/LessThan.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThan.php
@@ -27,5 +27,8 @@ class LessThan extends AbstractComparison
         self::TOO_HIGH_ERROR => 'TOO_HIGH_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be less than {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/LessThanOrEqual.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThanOrEqual.php
@@ -27,5 +27,8 @@ class LessThanOrEqual extends AbstractComparison
         self::TOO_HIGH_ERROR => 'TOO_HIGH_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be less than or equal to {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/Locale.php
+++ b/src/Symfony/Component/Validator/Constraints/Locale.php
@@ -30,7 +30,14 @@ class Locale extends Constraint
         self::NO_SUCH_LOCALE_ERROR => 'NO_SUCH_LOCALE_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value is not a valid locale.';
+
+    /**
+     * @var bool
+     */
     public $canonicalize = true;
 
     public function __construct(

--- a/src/Symfony/Component/Validator/Constraints/Luhn.php
+++ b/src/Symfony/Component/Validator/Constraints/Luhn.php
@@ -34,6 +34,9 @@ class Luhn extends Constraint
         self::CHECKSUM_FAILED_ERROR => 'CHECKSUM_FAILED_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'Invalid card number.';
 
     public function __construct(

--- a/src/Symfony/Component/Validator/Constraints/Negative.php
+++ b/src/Symfony/Component/Validator/Constraints/Negative.php
@@ -22,5 +22,8 @@ class Negative extends LessThan
 {
     use ZeroComparisonConstraintTrait;
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be negative.';
 }

--- a/src/Symfony/Component/Validator/Constraints/NegativeOrZero.php
+++ b/src/Symfony/Component/Validator/Constraints/NegativeOrZero.php
@@ -22,5 +22,8 @@ class NegativeOrZero extends LessThanOrEqual
 {
     use ZeroComparisonConstraintTrait;
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be either negative or zero.';
 }

--- a/src/Symfony/Component/Validator/Constraints/NotBlank.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlank.php
@@ -30,8 +30,19 @@ class NotBlank extends Constraint
         self::IS_BLANK_ERROR => 'IS_BLANK_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should not be blank.';
+
+    /**
+     * @var bool
+     */
     public $allowNull = false;
+
+    /**
+     * @var callable|null
+     */
     public $normalizer;
 
     public function __construct(array $options = null, string $message = null, bool $allowNull = null, callable $normalizer = null, array $groups = null, $payload = null)

--- a/src/Symfony/Component/Validator/Constraints/NotCompromisedPassword.php
+++ b/src/Symfony/Component/Validator/Constraints/NotCompromisedPassword.php
@@ -28,8 +28,19 @@ class NotCompromisedPassword extends Constraint
 
     protected static $errorNames = [self::COMPROMISED_PASSWORD_ERROR => 'COMPROMISED_PASSWORD_ERROR'];
 
+    /**
+     * @var string
+     */
     public $message = 'This password has been leaked in a data breach, it must not be used. Please use another password.';
+
+    /**
+     * @var int
+     */
     public $threshold = 1;
+
+    /**
+     * @var bool
+     */
     public $skipOnError = false;
 
     public function __construct(

--- a/src/Symfony/Component/Validator/Constraints/NotEqualTo.php
+++ b/src/Symfony/Component/Validator/Constraints/NotEqualTo.php
@@ -27,5 +27,8 @@ class NotEqualTo extends AbstractComparison
         self::IS_EQUAL_ERROR => 'IS_EQUAL_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should not be equal to {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/NotIdenticalTo.php
+++ b/src/Symfony/Component/Validator/Constraints/NotIdenticalTo.php
@@ -27,5 +27,8 @@ class NotIdenticalTo extends AbstractComparison
         self::IS_IDENTICAL_ERROR => 'IS_IDENTICAL_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should not be identical to {{ compared_value_type }} {{ compared_value }}.';
 }

--- a/src/Symfony/Component/Validator/Constraints/NotNull.php
+++ b/src/Symfony/Component/Validator/Constraints/NotNull.php
@@ -28,6 +28,9 @@ class NotNull extends Constraint
         self::IS_NULL_ERROR => 'IS_NULL_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should not be null.';
 
     public function __construct(array $options = null, string $message = null, array $groups = null, $payload = null)

--- a/src/Symfony/Component/Validator/Constraints/Positive.php
+++ b/src/Symfony/Component/Validator/Constraints/Positive.php
@@ -22,5 +22,8 @@ class Positive extends GreaterThan
 {
     use ZeroComparisonConstraintTrait;
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be positive.';
 }

--- a/src/Symfony/Component/Validator/Constraints/PositiveOrZero.php
+++ b/src/Symfony/Component/Validator/Constraints/PositiveOrZero.php
@@ -22,5 +22,8 @@ class PositiveOrZero extends GreaterThanOrEqual
 {
     use ZeroComparisonConstraintTrait;
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be either positive or zero.';
 }

--- a/src/Symfony/Component/Validator/Constraints/Range.php
+++ b/src/Symfony/Component/Validator/Constraints/Range.php
@@ -39,14 +39,49 @@ class Range extends Constraint
         self::TOO_LOW_ERROR => 'TOO_LOW_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $notInRangeMessage = 'This value should be between {{ min }} and {{ max }}.';
+
+    /**
+     * @var string
+     */
     public $minMessage = 'This value should be {{ limit }} or more.';
+
+    /**
+     * @var string
+     */
     public $maxMessage = 'This value should be {{ limit }} or less.';
+
+    /**
+     * @var string
+     */
     public $invalidMessage = 'This value should be a valid number.';
+
+    /**
+     * @var string
+     */
     public $invalidDateTimeMessage = 'This value should be a valid datetime.';
+
+    /**
+     * @var int|null
+     */
     public $min;
+
+    /**
+     * @var string|PropertyPathInterface|null
+     */
     public $minPropertyPath;
+
+    /**
+     * @var int|null
+     */
     public $max;
+
+    /**
+     * @var string|PropertyPathInterface|null
+     */
     public $maxPropertyPath;
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -29,10 +29,29 @@ class Regex extends Constraint
         self::REGEX_FAILED_ERROR => 'REGEX_FAILED_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value is not valid.';
+
+    /**
+     * @var string
+     */
     public $pattern;
+
+    /**
+     * @var string|null
+     */
     public $htmlPattern;
+
+    /**
+     * @var bool
+     */
     public $match = true;
+
+    /**
+     * @var callable|null
+     */
     public $normalizer;
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/Sequentially.php
+++ b/src/Symfony/Component/Validator/Constraints/Sequentially.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\Constraint;
+
 /**
  * Use this constraint to sequentially validate nested constraints.
  * Validation for the nested constraints collection will stop at first violation.
@@ -22,6 +24,9 @@ namespace Symfony\Component\Validator\Constraints;
  */
 class Sequentially extends Composite
 {
+    /**
+     * @var Constraint[]
+     */
     public $constraints = [];
 
     public function getDefaultOption()

--- a/src/Symfony/Component/Validator/Constraints/Time.php
+++ b/src/Symfony/Component/Validator/Constraints/Time.php
@@ -30,6 +30,9 @@ class Time extends Constraint
         self::INVALID_TIME_ERROR => 'INVALID_TIME_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value is not a valid time.';
 
     public function __construct(

--- a/src/Symfony/Component/Validator/Constraints/Timezone.php
+++ b/src/Symfony/Component/Validator/Constraints/Timezone.php
@@ -29,9 +29,24 @@ class Timezone extends Constraint
     public const TIMEZONE_IDENTIFIER_IN_COUNTRY_ERROR = 'c4a22222-dc92-4fc0-abb0-d95b268c7d0b';
     public const TIMEZONE_IDENTIFIER_INTL_ERROR = '45863c26-88dc-41ba-bf53-c73bd1f7e90d';
 
+    /**
+     * @var int
+     */
     public $zone = \DateTimeZone::ALL;
+
+    /**
+     * @var string
+     */
     public $countryCode;
+
+    /**
+     * @var bool
+     */
     public $intlCompatible = false;
+
+    /**
+     * @var string
+     */
     public $message = 'This value is not a valid timezone.';
 
     protected static $errorNames = [

--- a/src/Symfony/Component/Validator/Constraints/Traverse.php
+++ b/src/Symfony/Component/Validator/Constraints/Traverse.php
@@ -22,6 +22,9 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class Traverse extends Constraint
 {
+    /**
+     * @var bool
+     */
     public $traverse = true;
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/Type.php
+++ b/src/Symfony/Component/Validator/Constraints/Type.php
@@ -28,7 +28,14 @@ class Type extends Constraint
         self::INVALID_TYPE_ERROR => 'INVALID_TYPE_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value should be of type {{ type }}.';
+
+    /**
+     * @var string|string[]
+     */
     public $type;
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/Ulid.php
+++ b/src/Symfony/Component/Validator/Constraints/Ulid.php
@@ -33,6 +33,9 @@ class Ulid extends Constraint
         self::TOO_LARGE_ERROR => 'TOO_LARGE_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This is not a valid ULID.';
 
     public function __construct(

--- a/src/Symfony/Component/Validator/Constraints/Unique.php
+++ b/src/Symfony/Component/Validator/Constraints/Unique.php
@@ -29,7 +29,14 @@ class Unique extends Constraint
         self::IS_NOT_UNIQUE => 'IS_NOT_UNIQUE',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This collection should contain only unique elements.';
+
+    /**
+     * @var callable|null
+     */
     public $normalizer;
 
     public function __construct(

--- a/src/Symfony/Component/Validator/Constraints/Url.php
+++ b/src/Symfony/Component/Validator/Constraints/Url.php
@@ -29,9 +29,24 @@ class Url extends Constraint
         self::INVALID_URL_ERROR => 'INVALID_URL_ERROR',
     ];
 
+    /**
+     * @var string
+     */
     public $message = 'This value is not a valid URL.';
+
+    /**
+     * @var string[]
+     */
     public $protocols = ['http', 'https'];
+
+    /**
+     * @var bool
+     */
     public $relativeProtocol = false;
+
+    /**
+     * @var callable|null
+     */
     public $normalizer;
 
     public function __construct(

--- a/src/Symfony/Component/Validator/Constraints/Uuid.php
+++ b/src/Symfony/Component/Validator/Constraints/Uuid.php
@@ -81,6 +81,9 @@ class Uuid extends Constraint
      */
     public $versions = self::ALL_VERSIONS;
 
+    /**
+     * @var callable|null
+     */
     public $normalizer;
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/Valid.php
+++ b/src/Symfony/Component/Validator/Constraints/Valid.php
@@ -22,6 +22,9 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Valid extends Constraint
 {
+    /**
+     * @var bool
+     */
     public $traverse = true;
 
     public function __get(string $option)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

When extending some constraint and overriding some property, it's not always simple to know what can be passed to the properties and when it can be null. Those properties should have phpdoc to define their type.

Plus it avoid a psalm error `NonInvariantDocblockPropertyType` for the developer which use a more specific phpdoc (because atm, properties are considered as mixed).

And, it will help the typing for PHP8 on the branch 6.0 @nicolas-grekas :)