### PR TITLE
[Notifier] [5.4] Make sure Http TransportException is not leaking

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Mailjet/MailjetTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mailjet/MailjetTransport.php
@@ -18,6 +18,7 @@ use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Transport\AbstractTransport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -65,7 +66,13 @@ final class MailjetTransport extends AbstractTransport
             ],
         ]);
 
-        if (200 !== $response->getStatusCode()) {
+        try {
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new TransportException('Could not reach the remote Mailjet server.', $response, 0, $e);
+        }
+
+        if (200 !== $statusCode) {
             $content = $response->toArray(false);
             $errorMessage = $content['requestError']['serviceException']['messageId'] ?? '';
             $errorInfo = $content['requestError']['serviceException']['text'] ?? '';

--- a/src/Symfony/Component/Notifier/Bridge/MessageMedia/MessageMediaTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageMedia/MessageMediaTransport.php
@@ -80,7 +80,13 @@ final class MessageMediaTransport extends AbstractTransport
             ]
         );
 
-        if (202 === $response->getStatusCode()) {
+        try {
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new TransportException('Could not reach the remote MessageMedia server.', $response, 0, $e);
+        }
+
+        if (202 === $statusCode) {
             $result = $response->toArray(false)['messages'][0];
             $sentMessage = new SentMessage($message, (string) $this);
             $sentMessage->setMessageId($result['message_id']);

--- a/src/Symfony/Component/Notifier/Bridge/Telnyx/TelnyxTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telnyx/TelnyxTransport.php
@@ -19,6 +19,7 @@ use Symfony\Component\Notifier\Message\SentMessage;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Transport\AbstractTransport;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
@@ -84,7 +85,13 @@ final class TelnyxTransport extends AbstractTransport
             ],
         ]);
 
-        if (200 !== $response->getStatusCode()) {
+        try {
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new TransportException('Could not reach the remote Telnyx server.', $response, 0, $e);
+        }
+
+        if (200 !== $statusCode) {
             $error = $response->toArray(false);
             if (!isset($error['errors'])) {
                 throw new TransportException('Unable to send the SMS.', $response);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Same as #42182 but for bridges introduced in 5.4

