### PR TITLE
[WebProfilerBundle] Fix missing semicolon crashing profiler bar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -715,7 +715,7 @@ if (typeof Sfjs === 'undefined' || typeof Sfjs.loadToolbar === 'undefined') {
                     }
 
                     /* Prevents from disallowing clicks on "copy to clipboard" elements inside toggles */
-                    var copyToClipboardElements = toggles[i].querySelectorAll('span[data-clipboard-text]')
+                    var copyToClipboardElements = toggles[i].querySelectorAll('span[data-clipboard-text]');
                     for (var k = 0; k < copyToClipboardElements.length; k++) {
                         addEventListener(copyToClipboardElements[k], 'click', function(e) {
                             e.stopPropagation();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Missing semicolon is causing web profiler toolbar to crash. 

Default steps to reproduce:
1. install full symfony
2. create controller/ 
3. no toolbar visible 
4. JS errors:
Uncaught SyntaxError: Unexpected token 'for'
home:26 Uncaught ReferenceError: Sfjs is not defined
    at home:26
    at home:26
(anonymous) @ home:26
(anonymous) @ home:26
