### PR TITLE
[Intl] Improve phpdoc

### DIFF
--- a/src/Symfony/Component/Intl/Countries.php
+++ b/src/Symfony/Component/Intl/Countries.php
@@ -107,9 +107,9 @@ final class Countries extends ResourceBundle
     /**
      * Gets the list of country names indexed with alpha2 codes as keys.
      *
-     * @return string[]
+     * @return array<string, string>
      */
-    public static function getNames(?string $displayLocale = null): array
+    public static function getNames(string $displayLocale = null): array
     {
         return self::asort(self::readEntry(['Names'], $displayLocale), $displayLocale);
     }
@@ -119,9 +119,9 @@ final class Countries extends ResourceBundle
      *
      * Same as method getNames, but with alpha3 codes instead of alpha2 codes as keys.
      *
-     * @return string[]
+     * @return array<string, string>
      */
-    public static function getAlpha3Names(?string $displayLocale = null): array
+    public static function getAlpha3Names(string $displayLocale = null): array
     {
         $alpha2Names = self::getNames($displayLocale);
         $alpha3Names = [];

--- a/src/Symfony/Component/Intl/Languages.php
+++ b/src/Symfony/Component/Intl/Languages.php
@@ -76,7 +76,7 @@ final class Languages extends ResourceBundle
     /**
      * Gets the list of language names indexed with alpha2 codes as keys.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public static function getNames(string $displayLocale = null): array
     {
@@ -157,7 +157,7 @@ final class Languages extends ResourceBundle
      *
      * Same as method getNames, but with ISO 639-2 three-letter codes instead of ISO 639-1 codes as keys.
      *
-     * @return string[]
+     * @return array<string, string>
      */
     public static function getAlpha3Names(string $displayLocale = null): array
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

Those 4 methods are saying the array returned use `string` as key, but the phpdoc is `@return string[]`.
The previous phpdoc is understood as `array<int|string, string>` which can ends with static analysis false error when dealing with the keys of those array.