### PR TITLE
[Notifier] Added MessageBirdOptions to the message-bird-notifier bridge

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 5.4
 ---
 
-* Added MessageBirdOptions
+* Add `MessageBirdOptions`
 
 5.3
 ---

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+* Added MessageBirdOptions
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 5.4
 ---
 
-* Add `MessageBirdOptions`
+ * Add `MessageBirdOptions`
 
 5.3
 ---

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdOptions.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\MessageBird;
+
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+/**
+ * @author Evert Jan Hakvoort <evertjan@hakvoort.io>
+ *
+ * @see https://developers.messagebird.com/api/sms-messaging/#sms-api
+ */
+final class MessageBirdOptions implements MessageOptionsInterface
+{
+    private $options;
+
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+    }
+
+    public function toArray(): array
+    {
+        return $this->options;
+    }
+
+    public function getRecipientId(): ?string
+    {
+        return $this->options['recipients'] ?? null;
+    }
+
+    public function validity(int $validity): self
+    {
+        $this->options['validity'] = $validity;
+
+        return $this;
+    }
+
+    public function reference(string $reference): self
+    {
+        $this->options['reference'] = $reference;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdOptions.php
@@ -37,6 +37,9 @@ final class MessageBirdOptions implements MessageOptionsInterface
         return $this->options['recipients'] ?? null;
     }
 
+    /**
+     * @return $this
+     */
     public function validity(int $validity): self
     {
         $this->options['validity'] = $validity;
@@ -44,6 +47,9 @@ final class MessageBirdOptions implements MessageOptionsInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function reference(string $reference): self
     {
         $this->options['reference'] = $reference;

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/MessageBirdTransport.php
@@ -57,7 +57,7 @@ final class MessageBirdTransport extends AbstractTransport
         }
 
         $options = $message->getOptions();
-        if ($options !== null && !$options  instanceof MessageBirdOptions) {
+        if (null !== $options && !$options instanceof MessageBirdOptions) {
             throw new LogicException(sprintf('The "%s" transport only supports instances of "%s" for options.', __CLASS__, MessageBirdOptions::class));
         }
 
@@ -68,7 +68,7 @@ final class MessageBirdTransport extends AbstractTransport
                 'originator' => $this->from,
                 'recipients' => $message->getPhone(),
                 'body' => $message->getSubject(),
-            ], $options !== null ? $options->toArray() : []),
+            ], null !== $options ? $options->toArray() : []),
         ]);
 
         try {

--- a/src/Symfony/Component/Notifier/Bridge/MessageBird/Tests/MessageBirdOptionsTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/MessageBird/Tests/MessageBirdOptionsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\MessageBird\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Bridge\MessageBird\MessageBirdOptions;
+
+final class MessageBirdOptionsTest extends TestCase
+{
+    public function testGetRecipientIdWhenSet()
+    {
+        $messagebirdOptions = new MessageBirdOptions([
+            'recipients' => 'foo',
+        ]);
+
+        $this->assertSame('foo', $messagebirdOptions->getRecipientId());
+    }
+
+    public function testGetRecipientIdWhenNotSet()
+    {
+        $this->assertNull((new MessageBirdOptions())->getRecipientId());
+    }
+
+    public function testSetValidity()
+    {
+        $messagebirdOptions = new MessageBirdOptions();
+
+        $messagebirdOptions->validity(500);
+
+        $this->assertSame(500, $messagebirdOptions->toArray()['validity']);
+    }
+
+    public function testSetReference()
+    {
+        $messagebirdOptions = new MessageBirdOptions();
+
+        $messagebirdOptions->reference('foo');
+
+        $this->assertSame('foo', $messagebirdOptions->toArray()['reference']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Added a MessageBirdOptions to the message-bird-notifier. This allows adding validity and reference to the messages send with the notifier component.


