### PR TITLE
[Lock] Make lazy create table in PdoStore optionable

### DIFF
--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -219,9 +219,10 @@ class PdoStore implements PersistingStoreInterface
     }
 
     /**
-     *  Сhecking if it is possible to lazy create a table
+     *  Сhecking if it is possible to lazy create a table.
      */
-    private function isLazyCreateTablePossible(object $connection): bool {
+    private function isLazyCreateTablePossible(object $connection): bool
+    {
         return $this->lazyCreateTable && (!$connection->isTransactionActive() || \in_array($this->driver, ['pgsql', 'sqlite', 'sqlsrv'], true));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 <!-- see below -->
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/15561

Still use a migration with a few custom table fields from 4.x version for that. After update to the 5.x version I realized that I can't guarantee that console commands that use PdoStore lock would run only after all migrations execution especially from scratch. So was looking for a way to make that lazy creation optional. 
