### PR TITLE
[Messenger] Add `WorkerMetadata` to `Worker` class.

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * Add `StopWorkerExceptionInterface` and its implementation `StopWorkerException` to stop the worker.
  * Add support for resetting container services after each messenger message.
+ * Added `WorkerMetadata` class which allows you to access the configuration details of a worker, like `queueNames` and `transportNames` it consumes from.
+ * New method `getMetadata()` was added to `Worker` class which returns the `WorkerMetadata` object.
 
 5.3
 ---

--- a/src/Symfony/Component/Messenger/Tests/WorkerMetadataTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerMetadataTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\WorkerMetadata;
+
+/**
+ * @author Oleg Krasavin <okwinza@gmail.com>
+ */
+class WorkerMetadataTest extends TestCase
+{
+    public function testItReturnsDefaultValuesIfNoneProvided()
+    {
+        $metadata = new WorkerMetadata([]);
+
+        $this->assertNull($metadata->getQueueNames());
+        $this->assertSame([], $metadata->getTransportNames());
+    }
+
+    public function testItReturnsProvidedMetadata()
+    {
+        $data = [
+            'queueNames' => ['c', 'b', 'a'],
+            'transportNames' => ['a', 'b', 'c'],
+        ];
+
+        $metadata = new WorkerMetadata($data);
+
+        $this->assertSame($data['queueNames'], $metadata->getQueueNames());
+        $this->assertSame($data['transportNames'], $metadata->getTransportNames());
+    }
+
+    public function testItSetsMetadataViaSetter()
+    {
+        $data = [
+            'queueNames' => ['c', 'b', 'a'],
+            'transportNames' => ['a', 'b', 'c'],
+        ];
+
+        $metadata = new WorkerMetadata([]);
+
+        $metadata->set($data);
+
+        $this->assertSame($data['queueNames'], $metadata->getQueueNames());
+        $this->assertSame($data['transportNames'], $metadata->getTransportNames());
+    }
+}

--- a/src/Symfony/Component/Messenger/WorkerMetadata.php
+++ b/src/Symfony/Component/Messenger/WorkerMetadata.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger;
+
+/**
+ * @author Oleg Krasavin <okwinza@gmail.com>
+ */
+final class WorkerMetadata
+{
+    private $metadata;
+
+    public function __construct(array $metadata)
+    {
+        $this->metadata = $metadata;
+    }
+
+    public function set(array $newMetadata): void
+    {
+        $this->metadata = array_merge($this->metadata, $newMetadata);
+    }
+
+    /**
+     * Returns the queue names the worker consumes from, if "--queues" option was used.
+     * Returns null otherwise.
+     */
+    public function getQueueNames(): ?array
+    {
+        return $this->metadata['queueNames'] ?? null;
+    }
+
+    /**
+     * Returns an array of unique identifiers for transport receivers the worker consumes from.
+     */
+    public function getTransportNames(): array
+    {
+        return $this->metadata['transportNames'] ?? [];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fixes #37736
| License       | MIT
| Doc PR        | -

At the moment, there is no clean way to access the values of `transportNames` or recently introduced `queueNames` that the worker was configured with, although such data might be quite useful for logging/monitoring or other tasks.

This PR attempts to fix that by adding a new and extensible way to provide additional information about a particular `Worker` object.

So far, the following PRs could benefit from this change:

- #43133 
- #42723

**Use case example:**
----

- As I developer
- When a message was consumed from transport with name `async`.
- And the worker state is `idle`.
- Then I want to reset services.

**Before this PR**, the only solution not relying on using Reflection API would look like this:
```php
    private $servicesResetter;
    private $receiversName;
    private $actualReceiverName = null;

    public function __construct(ServicesResetter $servicesResetter, array $receiversName)
    {
        $this->servicesResetter = $servicesResetter;
        $this->receiversName = $receiversName;
    }

    public function saveReceiverName(AbstractWorkerMessageEvent $event): void
    {
        $this->actualReceiverName = $event->getReceiverName();
    }

    public function resetServices(WorkerRunningEvent $event): void
    {
        if (!$event->isWorkerIdle() && \in_array($this->actualReceiverName, $this->receiversName, true)) {
            $this->servicesResetter->reset();
        }

        $this->actualReceiverName = null;
    }

    public static function getSubscribedEvents(): array
    {
        return [
            WorkerMessageHandledEvent::class => ['saveReceiverName'],
            WorkerMessageFailedEvent::class => ['saveReceiverName'],
            WorkerRunningEvent::class => ['resetServices'],
        ];
    }
```
**With this PR**, one could simply use this to retrieve the transport name.
```php
$event->getWorker()->getWorkerMetadata()->getTransportName() === $this->transportName;
```
So the whole solution would look like this:
```php
    private $servicesResetter;
    private $receiversName;

    public function __construct(ServicesResetter $servicesResetter, array $receiversName)
    {
        $this->servicesResetter = $servicesResetter;
        $this->receiversName = $receiversName;
    }

    public function resetServices(WorkerRunningEvent $event): void
    {
        $actualTransportName = $event->getWorker()->getWorkerMetadata()->getTransportName();
        if (!$event->isWorkerIdle() || !in_array($actualTransportName, $this->receiversName, true)) {
            return;
        }

        $this->servicesResetter->reset();
    }

    public static function getSubscribedEvents(): array
    {
        return [
            WorkerRunningEvent::class => ['resetServices'],
        ];
    }
```
