### PR TITLE
[Console] Readd missing php-doc parameter for constructor

### DIFF
--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -48,9 +48,11 @@ class InputOption
     private $description;
 
     /**
-     * @param string|array|null                $shortcut The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
-     * @param int|null                         $mode     The option mode: One of the VALUE_* constants
-     * @param string|bool|int|float|array|null $default  The default value (must be null for self::VALUE_NONE)
+     * @param string                           $name        The option name
+     * @param string|array|null                $shortcut    The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
+     * @param int|null                         $mode        The option mode: One of the VALUE_* constants
+     * @param string                           $description A description text
+     * @param string|bool|int|float|array|null $default     The default value (must be null for self::VALUE_NONE)
      *
      * @throws InvalidArgumentException If option mode is invalid or incompatible
      */


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  |no 
| Deprecations? |no 
| Tickets       | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

partly revert the php constroctur php doc (readd missing php-doc for $name and $description) even if they not that meaningfull

This is needed as Magento2 uses this library and needs all php-doc parameter for interception compilation. if there are any missing parameters (in this case $name and $description) break compile step as the parameters are missmatching the actual parameters:
![image](https://user-images.githubusercontent.com/2969243/127111853-671d0f70-e44e-4465-9d2b-54ec80b934ff.png)
(AbstractConfigOption extends InputOption)

