### PR TITLE
[Serializer] Add support for denormalizing invalid datetime without throwing an exception

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -45,3 +45,8 @@ Security
  * Deprecate `TokenInterface:isAuthenticated()` and `setAuthenticated()` methods without replacement.
    Security tokens won't have an "authenticated" flag anymore, so they will always be considered authenticated
  * Deprecate `DeauthenticatedEvent`, use `TokenDeauthenticatedEvent` instead
+
+Serializer
+----------
+
+ * Deprecate not setting a value for the context key `DateTimeNormalizer::THROW_EXCEPTION_ON_INVALID_KEY`

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -349,6 +349,7 @@ Serializer
  * Removed `ArrayDenormalizer::setSerializer()`, call `setDenormalizer()` instead.
  * `ArrayDenormalizer` does not implement `SerializerAwareInterface` anymore.
  * The annotation classes cannot be constructed by passing an array of parameters as first argument anymore, use named arguments instead
+ * The default context value for `DateTimeNormalizer::THROW_EXCEPTION_ON_INVALID_KEY` becomes `false`.
 
 TwigBundle
 ----------

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
@@ -13,3 +13,9 @@ framework:
 
 services:
     logger: { class: Psr\Log\NullLogger }
+
+    serializer.normalizer.datetime:
+        class: Symfony\Component\Serializer\Normalizer\DateTimeNormalizer
+        arguments:
+            $defaultContext:
+                throw_exception_on_invalid_key: false

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support of PHP backed enumerations
+ * Add support for denormalizing invalid datetime without throwing an exception
 
 5.3
 ---

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ContextMetadataTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ContextMetadataTestTrait.php
@@ -32,7 +32,7 @@ trait ContextMetadataTestTrait
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
         $normalizer = new ObjectNormalizer($classMetadataFactory, null, null, new PhpDocExtractor());
-        new Serializer([new DateTimeNormalizer(), $normalizer]);
+        new Serializer([new DateTimeNormalizer([DateTimeNormalizer::THROW_EXCEPTION_ON_INVALID_KEY => false]), $normalizer]);
 
         $dummy = new ContextMetadataDummy();
         $dummy->date = new \DateTime('2011-07-28T08:44:00.123+00:00');
@@ -52,7 +52,7 @@ trait ContextMetadataTestTrait
     {
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
         $normalizer = new ObjectNormalizer($classMetadataFactory, null, null, new PhpDocExtractor());
-        new Serializer([new DateTimeNormalizer(), $normalizer]);
+        new Serializer([new DateTimeNormalizer([DateTimeNormalizer::THROW_EXCEPTION_ON_INVALID_KEY => false]), $normalizer]);
 
         /** @var ContextMetadataDummy $dummy */
         $dummy = $normalizer->denormalize(['date' => '2011-07-28T08:44:00+00:00'], ContextMetadataDummy::class);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -619,7 +619,7 @@ class ObjectNormalizerTest extends TestCase
     {
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
         $normalizer = new ObjectNormalizer(null, null, null, $extractor);
-        $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), $normalizer]);
+        $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer([DateTimeNormalizer::THROW_EXCEPTION_ON_INVALID_KEY => false]), $normalizer]);
 
         $obj = $serializer->denormalize([
             'inner' => ['foo' => 'foo', 'bar' => 'bar'],
@@ -638,7 +638,7 @@ class ObjectNormalizerTest extends TestCase
     {
         $extractor = new PropertyInfoExtractor([], [new PhpDocExtractor(), new ReflectionExtractor()]);
         $normalizer = new ObjectNormalizer(null, null, null, $extractor);
-        $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer(), $normalizer]);
+        $serializer = new Serializer([new ArrayDenormalizer(), new DateTimeNormalizer([DateTimeNormalizer::THROW_EXCEPTION_ON_INVALID_KEY => false]), $normalizer]);
 
         $this->assertSame(10.0, $serializer->denormalize(['number' => 10], JsonNumber::class, 'json')->number);
         $this->assertSame(10.0, $serializer->denormalize(['number' => 10], JsonNumber::class, 'jsonld')->number);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #27824
| License       | MIT
| Doc PR        |