### PR TITLE
[Security] Remove time-sensitivity from `LoginLinkHandlerTest`

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/LoginLink/LoginLinkHandlerTest.php
@@ -53,7 +53,6 @@ class LoginLinkHandlerTest extends TestCase
 
     /**
      * @dataProvider provideCreateLoginLinkData
-     * @group time-sensitive
      */
     public function testCreateLoginLink($user, array $extraProperties, Request $request = null)
     {
@@ -65,8 +64,10 @@ class LoginLinkHandlerTest extends TestCase
                     return 'weaverryan' == $parameters['user']
                         && isset($parameters['expires'])
                         && isset($parameters['hash'])
+                         // allow a small expiration offset to avoid time-sensitivity
+                        && abs(time() + 600 - $parameters['expires']) <= 1
                         // make sure hash is what we expect
-                        && $parameters['hash'] === $this->createSignatureHash('weaverryan', time() + 600, array_values($extraProperties));
+                        && $parameters['hash'] === $this->createSignatureHash('weaverryan', $parameters['expires'], array_values($extraProperties));
                 }),
                 UrlGeneratorInterface::ABSOLUTE_URL
             )


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41338 
| License       | MIT
| Doc PR        | n/a

Removes time-sensitivity from `LoginLinkHandlerTest::testCreateLoginLink` by additionally comparing the provided expiration time with the current time by using an allowed drift/leeway. Previously only the provided hash was compared by using the current time as basis which was prone to missmatches. Now it uses the provided expiration time as basis instead.

Fixes the problem where the test code is assuming that calling `time()` twice (once in the link generation and once in the test expectation) will return the same value where in realityit might return 5 for the first and 6 for the second call only a split second later.