### PR TITLE
[HttpFoundation] update phpdoc to recommend createIndex over ensureIndex

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -51,7 +51,7 @@ class MongoDbSessionHandler extends AbstractSessionHandler
      * A TTL collections can be used on MongoDB 2.2+ to cleanup expired sessions
      * automatically. Such an index can for example look like this:
      *
-     *     db.<session-collection>.ensureIndex(
+     *     db.<session-collection>.createIndex(
      *         { "<expiry-field>": 1 },
      *         { "expireAfterSeconds": 0 }
      *     )


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no - kinda (phpdoc only fix)
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42229
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/15548

Updated PHPDoc to recommend using `createIndex` instead of `ensureIndex`. `ensureIndex` was deprecated in `mongodb 3.0.0` and removed in `mongodb 5.0.0`
