### PR TITLE
[Security] add return types

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CacheWarmer/ExpressionCacheWarmer.php
+++ b/src/Symfony/Bundle/SecurityBundle/CacheWarmer/ExpressionCacheWarmer.php
@@ -29,7 +29,7 @@ class ExpressionCacheWarmer implements CacheWarmerInterface
         $this->expressionLanguage = $expressionLanguage;
     }
 
-    public function isOptional()
+    public function isOptional(): bool
     {
         return true;
     }
@@ -37,7 +37,7 @@ class ExpressionCacheWarmer implements CacheWarmerInterface
     /**
      * @return string[]
      */
-    public function warmUp(string $cacheDir)
+    public function warmUp(string $cacheDir): array
     {
         foreach ($this->expressions as $expression) {
             $this->expressionLanguage->parse($expression, ['token', 'user', 'object', 'subject', 'role_names', 'request', 'trust_resolver']);

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -230,20 +230,16 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
 
     /**
      * Gets the roles of the user.
-     *
-     * @return array|Data
      */
-    public function getRoles()
+    public function getRoles(): array|Data
     {
         return $this->data['roles'];
     }
 
     /**
      * Gets the inherited roles of the user.
-     *
-     * @return array|Data
      */
-    public function getInheritedRoles()
+    public function getInheritedRoles(): array|Data
     {
         return $this->data['inherited_roles'];
     }
@@ -282,10 +278,8 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
 
     /**
      * Get the class name of the security token.
-     *
-     * @return string|Data|null
      */
-    public function getTokenClass()
+    public function getTokenClass(): string|Data|null
     {
         return $this->data['token_class'];
     }
@@ -305,7 +299,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
      *
      * @return string[]|Data
      */
-    public function getVoters()
+    public function getVoters(): array|Data
     {
         return $this->data['voters'];
     }
@@ -317,28 +311,21 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
 
     /**
      * Returns the log of the security decisions made by the access decision manager.
-     *
-     * @return array|Data
      */
-    public function getAccessDecisionLog()
+    public function getAccessDecisionLog(): array|Data
     {
         return $this->data['access_decision_log'];
     }
 
     /**
      * Returns the configuration of the current firewall context.
-     *
-     * @return array|Data|null
      */
-    public function getFirewall()
+    public function getFirewall(): array|Data|null
     {
         return $this->data['firewall'];
     }
 
-    /**
-     * @return array|Data
-     */
-    public function getListeners()
+    public function getListeners(): array|Data
     {
         return $this->data['listeners'];
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -42,10 +42,8 @@ class MainConfiguration implements ConfigurationInterface
 
     /**
      * Generates the configuration tree builder.
-     *
-     * @return TreeBuilder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $tb = new TreeBuilder('security');
         $rootNode = $tb->getRootNode();

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -48,7 +48,7 @@ abstract class AbstractFactory implements AuthenticatorFactoryInterface
         'failure_path_parameter' => '_failure_path',
     ];
 
-    final public function addOption(string $name, mixed $default = null)
+    final public function addOption(string $name, mixed $default = null): void
     {
         $this->options[$name] = $default;
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AuthenticatorFactoryInterface.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AuthenticatorFactoryInterface.php
@@ -27,10 +27,8 @@ interface AuthenticatorFactoryInterface
     /**
      * Defines the configuration key used to reference the provider
      * in the firewall configuration.
-     *
-     * @return string
      */
-    public function getKey();
+    public function getKey(): string;
 
     public function addConfiguration(NodeDefinition $builder);
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -15,6 +15,7 @@ use Symfony\Bridge\Twig\Extension\LogoutUrlExtension;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FirewallListenerFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Application;
@@ -847,17 +848,17 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
     /**
      * {@inheritdoc}
      */
-    public function getXsdValidationBasePath()
+    public function getXsdValidationBasePath(): string|false
     {
         return __DIR__.'/../Resources/config/schema';
     }
 
-    public function getNamespace()
+    public function getNamespace(): string
     {
         return 'http://symfony.com/schema/dic/security';
     }
 
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
     {
         // first assemble the factories
         return new MainConfiguration($this->getSortedFactories(), $this->userProviderFactories);

--- a/src/Symfony/Bundle/SecurityBundle/EventListener/FirewallListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/EventListener/FirewallListener.php
@@ -59,7 +59,7 @@ class FirewallListener extends Firewall
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => [

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -33,7 +33,7 @@ class FirewallMap implements FirewallMapInterface
         $this->map = $map;
     }
 
-    public function getListeners(Request $request)
+    public function getListeners(Request $request): array
     {
         $context = $this->getFirewallContext($request);
 
@@ -44,10 +44,7 @@ class FirewallMap implements FirewallMapInterface
         return [$context->getListeners(), $context->getExceptionListener(), $context->getLogoutListener()];
     }
 
-    /**
-     * @return FirewallConfig|null
-     */
-    public function getFirewallConfig(Request $request)
+    public function getFirewallConfig(Request $request): ?FirewallConfig
     {
         $context = $this->getFirewallContext($request);
 

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolver.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolver.php
@@ -29,7 +29,7 @@ class AuthenticationTrustResolver implements AuthenticationTrustResolverInterfac
     /**
      * {@inheritdoc}
      */
-    public function isRememberMe(TokenInterface $token = null)
+    public function isRememberMe(TokenInterface $token = null): bool
     {
         return $token && $token instanceof RememberMeToken;
     }
@@ -37,7 +37,7 @@ class AuthenticationTrustResolver implements AuthenticationTrustResolverInterfac
     /**
      * {@inheritdoc}
      */
-    public function isFullFledged(TokenInterface $token = null)
+    public function isFullFledged(TokenInterface $token = null): bool
     {
         return $this->isAuthenticated($token) && !$this->isRememberMe($token);
     }

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/InMemoryTokenProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/InMemoryTokenProvider.php
@@ -25,7 +25,7 @@ class InMemoryTokenProvider implements TokenProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function loadTokenBySeries(string $series)
+    public function loadTokenBySeries(string $series): PersistentTokenInterface
     {
         if (!isset($this->tokens[$series])) {
             throw new TokenNotFoundException('No token found.');

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentTokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/PersistentTokenInterface.php
@@ -21,31 +21,23 @@ interface PersistentTokenInterface
 {
     /**
      * Returns the class of the user.
-     *
-     * @return string
      */
-    public function getClass();
+    public function getClass(): string;
 
     /**
      * Returns the series.
-     *
-     * @return string
      */
-    public function getSeries();
+    public function getSeries(): string;
 
     /**
      * Returns the token value.
-     *
-     * @return string
      */
-    public function getTokenValue();
+    public function getTokenValue(): string;
 
     /**
      * Returns the time the token was last used.
-     *
-     * @return \DateTime
      */
-    public function getLastUsed();
+    public function getLastUsed(): \DateTime;
 
     /**
      * Returns the identifier used to authenticate (e.g. their email address or username).

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -11,9 +11,6 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Token;
 
-use Symfony\Component\Security\Core\User\EquatableInterface;
-use Symfony\Component\Security\Core\User\LegacyPasswordAuthenticatedUserInterface;
-use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
@@ -56,7 +53,7 @@ abstract class AbstractToken implements TokenInterface, \Serializable
     /**
      * {@inheritdoc}
      */
-    public function getUser()
+    public function getUser(): ?UserInterface
     {
         return $this->user;
     }
@@ -123,7 +120,7 @@ abstract class AbstractToken implements TokenInterface, \Serializable
     /**
      * {@inheritdoc}
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->attributes;
     }
@@ -139,7 +136,7 @@ abstract class AbstractToken implements TokenInterface, \Serializable
     /**
      * {@inheritdoc}
      */
-    public function hasAttribute(string $name)
+    public function hasAttribute(string $name): bool
     {
         return \array_key_exists($name, $this->attributes);
     }
@@ -147,7 +144,7 @@ abstract class AbstractToken implements TokenInterface, \Serializable
     /**
      * {@inheritdoc}
      */
-    public function getAttribute(string $name)
+    public function getAttribute(string $name): mixed
     {
         if (!\array_key_exists($name, $this->attributes)) {
             throw new \InvalidArgumentException(sprintf('This token has no "%s" attribute.', $name));

--- a/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
@@ -28,7 +28,7 @@ class NullToken implements TokenInterface
         return [];
     }
 
-    public function getUser()
+    public function getUser(): ?UserInterface
     {
         return null;
     }
@@ -47,7 +47,7 @@ class NullToken implements TokenInterface
     {
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return [];
     }
@@ -57,12 +57,12 @@ class NullToken implements TokenInterface
         throw new \BadMethodCallException('Cannot set attributes of NullToken.');
     }
 
-    public function hasAttribute(string $name)
+    public function hasAttribute(string $name): bool
     {
         return false;
     }
 
-    public function getAttribute(string $name)
+    public function getAttribute(string $name): mixed
     {
         return null;
     }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/RememberMeToken.php
@@ -51,10 +51,7 @@ class RememberMeToken extends AbstractToken
         return $this->firewallName;
     }
 
-    /**
-     * @return string
-     */
-    public function getSecret()
+    public function getSecret(): string
     {
         return $this->secret;
     }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorage.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorage.php
@@ -30,7 +30,7 @@ class TokenStorage implements TokenStorageInterface, ResetInterface
     /**
      * {@inheritdoc}
      */
-    public function getToken()
+    public function getToken(): ?TokenInterface
     {
         if ($initializer = $this->initializer) {
             $this->initializer = null;

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorageInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Storage/TokenStorageInterface.php
@@ -22,10 +22,8 @@ interface TokenStorageInterface
 {
     /**
      * Returns the current security token.
-     *
-     * @return TokenInterface|null
      */
-    public function getToken();
+    public function getToken(): ?TokenInterface;
 
     /**
      * Sets the authentication token.

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -40,11 +40,9 @@ interface TokenInterface
     /**
      * Returns a user representation.
      *
-     * @return UserInterface|null
-     *
      * @see AbstractToken::setUser()
      */
-    public function getUser();
+    public function getUser(): ?UserInterface;
 
     /**
      * Sets the authenticated user in the token.
@@ -58,27 +56,19 @@ interface TokenInterface
      */
     public function eraseCredentials();
 
-    /**
-     * @return array
-     */
-    public function getAttributes();
+    public function getAttributes(): array;
 
     /**
      * @param array $attributes The token attributes
      */
     public function setAttributes(array $attributes);
 
-    /**
-     * @return bool
-     */
-    public function hasAttribute(string $name);
+    public function hasAttribute(string $name): bool;
 
     /**
-     * @return mixed
-     *
      * @throws \InvalidArgumentException When attribute doesn't exist for this token
      */
-    public function getAttribute(string $name);
+    public function getAttribute(string $name): mixed;
 
     public function setAttribute(string $name, mixed $value);
 

--- a/src/Symfony/Component/Security/Core/AuthenticationEvents.php
+++ b/src/Symfony/Component/Security/Core/AuthenticationEvents.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Core;
 
-use Symfony\Component\Security\Core\Event\AuthenticationFailureEvent;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
 
 final class AuthenticationEvents

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -59,7 +59,7 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
      *
      * {@inheritdoc}
      */
-    public function decide(TokenInterface $token, array $attributes, mixed $object = null, bool $allowMultipleAttributes = false)
+    public function decide(TokenInterface $token, array $attributes, mixed $object = null, bool $allowMultipleAttributes = false): bool
     {
         // Special case for AccessListener, do not remove the right side of the condition before 6.0
         if (\count($attributes) > 1 && !$allowMultipleAttributes) {

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
@@ -25,8 +25,6 @@ interface AccessDecisionManagerInterface
      *
      * @param array $attributes An array of attributes associated with the method being invoked
      * @param mixed $object     The object to secure
-     *
-     * @return bool
      */
-    public function decide(TokenInterface $token, array $attributes, mixed $object = null);
+    public function decide(TokenInterface $token, array $attributes, mixed $object = null): bool;
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Security\Core\Authorization;
 
-use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationCheckerInterface.php
@@ -22,8 +22,6 @@ interface AuthorizationCheckerInterface
      * Checks if the attribute is granted against the current authentication token and optionally supplied subject.
      *
      * @param mixed $attribute A single attribute to vote on (can be of any type, string and instance of Expression are supported by the core)
-     *
-     * @return bool
      */
-    public function isGranted(mixed $attribute, mixed $subject = null);
+    public function isGranted(mixed $attribute, mixed $subject = null): bool;
 }

--- a/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguageProvider.php
+++ b/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguageProvider.php
@@ -21,7 +21,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
  */
 class ExpressionLanguageProvider implements ExpressionFunctionProviderInterface
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new ExpressionFunction('is_authenticated', function () {

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
@@ -43,7 +43,7 @@ class AuthenticatedVoter implements VoterInterface
     /**
      * {@inheritdoc}
      */
-    public function vote(TokenInterface $token, mixed $subject, array $attributes)
+    public function vote(TokenInterface $token, mixed $subject, array $attributes): int
     {
         if ($attributes === [self::PUBLIC_ACCESS]) {
             return VoterInterface::ACCESS_GRANTED;

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/ExpressionVoter.php
@@ -42,7 +42,7 @@ class ExpressionVoter implements VoterInterface
     /**
      * {@inheritdoc}
      */
-    public function vote(TokenInterface $token, mixed $subject, array $attributes)
+    public function vote(TokenInterface $token, mixed $subject, array $attributes): int
     {
         $result = VoterInterface::ACCESS_ABSTAIN;
         $variables = null;

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
@@ -30,7 +30,7 @@ class RoleVoter implements VoterInterface
     /**
      * {@inheritdoc}
      */
-    public function vote(TokenInterface $token, mixed $subject, array $attributes)
+    public function vote(TokenInterface $token, mixed $subject, array $attributes): int
     {
         $result = VoterInterface::ACCESS_ABSTAIN;
         $roles = $this->extractRoles($token);

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/Voter.php
@@ -24,7 +24,7 @@ abstract class Voter implements VoterInterface
     /**
      * {@inheritdoc}
      */
-    public function vote(TokenInterface $token, mixed $subject, array $attributes)
+    public function vote(TokenInterface $token, mixed $subject, array $attributes): int
     {
         // abstain vote by default in case none of the attributes are supported
         $vote = self::ACCESS_ABSTAIN;
@@ -58,16 +58,12 @@ abstract class Voter implements VoterInterface
      * Determines if the attribute and subject are supported by this voter.
      *
      * @param $subject The subject to secure, e.g. an object the user wants to access or any other PHP type
-     *
-     * @return bool
      */
-    abstract protected function supports(string $attribute, mixed $subject);
+    abstract protected function supports(string $attribute, mixed $subject): bool;
 
     /**
      * Perform a single access check operation on a given attribute, subject and token.
      * It is safe to assume that $attribute and $subject already passed the "supports()" method check.
-     *
-     * @return bool
      */
-    abstract protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token);
+    abstract protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool;
 }

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
@@ -35,5 +35,5 @@ interface VoterInterface
      *
      * @return int either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
      */
-    public function vote(TokenInterface $token, mixed $subject, array $attributes);
+    public function vote(TokenInterface $token, mixed $subject, array $attributes): int;
 }

--- a/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccessDeniedException.php
@@ -26,10 +26,7 @@ class AccessDeniedException extends RuntimeException
         parent::__construct($message, 403, $previous);
     }
 
-    /**
-     * @return array
-     */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->attributes;
     }
@@ -39,10 +36,7 @@ class AccessDeniedException extends RuntimeException
         $this->attributes = (array) $attributes;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getSubject()
+    public function getSubject(): mixed
     {
         return $this->subject;
     }

--- a/src/Symfony/Component/Security/Core/Exception/AccountExpiredException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountExpiredException.php
@@ -22,7 +22,7 @@ class AccountExpiredException extends AccountStatusException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Account has expired.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
@@ -26,10 +26,8 @@ abstract class AccountStatusException extends AuthenticationException
 
     /**
      * Get the user.
-     *
-     * @return UserInterface
      */
-    public function getUser()
+    public function getUser(): UserInterface
     {
         return $this->user;
     }

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationCredentialsNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationCredentialsNotFoundException.php
@@ -23,7 +23,7 @@ class AuthenticationCredentialsNotFoundException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Authentication credentials could not be found.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
@@ -23,10 +23,7 @@ class AuthenticationException extends RuntimeException
 {
     private $token;
 
-    /**
-     * @return TokenInterface|null
-     */
-    public function getToken()
+    public function getToken(): ?TokenInterface
     {
         return $this->token;
     }
@@ -89,10 +86,8 @@ class AuthenticationException extends RuntimeException
 
     /**
      * Message data to be used by the translation component.
-     *
-     * @return array
      */
-    public function getMessageData()
+    public function getMessageData(): array
     {
         return [];
     }

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationExpiredException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationExpiredException.php
@@ -24,7 +24,7 @@ class AuthenticationExpiredException extends AccountStatusException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Authentication expired because your account information has changed.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationServiceException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationServiceException.php
@@ -22,7 +22,7 @@ class AuthenticationServiceException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Authentication request could not be processed due to a system problem.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/BadCredentialsException.php
+++ b/src/Symfony/Component/Security/Core/Exception/BadCredentialsException.php
@@ -22,7 +22,7 @@ class BadCredentialsException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Invalid credentials.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/CookieTheftException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CookieTheftException.php
@@ -23,7 +23,7 @@ class CookieTheftException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Cookie has already been used by someone else.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/CredentialsExpiredException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CredentialsExpiredException.php
@@ -22,7 +22,7 @@ class CredentialsExpiredException extends AccountStatusException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Credentials have expired.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAccountStatusException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAccountStatusException.php
@@ -46,12 +46,12 @@ class CustomUserMessageAccountStatusException extends AccountStatusException
         $this->messageData = $messageData;
     }
 
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return $this->messageKey;
     }
 
-    public function getMessageData()
+    public function getMessageData(): array
     {
         return $this->messageData;
     }

--- a/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CustomUserMessageAuthenticationException.php
@@ -45,12 +45,12 @@ class CustomUserMessageAuthenticationException extends AuthenticationException
         $this->messageData = $messageData;
     }
 
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return $this->messageKey;
     }
 
-    public function getMessageData()
+    public function getMessageData(): array
     {
         return $this->messageData;
     }

--- a/src/Symfony/Component/Security/Core/Exception/DisabledException.php
+++ b/src/Symfony/Component/Security/Core/Exception/DisabledException.php
@@ -22,7 +22,7 @@ class DisabledException extends AccountStatusException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Account is disabled.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/InsufficientAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/InsufficientAuthenticationException.php
@@ -24,7 +24,7 @@ class InsufficientAuthenticationException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Not privileged to request the resource.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/InvalidCsrfTokenException.php
+++ b/src/Symfony/Component/Security/Core/Exception/InvalidCsrfTokenException.php
@@ -22,7 +22,7 @@ class InvalidCsrfTokenException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Invalid CSRF token.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/LockedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/LockedException.php
@@ -22,7 +22,7 @@ class LockedException extends AccountStatusException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Account is locked.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/ProviderNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/ProviderNotFoundException.php
@@ -23,7 +23,7 @@ class ProviderNotFoundException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'No authentication provider found to support the authentication token.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/SessionUnavailableException.php
+++ b/src/Symfony/Component/Security/Core/Exception/SessionUnavailableException.php
@@ -28,7 +28,7 @@ class SessionUnavailableException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'No session available, it either timed out or cookies are not enabled.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/TokenNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/TokenNotFoundException.php
@@ -22,7 +22,7 @@ class TokenNotFoundException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'No token could be found.';
     }

--- a/src/Symfony/Component/Security/Core/Exception/UserNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UserNotFoundException.php
@@ -24,7 +24,7 @@ class UserNotFoundException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Username could not be found.';
     }
@@ -48,7 +48,7 @@ class UserNotFoundException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageData()
+    public function getMessageData(): array
     {
         return ['{{ username }}' => $this->identifier, '{{ user_identifier }}' => $this->identifier];
     }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/Token/SwitchUserTokenTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/Token/SwitchUserTokenTest.php
@@ -16,7 +16,6 @@ use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Tests\Authentication\Token\Fixtures\CustomUser;
 use Symfony\Component\Security\Core\User\InMemoryUser;
-use Symfony\Component\Security\Core\User\UserInterface;
 
 class SwitchUserTokenTest extends TestCase
 {

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/AuthorizationCheckerTest.php
@@ -12,13 +12,11 @@
 namespace Symfony\Component\Security\Core\Tests\Authorization;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
-use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 
 class AuthorizationCheckerTest extends TestCase

--- a/src/Symfony/Component/Security/Core/Tests/Exception/UserNotFoundExceptionTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Exception/UserNotFoundExceptionTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Core\Tests\Exception;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 
 class UserNotFoundExceptionTest extends TestCase

--- a/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserProviderTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserProviderTest.php
@@ -16,7 +16,6 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
-use Symfony\Component\Security\Core\User\User;
 
 class InMemoryUserProviderTest extends TestCase
 {

--- a/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/User/InMemoryUserTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Security\Core\Tests\User;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
-use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserInterface;
 

--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -34,10 +34,7 @@ class ChainUserProvider implements UserProviderInterface, PasswordUpgraderInterf
         $this->providers = $providers;
     }
 
-    /**
-     * @return array
-     */
-    public function getProviders()
+    public function getProviders(): array
     {
         if ($this->providers instanceof \Traversable) {
             return iterator_to_array($this->providers);
@@ -49,7 +46,7 @@ class ChainUserProvider implements UserProviderInterface, PasswordUpgraderInterf
     /**
      * @internal for compatibility with Symfony 5.4
      */
-    public function loadUserByUsername(string $username)
+    public function loadUserByUsername(string $username): UserInterface
     {
         return $this->loadUserByIdentifier($username);
     }
@@ -72,7 +69,7 @@ class ChainUserProvider implements UserProviderInterface, PasswordUpgraderInterf
     /**
      * {@inheritdoc}
      */
-    public function refreshUser(UserInterface $user)
+    public function refreshUser(UserInterface $user): UserInterface
     {
         $supportedUserFound = false;
 
@@ -104,7 +101,7 @@ class ChainUserProvider implements UserProviderInterface, PasswordUpgraderInterf
     /**
      * {@inheritdoc}
      */
-    public function supportsClass(string $class)
+    public function supportsClass(string $class): bool
     {
         foreach ($this->providers as $provider) {
             if ($provider->supportsClass($class)) {

--- a/src/Symfony/Component/Security/Core/User/EquatableInterface.php
+++ b/src/Symfony/Component/Security/Core/User/EquatableInterface.php
@@ -25,8 +25,6 @@ interface EquatableInterface
      *
      * However, you do not need to compare every attribute, but only those that
      * are relevant for assessing whether re-authentication is required.
-     *
-     * @return bool
      */
-    public function isEqualTo(UserInterface $user);
+    public function isEqualTo(UserInterface $user): bool;
 }

--- a/src/Symfony/Component/Security/Core/User/InMemoryUserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUserChecker.php
@@ -11,10 +11,7 @@
 
 namespace Symfony\Component\Security\Core\User;
 
-use Symfony\Component\Security\Core\Exception\AccountExpiredException;
-use Symfony\Component\Security\Core\Exception\CredentialsExpiredException;
 use Symfony\Component\Security\Core\Exception\DisabledException;
-use Symfony\Component\Security\Core\Exception\LockedException;
 
 /**
  * Checks the state of the in-memory user account.

--- a/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
@@ -69,7 +69,7 @@ class InMemoryUserProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function refreshUser(UserInterface $user)
+    public function refreshUser(UserInterface $user): UserInterface
     {
         if (!$user instanceof InMemoryUser) {
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', get_debug_type($user)));
@@ -84,7 +84,7 @@ class InMemoryUserProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsClass(string $class)
+    public function supportsClass(string $class): bool
     {
         return InMemoryUser::class == $class;
     }

--- a/src/Symfony/Component/Security/Core/User/UserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserInterface.php
@@ -44,7 +44,7 @@ interface UserInterface
      *
      * @return string[]
      */
-    public function getRoles();
+    public function getRoles(): array;
 
     /**
      * Removes sensitive data from the user.

--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPassword.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPassword.php
@@ -34,7 +34,7 @@ class UserPassword extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return $this->service;
     }

--- a/src/Symfony/Component/Security/Csrf/CsrfToken.php
+++ b/src/Symfony/Component/Security/Csrf/CsrfToken.php
@@ -29,20 +29,16 @@ class CsrfToken
 
     /**
      * Returns the ID of the CSRF token.
-     *
-     * @return string
      */
-    public function getId()
+    public function getId(): string
     {
         return $this->id;
     }
 
     /**
      * Returns the value of the CSRF token.
-     *
-     * @return string
      */
-    public function getValue()
+    public function getValue(): string
     {
         return $this->value;
     }

--- a/src/Symfony/Component/Security/Csrf/CsrfTokenManager.php
+++ b/src/Symfony/Component/Security/Csrf/CsrfTokenManager.php
@@ -68,7 +68,7 @@ class CsrfTokenManager implements CsrfTokenManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function getToken(string $tokenId)
+    public function getToken(string $tokenId): CsrfToken
     {
         $namespacedId = $this->getNamespace().$tokenId;
         if ($this->storage->hasToken($namespacedId)) {
@@ -85,7 +85,7 @@ class CsrfTokenManager implements CsrfTokenManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function refreshToken(string $tokenId)
+    public function refreshToken(string $tokenId): CsrfToken
     {
         $namespacedId = $this->getNamespace().$tokenId;
         $value = $this->generator->generateToken();
@@ -98,7 +98,7 @@ class CsrfTokenManager implements CsrfTokenManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function removeToken(string $tokenId)
+    public function removeToken(string $tokenId): ?string
     {
         return $this->storage->removeToken($this->getNamespace().$tokenId);
     }
@@ -106,7 +106,7 @@ class CsrfTokenManager implements CsrfTokenManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function isTokenValid(CsrfToken $token)
+    public function isTokenValid(CsrfToken $token): bool
     {
         $namespacedId = $this->getNamespace().$token->getId();
         if (!$this->storage->hasToken($namespacedId)) {

--- a/src/Symfony/Component/Security/Csrf/CsrfTokenManagerInterface.php
+++ b/src/Symfony/Component/Security/Csrf/CsrfTokenManagerInterface.php
@@ -27,10 +27,8 @@ interface CsrfTokenManagerInterface
      *
      * @param string $tokenId The token ID. You may choose an arbitrary value
      *                        for the ID
-     *
-     * @return CsrfToken
      */
-    public function getToken(string $tokenId);
+    public function getToken(string $tokenId): CsrfToken;
 
     /**
      * Generates a new token value for the given ID.
@@ -41,10 +39,8 @@ interface CsrfTokenManagerInterface
      *
      * @param string $tokenId The token ID. You may choose an arbitrary value
      *                        for the ID
-     *
-     * @return CsrfToken
      */
-    public function refreshToken(string $tokenId);
+    public function refreshToken(string $tokenId): CsrfToken;
 
     /**
      * Invalidates the CSRF token with the given ID, if one exists.
@@ -52,12 +48,10 @@ interface CsrfTokenManagerInterface
      * @return string|null Returns the removed token value if one existed, NULL
      *                     otherwise
      */
-    public function removeToken(string $tokenId);
+    public function removeToken(string $tokenId): ?string;
 
     /**
      * Returns whether the given CSRF token is valid.
-     *
-     * @return bool
      */
-    public function isTokenValid(CsrfToken $token);
+    public function isTokenValid(CsrfToken $token): bool;
 }

--- a/src/Symfony/Component/Security/Csrf/TokenGenerator/TokenGeneratorInterface.php
+++ b/src/Symfony/Component/Security/Csrf/TokenGenerator/TokenGeneratorInterface.php
@@ -20,8 +20,6 @@ interface TokenGeneratorInterface
 {
     /**
      * Generates a CSRF token.
-     *
-     * @return string
      */
-    public function generateToken();
+    public function generateToken(): string;
 }

--- a/src/Symfony/Component/Security/Csrf/TokenGenerator/UriSafeTokenGenerator.php
+++ b/src/Symfony/Component/Security/Csrf/TokenGenerator/UriSafeTokenGenerator.php
@@ -33,7 +33,7 @@ class UriSafeTokenGenerator implements TokenGeneratorInterface
     /**
      * {@inheritdoc}
      */
-    public function generateToken()
+    public function generateToken(): string
     {
         // Generate an URI safe base64 encoded string that does not contain "+",
         // "/" or "=" which need to be URL encoded and make URLs unnecessarily

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/NativeSessionTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/NativeSessionTokenStorage.php
@@ -41,7 +41,7 @@ class NativeSessionTokenStorage implements ClearableTokenStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function getToken(string $tokenId)
+    public function getToken(string $tokenId): string
     {
         if (!$this->sessionStarted) {
             $this->startSession();
@@ -69,7 +69,7 @@ class NativeSessionTokenStorage implements ClearableTokenStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function hasToken(string $tokenId)
+    public function hasToken(string $tokenId): bool
     {
         if (!$this->sessionStarted) {
             $this->startSession();
@@ -81,7 +81,7 @@ class NativeSessionTokenStorage implements ClearableTokenStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function removeToken(string $tokenId)
+    public function removeToken(string $tokenId): ?string
     {
         if (!$this->sessionStarted) {
             $this->startSession();

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorage.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/SessionTokenStorage.php
@@ -45,7 +45,7 @@ class SessionTokenStorage implements ClearableTokenStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function getToken(string $tokenId)
+    public function getToken(string $tokenId): string
     {
         $session = $this->getSession();
         if (!$session->isStarted()) {
@@ -75,7 +75,7 @@ class SessionTokenStorage implements ClearableTokenStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function hasToken(string $tokenId)
+    public function hasToken(string $tokenId): bool
     {
         $session = $this->getSession();
         if (!$session->isStarted()) {
@@ -88,7 +88,7 @@ class SessionTokenStorage implements ClearableTokenStorageInterface
     /**
      * {@inheritdoc}
      */
-    public function removeToken(string $tokenId)
+    public function removeToken(string $tokenId): ?string
     {
         $session = $this->getSession();
         if (!$session->isStarted()) {

--- a/src/Symfony/Component/Security/Csrf/TokenStorage/TokenStorageInterface.php
+++ b/src/Symfony/Component/Security/Csrf/TokenStorage/TokenStorageInterface.php
@@ -21,11 +21,9 @@ interface TokenStorageInterface
     /**
      * Reads a stored CSRF token.
      *
-     * @return string
-     *
      * @throws \Symfony\Component\Security\Csrf\Exception\TokenNotFoundException If the token ID does not exist
      */
-    public function getToken(string $tokenId);
+    public function getToken(string $tokenId): string;
 
     /**
      * Stores a CSRF token.
@@ -38,12 +36,10 @@ interface TokenStorageInterface
      * @return string|null Returns the removed token if one existed, NULL
      *                     otherwise
      */
-    public function removeToken(string $tokenId);
+    public function removeToken(string $tokenId): ?string;
 
     /**
      * Checks whether a token with the given token ID exists.
-     *
-     * @return bool
      */
-    public function hasToken(string $tokenId);
+    public function hasToken(string $tokenId): bool;
 }

--- a/src/Symfony/Component/Security/Http/AccessMap.php
+++ b/src/Symfony/Component/Security/Http/AccessMap.php
@@ -36,7 +36,7 @@ class AccessMap implements AccessMapInterface
     /**
      * {@inheritdoc}
      */
-    public function getPatterns(Request $request)
+    public function getPatterns(Request $request): array
     {
         foreach ($this->map as $elements) {
             if (null === $elements[0] || $elements[0]->matches($request)) {

--- a/src/Symfony/Component/Security/Http/AccessMapInterface.php
+++ b/src/Symfony/Component/Security/Http/AccessMapInterface.php
@@ -27,5 +27,5 @@ interface AccessMapInterface
      *
      * @return array{0: array|null, 1: string|null} A tuple of security attributes and the required channel
      */
-    public function getPatterns(Request $request);
+    public function getPatterns(Request $request): array;
 }

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationFailureHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationFailureHandlerInterface.php
@@ -30,8 +30,6 @@ interface AuthenticationFailureHandlerInterface
      * This is called when an interactive authentication attempt fails. This is
      * called by authentication listeners inheriting from
      * AbstractAuthenticationListener.
-     *
-     * @return Response
      */
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception);
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response;
 }

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
@@ -30,8 +30,6 @@ interface AuthenticationSuccessHandlerInterface
      * This is called when an interactive authentication attempt succeeds. This
      * is called by authentication listeners inheriting from
      * AbstractAuthenticationListener.
-     *
-     * @return Response
      */
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token);
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token): Response;
 }

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationUtils.php
@@ -30,10 +30,7 @@ class AuthenticationUtils
         $this->requestStack = $requestStack;
     }
 
-    /**
-     * @return AuthenticationException|null
-     */
-    public function getLastAuthenticationError(bool $clearSession = true)
+    public function getLastAuthenticationError(bool $clearSession = true): ?AuthenticationException
     {
         $request = $this->getRequest();
         $authenticationException = null;
@@ -51,10 +48,7 @@ class AuthenticationUtils
         return $authenticationException;
     }
 
-    /**
-     * @return string
-     */
-    public function getLastUsername()
+    public function getLastUsername(): string
     {
         $request = $this->getRequest();
 

--- a/src/Symfony/Component/Security/Http/Authentication/CustomAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/CustomAuthenticationFailureHandler.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Authentication;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 /**
@@ -35,7 +36,7 @@ class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler
     /**
      * {@inheritdoc}
      */
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
         return $this->handler->onAuthenticationFailure($request, $exception);
     }

--- a/src/Symfony/Component/Security/Http/Authentication/CustomAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/CustomAuthenticationSuccessHandler.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Authentication;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 /**
@@ -39,7 +40,7 @@ class CustomAuthenticationSuccessHandler implements AuthenticationSuccessHandler
     /**
      * {@inheritdoc}
      */
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token)
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token): Response
     {
         return $this->handler->onAuthenticationSuccess($request, $token);
     }

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Http\Authentication;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Security;
@@ -52,10 +53,8 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
 
     /**
      * Gets the options.
-     *
-     * @return array
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }
@@ -68,7 +67,7 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
     /**
      * {@inheritdoc}
      */
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
         if ($failureUrl = ParameterBagUtils::getRequestParameterValue($request, $this->options['failure_path_parameter'])) {
             $this->options['failure_path'] = $failureUrl;

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Http\Authentication;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\ParameterBagUtils;
@@ -51,17 +52,15 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
     /**
      * {@inheritdoc}
      */
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token)
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token): Response
     {
         return $this->httpUtils->createRedirectResponse($request, $this->determineTargetUrl($request));
     }
 
     /**
      * Gets the options.
-     *
-     * @return array
      */
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }
@@ -83,10 +82,8 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
 
     /**
      * Builds the target URL according to the defined options.
-     *
-     * @return string
      */
-    protected function determineTargetUrl(Request $request)
+    protected function determineTargetUrl(Request $request): string
     {
         if ($this->options['always_use_default_target_path']) {
             return $this->options['default_target_path'];

--- a/src/Symfony/Component/Security/Http/Authenticator/AbstractAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/AbstractAuthenticator.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Http\Authenticator;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\LogicException;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
 

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/RememberMeBadge.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/RememberMeBadge.php
@@ -37,7 +37,7 @@ class RememberMeBadge implements BadgeInterface
      *
      * @return $this
      */
-    public function enable(): self
+    public function enable(): static
     {
         $this->enabled = true;
 
@@ -52,7 +52,7 @@ class RememberMeBadge implements BadgeInterface
      *
      * @return $this
      */
-    public function disable(): self
+    public function disable(): static
     {
         $this->enabled = false;
 

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Passport.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Passport.php
@@ -42,9 +42,6 @@ class Passport
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getUser(): UserInterface
     {
         if (null === $this->user) {
@@ -88,10 +85,7 @@ class Passport
         $this->attributes[$name] = $value;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getAttribute(string $name, mixed $default = null)
+    public function getAttribute(string $name, mixed $default = null): mixed
     {
         return $this->attributes[$name] ?? $default;
     }

--- a/src/Symfony/Component/Security/Http/Authenticator/Token/PostAuthenticationToken.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Token/PostAuthenticationToken.php
@@ -47,7 +47,7 @@ class PostAuthenticationToken extends AbstractToken
      *
      * {@inheritdoc}
      */
-    public function getCredentials()
+    public function getCredentials(): mixed
     {
         return [];
     }

--- a/src/Symfony/Component/Security/Http/Authorization/AccessDeniedHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Authorization/AccessDeniedHandlerInterface.php
@@ -25,8 +25,6 @@ interface AccessDeniedHandlerInterface
 {
     /**
      * Handles an access denied failure.
-     *
-     * @return Response|null
      */
-    public function handle(Request $request, AccessDeniedException $accessDeniedException);
+    public function handle(Request $request, AccessDeniedException $accessDeniedException): ?Response;
 }

--- a/src/Symfony/Component/Security/Http/Event/LoginSuccessEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/LoginSuccessEvent.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Security\Http\Event;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\LogicException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -13,15 +13,12 @@ namespace Symfony\Component\Security\Http\Firewall;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
-use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Http\AccessMapInterface;
-use Symfony\Component\Security\Http\Authentication\NoopAuthenticationManager;
 use Symfony\Component\Security\Http\Event\LazyResponseEvent;
 
 /**

--- a/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Http\AccessMapInterface;
-use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 
 /**
  * ChannelListener switches the HTTP protocol based on the access control

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -29,7 +29,6 @@ use Symfony\Component\Security\Core\User\LegacyPasswordAuthenticatedUserInterfac
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
-use Symfony\Component\Security\Http\Event\DeauthenticatedEvent;
 use Symfony\Component\Security\Http\Event\TokenDeauthenticatedEvent;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -299,9 +298,6 @@ class ContextListener extends AbstractListener
         return $token;
     }
 
-    /**
-     * @param UserInterface $originalUser
-     */
     private static function hasUserChanged(UserInterface $originalUser, TokenInterface $refreshedToken): bool
     {
         $refreshedUser = $refreshedToken->getUser();

--- a/src/Symfony/Component/Security/Http/FirewallMap.php
+++ b/src/Symfony/Component/Security/Http/FirewallMap.php
@@ -34,7 +34,7 @@ class FirewallMap implements FirewallMapInterface
     /**
      * {@inheritdoc}
      */
-    public function getListeners(Request $request)
+    public function getListeners(Request $request): array
     {
         foreach ($this->map as $elements) {
             if (null === $elements[0] || $elements[0]->matches($request)) {

--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -51,10 +51,8 @@ class HttpUtils
      *
      * @param string $path   A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))
      * @param int    $status The status code
-     *
-     * @return RedirectResponse
      */
-    public function createRedirectResponse(Request $request, string $path, int $status = 302)
+    public function createRedirectResponse(Request $request, string $path, int $status = 302): RedirectResponse
     {
         if (null !== $this->secureDomainRegexp && 'https' === $this->urlMatcher->getContext()->getScheme() && preg_match('#^https?:[/\\\\]{2,}+[^/]++#i', $path, $host) && !preg_match(sprintf($this->secureDomainRegexp, preg_quote($request->getHttpHost())), $host[0])) {
             $path = '/';
@@ -70,10 +68,8 @@ class HttpUtils
      * Creates a Request.
      *
      * @param string $path A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))
-     *
-     * @return Request
      */
-    public function createRequest(Request $request, string $path)
+    public function createRequest(Request $request, string $path): Request
     {
         $newRequest = Request::create($this->generateUri($request, $path), 'get', [], $request->cookies->all(), [], $request->server->all());
 
@@ -111,7 +107,7 @@ class HttpUtils
      *
      * @return bool true if the path is the same as the one from the Request, false otherwise
      */
-    public function checkRequestPath(Request $request, string $path)
+    public function checkRequestPath(Request $request, string $path): bool
     {
         if ('/' !== $path[0]) {
             try {
@@ -138,11 +134,9 @@ class HttpUtils
      *
      * @param string $path A path (an absolute path (/foo), an absolute URL (http://...), or a route name (foo))
      *
-     * @return string
-     *
      * @throws \LogicException
      */
-    public function generateUri(Request $request, string $path)
+    public function generateUri(Request $request, string $path): string
     {
         if (str_starts_with($path, 'http') || !$path) {
             return $path;

--- a/src/Symfony/Component/Security/Http/LoginLink/Exception/InvalidLoginLinkAuthenticationException.php
+++ b/src/Symfony/Component/Security/Http/LoginLink/Exception/InvalidLoginLinkAuthenticationException.php
@@ -23,7 +23,7 @@ class InvalidLoginLinkAuthenticationException extends AuthenticationException
     /**
      * {@inheritdoc}
      */
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Invalid or expired login link.';
     }

--- a/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutUrlGenerator.php
@@ -53,20 +53,16 @@ class LogoutUrlGenerator
 
     /**
      * Generates the absolute logout path for the firewall.
-     *
-     * @return string
      */
-    public function getLogoutPath(string $key = null)
+    public function getLogoutPath(string $key = null): string
     {
         return $this->generateLogoutUrl($key, UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 
     /**
      * Generates the absolute logout URL for the firewall.
-     *
-     * @return string
      */
-    public function getLogoutUrl(string $key = null)
+    public function getLogoutUrl(string $key = null): string
     {
         return $this->generateLogoutUrl($key, UrlGeneratorInterface::ABSOLUTE_URL);
     }

--- a/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authentication/DefaultAuthenticationFailureHandlerTest.php
@@ -30,12 +30,17 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
     private $httpUtils;
     private $logger;
     private $request;
+    private $response;
     private $session;
     private $exception;
 
     protected function setUp(): void
     {
+        $this->response = new Response();
         $this->httpKernel = $this->createMock(HttpKernelInterface::class);
+        $this->httpKernel->expects($this->any())
+            ->method('handle')->willReturn($this->response);
+
         $this->httpUtils = $this->createMock(HttpUtils::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
@@ -56,15 +61,10 @@ class DefaultAuthenticationFailureHandlerTest extends TestCase
             ->method('createRequest')->with($this->request, '/login')
             ->willReturn($subRequest);
 
-        $response = new Response();
-        $this->httpKernel->expects($this->once())
-            ->method('handle')->with($subRequest, HttpKernelInterface::SUB_REQUEST)
-            ->willReturn($response);
-
         $handler = new DefaultAuthenticationFailureHandler($this->httpKernel, $this->httpUtils, $options, $this->logger);
         $result = $handler->onAuthenticationFailure($this->request, $this->exception);
 
-        $this->assertSame($response, $result);
+        $this->assertSame($this->response, $result);
     }
 
     public function testRedirect()

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/UserCheckerListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/UserCheckerListenerTest.php
@@ -12,14 +12,12 @@
 namespace Symfony\Component\Security\Http\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
 use Symfony\Component\Security\Core\Event\AuthenticationSuccessEvent;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\PreAuthenticatedUserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
-use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\Authenticator\Token\PostAuthenticationToken;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -24,7 +24,6 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Http\AccessMapInterface;
 use Symfony\Component\Security\Http\Event\LazyResponseEvent;

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ChannelListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ChannelListenerTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Http\AccessMapInterface;
-use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\Firewall\ChannelListener;
 
 class ChannelListenerTest extends TestCase

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -34,7 +34,6 @@ use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
-use Symfony\Component\Security\Http\Event\DeauthenticatedEvent;
 use Symfony\Component\Security\Http\Firewall\ContextListener;
 use Symfony\Contracts\Service\ServiceLocatorTrait;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #40154
| License       | MIT
| Doc PR        | -

Extracted from #42496

Not all possible return types are patched for the attached components, to save breaking BC cross-components, for now at least.