### PR TITLE
[Security] Deprecate `PassportInterface`

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -52,3 +52,26 @@ Security
  * Deprecate `DeauthenticatedEvent`, use `TokenDeauthenticatedEvent` instead
  * Deprecate `CookieClearingLogoutHandler`, `SessionLogoutHandler` and `CsrfTokenClearingLogoutHandler`.
    Use `CookieClearingLogoutListener`, `SessionLogoutListener` and `CsrfTokenClearingLogoutListener` instead
+ * Deprecate `AuthenticatorInterface::createAuthenticatedToken()`, use `AuthenticatorInterface::createToken()` instead
+ * Deprecate `PassportInterface` and `UserPassportInterface`, use `Passport` instead.
+   As such, the return type declaration of `AuthenticatorInterface::authenticate()` will change to `Passport` in 6.0
+
+   Before:
+   ```php
+   class MyAuthenticator implements AuthenticatorInterface
+   {
+       public function authenticate(Request $request): PassportInterface
+       {
+       }
+   }
+   ```
+
+   After:
+   ```php
+   class MyAuthenticator implements AuthenticatorInterface
+   {
+       public function authenticate(Request $request): Passport
+       {
+       }
+   }
+   ```

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -328,6 +328,29 @@ Security
  * Remove `DeauthenticatedEvent`, use `TokenDeauthenticatedEvent` instead
  * Remove `CookieClearingLogoutHandler`, `SessionLogoutHandler` and `CsrfTokenClearingLogoutHandler`.
    Use `CookieClearingLogoutListener`, `SessionLogoutListener` and `CsrfTokenClearingLogoutListener` instead
+ * Remove `AuthenticatorInterface::createAuthenticatedToken()`, use `AuthenticatorInterface::createToken()` instead
+ * Remove `PassportInterface` and `UserPassportInterface`, use `Passport` instead.
+   Also, the return type declaration of `AuthenticatorInterface::authenticate()` was changed to `Passport`
+
+   Before:
+   ```php
+   class MyAuthenticator implements AuthenticatorInterface
+   {
+       public function authenticate(Request $request): PassportInterface
+       {
+       }
+   }
+   ```
+
+   After:
+   ```php
+   class MyAuthenticator implements AuthenticatorInterface
+   {
+       public function authenticate(Request $request): Passport
+       {
+       }
+   }
+   ```
 
 SecurityBundle
 --------------

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationExpiredException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationExpiredException.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Core\Exception;
 
 /**
- * AuthenticationExpiredException is thrown when an authenticated token becomes un-authenticated between requests.
+ * AuthenticationExpiredException is thrown when an authentication token becomes un-authenticated between requests.
  *
  * In practice, this is due to the User changing between requests (e.g. password changes),
  * causes the token to become un-authenticated.

--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractAuthenticator.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\Authenticator;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\LogicException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\UserPassportInterface;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
@@ -30,12 +31,23 @@ abstract class AbstractAuthenticator implements AuthenticatorInterface
      *
      * @return PostAuthenticationToken
      */
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
+        return new PostAuthenticationToken($passport->getUser(), $firewallName, $passport->getUser()->getRoles());
+    }
+
+    /**
+     * @deprecated since Symfony 5.4, use {@link createToken()} instead
+     */
     public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
     {
+        // @deprecated since Symfony 5.4
         if (!$passport instanceof UserPassportInterface) {
-            throw new LogicException(sprintf('Passport does not contain a user, overwrite "createAuthenticatedToken()" in "%s" to create a custom authenticated token.', static::class));
+            throw new LogicException(sprintf('Passport does not contain a user, overwrite "createToken()" in "%s" to create a custom authentication token.', static::class));
         }
 
-        return new PostAuthenticationToken($passport->getUser(), $firewallName, $passport->getUser()->getRoles());
+        trigger_deprecation('symfony/security-http', '5.4', 'Method "%s()" is deprecated, use "%s::createToken()" instead.', __METHOD__, __CLASS__);
+
+        return $this->createToken($passport, $firewallName);
     }
 }

