### PR TITLE
[Console] mark as skip test testTraversableMultiselectAutocomplete for Windows

### DIFF
--- a/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
@@ -835,6 +835,10 @@ class QuestionHelperTest extends AbstractQuestionHelperTest
 
     public function testTraversableMultiselectAutocomplete()
     {
+        if (!Terminal::hasSttyAvailable()) {
+            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+        }
+
         // <NEWLINE>
         // F<TAB><NEWLINE>
         // A<3x UP ARROW><TAB>,F<TAB><NEWLINE>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | no
| New feature?  |no 
| Deprecations? | no 
| Tickets       | Fix #... 
| License       | MIT
| Doc PR        | 

I think that in tests we need to adhere to one style, if we skip tests with "stty", then this one needs to be skipped or unchecked from all the others.

```cmd
C:\symfony>C:\php\7.1.3\php.exe C:\symfony\phpunit --color=never --bootstrap C:\symfony\vendor\autoload.php --configuration C:\symfony\phpunit.xml.dist src/Symfony/Component/Console/Tests/Helper/QuestionHelperTest.php
#!/usr/bin/env php
PHPUnit 7.5.20 by Sebastian Bergmann and contributors.

Testing Symfony\Component\Console\Tests\Helper\QuestionHelperTest
....SSSSSSSSSSSS..................................SSF             53 / 53 (100%)

Time: 912 ms, Memory: 8.00 MB

There was 1 failure:

1) Symfony\Component\Console\Tests\Helper\QuestionHelperTest::testTraversableMultiselectAutocomplete
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'FooBundle'
+    0 => 'AcmeDemoBundle'
+    1 => 'AsseticBundle'
 )

C:\symfony\src\Symfony\Component\Console\Tests\Helper\QuestionHelperTest.php:864

FAILURES!
Tests: 53, Assertions: 72, Failures: 1, Skipped: 14.
`