### PR TITLE
[Validator] Fix ExecutionContextInterface::buildViolation phpdoc example

### DIFF
--- a/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContextInterface.php
@@ -76,8 +76,8 @@ interface ExecutionContextInterface
      * add the violation when you're done with the configuration:
      *
      *     $context->buildViolation('Please enter a number between %min% and %max%.')
-     *         ->setParameter('%min%', 3)
-     *         ->setParameter('%max%', 10)
+     *         ->setParameter('%min%', '3')
+     *         ->setParameter('%max%', '10')
      *         ->setTranslationDomain('number_validation')
      *         ->addViolation();
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | np
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | -

`ConstraintViolationBuilder` contract declares that `setParameter` method accepts values as strings only and in upper branches this is enforced by typehint so blindly copying this wouldn't work
