### PR TITLE
[Notifier] Add Expo bridge

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -116,6 +116,7 @@ use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Clickatell\ClickatellTransportFactory;
 use Symfony\Component\Notifier\Bridge\Discord\DiscordTransportFactory;
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
+use Symfony\Component\Notifier\Bridge\Expo\ExpoTransportFactory;
 use Symfony\Component\Notifier\Bridge\FakeChat\FakeChatTransportFactory;
 use Symfony\Component\Notifier\Bridge\FakeSms\FakeSmsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransportFactory;
@@ -2452,6 +2453,7 @@ class FrameworkExtension extends Extension
             ClickatellTransportFactory::class => 'notifier.transport_factory.clickatell',
             DiscordTransportFactory::class => 'notifier.transport_factory.discord',
             EsendexTransportFactory::class => 'notifier.transport_factory.esendex',
+            ExpoTransportFactory::class => 'notifier.transport_factory.expo',
             FakeChatTransportFactory::class => 'notifier.transport_factory.fakechat',
             FakeSmsTransportFactory::class => 'notifier.transport_factory.fakesms',
             FirebaseTransportFactory::class => 'notifier.transport_factory.firebase',

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -16,6 +16,7 @@ use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Clickatell\ClickatellTransportFactory;
 use Symfony\Component\Notifier\Bridge\Discord\DiscordTransportFactory;
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
+use Symfony\Component\Notifier\Bridge\Expo\ExpoTransportFactory;
 use Symfony\Component\Notifier\Bridge\FakeChat\FakeChatTransportFactory;
 use Symfony\Component\Notifier\Bridge\FakeSms\FakeSmsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransportFactory;
@@ -235,5 +236,9 @@ return static function (ContainerConfigurator $container) {
         ->set('notifier.transport_factory.onesignal', OneSignalTransportFactory::class)
             ->parent('notifier.transport_factory.abstract')
             ->tag('texter.transport_factory')
+
+        ->set('notifier.transport_factory.expo', ExpoTransportFactory::class)
+            ->parent('notifier.transport_factory.abstract')
+            ->tag('chatter.transport_factory')
     ;
 };

--- a/src/Symfony/Component/Notifier/Bridge/Expo/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Expo/.gitignore
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Notifier/Bridge/Expo/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.4
+---
+
+ * Add the bridge

