### PR TITLE
[Cache] Add test on CachePoolPass chain-in-chain exception

### DIFF
--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -127,7 +127,9 @@ class CachePoolPass implements CompilerPassInterface
                     while ($adapter instanceof ChildDefinition) {
                         $adapter = $container->findDefinition($adapter->getParent());
                         if (ChainAdapter::class === $adapter->getClass()) {
-                            throw new InvalidArgumentException(sprintf('Invalid service "%s": chain of adapters cannot reference another chain, found "%s".', $id, $chainedPool->getParent()));
+                            throw new InvalidArgumentException(
+                                sprintf('Invalid service "%s": chain of adapters cannot reference another chain, found "%s".', $id, $chainedPool->getParent())
+                            );
                         }
                         if ($t = $adapter->getTag($this->cachePoolTag)) {
                             $chainedTags[0] += $t[0];

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -127,9 +127,7 @@ class CachePoolPass implements CompilerPassInterface
                     while ($adapter instanceof ChildDefinition) {
                         $adapter = $container->findDefinition($adapter->getParent());
                         if (ChainAdapter::class === $adapter->getClass()) {
-                            throw new InvalidArgumentException(
-                                sprintf('Invalid service "%s": chain of adapters cannot reference another chain, found "%s".', $id, $chainedPool->getParent())
-                            );
+                            throw new InvalidArgumentException(sprintf('Invalid service "%s": chain of adapters cannot reference another chain, found "%s".', $id, $chainedPool->getParent()));
                         }
                         if ($t = $adapter->getTag($this->cachePoolTag)) {
                             $chainedTags[0] += $t[0];

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -116,20 +116,20 @@ class CachePoolPass implements CompilerPassInterface
 
             if (ChainAdapter::class === $class) {
                 $adapters = [];
-                foreach ($adapter->getArgument(0) as $provider => $chainableAdapter) {
-                    $chainedPool = $chainableAdapter;
-                    if (false === $chainableAdapter instanceof ChildDefinition) {
-                        $chainedPool = $chainableAdapter = new ChildDefinition($chainableAdapter);
+                foreach ($adapter->getArgument(0) as $provider => $adapter) {
+                    $chainedPool = $adapter;
+                    if (false === $adapter instanceof ChildDefinition) {
+                        $chainedPool = $adapter = new ChildDefinition($adapter);
                     }
 
                     $chainedTags = [\is_int($provider) ? [] : ['provider' => $provider]];
 
-                    while ($chainableAdapter instanceof ChildDefinition) {
-                        $chainableAdapter = $container->findDefinition($chainableAdapter->getParent());
-                        if (ChainAdapter::class === $chainableAdapter->getClass()) {
+                    while ($adapter instanceof ChildDefinition) {
+                        $adapter = $container->findDefinition($adapter->getParent());
+                        if (ChainAdapter::class === $adapter->getClass()) {
                             throw new InvalidArgumentException(sprintf('Invalid service "%s": chain of adapters cannot reference another chain, found "%s".', $id, $chainedPool->getParent()));
                         }
-                        if ($t = $chainableAdapter->getTag($this->cachePoolTag)) {
+                        if ($t = $adapter->getTag($this->cachePoolTag)) {
                             $chainedTags[0] += $t[0];
                         }
                     }
@@ -140,7 +140,7 @@ class CachePoolPass implements CompilerPassInterface
                         $chainedPool->replaceArgument($i++, new Reference(static::getServiceProvider($container, $chainedTags[0]['provider'])));
                     }
 
-                    if (isset($tags[0]['namespace']) && ArrayAdapter::class !== $chainableAdapter->getClass()) {
+                    if (isset($tags[0]['namespace']) && ArrayAdapter::class !== $adapter->getClass()) {
                         $chainedPool->replaceArgument($i++, $tags[0]['namespace']);
                     }
 

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -118,7 +118,7 @@ class CachePoolPass implements CompilerPassInterface
                 $adapters = [];
                 foreach ($adapter->getArgument(0) as $provider => $adapter) {
                     $chainedPool = $adapter;
-                    if (false === $adapter instanceof ChildDefinition) {
+                    if (!$adapter instanceof ChildDefinition) {
                         $chainedPool = $adapter = new ChildDefinition($adapter);
                     }
 

--- a/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
+++ b/src/Symfony/Component/Cache/Tests/DependencyInjection/CachePoolPassTest.php
@@ -218,8 +218,6 @@ class CachePoolPassTest extends TestCase
 
     public function testChainInChainException()
     {
-        $this->expectException(InvalidArgumentException::class);
-
         $container = new ContainerBuilder();
         $container->setParameter('kernel.container_class', 'app');
         $container->setParameter('kernel.project_dir', 'foo');
@@ -236,6 +234,7 @@ class CachePoolPassTest extends TestCase
             ->addArgument(['cache.chain', 'cache.adapter.array', 'cache.adapter.apcu'])
             ->addTag('cache.pool');
 
+        $this->expectException(InvalidArgumentException::class);
         $this->cachePoolPass->process($container);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | related to #41685
| License       | MIT
| Doc PR        | -

Add test on `InvalidArgumentException` in preparation for #41685