--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractPreAuthenticatedAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractPreAuthenticatedAuthenticator.php
@@ -22,6 +22,7 @@ use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PreAuthenticatedUserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 
@@ -84,7 +85,7 @@ abstract class AbstractPreAuthenticatedAuthenticator implements InteractiveAuthe
         return true;
     }
 
-    public function authenticate(Request $request): PassportInterface
+    public function authenticate(Request $request): Passport
     {
         // @deprecated since 5.3, change to $this->userProvider->loadUserByIdentifier() in 6.0
         $method = 'loadUserByIdentifier';
@@ -100,7 +101,17 @@ abstract class AbstractPreAuthenticatedAuthenticator implements InteractiveAuthe
         );
     }
 
+    /**
+     * @deprecated since Symfony 5.4, use {@link createToken()} instead
+     */
     public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
+    {
+        trigger_deprecation('symfony/security-http', '5.4', 'Method "%s()" is deprecated, use "%s::createToken()" instead.', __METHOD__, __CLASS__);
+
+        return $this->createToken($passport, $firewallName);
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
     {
         return new PreAuthenticatedToken($passport->getUser(), null, $firewallName, $passport->getUser()->getRoles());
     }

--- a/src/Symfony/Component/Security/Http/Authenticator/AuthenticatorInterface.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AuthenticatorInterface.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 
 /**
@@ -23,6 +24,10 @@ use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
  * @author Ryan Weaver <ryan@symfonycasts.com>
  * @author Amaury Leroux de Lens <amaury@lerouxdelens.com>
  * @author Wouter de Jong <wouter@wouterj.nl>
+ *
+ * @method TokenInterface createToken(Passport $passport, string $firewallName) Creates a token for the given user.
+ *                                                                              If you don't care about which token class is used, you can skip this method by extending
+ *                                                                              the AbstractAuthenticator class from your authenticator.
  */
 interface AuthenticatorInterface
 {
@@ -47,8 +52,10 @@ interface AuthenticatorInterface
      * a UserNotFoundException when the user cannot be found).
      *
      * @throws AuthenticationException
+     *
+     * @return Passport
      */
-    public function authenticate(Request $request): PassportInterface;
+    public function authenticate(Request $request); /*: Passport;*/
 
     /**
      * Create an authenticated token for the given user.
@@ -60,6 +67,8 @@ interface AuthenticatorInterface
      * @see AbstractAuthenticator
      *
      * @param PassportInterface $passport The passport returned from authenticate()
+     *
+     * @deprecated since Symfony 5.4, use {@link createToken()} instead
      */
     public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface;
 

--- a/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/FormLoginAuthenticator.php
@@ -77,7 +77,7 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
             && $this->httpUtils->checkRequestPath($request, $this->options['check_path']);
     }
 
-    public function authenticate(Request $request): PassportInterface
+    public function authenticate(Request $request): Passport
     {
         $credentials = $this->getCredentials($request);
 
@@ -106,9 +106,19 @@ class FormLoginAuthenticator extends AbstractLoginFormAuthenticator
     }
 
     /**
-     * @param Passport $passport
+     * @deprecated since Symfony 5.4, use {@link createToken()} instead
      */
     public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
+    {
+        trigger_deprecation('symfony/security-http', '5.4', 'Method "%s()" is deprecated, use "%s::createToken()" instead.', __METHOD__, __CLASS__);
+
+        return $this->createToken($passport, $firewallName);
+    }
+
+    /**
+     * @return UsernamePasswordToken
+     */
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
     {
         return new UsernamePasswordToken($passport->getUser(), null, $firewallName, $passport->getUser()->getRoles());
     }

--- a/src/Symfony/Component/Security/Http/Authenticator/HttpBasicAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/HttpBasicAuthenticator.php
@@ -84,9 +84,16 @@ class HttpBasicAuthenticator implements AuthenticatorInterface, AuthenticationEn
     }
 
     /**
-     * @param Passport $passport
+     * @deprecated since Symfony 5.4, use {@link createToken()} instead
      */
     public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
