### PR TITLE
[ErrorHandler] Add missing to semi-colon to exception.js

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
+++ b/src/Symfony/Component/ErrorHandler/Resources/assets/js/exception.js
@@ -176,7 +176,7 @@ if (typeof Sfjs === 'undefined') {
                     }
 
                     /* Prevents from disallowing clicks on "copy to clipboard" elements inside toggles */
-                    var copyToClipboardElements = toggles[i].querySelectorAll('span[data-clipboard-text]')
+                    var copyToClipboardElements = toggles[i].querySelectorAll('span[data-clipboard-text]');
                     for (var k = 0; k < copyToClipboardElements.length; k++) {
                         addEventListener(copyToClipboardElements[k], 'click', function(e) {
                             e.stopPropagation();


### PR DESCRIPTION
Without this, the js is reported as in error using at least Firefox on Linux, which ultimately prevents the debug bar appearing.

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 
