### PR TITLE
[Notifier] Autoconfigure chatter.transport_factory

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -151,6 +151,7 @@ use Symfony\Component\Notifier\Bridge\Yunpian\YunpianTransportFactory;
 use Symfony\Component\Notifier\Bridge\Zulip\ZulipTransportFactory;
 use Symfony\Component\Notifier\Notifier;
 use Symfony\Component\Notifier\Recipient\Recipient;
+use Symfony\Component\Notifier\Transport\TransportFactoryInterface as NotifierTransportFactoryInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyInfo\PropertyAccessExtractorInterface;
 use Symfony\Component\PropertyInfo\PropertyDescriptionExtractorInterface;
@@ -2425,6 +2426,12 @@ class FrameworkExtension extends Extension
         }
 
         $container->getDefinition('notifier.channel_policy')->setArgument(0, $config['channel_policy']);
+
+        $container->registerForAutoconfiguration(NotifierTransportFactoryInterface::class)
+            ->addTag('chatter.transport_factory');
+
+        $container->registerForAutoconfiguration(NotifierTransportFactoryInterface::class)
+            ->addTag('texter.transport_factory');
 
         $classToServices = [
             AllMySmsTransportFactory::class => 'notifier.transport_factory.allmysms',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 |
| Bug fix?      | no
| New feature?  | yes
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I'm wondering why we not autoconfigure `chatter.transport_factory` and `texter.transport_factory` with `TransportFactoryInterface`. It will avoid to manually tag the `TransportFactory`