### PR TITLE
[4.4] Add missing `@return` annotations

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/ElasticsearchLogstashHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/ElasticsearchLogstashHandler.php
@@ -129,6 +129,9 @@ class ElasticsearchLogstashHandler extends AbstractHandler
         $this->wait(false);
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -318,6 +318,9 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
         return $this->invalidateTags([]);
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/Cache/DoctrineProvider.php
+++ b/src/Symfony/Component/Cache/DoctrineProvider.php
@@ -48,6 +48,8 @@ class DoctrineProvider extends CacheProvider implements PruneableInterface, Rese
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     protected function doFetch($id)
     {

--- a/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
@@ -115,6 +115,9 @@ trait AbstractAdapterTrait
         return true;
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/AbstractConfigurator.php
@@ -34,6 +34,9 @@ abstract class AbstractConfigurator
         throw new \BadMethodCallException(sprintf('Call to undefined method "%s::%s()".', static::class, $method));
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -346,6 +346,8 @@ class Form extends Link implements \ArrayAccess
      * @param string       $name  The field name
      * @param string|array $value The value of the field
      *
+     * @return void
+     *
      * @throws \InvalidArgumentException if the field does not exist
      */
     public function offsetSet($name, $value)
@@ -357,6 +359,8 @@ class Form extends Link implements \ArrayAccess
      * Removes a field from the form.
      *
      * @param string $name The field name
+     *
+     * @return void
      */
     public function offsetUnset($name)
     {

--- a/src/Symfony/Component/ErrorHandler/BufferingLogger.php
+++ b/src/Symfony/Component/ErrorHandler/BufferingLogger.php
@@ -35,6 +35,9 @@ class BufferingLogger extends AbstractLogger
         return $logs;
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/EventDispatcher/GenericEvent.php
+++ b/src/Symfony/Component/EventDispatcher/GenericEvent.php
@@ -133,6 +133,8 @@ class GenericEvent extends Event implements \ArrayAccess, \IteratorAggregate
      *
      * @param string $key   Array key to set
      * @param mixed  $value Value
+     *
+     * @return void
      */
     public function offsetSet($key, $value)
     {
@@ -143,6 +145,8 @@ class GenericEvent extends Event implements \ArrayAccess, \IteratorAggregate
      * ArrayAccess for unset argument.
      *
      * @param string $key Array key
+     *
+     * @return void
      */
     public function offsetUnset($key)
     {

--- a/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
@@ -76,6 +76,9 @@ class ExcludeDirectoryFilterIterator extends \FilterIterator implements \Recursi
         return $this->isRecursive && $this->iterator->hasChildren();
     }
 
+    /**
+     * @return self
+     */
     public function getChildren()
     {
         $children = new self($this->iterator->getChildren(), []);

--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -63,6 +63,8 @@ class Button implements \IteratorAggregate, FormInterface
      *
      * @param mixed $offset
      *
+     * @return mixed
+     *
      * @throws BadMethodCallException
      */
     public function offsetGet($offset)
@@ -78,6 +80,8 @@ class Button implements \IteratorAggregate, FormInterface
      * @param mixed $offset
      * @param mixed $value
      *
+     * @return void
+     *
      * @throws BadMethodCallException
      */
     public function offsetSet($offset, $value)
@@ -91,6 +95,8 @@ class Button implements \IteratorAggregate, FormInterface
      * This method should not be invoked.
      *
      * @param mixed $offset
+     *
+     * @return void
      *
      * @throws BadMethodCallException
      */

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -983,6 +983,8 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
      * @param string        $name  Ignored. The name of the child is used
      * @param FormInterface $child The child to be added
      *
+     * @return void
+     *
      * @throws AlreadySubmittedException if the form has already been submitted
      * @throws LogicException            when trying to add a child to a non-compound form
      *
@@ -998,6 +1000,8 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
      *
      * @param string $name The name of the child to remove
      *
+     * @return void
+     *
      * @throws AlreadySubmittedException if the form has already been submitted
      */
     public function offsetUnset($name)
@@ -1008,7 +1012,7 @@ class Form implements \IteratorAggregate, FormInterface, ClearableErrorsInterfac
     /**
      * Returns the iterator for this group.
      *
-     * @return \Traversable|FormInterface[]
+     * @return \Traversable<FormInterface>
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -170,6 +170,8 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
     /**
      * Unsupported method.
      *
+     * @return void
+     *
      * @throws BadMethodCallException
      */
     public function offsetSet($position, $value)
@@ -179,6 +181,8 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
 
     /**
      * Unsupported method.
+     *
+     * @return void
      *
      * @throws BadMethodCallException
      */
@@ -200,6 +204,8 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
 
     /**
      * Alias of {@link current()}.
+     *
+     * @return self
      */
     public function getChildren()
     {
@@ -232,6 +238,8 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
      * Sets the position of the iterator.
      *
      * @param int $position The new position
+     *
+     * @return void
      *
      * @throws OutOfBoundsException If the position is invalid
      */

--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -128,6 +128,8 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * Implements \ArrayAccess.
      *
+     * @return void
+     *
      * @throws BadMethodCallException always as setting a child by name is not allowed
      */
     public function offsetSet($name, $value)
@@ -139,6 +141,8 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
      * Removes a child (implements \ArrayAccess).
      *
      * @param string $name The child name
+     *
+     * @return void
      */
     public function offsetUnset($name)
     {

--- a/src/Symfony/Component/Form/Util/InheritDataAwareIterator.php
+++ b/src/Symfony/Component/Form/Util/InheritDataAwareIterator.php
@@ -27,6 +27,8 @@ class InheritDataAwareIterator extends \IteratorIterator implements \RecursiveIt
 {
     /**
      * {@inheritdoc}
+     *
+     * @return static
      */
     public function getChildren()
     {

--- a/src/Symfony/Component/Form/Util/OrderedHashMap.php
+++ b/src/Symfony/Component/Form/Util/OrderedHashMap.php
@@ -108,6 +108,8 @@ class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function offsetGet($key)
     {
@@ -120,6 +122,8 @@ class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function offsetSet($key, $value)
     {
@@ -141,6 +145,8 @@ class OrderedHashMap implements \ArrayAccess, \IteratorAggregate, \Countable
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function offsetUnset($key)
     {

--- a/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
+++ b/src/Symfony/Component/Form/Util/OrderedHashMapIterator.php
@@ -76,6 +76,9 @@ class OrderedHashMapIterator implements \Iterator
         $this->managedCursors[$this->cursorId] = &$this->cursor;
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);
@@ -99,6 +102,8 @@ class OrderedHashMapIterator implements \Iterator
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function current()
     {
@@ -107,6 +112,8 @@ class OrderedHashMapIterator implements \Iterator
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function next()
     {
@@ -123,6 +130,8 @@ class OrderedHashMapIterator implements \Iterator
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function key()
     {
@@ -145,6 +154,8 @@ class OrderedHashMapIterator implements \Iterator
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function rewind()
     {

--- a/src/Symfony/Component/HttpClient/Chunk/ErrorChunk.php
+++ b/src/Symfony/Component/HttpClient/Chunk/ErrorChunk.php
@@ -115,6 +115,9 @@ class ErrorChunk implements ChunkInterface
         return $this->didThrow;
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -362,6 +362,9 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
         }
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/HttpClient/HttplugClient.php
+++ b/src/Symfony/Component/HttpClient/HttplugClient.php
@@ -218,6 +218,9 @@ final class HttplugClient implements HttplugInterface, HttpAsyncClient, RequestF
         throw new \LogicException(sprintf('You cannot use "%s()" as the "nyholm/psr7" package is not installed. Try running "composer require nyholm/psr7".', __METHOD__));
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/HttpFoundation/File/Stream.php
+++ b/src/Symfony/Component/HttpFoundation/File/Stream.php
@@ -20,6 +20,8 @@ class Stream extends File
 {
     /**
      * {@inheritdoc}
+     *
+     * @return int|false
      */
     public function getSize()
     {

--- a/src/Symfony/Component/Intl/Data/Util/ArrayAccessibleResourceBundle.php
+++ b/src/Symfony/Component/Intl/Data/Util/ArrayAccessibleResourceBundle.php
@@ -44,16 +44,25 @@ class ArrayAccessibleResourceBundle implements \ArrayAccess, \IteratorAggregate,
         return null !== $this->bundleImpl->get($offset);
     }
 
+    /**
+     * @return mixed
+     */
     public function offsetGet($offset)
     {
         return $this->get($offset);
     }
 
+    /**
+     * @return void
+     */
     public function offsetSet($offset, $value)
     {
         throw new BadMethodCallException('Resource bundles cannot be modified.');
     }
 
+    /**
+     * @return void
+     */
     public function offsetUnset($offset)
     {
         throw new BadMethodCallException('Resource bundles cannot be modified.');

--- a/src/Symfony/Component/Intl/Data/Util/RingBuffer.php
+++ b/src/Symfony/Component/Intl/Data/Util/RingBuffer.php
@@ -49,6 +49,8 @@ class RingBuffer implements \ArrayAccess
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function offsetGet($key)
     {
@@ -61,6 +63,8 @@ class RingBuffer implements \ArrayAccess
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function offsetSet($key, $value)
     {
@@ -76,6 +80,8 @@ class RingBuffer implements \ArrayAccess
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function offsetUnset($key)
     {

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Collection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Collection.php
@@ -97,6 +97,9 @@ class Collection implements CollectionInterface
         return isset($this->entries[$offset]);
     }
 
+    /**
+     * @return mixed
+     */
     public function offsetGet($offset)
     {
         $this->toArray();
@@ -104,6 +107,9 @@ class Collection implements CollectionInterface
         return $this->entries[$offset] ?? null;
     }
 
+    /**
+     * @return void
+     */
     public function offsetSet($offset, $value)
     {
         $this->toArray();
@@ -111,6 +117,9 @@ class Collection implements CollectionInterface
         $this->entries[$offset] = $value;
     }
 
+    /**
+     * @return void
+     */
     public function offsetUnset($offset)
     {
         $this->toArray();

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -35,6 +35,9 @@ class Connection extends AbstractConnection
     /** @var resource */
     private $connection;
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -38,6 +38,9 @@ class Query extends AbstractQuery
         parent::__construct($connection, $dn, $query, $options);
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/Lock/Lock.php
+++ b/src/Symfony/Component/Lock/Lock.php
@@ -50,6 +50,9 @@ final class Lock implements LockInterface, LoggerAwareInterface
         $this->logger = new NullLogger();
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Transport/Smtp/SmtpTransport.php
@@ -340,6 +340,9 @@ class SmtpTransport extends AbstractTransport
         $this->restartCounter = 0;
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -1084,6 +1084,8 @@ class OptionsResolver implements Options
     /**
      * Not supported.
      *
+     * @return void
+     *
      * @throws AccessException
      */
     public function offsetSet($option, $value)
@@ -1093,6 +1095,8 @@ class OptionsResolver implements Options
 
     /**
      * Not supported.
+     *
+     * @return void
      *
      * @throws AccessException
      */

--- a/src/Symfony/Component/Process/Pipes/UnixPipes.php
+++ b/src/Symfony/Component/Process/Pipes/UnixPipes.php
@@ -35,6 +35,9 @@ class UnixPipes extends AbstractPipes
         parent::__construct($input);
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/Process/Pipes/WindowsPipes.php
+++ b/src/Symfony/Component/Process/Pipes/WindowsPipes.php
@@ -88,6 +88,9 @@ class WindowsPipes extends AbstractPipes
         parent::__construct($input);
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -198,6 +198,9 @@ class Process implements \IteratorAggregate
         return $process;
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
@@ -36,6 +36,9 @@ class CollectionConfigurator
         $this->parentPrefixes = $parentPrefixes;
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
@@ -30,6 +30,9 @@ class ImportConfigurator
         $this->route = $route;
     }
 
+    /**
+     * @return array
+     */
     public function __sleep()
     {
         throw new \BadMethodCallException('Cannot serialize '.__CLASS__);

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -195,6 +195,8 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      *
      * @param HelperInterface $name  The helper instance
      * @param string          $value An alias
+     *
+     * @return void
      */
     public function offsetSet($name, $value)
     {
@@ -205,6 +207,8 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      * Removes a helper.
      *
      * @param string $name The helper name
+     *
+     * @return void
      *
      * @throws \LogicException
      */

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -286,6 +286,8 @@ abstract class Constraint
     /**
      * Optimizes the serialized value to minimize storage space.
      *
+     * @return array
+     *
      * @internal
      */
     public function __sleep()

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -133,6 +133,8 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function offsetGet($offset)
     {
@@ -141,6 +143,8 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function offsetSet($offset, $violation)
     {
@@ -153,6 +157,8 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function offsetUnset($offset)
     {

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -155,16 +155,25 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate
         return $this->__isset($key);
     }
 
+    /**
+     * @return mixed
+     */
     public function offsetGet($key)
     {
         return $this->__get($key);
     }
 
+    /**
+     * @return void
+     */
     public function offsetSet($key, $value)
     {
         throw new \BadMethodCallException(self::class.' objects are immutable.');
     }
 
+    /**
+     * @return void
+     */
     public function offsetUnset($key)
     {
         throw new \BadMethodCallException(self::class.' objects are immutable.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

These annotations are needed to notify that the return is going to change because a parent class/interface is already advertising that (eg using PHP 8.1's tentative return types).

We should add the `#[ReturnTypeWillChange]` attribute on many of those methods, but `DebugClassLoader` is not ready to do it yet.