### PR TITLE
[Messenger] Allow using user's serializer for message do not fit the expected JSON structure

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Fixtures/ExternalMessage.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Fixtures/ExternalMessage.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Symfony\Component\Messenger\Bridge\Redis\Tests\Fixtures;
+
+class ExternalMessage
+{
+    private $foo;
+    private $bar = [];
+
+    public function __construct(string $foo)
+    {
+        $this->foo = $foo;
+    }
+
+    public function getFoo(): string
+    {
+        return $this->foo;
+    }
+
+    public function setBar(array $bar): self
+    {
+        $this->bar = $bar;
+
+        return $this;
+    }
+
+    public function getBar(): array
+    {
+        return $this->bar;
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Fixtures/ExternalMessageSerializer.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Fixtures/ExternalMessageSerializer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Component\Messenger\Bridge\Redis\Tests\Fixtures;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+
+class ExternalMessageSerializer implements SerializerInterface
+{
+    public function decode(array $encodedEnvelope): Envelope
+    {
+        $message = new ExternalMessage($encodedEnvelope['foo']);
+        $message->setBar($encodedEnvelope['bar']);
+
+        return new Envelope($message);
+    }
+
+    public function encode(Envelope $envelope): array
+    {
+        return [
+            'body' => $envelope->getMessage(),
+            'headers' => [],
+        ];
+    }
+}

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -251,7 +251,17 @@ class ConnectionTest extends TestCase
             ->willReturn(['queue' => [['message' => '{"body":"1","headers":[]}']]]);
 
         $connection = Connection::fromDsn('redis://localhost/queue', ['delete_after_ack' => true], $redis);
-        $connection->get();
+        $message = $connection->get();
+
+        $this->assertSame([
+            'id' => 0,
+            'data' => [
+                'message' => json_encode([
+                    'body' => '1',
+                    'headers' => [],
+                ]),
+            ],
+        ], $message);
     }
 
     public function testClaimAbandonedMessageWithRaceCondition()

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisReceiverTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisReceiverTest.php
@@ -13,64 +13,109 @@ namespace Symfony\Component\Messenger\Bridge\Redis\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Bridge\Redis\Tests\Fixtures\DummyMessage;
+use Symfony\Component\Messenger\Bridge\Redis\Tests\Fixtures\ExternalMessage;
+use Symfony\Component\Messenger\Bridge\Redis\Tests\Fixtures\ExternalMessageSerializer;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\Connection;
 use Symfony\Component\Messenger\Bridge\Redis\Transport\RedisReceiver;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 use Symfony\Component\Messenger\Transport\Serialization\Serializer;
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Serializer as SerializerComponent;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
 class RedisReceiverTest extends TestCase
 {
-    public function testItReturnsTheDecodedMessageToTheHandler()
+    /**
+     * @dataProvider redisEnvelopeProvider
+     */
+    public function testItReturnsTheDecodedMessageToTheHandler(array $redisEnvelope, $expectedMessage, SerializerInterface $serializer)
     {
-        $serializer = $this->createSerializer();
-
-        $redisEnvelop = $this->createRedisEnvelope();
         $connection = $this->createMock(Connection::class);
-        $connection->method('get')->willReturn($redisEnvelop);
+        $connection->method('get')->willReturn($redisEnvelope);
 
         $receiver = new RedisReceiver($connection, $serializer);
         $actualEnvelopes = $receiver->get();
         $this->assertCount(1, $actualEnvelopes);
-        $this->assertEquals(new DummyMessage('Hi'), $actualEnvelopes[0]->getMessage());
+        $this->assertEquals($expectedMessage, $actualEnvelopes[0]->getMessage());
     }
 
-    public function testItRejectTheMessageIfThereIsAMessageDecodingFailedException()
+    /**
+     * @dataProvider rejectedRedisEnvelopeProvider
+     */
+    public function testItRejectTheMessageIfThereIsAMessageDecodingFailedException(array $redisEnvelope)
     {
         $this->expectException(MessageDecodingFailedException::class);
 
         $serializer = $this->createMock(PhpSerializer::class);
         $serializer->method('decode')->willThrowException(new MessageDecodingFailedException());
 
-        $redisEnvelop = $this->createRedisEnvelope();
         $connection = $this->createMock(Connection::class);
-        $connection->method('get')->willReturn($redisEnvelop);
+        $connection->method('get')->willReturn($redisEnvelope);
         $connection->expects($this->once())->method('reject');
 
         $receiver = new RedisReceiver($connection, $serializer);
         $receiver->get();
     }
 
-    private function createRedisEnvelope(): array
+    public function redisEnvelopeProvider(): \Generator
     {
-        return [
-            'id' => 1,
-            'body' => '{"message": "Hi"}',
-            'headers' => [
-                'type' => DummyMessage::class,
+        yield [
+            [
+                'id' => 1,
+                'data' => json_encode([
+                    'body' => '{"message": "Hi"}',
+                    'headers' => [
+                        'type' => DummyMessage::class,
+                    ],
+                ]),
             ],
+            new DummyMessage('Hi'),
+            new Serializer(
+                new SerializerComponent\Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()])
+            ),
+        ];
+
+        yield [
+            [
+                'id' => 2,
+                'data' => json_encode([
+                    'foo' => 'fooValue',
+                    'bar' => [
+                        'baz' => 'bazValue',
+                    ],
+                ]),
+            ],
+            (new ExternalMessage('fooValue'))->setBar(['baz' => 'bazValue']),
+            new ExternalMessageSerializer(),
         ];
     }
 
-    private function createSerializer(): Serializer
+    public function rejectedRedisEnvelopeProvider(): \Generator
     {
-        $serializer = new Serializer(
-            new SerializerComponent\Serializer([new ObjectNormalizer()], ['json' => new JsonEncoder()])
-        );
+        yield [
+            [
+                'id' => 1,
+                'data' => json_encode([
+                    'body' => '{"message": "Hi"}',
+                    'headers' => [
+                        'type' => DummyMessage::class,
+                    ],
+                ]),
+            ],
+        ];
 
-        return $serializer;
+        yield [
+            [
+                'id' => 2,
+                'data' => json_encode([
+                    'foo' => 'fooValue',
+                    'bar' => [
+                        'baz' => 'bazValue',
+                    ],
+                ]),
+            ],
+        ];
     }
 }

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportTest.php
@@ -39,8 +39,10 @@ class RedisTransportTest extends TestCase
 
         $redisEnvelope = [
             'id' => '5',
-            'body' => 'body',
-            'headers' => ['my' => 'header'],
+            'data' => json_encode([
+                'body' => 'body',
+                'headers' => ['my' => 'header'],
+            ]),
         ];
 
         $serializer->method('decode')->with(['body' => 'body', 'headers' => ['my' => 'header']])->willReturn(new Envelope($decodedMessage));

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -356,13 +356,13 @@ class Connection
                 }
 
                 foreach ($queuedMessages as $queuedMessage => $time) {
-                    $queuedMessage = json_decode($queuedMessage, true);
+                    $decodedQueuedMessage = json_decode($queuedMessage, true);
                     // if a futured placed message is actually popped because of a race condition with
                     // another running message consumer, the message is readded to the queue by add function
                     // else its just added stream and will be available for all stream consumers
                     $this->add(
-                        $queuedMessage['body'],
-                        $queuedMessage['headers'],
+                        \array_key_exists('body', $decodedQueuedMessage) ? $decodedQueuedMessage['body'] : $queuedMessage,
+                        $decodedQueuedMessage['headers'] ?? [],
                         $time - $this->getCurrentTimeInMilliseconds()
                     );
                 }
