### PR TITLE
[Validator] Define which collection keys should be checked for uniqueness

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 6.1
 ---
 
+ * Add the `fields` option to the `Unique` constraint, to define which collection keys should be checked for uniqueness
  * Deprecate `Constraint::$errorNames`, use `Constraint::ERROR_NAMES` instead
  * Deprecate constraint `ExpressionLanguageSyntax`, use `ExpressionSyntax` instead
  * Add method `__toString()` to `ConstraintViolationInterface` & `ConstraintViolationListInterface`

--- a/src/Symfony/Component/Validator/Constraints/Unique.php
+++ b/src/Symfony/Component/Validator/Constraints/Unique.php
@@ -25,7 +25,7 @@ class Unique extends Constraint
 {
     public const IS_NOT_UNIQUE = '7911c98d-b845-4da0-94b7-a8dac36bc55a';
 
-    public $fields = [];
+    public array|string $fields = [];
 
     protected const ERROR_NAMES = [
         self::IS_NOT_UNIQUE => 'IS_NOT_UNIQUE',
@@ -50,7 +50,7 @@ class Unique extends Constraint
         callable $normalizer = null,
         array $groups = null,
         mixed $payload = null,
-        $fields = null,
+        array|string $fields = null,
     ) {
         if (\is_array($fields) && \is_string(key($fields))) {
             $options = array_merge($fields, $options);
@@ -68,12 +68,12 @@ class Unique extends Constraint
         }
     }
 
-    public function getOptions()
+    public function getOptions(): array
     {
         return ['fields'];
     }
 
-    public function getDefaultOption()
+    public function getDefaultOption(): string
     {
         return 'fields';
     }

--- a/src/Symfony/Component/Validator/Constraints/Unique.php
+++ b/src/Symfony/Component/Validator/Constraints/Unique.php
@@ -25,6 +25,8 @@ class Unique extends Constraint
 {
     public const IS_NOT_UNIQUE = '7911c98d-b845-4da0-94b7-a8dac36bc55a';
 
+    public $fields = [];
+
     protected const ERROR_NAMES = [
         self::IS_NOT_UNIQUE => 'IS_NOT_UNIQUE',
     ];
@@ -37,13 +39,25 @@ class Unique extends Constraint
     public $message = 'This collection should contain only unique elements.';
     public $normalizer;
 
+    /**
+     * {@inheritdoc}
+     *
+     * @param array|string $fields the combination of fields that must contain unique values or a set of options
+     */
     public function __construct(
         array $options = null,
         string $message = null,
         callable $normalizer = null,
         array $groups = null,
-        mixed $payload = null
+        mixed $payload = null,
+        $fields = null,
     ) {
+        if (\is_array($fields) && \is_string(key($fields))) {
+            $options = array_merge($fields, $options);
+        } elseif (null !== $fields) {
+            $options['fields'] = $fields;
+        }
+
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;
@@ -52,5 +66,15 @@ class Unique extends Constraint
         if (null !== $this->normalizer && !\is_callable($this->normalizer)) {
             throw new InvalidArgumentException(sprintf('The "normalizer" option must be a valid callable ("%s" given).', get_debug_type($this->normalizer)));
         }
+    }
+
+    public function getOptions()
+    {
+        return ['fields'];
+    }
+
+    public function getDefaultOption()
+    {
+        return 'fields';
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Unique.php
+++ b/src/Symfony/Component/Validator/Constraints/Unique.php
@@ -52,29 +52,14 @@ class Unique extends Constraint
         mixed $payload = null,
         array|string $fields = null,
     ) {
-        if (\is_array($fields) && \is_string(key($fields))) {
-            $options = array_merge($fields, $options);
-        } elseif (null !== $fields) {
-            $options['fields'] = $fields;
-        }
-
         parent::__construct($options, $groups, $payload);
 
         $this->message = $message ?? $this->message;
         $this->normalizer = $normalizer ?? $this->normalizer;
+        $this->fields = $fields ?? $this->fields;
 
         if (null !== $this->normalizer && !\is_callable($this->normalizer)) {
             throw new InvalidArgumentException(sprintf('The "normalizer" option must be a valid callable ("%s" given).', get_debug_type($this->normalizer)));
         }
-    }
-
-    public function getOptions(): array
-    {
-        return ['fields'];
-    }
-
-    public function getDefaultOption(): string
-    {
-        return 'fields';
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
@@ -79,6 +79,9 @@ class UniqueValidator extends ConstraintValidator
     {
         $output = [];
         foreach ($fields as $field) {
+            if (!\is_string($field)) {
+                throw new UnexpectedTypeException($field, 'string');
+            }
             if (isset($element[$field])) {
                 $output[$field] = $element[$field];
             }

--- a/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
@@ -30,6 +30,12 @@ class UniqueValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, Unique::class);
         }
 
+        if (!\is_array($constraint->fields) && !\is_string($constraint->fields)) {
+            throw new UnexpectedTypeException($constraint->fields, 'array');
+        }
+
+        $fields = (array) $constraint->fields;
+
         if (null === $value) {
             return;
         }

--- a/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
@@ -43,11 +43,8 @@ class UniqueValidator extends ConstraintValidator
         $collectionElements = [];
         $normalizer = $this->getNormalizer($constraint);
         foreach ($value as $element) {
-            if (!empty($fields)) {
-                $element = $this->reduceElementKeys($fields, $element);
-                if (empty($element)) {
-                    continue;
-                }
+            if ($fields && !$element = $this->reduceElementKeys($fields, $element)) {
+                continue;
             }
 
             $element = $normalizer($element);

--- a/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
@@ -30,10 +30,6 @@ class UniqueValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, Unique::class);
         }
 
-        if (!\is_array($constraint->fields) && !\is_string($constraint->fields)) {
-            throw new UnexpectedTypeException($constraint->fields, 'array');
-        }
-
         $fields = (array) $constraint->fields;
 
         if (null === $value) {

--- a/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UniqueValidator.php
@@ -47,6 +47,13 @@ class UniqueValidator extends ConstraintValidator
         $collectionElements = [];
         $normalizer = $this->getNormalizer($constraint);
         foreach ($value as $element) {
+            if (!empty($fields)) {
+                $element = $this->reduceElementKeys($fields, $element);
+                if (empty($element)) {
+                    continue;
+                }
+            }
+
             $element = $normalizer($element);
 
             if (\in_array($element, $collectionElements, true)) {
@@ -70,5 +77,17 @@ class UniqueValidator extends ConstraintValidator
         }
 
         return $unique->normalizer;
+    }
+
+    private function reduceElementKeys(array $fields, array $element): array
+    {
+        $output = [];
+        foreach ($fields as $field) {
+            if (isset($element[$field])) {
+                $output[$field] = $element[$field];
+            }
+        }
+
+        return $output;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -220,6 +220,35 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
 
         $this->assertNoViolation();
     }
+
+    /**
+     * @dataProvider getValidCollectionValues
+     */
+    public function testValidCollectionValues($value, $fields)
+    {
+        $this->validator->validate($value, new Unique($fields));
+
+        $this->assertNoViolation();
+    }
+
+    public function getValidCollectionValues()
+    {
+        return [
+            yield 'single string' => [[['letter' => 'a']], 'letter'],
+            yield 'unique strings' => [[['language' => 'eng'], ['language' => 'fra'], ['language' => 'pol']], 'language'],
+            yield 'unique floats' => [[
+                ['latitude' => 51.509865, 'longitude' => -0.118092],
+                ['latitude' => 48.864716, 'longitude' => 2.349014],
+                ['latitude' => 52.520008, 'longitude' => 13.404954],
+            ], ['latitude', 'longitude']],
+            yield 'unique int and string' => [[
+                ['id' => 1, 'email' => 'bar@email.com'], ['id' => 2, 'email' => 'foo@email.com'],
+            ], ['id', 'name']],
+            yield 'unique arrays' => [[['vector' => [1, 2]], ['vector' => [2, 4]], ['vector' => [4, 6]]
+            ], ['vector']],
+            yield 'unique objects' => [[['object' => new \stdClass()], ['object' => new \stdClass()]], ['object']],
+        ];
+    }
 }
 
 class CallableClass

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -222,35 +222,6 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
-     * @dataProvider getValidCollectionValues
-     */
-    public function testValidCollectionValues($value, $fields)
-    {
-        $this->validator->validate($value, new Unique($fields));
-
-        $this->assertNoViolation();
-    }
-
-    public function getValidCollectionValues()
-    {
-        return [
-            yield 'single string' => [[['letter' => 'a']], 'letter'],
-            yield 'unique strings' => [[['language' => 'eng'], ['language' => 'fra'], ['language' => 'pol']], 'language'],
-            yield 'unique floats' => [[
-                ['latitude' => 51.509865, 'longitude' => -0.118092],
-                ['latitude' => 48.864716, 'longitude' => 2.349014],
-                ['latitude' => 52.520008, 'longitude' => 13.404954],
-            ], ['latitude', 'longitude']],
-            yield 'unique int and string' => [[
-                ['id' => 1, 'email' => 'bar@email.com'], ['id' => 2, 'email' => 'foo@email.com'],
-            ], ['id', 'name']],
-            yield 'unique arrays' => [[['vector' => [1, 2]], ['vector' => [2, 4]], ['vector' => [4, 6]]
-            ], ['vector']],
-            yield 'unique objects' => [[['object' => new \stdClass()], ['object' => new \stdClass()]], ['object']],
-        ];
-    }
-
-    /**
      * @dataProvider getInvalidCollectionValues
      */
     public function testInvalidCollectionValues($value, $fields)

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -267,7 +267,9 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
     public function getInvalidCollectionValues(): array
     {
         return [
-            'unique string' => [[['lang' => 'eng', 'translation' => 'hi'], ['lang' => 'eng', 'translation' => 'hello'],
+            'unique string' => [[
+                ['lang' => 'eng', 'translation' => 'hi'],
+                ['lang' => 'eng', 'translation' => 'hello'],
             ], ['lang']],
             'unique floats' => [[
                 ['latitude' => 51.509865, 'longitude' => -0.118092, 'poi' => 'capital'],
@@ -275,7 +277,8 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
                 ['latitude' => 51.509865, 'longitude' => -0.118092],
             ], ['latitude', 'longitude']],
             'unique int' => [[
-                ['id' => 1, 'email' => 'bar@email.com'], ['id' => 1, 'email' => 'foo@email.com'],
+                ['id' => 1, 'email' => 'bar@email.com'],
+                ['id' => 1, 'email' => 'foo@email.com'],
             ], ['id']],
         ];
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -249,6 +249,37 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
             yield 'unique objects' => [[['object' => new \stdClass()], ['object' => new \stdClass()]], ['object']],
         ];
     }
+
+    /**
+     * @dataProvider getInvalidCollectionValues
+     */
+    public function testInvalidCollectionValues($value, $fields)
+    {
+        $this->validator->validate($value, new Unique($fields, [
+            'message' => 'myMessage',
+        ]));
+
+        $this->buildViolation('myMessage')
+            ->setParameter('{{ value }}', 'array')
+            ->setCode(Unique::IS_NOT_UNIQUE)
+            ->assertRaised();
+    }
+
+    public function getInvalidCollectionValues()
+    {
+        return [
+            yield 'unique string' => [[['lang' => 'eng', 'translation' => 'hi'], ['lang' => 'eng', 'translation' => 'hi'],
+            ], ['lang']],
+            yield 'unique floats' => [[
+                ['latitude' => 51.509865, 'longitude' => -0.118092, 'poi' => 'capital'],
+                ['latitude' => 52.520008, 'longitude' => 13.404954],
+                ['latitude' => 51.509865, 'longitude' => -0.118092],
+            ], ['latitude', 'longitude']],
+            yield 'unique int' => [[
+                ['id' => 1, 'email' => 'bar@email.com'], ['id' => 1, 'email' => 'bar@email.com'],
+            ], ['id']],
+        ];
+    }
 }
 
 class CallableClass

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -154,15 +154,15 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public function getCallback()
+    public function getCallback(): array
     {
         return [
-            yield 'static function' => [static function (\stdClass $object) {
+            'static function' => [static function (\stdClass $object) {
                 return [$object->name, $object->email];
             }],
-            yield 'callable with string notation' => ['Symfony\Component\Validator\Tests\Constraints\CallableClass::execute'],
-            yield 'callable with static notation' => [[CallableClass::class, 'execute']],
-            yield 'callable with object' => [[new CallableClass(), 'execute']],
+            'callable with string notation' => ['Symfony\Component\Validator\Tests\Constraints\CallableClass::execute'],
+            'callable with static notation' => [[CallableClass::class, 'execute']],
+            'callable with object' => [[new CallableClass(), 'execute']],
         ];
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -224,7 +224,7 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
 
     public function testCollectionFieldsAreOptional()
     {
-        $this->validator->validate([['value' => 5], ['id' => 1, 'value' => 6]], new Unique('id'));
+        $this->validator->validate([['value' => 5], ['id' => 1, 'value' => 6]], new Unique(fields: 'id'));
 
         $this->assertNoViolation();
     }
@@ -237,15 +237,15 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
         $this->expectException(UnexpectedTypeException::class);
         $this->expectExceptionMessage(sprintf('Expected argument of type "string", "%s" given', $type));
 
-        $this->validator->validate([['value' => 5], ['id' => 1, 'value' => 6]], new Unique([$field]));
+        $this->validator->validate([['value' => 5], ['id' => 1, 'value' => 6]], new Unique(fields: [$field]));
     }
 
-    public function getInvalidFieldNames(): \Generator
+    public function getInvalidFieldNames(): array
     {
         return [
-            yield ['stdClass', new \stdClass()],
-            yield ['int', 2],
-            yield ['bool', false],
+            ['stdClass', new \stdClass()],
+            ['int', 2],
+            ['bool', false],
         ];
     }
 
@@ -254,9 +254,9 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
      */
     public function testInvalidCollectionValues(array $value, array $fields)
     {
-        $this->validator->validate($value, new Unique($fields, [
+        $this->validator->validate($value, new Unique([
             'message' => 'myMessage',
-        ]));
+        ], fields: $fields));
 
         $this->buildViolation('myMessage')
             ->setParameter('{{ value }}', 'array')
@@ -264,17 +264,17 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
             ->assertRaised();
     }
 
-    public function getInvalidCollectionValues(): \Generator
+    public function getInvalidCollectionValues(): array
     {
         return [
-            yield 'unique string' => [[['lang' => 'eng', 'translation' => 'hi'], ['lang' => 'eng', 'translation' => 'hello'],
+            'unique string' => [[['lang' => 'eng', 'translation' => 'hi'], ['lang' => 'eng', 'translation' => 'hello'],
             ], ['lang']],
-            yield 'unique floats' => [[
+            'unique floats' => [[
                 ['latitude' => 51.509865, 'longitude' => -0.118092, 'poi' => 'capital'],
                 ['latitude' => 52.520008, 'longitude' => 13.404954],
                 ['latitude' => 51.509865, 'longitude' => -0.118092],
             ], ['latitude', 'longitude']],
-            yield 'unique int' => [[
+            'unique int' => [[
                 ['id' => 1, 'email' => 'bar@email.com'], ['id' => 1, 'email' => 'foo@email.com'],
             ], ['id']],
         ];

--- a/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UniqueValidatorTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 class UniqueValidatorTest extends ConstraintValidatorTestCase
 {
-    protected function createValidator()
+    protected function createValidator(): UniqueValidator
     {
         return new UniqueValidator();
     }
@@ -217,6 +217,13 @@ class UniqueValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate(['Hello', 'World'], new Unique([
             'normalizer' => $callback,
         ]));
+
+        $this->assertNoViolation();
+    }
+
+    public function testCollectionFieldsAreOptional()
+    {
+        $this->validator->validate([['value' => 5], ['id' => 1, 'value' => 6]], new Unique('id'));
 
         $this->assertNoViolation();
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Fix #9888
| License       | MIT
| Doc PR        | symfony/symfony-docs#16713

Currently, the validator checks each element of the collection as a whole. We already have a custom normalizer (which is great), but it would be nice to be able to check for uniqueness certain [collection](https://symfony.com/doc/current/reference/constraints/Collection.html) keys. 

For example, some fields in the collection element can be identifiers. They should be unique within the collection, even when the rest of the element data are different.

Current state:
- validates that all the elements of the given collection are unique

New state:
- preserve the current state,
- all old tests pass (no changes in them),
- no breaking changes,
- define which collection fields should be checked for uniqueness (optional),
- fields are optional in each element of the collection. Use [collection constraints](https://symfony.com/doc/current/reference/constraints/Collection.html) if they are required

Examples:

1. Basic example. Each translation of the same resource must be in a different language.
```php
use Symfony\Component\Validator\Constraints as Assert;

/**
 * @Assert\Count(min=1),
 * @Assert\Unique(fields={"language"}),
 * @Assert\Collection(
 *         fields = {
 *             "language" = {
 *                  @Assert\NotBlank,
 *                  @Assert\Length(min = 2, max = 2),
 *                  @Assert\Language
 *             },
 *             "title" = {
 *                  @Assert\NotBlank,
 *                  @Assert\Length(max = 255)
 *             },
 *             "description" = {
 *                  @Assert\NotBlank,
 *                  @Assert\Length(max = 255)
 *             }
 *         }
 * )
 */
public array $translations = [];
```
2. An example where Optional is recognizable. Items with the id are changed and without are new.
```php
use Symfony\Component\Validator\Constraints as Assert;
use Symfony\Component\Validator\Constraints\Optional;

/**
 * @Assert\Unique(fields={"id"}),
 * @Assert\Collection(
 *         fields = {
 *             "id" = @Assert\Optional({
 *                  @Assert\Uuid
 *             }),
 *             "name" = {
 *                  @Assert\NotBlank,
 *                  @Assert\Length(max = 255)
 *             }
 *         }
 * )
 */
public array $items = [];
```
3. An example with composite uniqueness
```php
use Symfony\Component\Validator\Constraints as Assert;

/**
 * @Assert\Unique(fields={"latitude", "longitude"}),
 * @Assert\Collection(
 *         fields = {
 *             "latitude" = {
 *                  @Assert\NotBlank
 *             },
 *             "longitude" = {
 *                  @Assert\NotBlank
 *             },
 *             "poi" = {
 *                  @Assert\Length(max = 255)
 *             }
 *         }
 * )
 */
public array $coordinates = [];  
```
