### PR TITLE
[Security] Deprecate remaining anonymous checks

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -62,6 +62,30 @@ Security
  * Deprecate `AnonymousToken`, as the related authenticator was deprecated in 5.3
  * Deprecate `Token::getCredentials()`, tokens should no longer contain credentials (as they represent authenticated sessions)
  * Deprecate not returning an `UserInterface` from `Token::getUser()`
+ * Deprecate `AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY` and `AuthenticatedVoter::IS_ANONYMOUS`,
+   use `AuthenticatedVoter::PUBLIC_ACCESS` instead.
+
+   Before:
+   ```yaml
+   # config/packages/security.yaml
+   security:
+       # ...
+       access_control:
+           - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+   ```
+
+   After:
+   ```yaml
+   # config/packages/security.yaml
+   security:
+       # ...
+       access_control:
+           - { path: ^/login, roles: PUBLIC_ACCESS }
+   ```
+
+ * Deprecate `AuthenticationTrustResolverInterface::isAnonymous()` and the `is_anonymous()` expression function
+   as anonymous no longer exists in version 6, use the `isFullFledged()` or the new `isAuthenticated()` instead
+   if you want to check if the request is (fully) authenticated.
  * Deprecate the `$authManager` argument of `AccessListener`, the argument will be removed
  * Deprecate the `$authenticationManager` argument of the `AuthorizationChecker` constructor, the argument will be removed
  * Deprecate setting the `$alwaysAuthenticate` argument to `true` and not setting the

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -210,6 +210,30 @@ Security
  * Remove `AnonymousToken`
  * Remove `Token::getCredentials()`, tokens should no longer contain credentials (as they represent authenticated sessions)
  * Restrict the return type of `Token::getUser()` to `UserInterface` (removing `string|\Stringable`)
+ * Remove `AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY` and `AuthenticatedVoter::IS_ANONYMOUS`,
+   use `AuthenticatedVoter::PUBLIC_ACCESS` instead.
+
+   Before:
+   ```yaml
+   # config/packages/security.yaml
+   security:
+       # ...
+       access_control:
+           - { path: ^/login, roles: IS_AUTHENTICATED_ANONYMOUSLY }
+   ```
+
+   After:
+   ```yaml
+   # config/packages/security.yaml
+   security:
+       # ...
+       access_control:
+           - { path: ^/login, roles: PUBLIC_ACCESS }
+   ```
+
+ * Remove `AuthenticationTrustResolverInterface::isAnonymous()` and the `is_anonymous()` expression function
+   as anonymous no longer exists in version 6, use the `isFullFledged()` or the new `isAuthenticated()` instead
+   if you want to check if the request is (fully) authenticated.
  * Remove the 4th and 5th argument of `AuthorizationChecker`
  * Remove the 5th argument of `AccessListener`
  * Remove class `User`, use `InMemoryUser` or your own implementation instead.

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.4
 ---
 
