### PR TITLE
[Serializer] Rename Serializer::EMPTY_ARRAYS_AS_OBJECT to EMPTY_ARRAY_AS_OBJECT

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -49,9 +49,9 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
 {
     /**
      * Flag to control whether an empty array should be transformed to an
-     * object (in JSON: {}) or to a map (in JSON: []).
+     * object (in JSON: {}) or to a list (in JSON: []).
      */
-    public const EMPTY_ARRAYS_AS_OBJECT = 'empty_arrays_as_object';
+    public const EMPTY_ARRAY_AS_OBJECT = 'empty_array_as_object';
 
     private const SCALAR_TYPES = [
         'int' => true,
@@ -169,7 +169,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
                 switch (true) {
                     case ($context[AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS] ?? false) && \is_object($data):
                         return $data;
-                    case ($context[self::EMPTY_ARRAYS_AS_OBJECT] ?? false) && \is_array($data):
+                    case ($context[self::EMPTY_ARRAY_AS_OBJECT] ?? false) && \is_array($data):
                         return new \ArrayObject();
                 }
             }

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -592,7 +592,7 @@ class SerializerTest extends TestCase
     {
         $expected = '{"a1":[],"a2":{"k":"v"},"b1":{},"b2":{"k":"v"},"c1":{"nested":[]},"c2":{"nested":{"k":"v"}},"d1":{"nested":{}},"d2":{"nested":{"k":"v"}},"e1":{"map":{}},"e2":{"map":{"k":"v"}},"f1":{"map":[]},"f2":{"map":{"k":"v"}},"g1":{"list":[],"settings":{}},"g2":{"list":["greg"],"settings":{}}}';
         $this->assertSame($expected, $serializer->serialize($data, 'json', [
-            Serializer::EMPTY_ARRAYS_AS_OBJECT => true,
+            Serializer::EMPTY_ARRAY_AS_OBJECT => true,
         ]));
     }
 
@@ -601,7 +601,7 @@ class SerializerTest extends TestCase
     {
         $expected = '{"a1":{},"a2":{"k":"v"},"b1":{},"b2":{"k":"v"},"c1":{"nested":{}},"c2":{"nested":{"k":"v"}},"d1":{"nested":{}},"d2":{"nested":{"k":"v"}},"e1":{"map":{}},"e2":{"map":{"k":"v"}},"f1":{"map":{}},"f2":{"map":{"k":"v"}},"g1":{"list":{"list":[]},"settings":{}},"g2":{"list":["greg"],"settings":{}}}';
         $this->assertSame($expected, $serializer->serialize($data, 'json', [
-            Serializer::EMPTY_ARRAYS_AS_OBJECT => true,
+            Serializer::EMPTY_ARRAY_AS_OBJECT => true,
             AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true,
         ]));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a

I also propose to change `EMPTY_ARRAYS_AS_OBJECT` to `EMPTY_ARRAY_AS_OBJECT`. It's kind of strange to see one noun in plural and another in singular form. @lyrixx, what do you think?