### PR TITLE
Remove some unneeded dirname() calls

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -317,7 +317,7 @@ class Deprecation
             foreach (get_declared_classes() as $class) {
                 if ('C' === $class[0] && 0 === strpos($class, 'ComposerAutoloaderInit')) {
                     $r = new \ReflectionClass($class);
-                    $v = \dirname(\dirname($r->getFileName()));
+                    $v = \dirname($r->getFileName(), 2);
                     if (file_exists($v.'/composer/installed.json')) {
                         self::$vendors[] = $v;
                         $loader = require $v.'/autoload.php';

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/DeprecationTest.php
@@ -30,7 +30,7 @@ class DeprecationTest extends TestCase
         foreach (get_declared_classes() as $class) {
             if ('C' === $class[0] && 0 === strpos($class, 'ComposerAutoloaderInit')) {
                 $r = new \ReflectionClass($class);
-                $vendorDir = \dirname(\dirname($r->getFileName()));
+                $vendorDir = \dirname($r->getFileName(), 2);
                 if (file_exists($vendorDir.'/composer/installed.json') && @mkdir($vendorDir.'/myfakevendor/myfakepackage1', 0777, true)) {
                     break;
                 }
@@ -58,7 +58,7 @@ class DeprecationTest extends TestCase
     {
         $r = new \ReflectionClass(Deprecation::class);
 
-        if (\dirname(\dirname($r->getFileName())) !== \dirname(\dirname(__DIR__))) {
+        if (\dirname($r->getFileName(), 2) !== \dirname(__DIR__, 2)) {
             $this->markTestSkipped('Test case is not compatible with having the bridge in vendor/');
         }
 
@@ -270,7 +270,7 @@ class DeprecationTest extends TestCase
         foreach (get_declared_classes() as $class) {
             if ('C' === $class[0] && 0 === strpos($class, 'ComposerAutoloaderInit')) {
                 $r = new \ReflectionClass($class);
-                $v = \dirname(\dirname($r->getFileName()));
+                $v = \dirname($r->getFileName(), 2);
                 if (file_exists($v.'/composer/installed.json')) {
                     $loader = require $v.'/autoload.php';
                     $reflection = new \ReflectionClass($loader);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

PHP added the `$levels` argument to `dirname()` in 7.0 (see https://www.php.net/manual/en/function.dirname.php) so we can use it to save some function calls.