### PR TITLE
[Translation] Extract translatable content on twig set

### DIFF
--- a/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNodeVisitor.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/TranslationNodeVisitor.php
@@ -69,12 +69,10 @@ final class TranslationNodeVisitor extends AbstractNodeVisitor
                 $this->getReadDomainFromArguments($node->getNode('arguments'), 1),
             ];
         } elseif (
-            $node instanceof FilterExpression &&
-            'trans' === $node->getNode('filter')->getAttribute('value') &&
-            $node->getNode('node') instanceof FunctionExpression &&
-            't' === $node->getNode('node')->getAttribute('name')
+            $node instanceof FunctionExpression &&
+            't' === $node->getAttribute('name')
         ) {
-            $nodeArguments = $node->getNode('node')->getNode('arguments');
+            $nodeArguments = $node->getNode('arguments');
 
             if ($nodeArguments->getIterator()->current() instanceof ConstantExpression) {
                 $this->messages[] = [

--- a/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Translation/TwigExtractorTest.php
@@ -66,6 +66,7 @@ class TwigExtractorTest extends TestCase
             ['{% set foo = "new key" | trans %}', ['new key' => 'messages']],
             ['{{ 1 ? "new key" | trans : "another key" | trans }}', ['new key' => 'messages', 'another key' => 'messages']],
             ['{{ t("new key") | trans() }}', ['new key' => 'messages']],
+            ['{% set foo = t("new key") %}', ['new key' => 'messages']],
             ['{{ t("new key", {}, "domain") | trans() }}', ['new key' => 'domain']],
             ['{{ 1 ? t("new key") | trans : t("another key") | trans }}', ['new key' => 'messages', 'another key' => 'messages']],
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

When extracting messages from Twig templates, the extractor was only considering the `t()` function when it was being immediately filtered by the `trans` filter. Instead it should be happening when the message object is created.