### PR TITLE
[Security] Fix persistent remember me being only usable once

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php
@@ -89,13 +89,12 @@ final class PersistentRememberMeHandler extends AbstractRememberMeHandler
         // if a token was regenerated less than a minute ago, there is no need to regenerate it
         // if multiple concurrent requests reauthenticate a user we do not want to update the token several times
         if ($persistentToken->getLastUsed()->getTimestamp() + 60 < time()) {
-            $tokenValue = base64_encode(random_bytes(64));
-            $tokenValueHash = $this->generateHash($tokenValue);
+            $tokenValue = $this->generateHash(base64_encode(random_bytes(64)));
             $tokenLastUsed = new \DateTime();
             if ($this->tokenVerifier) {
-                $this->tokenVerifier->updateExistingToken($persistentToken, $tokenValueHash, $tokenLastUsed);
+                $this->tokenVerifier->updateExistingToken($persistentToken, $tokenValue, $tokenLastUsed);
             }
-            $this->tokenProvider->updateToken($series, $tokenValueHash, $tokenLastUsed);
+            $this->tokenProvider->updateToken($series, $tokenValue, $tokenLastUsed);
         }
 
         $this->createCookie($rememberMeDetails->withValue($series.':'.$tokenValue));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        |

Quite the head-scratching debugging session to find this one 😄 

It appears the new persistent remember me was broken in this way from the very first iteration https://github.com/symfony/symfony/blame/a942b5f6849810d45aab163c40381a16d5e8dbd9~1/src/Symfony/Component/Security/Http/RememberMe/PersistentRememberMeHandler.php#L77-L80

Essentially what happens is the first time (on login) you get a cookie with a hashed token, which is also stored in token provider. Then when session drops off, the handler recreates a new cookie but with the new un-hashed token. However the new hashed token is persisted, so when the session drops off again your cookie cannot be verified anymore, and you get logged out.

The fix is simply to correctly create new cookies with the hashed token.

Please be aware that if trying to repro this, due to line 91 clearing the session cookie isn't enough, you need to also wait a minute to really trigger a new token to be created.