### PR TITLE
[HttpKernel] Bugfix/last modified response strategy

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/ResponseCacheStrategy.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/ResponseCacheStrategy.php
@@ -37,6 +37,7 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
     private int $embeddedResponses = 0;
     private bool $isNotCacheableResponseEmbedded = false;
     private int $age = 0;
+    private \DateTimeInterface|null|false $lastModified = null;
     private array $flagDirectives = [
         'no-cache' => null,
         'no-store' => null,
@@ -90,6 +91,11 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
         $expires = $response->getExpires();
         $expires = null !== $expires ? (int) $expires->format('U') - (int) $response->getDate()->format('U') : null;
         $this->storeRelativeAgeDirective('expires', $expires >= 0 ? $expires : null, 0, $isHeuristicallyCacheable);
+
+        if (false !== $this->lastModified) {
+            $lastModified = $response->getLastModified();
+            $this->lastModified = $lastModified ? max($this->lastModified, $lastModified) : false;
+        }
     }
 
     /**
@@ -102,17 +108,16 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
             return;
         }
 
-        // Remove validation related headers of the master response,
-        // because some of the response content comes from at least
-        // one embedded response (which likely has a different caching strategy).
+        // Remove Etag since it cannot be merged from embedded responses.
         $response->setEtag(null);
-        $response->setLastModified(null);
 
         $this->add($response);
 
         $response->headers->set('Age', $this->age);
 
         if ($this->isNotCacheableResponseEmbedded) {
+            $response->setLastModified();
+
             if ($this->flagDirectives['no-store']) {
                 $response->headers->set('Cache-Control', 'no-cache, no-store, must-revalidate');
             } else {
@@ -121,6 +126,8 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
 
             return;
         }
+
+        $response->setLastModified($this->lastModified ?: null);
 
         $flags = array_filter($this->flagDirectives);
 
@@ -162,17 +169,14 @@ class ResponseCacheStrategy implements ResponseCacheStrategyInterface
         // RFC2616: A response received with a status code of 200, 203, 300, 301 or 410
         // MAY be stored by a cache […] unless a cache-control directive prohibits caching.
         if ($response->headers->hasCacheControlDirective('no-cache')
-            || $response->headers->getCacheControlDirective('no-store')
+            || $response->headers->hasCacheControlDirective('no-store')
         ) {
             return true;
         }
 
-        // Last-Modified and Etag headers cannot be merged, they render the response uncacheable
+        // Etag headers cannot be merged, they render the response uncacheable
         // by default (except if the response also has max-age etc.).
-        if (\in_array($response->getStatusCode(), [200, 203, 300, 301, 410])
-            && null === $response->getLastModified()
-            && null === $response->getEtag()
-        ) {
+        if (null === $response->getEtag() && \in_array($response->getStatusCode(), [200, 203, 300, 301, 410])) {
             return false;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41666
| License       | MIT
| Doc PR        | ~

---



The `HttpCache` uses the `ResponseCacheStrategy` to merge caching headers when merging ESI or SSI fragments into the main response content. Caching headers are merged as far as possible (age, cache-control/max-age, etc.). However, we forgot to merge the `Last-Modified` header which prevents revalidation of responses.

from @mpdude in #41666
> Currently, ResponseCacheStrategy will always remove the Last-Modified header when merging ESI responses. This makes it impossible to revalidate the result.
>
> My suggestion is to keep the maximum = most recent Last-Modified value on the final response as long as all (sub-)responses provided Last-Modified.
