### PR TITLE
[FrameworkBundle] Deprecate AbstractController::get() and has()

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -17,7 +17,7 @@ FrameworkBundle
 
  * Deprecate the `AdapterInterface` autowiring alias, use `CacheItemPoolInterface` instead
  * Deprecate the public `profiler` service to private
- * Deprecate `getDoctrine()` and `dispatchMessage()` in `AbstractController`, use method/constructor injection instead
+ * Deprecate `get()`, `has()`, `getDoctrine()`, and `dispatchMessage()` in `AbstractController`, use method/constructor injection instead
 
 HttpKernel
 ----------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -101,7 +101,7 @@ FrameworkBundle
  * Remove option `--xliff-version` of the `translation:update` command, use e.g. `--output-format=xlf20` instead
  * Remove option `--output-format` of the `translation:update` command, use e.g. `--output-format=xlf20` instead
  * Remove the `AdapterInterface` autowiring alias, use `CacheItemPoolInterface` instead
- * Remove `getDoctrine()` and `dispatchMessage()` in `AbstractController`, use method/constructor injection instead
+ * Remove `get()`, `has()`, `getDoctrine()`, and `dispatchMessage()` in `AbstractController`, use method/constructor injection instead
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * Add autowiring alias for `HttpCache\StoreInterface`
  * Deprecate the `AdapterInterface` autowiring alias, use `CacheItemPoolInterface` instead
  * Deprecate the public `profiler` service to private
- * Deprecate `getDoctrine()` and `dispatchMessage()` in `AbstractController`, use method/constructor injection instead
+ * Deprecate `get()`, `has()`, `getDoctrine()`, and `dispatchMessage()` in `AbstractController`, use method/constructor injection instead
 
 5.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.php
@@ -96,21 +96,25 @@ abstract class AbstractController implements ServiceSubscriberInterface
             'session' => '?'.SessionInterface::class,
             'security.authorization_checker' => '?'.AuthorizationCheckerInterface::class,
             'twig' => '?'.Environment::class,
-            'doctrine' => '?'.ManagerRegistry::class,
+            'doctrine' => '?'.ManagerRegistry::class, // to be removed in 6.0
             'form.factory' => '?'.FormFactoryInterface::class,
             'security.token_storage' => '?'.TokenStorageInterface::class,
             'security.csrf.token_manager' => '?'.CsrfTokenManagerInterface::class,
             'parameter_bag' => '?'.ContainerBagInterface::class,
-            'message_bus' => '?'.MessageBusInterface::class,
-            'messenger.default_bus' => '?'.MessageBusInterface::class,
+            'message_bus' => '?'.MessageBusInterface::class, // to be removed in 6.0
+            'messenger.default_bus' => '?'.MessageBusInterface::class, // to be removed in 6.0
         ];
     }
 
     /**
      * Returns true if the service id is defined.
+     *
+     * @deprecated since 5.4, use method or constructor injection in your controller instead
      */
     protected function has(string $id): bool
     {
+        trigger_deprecation('symfony/framework-bundle', '5.4', 'Method "%s()" is deprecated, use method or constructor injection in your controller instead.', __METHOD__);
+
         return $this->container->has($id);
     }
 
@@ -118,9 +122,13 @@ abstract class AbstractController implements ServiceSubscriberInterface
      * Gets a container service by its id.
      *
      * @return object The service
+     *
+     * @deprecated since 5.4, use method or constructor injection in your controller instead
      */
     protected function get(string $id): object
     {
+        trigger_deprecation('symfony/framework-bundle', '5.4', 'Method "%s()" is deprecated, use method or constructor injection in your controller instead.', __METHOD__);
+
         return $this->container->get($id);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/AbstractControllerTest.php
@@ -601,6 +601,9 @@ class AbstractControllerTest extends TestCase
         $this->assertEquals($formBuilder, $controller->createFormBuilder('foo'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetDoctrine()
     {
         $doctrine = $this->createMock(ManagerRegistry::class);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a

Controllers extending `AbstractController` have access to the services registered for the shortcuts defined in `AbstractController` via `get()` and `has()`. These methods can make developers think that they have access to the whole container, which is not true. Moreover, the limited set of services are precisely the ones needed for the shortcuts, so probably not the ones people would need anyway.

I propose to deprecate these methods and advocate using method/constructor injection instead.

If people want to still use the container, they can access it via the `$this->container` property (useful if they extend `getSubscribedServices()` for instance).
