### PR TITLE
[Messenger] [Redis] Fix auth option wrongly considered invalid

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
@@ -76,20 +76,14 @@ class AmqpExtIntegrationTest extends TestCase
         $this->assertEmpty(iterator_to_array($receiver->get()));
     }
 
-    /**
-     * @group legacy
-     * ^ for now, deprecation errors are thrown during serialization.
-     */
     public function testRetryAndDelay()
     {
-        $serializer = $this->createSerializer();
-
         $connection = Connection::fromDsn(getenv('MESSENGER_AMQP_DSN'));
         $connection->setup();
         $connection->purgeQueues();
 
-        $sender = new AmqpSender($connection, $serializer);
-        $receiver = new AmqpReceiver($connection, $serializer);
+        $sender = new AmqpSender($connection);
+        $receiver = new AmqpReceiver($connection);
 
         // send a first message
         $sender->send($first = new Envelope(new DummyMessage('First')));

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -191,17 +191,6 @@ class ConnectionTest extends TestCase
         Connection::fromDsn('redis://password1@localhost/queue', ['auth' => 'password2'], $redis);
     }
 
-    public function testAuthAsUserInDsn()
-    {
-        $redis = $this->createMock(\Redis::class);
-
-        $redis->expects($this->exactly(1))->method('auth')
-            ->with('password')
-            ->willReturn(true);
-
-        Connection::fromDsn('redis://password:localhost/queue', [], $redis);
-    }
-
     public function testNoAuthWithEmptyPassword()
     {
         $redis = $this->createMock(\Redis::class);

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -40,6 +40,8 @@ class Connection
         'redeliver_timeout' => 3600, // Timeout before redeliver messages still in pending state (seconds)
         'claim_interval' => 60000, // Interval by which pending/abandoned messages should be checked
         'lazy' => false,
+        'auth' => null,
+        'serializer' => \Redis::SERIALIZER_PHP,
     ];
 
     private $connection;
@@ -224,7 +226,6 @@ class Connection
     private static function validateOptions(array $options): void
     {
         $availableOptions = array_keys(self::DEFAULT_OPTIONS);
-        $availableOptions[] = 'serializer';
 
         if (0 < \count($invalidOptions = array_diff(array_keys($options), $availableOptions))) {
             trigger_deprecation('symfony/messenger', '5.1', 'Invalid option(s) "%s" passed to the Redis Messenger transport. Passing invalid options is deprecated.', implode('", "', $invalidOptions));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Will also make the CI back to green on 5.2.