### PR TITLE
[Console] Don't pass null to preg_replace()

### DIFF
--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -170,7 +170,7 @@ abstract class Helper implements HelperInterface
         // remove <...> formatting
         $string = $formatter->format($string ?? '');
         // remove already formatted characters
-        $string = preg_replace("/\033\[[^m]*m/", '', $string);
+        $string = preg_replace("/\033\[[^m]*m/", '', $string ?? '');
         $formatter->setDecorated($isDecorated);
 
         return $string;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #41552
| License       | MIT
| Doc PR        | N/A

An output formatter might return `null` (see `NullOutputFormatter`). In this case, we would pass `null` to `preg_replace()` which would trigger a deprecation warning in PHP 8.1. Let's not do that.