### PR TITLE
[Notifier] Add Yunpian Notifier Bridge

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -144,6 +144,7 @@ use Symfony\Component\Notifier\Bridge\SpotHit\SpotHitTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telnyx\TelnyxTransportFactory;
 use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory;
+use Symfony\Component\Notifier\Bridge\Yunpian\YunpianTransportFactory;
 use Symfony\Component\Notifier\Bridge\Zulip\ZulipTransportFactory;
 use Symfony\Component\Notifier\Notifier;
 use Symfony\Component\Notifier\Recipient\Recipient;
@@ -2453,6 +2454,7 @@ class FrameworkExtension extends Extension
             TelegramTransportFactory::class => 'notifier.transport_factory.telegram',
             TelnyxTransportFactory::class => 'notifier.transport_factory.telnyx',
             TwilioTransportFactory::class => 'notifier.transport_factory.twilio',
+            YunpianTransportFactory::class => 'notifier.transport_factory.yunpian',
             ZulipTransportFactory::class => 'notifier.transport_factory.zulip',
         ];
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -46,6 +46,7 @@ use Symfony\Component\Notifier\Bridge\SpotHit\SpotHitTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telnyx\TelnyxTransportFactory;
 use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory;
+use Symfony\Component\Notifier\Bridge\Yunpian\YunpianTransportFactory;
 use Symfony\Component\Notifier\Bridge\Zulip\ZulipTransportFactory;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\NullTransportFactory;
