### PR TITLE
[Serializer] Better value for constant Serializer::EMPTY_ARRAYS_AS_OBJECT

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -51,7 +51,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
      * Flag to control whether an empty array should be transformed to an
      * object (in JSON: {}) or to a map (in JSON: []).
      */
-    public const EMPTY_ARRAYS_AS_OBJECT = 'empty_iterable_as_object';
+    public const EMPTY_ARRAYS_AS_OBJECT = 'empty_arrays_as_object';
 
     private const SCALAR_TYPES = [
         'int' => true,
@@ -165,11 +165,11 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
         }
 
         if (is_iterable($data)) {
-            if (is_countable($data) && \count($data) === 0) {
+            if (is_countable($data) && 0 === \count($data)) {
                 switch (true) {
-                    case ($context[AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS] ?? false) && is_object($data):
+                    case ($context[AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS] ?? false) && \is_object($data):
                         return $data;
-                    case ($context[self::EMPTY_ARRAYS_AS_OBJECT] ?? false) && is_array($data):
+                    case ($context[self::EMPTY_ARRAYS_AS_OBJECT] ?? false) && \is_array($data):
                         return new \ArrayObject();
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

I noticed that while documenting the feature