### PR TITLE
[HttpKernel] always close open stopwatch section after handling `kernel.request` events

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -30,6 +30,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
     {
         switch ($eventName) {
             case KernelEvents::REQUEST:
+                $event->getRequest()->attributes->set('_stopwatch_token', substr(hash('sha256', uniqid(mt_rand(), true)), 0, 6));
                 $this->stopwatch->openSection();
                 break;
             case KernelEvents::VIEW:
@@ -40,8 +41,8 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
                 }
                 break;
             case KernelEvents::TERMINATE:
-                $token = $event->getResponse()->headers->get('X-Debug-Token');
-                if (null === $token) {
+                $sectionId = $event->getRequest()->attributes->get('_stopwatch_token');
+                if (null === $sectionId) {
                     break;
                 }
                 // There is a very special case when using built-in AppCache class as kernel wrapper, in the case
@@ -50,7 +51,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
                 // is equal to the [A] debug token. Trying to reopen section with the [B] token throws an exception
                 // which must be caught.
                 try {
-                    $this->stopwatch->openSection($token);
+                    $this->stopwatch->openSection($sectionId);
                 } catch (\LogicException $e) {
                 }
                 break;
@@ -67,21 +68,21 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
                 $this->stopwatch->start('controller', 'section');
                 break;
             case KernelEvents::RESPONSE:
-                $token = $event->getResponse()->headers->get('X-Debug-Token');
-                if (null === $token) {
+                $sectionId = $event->getRequest()->attributes->get('_stopwatch_token');
+                if (null === $sectionId) {
                     break;
                 }
-                $this->stopwatch->stopSection($token);
+                $this->stopwatch->stopSection($sectionId);
                 break;
             case KernelEvents::TERMINATE:
                 // In the special case described in the `preDispatch` method above, the `$token` section
                 // does not exist, then closing it throws an exception which must be caught.
-                $token = $event->getResponse()->headers->get('X-Debug-Token');
-                if (null === $token) {
+                $sectionId = $event->getRequest()->attributes->get('_stopwatch_token');
+                if (null === $sectionId) {
                     break;
                 }
                 try {
-                    $this->stopwatch->stopSection($token);
+                    $this->stopwatch->stopSection($sectionId);
                 } catch (\LogicException $e) {
                 }
                 break;

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -28,12 +28,12 @@ class TraceableEventDispatcherTest extends TestCase
     public function testStopwatchSections()
     {
         $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), $stopwatch = new Stopwatch());
-        $kernel = $this->getHttpKernel($dispatcher, function () { return new Response('', 200, ['X-Debug-Token' => '292e1e']); });
+        $kernel = $this->getHttpKernel($dispatcher);
         $request = Request::create('/');
         $response = $kernel->handle($request);
         $kernel->terminate($request, $response);
 
-        $events = $stopwatch->getSectionEvents($response->headers->get('X-Debug-Token'));
+        $events = $stopwatch->getSectionEvents($request->attributes->get('_stopwatch_token'));
         $this->assertEquals([
             '__section__',
             'kernel.request',
@@ -56,7 +56,7 @@ class TraceableEventDispatcherTest extends TestCase
 
         $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), $stopwatch);
 
-        $kernel = $this->getHttpKernel($dispatcher, function () { return new Response(); });
+        $kernel = $this->getHttpKernel($dispatcher);
         $request = Request::create('/');
         $kernel->handle($request);
     }
@@ -69,12 +69,12 @@ class TraceableEventDispatcherTest extends TestCase
         $stopwatch->expects($this->once())
             ->method('isStarted')
             ->willReturn(true);
-        $stopwatch->expects($this->once())
+        $stopwatch->expects($this->exactly(3))
             ->method('stop');
 
         $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), $stopwatch);
 
-        $kernel = $this->getHttpKernel($dispatcher, function () { return new Response(); });
+        $kernel = $this->getHttpKernel($dispatcher);
         $request = Request::create('/');
         $kernel->handle($request);
     }
@@ -110,10 +110,12 @@ class TraceableEventDispatcherTest extends TestCase
         $this->assertCount(1, $eventDispatcher->getListeners('foo'), 'expected listener1 to be removed');
     }
 
-    protected function getHttpKernel($dispatcher, $controller)
+    protected function getHttpKernel($dispatcher)
     {
         $controllerResolver = $this->createMock(ControllerResolverInterface::class);
-        $controllerResolver->expects($this->once())->method('getController')->willReturn($controller);
+        $controllerResolver->expects($this->once())->method('getController')->willReturn(function () {
+            return new Response();
+        });
         $argumentResolver = $this->createMock(ArgumentResolverInterface::class);
         $argumentResolver->expects($this->once())->method('getArguments')->willReturn([]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #36623
| License       | MIT
| Doc PR        | 