### PR TITLE
Report mismatches between trans-unit id and source text via status script

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -117,3 +117,13 @@ jobs:
       #    docker run --rm -e COMPOSER_ROOT_VERSION -v $(pwd):/app -v $(which composer):/usr/local/bin/composer -v $(which vulcain):/usr/local/bin/vulcain -w /app php:8.0-alpine ./phpunit src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php --filter testHttp2Push
       #    sudo rm -rf .phpunit
       #    [ -d .phpunit.bak ] && mv .phpunit.bak .phpunit
+
+      - uses: marceloprado/has-changed-path@v1
+        id: changed-translation-files
+        with:
+          paths: src/**/Resources/translations/*.xlf
+
+      - name: Check Translation Status
+        if: steps.changed-translation-files.outputs.changed == 'true'
+        run: |
+          php src/Symfony/Component/Translation/Resources/bin/translation-status.php -v

--- a/src/Symfony/Component/Translation/Resources/bin/translation-status.php
+++ b/src/Symfony/Component/Translation/Resources/bin/translation-status.php
@@ -19,13 +19,16 @@ $usageInstructions = <<<END
   # show the translation status of all locales
   $ php translation-status.php
 
-  # show the translation status of all locales and all their missing translations
+  # only show the translation status of incomplete or erroneous locales
+  $ php translation-status.php --incomplete
+
+  # show the translation status of all locales, all their missing translations and mismatches between trans-unit id and source
   $ php translation-status.php -v
 
   # show the status of a single locale
   $ php translation-status.php fr
 
-  # show the status of a single locale and all its missing translations
+  # show the status of a single locale, missing translations and mismatches between trans-unit id and source
   $ php translation-status.php fr -v
 
 END;
@@ -35,6 +38,8 @@ $config = [
     'verbose_output' => false,
     // NULL = analyze all locales
     'locale_to_analyze' => null,
+    // append --incomplete to only show incomplete languages
+    'include_completed_languages' => true,
     // the reference files all the other translations are compared to
     'original_files' => [
         'src/Symfony/Component/Form/Resources/translations/validators.en.xlf',
@@ -46,12 +51,17 @@ $config = [
 $argc = $_SERVER['argc'];
 $argv = $_SERVER['argv'];
 
-if ($argc > 3) {
+if ($argc > 4) {
     echo str_replace('translation-status.php', $argv[0], $usageInstructions);
     exit(1);
 }
 
 foreach (array_slice($argv, 1) as $argumentOrOption) {
+    if ('--incomplete' === $argumentOrOption) {
+        $config['include_completed_languages'] = false;
+        continue;
+    }
+
     if (str_starts_with($argumentOrOption, '-')) {
         $config['verbose_output'] = true;
     } else {
@@ -67,6 +77,7 @@ foreach ($config['original_files'] as $originalFilePath) {
 }
 
 $totalMissingTranslations = 0;
+$totalTranslationMismatches = 0;
 
 foreach ($config['original_files'] as $originalFilePath) {
     $translationFilePaths = findTranslationFiles($originalFilePath, $config['locale_to_analyze']);
@@ -75,11 +86,14 @@ foreach ($config['original_files'] as $originalFilePath) {
     $totalMissingTranslations += array_sum(array_map(function ($translation) {
         return count($translation['missingKeys']);
     }, array_values($translationStatus)));
+    $totalTranslationMismatches += array_sum(array_map(function ($translation) {
+        return count($translation['mismatches']);
+    }, array_values($translationStatus)));
 
-    printTranslationStatus($originalFilePath, $translationStatus, $config['verbose_output']);
+    printTranslationStatus($originalFilePath, $translationStatus, $config['verbose_output'], $config['include_completed_languages']);
 }
 
-exit($totalMissingTranslations > 0 ? 1 : 0);
+exit($totalTranslationMismatches > 0 ? 1 : 0);
 
 function findTranslationFiles($originalFilePath, $localeToAnalyze)
 {
@@ -112,21 +126,29 @@ function calculateTranslationStatus($originalFilePath, $translationFilePaths)
     foreach ($translationFilePaths as $locale => $translationPath) {
         $translatedKeys = extractTranslationKeys($translationPath);
         $missingKeys = array_diff_key($allTranslationKeys, $translatedKeys);
+        $mismatches = findTransUnitMismatches($allTranslationKeys, $translatedKeys);
 
         $translationStatus[$locale] = [
             'total' => count($allTranslationKeys),
             'translated' => count($translatedKeys),
             'missingKeys' => $missingKeys,
+            'mismatches' => $mismatches,
         ];
+        $translationStatus[$locale]['is_completed'] = isTranslationCompleted($translationStatus[$locale]);
     }
 
     return $translationStatus;
 }
 
-function printTranslationStatus($originalFilePath, $translationStatus, $verboseOutput)
+function isTranslationCompleted(array $translationStatus): bool
+{
+    return $translationStatus['total'] === $translationStatus['translated'] && 0 === count($translationStatus['mismatches']);
+}
+
+function printTranslationStatus($originalFilePath, $translationStatus, $verboseOutput, $includeCompletedLanguages)
 {
     printTitle($originalFilePath);
-    printTable($translationStatus, $verboseOutput);
+    printTable($translationStatus, $verboseOutput, $includeCompletedLanguages);
     echo \PHP_EOL.\PHP_EOL;
 }
 
@@ -152,13 +174,35 @@ function extractTranslationKeys($filePath)
     return $translationKeys;
 }
 
+/**
+ * Check whether the trans-unit id and source match with the base translation.
+ */
+function findTransUnitMismatches(array $baseTranslationKeys, array $translatedKeys): array
+{
+    $mismatches = [];
+
+    foreach ($baseTranslationKeys as $translationId => $translationKey) {
+        if (!isset($translatedKeys[$translationId])) {
+            continue;
+        }
+        if ($translatedKeys[$translationId] !== $translationKey) {
+            $mismatches[$translationId] = [
+                'found' => $translatedKeys[$translationId],
+                'expected' => $translationKey,
+            ];
+        }
+    }
+
+    return $mismatches;
+}
+
 function printTitle($title)
 {
     echo $title.\PHP_EOL;
     echo str_repeat('=', strlen($title)).\PHP_EOL.\PHP_EOL;
 }
 
