### PR TITLE
[Lock] Handle lock with long key

### DIFF
--- a/src/Symfony/Component/Lock/Store/FlockStore.php
+++ b/src/Symfony/Component/Lock/Store/FlockStore.php
@@ -74,7 +74,7 @@ class FlockStore implements StoreInterface, BlockingStoreInterface
 
         $fileName = sprintf('%s/sf.%s.%s.lock',
             $this->lockPath,
-            preg_replace('/[^a-z0-9\._-]+/i', '-', $key),
+            substr(preg_replace('/[^a-z0-9\._-]+/i', '-', $key), 0, 50),
             strtr(substr(base64_encode(hash('sha256', $key, true)), 0, 7), '/', '_')
         );
 

--- a/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
+++ b/src/Symfony/Component/Lock/Tests/Store/FlockStoreTest.php
@@ -73,4 +73,25 @@ class FlockStoreTest extends AbstractStoreTest
 
         $store->delete($key);
     }
+
+    public function testSaveSanitizeLongName()
+    {
+        $store = $this->getStore();
+
+        $key = new Key(str_repeat(__CLASS__, 100));
+
+        $file = sprintf(
+            '%s/sf.Symfony-Component-Lock-Tests-Store-FlockStoreTestS.%s.lock',
+            sys_get_temp_dir(),
+            strtr(substr(base64_encode(hash('sha256', $key, true)), 0, 7), '/', '_')
+        );
+        // ensure the file does not exist before the store
+        @unlink($file);
+
+        $store->save($key);
+
+        $this->assertFileExists($file);
+
+        $store->delete($key);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When lock key is very long, the generated file exceeded the maximum length supported by the system, leading to an exception
`fopen(/tmp/sf.username_xxxxxxxx[...].d3rUs2a.lock): Failed to open stream: File name too long`
