### PR TITLE
[EventDispatcher] fix getSubscribedEvents() event yielding instead or returning array

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Messenger/DoctrineClearEntityManagerWorkerSubscriber.php
+++ b/src/Symfony/Bridge/Doctrine/Messenger/DoctrineClearEntityManagerWorkerSubscriber.php
@@ -42,8 +42,10 @@ class DoctrineClearEntityManagerWorkerSubscriber implements EventSubscriberInter
 
     public static function getSubscribedEvents()
     {
-        yield WorkerMessageHandledEvent::class => 'onWorkerMessageHandled';
-        yield WorkerMessageFailedEvent::class => 'onWorkerMessageFailed';
+        return [
+            WorkerMessageHandledEvent::class => 'onWorkerMessageHandled',
+            WorkerMessageFailedEvent::class => 'onWorkerMessageFailed',
+        ];
     }
 
     private function clearEntityManagers()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`EventSubscriberInterface::getSubscribedEvents()` is described as returning an `array`. Yielding here is breaking the contracts.