### PR TITLE
[FrameworkBundle] remove dead conditions in Translation Commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php
@@ -165,7 +165,7 @@ EOF
                 $transPaths = [$path.'/translations'];
                 $codePaths = [$path.'/templates'];
 
-                if (!is_dir($transPaths[0]) && !isset($transPaths[1])) {
+                if (!is_dir($transPaths[0])) {
                     throw new InvalidArgumentException(sprintf('"%s" is neither an enabled bundle nor a directory.', $transPaths[0]));
                 }
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -197,7 +197,7 @@ EOF
                 $transPaths = [$path.'/translations'];
                 $codePaths = [$path.'/templates'];
 
-                if (!is_dir($transPaths[0]) && !isset($transPaths[1])) {
+                if (!is_dir($transPaths[0])) {
                     throw new InvalidArgumentException(sprintf('"%s" is neither an enabled bundle nor a directory.', $transPaths[0]));
                 }
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This is just a trivial removal of unused code I stumbled upon while debugging #42361. In the [original code](https://github.com/symfony/symfony/blob/e617a9b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationDebugCommand.php#L165-L170):

~~~php
$transPaths = [$path.'/translations'];
$codePaths = [$path.'/templates'];

if (!is_dir($transPaths[0]) && !isset($transPaths[1])) {
		throw new InvalidArgumentException(sprintf('"%s" is neither an enabled bundle nor a directory.', $transPaths[0]));
}
~~~

The second part of the condition `isset($transPaths[1])` will **always** evaluate to true, since `$targetPath` is just set 3 lines above but only has a single element.

This check was originally to support legacy paths which was removed in b6eb1f4979db346ffe9fe7f6a5f335323f0c7175:
* in [`TranslationDebugCommand.php`](https://github.com/symfony/symfony/commit/b6eb1f4979db346ffe9fe7f6a5f335323f0c7175#diff-67afa5b8860d0df4e44f1e1fc89f444b7ac77de515b698a6824dd5403a0acdbcL187-L194)
* in [`TranslationUpdateCommand.php `](https://github.com/symfony/symfony/commit/b6eb1f4979db346ffe9fe7f6a5f335323f0c7175#diff-a01c7858e84f1868a427634740511da7c8c73e56772baa78bdcd98200d7125c0L180-L187)

Rebased from 5.3 to 5.4, see #42362
/cc @fabpot 