### PR TITLE
[ErrorHandler] Improve error messages in CLI

### DIFF
--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/CliErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/CliErrorRenderer.php
@@ -40,7 +40,44 @@ class CliErrorRenderer implements ErrorRendererInterface
             }
         };
 
-        return FlattenException::createFromThrowable($exception)
-            ->setAsString($dumper->dump($cloner->cloneVar($exception), true));
+        $flattenException = FlattenException::createFromThrowable($exception);
+        $exceptionTraceDump = $dumper->dump($cloner->cloneVar($exception)['trace'], true);
+
+        return $flattenException->setAsString($this->doRender($exception, $exceptionTraceDump));
+    }
+
+    private function doRender(\Throwable $exception, string $traceAsString): string
+    {
+        $resetStyle = "\033[0m";
+        $textBold = "\033[1m";
+        $textBrightWhite = "\033[37;1m";
+        $textBrightRed = "\033[31;1m";
+        $textGray = "\033[38;5;245m";
+
+        $result = '';
+
+        $result .= $textBold.$textBrightWhite."Exception Trace".$resetStyle."\n";
+        $result .= $traceAsString."\n";
+
+        $result .= $textBold.$textBrightRed.\get_class($exception).$resetStyle."\n";
+        $result .= $exception->getMessage()."\n\n";
+
+        $sourceCode =file($exception->getFile());
+        $sourceCodeExtract = [];
+        for ($i = $exception->getLine() - 5; $i <= $exception->getLine() + 4; ++$i) {
+            $sourceCodeExtract[$i] = ($sourceCode[$i] ?? '')."\n";
+        }
+
+        $result .= $textGray.sprintf('at %s:%d', $exception->getFile(), $exception->getLine()).$resetStyle."\n";
+        foreach ($sourceCodeExtract as $lineNumber => $code) {
+            if ($lineNumber === $exception->getLine()) {
+                $result .= sprintf("%s~~~~>%s %s\n", $textBrightRed, $resetStyle, rtrim($code));
+            } else {
+                $result .= sprintf("%s%3d |%s %s\n", $textGray, $lineNumber, $resetStyle, rtrim($code));
+            }
+        }
+        $result .= "\n\n";
+
+        return $result;
     }
 }

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/CliErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/CliErrorRenderer.php
@@ -78,9 +78,9 @@ class CliErrorRenderer implements ErrorRendererInterface
         foreach ($sourceCodeExtract as $lineNumber => $code) {
             $lineNumberFormatted = sprintf("%{$maxLineNumberLengthInDigits}d |", $lineNumber);
             if ($lineNumber === $exceptionLineNumber) {
-                $content .= $this->textRedBackground($lineNumberFormatted);
+                $content .= $this->textBrightRed('-> '.$lineNumberFormatted);
             } else {
-                $content .= $this->textGray($lineNumberFormatted);
+                $content .= '   '.$this->textGray($lineNumberFormatted);
             }
 
             $content .= sprintf(" %s\n", rtrim($code));

--- a/src/Symfony/Component/ErrorHandler/ErrorRenderer/CliErrorRenderer.php
+++ b/src/Symfony/Component/ErrorHandler/ErrorRenderer/CliErrorRenderer.php
@@ -62,7 +62,7 @@ class CliErrorRenderer implements ErrorRendererInterface
         $exceptionPathInformation = $this->textGray($this->makePathRelative($exceptionFilePath)).$this->textBrightWhite(sprintf('%s:%d', $exceptionFileName, $exceptionLineNumber))."\n";
         $content .= $this->textGray('at ').$this->renderAsLink($exceptionPathInformation, $exception->getFile(), $exceptionLineNumber);
 
-        $sourceCode = file($exception->getFile());
+        $sourceCode = file_exists($exception->getFile()) ? file($exception->getFile()) : false;
         if (false === $sourceCode) {
             return $content."\n";
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This is still WIP. Don't look or comment the code changes. Thanks!

## Context

When there's an exception in your Symfony app and you're in the command console, you see something like this:

![](https://user-images.githubusercontent.com/73419/126999476-c91f10f7-732a-4bcf-8684-3753d45c72b6.png)

Although sometimes you see exceptions like this:

![](https://user-images.githubusercontent.com/73419/126999558-7c5fb6eb-48b3-4110-820b-d6b726d17693.png)

I see two problems here:

* Inconsistency: not all exceptions are displayed the same way in the console
* Design: both errors provide lots of information, but it should be easier to spot the exact issue

## Problem

To me the main problem is designing this error message around "stack traces" (like in Java) instead of focusing on the error cause and location (like in modern languages/tools).

See "Rails + Pry" exception message:

![rails-pry](https://user-images.githubusercontent.com/73419/127000228-e9041675-1d76-4b06-a7ef-9efb4a29b941.png)

See "Collision" exception message (used by Laravel and compatible with Symfony too):

<img width="1141" alt="collision" src="https://user-images.githubusercontent.com/73419/127000307-eb1a5030-bbb4-4f42-bd92-107c025416f6.png">

See the amazing "Rust" error messages:

![rust-compiler](https://user-images.githubusercontent.com/73419/127000367-7bdd4e7c-a4be-46d7-b869-013f73f13f7f.png)

## Proposal

I'd like to redesign Symfony exception messages to match that modern design.

The three main elements of the console output should be:

1. What happened _(the exception message)_
2. Where did it happen _(file path, line number and code extract)_
3. How/why did it happen _(stack trace)_

The code of this PR is a quick proof-of-concept of this idea:

![](https://user-images.githubusercontent.com/73419/127000825-e60297da-8c78-4d99-95c7-34f381ee31f2.png)

The logical order would be "What -> Where -> Why" ... but "Why" is a long and ugly stack trace which hides the most important information ("What" and "Where"). That's why the order is "Why -> What -> Where".

## What do you think?

* Do you agree that we need to improve this?
* If yo do, do you like this proposal about what ideas to follow for the redesign?
* Would you agree on removing the stack trace completely form console output? _(I very rarely need or use it in the console ... but I want to read other opinions)_
* What could we do to fix the consistency problems and always display all exception messages in the same way in the console?

Thanks!




