### PR TITLE
[Validator] Update MIR card scheme

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
@@ -77,9 +77,9 @@ class CardSchemeValidator extends ConstraintValidator
             '/^5[1-5][0-9]{14}$/',
             '/^2(22[1-9][0-9]{12}|2[3-9][0-9]{13}|[3-6][0-9]{14}|7[0-1][0-9]{13}|720[0-9]{12})$/',
         ],
-        // Payment system MIR numbers start with 220, then 1 digit from 0 to 4, then 12 digits
+        // Payment system MIR numbers start with 220, then 1 digit from 0 to 4, then between 12 and 15 digits
         'MIR' => [
-            '/^220[0-4][0-9]{12}$/',
+            '/^220[0-4][0-9]{12,15}$/',
         ],
         // All UATP card numbers start with a 1 and have a length of 15 digits.
         'UATP' => [

--- a/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
@@ -104,6 +104,9 @@ class CardSchemeValidatorTest extends ConstraintValidatorTestCase
             ['MASTERCARD', '2709999999999999'],
             ['MASTERCARD', '2720995105105100'],
             ['MIR', '2200381427330082'],
+            ['MIR', '22003814273300821'],
+            ['MIR', '220038142733008212'],
+            ['MIR', '2200381427330082123'],
             ['UATP', '110165309696173'],
             ['VISA', '4111111111111111'],
             ['VISA', '4012888888881881'],
@@ -136,7 +139,8 @@ class CardSchemeValidatorTest extends ConstraintValidatorTestCase
             ['MASTERCARD', '2721001234567890', CardScheme::INVALID_FORMAT_ERROR], // Not assigned yet
             ['MASTERCARD', '2220991234567890', CardScheme::INVALID_FORMAT_ERROR], // Not assigned yet
             ['UATP', '11016530969617', CardScheme::INVALID_FORMAT_ERROR], // invalid length
-            ['MIR', '22003814273300821', CardScheme::INVALID_FORMAT_ERROR], // invalid length
+            ['MIR', '220038142733008', CardScheme::INVALID_FORMAT_ERROR], // invalid length
+            ['MIR', '22003814273300821234', CardScheme::INVALID_FORMAT_ERROR], // invalid length
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Update card scheme validator for MIR cards, it's allowing 16-19 numbers length