### PR TITLE
[Form] Deprecate calling FormErrorIterator::children() if the current element is not iterable

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -12,6 +12,11 @@ Finder
  * Deprecate `Comparator::setTarget()` and `Comparator::setOperator()`
  * Add a constructor to `Comparator` that allows setting target and operator
 
+Form
+------
+
+ * Deprecate calling `FormErrorIterator::children()` if the current element is not iterable.
+
 FrameworkBundle
 ---------------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -69,6 +69,7 @@ Finder
 Form
 ----
 
+ * `FormErrorIterator::children()` throws an exception if the current element is not iterable.
  * The default value of the `rounding_mode` option of the `PercentType` has been changed to `\NumberFormatter::ROUND_HALFUP`.
  * The default rounding mode of the `PercentToLocalizedStringTransformer` has been changed to `\NumberFormatter::ROUND_HALFUP`.
  * Added the `getIsEmptyCallback()` method to the `FormConfigInterface`.

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.4
 ---
 
+ * Deprecate calling `FormErrorIterator::children()` if the current element is not iterable.
  * Allow to pass `TranslatableMessage` objects to the `help` option
 
 5.3

--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form;
 
 use Symfony\Component\Form\Exception\BadMethodCallException;
 use Symfony\Component\Form\Exception\InvalidArgumentException;
+use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\Exception\OutOfBoundsException;
 use Symfony\Component\Validator\ConstraintViolation;
 
@@ -213,13 +214,16 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
     }
 
     /**
-     * Alias of {@link current()}.
-     *
      * @return self
      */
     #[\ReturnTypeWillChange]
     public function getChildren()
     {
+        if (!$this->hasChildren()) {
+            trigger_deprecation('symfony/form', '5.4', 'Calling "%s()" if the current element is not iterable is deprecated, call "%s" to get the current element.', __METHOD__, self::class.'::current()');
+            // throw new LogicException(sprintf('The current element is not iterable. Use "%s" to get the current element.', self::class.'::current()'));
+        }
+
         return current($this->errors);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 for features
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | https://github.com/symfony/symfony/pull/42301#discussion_r679203915
| License       | MIT
| Doc PR        | 
