### PR TITLE
[Form] Fix return types in form builder

### DIFF
--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -430,10 +430,12 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
 
     /**
      * Unsupported method.
+     *
+     * @throws BadMethodCallException
      */
     public function getEventDispatcher()
     {
-        return null;
+        throw new BadMethodCallException('Buttons do not support event dispatching.');
     }
 
     /**
@@ -626,26 +628,32 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
 
     /**
      * Unsupported method.
+     *
+     * @throws BadMethodCallException
      */
     public function getAction()
     {
-        return null;
+        throw new BadMethodCallException('Buttons do not support actions.');
     }
 
     /**
      * Unsupported method.
+     *
+     * @throws BadMethodCallException
      */
     public function getMethod()
     {
-        return null;
+        throw new BadMethodCallException('Buttons do not support methods.');
     }
 
     /**
      * Unsupported method.
+     *
+     * @throws BadMethodCallException
      */
     public function getRequestHandler()
     {
-        return null;
+        throw new BadMethodCallException('Buttons do not support request handlers.');
     }
 
     /**

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -88,11 +88,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      */
     private $formFactory;
 
-    /**
-     * @var string|null
-     */
-    private $action;
-
+    private $action = '';
     private $method = 'POST';
 
     /**
@@ -396,6 +392,10 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      */
     public function getFormFactory()
     {
+        if (!isset($this->formFactory)) {
+            throw new BadMethodCallException('The form factory must be set before retrieving it.');
+        }
+
         return $this->formFactory;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT
| Doc PR        | 

Fix return types incompatibilities found by psalm in #42511


> Error: The declared return type 'Symfony\Component\EventDispatcher\EventDispatcherInterface' for Symfony\Component\Form\ButtonBuilder::getEventDispatcher is not nullable, but 'null' contains null (see https://psalm.dev/144)
Error: The declared return type 'string' for Symfony\Component\Form\ButtonBuilder::getAction is not nullable, but 'null' contains null (see https://psalm.dev/144)
Error: The declared return type 'string' for Symfony\Component\Form\ButtonBuilder::getMethod is not nullable, but 'null' contains null (see https://psalm.dev/144)
Error: The declared return type 'Symfony\Component\Form\RequestHandlerInterface' for Symfony\Component\Form\ButtonBuilder::getRequestHandler is not nullable, but 'null' contains null (see https://psalm.dev/144)
Error: The declared return type 'Symfony\Component\Form\FormFactoryInterface' for Symfony\Component\Form\FormConfigBuilder::getFormFactory is not nullable, but 'Symfony\Component\Form\FormFactoryInterface|null' contains null (see https://psalm.dev/144)
Error: The declared return type 'string' for Symfony\Component\Form\FormConfigBuilder::getAction is not nullable, but 'null|string' contains null (see https://psalm.dev/144)