### PR TITLE
[Lock] recommend createIndex over ensureIndex

### DIFF
--- a/src/Symfony/Component/Lock/Store/MongoDbStore.php
+++ b/src/Symfony/Component/Lock/Store/MongoDbStore.php
@@ -168,7 +168,7 @@ class MongoDbStore implements PersistingStoreInterface
      *
      * Alternatively the TTL index can be created manually on the database:
      *
-     *  db.lock.ensureIndex(
+     *  db.lock.createIndex(
      *      { "expires_at": 1 },
      *      { "expireAfterSeconds": 0 }
      *  )


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | no - kinda (phpdoc only fix)
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42227 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/15547

Updated PHPDoc to recommend using `createIndex` instead of `ensureIndex`. `ensureIndex` was deprecated in `mongodb 3.0.0` and removed in `mongodb 5.0.0`
