### PR TITLE
[WebProfilerBundle] [WebProfiler] Fix Unknown empty filter

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -67,7 +67,7 @@
 {% block menu %}
     {% set events = collector.events %}
 
-    <span class="label {{ events.messages|empty ? 'disabled' }}">
+    <span class="label {{ events.messages|length ? '' : 'disabled' }}">
         <span class="icon">{{ include('@WebProfiler/Icon/mailer.svg') }}</span>
 
         <strong>E-mails</strong>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/42268
| License       | MIT
| Doc PR        | N/A

This PR reverted back usage of the unknown `empty` twig filter introduced in https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig#L70