### PR TITLE
[RateLimiter] Fix wait duration for fixed window policy

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/FixedWindowLimiter.php
@@ -70,8 +70,7 @@ final class FixedWindowLimiter implements LimiterInterface
 
                 $reservation = new Reservation($now, new RateLimit($window->getAvailableTokens($now), \DateTimeImmutable::createFromFormat('U', floor($now)), true, $this->limit));
             } else {
-                $remainingTokens = $tokens - $availableTokens;
-                $waitDuration = $window->calculateTimeForTokens($remainingTokens);
+                $waitDuration = $this->interval;
 
                 if (null !== $maxTime && $waitDuration > $maxTime) {
                     // process needs to wait longer than set interval

--- a/src/Symfony/Component/RateLimiter/Policy/Window.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Window.php
@@ -80,15 +80,4 @@ final class Window implements LimiterStateInterface
 
         return $this->maxSize - $this->hitCount;
     }
-
-    public function calculateTimeForTokens(int $tokens): int
-    {
-        if (($this->maxSize - $this->hitCount) >= $tokens) {
-            return 0;
-        }
-
-        $cyclesRequired = ceil($tokens / $this->maxSize);
-
-        return $cyclesRequired * $this->intervalInSeconds;
-    }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\RateLimiter\Exception\ReserveNotSupportedException;
 use Symfony\Component\RateLimiter\Policy\SlidingWindowLimiter;
+use Symfony\Component\RateLimiter\RateLimit;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 
 /**
@@ -29,6 +30,7 @@ class SlidingWindowLimiterTest extends TestCase
         $this->storage = new InMemoryStorage();
 
         ClockMock::register(InMemoryStorage::class);
+        ClockMock::register(RateLimit::class);
     }
 
     public function testConsume()
@@ -51,6 +53,20 @@ class SlidingWindowLimiterTest extends TestCase
         $rateLimit = $limiter->consume(10);
         $this->assertTrue($rateLimit->isAccepted());
         $this->assertSame(10, $rateLimit->getLimit());
+    }
+
+    public function testWaitIntervalOnConsumeOverLimit()
+    {
+        $limiter = $this->createLimiter();
+
+        // initial consume
+        $limiter->consume(8);
+        // consumer over the limit
+        $rateLimit = $limiter->consume(4);
+
+        $start = microtime(true);
+        $rateLimit->wait(); // wait 12 seconds
+        $this->assertEqualsWithDelta($start + 12, microtime(true), 0.5);
     }
 
     public function testReserve()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4, 5.3, 5.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

When using `fixed_window` policy and calling `->wait()` after overconsuming, there might be no `sleep()` called. Reproducer below:

```php
<?php

use Symfony\Component\RateLimiter\RateLimiterFactory;
use Symfony\Component\RateLimiter\Storage\InMemoryStorage;

require_once './vendor/autoload.php';


$factory = new RateLimiterFactory([
    'id' => 'some_id',
    'policy' => 'fixed_window',
    'limit' => 10,
    'interval' => '2 seconds',
], new InMemoryStorage());

$limiter = $factory->create();

$limit = $limiter->consume(8);

$limit = $limiter->consume(4);
$start = microtime(true);
$limit->wait();
echo 'WAITED: ' . 1000 * (microtime(true) - $start);
// WAITED: 0.0030994415283203 - instantaneous instead of WAITED: 2000.3020763397 after the fix
```
