### PR TITLE
[Notifier] Add notify helper in AbstractController

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -463,7 +463,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
     /**
      * Send a notification via the Notifier.
      *
-     * @param Notification $notification The $notification.
+     * @param Notification $notification the $notification
      */
     protected function notify(Notification $notification): void
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -35,6 +35,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\NotifierInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -103,6 +105,7 @@ abstract class AbstractController implements ServiceSubscriberInterface
             'parameter_bag' => '?'.ContainerBagInterface::class,
             'message_bus' => '?'.MessageBusInterface::class,
             'messenger.default_bus' => '?'.MessageBusInterface::class,
+            'notifier' => '?'.NotifierInterface::class,
         ];
     }
 
@@ -455,5 +458,19 @@ abstract class AbstractController implements ServiceSubscriberInterface
         }
 
         $request->attributes->set('_links', $linkProvider->withLink($link));
+    }
+
+    /**
+     * Send a notification via the Notifier.
+     *
+     * @param Notification $notification The $notification.
+     */
+    protected function notify(Notification $notification): void
+    {
+        if (!$this->container->has('notifier')) {
+            throw new \LogicException('The Notifier is not registered in your application. Try running "composer require symfony/notifier".');
+        }
+
+        $this->container->get('notifier')->send($notification);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

As the Notifier become more popular and is not experimental anymore, I propose to add a shortcut in the AbstractController.
I would add tests if you're agree with this feature.

```php
namespace App\Controller;

use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
use Symfony\Component\Notifier\Notification\Notification;

class SandboxController extends AbstractController
{
    /**
     * @Route("/onboarding", name="onboarding")
     */
     public function __invoke(): Response
     {
       $notification = new Notification('Welcome Sma <3', ['chat/slack']);
       $this->notify($notification);
       // stuff
     }
}
```
