### PR TITLE
[Mailer] Add support of ping_threshold to SesTransportFactory

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesTransportFactoryTest.php
@@ -116,6 +116,11 @@ class SesTransportFactoryTest extends TransportFactoryTestCase
             new Dsn('ses+smtps', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu-west-1']),
             new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', $dispatcher, $logger),
         ];
+
+        yield [
+            new Dsn('ses+smtps', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu-west-1', 'ping_threshold' => '10']),
+            (new SesSmtpTransport(self::USER, self::PASSWORD, 'eu-west-1', $dispatcher, $logger))->setPingThreshold(10),
+        ];
     }
 
     public function unsupportedSchemeProvider(): iterable

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesTransportFactory.php
@@ -30,7 +30,13 @@ final class SesTransportFactory extends AbstractTransportFactory
         $region = $dsn->getOption('region');
 
         if ('ses+smtp' === $scheme || 'ses+smtps' === $scheme) {
-            return new SesSmtpTransport($this->getUser($dsn), $this->getPassword($dsn), $region, $this->dispatcher, $this->logger);
+            $transport = new SesSmtpTransport($this->getUser($dsn), $this->getPassword($dsn), $region, $this->dispatcher, $this->logger);
+
+            if (null !== ($pingThreshold = $dsn->getOption('ping_threshold'))) {
+                $transport->setPingThreshold((int) $pingThreshold);
+            }
+
+            return $transport;
         }
 
         switch ($scheme) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #39044
| License       | MIT
| Doc PR        | -

Added support of ping_threshold option to `SesTransportFactory` for `ses+smtp` and `ses+smtps` schemes. Needed because SES closes SMTP connection after 10 seconds of inactivity and `TransportException` will be thrown on next send: `Expected response code "250" but got code "451", with message "451 4.4.2 Timeout waiting for data from client.".`
