### PR TITLE
[Validator] remove `@internal` annotation on Constraint::__get()

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -204,8 +204,6 @@ abstract class Constraint
      * @return mixed The value of the option
      *
      * @throws InvalidOptionsException If an invalid option name is given
-     *
-     * @internal this method should not be used or overwritten in userland code
      */
     public function __get(string $option)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This annotation is misleading and too limiting for no good reason.
The `File` and `Valid` constraints already extend the method without making it internal.