### PR TITLE
Update Tagalog translations

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.tl.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.tl.xlf
@@ -70,6 +70,14 @@
                 <source>Invalid or expired login link.</source>
                 <target>Inbalido o nagexpire na ang link para makapaglogin.</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+                <target>Madaming bagsak na pagtatangka, pakisubukan ulit pagkatapos ng %minutes% minuto.</target>
+            </trans-unit>
+            <trans-unit id="20">
+                <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+                <target>Madaming bagsak na pagtatangka, pakisubukan ulit pagkatapos ng %minutes% minuto.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.tl.xlf
@@ -386,6 +386,10 @@
                 <source>This value is not a valid International Securities Identification Number (ISIN).</source>
                 <target>Ang halagang ito ay hindi wastong International Securities Identification Number (ISIN).</target>
             </trans-unit>
+            <trans-unit id="100">
+                <source>This value should be a valid expression.</source>
+                <target>Ang halagang ito ay dapat wastong ekspresyon.</target>
+            </trans-unit>
         </body>
     </file>
  </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41085 
| License       | MIT

I added Tagalog translations for security messages 19 and 20 and validator message 100.