+ * Deprecate `FirewallConfig::allowsAnonymous()` and the `allows_anonymous` from the data collector data, there will be no anonymous concept as of version 6.
  * Deprecate not setting `$authenticatorManagerEnabled` to `true` in `SecurityDataCollector` and `DebugFirewallCommand`
  * Deprecate `SecurityFactoryInterface` and `SecurityExtension::addSecurityListenerFactory()` in favor of
    `AuthenticatorFactoryInterface` and `SecurityExtension::addAuthenticatorFactory()`

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -184,7 +184,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
             if (null !== $firewallConfig) {
                 $this->data['firewall'] = [
                     'name' => $firewallConfig->getName(),
-                    'allows_anonymous' => $firewallConfig->allowsAnonymous(),
+                    'allows_anonymous' => $this->authenticatorManagerEnabled ? false : $firewallConfig->allowsAnonymous(),
                     'request_matcher' => $firewallConfig->getRequestMatcher(),
                     'security_enabled' => $firewallConfig->isSecurityEnabled(),
                     'stateless' => $firewallConfig->isStateless(),

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
@@ -64,8 +64,13 @@ final class FirewallConfig
         return $this->securityEnabled;
     }
 
+    /**
+     * @deprecated since Symfony 5.4
+     */
     public function allowsAnonymous(): bool
     {
+        trigger_deprecation('symfony/security-bundle', '5.4', 'The "%s()" method is deprecated.', __METHOD__);
+
         return \in_array('anonymous', $this->listeners, true);
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -141,7 +141,6 @@ class SecurityDataCollectorTest extends TestCase
         $collected = $collector->getFirewall();
 
         $this->assertSame($firewallConfig->getName(), $collected['name']);
-        $this->assertSame($firewallConfig->allowsAnonymous(), $collected['allows_anonymous']);
         $this->assertSame($firewallConfig->getRequestMatcher(), $collected['request_matcher']);
         $this->assertSame($firewallConfig->isSecurityEnabled(), $collected['security_enabled']);
         $this->assertSame($firewallConfig->isStateless(), $collected['stateless']);

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/base_config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/base_config.yml
@@ -53,5 +53,5 @@ security:
         - { path: ^/secured-by-one-env-placeholder-and-one-real-ip$, ips: ['%env(APP_IP)%', 198.51.100.0], roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/secured-by-one-env-placeholder-multiple-ips-and-one-real-ip$, ips: ['%env(APP_IPS)%', 198.51.100.0], roles: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/highly_protected_resource$, roles: IS_ADMIN }
-        - { path: ^/protected-via-expression$, allow_if: "(is_anonymous() and request.headers.get('user-agent') matches '/Firefox/i') or is_granted('ROLE_USER')" }
+        - { path: ^/protected-via-expression$, allow_if: "(!is_authenticated() and request.headers.get('user-agent') matches '/Firefox/i') or is_granted('ROLE_USER')" }
         - { path: .*, roles: IS_AUTHENTICATED_FULLY }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallConfigTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallConfigTest.php
@@ -18,7 +18,7 @@ class FirewallConfigTest extends TestCase
 {
     public function testGetters()
     {
-        $listeners = ['logout', 'remember_me', 'anonymous'];
+        $listeners = ['logout', 'remember_me'];
         $options = [
             'request_matcher' => 'foo_request_matcher',
             'security' => false,
@@ -57,7 +57,6 @@ class FirewallConfigTest extends TestCase
         $this->assertSame($options['access_denied_handler'], $config->getAccessDeniedHandler());
         $this->assertSame($options['access_denied_url'], $config->getAccessDeniedUrl());
         $this->assertSame($options['user_checker'], $config->getUserChecker());
-        $this->assertTrue($config->allowsAnonymous());
         $this->assertSame($listeners, $config->getListeners());
         $this->assertSame($options['switch_user'], $config->getSwitchUser());
     }

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolver.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolver.php
@@ -23,11 +23,22 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  */
 class AuthenticationTrustResolver implements AuthenticationTrustResolverInterface
 {
+    public function isAuthenticated(TokenInterface $token = null): bool
+    {
+        return null !== $token && !$token instanceof NullToken
+            // @deprecated since Symfony 5.4, TokenInterface::isAuthenticated() and AnonymousToken no longer exists in 6.0
+            && !$token instanceof AnonymousToken && $token->isAuthenticated(false);
+    }
+
     /**
      * {@inheritdoc}
      */
-    public function isAnonymous(TokenInterface $token = null)
+    public function isAnonymous(TokenInterface $token = null/*, $deprecation = true*/)
     {
+        if (1 === \func_num_args() || false !== func_get_arg(1)) {
+            trigger_deprecation('symfony/security-core', '5.4', 'The "%s()" method is deprecated, use "isAuthenticated()" or "isFullFledged()" if you want to check if the request is (fully) authenticated.', __METHOD__);
+        }
+
         if (null === $token) {
             return false;
         }
@@ -56,6 +67,6 @@ class AuthenticationTrustResolver implements AuthenticationTrustResolverInterfac
             return false;
         }
 
-        return !$this->isAnonymous($token) && !$this->isRememberMe($token);
+        return !$this->isAnonymous($token, false) && !$this->isRememberMe($token);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolverInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolverInterface.php
@@ -17,6 +17,8 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  * Interface for resolving the authentication status of a given token.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @method bool isAuthenticated(TokenInterface $token = null)
  */
 interface AuthenticationTrustResolverInterface
 {
@@ -27,6 +29,8 @@ interface AuthenticationTrustResolverInterface
      * If null is passed, the method must return false.
      *
      * @return bool
+     *
+     * @deprecated since Symfony 5.4, use !isAuthenticated() instead
      */
     public function isAnonymous(TokenInterface $token = null);
 

--- a/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguageProvider.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Core\Authorization;
 
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 
 /**
  * Define some ExpressionLanguage functions.
@@ -25,15 +26,18 @@ class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
     {
         return [
             new ExpressionFunction('is_anonymous', function () {
-                return '$token && $auth_checker->isGranted("IS_ANONYMOUS")';
+                return 'trigger_deprecation("symfony/security-core", "5.4", "The \"is_anonymous()\" expression function is deprecated.") || ($token && $auth_checker->isGranted("IS_ANONYMOUS"))';
             }, function (array $variables) {
+                trigger_deprecation('symfony/security-core', '5.4', 'The "is_anonymous()" expression function is deprecated.');
+
                 return $variables['token'] && $variables['auth_checker']->isGranted('IS_ANONYMOUS');
             }),
 
+            // @deprecated remove the ternary and always use IS_AUTHENTICATED in 6.0
             new ExpressionFunction('is_authenticated', function () {
-                return '$token && !$auth_checker->isGranted("IS_ANONYMOUS")';
+                return 'defined("'.AuthenticatedVoter::class.'::IS_AUTHENTICATED") ? $auth_checker->isGranted("IS_AUTHENTICATED") : ($token && !$auth_checker->isGranted("IS_ANONYMOUS"))';
             }, function (array $variables) {
-                return $variables['token'] && !$variables['auth_checker']->isGranted('IS_ANONYMOUS');
+                return \defined(AuthenticatedVoter::class.'::IS_AUTHENTICATED') ? $variables['auth_checker']->isGranted('IS_AUTHENTICATED') : ($variables['token'] && !$variables['auth_checker']->isGranted('IS_ANONYMOUS'));
             }),
 
             new ExpressionFunction('is_fully_authenticated', function () {

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -7,6 +7,11 @@ CHANGELOG
  * Deprecate `AnonymousToken`, as the related authenticator was deprecated in 5.3
  * Deprecate `Token::getCredentials()`, tokens should no longer contain credentials (as they represent authenticated sessions)
  * Deprecate returning `string|\Stringable` from `Token::getUser()` (it must return a `UserInterface`)
+ * Deprecate `AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY` and `AuthenticatedVoter::IS_ANONYMOUS`,
+   use `AuthenticatedVoter::IS_AUTHENTICATED_FULLY` or `AuthenticatedVoter::IS_AUTHENTICATED` instead.
+ * Deprecate `AuthenticationTrustResolverInterface::isAnonymous()` and the `is_anonymous()` expression
+   function as anonymous no longer exists in version 6, use the `isFullFledged()` or the new
+   `isAuthenticated()` instead if you want to check if the request is (fully) authenticated.
  * Deprecate the `$authenticationManager` argument of the `AuthorizationChecker` constructor
  * Deprecate setting the `$alwaysAuthenticate` argument to `true` and not setting the
    `$exceptionOnNoToken` argument to `false` of `AuthorizationChecker`

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/ExpressionLanguageTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/ExpressionLanguageTest.php
@@ -28,7 +28,6 @@ class ExpressionLanguageTest extends TestCase
 {
     /**
      * @dataProvider provider
-     * @dataProvider legacyProvider
      */
     public function testIsAuthenticated($token, $expression, $result)
     {
@@ -56,19 +55,16 @@ class ExpressionLanguageTest extends TestCase
         $usernamePasswordToken = new UsernamePasswordToken($user, 'firewall-name', $roles);
 
         return [
-            [$noToken, 'is_anonymous()', false],
             [$noToken, 'is_authenticated()', false],
             [$noToken, 'is_fully_authenticated()', false],
             [$noToken, 'is_remember_me()', false],
 
-            [$rememberMeToken, 'is_anonymous()', false],
             [$rememberMeToken, 'is_authenticated()', true],
             [$rememberMeToken, 'is_fully_authenticated()', false],
             [$rememberMeToken, 'is_remember_me()', true],
             [$rememberMeToken, "is_granted('ROLE_FOO')", false],
             [$rememberMeToken, "is_granted('ROLE_USER')", true],
 
-            [$usernamePasswordToken, 'is_anonymous()', false],
             [$usernamePasswordToken, 'is_authenticated()', true],
             [$usernamePasswordToken, 'is_fully_authenticated()', true],
             [$usernamePasswordToken, 'is_remember_me()', false],
@@ -78,10 +74,21 @@ class ExpressionLanguageTest extends TestCase
     }
 
     /**
+     * @dataProvider legacyProvider
+     * @group legacy
+     */
+    public function testLegacyIsAuthenticated($token, $expression, $result)
+    {
+        $this->testIsAuthenticated($token, $expression, $result);
+    }
+
+    /**
      * @group legacy
      */
     public function legacyProvider()
     {
+        $roles = ['ROLE_USER', 'ROLE_ADMIN'];
+        $user = new InMemoryUser('username', 'password', $roles);
         $anonymousToken = new AnonymousToken('firewall', 'anon.');
 
         return [
@@ -90,6 +97,10 @@ class ExpressionLanguageTest extends TestCase
             [$anonymousToken, 'is_fully_authenticated()', false],
             [$anonymousToken, 'is_remember_me()', false],
             [$anonymousToken, "is_granted('ROLE_USER')", false],
+
+            [null, 'is_anonymous()', false],
+            [new RememberMeToken($user, 'firewall-name', 'firewall'), 'is_anonymous()', false],
+            [new UsernamePasswordToken($user, 'firewall-name', $roles), 'is_anonymous()', false],
         ];
     }
 }

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
@@ -40,17 +40,11 @@ class AuthenticatedVoterTest extends TestCase
             ['remembered', [], VoterInterface::ACCESS_ABSTAIN],
             ['remembered', ['FOO'], VoterInterface::ACCESS_ABSTAIN],
 
-            ['fully', ['IS_AUTHENTICATED_ANONYMOUSLY'], VoterInterface::ACCESS_GRANTED],
-            ['remembered', ['IS_AUTHENTICATED_ANONYMOUSLY'], VoterInterface::ACCESS_GRANTED],
-
             ['fully', ['IS_AUTHENTICATED_REMEMBERED'], VoterInterface::ACCESS_GRANTED],
             ['remembered', ['IS_AUTHENTICATED_REMEMBERED'], VoterInterface::ACCESS_GRANTED],
 
             ['fully', ['IS_AUTHENTICATED_FULLY'], VoterInterface::ACCESS_GRANTED],
             ['remembered', ['IS_AUTHENTICATED_FULLY'], VoterInterface::ACCESS_DENIED],
-
-            ['fully', ['IS_ANONYMOUS'], VoterInterface::ACCESS_DENIED],
-            ['remembered', ['IS_ANONYMOUS'], VoterInterface::ACCESS_DENIED],
 
             ['fully', ['IS_IMPERSONATOR'], VoterInterface::ACCESS_DENIED],
             ['remembered', ['IS_IMPERSONATOR'], VoterInterface::ACCESS_DENIED],
@@ -77,6 +71,14 @@ class AuthenticatedVoterTest extends TestCase
             ['anonymously', ['IS_AUTHENTICATED_FULLY'], VoterInterface::ACCESS_DENIED],
             ['anonymously', ['IS_ANONYMOUS'], VoterInterface::ACCESS_GRANTED],
             ['anonymously', ['IS_IMPERSONATOR'], VoterInterface::ACCESS_DENIED],
+
+            ['fully', ['IS_ANONYMOUS'], VoterInterface::ACCESS_DENIED],
+            ['remembered', ['IS_ANONYMOUS'], VoterInterface::ACCESS_DENIED],
+            ['anonymously', ['IS_ANONYMOUS'], VoterInterface::ACCESS_GRANTED],
+
+            ['fully', ['IS_AUTHENTICATED_ANONYMOUSLY'], VoterInterface::ACCESS_GRANTED],
+            ['remembered', ['IS_AUTHENTICATED_ANONYMOUSLY'], VoterInterface::ACCESS_GRANTED],
+            ['anonymously', ['IS_AUTHENTICATED_ANONYMOUSLY'], VoterInterface::ACCESS_GRANTED],
         ];
     }
 

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -187,7 +187,9 @@ class ContextListener extends AbstractListener
         $usageIndexValue = $session instanceof Session ? $usageIndexReference = &$session->getUsageIndex() : null;
         $token = $this->tokenStorage->getToken();
 
-        if (null === $token || $this->trustResolver->isAnonymous($token)) {
+        // @deprecated always use isAuthenticated() in 6.0
+        $notAuthenticated = method_exists($this->trustResolver, 'isAuthenticated') ? !$this->trustResolver->isAuthenticated($token) : (null === $token || $this->trustResolver->isAnonymous($token));
+        if ($notAuthenticated) {
             if ($request->hasPreviousSession()) {
                 $session->remove($this->sessionKey);
             }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -63,7 +63,7 @@ class ContextListenerTest extends TestCase
     public function testOnKernelResponseWillAddSession()
     {
         $session = $this->runSessionOnKernelResponse(
-            new UsernamePasswordToken(new InMemoryUser('test1', 'pass1'), 'phpunit'),
+            new UsernamePasswordToken(new InMemoryUser('test1', 'pass1'), 'phpunit', ['ROLE_USER']),
             null
         );
 
@@ -75,7 +75,7 @@ class ContextListenerTest extends TestCase
     public function testOnKernelResponseWillReplaceSession()
     {
         $session = $this->runSessionOnKernelResponse(
-            new UsernamePasswordToken(new InMemoryUser('test1', 'pass1'), 'phpunit'),
+            new UsernamePasswordToken(new InMemoryUser('test1', 'pass1'), 'phpunit', ['ROLE_USER']),
             'C:10:"serialized"'
         );
 
@@ -107,7 +107,7 @@ class ContextListenerTest extends TestCase
     public function testOnKernelResponseWithoutSession()
     {
         $tokenStorage = new TokenStorage();
-        $tokenStorage->setToken(new UsernamePasswordToken(new InMemoryUser('test1', 'pass1'), 'phpunit'));
+        $tokenStorage->setToken(new UsernamePasswordToken(new InMemoryUser('test1', 'pass1'), 'phpunit', ['ROLE_USER']));
         $request = new Request();
         $request->attributes->set('_security_firewall_run', '_security_session');
         $session = new Session(new MockArraySessionStorage());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Ref #41613
| License       | MIT
| Doc PR        | tbd

Deprecates the remaining checks for anonymous found in #41613.  It's WIP because the tests are failing until #42423 is merged and this PR is rebased (didn't update one test to avoid merge conflicts).

Besides this, it also introduced `IS_AUTHENTICATED` and `AuthenticationTrustResolver::isAutenticated()`. Previously, `IS_AUTHENTICATED_ANONYMOUSLY` was considered to be the "bottom type" for authenticated requests. As this is no longer true, `IS_AUTHENTICATED_REMEMBERME` is now the new "bottom type". I suggest we use an explicit bottom type (the ones introduced) instead to avoid another such update if we change something with remember me. It's also more clear on the exact intent of the check.