### PR TITLE
[SecurityBundle] Allow developers to override profiler toolbar

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -76,6 +76,8 @@
                     </div>
                 {% endif %}
             </div>
+
+            {% block additional_toolbar_information '' %}
         {% endset %}
 
         {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url, status: color_code }) }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This very simple PR allow the developer to override the security profiler toolbar to add custom information.

Its as simple as creating a template in `templates/bundles/SecurityBundle/Collector/security.html.twig` containing extra information like this:

```twig
{% extends '@!Security/Collector/security.html.twig' %}

{% block additional_toolbar_information %}
    <div class="sf-toolbar-info-group">
        <div class="sf-toolbar-info-piece">
            <b>A custom information</b>
            <span class="sf-toolbar-status sf-toolbar-status-yellow">Foobar</span>
        </div>
    </div>
{% endblock %}
```

Here is the result you get
![image](https://user-images.githubusercontent.com/680206/128875399-793a299d-974a-406a-9033-7137ec2ebef2.png)

This can be pretty useful to add extra information directly linked to the connected user when relevant (could be an attribute from the entity, a link to an external profile like Stripe or anything else, ...) without creating a custom data collector nor overwriting the whole parent `toolbar` block.

* The same logic could be used for other profiler toolbars if you consider it makes sense
* We could add 2 blocks, respectively at the beginning & at the end of the existing `text` variable.

WDYT?