### PR TITLE
[Security] Add authenticators info to the profiler

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -51,6 +51,7 @@ Messenger
 SecurityBundle
 --------------
 
+ * Deprecate `FirewallConfig::getListeners()`, use `FirewallConfig::getAuthenticators()` instead
  * Deprecate `security.authentication.basic_entry_point` and `security.authentication.retry_entry_point` services, the logic is moved into the
    `HttpBasicAuthenticator` and `ChannelListener` respectively
  * Deprecate not setting `$authenticatorManagerEnabled` to `true` in `SecurityDataCollector` and `DebugFirewallCommand`

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -394,6 +394,7 @@ Security
 SecurityBundle
 --------------
 
+ * Remove `FirewallConfig::getListeners()`, use `FirewallConfig::getAuthenticators()` instead
  * Remove `security.authentication.basic_entry_point` and `security.authentication.retry_entry_point` services,
    the logic is moved into the `HttpBasicAuthenticator` and `ChannelListener` respectively
  * Remove `SecurityFactoryInterface` and `SecurityExtension::addSecurityListenerFactory()` in favor of

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.4
 ---
 
+ * Deprecate `FirewallConfig::getListeners()`, use `FirewallConfig::getAuthenticators()` instead
  * Deprecate `security.authentication.basic_entry_point` and `security.authentication.retry_entry_point` services, the logic is moved into the
    `HttpBasicAuthenticator` and `ChannelListener` respectively
  * Deprecate `FirewallConfig::allowsAnonymous()` and the `allows_anonymous` from the data collector data, there will be no anonymous concept as of version 6.

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -194,7 +194,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
                     'access_denied_handler' => $firewallConfig->getAccessDeniedHandler(),
                     'access_denied_url' => $firewallConfig->getAccessDeniedUrl(),
                     'user_checker' => $firewallConfig->getUserChecker(),
-                    'listeners' => $firewallConfig->getListeners(),
+                    'authenticators' => $firewallConfig->getAuthenticators(),
                 ];
 
                 // generate exit impersonation path from current request
@@ -215,6 +215,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
         }
 
         $this->data['authenticator_manager_enabled'] = $this->authenticatorManagerEnabled;
