### PR TITLE
[Routing] Allow non-callable arrays as controllers

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
@@ -130,7 +130,7 @@ trait RouteTrait
      *
      * @return $this
      */
-    final public function controller(callable|string $controller): self
+    final public function controller(callable|string|array $controller): self
     {
         $this->route->addDefaults(['_controller' => $controller]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Spotted in the test suite of psr-http-message-bridge: https://github.com/symfony/psr-http-message-bridge/runs/3174840082

A non-callable array like `['service_id', 'methodName']` is a valid controller reference. When adding union types to `RouteTrait`, this apparently wasn't taken into account.