### PR TITLE
Add return types everywhere possible

### DIFF
--- a/src/Symfony/Component/BrowserKit/AbstractBrowser.php
+++ b/src/Symfony/Component/BrowserKit/AbstractBrowser.php
@@ -403,11 +403,9 @@ abstract class AbstractBrowser
     /**
      * Makes a request in another process.
      *
-     * @return object
-     *
      * @throws \RuntimeException When processing returns exit code
      */
-    protected function doRequestInProcess(object $request)
+    protected function doRequestInProcess(object $request): object
     {
         $deprecationsFile = tempnam(sys_get_temp_dir(), 'deprec');
         putenv('SYMFONY_DEPRECATIONS_SERIALIZE='.$deprecationsFile);
@@ -437,10 +435,8 @@ abstract class AbstractBrowser
 
     /**
      * Makes a request.
-     *
-     * @return object
      */
-    abstract protected function doRequest(object $request);
+    abstract protected function doRequest(object $request): object;
 
     /**
      * Returns the script to execute when the request must be insulated.
@@ -456,20 +452,16 @@ abstract class AbstractBrowser
 
     /**
      * Filters the BrowserKit request to the origin one.
-     *
-     * @return object
      */
-    protected function filterRequest(Request $request)
+    protected function filterRequest(Request $request): object
     {
         return $request;
     }
 
     /**
      * Filters the origin response to the BrowserKit one.
-     *
-     * @return Response
      */
-    protected function filterResponse(object $response)
+    protected function filterResponse(object $response): Response
     {
         return $response;
     }

--- a/src/Symfony/Component/Config/Definition/ConfigurationInterface.php
+++ b/src/Symfony/Component/Config/Definition/ConfigurationInterface.php
@@ -22,8 +22,6 @@ interface ConfigurationInterface
 {
     /**
      * Generates the configuration tree builder.
-     *
-     * @return TreeBuilder
      */
-    public function getConfigTreeBuilder();
+    public function getConfigTreeBuilder(): TreeBuilder;
 }

--- a/src/Symfony/Component/Config/FileLocator.php
+++ b/src/Symfony/Component/Config/FileLocator.php
@@ -33,7 +33,7 @@ class FileLocator implements FileLocatorInterface
     /**
      * {@inheritdoc}
      */
-    public function locate(string $name, string $currentPath = null, bool $first = true)
+    public function locate(string $name, string $currentPath = null, bool $first = true): string|array
     {
         if ('' === $name) {
             throw new \InvalidArgumentException('An empty file name is not valid to be located.');

--- a/src/Symfony/Component/Config/FileLocatorInterface.php
+++ b/src/Symfony/Component/Config/FileLocatorInterface.php
@@ -30,5 +30,5 @@ interface FileLocatorInterface
      * @throws \InvalidArgumentException        If $name is empty
      * @throws FileLocatorFileNotFoundException If a file is not found
      */
-    public function locate(string $name, string $currentPath = null, bool $first = true);
+    public function locate(string $name, string $currentPath = null, bool $first = true): string|array;
 }

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -62,13 +62,11 @@ abstract class FileLoader extends Loader
      * @param string|null          $sourceResource The original resource importing the new resource
      * @param string|string[]|null $exclude        Glob patterns to exclude from the import
      *
-     * @return mixed
-     *
      * @throws LoaderLoadException
      * @throws FileLoaderImportCircularReferenceException
      * @throws FileLocatorFileNotFoundException
      */
-    public function import(mixed $resource, string $type = null, bool $ignoreErrors = false, string $sourceResource = null, string|array $exclude = null)
+    public function import(mixed $resource, string $type = null, bool $ignoreErrors = false, string $sourceResource = null, string|array $exclude = null): mixed
     {
         if (\is_string($resource) && \strlen($resource) !== ($i = strcspn($resource, '*?{[')) && !str_contains($resource, "\n")) {
             $excluded = [];

--- a/src/Symfony/Component/Config/Loader/Loader.php
+++ b/src/Symfony/Component/Config/Loader/Loader.php
@@ -46,10 +46,8 @@ abstract class Loader implements LoaderInterface
 
     /**
      * Imports a resource.
-     *
-     * @return mixed
      */
-    public function import(mixed $resource, string $type = null)
+    public function import(mixed $resource, string $type = null): mixed
     {
         return $this->resolve($resource, $type)->load($resource, $type);
     }

--- a/src/Symfony/Component/Config/Loader/LoaderInterface.php
+++ b/src/Symfony/Component/Config/Loader/LoaderInterface.php
@@ -21,27 +21,21 @@ interface LoaderInterface
     /**
      * Loads a resource.
      *
-     * @return mixed
-     *
      * @throws \Exception If something went wrong
      */
-    public function load(mixed $resource, string $type = null);
+    public function load(mixed $resource, string $type = null): mixed;
 
     /**
      * Returns whether this class supports the given resource.
      *
      * @param mixed $resource A resource
-     *
-     * @return bool
      */
-    public function supports(mixed $resource, string $type = null);
+    public function supports(mixed $resource, string $type = null): bool;
 
     /**
      * Gets the loader resolver.
-     *
-     * @return LoaderResolverInterface
      */
-    public function getResolver();
+    public function getResolver(): LoaderResolverInterface;
 
     /**
      * Sets the loader resolver.

--- a/src/Symfony/Component/Config/ResourceCheckerInterface.php
+++ b/src/Symfony/Component/Config/ResourceCheckerInterface.php
@@ -29,17 +29,13 @@ interface ResourceCheckerInterface
     /**
      * Queries the ResourceChecker whether it can validate a given
      * resource or not.
-     *
-     * @return bool
      */
-    public function supports(ResourceInterface $metadata);
+    public function supports(ResourceInterface $metadata): bool;
 
     /**
      * Validates the resource.
      *
      * @param int $timestamp The timestamp at which the cache associated with this resource was created
-     *
-     * @return bool
      */
-    public function isFresh(ResourceInterface $resource, int $timestamp);
+    public function isFresh(ResourceInterface $resource, int $timestamp): bool;
 }

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -213,7 +213,7 @@ class Application implements ResetInterface
      *
      * @return int 0 if everything went fine, or an error code
      */
-    public function doRun(InputInterface $input, OutputInterface $output)
+    public function doRun(InputInterface $input, OutputInterface $output): int
     {
         if (true === $input->hasParameterOption(['--version', '-V'], true)) {
             $output->writeln($this->getLongVersion());
@@ -420,10 +420,8 @@ class Application implements ResetInterface
 
     /**
      * Returns the long version of the application.
-     *
-     * @return string
      */
-    public function getLongVersion()
+    public function getLongVersion(): string
     {
         if ('UNKNOWN' !== $this->getName()) {
             if ('UNKNOWN' !== $this->getVersion()) {
@@ -463,10 +461,8 @@ class Application implements ResetInterface
      *
      * If a command with the same name already exists, it will be overridden.
      * If the command is not enabled it will not be added.
-     *
-     * @return Command|null
      */
-    public function add(Command $command)
+    public function add(Command $command): ?Command
     {
         $this->init();
 
@@ -499,11 +495,9 @@ class Application implements ResetInterface
     /**
      * Returns a registered command by name or alias.
      *
-     * @return Command
-     *
      * @throws CommandNotFoundException When given command name does not exist
      */
-    public function get(string $name)
+    public function get(string $name): Command
     {
         $this->init();
 
@@ -606,11 +600,9 @@ class Application implements ResetInterface
      * Contrary to get, this command tries to find the best
      * match if you give it an abbreviation of a name or alias.
      *
-     * @return Command
-     *
      * @throws CommandNotFoundException When command name is incorrect or ambiguous
      */
-    public function find(string $name)
+    public function find(string $name): Command
     {
         $this->init();
 
@@ -720,7 +712,7 @@ class Application implements ResetInterface
      *
      * @return Command[]
      */
-    public function all(string $namespace = null)
+    public function all(string $namespace = null): array
     {
         $this->init();
 
@@ -919,7 +911,7 @@ class Application implements ResetInterface
      *
      * @return int 0 if everything went fine, or an error code
      */
-    protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output)
+    protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output): int
     {
         foreach ($command->getHelperSet() as $helper) {
             if ($helper instanceof InputAwareInterface) {

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -165,10 +165,8 @@ class Command
      *
      * Override this to check for x or y and return false if the command can not
      * run properly under the current conditions.
-     *
-     * @return bool
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         return true;
     }
@@ -194,7 +192,7 @@ class Command
      *
      * @see setCode()
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         throw new LogicException('You must override the execute() method in the concrete command class.');
     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
@@ -69,7 +69,7 @@ abstract class AbstractRecursivePass implements CompilerPassInterface
      *
      * @return mixed
      */
-    protected function processValue(mixed $value, bool $isRoot = false)
+    protected function processValue(mixed $value, bool $isRoot = false): mixed
     {
         if (\is_array($value)) {
             foreach ($value as $k => $v) {

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -103,11 +103,9 @@ class Container implements ContainerInterface, ResetInterface
     /**
      * Gets a parameter.
      *
-     * @return array|bool|string|int|float|null
-     *
      * @throws InvalidArgumentException if the parameter is not defined
      */
-    public function getParameter(string $name)
+    public function getParameter(string $name): array|bool|string|int|float|null
     {
         return $this->parameterBag->get($name);
     }

--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -48,11 +48,9 @@ interface ContainerInterface extends PsrContainerInterface
     public function initialized(string $id): bool;
 
     /**
-     * @return array|bool|string|int|float|null
-     *
      * @throws InvalidArgumentException if the parameter is not defined
      */
-    public function getParameter(string $name);
+    public function getParameter(string $name): array|bool|string|int|float|null;
 
     public function hasParameter(string $name): bool;
 

--- a/src/Symfony/Component/DependencyInjection/Extension/ConfigurationExtensionInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/ConfigurationExtensionInterface.php
@@ -23,8 +23,6 @@ interface ConfigurationExtensionInterface
 {
     /**
      * Returns extension configuration.
-     *
-     * @return ConfigurationInterface|null
      */
-    public function getConfiguration(array $config, ContainerBuilder $container);
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface;
 }

--- a/src/Symfony/Component/DependencyInjection/Extension/Extension.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/Extension.php
@@ -31,7 +31,7 @@ abstract class Extension implements ExtensionInterface, ConfigurationExtensionIn
     /**
      * {@inheritdoc}
      */
-    public function getXsdValidationBasePath()
+    public function getXsdValidationBasePath(): string|false
     {
         return false;
     }
@@ -39,7 +39,7 @@ abstract class Extension implements ExtensionInterface, ConfigurationExtensionIn
     /**
      * {@inheritdoc}
      */
-    public function getNamespace()
+    public function getNamespace(): string
     {
         return 'http://example.org/schema/dic/'.$this->getAlias();
     }
@@ -76,7 +76,7 @@ abstract class Extension implements ExtensionInterface, ConfigurationExtensionIn
     /**
      * {@inheritdoc}
      */
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
         $class = static::class;
 

--- a/src/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.php
@@ -29,24 +29,18 @@ interface ExtensionInterface
 
     /**
      * Returns the namespace to be used for this extension (XML namespace).
-     *
-     * @return string
      */
-    public function getNamespace();
+    public function getNamespace(): string;
 
     /**
      * Returns the base path for the XSD files.
-     *
-     * @return string|false
      */
-    public function getXsdValidationBasePath();
+    public function getXsdValidationBasePath(): string|false;
 
     /**
      * Returns the recommended alias to use in XML.
      *
      * This alias is also the mandatory prefix to use when using YAML.
-     *
-     * @return string
      */
-    public function getAlias();
+    public function getAlias(): string;
 }

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/InstantiatorInterface.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/Instantiator/InstantiatorInterface.php
@@ -27,8 +27,6 @@ interface InstantiatorInterface
      *
      * @param string   $id               Identifier of the requested service
      * @param callable $realInstantiator Zero-argument callback that is capable of producing the real service instance
-     *
-     * @return object
      */
-    public function instantiateProxy(ContainerInterface $container, Definition $definition, string $id, callable $realInstantiator);
+    public function instantiateProxy(ContainerInterface $container, Definition $definition, string $id, callable $realInstantiator): object;
 }

--- a/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
@@ -45,5 +45,5 @@ interface EventSubscriberInterface
      *
      * @return array<string, string|array{0: string, 1: int}|list<array{0: string, 1?: int}>>
      */
-    public static function getSubscribedEvents();
+    public static function getSubscribedEvents(): array;
 }

--- a/src/Symfony/Component/ExpressionLanguage/ExpressionFunctionProviderInterface.php
+++ b/src/Symfony/Component/ExpressionLanguage/ExpressionFunctionProviderInterface.php
@@ -19,5 +19,5 @@ interface ExpressionFunctionProviderInterface
     /**
      * @return ExpressionFunction[]
      */
-    public function getFunctions();
+    public function getFunctions(): array;
 }

--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -113,7 +113,7 @@ abstract class AbstractExtension implements FormExtensionInterface
      *
      * @return FormTypeInterface[]
      */
-    protected function loadTypes()
+    protected function loadTypes(): array
     {
         return [];
     }
@@ -130,10 +130,8 @@ abstract class AbstractExtension implements FormExtensionInterface
 
     /**
      * Registers the type guesser.
-     *
-     * @return FormTypeGuesserInterface|null
      */
-    protected function loadTypeGuesser()
+    protected function loadTypeGuesser(): ?FormTypeGuesserInterface
     {
         return null;
     }

--- a/src/Symfony/Component/Form/AbstractRendererEngine.php
+++ b/src/Symfony/Component/Form/AbstractRendererEngine.php
@@ -131,10 +131,8 @@ abstract class AbstractRendererEngine implements FormRendererEngineInterface
      * Loads the cache with the resource for a given block name.
      *
      * @see getResourceForBlock()
-     *
-     * @return bool
      */
-    abstract protected function loadResourceForBlockName(string $cacheKey, FormView $view, string $blockName);
+    abstract protected function loadResourceForBlockName(string $cacheKey, FormView $view, string $blockName): bool;
 
     /**
      * Loads the cache with the resource for a specific level of a block hierarchy.

--- a/src/Symfony/Component/Form/AbstractType.php
+++ b/src/Symfony/Component/Form/AbstractType.php
@@ -51,7 +51,7 @@ abstract class AbstractType implements FormTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return StringUtil::fqcnToBlockPrefix(static::class) ?: '';
     }
@@ -59,7 +59,7 @@ abstract class AbstractType implements FormTypeInterface
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return FormType::class;
     }

--- a/src/Symfony/Component/Form/DataTransformerInterface.php
+++ b/src/Symfony/Component/Form/DataTransformerInterface.php
@@ -55,11 +55,9 @@ interface DataTransformerInterface
      *
      * @param mixed $value The value in the original representation
      *
-     * @return mixed
-     *
      * @throws TransformationFailedException when the transformation fails
      */
-    public function transform(mixed $value);
+    public function transform(mixed $value): mixed;
 
     /**
      * Transforms a value from the transformed representation to its original
@@ -84,9 +82,7 @@ interface DataTransformerInterface
      *
      * @param mixed $value The value in the transformed representation
      *
-     * @return mixed
-     *
      * @throws TransformationFailedException when the transformation fails
      */
-    public function reverseTransform(mixed $value);
+    public function reverseTransform(mixed $value): mixed;
 }

--- a/src/Symfony/Component/Form/FormRendererEngineInterface.php
+++ b/src/Symfony/Component/Form/FormRendererEngineInterface.php
@@ -127,8 +127,6 @@ interface FormRendererEngineInterface
      * @param FormView $view      The view to render
      * @param mixed    $resource  The renderer resource
      * @param array    $variables The variables to pass to the template
-     *
-     * @return string
      */
-    public function renderBlock(FormView $view, mixed $resource, string $blockName, array $variables = []);
+    public function renderBlock(FormView $view, mixed $resource, string $blockName, array $variables = []): string;
 }

--- a/src/Symfony/Component/Form/FormTypeGuesserInterface.php
+++ b/src/Symfony/Component/Form/FormTypeGuesserInterface.php
@@ -18,24 +18,18 @@ interface FormTypeGuesserInterface
 {
     /**
      * Returns a field guess for a property name of a class.
-     *
-     * @return Guess\TypeGuess|null
      */
-    public function guessType(string $class, string $property);
+    public function guessType(string $class, string $property): ?Guess\TypeGuess;
 
     /**
      * Returns a guess whether a property of a class is required.
-     *
-     * @return Guess\ValueGuess|null
      */
-    public function guessRequired(string $class, string $property);
+    public function guessRequired(string $class, string $property): ?Guess\ValueGuess;
 
     /**
      * Returns a guess about the field's maximum length.
-     *
-     * @return Guess\ValueGuess|null
      */
-    public function guessMaxLength(string $class, string $property);
+    public function guessMaxLength(string $class, string $property): ?Guess\ValueGuess;
 
     /**
      * Returns a guess about the field's pattern.
@@ -46,8 +40,6 @@ interface FormTypeGuesserInterface
      *  You want a float greater than 5, 4.512313 is not valid but length(4.512314) > length(5)
      *
      * @see https://github.com/symfony/symfony/pull/3927
-     *
-     * @return Guess\ValueGuess|null
      */
-    public function guessPattern(string $class, string $property);
+    public function guessPattern(string $class, string $property): ?Guess\ValueGuess;
 }

--- a/src/Symfony/Component/Form/FormTypeInterface.php
+++ b/src/Symfony/Component/Form/FormTypeInterface.php
@@ -73,15 +73,11 @@ interface FormTypeInterface
      *
      * The block prefix defaults to the underscored short class name with
      * the "Type" suffix removed (e.g. "UserProfileType" => "user_profile").
-     *
-     * @return string
      */
-    public function getBlockPrefix();
+    public function getBlockPrefix(): string;
 
     /**
      * Returns the name of the parent type.
-     *
-     * @return string|null
      */
-    public function getParent();
+    public function getParent(): ?string;
 }

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerInterface.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerInterface.php
@@ -25,8 +25,6 @@ interface CacheWarmerInterface extends WarmableInterface
      *
      * A warmer should return true if the cache can be
      * generated incrementally and on-demand.
-     *
-     * @return bool
      */
-    public function isOptional();
+    public function isOptional(): bool;
 }

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/WarmableInterface.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/WarmableInterface.php
@@ -23,5 +23,5 @@ interface WarmableInterface
      *
      * @return string[] A list of classes or files to preload on PHP 7.4+
      */
-    public function warmUp(string $cacheDir);
+    public function warmUp(string $cacheDir): array;
 }

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollector.php
@@ -61,7 +61,7 @@ abstract class DataCollector implements DataCollectorInterface
     /**
      * @return callable[] The casters to add to the cloner
      */
-    protected function getCasters()
+    protected function getCasters(): array
     {
         $casters = [
             '*' => function ($v, array $a, Stub $s, $isNested) {

--- a/src/Symfony/Component/HttpKernel/DataCollector/DataCollectorInterface.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/DataCollectorInterface.php
@@ -29,8 +29,6 @@ interface DataCollectorInterface extends ResetInterface
 
     /**
      * Returns the name of the collector.
-     *
-     * @return string
      */
-    public function getName();
+    public function getName(): string;
 }

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -442,10 +442,8 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      *
      * @param bool          $catch Whether to catch exceptions or not
      * @param Response|null $entry A Response instance (the stale entry if present, null otherwise)
-     *
-     * @return Response
      */
-    protected function forward(Request $request, bool $catch = false, Response $entry = null)
+    protected function forward(Request $request, bool $catch = false, Response $entry = null): Response
     {
         if ($this->surrogate) {
             $this->surrogate->addSurrogateCapability($request);

--- a/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelBrowser.php
@@ -57,10 +57,8 @@ class HttpKernelBrowser extends AbstractBrowser
      * {@inheritdoc}
      *
      * @param Request $request
-     *
-     * @return Response
      */
-    protected function doRequest(object $request)
+    protected function doRequest(object $request): Response
     {
         $response = $this->kernel->handle($request, HttpKernelInterface::MAIN_REQUEST, $this->catchExceptions);
 
@@ -75,10 +73,8 @@ class HttpKernelBrowser extends AbstractBrowser
      * {@inheritdoc}
      *
      * @param Request $request
-     *
-     * @return string
      */
-    protected function getScript(object $request)
+    protected function getScript(object $request): string
     {
         $kernel = var_export(serialize($this->kernel), true);
         $request = var_export(serialize($request), true);

--- a/src/Symfony/Component/HttpKernel/Log/DebugLoggerInterface.php
+++ b/src/Symfony/Component/HttpKernel/Log/DebugLoggerInterface.php
@@ -26,17 +26,13 @@ interface DebugLoggerInterface
      * A log is an array with the following mandatory keys:
      * timestamp, message, priority, and priorityName.
      * It can also have an optional context key containing an array.
-     *
-     * @return array
      */
-    public function getLogs(Request $request = null);
+    public function getLogs(Request $request = null): array;
 
     /**
      * Returns the number of errors.
-     *
-     * @return int
      */
-    public function countErrors(Request $request = null);
+    public function countErrors(Request $request = null): int;
 
     /**
      * Removes all log records.

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -483,7 +483,7 @@ class OptionsResolver implements Options
      * @throws UndefinedOptionsException If the option is undefined
      * @throws AccessException           If called from a lazy option or normalizer
      */
-    public function setNormalizer(string $option, \Closure $normalizer)
+    public function setNormalizer(string $option, \Closure $normalizer): static
     {
         if ($this->locked) {
             throw new AccessException('Normalizers cannot be set from a lazy option or normalizer.');
@@ -567,7 +567,7 @@ class OptionsResolver implements Options
      * @throws UndefinedOptionsException If the option is undefined
      * @throws AccessException           If called from a lazy option or normalizer
      */
-    public function setAllowedValues(string $option, mixed $allowedValues)
+    public function setAllowedValues(string $option, mixed $allowedValues): static
     {
         if ($this->locked) {
             throw new AccessException('Allowed values cannot be set from a lazy option or normalizer.');
@@ -607,7 +607,7 @@ class OptionsResolver implements Options
      * @throws UndefinedOptionsException If the option is undefined
      * @throws AccessException           If called from a lazy option or normalizer
      */
-    public function addAllowedValues(string $option, mixed $allowedValues)
+    public function addAllowedValues(string $option, mixed $allowedValues): static
     {
         if ($this->locked) {
             throw new AccessException('Allowed values cannot be added from a lazy option or normalizer.');
@@ -647,7 +647,7 @@ class OptionsResolver implements Options
      * @throws UndefinedOptionsException If the option is undefined
      * @throws AccessException           If called from a lazy option or normalizer
      */
-    public function setAllowedTypes(string $option, string|array $allowedTypes)
+    public function setAllowedTypes(string $option, string|array $allowedTypes): static
     {
         if ($this->locked) {
             throw new AccessException('Allowed types cannot be set from a lazy option or normalizer.');
@@ -681,7 +681,7 @@ class OptionsResolver implements Options
      * @throws UndefinedOptionsException If the option is undefined
      * @throws AccessException           If called from a lazy option or normalizer
      */
-    public function addAllowedTypes(string $option, string|array $allowedTypes)
+    public function addAllowedTypes(string $option, string|array $allowedTypes): static
     {
         if ($this->locked) {
             throw new AccessException('Allowed types cannot be added from a lazy option or normalizer.');

--- a/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathInterface.php
@@ -25,10 +25,8 @@ interface PropertyPathInterface extends \Traversable
 
     /**
      * Returns the length of the property path, i.e. the number of elements.
-     *
-     * @return int
      */
-    public function getLength();
+    public function getLength(): int;
 
     /**
      * Returns the parent property path.
@@ -37,48 +35,38 @@ interface PropertyPathInterface extends \Traversable
      * this one except for the last one.
      *
      * If this property path only contains one item, null is returned.
-     *
-     * @return self|null
      */
-    public function getParent();
+    public function getParent(): ?self;
 
     /**
      * Returns the elements of the property path as array.
-     *
-     * @return array
      */
-    public function getElements();
+    public function getElements(): array;
 
     /**
      * Returns the element at the given index in the property path.
      *
      * @param int $index The index key
      *
-     * @return string
-     *
      * @throws Exception\OutOfBoundsException If the offset is invalid
      */
-    public function getElement(int $index);
+    public function getElement(int $index): string;
 
     /**
      * Returns whether the element at the given index is a property.
      *
      * @param int $index The index in the property path
      *
-     * @return bool
-     *
      * @throws Exception\OutOfBoundsException If the offset is invalid
      */
-    public function isProperty(int $index);
+    public function isProperty(int $index): bool;
 
     /**
      * Returns whether the element at the given index is an array index.
      *
      * @param int $index The index in the property path
      *
-     * @return bool
-     *
      * @throws Exception\OutOfBoundsException If the offset is invalid
      */
-    public function isIndex(int $index);
+    public function isIndex(int $index): bool;
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyAccessExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyAccessExtractorInterface.php
@@ -20,15 +20,11 @@ interface PropertyAccessExtractorInterface
 {
     /**
      * Is the property readable?
-     *
-     * @return bool|null
      */
-    public function isReadable(string $class, string $property, array $context = []);
+    public function isReadable(string $class, string $property, array $context = []): ?bool;
 
     /**
      * Is the property writable?
-     *
-     * @return bool|null
      */
-    public function isWritable(string $class, string $property, array $context = []);
+    public function isWritable(string $class, string $property, array $context = []): ?bool;
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyListExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyListExtractorInterface.php
@@ -23,5 +23,5 @@ interface PropertyListExtractorInterface
      *
      * @return string[]|null
      */
-    public function getProperties(string $class, array $context = []);
+    public function getProperties(string $class, array $context = []): ?array;
 }

--- a/src/Symfony/Component/PropertyInfo/PropertyTypeExtractorInterface.php
+++ b/src/Symfony/Component/PropertyInfo/PropertyTypeExtractorInterface.php
@@ -23,5 +23,5 @@ interface PropertyTypeExtractorInterface
      *
      * @return Type[]|null
      */
-    public function getTypes(string $class, string $property, array $context = []);
+    public function getTypes(string $class, string $property, array $context = []): ?array;
 }

--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -256,10 +256,8 @@ abstract class AnnotationClassLoader implements LoaderInterface
 
     /**
      * Gets the default route name for a class method.
-     *
-     * @return string
      */
-    protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method)
+    protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method): string
     {
         $name = str_replace('\\', '_', $class->name).'_'.$method->name;
         $name = \function_exists('mb_strtolower') && preg_match('//u', $name) ? mb_strtolower($name, 'UTF-8') : strtolower($name);

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -180,7 +180,7 @@ class Router implements RouterInterface, RequestMatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function getRouteCollection()
+    public function getRouteCollection(): RouteCollection
     {
         if (null === $this->collection) {
             $this->collection = $this->loader->load($this->resource, $this->options['resource_type']);

--- a/src/Symfony/Component/Routing/RouterInterface.php
+++ b/src/Symfony/Component/Routing/RouterInterface.php
@@ -28,8 +28,6 @@ interface RouterInterface extends UrlMatcherInterface, UrlGeneratorInterface
      *
      * WARNING: This method should never be used at runtime as it is SLOW.
      *          You might use it in a cache warmer though.
-     *
-     * @return RouteCollection
      */
-    public function getRouteCollection();
+    public function getRouteCollection(): RouteCollection;
 }

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
@@ -23,11 +23,9 @@ interface TokenProviderInterface
     /**
      * Loads the active token for the given series.
      *
-     * @return PersistentTokenInterface
-     *
      * @throws TokenNotFoundException if the token is not found
      */
-    public function loadTokenBySeries(string $series);
+    public function loadTokenBySeries(string $series): PersistentTokenInterface;
 
     /**
      * Deletes all tokens belonging to series.

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
@@ -76,10 +76,8 @@ class AuthenticationException extends RuntimeException
 
     /**
      * Message key to be used by the translation component.
-     *
-     * @return string
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'An authentication exception occurred.';
     }

--- a/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
@@ -29,8 +29,6 @@ use Symfony\Component\Security\Core\Exception\UserNotFoundException;
  *
  * @see UserInterface
  *
- * @method UserInterface loadUserByIdentifier(string $identifier)
- *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 interface UserProviderInterface
@@ -43,19 +41,15 @@ interface UserProviderInterface
      * object can just be merged into some internal array of users / identity
      * map.
      *
-     * @return UserInterface
-     *
      * @throws UnsupportedUserException if the user is not supported
      * @throws UserNotFoundException    if the user is not found
      */
-    public function refreshUser(UserInterface $user);
+    public function refreshUser(UserInterface $user): UserInterface;
 
     /**
      * Whether this provider supports the given user class.
-     *
-     * @return bool
      */
-    public function supportsClass(string $class);
+    public function supportsClass(string $class): bool;
 
     /**
      * Loads the user for the given user identifier (e.g. username or email).

--- a/src/Symfony/Component/Security/Http/EntryPoint/AuthenticationEntryPointInterface.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/AuthenticationEntryPointInterface.php
@@ -39,8 +39,6 @@ interface AuthenticationEntryPointInterface
      * - For an API token authentication system, you return a 401 response
      *
      *     return new Response('Auth header required', 401);
-     *
-     * @return Response
      */
-    public function start(Request $request, AuthenticationException $authException = null);
+    public function start(Request $request, AuthenticationException $authException = null): Response;
 }

--- a/src/Symfony/Component/Security/Http/Firewall.php
+++ b/src/Symfony/Component/Security/Http/Firewall.php
@@ -99,7 +99,7 @@ class Firewall implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => ['onKernelRequest', 8],

--- a/src/Symfony/Component/Security/Http/FirewallMapInterface.php
+++ b/src/Symfony/Component/Security/Http/FirewallMapInterface.php
@@ -35,5 +35,5 @@ interface FirewallMapInterface
      *
      * @return array of the format [[AuthenticationListener], ExceptionListener, LogoutListener]
      */
-    public function getListeners(Request $request);
+    public function getListeners(Request $request): array;
 }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ExceptionListenerTest.php
@@ -75,29 +75,6 @@ class ExceptionListenerTest extends TestCase
     }
 
     /**
-     * This test should be removed in Symfony 7.0 when adding native return types to AuthenticationEntryPointInterface::start().
-     *
-     * @group legacy
-     */
-    public function testExceptionWhenEntryPointReturnsBadValue()
-    {
-        if ((new \ReflectionMethod(AuthenticationEntryPointInterface::class, 'start'))->hasReturnType()) {
-            $this->markTestSkipped('Native return type found');
-        }
-
-        $event = $this->createEvent(new AuthenticationException());
-
-        $entryPoint = $this->createMock(AuthenticationEntryPointInterface::class);
-        $entryPoint->expects($this->once())->method('start')->willReturn('NOT A RESPONSE');
-
-        $listener = $this->createExceptionListener(null, null, null, $entryPoint);
-        $listener->onKernelException($event);
-        // the exception has been replaced by our LogicException
-        $this->assertInstanceOf(\LogicException::class, $event->getThrowable());
-        $this->assertStringEndsWith('start()" method must return a Response object ("string" returned).', $event->getThrowable()->getMessage());
-    }
-
-    /**
      * @dataProvider getAccessDeniedExceptionProvider
      */
     public function testAccessDeniedExceptionFullFledgedAndWithoutAccessDeniedHandlerAndWithoutErrorPage(\Exception $exception, \Exception $eventException = null)

--- a/src/Symfony/Component/Translation/Extractor/AbstractFileExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/AbstractFileExtractor.php
@@ -55,13 +55,7 @@ abstract class AbstractFileExtractor
         return true;
     }
 
-    /**
-     * @return bool
-     */
-    abstract protected function canBeExtracted(string $file);
+    abstract protected function canBeExtracted(string $file): bool;
 
-    /**
-     * @return iterable
-     */
-    abstract protected function extractFromDirectory(string|array $resource);
+    abstract protected function extractFromDirectory(string|array $resource): iterable;
 }

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -230,11 +230,9 @@ abstract class Constraint
      *
      * Override this method to define a default option.
      *
-     * @return string|null
-     *
      * @see __construct()
      */
-    public function getDefaultOption()
+    public function getDefaultOption(): ?string
     {
         return null;
     }
@@ -248,7 +246,7 @@ abstract class Constraint
      *
      * @see __construct()
      */
-    public function getRequiredOptions()
+    public function getRequiredOptions(): array
     {
         return [];
     }
@@ -259,10 +257,8 @@ abstract class Constraint
      * By default, this is the fully qualified name of the constraint class
      * suffixed with "Validator". You can override this method to change that
      * behavior.
-     *
-     * @return string
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return static::class.'Validator';
     }
@@ -276,7 +272,7 @@ abstract class Constraint
      *
      * @return string|string[] One or more constant values
      */
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::PROPERTY_CONSTRAINT;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #40154
| License       | MIT
| Doc PR        | -

This patch is generated by `DebugClassLoader` with a few manual tweaks when tests failed. These tweaks were isolated in #42490 for 5.4 when applicable.

As of now, tests pass for all components in no-deps mode, but for `Security/Http`, `Security/Core` and `SecurityBundle`, mostly because #41613 should be merged first. Tests on `Serializer` don't pass either yet (help welcome.)

As a first step, I'd like we make these no-deps jobs green.

Then we'll be left with cross versions tests (high-deps/low-deps). Because adding return types is a BC break, I expect these cross versions tests to require us to break compatibility between 5.4 and 6.0 components. I anticipate that in some cases, adding all possible return types will hit the community too hard. That's why I think we should review case-by-case before marking a component as incompatible with another. Instead, we could decide to *not* add the corresponding return type. The canonical example of this is `Command::execute()`: I'm not sure adding the native return type in 6.0 is worth the cost it will create. We might better wait for 7.0 to add it.
