### PR TITLE
[HttpFoundation] Fix str_contains type mismatch in ApacheRequest

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ApacheRequest.php
+++ b/src/Symfony/Component/HttpFoundation/ApacheRequest.php
@@ -27,7 +27,7 @@ class ApacheRequest extends Request
      */
     protected function prepareRequestUri()
     {
-        return $this->server->get('REQUEST_URI');
+        return $this->server->get('REQUEST_URI', '/');
     }
 
     /**
@@ -37,7 +37,7 @@ class ApacheRequest extends Request
     {
         $baseUrl = $this->server->get('SCRIPT_NAME');
 
-        if (!str_contains($this->server->get('REQUEST_URI'), $baseUrl)) {
+        if (!str_contains($this->server->get('REQUEST_URI', '/'), $baseUrl)) {
             // assume mod_rewrite
             return rtrim(\dirname($baseUrl), '/\\');
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/ApacheRequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ApacheRequestTest.php
@@ -89,6 +89,14 @@ class ApacheRequestTest extends TestCase
                 '',
                 '/',
             ],
+            [
+                [
+                    'SCRIPT_NAME' => '/app_dev.php',
+                ],
+                '/',
+                '',
+                '/',
+            ],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | - <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | - <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

When scanning for more possible error like fixed in #42316, I found this one. I decided to create a separate MR as I'm not sure falling back to `/` would be the desired behaviour for a missing `REQUEST_URI`, or that maybe an exception would be more suitable.