### PR TITLE
[DomCrawler] Added Crawler::innerText() method

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Add `Crawler::innerText` method.
+
 5.3
 ---
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -635,6 +635,14 @@ class Crawler implements \Countable, \IteratorAggregate
     }
 
     /**
+     * Returns only the inner text that is the direct descendent of the current node, excluding any child nodes.
+     */
+    public function innerText(): string
+    {
+        return $this->filterXPath('.//text()')->text();
+    }
+
+    /**
      * Returns the first node of the list as HTML.
      *
      * @param string|null $default When not null: the value to return when the current node is empty

--- a/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/AbstractCrawlerTest.php
@@ -354,6 +354,18 @@ abstract class AbstractCrawlerTest extends TestCase
         $this->assertSame('my value', $this->createTestCrawler(null)->filterXPath('//ol')->text('my value'));
     }
 
+    /**
+     * Tests that innerText() returns only text that is the direct descendent of the current node, in contrast to
+     * text() that returns the text of all child nodes.
+     */
+    public function testInnerText()
+    {
+        self::assertCount(1, $crawler = $this->createTestCrawler()->filterXPath('//*[@id="complex-element"]'));
+
+        self::assertSame('Parent text Child text', $crawler->text());
+        self::assertSame('Parent text', $crawler->innerText());
+    }
+
     public function testHtml()
     {
         $this->assertEquals('<img alt="Bar">', $this->createTestCrawler()->filterXPath('//a[5]')->html());
@@ -1283,6 +1295,10 @@ HTML;
                         <div id="child2" xmlns:foo="http://example.com"></div>
                     </div>
                     <div id="sibling"><img /></div>
+                    <div id="complex-element">
+                        Parent text
+                        <span>Child text</span>
+                    </div>
                 </body>
             </html>
         ');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Fix #42294 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Adds a method to get the inner text that is directly descended from the current node only, ignoring text nodes in any child nodes.