@@ -202,6 +203,10 @@ return static function (ContainerConfigurator $container) {
             ->tag('texter.transport_factory')
 
         ->set('notifier.transport_factory.mailjet', MailjetTransportFactory::class)
+            ->parent('notifier.transport_factory.abstract')
+            ->tag('texter.transport_factory')
+
+        ->set('notifier.transport_factory.yunpian', YunpianTransportFactory::class)
             ->parent('notifier.transport_factory.abstract')
             ->tag('texter.transport_factory')
     ;

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/.gitignore
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.4
+---
+
+ * Add the bridge

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2021 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/README.md
@@ -1,0 +1,22 @@
+Yunpian Notifier
+===============
+
+Provides [Yunpian](https://www.yunpian.com) integration for Symfony Notifier.
+
+DSN example
+-----------
+
+```
+YUNPIAN_DSN=yunpian://APIKEY@default
+```
+
+where:
+ - `APIKEY` is your Yunpian API key
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/Tests/YunpianTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/Tests/YunpianTransportFactoryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Yunpian\Tests;
+
+use Symfony\Component\Notifier\Bridge\Yunpian\YunpianTransportFactory;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
+
+final class YunpianTransportFactoryTest extends TransportFactoryTestCase
+{
+    /**
+     * @return YunpianTransportFactory
+     */
+    public function createFactory(): TransportFactoryInterface
+    {
+        return new YunpianTransportFactory();
+    }
+
+    public function createProvider(): iterable
+    {
+        yield [
+            'yunpian://host.test',
+            'yunpian://api_key@host.test',
+        ];
+    }
+
+    public function supportsProvider(): iterable
+    {
+        yield [true, 'yunpian://api_key@default'];
+        yield [false, 'somethingElse://api_key@default'];
+    }
+
+    public function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://api_key@default'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/Tests/YunpianTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/Tests/YunpianTransportTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Yunpian\Tests;
+
+use Symfony\Component\Notifier\Bridge\Yunpian\YunpianTransport;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class YunpianTransportTest extends TransportTestCase
+{
+    /**
+     * @return YunpianTransport
+     */
+    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    {
+        return new YunpianTransport('api_key', $client ?? $this->createMock(HttpClientInterface::class));
+    }
+
+    public function toStringProvider(): iterable
+    {
+        yield ['yunpian://sms.yunpian.com', $this->createTransport()];
+    }
+
+    public function supportedMessagesProvider(): iterable
+    {
+        yield [new SmsMessage('+0611223344', 'Hello!')];
+    }
+
+    public function unsupportedMessagesProvider(): iterable
+    {
+        yield [new ChatMessage('Hello!')];
+        yield [$this->createMock(MessageInterface::class)];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/YunpianTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/YunpianTransport.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Yunpian;
+
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Mathieu Santostefano <msantostefano@protonmail.com>
+ */
+class YunpianTransport extends AbstractTransport
+{
+    protected const HOST = 'sms.yunpian.com';
+
+    private $apiKey;
+
+    public function __construct(string $apiKey, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    {
+        $this->apiKey = $apiKey;
+
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('yunpian://%s', $this->getEndpoint());
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof SmsMessage;
+    }
+
+    protected function doSend(MessageInterface $message): SentMessage
+    {
+        if (!$message instanceof SmsMessage) {
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
+        }
+
+        $endpoint = sprintf('https://%s/v2/sms/single_send.json', self::HOST);
+        $response = $this->client->request('POST', $endpoint, [
+            'body' => [
+                'apikey' => $this->apiKey,
+                'mobile' => $message->getPhone(),
+                'text' => $message->getSubject(),
+            ],
+        ]);
+
+        try {
+            $data = $response->toArray(false);
+        } catch (ExceptionInterface $exception) {
+            throw new TransportException('Unable to send the SMS.', $response);
+        }
+
+        if (isset($data['code']) && 0 !== (int) $data['code']) {
+            throw new TransportException(sprintf('Unable to send SMS: "Code: "%s". Message: "%s"".', $data['code'], $data['msg'] ?? 'Unknown reason'), $response);
+        }
+
+        return new SentMessage($message, (string) $this);
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/YunpianTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/YunpianTransportFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Yunpian;
+
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+
+/**
+ * @author Mathieu Santostefano <msantostefano@protonmail.com>
+ */
+class YunpianTransportFactory extends AbstractTransportFactory
+{
+    /**
+     * @return YunpianTransport
+     */
+    public function create(Dsn $dsn): TransportInterface
+    {
+        if ('yunpian' !== $dsn->getScheme()) {
+            throw new UnsupportedSchemeException($dsn, 'yunpian', $this->getSupportedSchemes());
+        }
+
+        $apiKey = $this->getUser($dsn);
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+
+        return (new YunpianTransport($apiKey, $this->client, $this->dispatcher))->setHost($host)->setPort($dsn->getPort());
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['yunpian'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "symfony/yunpian-notifier",
+    "type": "symfony-bridge",
+    "description": "Symfony Yunpian Notifier Bridge",
+    "keywords": ["sms", "yunpian", "notifier"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Mathieu Santostefano",
+            "email": "msantostefano@protonmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=7.2.5",
+        "symfony/http-client": "^4.4|^5.2",
+        "symfony/notifier": "^5.3"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Yunpian\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Notifier/Bridge/Yunpian/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/Yunpian/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Yunpian Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -160,6 +160,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Twilio\TwilioTransportFactory::class,
             'package' => 'symfony/twilio-notifier',
         ],
+        'yunpian' => [
+            'class' => Bridge\Yunpian\YunpianTransportFactory::class,
+            'package' => 'symfony/yunpian-notifier',
+        ],
         'zulip' => [
             'class' => Bridge\Zulip\ZulipTransportFactory::class,
             'package' => 'symfony/zulip-notifier',

--- a/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -48,6 +48,7 @@ use Symfony\Component\Notifier\Bridge\SpotHit\SpotHitTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telnyx\TelnyxTransportFactory;
 use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory;
+use Symfony\Component\Notifier\Bridge\Yunpian\YunpianTransportFactory;
 use Symfony\Component\Notifier\Bridge\Zulip\ZulipTransportFactory;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -96,6 +97,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
             TelegramTransportFactory::class => false,
             TelnyxTransportFactory::class => false,
             TwilioTransportFactory::class => false,
+            YunpianTransportFactory::class => false,
             ZulipTransportFactory::class => false,
         ]);
     }

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -40,6 +40,7 @@ use Symfony\Component\Notifier\Bridge\SmsBiuras\SmsBiurasTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telnyx\TelnyxTransportFactory;
 use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory;
+use Symfony\Component\Notifier\Bridge\Yunpian\YunpianTransportFactory;
 use Symfony\Component\Notifier\Bridge\Zulip\ZulipTransportFactory;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -87,6 +88,7 @@ class Transport
         TelegramTransportFactory::class,
         TelnyxTransportFactory::class,
         TwilioTransportFactory::class,
+        YunpianTransportFactory::class,
         ZulipTransportFactory::class,
     ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/15553

This PR provides support for [Yunpian](https://www.yunpian.com/) in Notifier. Yunpian is a Chinese SMS provider.
I based this bridge on this repository https://github.com/siganushka/yunpian-notifier, I made some fixes, and add tests.

It only supports single SMS send. Yunpian provides a batch mode which I have never used.