### PR TITLE
Extract deprecation channel from triggering file

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.php
@@ -57,6 +57,7 @@ return static function (ContainerConfigurator $container) {
                 service('logger')->ignoreOnInvalid(),
                 sprintf('%s/%s', param('kernel.build_dir'), param('kernel.container_class')),
                 service('request_stack')->ignoreOnInvalid(),
+                param('kernel.project_dir'),
             ])
             ->tag('monolog.logger', ['channel' => 'profiler'])
             ->tag('data_collector', ['template' => '@WebProfiler/Collector/logger.html.twig', 'id' => 'logger', 'priority' => 300])

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -31,7 +31,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
     private $processedLogs;
     private $projectDir;
 
-    public function __construct(object $logger = null, string $containerPathPrefix = null, RequestStack $requestStack = null, string $projectDir)
+    public function __construct(object $logger = null, string $containerPathPrefix = null, RequestStack $requestStack = null, string $projectDir = null)
     {
         if (null !== $logger && $logger instanceof DebugLoggerInterface) {
             $this->logger = $logger;

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -371,7 +371,7 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
 
         // Composer packages
         if (str_starts_with($throwable->getFile(), $vendorPrefix)) {
-            preg_match('@'.preg_quote($vendorPrefix, '@').'([^/]+)/([^/]+).*$@', $throwable->getFile(), $matches);
+            preg_match('@^'.preg_quote($vendorPrefix, '@').'([^/]+)/([^/]+).*$@', $throwable->getFile(), $matches);
 
             return $matches[1].'/'.$matches[2];
         }

--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -366,14 +366,14 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
             return null;
         }
 
-        $appPrefix = $this->projectDir . '/src/';
-        $vendorPrefix = $this->projectDir . '/vendor/';
+        $appPrefix = $this->projectDir.'/src/';
+        $vendorPrefix = $this->projectDir.'/vendor/';
 
         // Composer packages
         if (str_starts_with($throwable->getFile(), $vendorPrefix)) {
-            preg_match('@' . preg_quote($vendorPrefix, '@') . '([^/]+)/([^/]+).*$@', $throwable->getFile(), $matches);
+            preg_match('@'.preg_quote($vendorPrefix, '@').'([^/]+)/([^/]+).*$@', $throwable->getFile(), $matches);
 
-            return $matches[1] . '/' . $matches[2];
+            return $matches[1].'/'.$matches[2];
         }
 
         // App


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | -

I think it would be great if deprecations were automatically channelled by their Composer package.
That way you can easily spot where the deprecation was triggered from and you can easily filter it thanks to @javiereguiluz's nice new interface (thank you, Javier!) :-)

It would look something like this:

<img width="945" alt="Bildschirmfoto 2021-07-29 um 19 08 48" src="https://user-images.githubusercontent.com/481937/127535755-5cc4c2c2-fe6a-4ac3-bef9-3753bbd0d90b.png">


Just a quick POC without any tests etc. just to clarify if this would be an interesting addition to Symfony and if so, if using channels for that is even the correct approach.