@@ -406,12 +406,9 @@ class Connection
         }
 
         foreach ($messages[$this->stream] ?? [] as $key => $message) {
-            $redisEnvelope = json_decode($message['message'], true);
-
             return [
                 'id' => $key,
-                'body' => $redisEnvelope['body'],
-                'headers' => $redisEnvelope['headers'],
+                'data' => $message,
             ];
         }
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisReceiver.php
@@ -38,24 +38,30 @@ class RedisReceiver implements ReceiverInterface
      */
     public function get(): iterable
     {
-        $redisEnvelope = $this->connection->get();
+        $message = $this->connection->get();
 
-        if (null === $redisEnvelope) {
+        if (null === $message) {
             return [];
         }
 
+        $redisEnvelope = json_decode($message['data'], true);
+
         try {
-            $envelope = $this->serializer->decode([
-                'body' => $redisEnvelope['body'],
-                'headers' => $redisEnvelope['headers'],
-            ]);
+            if (\array_key_exists('body', $redisEnvelope) && \array_key_exists('headers', $redisEnvelope)) {
+                $envelope = $this->serializer->decode([
+                    'body' => $redisEnvelope['body'],
+                    'headers' => $redisEnvelope['headers'],
+                ]);
+            } else {
+                $envelope = $this->serializer->decode($redisEnvelope);
+            }
         } catch (MessageDecodingFailedException $exception) {
-            $this->connection->reject($redisEnvelope['id']);
+            $this->connection->reject($message['id']);
 
             throw $exception;
         }
 
-        return [$envelope->with(new RedisReceivedStamp($redisEnvelope['id']))];
+        return [$envelope->with(new RedisReceivedStamp($message['id']))];
     }
 
     /**

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
@@ -34,7 +34,7 @@ class PhpSerializerTest extends TestCase
     public function testDecodingFailsWithMissingBodyKey()
     {
         $this->expectException(MessageDecodingFailedException::class);
-        $this->expectExceptionMessage('Encoded envelope should have at least a "body".');
+        $this->expectExceptionMessage('Encoded envelope should have at least a "body", or maybe you should implement your own serializer');
 
         $serializer = new PhpSerializer();
 

--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/SerializerTest.php
@@ -168,12 +168,12 @@ class SerializerTest extends TestCase
     {
         yield 'no_body' => [
             ['headers' => ['type' => 'bar']],
-            'Encoded envelope should have at least a "body" and some "headers".',
+            'Encoded envelope should have at least a "body" and some "headers", or maybe you should implement your own serializer.',
         ];
 
         yield 'no_headers' => [
             ['body' => '{}'],
-            'Encoded envelope should have at least a "body" and some "headers".',
+            'Encoded envelope should have at least a "body" and some "headers", or maybe you should implement your own serializer.',
         ];
 
         yield 'no_headers_type' => [

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -26,7 +26,7 @@ class PhpSerializer implements SerializerInterface
     public function decode(array $encodedEnvelope): Envelope
     {
         if (empty($encodedEnvelope['body'])) {
-            throw new MessageDecodingFailedException('Encoded envelope should have at least a "body".');
+            throw new MessageDecodingFailedException('Encoded envelope should have at least a "body", or maybe you should implement your own serializer.');
         }
 
         if (!str_ends_with($encodedEnvelope['body'], '}')) {

--- a/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php
@@ -63,7 +63,7 @@ class Serializer implements SerializerInterface
     public function decode(array $encodedEnvelope): Envelope
     {
         if (empty($encodedEnvelope['body']) || empty($encodedEnvelope['headers'])) {
-            throw new MessageDecodingFailedException('Encoded envelope should have at least a "body" and some "headers".');
+            throw new MessageDecodingFailedException('Encoded envelope should have at least a "body" and some "headers", or maybe you should implement your own serializer.');
         }
 
         if (empty($encodedEnvelope['headers']['type'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/42072
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

It allows user to use their own serializer to decode messages that do not fit the expected JSON structure (`{ "message": { "body": "", "headers": {} } }`).

Once this PR will be ok, I'll report the fix in Beanstalkd, SQS, and Doctrine Transports