### PR TITLE
[RateLimiter] Remove redundant properties

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
@@ -29,19 +29,12 @@ final class FixedWindowLimiter implements LimiterInterface
 {
     use ResetLimiterTrait;
 
-    private $id;
     private $limit;
-    private $storage;
 
     /**
      * @var int seconds
      */
     private $interval;
-
-    /**
-     * @var LockInterface
-     */
-    private $lock;
 
     public function __construct(string $id, int $limit, \DateInterval $interval, StorageInterface $storage, LockInterface $lock = null)
     {

--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindowLimiter.php
@@ -37,19 +37,12 @@ final class SlidingWindowLimiter implements LimiterInterface
 {
     use ResetLimiterTrait;
 
-    private $id;
     private $limit;
-    private $storage;
 
     /**
      * @var int seconds
      */
     private $interval;
-
-    /**
-     * @var LockInterface
-     */
-    private $lock;
 
     public function __construct(string $id, int $limit, \DateInterval $interval, StorageInterface $storage, LockInterface $lock = null)
     {

--- a/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/TokenBucketLimiter.php
@@ -28,15 +28,8 @@ final class TokenBucketLimiter implements LimiterInterface
 {
     use ResetLimiterTrait;
 
-    private $id;
     private $maxBurst;
     private $rate;
-    private $storage;
-
-    /**
-     * @var LockInterface
-     */
-    private $lock;
 
     public function __construct(string $id, int $maxBurst, Rate $rate, StorageInterface $storage, LockInterface $lock = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Backported from #42140: Those three classes use `ResetLimiterTrait` and redeclare the properties that the trait already provides. This PR removes that redundancy.