### PR TITLE
[Notifier] Add more explicit error if a SMSChannel doesn't have a Recipient

### DIFF
--- a/src/Symfony/Component/Notifier/Notifier.php
+++ b/src/Symfony/Component/Notifier/Notifier.php
@@ -15,6 +15,7 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\Notifier\Channel\ChannelInterface;
 use Symfony\Component\Notifier\Channel\ChannelPolicy;
 use Symfony\Component\Notifier\Channel\ChannelPolicyInterface;
+use Symfony\Component\Notifier\Channel\SmsChannel;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\Recipient\NoRecipient;
@@ -87,6 +88,10 @@ final class Notifier implements NotifierInterface
 
             if (null === $channel = $this->getChannel($channelName)) {
                 throw new LogicException(sprintf('The "%s" channel does not exist.', $channelName));
+            }
+
+            if ($channel instanceof SmsChannel && $recipient instanceof NoRecipient) {
+                throw new LogicException(sprintf('The "%s" channel needs a Recipient.', $channelName));
             }
 
             if (!$channel->supports($notification, $recipient)) {

--- a/src/Symfony/Component/Notifier/Tests/NotifierTest.php
+++ b/src/Symfony/Component/Notifier/Tests/NotifierTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Component\Notifier\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Notifier\Channel\SmsChannel;
+use Symfony\Component\Notifier\Exception\LogicException;
+use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\Notifier;
+use Symfony\Component\Notifier\Transport\NullTransport;
+
+/**
+ * @author Smaïne Milianni <smaine.milianni@gmail.com>
+ */
+final class NotifierTest extends TestCase
+{
+    public function testItThrowAnExplicitErrorIfAnSmsChannelDoesNotHaveRecipient()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The "sms" channel needs a Recipient.');
+
+        $notifier = new Notifier(['sms' => new SmsChannel(new NullTransport())]);
+        $notifier->send(new Notification('Hello World!', ['sms/twilio']));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | yes
| License       | MIT

Improve error message if a `SmSChannel` doesn't have a Recipient. ATM The snippet bellow output the message:
 `The "sms" channel is not supported.`  because the `SmsChannel::supports` return `false` if you pass an instance of  `NoRecipient`.

This PR improve the error message with : "The "sms" channel needs a Recipient."

```php
<?php
        $notifier = new Notifier(['sms' => new SmsChannel(new NullTransport())]);
        $notifier->send(new Notification("Hello World!", ["sms/twilio"]));