### PR TITLE
[Security] Add an interface for security passports which support attributes

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/AttributedPassportInterface.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/AttributedPassportInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authenticator\Passport;
+
+/**
+ * Represents a passport which contains attributes.
+ */
+interface AttributedPassportInterface extends PassportInterface
+{
+    /**
+     * @param mixed $value
+     */
+    public function setAttribute(string $name, $value): void;
+
+    /**
+     * @param mixed $default
+     *
+     * @return mixed
+     */
+    public function getAttribute(string $name, $default = null);
+}

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Passport.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Passport.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\Credentia
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
-class Passport implements UserPassportInterface
+class Passport implements UserPassportInterface, AttributedPassportInterface
 {
     use PassportTrait;
 
@@ -60,7 +60,7 @@ class Passport implements UserPassportInterface
     }
 
     /**
-     * @param mixed $value
+     * {@inheritdoc}
      */
     public function setAttribute(string $name, $value): void
     {
@@ -68,9 +68,7 @@ class Passport implements UserPassportInterface
     }
 
     /**
-     * @param mixed $default
-     *
-     * @return mixed
+     * {@inheritdoc}
      */
     public function getAttribute(string $name, $default = null)
     {

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate not setting the 5th argument (`$exceptionOnNoToken`) of `AccessListener` to `false`
  * Deprecate `DeauthenticatedEvent`, use `TokenDeauthenticatedEvent` instead
+ * Add `AttributedPassportInterface`
 
 5.3
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Right now, attributes for security passports can't be relied upon as they don't exist in the interface, so to use them you effectively have to type check the concrete Passport class.  This proposes an interface exposing the attributes API from the Passport class which can make the feature more reliable without expecting concrete classes.