### PR TITLE
[Form] Fix return type of FormErrorIterator::getChildren()

### DIFF
--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -205,7 +205,7 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
     /**
      * Alias of {@link current()}.
      *
-     * @return self
+     * @return FormError|self
      */
     public function getChildren()
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

https://github.com/symfony/symfony/commit/3c578b179470ebb8a81d469f507fcb0b2d93ca23 added `self` return type to `FormErrorIterator::getChildren()`.

However, from the constructor I assume that this method can return either `self` or an instance of `FormError`.