-function printTable($translations, $verboseOutput)
+function printTable($translations, $verboseOutput, bool $includeCompletedLanguages)
 {
     if (0 === count($translations)) {
         echo 'No translations found';
@@ -168,24 +212,47 @@ function printTable($translations, $verboseOutput)
     $longestLocaleNameLength = max(array_map('strlen', array_keys($translations)));
 
     foreach ($translations as $locale => $translation) {
+        if (!$includeCompletedLanguages && $translation['is_completed']) {
+            continue;
+        }
+
         if ($translation['translated'] > $translation['total']) {
             textColorRed();
-        } elseif ($translation['translated'] === $translation['total']) {
+        } elseif (count($translation['mismatches']) > 0) {
+            textColorRed();
+        } elseif ($translation['is_completed']) {
             textColorGreen();
         }
 
-        echo sprintf('| Locale: %-'.$longestLocaleNameLength.'s | Translated: %d/%d', $locale, $translation['translated'], $translation['total']).\PHP_EOL;
+        echo sprintf(
+            '|  Locale: %-'.$longestLocaleNameLength.'s  |  Translated: %2d/%2d  |  Mismatches: %d  |',
+            $locale,
+            $translation['translated'],
+            $translation['total'],
+            count($translation['mismatches'])
+        ).\PHP_EOL;
 
         textColorNormal();
 
+        $shouldBeClosed = false;
         if (true === $verboseOutput && count($translation['missingKeys']) > 0) {
-            echo str_repeat('-', 80).\PHP_EOL;
-            echo '| Missing Translations:'.\PHP_EOL;
+            echo '|    Missing Translations:'.\PHP_EOL;
 
             foreach ($translation['missingKeys'] as $id => $content) {
-                echo sprintf('|   (id=%s) %s', $id, $content).\PHP_EOL;
+                echo sprintf('|      (id=%s) %s', $id, $content).\PHP_EOL;
             }
+            $shouldBeClosed = true;
+        }
+        if (true === $verboseOutput && count($translation['mismatches']) > 0) {
+            echo '|    Mismatches between trans-unit id and source:'.\PHP_EOL;
 
+            foreach ($translation['mismatches'] as $id => $content) {
+                echo sprintf('|      (id=%s) Expected: %s', $id, $content['expected']).\PHP_EOL;
+                echo sprintf('|              Found:    %s', $content['found']).\PHP_EOL;
+            }
+            $shouldBeClosed = true;
+        }
+        if ($shouldBeClosed) {
             echo str_repeat('-', 80).\PHP_EOL;
         }
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no<!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | related to #42197 and #42189 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


As can be seen in #42197 there are several translation mismatches between trans-unit id and source. 

The `translation-status.php` script helps with checking translation statusses. This PR improves that script by matching the trans-unit id and source with the base translation, 

![image](https://user-images.githubusercontent.com/2707563/126312148-a78ff99c-97b5-4a0b-bd91-55dcdc7982e6.png)
 
The script shows the related mismatch translation ids in `-v` verbose mode:

![image](https://user-images.githubusercontent.com/2707563/126312474-f95f361f-3159-49eb-8f12-7c652ababba8.png)

And now also allows to solely show incomplete locales via the `--incomplete` script argument.

