### PR TITLE
[Routing] Add test for non-callable arrays as controllers

### DIFF
--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
@@ -126,7 +126,7 @@ trait RouteTrait
     /**
      * Adds the "_controller" entry to defaults.
      *
-     * @param callable|string $controller a callable or parseable pseudo-callable
+     * @param callable|string|array $controller a callable or parseable pseudo-callable
      *
      * @return $this
      */

--- a/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/php_dsl.php
@@ -9,7 +9,9 @@ return function (RoutingConfigurator $routes) {
             ->condition('abc')
             ->options(['utf8' => true])
         ->add('buz', 'zub')
-            ->controller('foo:act');
+            ->controller('foo:act')
+        ->add('controller_class', '/controller')
+            ->controller(['Acme\MyApp\MyController', 'myAction']);
 
     $routes->import('php_dsl_sub.php')
         ->prefix('/sub')

--- a/src/Symfony/Component/Routing/Tests/Fixtures/php_object_dsl.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/php_object_dsl.php
@@ -11,7 +11,9 @@ return new class() {
             ->condition('abc')
             ->options(['utf8' => true])
             ->add('buz', 'zub')
-            ->controller('foo:act');
+            ->controller('foo:act')
+            ->add('controller_class', '/controller')
+            ->controller(['Acme\MyApp\MyController', 'myAction']);
 
         $routes->import('php_dsl_sub.php')
             ->prefix('/sub')

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -174,6 +174,9 @@ class PhpFileLoaderTest extends TestCase
         $expectedCollection->add('buz', (new Route('/zub'))
             ->setDefaults(['_controller' => 'foo:act'])
         );
+        $expectedCollection->add('controller_class', (new Route('/controller'))
+            ->setDefaults(['_controller' => ['Acme\MyApp\MyController', 'myAction']])
+        );
         $expectedCollection->add('c_root', (new Route('/sub/pub/'))
             ->setRequirements(['id' => '\d+'])
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

I've backported the test and doc block change from #42298.