### PR TITLE
[Notifier] Allow passing a previous throwable to exceptions

### DIFF
--- a/src/Symfony/Component/Notifier/Exception/TransportException.php
+++ b/src/Symfony/Component/Notifier/Exception/TransportException.php
@@ -23,7 +23,7 @@ class TransportException extends RuntimeException implements TransportExceptionI
     private $response;
     private $debug = '';
 
-    public function __construct(string $message, ResponseInterface $response, int $code = 0, \Exception $previous = null)
+    public function __construct(string $message, ResponseInterface $response, int $code = 0, \Throwable $previous = null)
     {
         $this->response = $response;
         $this->debug .= $response->getInfo('debug') ?? '';

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -91,7 +91,7 @@ class UnsupportedSchemeException extends LogicException
     /**
      * @param string[] $supported
      */
-    public function __construct(Dsn $dsn, string $name = null, array $supported = [])
+    public function __construct(Dsn $dsn, string $name = null, array $supported = [], \Throwable $previous = null)
     {
         $provider = $dsn->getScheme();
         if (false !== $pos = strpos($provider, '+')) {
@@ -109,6 +109,6 @@ class UnsupportedSchemeException extends LogicException
             $message .= sprintf('; supported schemes for notifier "%s" are: "%s"', $name, implode('", "', $supported));
         }
 
-        parent::__construct($message.'.');
+        parent::__construct($message.'.', 0, $previous);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

It should always be possible to pass a a previous throwable to a new exception. This PR streamlines the constructors of the Notifier component's exception classes.