### PR TITLE
[HttpFoundation] Fix broken mock

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Proxy/SessionHandlerProxyTest.php
@@ -103,17 +103,21 @@ class SessionHandlerProxyTest extends TestCase
     public function testWrite()
     {
         $this->mock->expects($this->once())
-            ->method('write');
+            ->method('write')
+            ->willReturn(true)
+        ;
 
-        $this->proxy->write('id', 'data');
+        $this->assertTrue($this->proxy->write('id', 'data'));
     }
 
     public function testDestroy()
     {
         $this->mock->expects($this->once())
-            ->method('destroy');
+            ->method('destroy')
+            ->willReturn(true)
+        ;
 
-        $this->proxy->destroy('id');
+        $this->assertTrue($this->proxy->destroy('id'));
     }
 
     public function testGc()
@@ -149,7 +153,9 @@ class SessionHandlerProxyTest extends TestCase
         $proxy->updateTimestamp('id', 'data');
 
         $this->mock->expects($this->once())
-            ->method('write');
+            ->method('write')
+            ->willReturn(true)
+        ;
 
         $this->proxy->updateTimestamp('id', 'data');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Backport from #42378.

This PR fixes a couple of mocked methods that currently return `null` although a real implementation would never do that.