### PR TITLE
[Serializer] Add support for serializing empty array as object

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Add support of PHP backed enumerations
- * Add support for preserving empty object in object property
+ * Add support for serializing empty array as object
 
 5.3
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -90,6 +90,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
      */
     public const DEEP_OBJECT_TO_POPULATE = 'deep_object_to_populate';
 
+    /**
+     * Flag to control whether an empty object should be kept as an object (in
+     * JSON: {}) or converted to a list (in JSON: []).
+     */
     public const PRESERVE_EMPTY_OBJECTS = 'preserve_empty_objects';
 
     private $propertyTypeExtractor;
@@ -590,10 +594,6 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     {
         if (null === $attributeValue && ($context[self::SKIP_NULL_VALUES] ?? $this->defaultContext[self::SKIP_NULL_VALUES] ?? false)) {
             return $data;
-        }
-
-        if ([] === $attributeValue && ($context[self::PRESERVE_EMPTY_OBJECTS] ?? $this->defaultContext[self::PRESERVE_EMPTY_OBJECTS] ?? false)) {
-            $attributeValue = new \ArrayObject();
         }
 
         if ($this->nameConverter) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes (fix a new feature)
| New feature?  | yes (fix a new feature)
| Deprecations? | no
| Tickets       | Fix #42282
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/issues/15554

---

New usage:

```php
    public function __construct(
        #[Context([Serializer::EMPTY_ARRAY_AS_OBJECT => true ])]
        public array $mapWithOption = [],
        #[Context([Serializer::EMPTY_ARRAY_AS_OBJECT => true ])]
        public array $mapWithOptionAndData = ['foo' => 'bar'],
        public array $mapWithoutOption = [],
        public array $mapWithoutOptionAndData = ['foo' => 'bar'],
    ) {
    }
```
=>
```
{"mapWithOption":{},"mapWithOptionAndData":{"foo":"bar"},"mapWithoutOption":[],"mapWithoutOptionAndData":{"foo":"bar"}}
```