+    {
+        trigger_deprecation('symfony/security-http', '5.4', 'Method "%s()" is deprecated, use "%s::createToken()" instead.', __METHOD__, __CLASS__);
+
+        return $this->createToken($passport, $firewallName);
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
     {
         return new UsernamePasswordToken($passport->getUser(), null, $firewallName, $passport->getUser()->getRoles());
     }

--- a/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/JsonLoginAuthenticator.php
@@ -110,7 +110,17 @@ class JsonLoginAuthenticator implements InteractiveAuthenticatorInterface
         return $passport;
     }
 
+    /**
+     * @deprecated since Symfony 5.4, use {@link createToken()} instead
+     */
     public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
+    {
+        trigger_deprecation('symfony/security-http', '5.4', 'Method "%s()" is deprecated, use "%s::createToken()" instead.', __METHOD__, __CLASS__);
+
+        return $this->createToken($passport, $firewallName);
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
     {
         return new UsernamePasswordToken($passport->getUser(), null, $firewallName, $passport->getUser()->getRoles());
     }

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/PassportInterface.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/PassportInterface.php
@@ -21,6 +21,8 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
  * passport.
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
+ *
+ * @deprecated since Symfony 5.4, use {@link Passport} instead
  */
 interface PassportInterface
 {

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/UserPassportInterface.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/UserPassportInterface.php
@@ -18,6 +18,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * Represents a passport for a Security User.
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
+ *
+ * @deprecated since Symfony 5.4, use {@link Passport} instead
  */
 interface UserPassportInterface extends PassportInterface
 {

--- a/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/RememberMeAuthenticator.php
@@ -22,6 +22,7 @@ use Symfony\Component\Security\Core\Exception\CookieTheftException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\RememberMe\RememberMeDetails;
@@ -95,7 +96,17 @@ class RememberMeAuthenticator implements InteractiveAuthenticatorInterface
         }));
     }
 
+    /**
+     * @deprecated since Symfony 5.4, use {@link createToken()} instead
+     */
     public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
+    {
+        trigger_deprecation('symfony/security-http', '5.4', 'Method "%s()" is deprecated, use "%s::createToken()" instead.', __METHOD__, __CLASS__);
+
+        return $this->createToken($passport, $firewallName);
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
     {
         return new RememberMeToken($passport->getUser(), $firewallName, $this->secret);
     }

--- a/src/Symfony/Component/Security/Http/Authenticator/Token/PostAuthenticationToken.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Token/PostAuthenticationToken.php
@@ -40,7 +40,7 @@ class PostAuthenticationToken extends AbstractToken
     }
 
     /**
-     * This is meant to be only an authenticated token, where credentials
+     * This is meant to be only a token, where credentials
      * have already been used and are thus cleared.
      *
      * {@inheritdoc}

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Deprecate `DeauthenticatedEvent`, use `TokenDeauthenticatedEvent` instead
  * Deprecate `CookieClearingLogoutHandler`, `SessionLogoutHandler` and `CsrfTokenClearingLogoutHandler`.
    Use `CookieClearingLogoutListener`, `SessionLogoutListener` and `CsrfTokenClearingLogoutListener` instead
+ * Deprecate `PassportInterface` and `UserPassportInterface`, use `Passport` instead
 
 5.3
 ---

--- a/src/Symfony/Component/Security/Http/Event/LoginSuccessEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/LoginSuccessEvent.php
@@ -24,8 +24,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 /**
  * This event is dispatched after authentication has successfully completed.
  *
- * At this stage, the authenticator created an authenticated token
- * and generated an authentication success response. Listeners to
+ * At this stage, the authenticator created a token and
+ * generated an authentication success response. Listeners to
  * this event can do actions related to successful authentication
  * (such as migrating the password).
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

As explained in #42181, the right extension point is badges, not passports. 

Also renames `AuthenticatorInterface::createAuthenticatedToken()` to `createToken()` because of the signature change and the recent abandon of the `authenticated` state for tokens.