### PR TITLE
[Console] Add return type to OutputFormatterInterface::format()

### DIFF
--- a/src/Symfony/Component/Console/Formatter/NullOutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/NullOutputFormatter.php
@@ -21,9 +21,9 @@ final class NullOutputFormatter implements OutputFormatterInterface
     /**
      * {@inheritdoc}
      */
-    public function format(?string $message): void
+    public function format(?string $message): ?string
     {
-        // do nothing
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
@@ -53,6 +53,8 @@ interface OutputFormatterInterface
 
     /**
      * Formats a message according to the given styles.
+     *
+     * @return string|null
      */
     public function format(?string $message);
 }

--- a/src/Symfony/Component/Console/Tests/Formatter/NullOutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/NullOutputFormatterTest.php
@@ -25,10 +25,7 @@ class NullOutputFormatterTest extends TestCase
     {
         $formatter = new NullOutputFormatter();
 
-        $message = 'this message will not be changed';
-        $formatter->format($message);
-
-        $this->assertSame('this message will not be changed', $message);
+        $this->assertNull($formatter->format('this message will be destroyed'));
     }
 
     public function testGetStyle()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Spotted while working on #42381. If we look at how `OutputFormatterInterface::format()` is used in the codebase, we can see that an implementation of that method is supposed to return something. Yet the interface does not declare a return value and the `NullOutputFormatter` implementation even has a `void` return type which does not make sense at all, imho.

This PR attempts to fix that.