### PR TITLE
[HttpFoundation] Add `litespeed_finish_request` to `Response`

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Add the `litespeed_finish_request` method to work with Litespeed
+
 5.3
 ---
 

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -395,6 +395,8 @@ class Response
 
         if (\function_exists('fastcgi_finish_request')) {
             fastcgi_finish_request();
+        } elseif (\function_exists('litespeed_finish_request')) {
+            litespeed_finish_request();
         } elseif (!\in_array(\PHP_SAPI, ['cli', 'phpdbg'], true)) {
             static::closeOutputBuffers(0, true);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #42293
| License       | MIT

For now Litespeed has dropped support for `fastcgi_finish_request` function due to some problems: https://github.com/php/php-src/commit/ccf051c317e606c2a4d9099c6e79a5c42bfdb298 so when Litespeed is being used on a server instead of Apache, then there is no possibility to use `fastcgi_finish_request` function as the alias for `litespeed_finish_request` is turned off.

