### PR TITLE
[String] Add a failing test for the `String::snake()` method

### DIFF
--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -1035,6 +1035,7 @@ abstract class AbstractAsciiTestCase extends TestCase
             ['symfony_is_great', 'symfonyIsGreat'],
             ['symfony5_is_great', 'symfony5IsGreat'],
             ['symfony5is_great', 'symfony5isGreat'],
+            ['symfony_5_is_great', 'symfony_5_Is_Great'],
             ['symfony_is_great', 'Symfony is great'],
             ['symfony_is_a_great_framework', 'symfonyIsAGreatFramework'],
             ['symfony_is_great', 'symfonyIsGREAT'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

Hi guys!
It seems to me that the `snake()` method doesn't work as it should for certain inputs.
I've added a failing test to illustrate it.