### PR TITLE
Drop irrelevant UPGRADE note

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -61,8 +61,6 @@ Security
 
  * Deprecate the `$authManager` argument of `AccessListener`
  * Deprecate the `$authenticationManager` argument of the `AuthorizationChecker` constructor
- * Deprecate not setting `$authenticatorManagerEnabled` to `true` in `SecurityDataCollector` and `DebugFirewallCommand`
-   (this is the default behavior when using `enable_authenticator_manager: true`)
  * Deprecate setting the `$alwaysAuthenticate` argument to `true` and not setting the
    `$exceptionOnNoToken argument to `false` of `AuthorizationChecker` (this is the default
    behavior when using `enable_authenticator_manager: true`)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  |  no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | -

The removed entry is about classes that are part of `security-bundle`, not `security-*` components, and it's already present in the SecurityBundle section.
(This is not related to our recent discussions about UPGRADE files)