### PR TITLE
[WebProfilerBundle] Use multi line comment

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -748,7 +748,7 @@ if (typeof Sfjs === 'undefined' || typeof Sfjs.loadToolbar === 'undefined') {
                     return;
                 }
 
-                // hide rows that don't match the current filters
+                /* hide rows that don't match the current filters */
                 let numVisibleRows = 0;
                 logs.querySelectorAll('tbody tr').forEach((row) => {
                     if ('all' !== selectedType && selectedType !== row.getAttribute('data-type')) {
@@ -773,11 +773,11 @@ if (typeof Sfjs === 'undefined' || typeof Sfjs.loadToolbar === 'undefined') {
                 document.querySelector('table.logs').style.display = 0 === numVisibleRows ? 'none' : 'table';
                 document.querySelector('.no-logs-message').style.display = 0 === numVisibleRows ? 'block' : 'none';
 
-                // update the selected totals of all filters
+                /* update the selected totals of all filters */
                 document.querySelector('#log-filter-priority .filter-active-num').innerText = (priorities.length === selectedPriorities.length) ? 'All' : selectedPriorities.length;
                 document.querySelector('#log-filter-channel .filter-active-num').innerText = (channels.length === selectedChannels.length) ? 'All' : selectedChannels.length;
 
-                // update the currently selected "log type" tab
+                /* update the currently selected "log type" tab */
                 document.querySelectorAll('#log-filter-type li').forEach((tab) => tab.classList.remove('active'));
                 document.querySelector(`#log-filter-type input[value="${selectedType}"]`).parentElement.classList.add('active');
             },

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Resources/MinifyTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Resources/MinifyTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\WebProfilerBundle\Tests\Resources;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Make sure we can minify content in toolbar.
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class MinifyTest extends TestCase
+{
+    public function testNoSingleLineComments()
+    {
+        $dir = dirname(__DIR__, 2).'/Resources/views/Profiler';
+        $message = 'There cannot be any single line comment in this file. Consider using multiple line comment. ';
+        $this->assertTrue(2 === substr_count(file_get_contents($dir . '/base_js.html.twig'), '//'), $message);
+        $this->assertTrue(0 === substr_count(file_get_contents($dir.'/toolbar.css.twig'), '//'), $message);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42248
| License       | MIT
| Doc PR        | 

Since the css/js is "fake minified" (we just remove the new line character) we cannot use `//`. See comment in the head of `base_js.html.twig`: 

```
  {# Caution: the contents of this file are processed by Twig before loading
   them as JavaScript source code. Always use '/*' comments instead
   of '//' comments to avoid impossible-to-debug side-effects #}
```

I also added a small test to enforce this. 