### PR TITLE
[Serializer] Add support for preserving empty object in object property

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support of PHP backed enumerations
+ * Add support for preserving empty object in object property
 
 5.3
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -592,6 +592,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             return $data;
         }
 
+        if ([] === $attributeValue && ($context[self::PRESERVE_EMPTY_OBJECTS] ?? $this->defaultContext[self::PRESERVE_EMPTY_OBJECTS] ?? false)) {
+            $attributeValue = new \ArrayObject();
+        }
+
         if ($this->nameConverter) {
             $attribute = $this->nameConverter->normalize($attribute, $class, $format, $context);
         }

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -535,7 +535,10 @@ class SerializerTest extends TestCase
         $object['foo'] = new \ArrayObject();
         $object['bar'] = new \ArrayObject(['notempty']);
         $object['baz'] = new \ArrayObject(['nested' => new \ArrayObject()]);
-        $this->assertEquals('{"foo":{},"bar":["notempty"],"baz":{"nested":{}}}', $serializer->serialize($object, 'json', [AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true]));
+        $object['innerObject'] = new class() {
+            public $map = [];
+        };
+        $this->assertEquals('{"foo":{},"bar":["notempty"],"baz":{"nested":{}},"innerObject":{"map":{}}}', $serializer->serialize($object, 'json', [AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true]));
     }
 
     public function testNormalizeScalar()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? |
| Tickets       | Fix #38192
| License       | MIT
| Doc PR        |

This PR leverage https://symfony.com/blog/new-in-symfony-5-3-inlined-serialization-context to fix #38192.

Example:

```php
class MyDto
{
    public function __construct(
        #[Context([AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true ])]
        public array $mapWithOption = [],
        #[Context([AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true ])]
        public array $mapWithOptionAndData = ['foo' => 'bar'],
        public array $mapWithoutOption = [],
        public array $mapWithoutOptionAndData = ['foo' => 'bar'],
    ) {
    }
}
```

Will produce:
```json
{"mapWithOption":{},"mapWithOptionAndData":{"foo":"bar"},"mapWithoutOption":[],"mapWithoutOptionAndData":{"foo":"bar"}}
```