### PR TITLE
[HttpFoundation] Add `SessionFactoryInterface`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/SessionFactory.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionFactory.php
@@ -20,7 +20,7 @@ class_exists(Session::class);
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class SessionFactory
+class SessionFactory implements SessionFactoryInterface
 {
     private $requestStack;
     private $storageFactory;

--- a/src/Symfony/Component/HttpFoundation/Session/SessionFactoryInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionFactoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+interface SessionFactoryInterface
+{
+    public function createSession(): SessionInterface;
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #41443
| License       | MIT
| Doc PR        | -

Assuming @jderusse's [solution](https://github.com/symfony/symfony/issues/41443#issuecomment-853432481) in #41443 is the best way to add custom session bags by a 3rd party bundle, there should really be a `SessionFactoryInterface` to make decorating the `SessionFactory` easier.