+        $this->data['authenticators'] = $this->firewall ? $this->firewall->getAuthenticatorsInfo() : [];
     }
 
     /**
@@ -368,6 +369,14 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
     public function getListeners()
     {
         return $this->data['listeners'];
+    }
+
+    /**
+     * @return array|Data
+     */
+    public function getAuthenticators()
+    {
+        return $this->data['authenticators'];
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Debug/Authenticator/TraceableAuthenticator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/Authenticator/TraceableAuthenticator.php
@@ -1,0 +1,106 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Debug\Authenticator;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Guard\Authenticator\GuardBridgeAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use Symfony\Component\Security\Http\EntryPoint\Exception\NotAnEntryPointException;
+use Symfony\Component\VarDumper\Caster\ClassStub;
+
+/**
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ *
+ * @internal
+ */
+final class TraceableAuthenticator implements AuthenticatorInterface, InteractiveAuthenticatorInterface, AuthenticationEntryPointInterface
+{
+    private $authenticator;
+    private $passport;
+    private $duration;
+    private $stub;
+
+    public function __construct(AuthenticatorInterface $authenticator)
+    {
+        $this->authenticator = $authenticator;
+    }
+
+    public function getInfo(): array
+    {
+        return [
+            'supports' => true,
+            'passport' => $this->passport,
+            'duration' => $this->duration,
+            'stub' => $this->stub ?? $this->stub = new ClassStub(\get_class($this->authenticator instanceof GuardBridgeAuthenticator ? $this->authenticator->getGuardAuthenticator() : $this->authenticator)),
+        ];
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        return $this->authenticator->supports($request);
+    }
+
+    public function authenticate(Request $request): PassportInterface
+    {
+        $startTime = microtime(true);
+        $this->passport = $this->authenticator->authenticate($request);
+        $this->duration = microtime(true) - $startTime;
+
+        return $this->passport;
+    }
+
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
+        return method_exists($this->authenticator, 'createToken') ? $this->authenticator->createToken($passport, $firewallName) : $this->authenticator->createAuthenticatedToken($passport, $firewallName);
+    }
+
+    public function createAuthenticatedToken(PassportInterface $passport, string $firewallName): TokenInterface
+    {
+        return $this->authenticator->createAuthenticatedToken($passport, $firewallName);
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, string $firewallName): ?Response
+    {
+        return $this->authenticator->onAuthenticationSuccess($request, $token, $firewallName);
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): ?Response
+    {
+        return $this->authenticator->onAuthenticationFailure($request, $exception);
+    }
+
+    public function start(Request $request, AuthenticationException $authException = null): Response
+    {
+        if (!$this->authenticator instanceof AuthenticationEntryPointInterface) {
+            throw new NotAnEntryPointException();
+        }
+
+        return $this->authenticator->start($request, $authException);
+    }
+
+    public function isInteractive(): bool
+    {
+        return $this->authenticator instanceof InteractiveAuthenticatorInterface && $this->authenticator->isInteractive();
+    }
+
+    public function __call($method, $args)
+    {
+        return $this->authenticator->{$method}(...$args);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Debug/Authenticator/TraceableAuthenticatorManagerListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/Authenticator/TraceableAuthenticatorManagerListener.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Debug\Authenticator;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\Security\Http\Firewall\AbstractListener;
+use Symfony\Component\Security\Http\Firewall\AuthenticatorManagerListener;
+use Symfony\Component\VarDumper\Caster\ClassStub;
+
+/**
+ * Decorates the AuthenticatorManagerListener to collect information about security authenticators.
+ *
+ * @author Robin Chalas <robin.chalas@gmail.com>
+ *
+ * @internal
+ */
+class TraceableAuthenticatorManagerListener extends AbstractListener
+{
+    private $authenticationManagerListener;
+    private $authenticatorsInfo = [];
+
+    public function __construct(AuthenticatorManagerListener $authenticationManagerListener)
+    {
+        $this->authenticationManagerListener = $authenticationManagerListener;
+    }
+
+    public function supports(Request $request): ?bool
+    {
+        return $this->authenticationManagerListener->supports($request);
+    }
+
+    public function authenticate(RequestEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        if (!$authenticators = $request->attributes->get('_security_authenticators')) {
+            return;
+        }
+
+        foreach ($request->attributes->get('_security_skipped_authenticators') as $skippedAuthenticator) {
+            $this->authenticatorsInfo[] = [
+                'supports' => false,
+                'stub' => new ClassStub(\get_class($skippedAuthenticator)),
+                'passport' => null,
+                'duration' => 0,
+            ];
+        }
+
+        foreach ($authenticators as $key => $authenticator) {
+            $authenticators[$key] = new TraceableAuthenticator($authenticator);
+        }
+
+        $request->attributes->set('_security_authenticators', $authenticators);
+
+        $this->authenticationManagerListener->authenticate($event);
+
+        foreach ($authenticators as $authenticator) {
+            $this->authenticatorsInfo[] = $authenticator->getInfo();
+        }
+    }
+
+    public function getAuthenticatorManagerListener(): AuthenticatorManagerListener
+    {
+        return $this->authenticationManagerListener;
+    }
+
+    public function getAuthenticatorsInfo(): array
+    {
+        return $this->authenticatorsInfo;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Debug/TraceableFirewallListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/TraceableFirewallListener.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Debug;
 
+use Symfony\Bundle\SecurityBundle\Debug\Authenticator\TraceableAuthenticatorManagerListener;
 use Symfony\Bundle\SecurityBundle\EventListener\FirewallListener;
 use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
 use Symfony\Bundle\SecurityBundle\Security\LazyFirewallContext;
@@ -18,29 +19,39 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Security\Http\Firewall\FirewallListenerInterface;
 
 /**
- * Firewall collecting called listeners.
+ * Firewall collecting called security listeners and authenticators.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
  */
 final class TraceableFirewallListener extends FirewallListener
 {
     private $wrappedListeners = [];
+    private $authenticatorsInfo = [];
 
     public function getWrappedListeners()
     {
         return $this->wrappedListeners;
     }
 
+    public function getAuthenticatorsInfo(): array
+    {
+        return $this->authenticatorsInfo;
+    }
+
     protected function callListeners(RequestEvent $event, iterable $listeners)
     {
         $wrappedListeners = [];
         $wrappedLazyListeners = [];
+        $authenticatorManagerListener = null;
 
         foreach ($listeners as $listener) {
             if ($listener instanceof LazyFirewallContext) {
-                \Closure::bind(function () use (&$wrappedLazyListeners, &$wrappedListeners) {
+                \Closure::bind(function () use (&$wrappedLazyListeners, &$wrappedListeners, &$authenticatorManagerListener) {
                     $listeners = [];
                     foreach ($this->listeners as $listener) {
+                        if (!$authenticatorManagerListener && $listener instanceof TraceableAuthenticatorManagerListener) {
+                            $authenticatorManagerListener = $listener;
+                        }
                         if ($listener instanceof FirewallListenerInterface) {
                             $listener = new WrappedLazyListener($listener);
                             $listeners[] = $listener;
@@ -61,6 +72,9 @@ final class TraceableFirewallListener extends FirewallListener
                 $wrappedListener = $listener instanceof FirewallListenerInterface ? new WrappedLazyListener($listener) : new WrappedListener($listener);
                 $wrappedListener($event);
                 $wrappedListeners[] = $wrappedListener->getInfo();
+                if (!$authenticatorManagerListener && $listener instanceof TraceableAuthenticatorManagerListener) {
+                    $authenticatorManagerListener = $listener;
+                }
             }
 
             if ($event->hasResponse()) {
@@ -75,5 +89,9 @@ final class TraceableFirewallListener extends FirewallListener
         }
 
         $this->wrappedListeners = array_merge($this->wrappedListeners, $wrappedListeners);
+
+        if ($authenticatorManagerListener) {
+            $this->authenticatorsInfo = $authenticatorManagerListener->getAuthenticatorsInfo();
+        }
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Debug/TraceableListenerTrait.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/TraceableListenerTrait.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Debug;
 
+use Symfony\Bundle\SecurityBundle\Debug\Authenticator\TraceableAuthenticatorManagerListener;
 use Symfony\Component\VarDumper\Caster\ClassStub;
 
 /**
@@ -43,7 +44,7 @@ trait TraceableListenerTrait
         return [
             'response' => $this->response,
             'time' => $this->time,
-            'stub' => $this->stub ?? $this->stub = ClassStub::wrapCallable($this->listener),
+            'stub' => $this->stub ?? $this->stub = ClassStub::wrapCallable($this->listener instanceof TraceableAuthenticatorManagerListener ? $this->listener->getAuthenticatorManagerListener() : $this->listener),
         ];
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -104,289 +104,346 @@
 {% endblock %}
 
 {% block panel %}
-    <h2>Security Token</h2>
-
+    <h2>Security</h2>
     {% if collector.enabled %}
-        {% if collector.token %}
-            <div class="metrics">
-                <div class="metric">
-                    <span class="value">{{ collector.user == 'anon.' ? 'Anonymous' : collector.user }}</span>
-                    <span class="label">Username</span>
-                </div>
+        <div class="sf-tabs">
+            <div class="tab {{ collector.token is empty ? 'disabled' }}">
+                <h3 class="tab-title">Token</h3>
 
-                <div class="metric">
-                    <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.authenticated ? 'yes' : 'no') ~ '.svg') }}</span>
-                    <span class="label">Authenticated</span>
-                </div>
-            </div>
-
-            <table>
-                <thead>
-                    <tr>
-                        <th scope="col" class="key">Property</th>
-                        <th scope="col">Value</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <th>Roles</th>
-                        <td>
-                            {{ collector.roles is empty ? 'none' : profiler_dump(collector.roles, maxDepth=1) }}
-
-                            {% if not collector.authenticated and collector.roles is empty %}
-                                <p class="help">User is not authenticated probably because they have no roles.</p>
-                            {% endif %}
-                        </td>
-                    </tr>
-
-                    {% if collector.supportsRoleHierarchy %}
-                    <tr>
-                        <th>Inherited Roles</th>
-                        <td>{{ collector.inheritedRoles is empty ? 'none' : profiler_dump(collector.inheritedRoles, maxDepth=1) }}</td>
-                    </tr>
-                    {% endif %}
-
+                <div class="tab-content">
                     {% if collector.token %}
-                    <tr>
-                        <th>Token</th>
-                        <td>{{ profiler_dump(collector.token) }}</td>
-                    </tr>
-                    {% endif %}
-                </tbody>
-            </table>
-        {% elseif collector.enabled %}
-            <div class="empty">
-                <p>There is no security token.</p>
-            </div>
-        {% endif %}
-
-
-        <h2>Security Firewall</h2>
-
-        {% if collector.firewall %}
-            <div class="metrics">
-                <div class="metric">
-                    <span class="value">{{ collector.firewall.name }}</span>
-                    <span class="label">Name</span>
-                </div>
-                <div class="metric">
-                    <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.firewall.security_enabled ? 'yes' : 'no') ~ '.svg') }}</span>
-                    <span class="label">Security enabled</span>
-                </div>
-                <div class="metric">
-                    <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.firewall.stateless ? 'yes' : 'no') ~ '.svg') }}</span>
-                    <span class="label">Stateless</span>
-                </div>
-                {% if collector.authenticatorManagerEnabled == false %}
-                <div class="metric">
-                    <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.firewall.allows_anonymous ? 'yes' : 'no') ~ '.svg') }}</span>
-                    <span class="label">Allows anonymous</span>
-                </div>
-                {% endif %}
-            </div>
-
-            {% if collector.firewall.security_enabled %}
-                <h4>Configuration</h4>
-
-                <table>
-                    <thead>
-                        <tr>
-                            <th scope="col" class="key">Key</th>
-                            <th scope="col">Value</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <th>provider</th>
-                            <td>{{ collector.firewall.provider ?: '(none)' }}</td>
-                        </tr>
-                        <tr>
-                            <th>context</th>
-                            <td>{{ collector.firewall.context ?: '(none)' }}</td>
-                        </tr>
-                        <tr>
-                            <th>entry_point</th>
-                            <td>{{ collector.firewall.entry_point ?: '(none)' }}</td>
-                        </tr>
-                        <tr>
-                            <th>user_checker</th>
-                            <td>{{ collector.firewall.user_checker ?: '(none)' }}</td>
-                        </tr>
-                        <tr>
-                            <th>access_denied_handler</th>
-                            <td>{{ collector.firewall.access_denied_handler ?: '(none)' }}</td>
-                        </tr>
-                        <tr>
-                            <th>access_denied_url</th>
-                            <td>{{ collector.firewall.access_denied_url ?: '(none)' }}</td>
-                        </tr>
-                        <tr>
-                            <th>listeners</th>
-                            <td>{{ collector.firewall.listeners is empty ? '(none)' : profiler_dump(collector.firewall.listeners, maxDepth=1) }}</td>
-                        </tr>
-                    </tbody>
-                </table>
-
-                <h4>Listeners</h4>
-
-                {% if collector.listeners|default([]) is empty %}
-                    <div class="empty">
-                        <p>No security listeners have been recorded. Check that debugging is enabled in the kernel.</p>
-                    </div>
-                {% else %}
-                    <table>
-                        <thead>
-                        <tr>
-                            <th>Listener</th>
-                            <th>Duration</th>
-                            <th>Response</th>
-                        </tr>
-                        </thead>
-
-                        {% set previous_event = (collector.listeners|first) %}
-                        {% for listener in collector.listeners %}
-                            {% if loop.first or listener != previous_event %}
-                                {% if not loop.first %}
-                                    </tbody>
-                                {% endif %}
-
-                                <tbody>
-                                {% set previous_event = listener %}
-                            {% endif %}
-
-                            <tr>
-                                <td class="font-normal">{{ profiler_dump(listener.stub) }}</td>
-                                <td class="no-wrap">{{ '%0.2f'|format(listener.time * 1000) }} ms</td>
-                                <td class="font-normal">{{ listener.response ? profiler_dump(listener.response) : '(none)' }}</td>
-                            </tr>
-
-                            {% if loop.last %}
-                                </tbody>
-                            {% endif %}
-                        {% endfor %}
-                    </table>
-                {% endif %}
-            {% endif %}
-        {% elseif collector.enabled %}
-            <div class="empty">
-                <p>This request was not covered by any firewall.</p>
-            </div>
-        {% endif %}
-    {% else %}
-        <div class="empty">
-            <p>The security component is disabled.</p>
-        </div>
-    {% endif %}
-
-    {% if collector.voters|default([]) is not empty %}
-        <h2>Security Voters <small>({{ collector.voters|length }})</small></h2>
-
-        <div class="metrics">
-            <div class="metric">
-                <span class="value">{{ collector.voterStrategy|default('unknown') }}</span>
-                <span class="label">Strategy</span>
-            </div>
-        </div>
-
-        <table class="voters">
-            <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Voter class</th>
-                </tr>
-            </thead>
-
-            <tbody>
-                {% for voter in collector.voters %}
-                    <tr>
-                        <td class="font-normal text-small text-muted nowrap">{{ loop.index }}</td>
-                        <td class="font-normal">{{ profiler_dump(voter) }}</td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    {% endif %}
-
-    {% if collector.accessDecisionLog|default([]) is not empty %}
-        <h2>Access decision log</h2>
-
-        <table class="decision-log">
-            <col style="width: 30px">
-            <col style="width: 120px">
-            <col style="width: 25%">
-            <col style="width: 60%">
-
-            <thead>
-                <tr>
-                    <th>#</th>
-                    <th>Result</th>
-                    <th>Attributes</th>
-                    <th>Object</th>
-                </tr>
-            </thead>
-
-            <tbody>
-                {% for decision in collector.accessDecisionLog %}
-                    <tr class="voter_result">
-                        <td class="font-normal text-small text-muted nowrap">{{ loop.index }}</td>
-                        <td class="font-normal">
-                            {{ decision.result
-                                ? '<span class="label status-success same-width">GRANTED</span>'
-                                : '<span class="label status-error same-width">DENIED</span>'
-                            }}
-                        </td>
-                        <td>
-                            {% if decision.attributes|length == 1 %}
-                                {% set attribute = decision.attributes|first %}
-                                {% if attribute.expression is defined %}
-                                    Expression: <pre><code>{{ attribute.expression }}</code></pre>
-                                {% elseif attribute.type == 'string' %}
-                                    {{ attribute }}
-                                {% else %}
-                                     {{ profiler_dump(attribute) }}
-                                {% endif %}
-                            {% else %}
-                                {{ profiler_dump(decision.attributes) }}
-                            {% endif %}
-                        </td>
-                        <td>{{ profiler_dump(decision.seek('object')) }}</td>
-                    </tr>
-                    <tr class="voter_details">
-                        <td></td>
-                        <td colspan="3">
-                        {% if decision.voter_details is not empty %}
-                            {% set voter_details_id = 'voter-details-' ~ loop.index %}
-                            <div id="{{ voter_details_id }}" class="sf-toggle-content sf-toggle-hidden">
-                                <table>
-                                   <tbody>
-                                    {% for voter_detail in decision.voter_details %}
-                                        <tr>
-                                            <td class="font-normal">{{ profiler_dump(voter_detail['class']) }}</td>
-                                            {% if collector.voterStrategy == constant('Symfony\\Component\\Security\\Core\\Authorization\\AccessDecisionManager::STRATEGY_UNANIMOUS') %}
-                                            <td class="font-normal text-small">attribute {{ voter_detail['attributes'][0] }}</td>
-                                            {% endif %}
-                                            <td class="font-normal text-small">
-                                                {% if voter_detail['vote'] == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_GRANTED') %}
-                                                    ACCESS GRANTED
-                                                {% elseif voter_detail['vote'] == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_ABSTAIN') %}
-                                                    ACCESS ABSTAIN
-                                                {% elseif voter_detail['vote'] == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_DENIED') %}
-                                                    ACCESS DENIED
-                                                {% else %}
-                                                    unknown ({{ voter_detail['vote'] }})
-                                                {% endif %}
-                                            </td>
-                                        </tr>
-                                    {% endfor %}
-                                    </tbody>
-                                </table>
+                        <div class="metrics">
+                            <div class="metric">
+                                <span class="value">{{ collector.user == 'anon.' ? 'Anonymous' : collector.user }}</span>
+                                <span class="label">Username</span>
                             </div>
-                            <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ voter_details_id }}" data-toggle-alt-content="Hide voter details">Show voter details</a>
+
+                            <div class="metric">
+                                <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.authenticated ? 'yes' : 'no') ~ '.svg') }}</span>
+                                <span class="label">Authenticated</span>
+                            </div>
+                        </div>
+
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th scope="col" class="key">Property</th>
+                                    <th scope="col">Value</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <th>Roles</th>
+                                    <td>
+                                        {{ collector.roles is empty ? 'none' : profiler_dump(collector.roles, maxDepth=1) }}
+
+                                        {% if not collector.authenticated and collector.roles is empty %}
+                                            <p class="help">User is not authenticated probably because they have no roles.</p>
+                                        {% endif %}
+                                    </td>
+                                </tr>
+
+                                {% if collector.supportsRoleHierarchy %}
+                                <tr>
+                                    <th>Inherited Roles</th>
+                                    <td>{{ collector.inheritedRoles is empty ? 'none' : profiler_dump(collector.inheritedRoles, maxDepth=1) }}</td>
+                                </tr>
+                                {% endif %}
+
+                                {% if collector.token %}
+                                <tr>
+                                    <th>Token</th>
+                                    <td>{{ profiler_dump(collector.token) }}</td>
+                                </tr>
+                                {% endif %}
+                            </tbody>
+                        </table>
+                    {% elseif collector.enabled %}
+                        <div class="empty">
+                            <p>There is no security token.</p>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="tab {{ collector.firewall.security_enabled is empty ? 'disabled' }}">
+                <h3 class="tab-title">Firewall</h3>
+                <div class="tab-content">
+                    {% if collector.firewall %}
+                        <div class="metrics">
+                            <div class="metric">
+                                <span class="value">{{ collector.firewall.name }}</span>
+                                <span class="label">Name</span>
+                            </div>
+                            <div class="metric">
+                                <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.firewall.security_enabled ? 'yes' : 'no') ~ '.svg') }}</span>
+                                <span class="label">Security enabled</span>
+                            </div>
+                            <div class="metric">
+                                <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.firewall.stateless ? 'yes' : 'no') ~ '.svg') }}</span>
+                                <span class="label">Stateless</span>
+                            </div>
+                            {% if collector.authenticatorManagerEnabled == false %}
+                                <div class="metric">
+                                    <span class="value">{{ include('@WebProfiler/Icon/' ~ (collector.firewall.allows_anonymous ? 'yes' : 'no') ~ '.svg') }}</span>
+                                    <span class="label">Allows anonymous</span>
+                                </div>
+                            {% endif %}
+                        </div>
+
+                        {% if collector.firewall.security_enabled %}
+                            <h4>Configuration</h4>
+                            <table>
+                                <thead>
+                                    <tr>
+                                        <th scope="col" class="key">Key</th>
+                                        <th scope="col">Value</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th>provider</th>
+                                        <td>{{ collector.firewall.provider ?: '(none)' }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th>context</th>
+                                        <td>{{ collector.firewall.context ?: '(none)' }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th>entry_point</th>
+                                        <td>{{ collector.firewall.entry_point ?: '(none)' }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th>user_checker</th>
+                                        <td>{{ collector.firewall.user_checker ?: '(none)' }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th>access_denied_handler</th>
+                                        <td>{{ collector.firewall.access_denied_handler ?: '(none)' }}</td>
+                                    </tr>
+                                    <tr>
+                                        <th>access_denied_url</th>
+                                        <td>{{ collector.firewall.access_denied_url ?: '(none)' }}</td>
+                                    </tr>
+                                    {% if collector.authenticatorManagerEnabled %}
+                                        <tr>
+                                            <th>authenticators</th>
+                                            <td>{{ collector.firewall.authenticators is empty ? '(none)' : profiler_dump(collector.firewall.authenticators, maxDepth=1) }}</td>
+                                        </tr>
+                                    {% else %}
+                                        <tr>
+                                            <th>listeners</th>
+                                            <td>{{ collector.firewall.listeners is empty ? '(none)' : profiler_dump(collector.firewall.listeners, maxDepth=1) }}</td>
+                                        </tr>
+                                    {% endif %}
+                                </tbody>
+                            </table>
                         {% endif %}
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="tab {{ collector.listeners|default([]) is empty ? 'disabled' }}">
+                <h3 class="tab-title">Listeners</h3>
+                <div class="tab-content">
+                    {% if collector.listeners|default([]) is empty %}
+                        <div class="empty">
+                            <p>No security listeners have been recorded. Check that debugging is enabled in the kernel.</p>
+                        </div>
+                    {% else %}
+                        <table>
+                            <thead>
+                            <tr>
+                                <th>Listener</th>
+                                <th>Duration</th>
+                                <th>Response</th>
+                            </tr>
+                            </thead>
+
+                            {% set previous_event = (collector.listeners|first) %}
+                            {% for listener in collector.listeners %}
+                                {% if loop.first or listener != previous_event %}
+                                    {% if not loop.first %}
+                                        </tbody>
+                                    {% endif %}
+
+                                    <tbody>
+                                    {% set previous_event = listener %}
+                                {% endif %}
+
+                                <tr>
+                                    <td class="font-normal">{{ profiler_dump(listener.stub) }}</td>
+                                    <td class="no-wrap">{{ '%0.2f'|format(listener.time * 1000) }} ms</td>
+                                    <td class="font-normal">{{ listener.response ? profiler_dump(listener.response) : '(none)' }}</td>
+                                </tr>
+
+                                {% if loop.last %}
+                                    </tbody>
+                                {% endif %}
+                            {% endfor %}
+                        </table>
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="tab {{ collector.authenticators|default([]) is empty ? 'disabled' }}">
+                <h3 class="tab-title">Authenticators</h3>
+                <div class="tab-content">
+                    {% if collector.authenticators|default([]) is not empty %}
+                        <table>
+                            <thead>
+                            <tr>
+                                <th>Authenticator</th>
+                                <th>Supports</th>
+                                <th>Duration</th>
+                                <th>Passport</th>
+                            </tr>
+                            </thead>
+
+                            {% set previous_event = (collector.listeners|first) %}
+                            {% for authenticator in collector.authenticators %}
+                                {% if loop.first or authenticator != previous_event %}
+                                    {% if not loop.first %}
+                                        </tbody>
+                                    {% endif %}
+
+                                    <tbody>
+                                    {% set previous_event = authenticator %}
+                                {% endif %}
+
+                                <tr>
+                                    <td class="font-normal">{{ profiler_dump(authenticator.stub) }}</td>
+                                    <td class="no-wrap">{{ include('@WebProfiler/Icon/' ~ (authenticator.supports ? 'yes' : 'no') ~ '.svg') }}</td>
+                                    <td class="no-wrap">{{ '%0.2f'|format(authenticator.duration * 1000) }} ms</td>
+                                    <td class="font-normal">{{ authenticator.passport ? profiler_dump(authenticator.passport) : '(none)' }}</td>
+                                </tr>
+
+                                {% if loop.last %}
+                                    </tbody>
+                                {% endif %}
+                            {% endfor %}
+                        </table>
+                    {% else %}
+                        <div class="empty">
+                            <p>No authenticators have been recorded. Check previous profiles on your authentication endpoint.</p>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="tab {{ collector.accessDecisionLog|default([]) is empty ? 'disabled' }}">
+                <h3 class="tab-title">Access Decision</h3>
+                <div class="tab-content">
+                    {% if collector.voters|default([]) is not empty %}
+                        <div class="metrics">
+                            <div class="metric">
+                                <span class="value">{{ collector.voterStrategy|default('unknown') }}</span>
+                                <span class="label">Strategy</span>
+                            </div>
+                        </div>
+
+                        <table class="voters">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Voter class</th>
+                                </tr>
+                            </thead>
+
+                            <tbody>
+                                {% for voter in collector.voters %}
+                                    <tr>
+                                        <td class="font-normal text-small text-muted nowrap">{{ loop.index }}</td>
+                                        <td class="font-normal">{{ profiler_dump(voter) }}</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    {% endif %}
+                    {% if collector.accessDecisionLog|default([]) is not empty %}
+                        <h2>Access decision log</h2>
+
+                        <table class="decision-log">
+                            <col style="width: 30px">
+                            <col style="width: 120px">
+                            <col style="width: 25%">
+                            <col style="width: 60%">
+
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Result</th>
+                                    <th>Attributes</th>
+                                    <th>Object</th>
+                                </tr>
+                            </thead>
+
+                            <tbody>
+                                {% for decision in collector.accessDecisionLog %}
+                                    <tr class="voter_result">
+                                        <td class="font-normal text-small text-muted nowrap">{{ loop.index }}</td>
+                                        <td class="font-normal">
+                                            {{ decision.result
+                                                ? '<span class="label status-success same-width">GRANTED</span>'
+                                                : '<span class="label status-error same-width">DENIED</span>'
+                                            }}
+                                        </td>
+                                        <td>
+                                            {% if decision.attributes|length == 1 %}
+                                                {% set attribute = decision.attributes|first %}
+                                                {% if attribute.expression is defined %}
+                                                    Expression: <pre><code>{{ attribute.expression }}</code></pre>
+                                                {% elseif attribute.type == 'string' %}
+                                                    {{ attribute }}
+                                                {% else %}
+                                                     {{ profiler_dump(attribute) }}
+                                                {% endif %}
+                                            {% else %}
+                                                {{ profiler_dump(decision.attributes) }}
+                                            {% endif %}
+                                        </td>
+                                        <td>{{ profiler_dump(decision.seek('object')) }}</td>
+                                    </tr>
+                                    <tr class="voter_details">
+                                        <td></td>
+                                        <td colspan="3">
+                                        {% if decision.voter_details is not empty %}
+                                            {% set voter_details_id = 'voter-details-' ~ loop.index %}
+                                            <div id="{{ voter_details_id }}" class="sf-toggle-content sf-toggle-hidden">
+                                                <table>
+                                                   <tbody>
+                                                    {% for voter_detail in decision.voter_details %}
+                                                        <tr>
+                                                            <td class="font-normal">{{ profiler_dump(voter_detail['class']) }}</td>
+                                                            {% if collector.voterStrategy == constant('Symfony\\Component\\Security\\Core\\Authorization\\AccessDecisionManager::STRATEGY_UNANIMOUS') %}
+                                                            <td class="font-normal text-small">attribute {{ voter_detail['attributes'][0] }}</td>
+                                                            {% endif %}
+                                                            <td class="font-normal text-small">
+                                                                {% if voter_detail['vote'] == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_GRANTED') %}
+                                                                    ACCESS GRANTED
+                                                                {% elseif voter_detail['vote'] == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_ABSTAIN') %}
+                                                                    ACCESS ABSTAIN
+                                                                {% elseif voter_detail['vote'] == constant('Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface::ACCESS_DENIED') %}
+                                                                    ACCESS DENIED
+                                                                {% else %}
+                                                                    unknown ({{ voter_detail['vote'] }})
+                                                                {% endif %}
+                                                            </td>
+                                                        </tr>
+                                                    {% endfor %}
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                            <a class="btn btn-link text-small sf-toggle" data-toggle-selector="#{{ voter_details_id }}" data-toggle-alt-content="Hide voter details">Show voter details</a>
+                                        {% endif %}
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
     {% endif %}
 {% endblock %}

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallConfig.php
@@ -26,10 +26,10 @@ final class FirewallConfig
     private $entryPoint;
     private $accessDeniedHandler;
     private $accessDeniedUrl;
-    private $listeners;
+    private $authenticators;
     private $switchUser;
 
-    public function __construct(string $name, string $userChecker, string $requestMatcher = null, bool $securityEnabled = true, bool $stateless = false, string $provider = null, string $context = null, string $entryPoint = null, string $accessDeniedHandler = null, string $accessDeniedUrl = null, array $listeners = [], array $switchUser = null)
+    public function __construct(string $name, string $userChecker, string $requestMatcher = null, bool $securityEnabled = true, bool $stateless = false, string $provider = null, string $context = null, string $entryPoint = null, string $accessDeniedHandler = null, string $accessDeniedUrl = null, array $authenticators = [], array $switchUser = null)
     {
         $this->name = $name;
         $this->userChecker = $userChecker;
@@ -41,7 +41,7 @@ final class FirewallConfig
         $this->entryPoint = $entryPoint;
         $this->accessDeniedHandler = $accessDeniedHandler;
         $this->accessDeniedUrl = $accessDeniedUrl;
-        $this->listeners = $listeners;
+        $this->authenticators = $authenticators;
         $this->switchUser = $switchUser;
     }
 
@@ -71,7 +71,7 @@ final class FirewallConfig
     {
         trigger_deprecation('symfony/security-bundle', '5.4', 'The "%s()" method is deprecated.', __METHOD__);
 
-        return \in_array('anonymous', $this->listeners, true);
+        return \in_array('anonymous', $this->authenticators, true);
     }
 
     public function isStateless(): bool
@@ -112,9 +112,19 @@ final class FirewallConfig
         return $this->accessDeniedUrl;
     }
 
+    /**
+     * @deprecated since Symfony 5.4, use {@see getListeners()} instead
+     */
     public function getListeners(): array
     {
-        return $this->listeners;
+        trigger_deprecation('symfony/security-bundle', '5.4', 'Method "%s()" is deprecated, use "%s::getAuthenticators()" instead.', __METHOD__, __CLASS__);
+
+        return $this->getAuthenticators();
+    }
+
+    public function getAuthenticators(): array
+    {
+        return $this->authenticators;
     }
 
     public function getSwitchUser(): ?array

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DataCollector/SecurityDataCollectorTest.php
@@ -150,7 +150,7 @@ class SecurityDataCollectorTest extends TestCase
         $this->assertSame($firewallConfig->getAccessDeniedHandler(), $collected['access_denied_handler']);
         $this->assertSame($firewallConfig->getAccessDeniedUrl(), $collected['access_denied_url']);
         $this->assertSame($firewallConfig->getUserChecker(), $collected['user_checker']);
-        $this->assertSame($firewallConfig->getListeners(), $collected['listeners']->getValue());
+        $this->assertSame($firewallConfig->getAuthenticators(), $collected['authenticators']->getValue());
         $this->assertTrue($collector->isAuthenticatorManagerEnabled());
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Debug/TraceableFirewallListenerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Debug/TraceableFirewallListenerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\Debug;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\SecurityBundle\Debug\Authenticator\TraceableAuthenticatorManagerListener;
 use Symfony\Bundle\SecurityBundle\Debug\TraceableFirewallListener;
 use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -19,6 +20,14 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+use Symfony\Component\Security\Http\Firewall\AuthenticatorManagerListener;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 
 /**
@@ -53,5 +62,79 @@ class TraceableFirewallListenerTest extends TestCase
         $listeners = $firewall->getWrappedListeners();
         $this->assertCount(1, $listeners);
         $this->assertSame($listener, $listeners[0]['stub']);
+    }
+
+    public function testOnKernelRequestRecordsAuthenticatorsInfo()
+    {
+        $request = new Request();
+
+        $event = new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST);
+        $event->setResponse($response = new Response());
+
+        $supportingAuthenticator = $this->createMock(DummyAuthenticator::class);
+        $supportingAuthenticator
+            ->method('supports')
+            ->with($request)
+            ->willReturn(true);
+        $supportingAuthenticator
+            ->expects($this->once())
+            ->method('authenticate')
+            ->with($request)
+            ->willReturn(new SelfValidatingPassport(new UserBadge('robin', function () {})));
+        $supportingAuthenticator
+            ->expects($this->once())
+            ->method('onAuthenticationSuccess')
+            ->willReturn($response);
+        $supportingAuthenticator
+            ->expects($this->once())
+            ->method('createToken')
+            ->willReturn($this->createMock(TokenInterface::class));
+
+        $notSupportingAuthenticator = $this->createMock(DummyAuthenticator::class);
+        $notSupportingAuthenticator
+            ->method('supports')
+            ->with($request)
+            ->willReturn(false);
+
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $dispatcher = new EventDispatcher();
+        $authenticatorManager = new AuthenticatorManager(
+            [$notSupportingAuthenticator, $supportingAuthenticator],
+            $tokenStorage,
+            $dispatcher,
+            'main'
+        );
+
+        $listener = new TraceableAuthenticatorManagerListener(new AuthenticatorManagerListener($authenticatorManager));
+        $firewallMap = $this->createMock(FirewallMap::class);
+        $firewallMap
+            ->expects($this->once())
+            ->method('getFirewallConfig')
+            ->with($request)
+            ->willReturn(null);
+        $firewallMap
+            ->expects($this->once())
+            ->method('getListeners')
+            ->with($request)
+            ->willReturn([[$listener], null, null]);
+
+        $firewall = new TraceableFirewallListener($firewallMap, $dispatcher, new LogoutUrlGenerator());
+        $firewall->configureLogoutUrlGenerator($event);
+        $firewall->onKernelRequest($event);
+
+        $this->assertCount(2, $authenticatorsInfo = $firewall->getAuthenticatorsInfo());
+
+        $this->assertFalse($authenticatorsInfo[0]['supports']);
+        $this->assertStringContainsString('DummyAuthenticator', $authenticatorsInfo[0]['stub']);
+
+        $this->assertTrue($authenticatorsInfo[1]['supports']);
+        $this->assertStringContainsString('DummyAuthenticator', $authenticatorsInfo[1]['stub']);
+    }
+}
+
+abstract class DummyAuthenticator implements InteractiveAuthenticatorInterface
+{
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    {
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallConfigTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallConfigTest.php
@@ -18,7 +18,7 @@ class FirewallConfigTest extends TestCase
 {
     public function testGetters()
     {
-        $listeners = ['logout', 'remember_me'];
+        $authenticators = ['form_login', 'remember_me'];
         $options = [
             'request_matcher' => 'foo_request_matcher',
             'security' => false,
@@ -43,7 +43,7 @@ class FirewallConfigTest extends TestCase
             $options['entry_point'],
             $options['access_denied_handler'],
             $options['access_denied_url'],
-            $listeners,
+            $authenticators,
             $options['switch_user']
         );
 
@@ -57,7 +57,7 @@ class FirewallConfigTest extends TestCase
         $this->assertSame($options['access_denied_handler'], $config->getAccessDeniedHandler());
         $this->assertSame($options['access_denied_url'], $config->getAccessDeniedUrl());
         $this->assertSame($options['user_checker'], $config->getUserChecker());
-        $this->assertSame($listeners, $config->getListeners());
+        $this->assertSame($authenticators, $config->getAuthenticators());
         $this->assertSame($options['switch_user'], $config->getSwitchUser());
     }
 }

--- a/src/Symfony/Component/Security/Guard/Authenticator/GuardBridgeAuthenticator.php
+++ b/src/Symfony/Component/Security/Guard/Authenticator/GuardBridgeAuthenticator.php
@@ -95,6 +95,11 @@ class GuardBridgeAuthenticator implements InteractiveAuthenticatorInterface, Aut
         return $passport;
     }
 
+    public function getGuardAuthenticator(): GuardAuthenticatorInterface
+    {
+        return $this->guard;
+    }
+
     private function getUser($credentials): UserInterface
     {
         $user = $this->guard->getUser($credentials, $this->userProvider);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The profiler's security panel needs an update regarding the not-so-new authenticator manager system.
Here it is:
<img width="1532" alt="Screenshot 2021-10-10 at 21 09 40" src="https://user-images.githubusercontent.com/7502063/136709926-8b97cca4-5f51-4495-9b93-4408fa11ece3.png">
