### PR TITLE
[Security] Deprecate legacy remember me services

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -70,6 +70,8 @@ Security
  * Deprecate `RetryAuthenticationEntryPoint`, this code is now inlined in the `ChannelListener`
  * Deprecate `FormAuthenticationEntryPoint` and `BasicAuthenticationEntryPoint`, in the new system the `FormLoginAuthenticator`
    and `HttpBasicAuthenticator` should be used instead
+ * Deprecate `AbstractRememberMeServices`, `PersistentTokenBasedRememberMeServices`, `RememberMeServicesInterface`,
+   `TokenBasedRememberMeServices`, use the remember me handler alternatives instead
  * Deprecate `AnonymousToken`, as the related authenticator was deprecated in 5.3
  * Deprecate `Token::getCredentials()`, tokens should no longer contain credentials (as they represent authenticated sessions)
  * Deprecate not returning an `UserInterface` from `Token::getUser()`

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -211,6 +211,8 @@ Security
  * Remove the `$authenticationEntryPoint` argument of `ChannelListener`
  * Remove `RetryAuthenticationEntryPoint`, this code was inlined in the `ChannelListener`
  * Remove `FormAuthenticationEntryPoint` and `BasicAuthenticationEntryPoint`, the `FormLoginAuthenticator` and `HttpBasicAuthenticator` should be used instead.
+ * Remove `AbstractRememberMeServices`, `PersistentTokenBasedRememberMeServices`, `RememberMeServicesInterface`,
+   `TokenBasedRememberMeServices`, use the remember me handler alternatives instead
  * Remove `AnonymousToken`
  * Remove `Token::getCredentials()`, tokens should no longer contain credentials (as they represent authenticated sessions)
  * Restrict the return type of `Token::getUser()` to `UserInterface` (removing `string|\Stringable`)

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
  * Deprecate `RetryAuthenticationEntryPoint`, this code is now inlined in the `ChannelListener`
  * Deprecate `FormAuthenticationEntryPoint` and `BasicAuthenticationEntryPoint`, in the new system the `FormLoginAuthenticator`
    and `HttpBasicAuthenticator` should be used instead
+ * Deprecate `AbstractRememberMeServices`, `PersistentTokenBasedRememberMeServices`, `RememberMeServicesInterface`,
+   `TokenBasedRememberMeServices`, use the remember me handler alternatives instead
  * Deprecate the `$authManager` argument of `AccessListener`
  * Deprecate not setting the `$exceptionOnNoToken` argument of `AccessListener` to `false`
  * Deprecate `DeauthenticatedEvent`, use `TokenDeauthenticatedEvent` instead

--- a/src/Symfony/Component/Security/Http/EventListener/RememberMeLogoutListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/RememberMeLogoutListener.php
@@ -16,10 +16,14 @@ use Symfony\Component\Security\Core\Exception\LogicException;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 
+trigger_deprecation('symfony/security-http', '5.4', 'The "%s" class is deprecated.', RememberMeLogoutListener::class);
+
 /**
  * @author Wouter de Jong <wouter@wouterj.nl>
  *
  * @final
+ *
+ * @deprecated since Symfony 5.4
  */
 class RememberMeLogoutListener implements EventSubscriberInterface
 {

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -387,8 +387,13 @@ class ContextListener extends AbstractListener
         throw new \ErrorException('Class not found: '.$class, 0x37313bc);
     }
 
+    /**
+     * @deprecated since Symfony 5.4
+     */
     public function setRememberMeServices(RememberMeServicesInterface $rememberMeServices)
     {
+        trigger_deprecation('symfony/security-http', '5.4', 'Method "%s()" is deprecated, use the new remember me handlers instead.', __METHOD__);
+
         $this->rememberMeServices = $rememberMeServices;
     }
 }

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -26,10 +26,14 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
 use Symfony\Component\Security\Http\ParameterBagUtils;
 
