### PR TITLE
[HttpFoundation] Add settable permissions and adopt stricter defaults

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -82,9 +82,9 @@ class File extends \SplFileInfo
      *
      * @throws FileException if the target file could not be created
      */
-    public function move(string $directory, string $name = null): self
+    public function move(string $directory, string $name = null, int $dirmode = 0755, int $filemode = 0644): self
     {
-        $target = $this->getTargetFile($directory, $name);
+        $target = $this->getTargetFile($directory, $name, $dirmode);
 
         set_error_handler(function ($type, $msg) use (&$error) { $error = $msg; });
         try {
@@ -96,7 +96,7 @@ class File extends \SplFileInfo
             throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s).', $this->getPathname(), $target, strip_tags($error)));
         }
 
-        @chmod($target, 0666 & ~umask());
+        @chmod($target, $filemode & ~umask());
 
         return $target;
     }
@@ -112,10 +112,10 @@ class File extends \SplFileInfo
         return $content;
     }
 
-    protected function getTargetFile(string $directory, string $name = null): self
+    protected function getTargetFile(string $directory, string $name = null, int $dirmode = 0755): self
     {
         if (!is_dir($directory)) {
-            if (false === @mkdir($directory, 0777, true) && !is_dir($directory)) {
+            if (false === @mkdir($directory, $dirmode, true) && !is_dir($directory)) {
                 throw new FileException(sprintf('Unable to create the "%s" directory.', $directory));
             }
         } elseif (!is_writable($directory)) {

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -158,14 +158,14 @@ class UploadedFile extends File
      *
      * @throws FileException if, for any reason, the file could not have been moved
      */
-    public function move(string $directory, string $name = null): File
+    public function move(string $directory, string $name = null, int $dirmode = 0755, int $filemode = 0644): File
     {
         if ($this->isValid()) {
             if ($this->test) {
-                return parent::move($directory, $name);
+                return parent::move($directory, $name, $dirmode, $filemode);
             }
 
-            $target = $this->getTargetFile($directory, $name);
+            $target = $this->getTargetFile($directory, $name, $dirmode);
 
             set_error_handler(function ($type, $msg) use (&$error) { $error = $msg; });
             try {
@@ -177,7 +177,7 @@ class UploadedFile extends File
                 throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s).', $this->getPathname(), $target, strip_tags($error)));
             }
 
-            @chmod($target, 0666 & ~umask());
+            @chmod($target, $filemode & ~umask());
 
             return $target;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

While porting GNU social's [TemporaryFile](https://code.undefinedhackers.net/GNUsocial/gnu-social/src/branch/v3/src/Util/TemporaryFile.php#L163) from v2 to v3, we've noticed that Symfony's File component didn't let us set permissions for new directories nor files. In addition, the [default permission for directories is 0777](https://github.com/symfony/symfony/blob/6.0/src/Symfony/Component/HttpFoundation/File/File.php#L118). 

If this was intended design, we would like to learn why; If not, I'll appreciate guidance on how to properly update the documentation and commit this patch.