--- a/src/Symfony/Component/Notifier/Bridge/Expo/ExpoOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/ExpoOptions.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Expo;
+
+use Symfony\Component\Notifier\Message\MessageOptionsInterface;
+
+/**
+ * @author Imad ZAIRIG <https://github.com/zairigimad>
+ *
+ * @see https://docs.expo.dev/push-notifications/sending-notifications/
+ */
+final class ExpoOptions implements MessageOptionsInterface
+{
+    private $to;
+
+    /**
+     * @see https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format
+     */
+    protected $options;
+
+    private $data;
+
+    public function __construct(string $to, array $options = [], array $data = [])
+    {
+        $this->to = $to;
+        $this->options = $options;
+        $this->data = $data;
+    }
+
+    public function toArray(): array
+    {
+        return array_merge(
+            $this->options,
+            [
+                'to' => $this->to,
+                'data' => $this->data,
+            ]
+        );
+    }
+
+    public function getRecipientId(): ?string
+    {
+        return $this->to;
+    }
+
+    /**
+     * @return $this
+     */
+    public function title(string $title): self
+    {
+        $this->options['title'] = $title;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function subtitle(string $subtitle): self
+    {
+        $this->options['subtitle'] = $subtitle;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function priority(string $priority): self
+    {
+        $this->options['priority'] = $priority;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function sound(string $sound): self
+    {
+        $this->options['sound'] = $sound;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function badge(int $badge): self
+    {
+        $this->options['badge'] = $badge;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function channelId(string $channelId): self
+    {
+        $this->options['channelId'] = $channelId;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function categoryId(string $categoryId): self
+    {
+        $this->options['categoryId'] = $categoryId;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function mutableContent(bool $mutableContent): self
+    {
+        $this->options['mutableContent'] = $mutableContent;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function body(string $body): self
+    {
+        $this->options['body'] = $body;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function ttl(int $ttl): self
+    {
+        $this->options['ttl'] = $ttl;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function expiration(int $expiration): self
+    {
+        $this->options['expiration'] = $expiration;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function data(array $data): self
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Expo/ExpoTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/ExpoTransport.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Expo;
+
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\PushMessage;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Imad ZAIRIG <https://github.com/zairigimad>
+ */
+final class ExpoTransport extends AbstractTransport
+{
+    protected const HOST = 'exp.host/--/api/v2/push/send';
+
+    /** @var string|null */
+    private $token;
+
+    public function __construct(string $token = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    {
+        $this->token = $token;
+        $this->client = $client;
+
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('expo://%s', $this->getEndpoint());
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof PushMessage;
+    }
+
+    protected function doSend(MessageInterface $message): SentMessage
+    {
+        if (!$message instanceof PushMessage) {
+            throw new UnsupportedMessageTypeException(__CLASS__, PushMessage::class, $message);
+        }
+
+        $endpoint = sprintf('https://%s', $this->getEndpoint());
+        $options = ($opts = $message->getOptions()) ? $opts->toArray() : [];
+        if (!isset($options['to'])) {
+            $options['to'] = $message->getRecipientId();
+        }
+        if (null === $options['to']) {
+            throw new InvalidArgumentException(sprintf('The "%s" transport required the "to" option to be set.', __CLASS__));
+        }
+
+        $options['title'] = $message->getSubject();
+        $options['body'] = $message->getContent();
+        $options['data'] = $options['data'] ?? [];
+
+        $response = $this->client->request('POST', $endpoint, [
+            'headers' => [
+                'Authorization' => $this->token ? sprintf('Bearer %s', $this->token) : null,
+            ],
+            'json' => array_filter($options),
+        ]);
+
+        try {
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new TransportException('Could not reach the remote Expo server.', $response, 0, $e);
+        }
+
+        $contentType = $response->getHeaders(false)['content-type'][0] ?? '';
+        $jsonContents = 0 === strpos($contentType, 'application/json') ? $response->toArray(false) : null;
+
+        if (200 !== $statusCode) {
+            $errorMessage = $jsonContents['error']['message'] ?? $response->getContent(false);
+
+            throw new TransportException('Unable to post the Expo message: '.$errorMessage, $response);
+        }
+
+        $success = $response->toArray(false);
+
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId($success['data']['id']);
+
+        return $sentMessage;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Expo/ExpoTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/ExpoTransportFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Expo;
+
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+
+/**
+ * @author Imad ZAIRIG <https://github.com/zairigimad>
+ */
+final class ExpoTransportFactory extends AbstractTransportFactory
+{
+    /**
+     * @return ExpoTransport
+     */
+    public function create(Dsn $dsn): TransportInterface
+    {
+        $scheme = $dsn->getScheme();
+
+        if ('expo' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'expo', $this->getSupportedSchemes());
+        }
+
+        $token = $dsn->getUser($dsn);
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        return (new ExpoTransport($token, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['expo'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Expo/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2021 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/Expo/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/README.md
@@ -1,0 +1,22 @@
+Expo Notifier
+=================
+
+Provides [Expo](https://docs.expo.dev/versions/latest/sdk/notifications/) integration for Symfony Notifier.
+
+DSN example
+-----------
+
+```
+EXPO_DSN=expo://TOKEN@default
+```
+
+where:
+ - `TOKEN` is your Expo Access Token
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Notifier/Bridge/Expo/Tests/ExpoTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/Tests/ExpoTransportFactoryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Expo\Tests;
+
+use Symfony\Component\Notifier\Bridge\Expo\ExpoTransportFactory;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
+
+/**
+ * @author Imad ZAIRIG <https://github.com/zairigimad>
+ */
+final class ExpoTransportFactoryTest extends TransportFactoryTestCase
+{
+    /**
+     * @return ExpoTransportFactory
+     */
+    public function createFactory(): TransportFactoryInterface
+    {
+        return new ExpoTransportFactory();
+    }
+
+    public function createProvider(): iterable
+    {
+        yield [
+            'expo://exp.host/--/api/v2/push/send',
+            'expo://default',
+        ];
+    }
+
+    public function supportsProvider(): iterable
+    {
+        yield [true, 'expo://default?accessToken=test'];
+        yield [false, 'somethingElse://username:password@default'];
+    }
+
+    public function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://username:password@default'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Expo/Tests/ExpoTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/Tests/ExpoTransportTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Expo\Tests;
+
+use Symfony\Component\Notifier\Bridge\Expo\ExpoTransport;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\PushMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Imad ZAIRIG <https://github.com/zairigimad>
+ */
+final class ExpoTransportTest extends TransportTestCase
+{
+    /**
+     * @return ExpoTransport
+     */
+    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    {
+        return new ExpoTransport('token', $client ?? $this->createMock(HttpClientInterface::class));
+    }
+
+    public function toStringProvider(): iterable
+    {
+        yield ['expo://exp.host/--/api/v2/push/send', $this->createTransport()];
+    }
+
+    public function supportedMessagesProvider(): iterable
+    {
+        yield [new PushMessage('Hello!', 'Symfony Notifier')];
+    }
+
+    public function unsupportedMessagesProvider(): iterable
+    {
+        yield [new SmsMessage('0670802161', 'Hello!')];
+        yield [$this->createMock(MessageInterface::class)];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Expo/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "symfony/expo-notifier",
+    "type": "symfony-bridge",
+    "description": "Symfony Expo Notifier Bridge",
+    "keywords": ["expo", "notifier"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Zairig Imad",
+            "homepage": "https://github.com/zairigimad"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=7.2.5",
+        "symfony/http-client": "^4.3|^5.0|^6.0",
+        "symfony/notifier": "^5.3|^6.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Expo\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Notifier/Bridge/Expo/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Expo Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -36,6 +36,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Esendex\EsendexTransportFactory::class,
             'package' => 'symfony/esendex-notifier',
         ],
+        'expo' => [
+            'class' => Bridge\Expo\ExpoTransportFactory::class,
+            'package' => 'symfony/expo-notifier',
+        ],
         'fakechat' => [
             'class' => Bridge\FakeChat\FakeChatTransportFactory::class,
             'package' => 'symfony/fake-chat-notifier',

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -16,6 +16,7 @@ use Symfony\Component\Notifier\Bridge\AmazonSns\AmazonSnsTransportFactory;
 use Symfony\Component\Notifier\Bridge\Clickatell\ClickatellTransportFactory;
 use Symfony\Component\Notifier\Bridge\Discord\DiscordTransportFactory;
 use Symfony\Component\Notifier\Bridge\Esendex\EsendexTransportFactory;
+use Symfony\Component\Notifier\Bridge\Expo\ExpoTransportFactory;
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransportFactory;
 use Symfony\Component\Notifier\Bridge\FreeMobile\FreeMobileTransportFactory;
 use Symfony\Component\Notifier\Bridge\GatewayApi\GatewayApiTransportFactory;
@@ -70,6 +71,7 @@ class Transport
         ClickatellTransportFactory::class,
         DiscordTransportFactory::class,
         EsendexTransportFactory::class,
+        ExpoTransportFactory::class,
         FirebaseTransportFactory::class,
         FreeMobileTransportFactory::class,
         GatewayApiTransportFactory::class,


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | no ticket
| License       | MIT


Expo makes implementing push notifications almost too easy. All the hassle with native device information and communicating with APNs (Apple Push Notification service) or FCM (Firebase Cloud Messaging) is taken care of behind the scenes, so that you can treat iOS and Android notifications the same, saving you time on the front-end, and back-end!

this PR will add the support of [Expo Notification](https://docs.expo.dev/push-notifications/overview/) as a bridge to Symfony 

screenshot from a real application build with expo

![2DA98E58-4F0A-4A89-B6CB-937878E00E4A](https://user-images.githubusercontent.com/9056839/128602022-4dde3a56-f623-49d0-8b66-7b1d1414169c.jpeg)

✏️  this is a work in progress I would love to hear your feedbacks to improve it.