+trigger_deprecation('symfony/security-http', '5.4', 'The "%s" class is deprecated, use "%s" instead.', AbstractRememberMeServices::class, AbstractRememberMeHandler::class);
+
 /**
  * Base class implementing the RememberMeServicesInterface.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated since Symfony 5.4, use {@see AbstractRememberMeHandler} instead
  */
 abstract class AbstractRememberMeServices implements RememberMeServicesInterface, LogoutHandlerInterface
 {

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
@@ -21,12 +21,16 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\CookieTheftException;
 
+trigger_deprecation('symfony/security-http', '5.4', 'The "%s" class is deprecated, use "%s" instead.', PersistentTokenBasedRememberMeServices::class, PersistentRememberMeHandler::class);
+
 /**
  * Concrete implementation of the RememberMeServicesInterface which needs
  * an implementation of TokenProviderInterface for providing remember-me
  * capabilities.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated since Symfony 5.4, use {@see PersistentRememberMeHandler} instead
  */
 class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
 {

--- a/src/Symfony/Component/Security/Http/RememberMe/RememberMeServicesInterface.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/RememberMeServicesInterface.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
+trigger_deprecation('symfony/security-http', '5.4', 'The "%s" interface is deprecated, use "%s" instead.', RememberMeServicesInterface::class, RememberMeHandlerInterface::class);
+
 /**
  * Interface that needs to be implemented by classes which provide remember-me
  * capabilities.
@@ -26,6 +28,8 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  *
  * @method logout(Request $request, Response $response, TokenInterface $token)
+ *
+ * @deprecated since Symfony 5.4, use {@see RememberMeHandlerInterface} instead
  */
 interface RememberMeServicesInterface
 {

--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -18,11 +18,15 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserInterface;
 
+trigger_deprecation('symfony/security-http', '5.4', 'The "%s" class is deprecated, use "%s" instead.', TokenBasedRememberMeServices::class, SignatureRememberMeHandler::class);
+
 /**
  * Concrete implementation of the RememberMeServicesInterface providing
  * remember-me capabilities without requiring a TokenProvider.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated since Symfony 5.4, use {@see SignatureRememberMeHandler} instead
  */
 class TokenBasedRememberMeServices extends AbstractRememberMeServices
 {

--- a/src/Symfony/Component/Security/Http/Tests/EventListener/RememberMeLogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/EventListener/RememberMeLogoutListenerTest.php
@@ -17,6 +17,9 @@ use Symfony\Component\Security\Http\Event\LogoutEvent;
 use Symfony\Component\Security\Http\EventListener\RememberMeLogoutListener;
 use Symfony\Component\Security\Http\RememberMe\AbstractRememberMeServices;
 
+/**
+ * @group legacy
+ */
 class RememberMeLogoutListenerTest extends TestCase
 {
     public function testOnLogoutDoesNothingIfNoToken()

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -242,6 +242,9 @@ class ContextListenerTest extends TestCase
         $this->assertSame($goodRefreshedUser, $tokenStorage->getToken()->getUser());
     }
 
+    /**
+     * @group legacy
+     */
     public function testRememberMeGetsCanceledIfTokenIsDeauthenticated()
     {
         $tokenStorage = new TokenStorage();

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/AbstractRememberMeServicesTest.php
@@ -21,6 +21,9 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\RememberMe\AbstractRememberMeServices;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 
+/**
+ * @group legacy
+ */
 class AbstractRememberMeServicesTest extends TestCase
 {
     public function testGetRememberMeParameter()

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentTokenBasedRememberMeServicesTest.php
@@ -28,6 +28,9 @@ use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Http\RememberMe\PersistentTokenBasedRememberMeServices;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 
+/**
+ * @group legacy
+ */
 class PersistentTokenBasedRememberMeServicesTest extends TestCase
 {
     public static function setUpBeforeClass(): void

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/ResponseListenerTest.php
@@ -19,7 +19,6 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 use Symfony\Component\Security\Http\RememberMe\ResponseListener;
 
 class ResponseListenerTest extends TestCase
@@ -29,7 +28,7 @@ class ResponseListenerTest extends TestCase
         $cookie = new Cookie('rememberme', null, 0, '/', null, false, true, false, null);
 
         $request = $this->getRequest([
-            RememberMeServicesInterface::COOKIE_ATTR_NAME => $cookie,
+            ResponseListener::COOKIE_ATTR_NAME => $cookie,
         ]);
 
         $response = $this->getResponse();
@@ -44,7 +43,7 @@ class ResponseListenerTest extends TestCase
         $cookie = new Cookie('rememberme', null, 0, '/', null, false, true, false, null);
 
         $request = $this->getRequest([
-            RememberMeServicesInterface::COOKIE_ATTR_NAME => $cookie,
+            ResponseListener::COOKIE_ATTR_NAME => $cookie,
         ]);
 
         $response = $this->getResponse();

--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/TokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/TokenBasedRememberMeServicesTest.php
@@ -23,6 +23,9 @@ use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 use Symfony\Component\Security\Http\RememberMe\TokenBasedRememberMeServices;
 
+/**
+ * @group legacy
+ */
 class TokenBasedRememberMeServicesTest extends TestCase
 {
     public function testAutoLoginReturnsNullWhenNoCookie()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

I was wrong :(, there is more to deprecate in security: the old remember me implementation.