### PR TITLE
Release v5.3.6

### DIFF
--- a/CHANGELOG-5.3.md
+++ b/CHANGELOG-5.3.md
@@ -7,6 +7,14 @@ in 5.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v5.3.0...v5.3.1
 
+* 5.3.6 (2021-07-29)
+
+ * bug #42307 [Mailer] Fixed decode exception when sendgrid response is 202 (rubanooo)
+ * bug #42296 [Dotenv][Yaml] Remove PHP 8.0 polyfill (derrabus)
+ * bug #42274 [VarDumper] `HtmlDumper::setDumpHeader()` accepts `null` (rrpadilla)
+ * bug #42289 [HttpFoundation] Fixed type mismatch (Toflar)
+ * bug #42259 [Security] fix Check if it has session before getSession() (mousezheng)
+
 * 5.3.5 (2021-07-27)
 
  * bug #42270 [WebProfilerBundle] [WebProfiler] "empty" filter bugfix. Filter with name "empty" is not … (luzrain)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -75,12 +75,12 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
 
     private static $freshCache = [];
 
-    public const VERSION = '5.3.6-DEV';
+    public const VERSION = '5.3.6';
     public const VERSION_ID = 50306;
     public const MAJOR_VERSION = 5;
     public const MINOR_VERSION = 3;
     public const RELEASE_VERSION = 6;
-    public const EXTRA_VERSION = 'DEV';
+    public const EXTRA_VERSION = '';
 
     public const END_OF_MAINTENANCE = '01/2022';
     public const END_OF_LIFE = '01/2022';


### PR DESCRIPTION
**Changelog** (https://github.com/symfony/symfony/compare/v5.3.5...v5.3.6)

 * bug #42307 [Mailer] Fixed decode exception when sendgrid response is 202 (@rubanooo)
 * bug #42296 [Dotenv][Yaml] Remove PHP 8.0 polyfill (@derrabus)
 * bug #42274 [VarDumper] `HtmlDumper::setDumpHeader()` accepts `null` (@rrpadilla)
 * bug #42289 [HttpFoundation] Fixed type mismatch (@Toflar)
 * bug #42259 [Security] fix Check if it has session before getSession() (@mousezheng)
