### PR TITLE
[Security] Fix str_contains type mismatch in ChannelListener

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
@@ -51,7 +51,7 @@ class ChannelListener extends AbstractListener implements ListenerInterface
             if (null !== $this->logger) {
                 if ('https' === $request->headers->get('X-Forwarded-Proto')) {
                     $this->logger->info('Redirecting to HTTPS. ("X-Forwarded-Proto" header is set to "https" - did you set "trusted_proxies" correctly?)');
-                } elseif (str_contains($request->headers->get('Forwarded'), 'proto=https')) {
+                } elseif (str_contains($request->headers->get('Forwarded', ''), 'proto=https')) {
                     $this->logger->info('Redirecting to HTTPS. ("Forwarded" header is set to "proto=https" - did you set "trusted_proxies" correctly?)');
                 } else {
                     $this->logger->info('Redirecting to HTTPS.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42300, Part of #41552
| License       | MIT
| Doc PR        | -

Also use a default empty string in the `ChannelListener` before using `str_contains`.
