### PR TITLE
[DependencyInjection] Add `SubscribedService` attribute, deprecate current `ServiceSubscriberTrait` usage

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/LegacyTestServiceSubscriberChild.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/LegacyTestServiceSubscriberChild.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+use Symfony\Contracts\Service\ServiceSubscriberTrait;
+
+class LegacyTestServiceSubscriberChild extends LegacyTestServiceSubscriberParent
+{
+    use ServiceSubscriberTrait;
+    use LegacyTestServiceSubscriberTrait;
+
+    private function testDefinition2(): TestDefinition2
+    {
+        return $this->container->get(__METHOD__);
+    }
+
+    private function invalidDefinition(): InvalidDefinition
+    {
+        return $this->container->get(__METHOD__);
+    }
+
+    private function privateFunction1(): string
+    {
+    }
+
+    private function privateFunction2(): string
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/LegacyTestServiceSubscriberParent.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/LegacyTestServiceSubscriberParent.php
@@ -2,19 +2,13 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
-use Symfony\Contracts\Service\Attribute\SubscribedService;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\Contracts\Service\ServiceSubscriberTrait;
 
-class TestServiceSubscriberParent implements ServiceSubscriberInterface
+class LegacyTestServiceSubscriberParent implements ServiceSubscriberInterface
 {
     use ServiceSubscriberTrait;
 
-    public function publicFunction1(): SomeClass
-    {
-    }
-
-    #[SubscribedService]
     private function testDefinition1(): TestDefinition1
     {
         return $this->container->get(__METHOD__);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/LegacyTestServiceSubscriberTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/LegacyTestServiceSubscriberTrait.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+trait LegacyTestServiceSubscriberTrait
+{
+    private function testDefinition3(): TestDefinition3
+    {
+        return $this->container->get(__CLASS__.'::'.__FUNCTION__);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberChild.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberChild.php
@@ -2,6 +2,7 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
+use Symfony\Contracts\Service\Attribute\SubscribedService;
 use Symfony\Contracts\Service\ServiceSubscriberTrait;
 
 class TestServiceSubscriberChild extends TestServiceSubscriberParent
@@ -9,11 +10,19 @@ class TestServiceSubscriberChild extends TestServiceSubscriberParent
     use ServiceSubscriberTrait;
     use TestServiceSubscriberTrait;
 
-    private function testDefinition2(): TestDefinition2
+    #[SubscribedService]
+    private function testDefinition2(): ?TestDefinition2
     {
         return $this->container->get(__METHOD__);
     }
 
+    #[SubscribedService('custom_name')]
+    private function testDefinition3(): TestDefinition3
+    {
+        return $this->container->get('custom_name');
+    }
+
+    #[SubscribedService]
     private function invalidDefinition(): InvalidDefinition
     {
         return $this->container->get(__METHOD__);
@@ -24,6 +33,10 @@ class TestServiceSubscriberChild extends TestServiceSubscriberParent
     }
 
     private function privateFunction2(): string
+    {
+    }
+
+    private function privateFunction3(): AnotherClass
     {
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/TestServiceSubscriberTrait.php
@@ -2,9 +2,16 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
 
+use Symfony\Contracts\Service\Attribute\SubscribedService;
+
 trait TestServiceSubscriberTrait
 {
-    private function testDefinition3(): TestDefinition3
+    protected function protectedFunction1(): SomeClass
+    {
+    }
+
+    #[SubscribedService]
+    private function testDefinition4(): TestDefinition3
     {
         return $this->container->get(__CLASS__.'::'.__FUNCTION__);
     }

--- a/src/Symfony/Contracts/Service/Attribute/SubscribedService.php
+++ b/src/Symfony/Contracts/Service/Attribute/SubscribedService.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Contracts\Service\Attribute;
+
+use Symfony\Contracts\Service\ServiceSubscriberTrait;
+
+/**
+ * Use with {@see ServiceSubscriberTrait} to mark a method's return type
+ * as a subscribed service.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_METHOD)]
+final class SubscribedService
+{
+    /**
+     * @param string|null $key The key to use for the service
+     *                         If null, use "ClassName::methodName"
+     */
+    public function __construct(
+        public ?string $key = null
+    ) {
+    }
+}

--- a/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
+++ b/src/Symfony/Contracts/Service/ServiceSubscriberTrait.php
@@ -12,10 +12,11 @@
 namespace Symfony\Contracts\Service;
 
 use Psr\Container\ContainerInterface;
+use Symfony\Contracts\Service\Attribute\SubscribedService;
 
 /**
  * Implementation of ServiceSubscriberInterface that determines subscribed services from
- * private method return types. Service ids are available as "ClassName::methodName".
+ * method return types. Service ids are available as "ClassName::methodName".
  *
  * @author Kevin Bond <kevinbond@gmail.com>
  */
@@ -36,13 +37,59 @@ trait ServiceSubscriberTrait
         }
 
         $services = \is_callable(['parent', __FUNCTION__]) ? parent::getSubscribedServices() : [];
+        $attributeOptIn = false;
 
-        foreach ((new \ReflectionClass(self::class))->getMethods() as $method) {
-            if ($method->isStatic() || $method->isAbstract() || $method->isGenerator() || $method->isInternal() || $method->getNumberOfRequiredParameters()) {
-                continue;
+        if (\PHP_VERSION_ID >= 80000) {
+            foreach ((new \ReflectionClass(self::class))->getMethods() as $method) {
+                if (self::class !== $method->getDeclaringClass()->name) {
+                    continue;
+                }
+
+                if (!$attribute = $method->getAttributes(SubscribedService::class)[0] ?? null) {
+                    continue;
+                }
+
+                if ($method->isStatic() || $method->isAbstract() || $method->isGenerator() || $method->isInternal() || $method->getNumberOfRequiredParameters()) {
+                    throw new \LogicException(sprintf('Cannot use "%s" on method "%s::%s()" (can only be used on non-static, non-abstract methods with no parameters).', SubscribedService::class, self::class, $method->name));
+                }
+
+                if (!$returnType = $method->getReturnType()) {
+                    throw new \LogicException(sprintf('Cannot use "%s" on methods without a return type in "%s::%s()".', SubscribedService::class, $method->name, self::class));
+                }
+
+                $serviceId = $returnType instanceof \ReflectionNamedType ? $returnType->getName() : (string) $returnType;
+
+                if ($returnType->allowsNull()) {
+                    $serviceId = '?'.$serviceId;
+                }
+
+                $services[$attribute->newInstance()->key ?? self::class.'::'.$method->name] = $serviceId;
+                $attributeOptIn = true;
             }
+        }
 
-            if (self::class === $method->getDeclaringClass()->name && ($returnType = $method->getReturnType()) && !$returnType->isBuiltin()) {
+        if (!$attributeOptIn) {
+            foreach ((new \ReflectionClass(self::class))->getMethods() as $method) {
+                if ($method->isStatic() || $method->isAbstract() || $method->isGenerator() || $method->isInternal() || $method->getNumberOfRequiredParameters()) {
+                    continue;
+                }
+
+                if (self::class !== $method->getDeclaringClass()->name) {
+                    continue;
+                }
+
+                if (!$returnType = $method->getReturnType()) {
+                    continue;
+                }
+
+                if ($returnType->isBuiltin()) {
+                    continue;
+                }
+
+                if (\PHP_VERSION_ID >= 80000) {
+                    trigger_deprecation('symfony/service-contracts', '2.5', 'Using "%s" in "%s" without using the "%s" attribute on any method is deprecated.', ServiceSubscriberTrait::class, self::class, SubscribedService::class);
+                }
+
                 $services[self::class.'::'.$method->name] = '?'.($returnType instanceof \ReflectionNamedType ? $returnType->getName() : $returnType);
             }
         }

--- a/src/Symfony/Contracts/Service/composer.json
+++ b/src/Symfony/Contracts/Service/composer.json
@@ -17,7 +17,8 @@
     ],
     "require": {
         "php": ">=7.2.5",
-        "psr/container": "^1.1"
+        "psr/container": "^1.1",
+        "symfony/deprecation-contracts": "^2.1"
     },
     "conflict": {
         "ext-psr": "<1.1|>=2"

--- a/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
+++ b/src/Symfony/Contracts/Tests/Service/ServiceSubscriberTraitTest.php
@@ -13,15 +13,34 @@ namespace Symfony\Contracts\Tests\Service;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Component1\Dir1\Service1;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\Prototype\OtherDir\Component1\Dir2\Service2;
+use Symfony\Contracts\Service\Attribute\SubscribedService;
 use Symfony\Contracts\Service\ServiceLocatorTrait;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 use Symfony\Contracts\Service\ServiceSubscriberTrait;
 
 class ServiceSubscriberTraitTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
+    public function testLegacyMethodsOnParentsAndChildrenAreIgnoredInGetSubscribedServices()
+    {
+        $expected = [LegacyTestService::class.'::aService' => '?'.Service2::class];
+
+        $this->assertEquals($expected, LegacyChildTestService::getSubscribedServices());
+    }
+
+    /**
+     * @requires PHP 8
+     */
     public function testMethodsOnParentsAndChildrenAreIgnoredInGetSubscribedServices()
     {
-        $expected = [TestService::class.'::aService' => '?Symfony\Contracts\Tests\Service\Service2'];
+        $expected = [
+            TestService::class.'::aService' => Service2::class,
+            TestService::class.'::nullableService' => '?'.Service2::class,
+        ];
 
         $this->assertEquals($expected, ChildTestService::getSubscribedServices());
     }
@@ -48,7 +67,7 @@ class ParentTestService
     }
 }
 
-class TestService extends ParentTestService implements ServiceSubscriberInterface
+class LegacyTestService extends ParentTestService implements ServiceSubscriberInterface
 {
     use ServiceSubscriberTrait;
 
@@ -57,9 +76,36 @@ class TestService extends ParentTestService implements ServiceSubscriberInterfac
     }
 }
 
-class ChildTestService extends TestService
+class LegacyChildTestService extends LegacyTestService
 {
     public function aChildService(): Service3
     {
     }
+}
+
+class TestService extends ParentTestService implements ServiceSubscriberInterface
+{
+    use ServiceSubscriberTrait;
+
+    #[SubscribedService]
+    public function aService(): Service2
+    {
+    }
+
+    #[SubscribedService]
+    public function nullableService(): ?Service2
+    {
+    }
+}
+
+class ChildTestService extends TestService
+{
+    #[SubscribedService]
+    public function aChildService(): Service3
+    {
+    }
+}
+
+class Service3
+{
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #42217
| License       | MIT
| Doc PR        | TODO

This is a fix for #42217 using what I proposed there (adding `SubscribedService` attribute). The current usage is deprecated in 5.4 only when using PHP 8+. I suggest removing the current usage entirely in Symfony 6.0 - this will _fully fix_ the bug.

**Deprecation Layer:**
1. Symfony 5.4 with PHP < 8, everything works as it does currently (no deprecation warnings).
2. Symfony 5.4 with PHP > 8 and using the trait on a class w/o any methods marked with the `SubscribedService` attribute, works as it does currently but a deprecation warning is triggered.
3. Symfony 5.4 with PHP > 8 and using the trait on a class with at least one method marked with the `SubscribedService` attribute, you've opted-into the new functionality (methods w/o the attribute are ignored).