### PR TITLE
[Notifier] Make sure Smsapi 5.2 has a changelog

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Smsapi/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Smsapi/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.2
+---
+
+ * Add the bridge


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Im not sure what the best way to fix this issue is. The smsapi bridge was released in 5.2 without a changelog. In 5.3 we added a changelog and incorrectly stated that the package was first released in 5.3. 

Related PR: #39557
Packagist: https://packagist.org/packages/symfony/smsapi-notifier


This PR adds the changelog for 5.2 and I hope the maintainer that do the merge up handles the conflict correctly. 