### PR TITLE
Do not use str_starts_with in translation-status.php

### DIFF
--- a/src/Symfony/Component/Translation/Resources/bin/translation-status.php
+++ b/src/Symfony/Component/Translation/Resources/bin/translation-status.php
@@ -62,7 +62,7 @@ foreach (array_slice($argv, 1) as $argumentOrOption) {
         continue;
     }
 
-    if (str_starts_with($argumentOrOption, '-')) {
+    if (0 === strpos($argumentOrOption, '-')) {
         $config['verbose_output'] = true;
     } else {
         $config['locale_to_analyze'] = $argumentOrOption;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`translation-status.php` is a standalone script that might be run with PHP version that is less than <8.0 where `str_starts_with` is not available. I propose that we revert the change that was made in https://github.com/symfony/symfony/pull/41576 instead of trying to load the polyfill somehow.
