### PR TITLE
[Security] Fix `AbstractAuthenticator::createToken()` BC layer

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractAuthenticator.php
@@ -31,6 +31,10 @@ abstract class AbstractAuthenticator implements AuthenticatorInterface
      */
     public function createToken(Passport $passport, string $firewallName): TokenInterface
     {
+        if (self::class !== (new \ReflectionMethod($this, 'createAuthenticatedToken'))->getDeclaringClass()->getName() && self::class === (new \ReflectionMethod($this, 'createToken'))->getDeclaringClass()->getName()) {
+            return $this->createAuthenticatedToken($passport, $firewallName);
+        }
+
         return new PostAuthenticationToken($passport->getUser(), $firewallName, $passport->getUser()->getRoles());
     }
 
@@ -46,6 +50,6 @@ abstract class AbstractAuthenticator implements AuthenticatorInterface
 
         trigger_deprecation('symfony/security-http', '5.4', 'Method "%s()" is deprecated, use "%s::createToken()" instead.', __METHOD__, __CLASS__);
 
-        return $this->createToken($passport, $firewallName);
+        return new PostAuthenticationToken($passport->getUser(), $firewallName, $passport->getUser()->getRoles());
     }
 }

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/AbstractAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/AbstractAuthenticatorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
+
+class AbstractAuthenticatorTest extends TestCase
+{
+    use ExpectDeprecationTrait;
+
+    public function testCreateToken()
+    {
+        $authenticator = new ConcreteAuthenticator();
+        $this->assertInstanceOf(
+            PostAuthenticationToken::class,
+            $authenticator->createToken(new SelfValidatingPassport(new UserBadge('dummy', function () { return new InMemoryUser('robin', 'hood'); })), 'dummy')
+        );
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyCreateAuthenticatedToken()
+    {
+        $authenticator = new ConcreteAuthenticator();
+        $this->expectDeprecation('Since symfony/security-http 5.4: Method "Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator::createAuthenticatedToken()" is deprecated, use "Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator::createToken()" instead.');
+        $this->assertInstanceOf(
+            PostAuthenticationToken::class,
+            $authenticator->createAuthenticatedToken(new SelfValidatingPassport(new UserBadge('dummy', function () { return new InMemoryUser('robin', 'hood'); })), 'dummy')
+        );
+    }
+}
+
+class ConcreteAuthenticator extends AbstractAuthenticator
+{
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
+        return parent::createToken($passport, $firewallName);
+    }
+
+    public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
+    {
+        return parent::createAuthenticatedToken($passport, $firewallName);
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        return null;
+    }
+
+    public function authenticate(Request $request): Passport
+    {
+        return new SelfValidatingPassport(new UserBadge('dummy'));
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return null;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

An authenticator might override the `createAuthenticatedToken()` method, hence it must keep being called until that authenticator has been migrated to use `createToken()`. 

Spotted in lexik/jwt-authentication-bundle's CI.