### PR TITLE
[Finder] Make Comparator immutable

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -6,6 +6,12 @@ Cache
 
  * Deprecate `DoctrineProvider` because this class has been added to the `doctrine/cache` package`
 
+Finder
+------
+
+ * Deprecate `Comparator::setTarget()` and `Comparator::setOperator()`
+ * Add a constructor to `Comparator` that allows setting target and operator
+
 FrameworkBundle
 ---------------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -60,6 +60,12 @@ EventDispatcher
 
  * Removed `LegacyEventDispatcherProxy`. Use the event dispatcher without the proxy.
 
+Finder
+------
+
+ * Remove `Comparator::setTarget()` and `Comparator::setOperator()`
+ * The `$target` parameter of `Comparator::__construct()` is now mandatory
+
 Form
 ----
 

--- a/src/Symfony/Component/Finder/CHANGELOG.md
+++ b/src/Symfony/Component/Finder/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.4.0
+-----
+
+ * Deprecate `Comparator::setTarget()` and `Comparator::setOperator()`
+ * Add a constructor to `Comparator` that allows setting target and operator
+
 5.0.0
 -----
 

--- a/src/Symfony/Component/Finder/Comparator/Comparator.php
+++ b/src/Symfony/Component/Finder/Comparator/Comparator.php
@@ -12,14 +12,22 @@
 namespace Symfony\Component\Finder\Comparator;
 
 /**
- * Comparator.
- *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class Comparator
 {
     private $target;
     private $operator = '==';
+
+    public function __construct(string $target = null, string $operator = '==')
+    {
+        if (null === $target) {
+            trigger_deprecation('symfony/finder', '5.4', 'Constructing a "%s" without setting "$target" is deprecated.', __CLASS__);
+        }
+
+        $this->target = $target;
+        $this->doSetOperator($operator);
+    }
 
     /**
      * Gets the target value.
@@ -28,11 +36,20 @@ class Comparator
      */
     public function getTarget()
     {
+        if (null === $this->target) {
+            trigger_deprecation('symfony/finder', '5.4', 'Calling "%s" without initializing the target is deprecated.', __METHOD__);
+        }
+
         return $this->target;
     }
 
+    /**
+     * @deprecated set the target via the constructor instead
+     */
     public function setTarget(string $target)
     {
+        trigger_deprecation('symfony/finder', '5.4', '"%s" is deprecated. Set the target via the constructor instead.', __METHOD__);
+
         $this->target = $target;
     }
 
@@ -50,18 +67,14 @@ class Comparator
      * Sets the comparison operator.
      *
      * @throws \InvalidArgumentException
+     *
+     * @deprecated set the operator via the constructor instead
      */
     public function setOperator(string $operator)
     {
-        if ('' === $operator) {
-            $operator = '==';
-        }
+        trigger_deprecation('symfony/finder', '5.4', '"%s" is deprecated. Set the operator via the constructor instead.', __METHOD__);
 
-        if (!\in_array($operator, ['>', '<', '>=', '<=', '==', '!='])) {
-            throw new \InvalidArgumentException(sprintf('Invalid operator "%s".', $operator));
-        }
-
-        $this->operator = $operator;
+        $this->doSetOperator('' === $operator ? '==' : $operator);
     }
 
     /**
@@ -73,6 +86,10 @@ class Comparator
      */
     public function test($test)
     {
+        if (null === $this->target) {
+            trigger_deprecation('symfony/finder', '5.4', 'Calling "%s" without initializing the target is deprecated.', __METHOD__);
+        }
+
         switch ($this->operator) {
             case '>':
                 return $test > $this->target;
@@ -87,5 +104,14 @@ class Comparator
         }
 
         return $test == $this->target;
+    }
+
+    private function doSetOperator(string $operator): void
+    {
+        if (!\in_array($operator, ['>', '<', '>=', '<=', '==', '!='])) {
+            throw new \InvalidArgumentException(sprintf('Invalid operator "%s".', $operator));
+        }
+
+        $this->operator = $operator;
     }
 }

--- a/src/Symfony/Component/Finder/Comparator/DateComparator.php
+++ b/src/Symfony/Component/Finder/Comparator/DateComparator.php
@@ -45,7 +45,6 @@ class DateComparator extends Comparator
             $operator = '<';
         }
 
-        $this->setOperator($operator);
-        $this->setTarget($target);
+        parent::__construct($target, $operator);
     }
 }

--- a/src/Symfony/Component/Finder/Comparator/NumberComparator.php
+++ b/src/Symfony/Component/Finder/Comparator/NumberComparator.php
@@ -73,7 +73,6 @@ class NumberComparator extends Comparator
             }
         }
 
-        $this->setTarget($target);
-        $this->setOperator($matches[1] ?? '==');
+        parent::__construct($target, $matches[1] ?: '==');
     }
 }

--- a/src/Symfony/Component/Finder/Tests/Comparator/ComparatorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Comparator/ComparatorTest.php
@@ -12,13 +12,21 @@
 namespace Symfony\Component\Finder\Tests\Comparator;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Finder\Comparator\Comparator;
 
 class ComparatorTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
+    /**
+     * @group legacy
+     */
     public function testGetSetOperator()
     {
-        $comparator = new Comparator();
+        $comparator = new Comparator('some target');
+
+        $this->expectDeprecation('Since symfony/finder 5.4: "Symfony\Component\Finder\Comparator\Comparator::setOperator" is deprecated. Set the operator via the constructor instead.');
         $comparator->setOperator('>');
         $this->assertEquals('>', $comparator->getOperator(), '->getOperator() returns the current operator');
     }
@@ -32,9 +40,16 @@ class ComparatorTest extends TestCase
         $comparator->setOperator('foo');
     }
 
+
+    /**
+     * @group legacy
+     */
     public function testGetSetTarget()
     {
+        $this->expectDeprecation('Since symfony/finder 5.4: Constructing a "Symfony\Component\Finder\Comparator\Comparator" without setting "$target" is deprecated.');
         $comparator = new Comparator();
+
+        $this->expectDeprecation('Since symfony/finder 5.4: "Symfony\Component\Finder\Comparator\Comparator::setTarget" is deprecated. Set the target via the constructor instead.');
         $comparator->setTarget(8);
         $this->assertEquals(8, $comparator->getTarget(), '->getTarget() returns the target');
     }
@@ -44,9 +59,10 @@ class ComparatorTest extends TestCase
      */
     public function testTestSucceeds(string $operator, string $target, string $testedValue)
     {
-        $c = new Comparator();
-        $c->setOperator($operator);
-        $c->setTarget($target);
+        $c = new Comparator($target, $operator);
+
+        $this->assertSame($target, $c->getTarget());
+        $this->assertSame($operator, $c->getOperator());
 
         $this->assertTrue($c->test($testedValue));
     }

--- a/src/Symfony/Component/Finder/composer.json
+++ b/src/Symfony/Component/Finder/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5"
+        "php": ">=7.2.5",
+        "symfony/deprecation-contracts": "^2.1|^3"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Finder\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The `Comparator` class exposes setters for its properties `$target` and `$operator`. I'd consider this design to be flawed for the following reasons:

* The `$target` property should be set before executing the main method `test()` on an instance of that class. However, we never make sure that this actually happens.
* The two child classes `DateComparator` and `NumberComparator` set both properties via their constructors, after parsing them from a string. It's a bit odd to allow those properties to be overridden via the setters because all validation happens inside those constructors.

This PR proposes to remove those setters and introduce a constructor instead that allows to set both properties once.