### PR TITLE
[HttpClient] [Contracts] doc: HttpClientInterface::withOptions method is not static

### DIFF
--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\HttpClient\Test\HttpClientTestCase;
  *
  * @see HttpClientTestCase for a reference test suite
  *
- * @method static withOptions(array $options) Returns a new instance of the client with new default options
+ * @method withOptions(array $options) Returns a new instance of the client with new default options
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`HttpClientInterface::withOptions()` method is documented as static, but it's not. This is triggering warning in some IDE like phpstorm

<img width="823" alt="Capture d’écran 2021-07-21 à 12 48 24" src="https://user-images.githubusercontent.com/4425529/126476950-e352a369-8d0d-45d2-8a21-cb4385cb7a4e.png">


