### PR TITLE
[Form] Do not fix URL protocol for relative URLs

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
@@ -36,7 +36,7 @@ class FixUrlProtocolListener implements EventSubscriberInterface
     {
         $data = $event->getData();
 
-        if ($this->defaultProtocol && $data && \is_string($data) && !preg_match('~^([\w+.-]+://|[^:/?@#]++@)~', $data)) {
+        if ($this->defaultProtocol && $data && \is_string($data) && !preg_match('~^(?:[/.]|[\w+.-]+://|[^:/?@#]++@)~', $data)) {
             $event->setData($this->defaultProtocol.'://'.$data);
         }
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixUrlProtocolListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixUrlProtocolListenerTest.php
@@ -20,17 +20,6 @@ use Symfony\Component\Form\FormEvent;
 
 class FixUrlProtocolListenerTest extends TestCase
 {
-    public function provideUrlToFix()
-    {
-        return [
-            ['www.symfony.com'],
-            ['twitter.com/@symfony'],
-            ['symfony.com?foo@bar'],
-            ['symfony.com#foo@bar'],
-            ['localhost'],
-        ];
-    }
-
     /**
      * @dataProvider provideUrlToFix
      */
@@ -42,20 +31,18 @@ class FixUrlProtocolListenerTest extends TestCase
         $filter = new FixUrlProtocolListener('http');
         $filter->onSubmit($event);
 
-        $this->assertEquals('http://'.$data, $event->getData());
+        $this->assertSame('http://'.$data, $event->getData());
     }
 
-    public function provideUrlToSkip()
+    public function provideUrlToFix()
     {
         return [
-            ['http://www.symfony.com'],
-            ['ftp://www.symfony.com'],
-            ['https://twitter.com/@symfony'],
-            ['chrome-extension://foo'],
-            ['h323://foo'],
-            ['iris.beep://foo'],
-            ['foo+bar://foo'],
-            ['fabien@symfony.com'],
+            ['www.symfony.com'],
+            ['symfony.com/doc'],
+            ['twitter.com/@symfony'],
+            ['symfony.com?foo@bar'],
+            ['symfony.com#foo@bar'],
+            ['localhost'],
         ];
     }
 
@@ -70,6 +57,23 @@ class FixUrlProtocolListenerTest extends TestCase
         $filter = new FixUrlProtocolListener('http');
         $filter->onSubmit($event);
 
-        $this->assertEquals($url, $event->getData());
+        $this->assertSame($url, $event->getData());
+    }
+
+    public function provideUrlToSkip()
+    {
+        return [
+            ['http://www.symfony.com'],
+            ['ftp://www.symfony.com'],
+            ['https://twitter.com/@symfony'],
+            ['chrome-extension://foo'],
+            ['h323://foo'],
+            ['iris.beep://foo'],
+            ['foo+bar://foo'],
+            ['fabien@symfony.com'],
+            ['//relative/url'],
+            ['/relative/url'],
+            ['./relative/url'],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Tickets | Fix #42329
| Deprecations? | no
| License       | MIT

Example when it doesn't work correctly:
/relative/path
The data will be changed to "http:///relative/path" (3 slashes)