### PR TITLE
[WebProfilerBundle] [WebProfiler] "empty" filter bugfix. Filter with name "empty" is not …

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -67,7 +67,7 @@
 {% block menu %}
     {% set events = collector.events %}
 
-    <span class="label {{ events.messages|empty ? 'disabled' }}">
+    <span class="label {{ events.messages is empty ? 'disabled' }}">
         <span class="icon">{{ include('@WebProfiler/Icon/mailer.svg') }}</span>
 
         <strong>E-mails</strong>


### PR DESCRIPTION
There is a bug, which make web profiler is completely broken with Mailer extension installed.
Bug is presented always in branches 5.2 and 5.3.