### PR TITLE
Cleanup `@return` annotations

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -47,7 +47,7 @@ class Application extends BaseApplication
     /**
      * Gets the Kernel associated with this Console.
      *
-     * @return KernelInterface A KernelInterface instance
+     * @return KernelInterface
      */
     public function getKernel()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -67,7 +67,7 @@ class KernelBrowser extends HttpKernelBrowser
     /**
      * Gets the profile associated with the current Response.
      *
-     * @return HttpProfile|false|null A Profile instance
+     * @return HttpProfile|false|null
      */
     public function getProfile()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.php
@@ -73,7 +73,7 @@ abstract class KernelTestCase extends TestCase
     /**
      * Boots the Kernel for this test.
      *
-     * @return KernelInterface A KernelInterface instance
+     * @return KernelInterface
      */
     protected static function bootKernel(array $options = [])
     {
@@ -118,7 +118,7 @@ abstract class KernelTestCase extends TestCase
      *  * environment
      *  * debug
      *
-     * @return KernelInterface A KernelInterface instance
+     * @return KernelInterface
      */
     protected static function createKernel(array $options = [])
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -35,7 +35,7 @@ abstract class WebTestCase extends KernelTestCase
      * @param array $options An array of options to pass to the createKernel method
      * @param array $server  An array of server parameters
      *
-     * @return KernelBrowser A KernelBrowser instance
+     * @return KernelBrowser
      */
     protected static function createClient(array $options = [], array $server = [])
     {

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -52,7 +52,7 @@ class ProfilerController
     /**
      * Redirects to the last profiles.
      *
-     * @return RedirectResponse A RedirectResponse instance
+     * @return RedirectResponse
      *
      * @throws NotFoundHttpException
      */
@@ -66,7 +66,7 @@ class ProfilerController
     /**
      * Renders a profiler panel for the given token.
      *
-     * @return Response A Response instance
+     * @return Response
      *
      * @throws NotFoundHttpException
      */
@@ -125,7 +125,7 @@ class ProfilerController
     /**
      * Renders the Web Debug Toolbar.
      *
-     * @return Response A Response instance
+     * @return Response
      *
      * @throws NotFoundHttpException
      */
@@ -170,7 +170,7 @@ class ProfilerController
     /**
      * Renders the profiler search bar.
      *
-     * @return Response A Response instance
+     * @return Response
      *
      * @throws NotFoundHttpException
      */
@@ -224,7 +224,7 @@ class ProfilerController
     /**
      * Renders the search results.
      *
-     * @return Response A Response instance
+     * @return Response
      *
      * @throws NotFoundHttpException
      */
@@ -265,7 +265,7 @@ class ProfilerController
     /**
      * Narrows the search bar.
      *
-     * @return Response A Response instance
+     * @return Response
      *
      * @throws NotFoundHttpException
      */
@@ -316,7 +316,7 @@ class ProfilerController
     /**
      * Displays the PHP info.
      *
-     * @return Response A Response instance
+     * @return Response
      *
      * @throws NotFoundHttpException
      */
@@ -338,7 +338,7 @@ class ProfilerController
     /**
      * Displays the source of a file.
      *
-     * @return Response A Response instance
+     * @return Response
      *
      * @throws NotFoundHttpException
      */

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -54,7 +54,7 @@ class RouterController
     /**
      * Renders the profiler panel for the given token.
      *
-     * @return Response A Response instance
+     * @return Response
      *
      * @throws NotFoundHttpException
      */

--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -105,8 +105,6 @@ abstract class AbstractBrowser
     /**
      * Sets the insulated flag.
      *
-     * @param bool $insulated Whether to insulate the requests or not
-     *
      * @throws \RuntimeException When Symfony Process Component is not installed
      */
     public function insulate(bool $insulated = true)
@@ -120,8 +118,6 @@ abstract class AbstractBrowser
 
     /**
      * Sets server parameters.
-     *
-     * @param array $server An array of server parameters
      */
     public function setServerParameters(array $server)
     {
@@ -143,7 +139,7 @@ abstract class AbstractBrowser
      *
      * @param mixed $default A default value when key is undefined
      *
-     * @return mixed A value of the parameter
+     * @return mixed
      */
     public function getServerParameter(string $key, $default = '')
     {
@@ -182,7 +178,7 @@ abstract class AbstractBrowser
     /**
      * Returns the History instance.
      *
-     * @return History A History instance
+     * @return History
      */
     public function getHistory()
     {
@@ -192,7 +188,7 @@ abstract class AbstractBrowser
     /**
      * Returns the CookieJar instance.
      *
-     * @return CookieJar A CookieJar instance
+     * @return CookieJar
      */
     public function getCookieJar()
     {
@@ -202,7 +198,7 @@ abstract class AbstractBrowser
     /**
      * Returns the current Crawler instance.
      *
-     * @return Crawler A Crawler instance
+     * @return Crawler
      */
     public function getCrawler()
     {
@@ -216,7 +212,7 @@ abstract class AbstractBrowser
     /**
      * Returns the current BrowserKit Response instance.
      *
-     * @return Response A BrowserKit Response instance
+     * @return Response
      */
     public function getInternalResponse()
     {
@@ -233,7 +229,7 @@ abstract class AbstractBrowser
      * The origin response is the response instance that is returned
      * by the code that handles requests.
      *
-     * @return object A response instance
+     * @return object
      *
      * @see doRequest()
      */
@@ -249,7 +245,7 @@ abstract class AbstractBrowser
     /**
      * Returns the current BrowserKit Request instance.
      *
-     * @return Request A BrowserKit Request instance
+     * @return Request
      */
     public function getInternalRequest()
     {
@@ -266,7 +262,7 @@ abstract class AbstractBrowser
      * The origin request is the request instance that is sent
      * to the code that handles requests.
      *
-     * @return object A Request instance
+     * @return object
      *
      * @see doRequest()
      */
@@ -435,9 +431,7 @@ abstract class AbstractBrowser
     /**
      * Makes a request in another process.
      *
-     * @param object $request An origin request instance
-     *
-     * @return object An origin response instance
+     * @return object
      *
      * @throws \RuntimeException When processing returns exit code
      */
@@ -472,9 +466,7 @@ abstract class AbstractBrowser
     /**
      * Makes a request.
      *
-     * @param object $request An origin request instance
-     *
-     * @return object An origin response instance
+     * @return object
      */
     abstract protected function doRequest(object $request);
 
@@ -493,7 +485,7 @@ abstract class AbstractBrowser
     /**
      * Filters the BrowserKit request to the origin one.
      *
-     * @return object An origin request instance
+     * @return object
      */
     protected function filterRequest(Request $request)
     {
@@ -503,9 +495,7 @@ abstract class AbstractBrowser
     /**
      * Filters the origin response to the BrowserKit one.
      *
-     * @param object $response The origin response to filter
-     *
-     * @return Response An BrowserKit Response instance
+     * @return Response
      */
     protected function filterResponse(object $response)
     {
@@ -648,8 +638,6 @@ abstract class AbstractBrowser
 
     /**
      * Takes a URI and converts it to absolute if it is not already absolute.
-     *
-     * @param string $uri A URI
      *
      * @return string An absolute URI
      */

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -33,7 +33,7 @@ class CookieJar
      * (this behavior ensures a BC behavior with previous versions of
      * Symfony).
      *
-     * @return Cookie|null A Cookie instance or null if the cookie does not exist
+     * @return Cookie|null
      */
     public function get(string $name, string $path = '/', string $domain = null)
     {

--- a/src/Symfony/Component/BrowserKit/History.php
+++ b/src/Symfony/Component/BrowserKit/History.php
@@ -53,7 +53,7 @@ class History
     /**
      * Goes back in the history.
      *
-     * @return Request A Request instance
+     * @return Request
      *
      * @throws \LogicException if the stack is already on the first page
      */
@@ -69,7 +69,7 @@ class History
     /**
      * Goes forward in the history.
      *
-     * @return Request A Request instance
+     * @return Request
      *
      * @throws \LogicException if the stack is already on the last page
      */
@@ -85,7 +85,7 @@ class History
     /**
      * Returns the current element in the history.
      *
-     * @return Request A Request instance
+     * @return Request
      *
      * @throws \LogicException if the stack is empty
      */

--- a/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/PdoAdapter.php
@@ -60,7 +60,7 @@ class PdoAdapter extends AbstractAdapter implements PruneableInterface
      *  * db_password: The password when lazy-connect [default: '']
      *  * db_connection_options: An array of driver-specific connection options [default: []]
      *
-     * @param \PDO|Connection|string $connOrDsn a \PDO or Connection instance or DSN string or null
+     * @param \PDO|Connection|string $connOrDsn
      *
      * @throws InvalidArgumentException When first argument is not PDO nor Connection nor string
      * @throws InvalidArgumentException When PDO error mode is not PDO::ERRMODE_EXCEPTION

--- a/src/Symfony/Component/Config/ConfigCacheFactoryInterface.php
+++ b/src/Symfony/Component/Config/ConfigCacheFactoryInterface.php
@@ -26,7 +26,7 @@ interface ConfigCacheFactoryInterface
      * @param string   $file     The absolute cache file path
      * @param callable $callable The callable to be executed when the cache needs to be filled (i. e. is not fresh). The cache will be passed as the only parameter to this callback
      *
-     * @return ConfigCacheInterface The cache instance
+     * @return ConfigCacheInterface
      */
     public function cache(string $file, callable $callable);
 }

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -357,7 +357,7 @@ abstract class NodeDefinition implements NodeParentInterface
     /**
      * Instantiate and configure the node according to this definition.
      *
-     * @return NodeInterface The node instance
+     * @return NodeInterface
      *
      * @throws InvalidDefinitionException When the definition is invalid
      */

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -338,7 +338,7 @@ class PrototypedArrayNode extends ArrayNode
      * Now, the key becomes 'name001' and the child node becomes 'value001' and
      * the prototype of child node 'name001' should be a ScalarNode instead of an ArrayNode instance.
      *
-     * @return mixed The prototype instance
+     * @return mixed
      */
     private function getPrototypeForChild(string $key)
     {

--- a/src/Symfony/Component/Config/Loader/LoaderInterface.php
+++ b/src/Symfony/Component/Config/Loader/LoaderInterface.php
@@ -41,7 +41,7 @@ interface LoaderInterface
     /**
      * Gets the loader resolver.
      *
-     * @return LoaderResolverInterface A LoaderResolverInterface instance
+     * @return LoaderResolverInterface
      */
     public function getResolver();
 

--- a/src/Symfony/Component/Config/Loader/LoaderResolver.php
+++ b/src/Symfony/Component/Config/Loader/LoaderResolver.php
@@ -59,7 +59,7 @@ class LoaderResolver implements LoaderResolverInterface
     /**
      * Returns the registered loaders.
      *
-     * @return LoaderInterface[] An array of LoaderInterface instances
+     * @return LoaderInterface[]
      */
     public function getLoaders()
     {

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -313,7 +313,7 @@ class Application implements ResetInterface
     /**
      * Get the helper set associated with the command.
      *
-     * @return HelperSet The HelperSet instance associated with this command
+     * @return HelperSet
      */
     public function getHelperSet()
     {
@@ -332,7 +332,7 @@ class Application implements ResetInterface
     /**
      * Gets the InputDefinition related to this Application.
      *
-     * @return InputDefinition The InputDefinition instance
+     * @return InputDefinition
      */
     public function getDefinition()
     {
@@ -626,7 +626,7 @@ class Application implements ResetInterface
      * Contrary to get, this command tries to find the best
      * match if you give it an abbreviation of a name or alias.
      *
-     * @return Command A Command instance
+     * @return Command
      *
      * @throws CommandNotFoundException When command name is incorrect or ambiguous
      */
@@ -738,7 +738,7 @@ class Application implements ResetInterface
      *
      * The array keys are the full names and the values the command instances.
      *
-     * @return Command[] An array of Command instances
+     * @return Command[]
      */
     public function all(string $namespace = null)
     {
@@ -1030,7 +1030,7 @@ class Application implements ResetInterface
     /**
      * Gets the default input definition.
      *
-     * @return InputDefinition An InputDefinition instance
+     * @return InputDefinition
      */
     protected function getDefaultInputDefinition()
     {
@@ -1048,7 +1048,7 @@ class Application implements ResetInterface
     /**
      * Gets the default commands that should always be available.
      *
-     * @return Command[] An array of default Command instances
+     * @return Command[]
      */
     protected function getDefaultCommands()
     {
@@ -1058,7 +1058,7 @@ class Application implements ResetInterface
     /**
      * Gets the default helper set with the helpers that should always be available.
      *
-     * @return HelperSet A HelperSet instance
+     * @return HelperSet
      */
     protected function getDefaultHelperSet()
     {

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -153,7 +153,7 @@ class Command
     /**
      * Gets the helper set.
      *
-     * @return HelperSet|null A HelperSet instance
+     * @return HelperSet|null
      */
     public function getHelperSet()
     {
@@ -163,7 +163,7 @@ class Command
     /**
      * Gets the application instance for this command.
      *
-     * @return Application|null An Application instance
+     * @return Application|null
      */
     public function getApplication()
     {
@@ -391,7 +391,7 @@ class Command
     /**
      * Gets the InputDefinition attached to this Command.
      *
-     * @return InputDefinition An InputDefinition instance
+     * @return InputDefinition
      */
     public function getDefinition()
     {
@@ -406,7 +406,7 @@ class Command
      *
      * This method is not part of public API and should not be used directly.
      *
-     * @return InputDefinition An InputDefinition instance
+     * @return InputDefinition
      */
     public function getNativeDefinition()
     {

--- a/src/Symfony/Component/Console/Event/ConsoleEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleEvent.php
@@ -38,7 +38,7 @@ class ConsoleEvent extends Event
     /**
      * Gets the command that is executed.
      *
-     * @return Command|null A Command instance
+     * @return Command|null
      */
     public function getCommand()
     {
@@ -48,7 +48,7 @@ class ConsoleEvent extends Event
     /**
      * Gets the input instance.
      *
-     * @return InputInterface An InputInterface instance
+     * @return InputInterface
      */
     public function getInput()
     {
@@ -58,7 +58,7 @@ class ConsoleEvent extends Event
     /**
      * Gets the output instance.
      *
-     * @return OutputInterface An OutputInterface instance
+     * @return OutputInterface
      */
     public function getOutput()
     {

--- a/src/Symfony/Component/Console/Helper/HelperSet.php
+++ b/src/Symfony/Component/Console/Helper/HelperSet.php
@@ -60,7 +60,7 @@ class HelperSet implements \IteratorAggregate
     /**
      * Gets a helper value.
      *
-     * @return HelperInterface The helper instance
+     * @return HelperInterface
      *
      * @throws InvalidArgumentException if the helper is not defined
      */
@@ -81,7 +81,7 @@ class HelperSet implements \IteratorAggregate
     /**
      * Gets the command associated with this helper set.
      *
-     * @return Command A Command instance
+     * @return Command
      */
     public function getCommand()
     {

--- a/src/Symfony/Component/Console/Tester/TesterTrait.php
+++ b/src/Symfony/Component/Console/Tester/TesterTrait.php
@@ -79,7 +79,7 @@ trait TesterTrait
     /**
      * Gets the input instance used by the last execution of the command or application.
      *
-     * @return InputInterface The current input instance
+     * @return InputInterface
      */
     public function getInput()
     {
@@ -89,7 +89,7 @@ trait TesterTrait
     /**
      * Gets the output instance used by the last execution of the command or application.
      *
-     * @return OutputInterface The current output instance
+     * @return OutputInterface
      */
     public function getOutput()
     {

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -1882,8 +1882,6 @@ class CustomApplication extends Application
 {
     /**
      * Overwrites the default input definition.
-     *
-     * @return InputDefinition An InputDefinition instance
      */
     protected function getDefaultInputDefinition(): InputDefinition
     {
@@ -1892,8 +1890,6 @@ class CustomApplication extends Application
 
     /**
      * Gets the default helper set with the helpers that should always be available.
-     *
-     * @return HelperSet A HelperSet instance
      */
     protected function getDefaultHelperSet(): HelperSet
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/Compiler.php
@@ -32,9 +32,7 @@ class Compiler
     }
 
     /**
-     * Returns the PassConfig.
-     *
-     * @return PassConfig The PassConfig instance
+     * @return PassConfig
      */
     public function getPassConfig()
     {
@@ -42,18 +40,13 @@ class Compiler
     }
 
     /**
-     * Returns the ServiceReferenceGraph.
-     *
-     * @return ServiceReferenceGraph The ServiceReferenceGraph instance
+     * @return ServiceReferenceGraph
      */
     public function getServiceReferenceGraph()
     {
         return $this->serviceReferenceGraph;
     }
 
-    /**
-     * Adds a pass to the PassConfig.
-     */
     public function addPass(CompilerPassInterface $pass, string $type = PassConfig::TYPE_BEFORE_OPTIMIZATION, int $priority = 0)
     {
         $this->passConfig->addPass($pass, $type, $priority);
@@ -72,9 +65,7 @@ class Compiler
     }
 
     /**
-     * Returns the log.
-     *
-     * @return array Log array
+     * @return array
      */
     public function getLog()
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphNode.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphNode.php
@@ -51,7 +51,7 @@ class ServiceReferenceGraphNode
     /**
      * Checks if the value of this node is an Alias.
      *
-     * @return bool True if the value is an Alias instance
+     * @return bool
      */
     public function isAlias()
     {

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -97,7 +97,7 @@ class Container implements ContainerInterface, ResetInterface
     /**
      * Gets the service container parameter bag.
      *
-     * @return ParameterBagInterface A ParameterBagInterface instance
+     * @return ParameterBagInterface
      */
     public function getParameterBag()
     {

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -204,7 +204,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Returns an extension by alias or namespace.
      *
-     * @return ExtensionInterface An extension instance
+     * @return ExtensionInterface
      *
      * @throws LogicException if the extension is not registered
      */
@@ -862,7 +862,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     }
 
     /**
-     * @return Alias An Alias instance
+     * @return Alias
      *
      * @throws InvalidArgumentException if the alias does not exist
      */
@@ -881,7 +881,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * This methods allows for simple registration of service definition
      * with a fluid interface.
      *
-     * @return Definition A Definition instance
+     * @return Definition
      */
     public function register(string $id, string $class = null)
     {
@@ -927,7 +927,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Gets all service definitions.
      *
-     * @return Definition[] An array of Definition instances
+     * @return Definition[]
      */
     public function getDefinitions()
     {
@@ -969,7 +969,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Gets a service definition.
      *
-     * @return Definition A Definition instance
+     * @return Definition
      *
      * @throws ServiceNotFoundException if the service definition does not exist
      */
@@ -987,7 +987,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * The method "unaliases" recursively to return a Definition instance.
      *
-     * @return Definition A Definition instance
+     * @return Definition
      *
      * @throws ServiceNotFoundException if the service definition does not exist
      */

--- a/src/Symfony/Component/DomCrawler/AbstractUriElement.php
+++ b/src/Symfony/Component/DomCrawler/AbstractUriElement.php
@@ -56,7 +56,7 @@ abstract class AbstractUriElement
     /**
      * Gets the node associated with this link.
      *
-     * @return \DOMElement A \DOMElement instance
+     * @return \DOMElement
      */
     public function getNode()
     {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -690,7 +690,7 @@ class Crawler implements \Countable, \IteratorAggregate
      * Since an XPath expression might evaluate to either a simple type or a \DOMNodeList,
      * this method will return either an array of simple types or a new Crawler instance.
      *
-     * @return array|Crawler An array of evaluation results or a new Crawler instance
+     * @return array|Crawler
      */
     public function evaluate(string $xpath)
     {
@@ -800,7 +800,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Selects images by alt value.
      *
-     * @return static A new instance of Crawler with the filtered list of nodes
+     * @return static
      */
     public function selectImage(string $value)
     {
@@ -824,7 +824,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns a Link object for the first node in the list.
      *
-     * @return Link A Link instance
+     * @return Link
      *
      * @throws \InvalidArgumentException If the current node list is empty or the selected node is not instance of DOMElement
      */
@@ -846,7 +846,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns an array of Link objects for the nodes in the list.
      *
-     * @return Link[] An array of Link instances
+     * @return Link[]
      *
      * @throws \InvalidArgumentException If the current node list contains non-DOMElement instances
      */
@@ -867,7 +867,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns an Image object for the first node in the list.
      *
-     * @return Image An Image instance
+     * @return Image
      *
      * @throws \InvalidArgumentException If the current node list is empty
      */
@@ -889,7 +889,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns an array of Image objects for the nodes in the list.
      *
-     * @return Image[] An array of Image instances
+     * @return Image[]
      */
     public function images()
     {
@@ -908,7 +908,7 @@ class Crawler implements \Countable, \IteratorAggregate
     /**
      * Returns a Form object for the first node in the list.
      *
-     * @return Form A Form instance
+     * @return Form
      *
      * @throws \InvalidArgumentException If the current node list is empty or the selected node is not instance of DOMElement
      */

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -55,7 +55,7 @@ class Form extends Link implements \ArrayAccess
     /**
      * Gets the form node associated with this form.
      *
-     * @return \DOMElement A \DOMElement instance
+     * @return \DOMElement
      */
     public function getFormNode()
     {

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionFunctionProviderInterface.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionFunctionProviderInterface.php
@@ -17,7 +17,7 @@ namespace Symfony\Component\ExpressionLanguage;
 interface ExpressionFunctionProviderInterface
 {
     /**
-     * @return ExpressionFunction[] An array of Function instances
+     * @return ExpressionFunction[]
      */
     public function getFunctions();
 }

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionLanguage.php
@@ -72,7 +72,7 @@ class ExpressionLanguage
      *
      * @param Expression|string $expression The expression to parse
      *
-     * @return ParsedExpression A ParsedExpression instance
+     * @return ParsedExpression
      */
     public function parse($expression, array $names)
     {

--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -21,7 +21,7 @@ class Lexer
     /**
      * Tokenizes an expression.
      *
-     * @return TokenStream A token stream instance
+     * @return TokenStream
      *
      * @throws SyntaxError
      */

--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -115,7 +115,7 @@ abstract class AbstractExtension implements FormExtensionInterface
     /**
      * Registers the types.
      *
-     * @return FormTypeInterface[] An array of FormTypeInterface instances
+     * @return FormTypeInterface[]
      */
     protected function loadTypes()
     {
@@ -125,7 +125,7 @@ abstract class AbstractExtension implements FormExtensionInterface
     /**
      * Registers the type extensions.
      *
-     * @return FormTypeExtensionInterface[] An array of FormTypeExtensionInterface instances
+     * @return FormTypeExtensionInterface[]
      */
     protected function loadTypeExtensions()
     {

--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -245,7 +245,7 @@ class Button implements \IteratorAggregate, FormInterface
     /**
      * Returns the button's configuration.
      *
-     * @return FormConfigInterface The configuration instance
+     * @return FormConfigInterface
      */
     public function getConfig()
     {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToStringTransformer.php
@@ -62,7 +62,7 @@ class DateIntervalToStringTransformer implements DataTransformerInterface
      *
      * @param string $value An ISO 8601 or date string like date interval presentation
      *
-     * @return \DateInterval|null An instance of \DateInterval
+     * @return \DateInterval|null
      *
      * @throws UnexpectedTypeException       if the given value is not a string
      * @throws TransformationFailedException if the date interval could not be parsed

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -101,7 +101,7 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
      *
      * @param string $value A value as produced by PHP's date() function
      *
-     * @return \DateTime|null An instance of \DateTime
+     * @return \DateTime|null
      *
      * @throws TransformationFailedException If the given value is not a string,
      *                                       or could not be transformed

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/UlidToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/UlidToStringTransformer.php
@@ -49,7 +49,7 @@ class UlidToStringTransformer implements DataTransformerInterface
      *
      * @param string $value A ULID string
      *
-     * @return Ulid|null An instance of Ulid
+     * @return Ulid|null
      *
      * @throws TransformationFailedException If the given value is not a string,
      *                                       or could not be transformed

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/UuidToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/UuidToStringTransformer.php
@@ -49,7 +49,7 @@ class UuidToStringTransformer implements DataTransformerInterface
      *
      * @param string $value A UUID string
      *
-     * @return Uuid|null An instance of Uuid
+     * @return Uuid|null
      *
      * @throws TransformationFailedException If the given value is not a string,
      *                                       or could not be transformed

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -89,14 +89,14 @@ interface FormConfigInterface
     /**
      * Returns the view transformers of the form.
      *
-     * @return DataTransformerInterface[] An array of {@link DataTransformerInterface} instances
+     * @return DataTransformerInterface[]
      */
     public function getViewTransformers();
 
     /**
      * Returns the model transformers of the form.
      *
-     * @return DataTransformerInterface[] An array of {@link DataTransformerInterface} instances
+     * @return DataTransformerInterface[]
      */
     public function getModelTransformers();
 

--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -204,7 +204,7 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
      * Returns whether the current element of the iterator can be recursed
      * into.
      *
-     * @return bool Whether the current element is an instance of this class
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function hasChildren()
@@ -274,7 +274,7 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
      *
      * @param string|string[] $codes The codes to find
      *
-     * @return static new instance which contains only specific errors
+     * @return static
      */
     public function findByCodes($codes)
     {

--- a/src/Symfony/Component/Form/FormExtensionInterface.php
+++ b/src/Symfony/Component/Form/FormExtensionInterface.php
@@ -41,7 +41,7 @@ interface FormExtensionInterface
      *
      * @param string $name The name of the type
      *
-     * @return FormTypeExtensionInterface[] An array of extensions as FormTypeExtensionInterface instances
+     * @return FormTypeExtensionInterface[]
      */
     public function getTypeExtensions(string $name);
 

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -172,7 +172,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns the form's configuration.
      *
-     * @return FormConfigInterface The configuration instance
+     * @return FormConfigInterface
      */
     public function getConfig();
 
@@ -195,7 +195,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns the property path that the form is mapped to.
      *
-     * @return PropertyPathInterface|null The property path instance
+     * @return PropertyPathInterface|null
      */
     public function getPropertyPath();
 
@@ -308,7 +308,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns the root of the form tree.
      *
-     * @return self The root of the tree, may be the instance itself
+     * @return self
      */
     public function getRoot();
 

--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -195,7 +195,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
      *
      * Override this method if you want to customize the builder class.
      *
-     * @return FormBuilderInterface The new builder instance
+     * @return FormBuilderInterface
      */
     protected function newBuilder(string $name, ?string $dataClass, FormFactoryInterface $factory, array $options)
     {
@@ -215,7 +215,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
      *
      * Override this method if you want to customize the view class.
      *
-     * @return FormView A new view instance
+     * @return FormView
      */
     protected function newView(FormView $parent = null)
     {

--- a/src/Symfony/Component/Form/ResolvedFormTypeInterface.php
+++ b/src/Symfony/Component/Form/ResolvedFormTypeInterface.php
@@ -44,7 +44,7 @@ interface ResolvedFormTypeInterface
     /**
      * Returns the extensions of the wrapped form type.
      *
-     * @return FormTypeExtensionInterface[] An array of {@link FormTypeExtensionInterface} instances
+     * @return FormTypeExtensionInterface[]
      */
     public function getTypeExtensions();
 

--- a/src/Symfony/Component/HttpFoundation/FileBag.php
+++ b/src/Symfony/Component/HttpFoundation/FileBag.php
@@ -67,7 +67,7 @@ class FileBag extends ParameterBag
      *
      * @param array|UploadedFile $file A (multi-dimensional) array of uploaded file information
      *
-     * @return UploadedFile[]|UploadedFile|null A (multi-dimensional) array of UploadedFile instances
+     * @return UploadedFile[]|UploadedFile|null
      */
     protected function convertFileInformation($file)
     {

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -250,7 +250,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
     /**
      * Returns an iterator for headers.
      *
-     * @return \ArrayIterator An \ArrayIterator instance
+     * @return \ArrayIterator
      */
     #[\ReturnTypeWillChange]
     public function getIterator()

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -205,7 +205,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Returns an iterator for parameters.
      *
-     * @return \ArrayIterator An \ArrayIterator instance
+     * @return \ArrayIterator
      */
     #[\ReturnTypeWillChange]
     public function getIterator()

--- a/src/Symfony/Component/HttpFoundation/Session/Attribute/AttributeBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Attribute/AttributeBag.php
@@ -129,7 +129,7 @@ class AttributeBag implements AttributeBagInterface, \IteratorAggregate, \Counta
     /**
      * Returns an iterator for attributes.
      *
-     * @return \ArrayIterator An \ArrayIterator instance
+     * @return \ArrayIterator
      */
     #[\ReturnTypeWillChange]
     public function getIterator()

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -126,7 +126,7 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
     /**
      * Returns an iterator for attributes.
      *
-     * @return \ArrayIterator An \ArrayIterator instance
+     * @return \ArrayIterator
      */
     #[\ReturnTypeWillChange]
     public function getIterator()

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractSessionListener.php
@@ -191,7 +191,7 @@ abstract class AbstractSessionListener implements EventSubscriberInterface
     /**
      * Gets the session object.
      *
-     * @return SessionInterface|null A SessionInterface instance or null if no session is available
+     * @return SessionInterface|null
      */
     abstract protected function getSession();
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/AbstractTestSessionListener.php
@@ -112,7 +112,7 @@ abstract class AbstractTestSessionListener implements EventSubscriberInterface
      *
      * @deprecated since Symfony 5.4, will be removed in 6.0.
      *
-     * @return SessionInterface|null A SessionInterface instance or null if no session is available
+     * @return SessionInterface|null
      */
     abstract protected function getSession();
 }

--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentRendererInterface.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentRendererInterface.php
@@ -27,7 +27,7 @@ interface FragmentRendererInterface
      *
      * @param string|ControllerReference $uri A URI as a string or a ControllerReference instance
      *
-     * @return Response A Response instance
+     * @return Response
      */
     public function render($uri, Request $request, array $options = []);
 

--- a/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/AbstractSurrogate.php
@@ -41,7 +41,7 @@ abstract class AbstractSurrogate implements SurrogateInterface
     /**
      * Returns a new cache strategy instance.
      *
-     * @return ResponseCacheStrategyInterface A ResponseCacheStrategyInterface instance
+     * @return ResponseCacheStrategyInterface
      */
     public function createCacheStrategy()
     {

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -106,7 +106,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     /**
      * Gets the current store.
      *
-     * @return StoreInterface A StoreInterface instance
+     * @return StoreInterface
      */
     public function getStore()
     {
@@ -158,7 +158,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     /**
      * Gets the Request instance associated with the main request.
      *
-     * @return Request A Request instance
+     * @return Request
      */
     public function getRequest()
     {
@@ -168,7 +168,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     /**
      * Gets the Kernel instance.
      *
-     * @return HttpKernelInterface An HttpKernelInterface instance
+     * @return HttpKernelInterface
      */
     public function getKernel()
     {
@@ -178,7 +178,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     /**
      * Gets the Surrogate instance.
      *
-     * @return SurrogateInterface A Surrogate instance
+     * @return SurrogateInterface
      *
      * @throws \LogicException
      */
@@ -258,7 +258,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      *
      * @param bool $catch Whether to process exceptions
      *
-     * @return Response A Response instance
+     * @return Response
      */
     protected function pass(Request $request, bool $catch = false)
     {
@@ -272,7 +272,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      *
      * @param bool $catch Whether to process exceptions
      *
-     * @return Response A Response instance
+     * @return Response
      *
      * @throws \Exception
      *
@@ -320,7 +320,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      *
      * @param bool $catch Whether to process exceptions
      *
-     * @return Response A Response instance
+     * @return Response
      *
      * @throws \Exception
      */
@@ -369,7 +369,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      *
      * @param bool $catch Whether to process exceptions
      *
-     * @return Response A Response instance
+     * @return Response
      */
     protected function validate(Request $request, Response $entry, bool $catch = false)
     {
@@ -432,7 +432,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      *
      * @param bool $catch Whether to process exceptions
      *
-     * @return Response A Response instance
+     * @return Response
      */
     protected function fetch(Request $request, bool $catch = false)
     {
@@ -465,7 +465,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * @param bool          $catch Whether to catch exceptions or not
      * @param Response|null $entry A Response instance (the stale entry if present, null otherwise)
      *
-     * @return Response A Response instance
+     * @return Response
      */
     protected function forward(Request $request, bool $catch = false, Response $entry = null)
     {

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -125,7 +125,7 @@ class Store implements StoreInterface
     /**
      * Locates a cached Response for the Request provided.
      *
-     * @return Response|null A Response instance, or null if no cache entry was found
+     * @return Response|null
      */
     public function lookup(Request $request)
     {

--- a/src/Symfony/Component/HttpKernel/HttpCache/StoreInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/StoreInterface.php
@@ -27,7 +27,7 @@ interface StoreInterface
     /**
      * Locates a cached Response for the Request provided.
      *
-     * @return Response|null A Response instance, or null if no cache entry was found
+     * @return Response|null
      */
     public function lookup(Request $request);
 

--- a/src/Symfony/Component/HttpKernel/HttpCache/SurrogateInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/SurrogateInterface.php
@@ -26,7 +26,7 @@ interface SurrogateInterface
     /**
      * Returns a new cache strategy instance.
      *
-     * @return ResponseCacheStrategyInterface A ResponseCacheStrategyInterface instance
+     * @return ResponseCacheStrategyInterface
      */
     public function createCacheStrategy();
 

--- a/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
@@ -58,7 +58,7 @@ class HttpKernelBrowser extends AbstractBrowser
      *
      * @param Request $request
      *
-     * @return Response A Response instance
+     * @return Response
      */
     protected function doRequest(object $request)
     {
@@ -130,7 +130,7 @@ EOF;
     /**
      * {@inheritdoc}
      *
-     * @return Request A Request instance
+     * @return Request
      */
     protected function filterRequest(DomRequest $request)
     {
@@ -194,7 +194,7 @@ EOF;
      *
      * @param Request $request
      *
-     * @return DomResponse A DomResponse instance
+     * @return DomResponse
      */
     protected function filterResponse(object $response)
     {

--- a/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
@@ -40,7 +40,7 @@ interface HttpKernelInterface
      *                    (one of HttpKernelInterface::MAIN_REQUEST or HttpKernelInterface::SUB_REQUEST)
      * @param bool $catch Whether to catch exceptions or not
      *
-     * @return Response A Response instance
+     * @return Response
      *
      * @throws \Exception When an Exception occurs during processing
      */

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -31,7 +31,7 @@ interface KernelInterface extends HttpKernelInterface
     /**
      * Returns an array of bundles to register.
      *
-     * @return iterable|BundleInterface[] An iterable of bundle instances
+     * @return iterable|BundleInterface[]
      */
     public function registerBundles();
 
@@ -55,14 +55,14 @@ interface KernelInterface extends HttpKernelInterface
     /**
      * Gets the registered bundle instances.
      *
-     * @return BundleInterface[] An array of registered bundle instances
+     * @return BundleInterface[]
      */
     public function getBundles();
 
     /**
      * Returns a bundle.
      *
-     * @return BundleInterface A BundleInterface instance
+     * @return BundleInterface
      *
      * @throws \InvalidArgumentException when the bundle is not enabled
      */

--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -208,7 +208,7 @@ class Profile
     /**
      * Gets a Collector by name.
      *
-     * @return DataCollectorInterface A DataCollectorInterface instance
+     * @return DataCollectorInterface
      *
      * @throws \InvalidArgumentException if the collector does not exist
      */

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -63,7 +63,7 @@ class Profiler implements ResetInterface
     /**
      * Loads the Profile for the given Response.
      *
-     * @return Profile|null A Profile instance
+     * @return Profile|null
      */
     public function loadProfileFromResponse(Response $response)
     {
@@ -77,7 +77,7 @@ class Profiler implements ResetInterface
     /**
      * Loads the Profile for the given token.
      *
-     * @return Profile|null A Profile instance
+     * @return Profile|null
      */
     public function loadProfile(string $token)
     {
@@ -132,7 +132,7 @@ class Profiler implements ResetInterface
     /**
      * Collects data for the given Response.
      *
-     * @return Profile|null A Profile instance or null if the profiler is disabled
+     * @return Profile|null
      */
     public function collect(Request $request, Response $response, \Throwable $exception = null)
     {
@@ -223,7 +223,7 @@ class Profiler implements ResetInterface
      *
      * @param string $name A collector name
      *
-     * @return DataCollectorInterface A DataCollectorInterface instance
+     * @return DataCollectorInterface
      *
      * @throws \InvalidArgumentException if the collector does not exist
      */

--- a/src/Symfony/Component/Routing/Generator/Dumper/GeneratorDumperInterface.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/GeneratorDumperInterface.php
@@ -31,7 +31,7 @@ interface GeneratorDumperInterface
     /**
      * Gets the routes to dump.
      *
-     * @return RouteCollection A RouteCollection instance
+     * @return RouteCollection
      */
     public function getRoutes();
 }

--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -104,7 +104,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
      *
      * @param string $class A class name
      *
-     * @return RouteCollection A RouteCollection instance
+     * @return RouteCollection
      *
      * @throws \InvalidArgumentException When route can't be parsed
      */

--- a/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
@@ -28,7 +28,7 @@ class AnnotationDirectoryLoader extends AnnotationFileLoader
      * @param string      $path A directory path
      * @param string|null $type The resource type
      *
-     * @return RouteCollection A RouteCollection instance
+     * @return RouteCollection
      *
      * @throws \InvalidArgumentException When the directory does not exist or its routes cannot be parsed
      */

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -43,7 +43,7 @@ class AnnotationFileLoader extends FileLoader
      * @param string      $file A PHP file path
      * @param string|null $type The resource type
      *
-     * @return RouteCollection|null A RouteCollection instance
+     * @return RouteCollection|null
      *
      * @throws \InvalidArgumentException When the file does not exist or its routes cannot be parsed
      */

--- a/src/Symfony/Component/Routing/Loader/ClosureLoader.php
+++ b/src/Symfony/Component/Routing/Loader/ClosureLoader.php
@@ -29,7 +29,7 @@ class ClosureLoader extends Loader
      * @param \Closure    $closure A Closure
      * @param string|null $type    The resource type
      *
-     * @return RouteCollection A RouteCollection instance
+     * @return RouteCollection
      */
     public function load($closure, string $type = null)
     {

--- a/src/Symfony/Component/Routing/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/PhpFileLoader.php
@@ -33,7 +33,7 @@ class PhpFileLoader extends FileLoader
      * @param string      $file A PHP file path
      * @param string|null $type The resource type
      *
-     * @return RouteCollection A RouteCollection instance
+     * @return RouteCollection
      */
     public function load($file, string $type = null)
     {

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -40,7 +40,7 @@ class XmlFileLoader extends FileLoader
      * @param string      $file An XML file path
      * @param string|null $type The resource type
      *
-     * @return RouteCollection A RouteCollection instance
+     * @return RouteCollection
      *
      * @throws \InvalidArgumentException when the file cannot be loaded or when the XML cannot be
      *                                   parsed because it does not validate against the scheme

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -44,7 +44,7 @@ class YamlFileLoader extends FileLoader
      * @param string      $file A Yaml file path
      * @param string|null $type The resource type
      *
-     * @return RouteCollection A RouteCollection instance
+     * @return RouteCollection
      *
      * @throws \InvalidArgumentException When a route can't be parsed because YAML is invalid
      */

--- a/src/Symfony/Component/Routing/Matcher/Dumper/MatcherDumperInterface.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/MatcherDumperInterface.php
@@ -31,7 +31,7 @@ interface MatcherDumperInterface
     /**
      * Gets the routes to dump.
      *
-     * @return RouteCollection A RouteCollection instance
+     * @return RouteCollection
      */
     public function getRoutes();
 }

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -439,7 +439,7 @@ class Route implements \Serializable
     /**
      * Compiles the route.
      *
-     * @return CompiledRoute A CompiledRoute instance
+     * @return CompiledRoute
      *
      * @throws \LogicException If the Route cannot be compiled because the
      *                         path or host pattern is invalid

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -112,7 +112,7 @@ class RouteCollection implements \IteratorAggregate, \Countable
     /**
      * Gets a route by name.
      *
-     * @return Route|null A Route instance or null when not found
+     * @return Route|null
      */
     public function get(string $name)
     {

--- a/src/Symfony/Component/Routing/RouteCompilerInterface.php
+++ b/src/Symfony/Component/Routing/RouteCompilerInterface.php
@@ -21,7 +21,7 @@ interface RouteCompilerInterface
     /**
      * Compiles the current route instance.
      *
-     * @return CompiledRoute A CompiledRoute instance
+     * @return CompiledRoute
      *
      * @throws \LogicException If the Route cannot be compiled because the
      *                         path or host pattern is invalid

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -303,7 +303,7 @@ class Router implements RouterInterface, RequestMatcherInterface
     /**
      * Gets the UrlGenerator instance associated with this Router.
      *
-     * @return UrlGeneratorInterface A UrlGeneratorInterface instance
+     * @return UrlGeneratorInterface
      */
     public function getGenerator()
     {

--- a/src/Symfony/Component/Routing/RouterInterface.php
+++ b/src/Symfony/Component/Routing/RouterInterface.php
@@ -29,7 +29,7 @@ interface RouterInterface extends UrlMatcherInterface, UrlGeneratorInterface
      * WARNING: This method should never be used at runtime as it is SLOW.
      *          You might use it in a cache warmer though.
      *
-     * @return RouteCollection A RouteCollection instance
+     * @return RouteCollection
      */
     public function getRouteCollection();
 }

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationManagerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationManagerInterface.php
@@ -27,7 +27,7 @@ interface AuthenticationManagerInterface
     /**
      * Attempts to authenticate a TokenInterface object.
      *
-     * @return TokenInterface An authenticated TokenInterface instance, never null
+     * @return TokenInterface
      *
      * @throws AuthenticationException if the authentication fails
      */

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorageInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorageInterface.php
@@ -23,7 +23,7 @@ interface TokenStorageInterface
     /**
      * Returns the current security token.
      *
-     * @return TokenInterface|null A TokenInterface instance or null if no authentication information is available
+     * @return TokenInterface|null
      */
     public function getToken();
 

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/PassportInterface.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/PassportInterface.php
@@ -42,7 +42,7 @@ interface PassportInterface
     public function getBadge(string $badgeFqcn): ?BadgeInterface;
 
     /**
-     * @return array<class-string<BadgeInterface>, BadgeInterface> An array of badge instances indexed by class name
+     * @return array<class-string<BadgeInterface>, BadgeInterface>
      */
     public function getBadges(): array;
 }

--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -56,7 +56,7 @@ class HttpUtils
      * @param string $path   A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))
      * @param int    $status The status code
      *
-     * @return RedirectResponse A RedirectResponse instance
+     * @return RedirectResponse
      */
     public function createRedirectResponse(Request $request, string $path, int $status = 302)
     {
@@ -75,7 +75,7 @@ class HttpUtils
      *
      * @param string $path A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))
      *
-     * @return Request A Request instance
+     * @return Request
      */
     public function createRequest(Request $request, string $path)
     {

--- a/src/Symfony/Component/Stopwatch/Section.php
+++ b/src/Symfony/Component/Stopwatch/Section.php
@@ -176,7 +176,7 @@ class Section
     /**
      * Returns the events from this section.
      *
-     * @return StopwatchEvent[] An array of StopwatchEvent instances
+     * @return StopwatchEvent[]
      */
     public function getEvents()
     {

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -147,7 +147,7 @@ class StopwatchEvent
     /**
      * Gets all event periods.
      *
-     * @return StopwatchPeriod[] An array of StopwatchPeriod instances
+     * @return StopwatchPeriod[]
      */
     public function getPeriods()
     {

--- a/src/Symfony/Component/Templating/Loader/LoaderInterface.php
+++ b/src/Symfony/Component/Templating/Loader/LoaderInterface.php
@@ -24,7 +24,7 @@ interface LoaderInterface
     /**
      * Loads a template.
      *
-     * @return Storage|false false if the template cannot be loaded, a Storage instance otherwise
+     * @return Storage|false
      */
     public function load(TemplateReferenceInterface $template);
 

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -265,7 +265,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     /**
      * Gets a helper value.
      *
-     * @return HelperInterface The helper instance
+     * @return HelperInterface
      *
      * @throws \InvalidArgumentException if the helper is not defined
      */
@@ -462,7 +462,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     /**
      * Gets the loader associated with this engine.
      *
-     * @return LoaderInterface A LoaderInterface instance
+     * @return LoaderInterface
      */
     public function getLoader()
     {
@@ -474,7 +474,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      *
      * @param string|TemplateReferenceInterface $name A template name or a TemplateReferenceInterface instance
      *
-     * @return Storage A Storage instance
+     * @return Storage
      *
      * @throws \InvalidArgumentException if the template cannot be found
      */

--- a/src/Symfony/Component/Translation/Loader/LoaderInterface.php
+++ b/src/Symfony/Component/Translation/Loader/LoaderInterface.php
@@ -29,7 +29,7 @@ interface LoaderInterface
      * @param string $locale   A locale
      * @param string $domain   The domain
      *
-     * @return MessageCatalogue A MessageCatalogue instance
+     * @return MessageCatalogue
      *
      * @throws NotFoundResourceException when the resource cannot be found
      * @throws InvalidResourceException  when the resource cannot be loaded

--- a/src/Symfony/Component/Translation/MessageCatalogueInterface.php
+++ b/src/Symfony/Component/Translation/MessageCatalogueInterface.php
@@ -120,7 +120,7 @@ interface MessageCatalogueInterface
     /**
      * Gets the fallback catalogue.
      *
-     * @return self|null A MessageCatalogueInterface instance or null when no fallback has been set
+     * @return self|null
      */
     public function getFallbackCatalogue();
 

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -184,7 +184,7 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
      *
      * @param string|string[] $codes The codes to find
      *
-     * @return static new instance which contains only specific errors
+     * @return static
      */
     public function findByCodes($codes)
     {

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadataInterface.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadataInterface.php
@@ -91,8 +91,7 @@ interface ClassMetadataInterface extends MetadataInterface
      *
      * @param string $property The property name
      *
-     * @return PropertyMetadataInterface[] A list of metadata instances. Empty if
-     *                                     no metadata exists for the property.
+     * @return PropertyMetadataInterface[]
      */
     public function getPropertyMetadata(string $property);
 

--- a/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Mapping\Loader;
 
 use Symfony\Component\Config\Util\XmlUtils;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Exception\MappingException;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 
@@ -68,7 +69,7 @@ class XmlFileLoader extends FileLoader
      *
      * @param \SimpleXMLElement $nodes The XML nodes
      *
-     * @return array The Constraint instances
+     * @return Constraint[]
      */
     protected function parseConstraints(\SimpleXMLElement $nodes)
     {

--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Mapping\Loader;
 
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Mapping\ClassMetadata;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Parser as YamlParser;
@@ -76,7 +77,7 @@ class YamlFileLoader extends FileLoader
      *
      * @param array $nodes The YAML nodes
      *
-     * @return array An array of values or Constraint instances
+     * @return array<array|scalar|Constraint>
      */
     protected function parseNodes(array $nodes)
     {

--- a/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
@@ -158,7 +158,7 @@ abstract class MemberMetadata extends GenericMetadata implements PropertyMetadat
      *
      * @param object|string $objectOrClassName The object or the class name
      *
-     * @return \ReflectionMethod|\ReflectionProperty The reflection instance
+     * @return \ReflectionMethod|\ReflectionProperty
      */
     public function getReflectionMember($objectOrClassName)
     {
@@ -177,7 +177,7 @@ abstract class MemberMetadata extends GenericMetadata implements PropertyMetadat
      *
      * @param object|string $objectOrClassName The object or the class name
      *
-     * @return \ReflectionMethod|\ReflectionProperty The reflection instance
+     * @return \ReflectionMethod|\ReflectionProperty
      */
     abstract protected function newReflectionMember($objectOrClassName);
 

--- a/src/Symfony/Component/Validator/Mapping/MetadataInterface.php
+++ b/src/Symfony/Component/Validator/Mapping/MetadataInterface.php
@@ -51,7 +51,7 @@ interface MetadataInterface
     /**
      * Returns all constraints of this element.
      *
-     * @return Constraint[] A list of Constraint instances
+     * @return Constraint[]
      */
     public function getConstraints();
 

--- a/src/Symfony/Component/VarExporter/Instantiator.php
+++ b/src/Symfony/Component/VarExporter/Instantiator.php
@@ -53,7 +53,7 @@ final class Instantiator
      * @param array  $privateProperties The private properties to set on the instance,
      *                                  keyed by their declaring class
      *
-     * @return object The created instance
+     * @return object
      *
      * @throws ExceptionInterface When the instance cannot be created
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The goal of this patch is to allow php-cs-fixer to remove these annotations on 6.0 when native return types will be used.