### PR TITLE
[Translation] add types to private properties

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
@@ -33,12 +33,12 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class CrowdinProvider implements ProviderInterface
 {
-    private $client;
-    private $loader;
-    private $logger;
-    private $xliffFileDumper;
-    private $defaultLocale;
-    private $endpoint;
+    private HttpClientInterface $client;
+    private LoaderInterface $loader;
+    private LoggerInterface $logger;
+    private XliffFileDumper $xliffFileDumper;
+    private string $defaultLocale;
+    private string $endpoint;
 
     public function __construct(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, XliffFileDumper $xliffFileDumper, string $defaultLocale, string $endpoint)
     {

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProviderFactory.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProviderFactory.php
@@ -29,20 +29,11 @@ final class CrowdinProviderFactory extends AbstractProviderFactory
 {
     private const HOST = 'api.crowdin.com';
 
-    /** @var LoaderInterface */
-    private $loader;
-
-    /** @var HttpClientInterface */
-    private $client;
-
-    /** @var LoggerInterface */
-    private $logger;
-
-    /** @var string */
-    private $defaultLocale;
-
-    /** @var XliffFileDumper */
-    private $xliffFileDumper;
+    private LoaderInterface $loader;
+    private HttpClientInterface $client;
+    private LoggerInterface $logger;
+    private string $defaultLocale;
+    private XliffFileDumper $xliffFileDumper;
 
     public function __construct(HttpClientInterface $client, LoggerInterface $logger, string $defaultLocale, LoaderInterface $loader, XliffFileDumper $xliffFileDumper)
     {

--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProvider.php
@@ -31,11 +31,11 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class LocoProvider implements ProviderInterface
 {
-    private $client;
-    private $loader;
-    private $logger;
-    private $defaultLocale;
-    private $endpoint;
+    private HttpClientInterface $client;
+    private LoaderInterface $loader;
+    private LoggerInterface $logger;
+    private string $defaultLocale;
+    private string $endpoint;
 
     public function __construct(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint)
     {

--- a/src/Symfony/Component/Translation/Bridge/Loco/LocoProviderFactory.php
+++ b/src/Symfony/Component/Translation/Bridge/Loco/LocoProviderFactory.php
@@ -27,10 +27,10 @@ final class LocoProviderFactory extends AbstractProviderFactory
 {
     private const HOST = 'localise.biz';
 
-    private $client;
-    private $logger;
-    private $defaultLocale;
-    private $loader;
+    private HttpClientInterface $client;
+    private LoggerInterface $logger;
+    private string $defaultLocale;
+    private LoaderInterface $loader;
 
     public function __construct(HttpClientInterface $client, LoggerInterface $logger, string $defaultLocale, LoaderInterface $loader)
     {

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -32,11 +32,11 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 final class LokaliseProvider implements ProviderInterface
 {
-    private $client;
-    private $loader;
-    private $logger;
-    private $defaultLocale;
-    private $endpoint;
+    private HttpClientInterface $client;
+    private LoaderInterface $loader;
+    private LoggerInterface $logger;
+    private string $defaultLocale;
+    private string $endpoint;
 
     public function __construct(HttpClientInterface $client, LoaderInterface $loader, LoggerInterface $logger, string $defaultLocale, string $endpoint)
     {

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProviderFactory.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProviderFactory.php
@@ -27,10 +27,10 @@ final class LokaliseProviderFactory extends AbstractProviderFactory
 {
     private const HOST = 'api.lokalise.com';
 
-    private $client;
-    private $logger;
-    private $defaultLocale;
-    private $loader;
+    private HttpClientInterface $client;
+    private LoggerInterface $logger;
+    private string $defaultLocale;
+    private LoaderInterface $loader;
 
     public function __construct(HttpClientInterface $client, LoggerInterface $logger, string $defaultLocale, LoaderInterface $loader)
     {

--- a/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
@@ -35,12 +35,12 @@ final class TranslationPullCommand extends Command
     protected static $defaultName = 'translation:pull';
     protected static $defaultDescription = 'Pull translations from a given provider.';
 
-    private $providerCollection;
-    private $writer;
-    private $reader;
-    private $defaultLocale;
-    private $transPaths;
-    private $enabledLocales;
+    private TranslationProviderCollection $providerCollection;
+    private TranslationWriterInterface $writer;
+    private TranslationReaderInterface $reader;
+    private string $defaultLocale;
+    private array $transPaths;
+    private array $enabledLocales;
 
     public function __construct(TranslationProviderCollection $providerCollection, TranslationWriterInterface $writer, TranslationReaderInterface $reader, string $defaultLocale, array $transPaths = [], array $enabledLocales = [])
     {

--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -34,10 +34,10 @@ final class TranslationPushCommand extends Command
     protected static $defaultName = 'translation:push';
     protected static $defaultDescription = 'Push translations to a given provider.';
 
-    private $providers;
-    private $reader;
-    private $transPaths;
-    private $enabledLocales;
+    private TranslationProviderCollection $providers;
+    private TranslationReaderInterface $reader;
+    private array $transPaths;
+    private array $enabledLocales;
 
     public function __construct(TranslationProviderCollection $providers, TranslationReaderInterface $reader, array $transPaths = [], array $enabledLocales = [])
     {

--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -34,18 +34,18 @@ class XliffLintCommand extends Command
     protected static $defaultName = 'lint:xliff';
     protected static $defaultDescription = 'Lint an XLIFF file and outputs encountered errors';
 
-    private $format;
-    private $displayCorrectFiles;
-    private $directoryIteratorProvider;
-    private $isReadableProvider;
-    private $requireStrictFileNames;
+    private string $format;
+    private bool $displayCorrectFiles;
+    private ?\Closure $directoryIteratorProvider;
+    private ?\Closure $isReadableProvider;
+    private bool $requireStrictFileNames;
 
     public function __construct(string $name = null, callable $directoryIteratorProvider = null, callable $isReadableProvider = null, bool $requireStrictFileNames = true)
     {
         parent::__construct($name);
 
-        $this->directoryIteratorProvider = $directoryIteratorProvider;
-        $this->isReadableProvider = $isReadableProvider;
+        $this->directoryIteratorProvider = null === $directoryIteratorProvider || $directoryIteratorProvider instanceof \Closure ? $directoryIteratorProvider : \Closure::fromCallable($directoryIteratorProvider);
+        $this->isReadableProvider = null === $isReadableProvider || $isReadableProvider instanceof \Closure ? $isReadableProvider : \Closure::fromCallable($isReadableProvider);
         $this->requireStrictFileNames = $requireStrictFileNames;
     }
 

--- a/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
+++ b/src/Symfony/Component/Translation/DataCollector/TranslationDataCollector.php
@@ -25,7 +25,7 @@ use Symfony\Component\VarDumper\Cloner\Data;
  */
 class TranslationDataCollector extends DataCollector implements LateDataCollectorInterface
 {
-    private $translator;
+    private DataCollectorTranslator $translator;
 
     public function __construct(DataCollectorTranslator $translator)
     {

--- a/src/Symfony/Component/Translation/DataCollectorTranslator.php
+++ b/src/Symfony/Component/Translation/DataCollectorTranslator.php
@@ -25,8 +25,8 @@ class DataCollectorTranslator implements TranslatorInterface, TranslatorBagInter
     public const MESSAGE_MISSING = 1;
     public const MESSAGE_EQUALS_FALLBACK = 2;
 
-    private $translator;
-    private $messages = [];
+    private TranslatorInterface $translator;
+    private array $messages = [];
 
     /**
      * @param TranslatorInterface&TranslatorBagInterface&LocaleAwareInterface $translator

--- a/src/Symfony/Component/Translation/DependencyInjection/TranslationDumperPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslationDumperPass.php
@@ -20,8 +20,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class TranslationDumperPass implements CompilerPassInterface
 {
-    private $writerServiceId;
-    private $dumperTag;
+    private string $writerServiceId;
+    private string $dumperTag;
 
     public function __construct(string $writerServiceId = 'translation.writer', string $dumperTag = 'translation.dumper')
     {

--- a/src/Symfony/Component/Translation/DependencyInjection/TranslationExtractorPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslationExtractorPass.php
@@ -21,8 +21,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class TranslationExtractorPass implements CompilerPassInterface
 {
-    private $extractorServiceId;
-    private $extractorTag;
+    private string $extractorServiceId;
+    private string $extractorTag;
 
     public function __construct(string $extractorServiceId = 'translation.extractor', string $extractorTag = 'translation.extractor')
     {

--- a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPass.php
@@ -18,11 +18,11 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class TranslatorPass implements CompilerPassInterface
 {
-    private $translatorServiceId;
-    private $readerServiceId;
-    private $loaderTag;
-    private $debugCommandServiceId;
-    private $updateCommandServiceId;
+    private string $translatorServiceId;
+    private string $readerServiceId;
+    private string $loaderTag;
+    private string $debugCommandServiceId;
+    private string $updateCommandServiceId;
 
     public function __construct(string $translatorServiceId = 'translator.default', string $readerServiceId = 'translation.reader', string $loaderTag = 'translation.loader', string $debugCommandServiceId = 'console.command.translation_debug', string $updateCommandServiceId = 'console.command.translation_update')
     {

--- a/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
+++ b/src/Symfony/Component/Translation/DependencyInjection/TranslatorPathsPass.php
@@ -22,26 +22,26 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
  */
 class TranslatorPathsPass extends AbstractRecursivePass
 {
-    private $translatorServiceId;
-    private $debugCommandServiceId;
-    private $updateCommandServiceId;
-    private $resolverServiceId;
-    private $level = 0;
+    private string $translatorServiceId;
+    private string $debugCommandServiceId;
+    private string $updateCommandServiceId;
+    private string $resolverServiceId;
+    private int $level = 0;
 
     /**
      * @var array<string, bool>
      */
-    private $paths = [];
+    private array $paths = [];
 
     /**
      * @var array<int, Definition>
      */
-    private $definitions = [];
+    private array $definitions = [];
 
     /**
      * @var array<string, array<string, bool>>
      */
-    private $controllers = [];
+    private array $controllers = [];
 
     public function __construct(string $translatorServiceId = 'translator', string $debugCommandServiceId = 'console.command.translation_debug', string $updateCommandServiceId = 'console.command.translation_update', string $resolverServiceId = 'argument_resolver.service')
     {

--- a/src/Symfony/Component/Translation/Dumper/CsvFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/CsvFileDumper.php
@@ -20,8 +20,8 @@ use Symfony\Component\Translation\MessageCatalogue;
  */
 class CsvFileDumper extends FileDumper
 {
-    private $delimiter = ';';
-    private $enclosure = '"';
+    private string $delimiter = ';';
+    private string $enclosure = '"';
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Translation/Dumper/YamlFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/YamlFileDumper.php
@@ -23,7 +23,7 @@ use Symfony\Component\Yaml\Yaml;
  */
 class YamlFileDumper extends FileDumper
 {
-    private $extension;
+    private string $extension;
 
     public function __construct(string $extension = 'yml')
     {

--- a/src/Symfony/Component/Translation/Exception/ProviderException.php
+++ b/src/Symfony/Component/Translation/Exception/ProviderException.php
@@ -20,8 +20,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 class ProviderException extends RuntimeException implements ProviderExceptionInterface
 {
-    private $response;
-    private $debug;
+    private ResponseInterface $response;
+    private string $debug;
 
     public function __construct(string $message, ResponseInterface $response, int $code = 0, \Exception $previous = null)
     {

--- a/src/Symfony/Component/Translation/Extractor/ChainExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/ChainExtractor.php
@@ -25,7 +25,7 @@ class ChainExtractor implements ExtractorInterface
      *
      * @var ExtractorInterface[]
      */
-    private $extractors = [];
+    private array $extractors = [];
 
     /**
      * Adds a loader to the translation extractor.

--- a/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
@@ -28,7 +28,7 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
     /**
      * Prefix for new found message.
      */
-    private $prefix = '';
+    private string $prefix = '';
 
     /**
      * The sequence that captures translation messages.

--- a/src/Symfony/Component/Translation/Formatter/MessageFormatter.php
+++ b/src/Symfony/Component/Translation/Formatter/MessageFormatter.php
@@ -22,8 +22,8 @@ class_exists(IntlFormatter::class);
  */
 class MessageFormatter implements MessageFormatterInterface, IntlFormatterInterface
 {
-    private $translator;
-    private $intlFormatter;
+    private TranslatorInterface $translator;
+    private IntlFormatterInterface $intlFormatter;
 
     /**
      * @param TranslatorInterface|null $translator An identity translator to use as selector for pluralization

--- a/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
@@ -20,9 +20,9 @@ use Symfony\Component\Translation\Exception\NotFoundResourceException;
  */
 class CsvFileLoader extends FileLoader
 {
-    private $delimiter = ';';
-    private $enclosure = '"';
-    private $escape = '\\';
+    private string $delimiter = ';';
+    private string $enclosure = '"';
+    private string $escape = '\\';
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Translation/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PhpFileLoader.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Translation\Loader;
  */
 class PhpFileLoader extends FileLoader
 {
-    private static $cache = [];
+    private static ?array $cache = [];
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Translation/LoggingTranslator.php
+++ b/src/Symfony/Component/Translation/LoggingTranslator.php
@@ -21,8 +21,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class LoggingTranslator implements TranslatorInterface, TranslatorBagInterface, LocaleAwareInterface
 {
-    private $translator;
-    private $logger;
+    private TranslatorInterface $translator;
+    private LoggerInterface $logger;
 
     /**
      * @param TranslatorInterface&TranslatorBagInterface&LocaleAwareInterface $translator The translator must implement TranslatorBagInterface

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -19,12 +19,12 @@ use Symfony\Component\Translation\Exception\LogicException;
  */
 class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterface
 {
-    private $messages = [];
-    private $metadata = [];
-    private $resources = [];
-    private $locale;
-    private $fallbackCatalogue;
-    private $parent;
+    private array $messages = [];
+    private array $metadata = [];
+    private array $resources = [];
+    private string $locale;
+    private ?MessageCatalogueInterface $fallbackCatalogue = null;
+    private ?self $parent = null;
 
     /**
      * @param array $messages An array of messages classified by domain

--- a/src/Symfony/Component/Translation/Provider/Dsn.php
+++ b/src/Symfony/Component/Translation/Provider/Dsn.php
@@ -20,14 +20,14 @@ use Symfony\Component\Translation\Exception\MissingRequiredOptionException;
  */
 final class Dsn
 {
-    private $scheme;
-    private $host;
-    private $user;
-    private $password;
-    private $port;
-    private $path;
-    private $options;
-    private $originalDsn;
+    private ?string $scheme;
+    private ?string $host;
+    private ?string $user;
+    private ?string $password;
+    private ?int $port;
+    private ?string $path;
+    private array $options = [];
+    private string $originalDsn;
 
     public function __construct(string $dsn)
     {

--- a/src/Symfony/Component/Translation/Provider/FilteringProvider.php
+++ b/src/Symfony/Component/Translation/Provider/FilteringProvider.php
@@ -23,9 +23,9 @@ use Symfony\Component\Translation\TranslatorBagInterface;
  */
 class FilteringProvider implements ProviderInterface
 {
-    private $provider;
-    private $locales;
-    private $domains;
+    private ProviderInterface $provider;
+    private array $locales;
+    private array $domains;
 
     public function __construct(ProviderInterface $provider, array $locales, array $domains = [])
     {

--- a/src/Symfony/Component/Translation/Provider/TranslationProviderCollectionFactory.php
+++ b/src/Symfony/Component/Translation/Provider/TranslationProviderCollectionFactory.php
@@ -20,8 +20,8 @@ use Symfony\Component\Translation\Exception\UnsupportedSchemeException;
  */
 class TranslationProviderCollectionFactory
 {
-    private $factories;
-    private $enabledLocales;
+    private iterable $factories;
+    private array $enabledLocales;
 
     /**
      * @param iterable<mixed, ProviderFactoryInterface> $factories

--- a/src/Symfony/Component/Translation/PseudoLocalizationTranslator.php
+++ b/src/Symfony/Component/Translation/PseudoLocalizationTranslator.php
@@ -20,16 +20,16 @@ final class PseudoLocalizationTranslator implements TranslatorInterface
 {
     private const EXPANSION_CHARACTER = '~';
 
-    private $translator;
-    private $accents;
-    private $expansionFactor;
-    private $brackets;
-    private $parseHTML;
+    private TranslatorInterface $translator;
+    private bool $accents;
+    private float $expansionFactor;
+    private bool $brackets;
+    private bool $parseHTML;
 
     /**
      * @var string[]
      */
-    private $localizableHTMLAttributes;
+    private array $localizableHTMLAttributes;
 
     /**
      * Available options:

--- a/src/Symfony/Component/Translation/Reader/TranslationReader.php
+++ b/src/Symfony/Component/Translation/Reader/TranslationReader.php
@@ -27,7 +27,7 @@ class TranslationReader implements TranslationReaderInterface
      *
      * @var array<string, LoaderInterface>
      */
-    private $loaders = [];
+    private array $loaders = [];
 
     /**
      * Adds a loader to the translation extractor.

--- a/src/Symfony/Component/Translation/TranslatableMessage.php
+++ b/src/Symfony/Component/Translation/TranslatableMessage.php
@@ -19,9 +19,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class TranslatableMessage implements TranslatableInterface
 {
-    private $message;
-    private $parameters;
-    private $domain;
+    private string $message;
+    private array $parameters;
+    private ?string $domain;
 
     public function __construct(string $message, array $parameters = [], string $domain = null)
     {

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -37,54 +37,33 @@ class Translator implements TranslatorInterface, TranslatorBagInterface, LocaleA
      */
     protected $catalogues = [];
 
-    /**
-     * @var string
-     */
-    private $locale;
+    private string $locale;
 
     /**
      * @var string[]
      */
-    private $fallbackLocales = [];
+    private array $fallbackLocales = [];
 
     /**
      * @var LoaderInterface[]
      */
-    private $loaders = [];
+    private array $loaders = [];
 
-    /**
-     * @var array
-     */
-    private $resources = [];
+    private array $resources = [];
 
-    /**
-     * @var MessageFormatterInterface
-     */
-    private $formatter;
+    private MessageFormatterInterface $formatter;
 
-    /**
-     * @var string
-     */
-    private $cacheDir;
+    private ?string $cacheDir;
 
-    /**
-     * @var bool
-     */
-    private $debug;
+    private bool $debug;
 
-    private $cacheVary;
+    private array $cacheVary;
 
-    /**
-     * @var ConfigCacheFactoryInterface|null
-     */
-    private $configCacheFactory;
+    private ?ConfigCacheFactoryInterface $configCacheFactory;
 
-    /**
-     * @var array|null
-     */
-    private $parentLocales;
+    private array $parentLocales;
 
-    private $hasIntlFormatter;
+    private bool $hasIntlFormatter;
 
     /**
      * @throws InvalidArgumentException If a locale contains invalid characters
@@ -409,9 +388,7 @@ EOF
 
     protected function computeFallbackLocales(string $locale)
     {
-        if (null === $this->parentLocales) {
-            $this->parentLocales = json_decode(file_get_contents(__DIR__.'/Resources/data/parents.json'), true);
-        }
+        $this->parentLocales ??= json_decode(file_get_contents(__DIR__.'/Resources/data/parents.json'), true);
 
         $originLocale = $locale;
         $locales = [];
@@ -468,9 +445,7 @@ EOF
      */
     private function getConfigCacheFactory(): ConfigCacheFactoryInterface
     {
-        if (!$this->configCacheFactory) {
-            $this->configCacheFactory = new ConfigCacheFactory($this->debug);
-        }
+        $this->configCacheFactory ??= new ConfigCacheFactory($this->debug);
 
         return $this->configCacheFactory;
     }

--- a/src/Symfony/Component/Translation/TranslatorBag.php
+++ b/src/Symfony/Component/Translation/TranslatorBag.php
@@ -17,7 +17,7 @@ use Symfony\Component\Translation\Catalogue\TargetOperation;
 final class TranslatorBag implements TranslatorBagInterface
 {
     /** @var MessageCatalogue[] */
-    private $catalogues = [];
+    private array $catalogues = [];
 
     public function addCatalogue(MessageCatalogue $catalogue): void
     {

--- a/src/Symfony/Component/Translation/Writer/TranslationWriter.php
+++ b/src/Symfony/Component/Translation/Writer/TranslationWriter.php
@@ -26,7 +26,7 @@ class TranslationWriter implements TranslationWriterInterface
     /**
      * @var array<string, DumperInterface>
      */
-    private $dumpers = [];
+    private array $dumpers = [];
 
     /**
      * Adds a dumper to the writer.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Saw @derrabus creating PRs that add types to private properties for other components (#42179, #42109, #42146), so figured out that I could help with the translation component.

Could not find a related ticket with an overview / list of TODOs (?)

Did only add types where certain, there are several places (like `YamlFileLoader`) where the type gets set after the constructor. 