### PR TITLE
[HttpClient] Fix HttpClientInterface::withOptions declaration

### DIFF
--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\HttpClient\Test\HttpClientTestCase;
  *
  * @see HttpClientTestCase for a reference test suite
  *
- * @method static withOptions(array $options) Returns a new instance of the client with new default options
+ * @method self withOptions(array $options) Returns a new instance of the client with new default options
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Hello :handshake: 

I am opening the PR after noticing a warning in my IDE about method `\Symfony\Contracts\HttpClient\HttpClientInterface::withOptions` that should be used statically:
![image](https://user-images.githubusercontent.com/895123/128055674-08040e94-a649-443e-8fe0-18e5b8d19e0c.png)

I found weird, then check [the doc](https://symfony.com/doc/current/http_client.html#configuration) and noticed it was because of `@method` annotation.

Here is my analysis from my commit message:
>This method is not static and thus should not be declared as static.
>The return type is dynamic though. I don't know how it could be declared
>as a dynamic return type but it looks enough to me as the caller knows
>the type of object it manipulates. Using this method should not break
>the original typing detected by the IDE or static analysis tools.
>
>See https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/method.html#method
