### PR TITLE
[Messenger] [Redis] Prepare turning `delete_after_ack` to `true` in 6.0

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -23,6 +23,12 @@ HttpKernel
 
  * Deprecate `AbstractTestSessionListener::getSession` inject a session in the request instead
 
+Messenger
+---------
+
+ * Deprecate not setting the `delete_after_ack` config option (or DSN parameter) using the Redis transport,
+   its default value will change to `true` in 6.0
+
 SecurityBundle
 --------------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -152,6 +152,7 @@ Messenger
  * The signature of method `RetryStrategyInterface::getWaitingTime()` has been updated to `RetryStrategyInterface::getWaitingTime(Envelope $message, \Throwable $throwable = null)`.
  * Removed the `prefetch_count` parameter in the AMQP bridge.
  * Removed the use of TLS option for Redis Bridge, use `rediss://127.0.0.1` instead of `redis://127.0.0.1?tls=1`
+ * The `delete_after_ack` config option of the Redis transport now defaults to `true`
 
 Mime
 ----

--- a/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Deprecate not setting the `delete_after_ack` config option (or DSN parameter),
+   its default value will change to `true` in 6.0
+
 5.3
 ---
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisExtIntegrationTest.php
@@ -33,7 +33,7 @@ class RedisExtIntegrationTest extends TestCase
 
         try {
             $this->redis = new \Redis();
-            $this->connection = Connection::fromDsn(getenv('MESSENGER_REDIS_DSN'), [], $this->redis);
+            $this->connection = Connection::fromDsn(getenv('MESSENGER_REDIS_DSN'), ['delete_after_ack' => true], $this->redis);
             $this->connection->cleanup();
             $this->connection->setup();
         } catch (\Exception $e) {
@@ -109,7 +109,7 @@ class RedisExtIntegrationTest extends TestCase
     public function testConnectionBelowRedeliverTimeout()
     {
         // lower redeliver timeout and claim interval
-        $connection = Connection::fromDsn(getenv('MESSENGER_REDIS_DSN'), [], $this->redis);
+        $connection = Connection::fromDsn(getenv('MESSENGER_REDIS_DSN'), ['delete_after_ack' => true], $this->redis);
 
         $connection->cleanup();
         $connection->setup();
@@ -137,7 +137,7 @@ class RedisExtIntegrationTest extends TestCase
         // lower redeliver timeout and claim interval
         $connection = Connection::fromDsn(
             getenv('MESSENGER_REDIS_DSN'),
-            ['redeliver_timeout' => 0, 'claim_interval' => 500],
+            ['redeliver_timeout' => 0, 'claim_interval' => 500, 'delete_after_ack' => true],
             $this->redis
         );
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportFactoryTest.php
@@ -40,9 +40,9 @@ class RedisTransportFactoryTest extends TestCase
 
         $factory = new RedisTransportFactory();
         $serializer = $this->createMock(SerializerInterface::class);
-        $expectedTransport = new RedisTransport(Connection::fromDsn('redis://'.getenv('REDIS_HOST'), ['stream' => 'bar']), $serializer);
+        $expectedTransport = new RedisTransport(Connection::fromDsn('redis://'.getenv('REDIS_HOST'), ['stream' => 'bar', 'delete_after_ack' => true]), $serializer);
 
-        $this->assertEquals($expectedTransport, $factory->createTransport('redis://'.getenv('REDIS_HOST'), ['stream' => 'bar'], $serializer));
+        $this->assertEquals($expectedTransport, $factory->createTransport('redis://'.getenv('REDIS_HOST'), ['stream' => 'bar', 'delete_after_ack' => true], $serializer));
     }
 
     private function skipIfRedisUnavailable()

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -182,6 +182,8 @@ class Connection
         if (\array_key_exists('delete_after_ack', $redisOptions)) {
             $deleteAfterAck = filter_var($redisOptions['delete_after_ack'], \FILTER_VALIDATE_BOOLEAN);
             unset($redisOptions['delete_after_ack']);
+        } else {
+            trigger_deprecation('symfony/redis-messenger', '5.4', 'Not setting the "delete_after_ack" boolean option explicitly is deprecated, its default value will change to true in 6.0.');
         }
 
         $deleteAfterReject = null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #42122 
| License      | MIT
| Docs PR    | todo

Having this option turned on makes redis-messenger much more consistent with other transports, more adapted to the 80% use case and more importantly, prevents having to deal with OOM issues. 