### PR TITLE
[Translation] correctly handle intl domains with TargetOperation

### DIFF
--- a/src/Symfony/Component/Translation/Catalogue/TargetOperation.php
+++ b/src/Symfony/Component/Translation/Catalogue/TargetOperation.php
@@ -49,7 +49,7 @@ class TargetOperation extends AbstractOperation
         foreach ($this->source->all($domain) as $id => $message) {
             if ($this->target->has($id, $domain)) {
                 $this->messages[$domain]['all'][$id] = $message;
-                $d = $this->target->defines($id, $intlDomain) ? $intlDomain : $domain;
+                $d = $this->source->defines($id, $intlDomain) ? $intlDomain : $domain;
                 $this->result->add([$id => $message], $d);
                 if (null !== $keyMetadata = $this->source->getMetadata($id, $d)) {
                     $this->result->setMetadata($id, $keyMetadata, $d);

--- a/src/Symfony/Component/Translation/Tests/Catalogue/TargetOperationTest.php
+++ b/src/Symfony/Component/Translation/Tests/Catalogue/TargetOperationTest.php
@@ -71,11 +71,43 @@ class TargetOperationTest extends AbstractOperationTest
     {
         $this->assertEquals(
             new MessageCatalogue('en', [
-                'messages+intl-icu' => ['a' => 'old_a'],
+                'messages' => ['a' => 'old_a'],
             ]),
             $this->createOperation(
                 new MessageCatalogue('en', ['messages' => ['a' => 'old_a']]),
                 new MessageCatalogue('en', ['messages+intl-icu' => ['a' => 'new_a']])
+            )->getResult()
+        );
+
+        $this->assertEquals(
+            new MessageCatalogue('en', [
+                'messages+intl-icu' => ['a' => 'old_a'],
+            ]),
+            $this->createOperation(
+                new MessageCatalogue('en', ['messages+intl-icu' => ['a' => 'old_a']]),
+                new MessageCatalogue('en', ['messages' => ['a' => 'new_a']])
+            )->getResult()
+        );
+
+        $this->assertEquals(
+            new MessageCatalogue('en', [
+                'messages+intl-icu' => ['a' => 'old_a'],
+                'messages' => ['b' => 'new_b'],
+            ]),
+            $this->createOperation(
+                new MessageCatalogue('en', ['messages+intl-icu' => ['a' => 'old_a']]),
+                new MessageCatalogue('en', ['messages' => ['a' => 'new_a', 'b' => 'new_b']])
+            )->getResult()
+        );
+
+        $this->assertEquals(
+            new MessageCatalogue('en', [
+                'messages' => ['a' => 'old_a'],
+                'messages+intl-icu' => ['b' => 'new_b'],
+            ]),
+            $this->createOperation(
+                new MessageCatalogue('en', ['messages' => ['a' => 'old_a']]),
+                new MessageCatalogue('en', ['messages+intl-icu' => ['a' => 'new_a', 'b' => 'new_b']])
             )->getResult()
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Executing `translations:update` with `--clean` was producing erratic result: creating duplicate non-/intl files for domains, removing used translations...

**TL;DR:** judging from context this was most probably just a typo in 33e6af5850ce167ddef96c467cd86b9a6f986f2c

# How to reproduce

## Setup Test Project
A fresh minimal project to verify this can be setup with
~~~sh
composer create-project symfony/skeleton translations_test
cd translations_test/
composer require translation
~~~
and adding extractable translations into a file in `src/`, e.g. 

~~~php
<?php
// in src/translations.php
use Symfony\Component\Translation\TranslatableMessage;

new TranslatableMessage('First Message');
new TranslatableMessage('Second Message');
~~~

Otherwise any existing project should work as well.

## Steps to reproduce
### Case 1: duplicate translation files
~~~sh
# remove all existing translations and extract them again
rm -rf translations/*
php bin/console translation:update --force --clean en

# verify translations/messages+intl-icu.en.xlf was created containing the messages

# extract messages again
php bin/console translation:update --force --clean en

# messages+intl-icu.en.xlf is unchanged but messages.en.xlf with all the same messages was added
~~~

### Case 2: lost translations
~~~sh
# remove all existing translations and extract them again
rm -rf translations/*
php bin/console translation:update --force --clean en

# verify translations/messages+intl-icu.en.xlf was created containing the messages
# remove one or more messages from messages+intl-icu.en.xlf, keeping at least one

# extract messages again
php bin/console translation:update --force --clean en

# messages+intl-icu.en.xlf will *only* contain the missing/"new" messages and all other messages got removed
~~~

# The Fix
The previous code was trying to merge with the `target` messages instead of the `source`. This was probably just a typo since `$keyMetadata` is take from `source` just below it and the `foreach` block below which is basically doing the same inverse just switches `target` and `source`.
Also the code is mostly identical to [`MergeOperation`](https://github.com/symfony/symfony/blob/2cee75bef9f6c1ca4e532986dc0dcae8461de4dd/src/Symfony/Component/Translation/Catalogue/MergeOperation.php#L39-L46) which also uses `source` at the respective line.

The code in both files was introduced in 33e6af5850ce167ddef96c467cd86b9a6f986f2c
