### PR TITLE
[CI] Fix wrongly skipped integration tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,7 @@
             <directory>./src/Symfony/Bridge/*/Tests/</directory>
             <directory>./src/Symfony/Component/*/Tests/</directory>
             <directory>./src/Symfony/Component/*/*/Tests/</directory>
+            <directory>./src/Symfony/Component/*/*/*/Tests/</directory>
             <directory>./src/Symfony/Contract/*/Tests/</directory>
             <directory>./src/Symfony/Bundle/*/Tests/</directory>
         </testsuite>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The integration tests from bridges located in components (e.g. `Notifier/Bridge/Discord/Tests` or `Messenger/Bridge/Redis/Tests`) were excluded from the CI.

Spotted while working on #42163 - Some redis-messenger tests are currently broken on 5.x, which we didn't spot because of the missing entry in the phpunit config. 