### PR TITLE
[Security][SecurityBundle] Implement ADM strategies as dedicated classes

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -159,3 +159,6 @@ Security
        }
    }
    ```
+ * Deprecate passing the strategy as string to `AccessDecisionManager`,
+   pass an instance of `AccessDecisionStrategyInterface` instead
+ * Flag `AccessDecisionManager` as `@final`

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -394,6 +394,8 @@ Security
        }
    }
    ```
+ * `AccessDecisionManager` does not accept strings as strategy anymore,
+   pass an instance of `AccessDecisionStrategyInterface` instead
 
 SecurityBundle
 --------------

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
    factories instead.
  * Deprecate the `always_authenticate_before_granting` option
  * Display the roles of the logged-in user in the Web Debug Toolbar
+ * Add the `security.access_decision_manager.strategy_service` option
 
 5.3
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -18,7 +18,6 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy;
@@ -30,6 +29,15 @@ use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy;
  */
 class MainConfiguration implements ConfigurationInterface
 {
+    /** @internal */
+    public const STRATEGY_AFFIRMATIVE = 'affirmative';
+    /** @internal */
+    public const STRATEGY_CONSENSUS = 'consensus';
+    /** @internal */
+    public const STRATEGY_UNANIMOUS = 'unanimous';
+    /** @internal */
+    public const STRATEGY_PRIORITY = 'priority';
+
     private $factories;
     private $userProviderFactories;
 
@@ -65,14 +73,18 @@ class MainConfiguration implements ConfigurationInterface
                         return true;
                     }
 
-                    if (!isset($v['access_decision_manager']['strategy']) && !isset($v['access_decision_manager']['service'])) {
+                    if (!isset($v['access_decision_manager']['strategy'])
+                        && !isset($v['access_decision_manager']['service'])
+                        && !isset($v['access_decision_manager']['strategy_service'])
+                        && !isset($v['access_decision_manager']['strategy-service'])
+                    ) {
                         return true;
                     }
 
                     return false;
                 })
                 ->then(function ($v) {
-                    $v['access_decision_manager']['strategy'] = AccessDecisionManager::STRATEGY_AFFIRMATIVE;
+                    $v['access_decision_manager']['strategy'] = self::STRATEGY_AFFIRMATIVE;
 
                     return $v;
                 })
@@ -114,12 +126,21 @@ class MainConfiguration implements ConfigurationInterface
                             ->values($this->getAccessDecisionStrategies())
                         ->end()
                         ->scalarNode('service')->end()
+                        ->scalarNode('strategy_service')->end()
                         ->booleanNode('allow_if_all_abstain')->defaultFalse()->end()
                         ->booleanNode('allow_if_equal_granted_denied')->defaultTrue()->end()
                     ->end()
                     ->validate()
-                        ->ifTrue(function ($v) { return isset($v['strategy']) && isset($v['service']); })
+                        ->ifTrue(function ($v) { return isset($v['strategy'], $v['service']); })
                         ->thenInvalid('"strategy" and "service" cannot be used together.')
+                    ->end()
+                    ->validate()
+                        ->ifTrue(function ($v) { return isset($v['strategy'], $v['strategy_service']); })
+                        ->thenInvalid('"strategy" and "strategy_service" cannot be used together.')
+                    ->end()
+                    ->validate()
+                        ->ifTrue(function ($v) { return isset($v['service'], $v['strategy_service']); })
+                        ->thenInvalid('"service" and "strategy_service" cannot be used together.')
                     ->end()
                 ->end()
             ->end()
@@ -507,18 +528,13 @@ class MainConfiguration implements ConfigurationInterface
         ->end();
     }
 
