### PR TITLE
[HttpFoundation] Fixed type mismatch

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -311,7 +311,7 @@ class Response
         }
 
         // Check if we need to send extra expire info headers
-        if ('1.0' == $this->getProtocolVersion() && str_contains($headers->get('Cache-Control'), 'no-cache')) {
+        if ('1.0' == $this->getProtocolVersion() && str_contains($headers->get('Cache-Control', ''), 'no-cache')) {
             $headers->set('pragma', 'no-cache');
             $headers->set('expires', -1);
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -578,6 +578,12 @@ class ResponseTest extends ResponseTestCase
         $this->assertEquals('no-cache', $response->headers->get('pragma'));
         $this->assertEquals('-1', $response->headers->get('expires'));
 
+        $response = new Response('foo');
+        $response->headers->remove('cache-control');
+        $response->prepare($request);
+        $this->assertFalse($response->headers->has('pragma'));
+        $this->assertFalse($response->headers->has('expires'));
+
         $request->server->set('SERVER_PROTOCOL', 'HTTP/1.1');
         $response = new Response('foo');
         $response->prepare($request);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/42290
| License       | MIT
| Doc PR        | -

Fixes

> Argument 1 passed to str_contains() must be of the type string, null given, called in /.../vendor/symfony/http-foundation/Response.php on line 327

in case there's no `cache-control` response header. This doesn't happen by default as the `Response` is initialized with one by default but any class extending from it can adjust that. Technically speaking, it's not disallowed to have no `cache-control` header set.

Want me to add a test for that? :) 
