### PR TITLE
[FrameworkBundle] Add BrowserKitAssertionsTrait::assertThatForBrowser

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/BrowserKitAssertionsTrait.php
@@ -96,17 +96,17 @@ trait BrowserKitAssertionsTrait
 
     public static function assertBrowserHasCookie(string $name, string $path = '/', string $domain = null, string $message = ''): void
     {
-        self::assertThat(self::getClient(), new BrowserKitConstraint\BrowserHasCookie($name, $path, $domain), $message);
+        self::assertThatForClient(new BrowserKitConstraint\BrowserHasCookie($name, $path, $domain), $message);
     }
 
     public static function assertBrowserNotHasCookie(string $name, string $path = '/', string $domain = null, string $message = ''): void
     {
-        self::assertThat(self::getClient(), new LogicalNot(new BrowserKitConstraint\BrowserHasCookie($name, $path, $domain)), $message);
+        self::assertThatForClient(new LogicalNot(new BrowserKitConstraint\BrowserHasCookie($name, $path, $domain)), $message);
     }
 
     public static function assertBrowserCookieValueSame(string $name, string $expectedValue, bool $raw = false, string $path = '/', string $domain = null, string $message = ''): void
     {
-        self::assertThat(self::getClient(), LogicalAnd::fromConstraints(
+        self::assertThatForClient(LogicalAnd::fromConstraints(
             new BrowserKitConstraint\BrowserHasCookie($name, $path, $domain),
             new BrowserKitConstraint\BrowserCookieValueSame($name, $expectedValue, $raw, $path, $domain)
         ), $message);
@@ -144,6 +144,11 @@ trait BrowserKitAssertionsTrait
 
             throw $exception;
         }
+    }
+
+    public static function assertThatForClient(Constraint $constraint, string $message = ''): void
+    {
+        self::assertThat(self::getClient(), $constraint, $message);
     }
 
     private static function getClient(AbstractBrowser $newClient = null): ?AbstractBrowser


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I wanted to create a constraint that acts on the request and the response (an openapi schema validator constraint that needs the method and pathinfo from the request and the body from the response). But, there is currently no way to get the current client, since `BrowserKitAssertionsTrait::getClient` is private and there is no method to do an assertion on the client/browser (like `BrowserKitAssertionsTrait::assertThatForResponse` for the response).

This small change will allow to do the following:

```
protected static function assertResponseMatchesOpenApiSchema(): void
{
    self::assertThatForBrowser(new ResponseMatchesOpenApiSchema(self::getOpenApiValidator()));
}
```