-    private function getAccessDecisionStrategies()
+    private function getAccessDecisionStrategies(): array
     {
-        $strategies = [
-            AccessDecisionManager::STRATEGY_AFFIRMATIVE,
-            AccessDecisionManager::STRATEGY_CONSENSUS,
-            AccessDecisionManager::STRATEGY_UNANIMOUS,
+        return [
+            self::STRATEGY_AFFIRMATIVE,
+            self::STRATEGY_CONSENSUS,
+            self::STRATEGY_UNANIMOUS,
+            self::STRATEGY_PRIORITY,
         ];
-
-        if (\defined(AccessDecisionManager::class.'::STRATEGY_PRIORITY')) {
-            $strategies[] = AccessDecisionManager::STRATEGY_PRIORITY;
-        }
-
-        return $strategies;
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/schema/security-1.0.xsd
@@ -63,6 +63,7 @@
     <xsd:complexType name="access_decision_manager">
         <xsd:attribute name="strategy" type="access_decision_manager_strategy" />
         <xsd:attribute name="service" type="xsd:string" />
+        <xsd:attribute name="strategy-service" type="xsd:string" />
         <xsd:attribute name="allow-if-all-abstain" type="xsd:boolean" />
         <xsd:attribute name="allow-if-equal-granted-denied" type="xsd:boolean" />
     </xsd:complexType>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -17,12 +17,14 @@ use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
 use Symfony\Component\PasswordHasher\Hasher\Pbkdf2PasswordHasher;
 use Symfony\Component\PasswordHasher\Hasher\PlaintextPasswordHasher;
 use Symfony\Component\PasswordHasher\Hasher\SodiumPasswordHasher;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
+use Symfony\Component\Security\Core\Authorization\Strategy\AffirmativeStrategy;
 use Symfony\Component\Security\Core\Encoder\NativePasswordEncoder;
 use Symfony\Component\Security\Core\Encoder\SodiumPasswordEncoder;
 use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
@@ -1046,7 +1048,7 @@ abstract class CompleteConfigurationTest extends TestCase
     {
         $container = $this->getContainer('access_decision_manager_default_strategy');
 
-        $this->assertSame(AccessDecisionManager::STRATEGY_AFFIRMATIVE, $container->getDefinition('security.access.decision_manager')->getArgument(1), 'Default vote strategy is affirmative');
+        $this->assertEquals((new Definition(AffirmativeStrategy::class, [false])), $container->getDefinition('security.access.decision_manager')->getArgument(1), 'Default vote strategy is affirmative');
     }
 
     public function testCustomAccessDecisionManagerService()
@@ -1069,9 +1071,17 @@ abstract class CompleteConfigurationTest extends TestCase
 
         $accessDecisionManagerDefinition = $container->getDefinition('security.access.decision_manager');
 
-        $this->assertSame(AccessDecisionManager::STRATEGY_AFFIRMATIVE, $accessDecisionManagerDefinition->getArgument(1));
-        $this->assertTrue($accessDecisionManagerDefinition->getArgument(2));
-        $this->assertFalse($accessDecisionManagerDefinition->getArgument(3));
+        $this->assertEquals((new Definition(AffirmativeStrategy::class, [true])), $accessDecisionManagerDefinition->getArgument(1));
+    }
+
+    public function testAccessDecisionManagerWithStrategyService()
+    {
+        $container = $this->getContainer('access_decision_manager_strategy_service');
+
+        $accessDecisionManagerDefinition = $container->getDefinition('security.access.decision_manager');
+
+        $this->assertEquals(AccessDecisionManager::class, $accessDecisionManagerDefinition->getClass());
+        $this->assertEquals(new Reference('app.custom_access_decision_strategy'), $accessDecisionManagerDefinition->getArgument(1));
     }
 
     public function testFirewallUndefinedUserProvider()

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_strategy_service.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/access_decision_manager_strategy_service.php
@@ -1,0 +1,20 @@
+<?php
+
+$container->loadFromExtension('security', [
+    'enable_authenticator_manager' => true,
+    'access_decision_manager' => [
+        'strategy_service' => 'app.custom_access_decision_strategy',
+    ],
+    'providers' => [
+        'default' => [
+            'memory' => [
+                'users' => [
+                    'foo' => ['password' => 'foo', 'roles' => 'ROLE_USER'],
+                ],
+            ],
+        ],
+    ],
+    'firewalls' => [
+        'simple' => ['pattern' => '/login', 'security' => false],
+    ],
+]);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_strategy_service.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/access_decision_manager_strategy_service.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<srv:container xmlns="http://symfony.com/schema/dic/security"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:srv="http://symfony.com/schema/dic/services"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services
+        https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/security
+        https://symfony.com/schema/dic/security/security-1.0.xsd">
+
+    <config enable-authenticator-manager="true">
+        <access-decision-manager strategy-service="app.custom_access_decision_strategy" />
+
+        <provider name="default">
+            <memory>
+                <user identifier="foo" password="foo" roles="ROLE_USER" />
+            </memory>
+        </provider>
+
+        <firewall name="simple" pattern="/login" security="false" />
+    </config>
+</srv:container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_strategy_service.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/access_decision_manager_strategy_service.yml
@@ -1,0 +1,11 @@
+security:
+    enable_authenticator_manager: true
+    access_decision_manager:
+        strategy_service: app.custom_access_decision_strategy
+    providers:
+        default:
+            memory:
+                users:
+                    foo: { password: foo, roles: ROLE_USER }
+    firewalls:
+        simple: { pattern: /login, security: false }

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -12,6 +12,11 @@
 namespace Symfony\Component\Security\Core\Authorization;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Strategy\AccessDecisionStrategyInterface;
+use Symfony\Component\Security\Core\Authorization\Strategy\AffirmativeStrategy;
+use Symfony\Component\Security\Core\Authorization\Strategy\ConsensusStrategy;
+use Symfony\Component\Security\Core\Authorization\Strategy\PriorityStrategy;
+use Symfony\Component\Security\Core\Authorization\Strategy\UnanimousStrategy;
 use Symfony\Component\Security\Core\Authorization\Voter\CacheableVoterInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
@@ -21,40 +26,62 @@ use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
  * that use decision voters.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @final since Symfony 5.4
  */
 class AccessDecisionManager implements AccessDecisionManagerInterface
 {
+    /**
+     * @deprecated use {@see AffirmativeStrategy} instead
+     */
     public const STRATEGY_AFFIRMATIVE = 'affirmative';
+
+    /**
+     * @deprecated use {@see ConsensusStrategy} instead
+     */
     public const STRATEGY_CONSENSUS = 'consensus';
+
+    /**
+     * @deprecated use {@see UnanimousStrategy} instead
+     */
     public const STRATEGY_UNANIMOUS = 'unanimous';
+
+    /**
+     * @deprecated use {@see PriorityStrategy} instead
+     */
     public const STRATEGY_PRIORITY = 'priority';
+
+    private const VALID_VOTES = [
+        VoterInterface::ACCESS_GRANTED => true,
+        VoterInterface::ACCESS_DENIED => true,
+        VoterInterface::ACCESS_ABSTAIN => true,
+    ];
 
     private $voters;
     private $votersCacheAttributes;
     private $votersCacheObject;
     private $strategy;
-    private $allowIfAllAbstainDecisions;
-    private $allowIfEqualGrantedDeniedDecisions;
 
     /**
-     * @param iterable|VoterInterface[] $voters                             An array or an iterator of VoterInterface instances
-     * @param string                    $strategy                           The vote strategy
-     * @param bool                      $allowIfAllAbstainDecisions         Whether to grant access if all voters abstained or not
-     * @param bool                      $allowIfEqualGrantedDeniedDecisions Whether to grant access if result are equals
+     * @param iterable<mixed, VoterInterface>      $voters   An array or an iterator of VoterInterface instances
+     * @param AccessDecisionStrategyInterface|null $strategy The vote strategy
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct(iterable $voters = [], string $strategy = self::STRATEGY_AFFIRMATIVE, bool $allowIfAllAbstainDecisions = false, bool $allowIfEqualGrantedDeniedDecisions = true)
+    public function __construct(iterable $voters = [], /* AccessDecisionStrategyInterface */ $strategy = null)
     {
-        $strategyMethod = 'decide'.ucfirst($strategy);
-        if ('' === $strategy || !\is_callable([$this, $strategyMethod])) {
-            throw new \InvalidArgumentException(sprintf('The strategy "%s" is not supported.', $strategy));
+        $this->voters = $voters;
+        if (\is_string($strategy)) {
+            trigger_deprecation('symfony/security-core', '5.4', 'Passing the access decision strategy as a string is deprecated, pass an instance of "%s" instead.', AccessDecisionStrategyInterface::class);
+            $allowIfAllAbstainDecisions = 3 <= \func_num_args() && func_get_arg(2);
+            $allowIfEqualGrantedDeniedDecisions = 4 > \func_num_args() || func_get_arg(3);
+
+            $strategy = $this->createStrategy($strategy, $allowIfAllAbstainDecisions, $allowIfEqualGrantedDeniedDecisions);
+        } elseif (null !== $strategy && !$strategy instanceof AccessDecisionStrategyInterface) {
+            throw new \TypeError(sprintf('"%s": Parameter #2 ($strategy) is expected to be an instance of "%s" or null, "%s" given.', __METHOD__, AccessDecisionStrategyInterface::class, get_debug_type($strategy)));
         }
 
-        $this->voters = $voters;
-        $this->strategy = $strategyMethod;
-        $this->allowIfAllAbstainDecisions = $allowIfAllAbstainDecisions;
-        $this->allowIfEqualGrantedDeniedDecisions = $allowIfEqualGrantedDeniedDecisions;
+        $this->strategy = $strategy ?? new AffirmativeStrategy();
     }
 
     /**
@@ -71,145 +98,50 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
             throw new InvalidArgumentException(sprintf('Passing more than one Security attribute to "%s()" is not supported.', __METHOD__));
         }
 
-        return $this->{$this->strategy}($token, $attributes, $object);
+        return $this->strategy->decide(
+            $this->collectResults($token, $attributes, $object)
+        );
     }
 
     /**
-     * Grants access if any voter returns an affirmative response.
+     * @param mixed $object
      *
-     * If all voters abstained from voting, the decision will be based on the
-     * allowIfAllAbstainDecisions property value (defaults to false).
+     * @return \Traversable<int, int>
      */
-    private function decideAffirmative(TokenInterface $token, array $attributes, $object = null): bool
-    {
-        $deny = 0;
-        foreach ($this->getVoters($attributes, $object) as $voter) {
-            $result = $voter->vote($token, $object, $attributes);
-
-            if (VoterInterface::ACCESS_GRANTED === $result) {
-                return true;
-            }
-
-            if (VoterInterface::ACCESS_DENIED === $result) {
-                ++$deny;
-            } elseif (VoterInterface::ACCESS_ABSTAIN !== $result) {
-                trigger_deprecation('symfony/security-core', '5.3', 'Returning "%s" in "%s::vote()" is deprecated, return one of "%s" constants: "ACCESS_GRANTED", "ACCESS_DENIED" or "ACCESS_ABSTAIN".', var_export($result, true), get_debug_type($voter), VoterInterface::class);
-            }
-        }
-
-        if ($deny > 0) {
-            return false;
-        }
-
-        return $this->allowIfAllAbstainDecisions;
-    }
-
-    /**
-     * Grants access if there is consensus of granted against denied responses.
-     *
-     * Consensus means majority-rule (ignoring abstains) rather than unanimous
-     * agreement (ignoring abstains). If you require unanimity, see
-     * UnanimousBased.
-     *
-     * If there were an equal number of grant and deny votes, the decision will
-     * be based on the allowIfEqualGrantedDeniedDecisions property value
-     * (defaults to true).
-     *
-     * If all voters abstained from voting, the decision will be based on the
-     * allowIfAllAbstainDecisions property value (defaults to false).
-     */
-    private function decideConsensus(TokenInterface $token, array $attributes, $object = null): bool
-    {
-        $grant = 0;
-        $deny = 0;
-        foreach ($this->getVoters($attributes, $object) as $voter) {
-            $result = $voter->vote($token, $object, $attributes);
-
-            if (VoterInterface::ACCESS_GRANTED === $result) {
-                ++$grant;
-            } elseif (VoterInterface::ACCESS_DENIED === $result) {
-                ++$deny;
-            } elseif (VoterInterface::ACCESS_ABSTAIN !== $result) {
-                trigger_deprecation('symfony/security-core', '5.3', 'Returning "%s" in "%s::vote()" is deprecated, return one of "%s" constants: "ACCESS_GRANTED", "ACCESS_DENIED" or "ACCESS_ABSTAIN".', var_export($result, true), get_debug_type($voter), VoterInterface::class);
-            }
-        }
-
-        if ($grant > $deny) {
-            return true;
-        }
-
-        if ($deny > $grant) {
-            return false;
-        }
-
-        if ($grant > 0) {
-            return $this->allowIfEqualGrantedDeniedDecisions;
-        }
-
-        return $this->allowIfAllAbstainDecisions;
-    }
-
-    /**
-     * Grants access if only grant (or abstain) votes were received.
-     *
-     * If all voters abstained from voting, the decision will be based on the
-     * allowIfAllAbstainDecisions property value (defaults to false).
-     */
-    private function decideUnanimous(TokenInterface $token, array $attributes, $object = null): bool
-    {
-        $grant = 0;
-        foreach ($this->getVoters($attributes, $object) as $voter) {
-            foreach ($attributes as $attribute) {
-                $result = $voter->vote($token, $object, [$attribute]);
-
-                if (VoterInterface::ACCESS_DENIED === $result) {
-                    return false;
-                }
-
-                if (VoterInterface::ACCESS_GRANTED === $result) {
-                    ++$grant;
-                } elseif (VoterInterface::ACCESS_ABSTAIN !== $result) {
-                    trigger_deprecation('symfony/security-core', '5.3', 'Returning "%s" in "%s::vote()" is deprecated, return one of "%s" constants: "ACCESS_GRANTED", "ACCESS_DENIED" or "ACCESS_ABSTAIN".', var_export($result, true), get_debug_type($voter), VoterInterface::class);
-                }
-            }
-        }
-
-        // no deny votes
-        if ($grant > 0) {
-            return true;
-        }
-
-        return $this->allowIfAllAbstainDecisions;
-    }
-
-    /**
-     * Grant or deny access depending on the first voter that does not abstain.
-     * The priority of voters can be used to overrule a decision.
-     *
-     * If all voters abstained from voting, the decision will be based on the
-     * allowIfAllAbstainDecisions property value (defaults to false).
-     */
-    private function decidePriority(TokenInterface $token, array $attributes, $object = null)
+    private function collectResults(TokenInterface $token, array $attributes, $object): \Traversable
     {
         foreach ($this->getVoters($attributes, $object) as $voter) {
             $result = $voter->vote($token, $object, $attributes);
-
-            if (VoterInterface::ACCESS_GRANTED === $result) {
-                return true;
-            }
-
-            if (VoterInterface::ACCESS_DENIED === $result) {
-                return false;
-            }
-
-            if (VoterInterface::ACCESS_ABSTAIN !== $result) {
+            if (!\is_int($result) || !(self::VALID_VOTES[$result] ?? false)) {
                 trigger_deprecation('symfony/security-core', '5.3', 'Returning "%s" in "%s::vote()" is deprecated, return one of "%s" constants: "ACCESS_GRANTED", "ACCESS_DENIED" or "ACCESS_ABSTAIN".', var_export($result, true), get_debug_type($voter), VoterInterface::class);
             }
-        }
 
-        return $this->allowIfAllAbstainDecisions;
+            yield $result;
+        }
     }
 
+    /**
+     * @throws \InvalidArgumentException if the $strategy is invalid
+     */
+    private function createStrategy(string $strategy, bool $allowIfAllAbstainDecisions, bool $allowIfEqualGrantedDeniedDecisions): AccessDecisionStrategyInterface
+    {
+        switch ($strategy) {
+            case self::STRATEGY_AFFIRMATIVE:
+                return new AffirmativeStrategy($allowIfAllAbstainDecisions);
+            case self::STRATEGY_CONSENSUS:
+                return new ConsensusStrategy($allowIfAllAbstainDecisions, $allowIfEqualGrantedDeniedDecisions);
+            case self::STRATEGY_UNANIMOUS:
+                return new UnanimousStrategy($allowIfAllAbstainDecisions);
+            case self::STRATEGY_PRIORITY:
+                return new PriorityStrategy($allowIfAllAbstainDecisions);
+        }
+
+        throw new \InvalidArgumentException(sprintf('The strategy "%s" is not supported.', $strategy));
+    }
+
+    /**
+     * @return iterable<mixed, VoterInterface>
+     */
     private function getVoters(array $attributes, $object = null): iterable
     {
         $keyAttributes = [];

--- a/src/Symfony/Component/Security/Core/Authorization/Strategy/AccessDecisionStrategyInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Strategy/AccessDecisionStrategyInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization\Strategy;
+
+/**
+ * A strategy for turning a stream of votes into a final decision.
+ *
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+interface AccessDecisionStrategyInterface
+{
+    /**
+     * @param \Traversable<int> $results
+     */
+    public function decide(\Traversable $results): bool;
+}

--- a/src/Symfony/Component/Security/Core/Authorization/Strategy/AffirmativeStrategy.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Strategy/AffirmativeStrategy.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization\Strategy;
+
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * Grants access if any voter returns an affirmative response.
+ *
+ * If all voters abstained from voting, the decision will be based on the
+ * allowIfAllAbstainDecisions property value (defaults to false).
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class AffirmativeStrategy implements AccessDecisionStrategyInterface, \Stringable
+{
+    /**
+     * @var bool
+     */
+    private $allowIfAllAbstainDecisions;
+
+    public function __construct(bool $allowIfAllAbstainDecisions = false)
+    {
+        $this->allowIfAllAbstainDecisions = $allowIfAllAbstainDecisions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function decide(\Traversable $results): bool
+    {
+        $deny = 0;
+        foreach ($results as $result) {
+            if (VoterInterface::ACCESS_GRANTED === $result) {
+                return true;
+            }
+
+            if (VoterInterface::ACCESS_DENIED === $result) {
+                ++$deny;
+            }
+        }
+
+        if ($deny > 0) {
+            return false;
+        }
+
+        return $this->allowIfAllAbstainDecisions;
+    }
+
+    public function __toString(): string
+    {
+        return 'affirmative';
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/Strategy/ConsensusStrategy.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Strategy/ConsensusStrategy.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization\Strategy;
+
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * Grants access if there is consensus of granted against denied responses.
+ *
+ * Consensus means majority-rule (ignoring abstains) rather than unanimous
+ * agreement (ignoring abstains). If you require unanimity, see
+ * UnanimousBased.
+ *
+ * If there were an equal number of grant and deny votes, the decision will
+ * be based on the allowIfEqualGrantedDeniedDecisions property value
+ * (defaults to true).
+ *
+ * If all voters abstained from voting, the decision will be based on the
+ * allowIfAllAbstainDecisions property value (defaults to false).
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class ConsensusStrategy implements AccessDecisionStrategyInterface, \Stringable
+{
+    private $allowIfAllAbstainDecisions;
+    private $allowIfEqualGrantedDeniedDecisions;
+
+    public function __construct(bool $allowIfAllAbstainDecisions = false, bool $allowIfEqualGrantedDeniedDecisions = true)
+    {
+        $this->allowIfAllAbstainDecisions = $allowIfAllAbstainDecisions;
+        $this->allowIfEqualGrantedDeniedDecisions = $allowIfEqualGrantedDeniedDecisions;
+    }
+
+    public function decide(\Traversable $results): bool
+    {
+        $grant = 0;
+        $deny = 0;
+        foreach ($results as $result) {
+            if (VoterInterface::ACCESS_GRANTED === $result) {
+                ++$grant;
+            } elseif (VoterInterface::ACCESS_DENIED === $result) {
+                ++$deny;
+            }
+        }
+
+        if ($grant > $deny) {
+            return true;
+        }
+
+        if ($deny > $grant) {
+            return false;
+        }
+
+        if ($grant > 0) {
+            return $this->allowIfEqualGrantedDeniedDecisions;
+        }
+
+        return $this->allowIfAllAbstainDecisions;
+    }
+
+    public function __toString(): string
+    {
+        return 'consensus';
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/Strategy/PriorityStrategy.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Strategy/PriorityStrategy.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization\Strategy;
+
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * Grant or deny access depending on the first voter that does not abstain.
+ * The priority of voters can be used to overrule a decision.
+ *
+ * If all voters abstained from voting, the decision will be based on the
+ * allowIfAllAbstainDecisions property value (defaults to false).
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class PriorityStrategy implements AccessDecisionStrategyInterface, \Stringable
+{
+    private $allowIfAllAbstainDecisions;
+
+    public function __construct(bool $allowIfAllAbstainDecisions = false)
+    {
+        $this->allowIfAllAbstainDecisions = $allowIfAllAbstainDecisions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function decide(\Traversable $results): bool
+    {
+        foreach ($results as $result) {
+            if (VoterInterface::ACCESS_GRANTED === $result) {
+                return true;
+            }
+
+            if (VoterInterface::ACCESS_DENIED === $result) {
+                return false;
+            }
+        }
+
+        return $this->allowIfAllAbstainDecisions;
+    }
+
+    public function __toString(): string
+    {
+        return 'priority';
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/Strategy/UnanimousStrategy.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Strategy/UnanimousStrategy.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization\Strategy;
+
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * Grants access if only grant (or abstain) votes were received.
+ *
+ * If all voters abstained from voting, the decision will be based on the
+ * allowIfAllAbstainDecisions property value (defaults to false).
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class UnanimousStrategy implements AccessDecisionStrategyInterface, \Stringable
+{
+    private $allowIfAllAbstainDecisions;
+
+    public function __construct(bool $allowIfAllAbstainDecisions = false)
+    {
+        $this->allowIfAllAbstainDecisions = $allowIfAllAbstainDecisions;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function decide(\Traversable $results): bool
+    {
+        $grant = 0;
+        foreach ($results as $result) {
+            if (VoterInterface::ACCESS_DENIED === $result) {
+                return false;
+            }
+
+            if (VoterInterface::ACCESS_GRANTED === $result) {
+                ++$grant;
+            }
+        }
+
+        // no deny votes
+        if ($grant > 0) {
+            return true;
+        }
+
+        return $this->allowIfAllAbstainDecisions;
+    }
+
+    public function __toString(): string
+    {
+        return 'unanimous';
+    }
+}

--- a/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/TraceableAccessDecisionManager.php
@@ -87,10 +87,14 @@ class TraceableAccessDecisionManager implements AccessDecisionManagerInterface
 
     public function getStrategy(): string
     {
-        // The $strategy property is misleading because it stores the name of its
-        // method (e.g. 'decideAffirmative') instead of the original strategy name
-        // (e.g. 'affirmative')
-        return null === $this->strategy ? '-' : strtolower(substr($this->strategy, 6));
+        if (null === $this->strategy) {
+            return '-';
+        }
+        if (method_exists($this->strategy, '__toString')) {
+            return (string) $this->strategy;
+        }
+
+        return get_debug_type($this->strategy);
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -19,6 +19,11 @@ CHANGELOG
    `$exceptionOnNoToken` argument to `false` of `AuthorizationChecker`
  * Deprecate methods `TokenInterface::isAuthenticated()` and `setAuthenticated`,
    return null from "getUser()" instead when a token is not authenticated
+ * Add `AccessDecisionStrategyInterface` to allow custom access decision strategies
+ * Add access decision strategies `AffirmativeStrategy`, `ConsensusStrategy`, `PriorityStrategy`, `UnanimousStrategy`
+ * Deprecate passing the strategy as string to `AccessDecisionManager`,
+   pass an instance of `AccessDecisionStrategyInterface` instead
+ * Flag `AccessDecisionManager` as `@final`
 
 5.3
 ---

--- a/src/Symfony/Component/Security/Core/Test/AccessDecisionStrategyTestCase.php
+++ b/src/Symfony/Component/Security/Core/Test/AccessDecisionStrategyTestCase.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Test;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManager;
+use Symfony\Component\Security\Core\Authorization\Strategy\AccessDecisionStrategyInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+
+/**
+ * Abstract test case for access decision strategies.
+ *
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+abstract class AccessDecisionStrategyTestCase extends TestCase
+{
+    /**
+     * @dataProvider provideStrategyTests
+     *
+     * @param VoterInterface[] $voters
+     */
+    final public function testDecide(AccessDecisionStrategyInterface $strategy, array $voters, bool $expected)
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $manager = new AccessDecisionManager($voters, $strategy);
+
+        $this->assertSame($expected, $manager->decide($token, ['ROLE_FOO']));
+    }
+
+    /**
+     * @return iterable<array{AccessDecisionStrategyInterface, VoterInterface[], bool}>
+     */
+    abstract public function provideStrategyTests(): iterable;
+
+    /**
+     * @return VoterInterface[]
+     */
+    final protected function getVoters(int $grants, int $denies, int $abstains): array
+    {
+        $voters = [];
+        for ($i = 0; $i < $grants; ++$i) {
+            $voters[] = $this->getVoter(VoterInterface::ACCESS_GRANTED);
+        }
+        for ($i = 0; $i < $denies; ++$i) {
+            $voters[] = $this->getVoter(VoterInterface::ACCESS_DENIED);
+        }
+        for ($i = 0; $i < $abstains; ++$i) {
+            $voters[] = $this->getVoter(VoterInterface::ACCESS_ABSTAIN);
+        }
+
+        return $voters;
+    }
+
+    final protected function getVoter(int $vote): VoterInterface
+    {
+        $voter = $this->createMock(VoterInterface::class);
+        $voter->method('vote')->willReturn($vote);
+
+        return $voter;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/AffirmativeStrategyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/AffirmativeStrategyTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Authorization\Strategy;
+
+use Symfony\Component\Security\Core\Authorization\Strategy\AffirmativeStrategy;
+use Symfony\Component\Security\Core\Test\AccessDecisionStrategyTestCase;
+
+class AffirmativeStrategyTest extends AccessDecisionStrategyTestCase
+{
+    public function provideStrategyTests(): iterable
+    {
+        $strategy = new AffirmativeStrategy();
+
+        yield [$strategy, $this->getVoters(1, 0, 0), true];
+        yield [$strategy, $this->getVoters(1, 2, 0), true];
+        yield [$strategy, $this->getVoters(0, 1, 0), false];
+        yield [$strategy, $this->getVoters(0, 0, 1), false];
+
+        $strategy = new AffirmativeStrategy(true);
+
+        yield [$strategy, $this->getVoters(0, 0, 1), true];
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/ConsensusStrategyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/ConsensusStrategyTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Authorization\Strategy;
+
+use Symfony\Component\Security\Core\Authorization\Strategy\ConsensusStrategy;
+use Symfony\Component\Security\Core\Test\AccessDecisionStrategyTestCase;
+
+class ConsensusStrategyTest extends AccessDecisionStrategyTestCase
+{
+    public function provideStrategyTests(): iterable
+    {
+        $strategy = new ConsensusStrategy();
+
+        yield [$strategy, $this->getVoters(1, 0, 0), true];
+        yield [$strategy, $this->getVoters(1, 2, 0), false];
+        yield [$strategy, $this->getVoters(2, 1, 0), true];
+        yield [$strategy, $this->getVoters(0, 0, 1), false];
+
+        yield [$strategy, $this->getVoters(2, 2, 0), true];
+        yield [$strategy, $this->getVoters(2, 2, 1), true];
+
+        $strategy = new ConsensusStrategy(true);
+
+        yield [$strategy, $this->getVoters(0, 0, 1), true];
+
+        $strategy = new ConsensusStrategy(false, false);
+
+        yield [$strategy, $this->getVoters(2, 2, 0), false];
+        yield [$strategy, $this->getVoters(2, 2, 1), false];
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/PriorityStrategyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/PriorityStrategyTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Authorization\Strategy;
+
+use Symfony\Component\Security\Core\Authorization\Strategy\PriorityStrategy;
+use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\Test\AccessDecisionStrategyTestCase;
+
+class PriorityStrategyTest extends AccessDecisionStrategyTestCase
+{
+    public function provideStrategyTests(): iterable
+    {
+        $strategy = new PriorityStrategy();
+
+        yield [$strategy, [
+            $this->getVoter(VoterInterface::ACCESS_ABSTAIN),
+            $this->getVoter(VoterInterface::ACCESS_GRANTED),
+            $this->getVoter(VoterInterface::ACCESS_DENIED),
+            $this->getVoter(VoterInterface::ACCESS_DENIED),
+        ], true];
+
+        yield [$strategy, [
+            $this->getVoter(VoterInterface::ACCESS_ABSTAIN),
+            $this->getVoter(VoterInterface::ACCESS_DENIED),
+            $this->getVoter(VoterInterface::ACCESS_GRANTED),
+            $this->getVoter(VoterInterface::ACCESS_GRANTED),
+        ], false];
+
+        yield [$strategy, $this->getVoters(0, 0, 2), false];
+
+        $strategy = new PriorityStrategy(true);
+
+        yield [$strategy, $this->getVoters(0, 0, 2), true];
+    }
+}

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/UnanimousStrategyTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Strategy/UnanimousStrategyTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Authorization\Strategy;
+
+use Symfony\Component\Security\Core\Authorization\Strategy\UnanimousStrategy;
+use Symfony\Component\Security\Core\Test\AccessDecisionStrategyTestCase;
+
+class UnanimousStrategyTest extends AccessDecisionStrategyTestCase
+{
+    public function provideStrategyTests(): iterable
+    {
+        $strategy = new UnanimousStrategy();
+
+        yield [$strategy, $this->getVoters(1, 0, 0), true];
+        yield [$strategy, $this->getVoters(1, 0, 1), true];
+        yield [$strategy, $this->getVoters(1, 1, 0), false];
+
+        yield [$strategy, $this->getVoters(0, 0, 2), false];
+
+        $strategy = new UnanimousStrategy(true);
+
+        yield [$strategy, $this->getVoters(0, 0, 2), true];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #42095
| License       | MIT
| Doc PR        | symfony/symfony-docs#16034

We currently allow to replace the access decision manager with a fully custom implementation. However, if the app makes use of that feature just because it needs a custom decision strategy, it also has to take care of wiring the voters into the custom implementation. This is a bit cumbersome.

This PR introduces a new interface `AccessDecisionStrategyInterface` that allows the app to implement a custom strategy that can be plugged into the default access decision manager. All built-in strategies have been migrated to that new interface.

Furthermore, a new option is added to SecurityBundle to leverage this feature:

```YAML
security:
    access_decision_manager:
        strategy_service: app.custom_access_decision_strategy
```

The "old" way of configuring the strategy will continue to work:

```YAML
security:
    access_decision_manager:
        strategy: unanimous
        allow_if_all_abstain: true
        allow_if_equal_granted_denied: false
```

In that case, SecurityBundle will wire the new strategy classes for us, so we don't have to change anything in our app when upgrading to Symfony 5.4.

Additionally, I decided to finalize `AccessDecisionManager` because once the strategies are pluggable, there shouldn't be a use-case left for extending the class that could not be covered with a decorator.

Implementing a custom strategy is straightforward. Your class implenting `AccessDecisionStrategyInterface` will receive a generator of voter results and is expected to return its decision as a boolean. This way, the interaction with the individual voters is abstracted away from the strategy and the strategy can stop the voter iteration whenever the decision is final.

```php
/**
 * Always picks the third voter.
 */
class ThirdVoterStrategy implements AccessDecisionStrategyInterface
{
    public function decide(\Traversable $results): bool
    {
        $votes = 0;
        foreach ($results as $result) {
            if (++$votes === 3) {
                return $result === VoterInterface::ACCESS_GRANTED;
            }
        }

        return false;
    }
}
```