### PR TITLE
[Security] Remove faulty legacy mark from SwitchUserListenerTest

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/SwitchUserListenerTest.php
@@ -30,9 +30,6 @@ use Symfony\Component\Security\Http\Firewall\SwitchUserListener;
 use Symfony\Component\Security\Http\SecurityEvents;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-/**
- * @group legacy
- */
 class SwitchUserListenerTest extends TestCase
 {
     private $tokenStorage;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The `SwitchUserListenerTest` was wrongly marked as legacy, the listener is not deprecated (and will not be removed).