### PR TITLE
[ExpressionLanguage] [Lexer] Remove PHP 8.0 polyfill

### DIFF
--- a/src/Symfony/Component/ExpressionLanguage/Lexer.php
+++ b/src/Symfony/Component/ExpressionLanguage/Lexer.php
@@ -50,13 +50,13 @@ class Lexer
                 }
                 $tokens[] = new Token(Token::NUMBER_TYPE, $number, $cursor + 1);
                 $cursor += \strlen($match[0]);
-            } elseif (str_contains('([{', $expression[$cursor])) {
+            } elseif (false !== strpos('([{', $expression[$cursor])) {
                 // opening bracket
                 $brackets[] = [$expression[$cursor], $cursor];
 
                 $tokens[] = new Token(Token::PUNCTUATION_TYPE, $expression[$cursor], $cursor + 1);
                 ++$cursor;
-            } elseif (str_contains(')]}', $expression[$cursor])) {
+            } elseif (false !== strpos(')]}', $expression[$cursor])) {
                 // closing bracket
                 if (empty($brackets)) {
                     throw new SyntaxError(sprintf('Unexpected "%s".', $expression[$cursor]), $cursor, $expression);
@@ -77,7 +77,7 @@ class Lexer
                 // operators
                 $tokens[] = new Token(Token::OPERATOR_TYPE, $match[0], $cursor + 1);
                 $cursor += \strlen($match[0]);
-            } elseif (str_contains('.,?:', $expression[$cursor])) {
+            } elseif (false !== strpos('.,?:', $expression[$cursor])) {
                 // punctuation
                 $tokens[] = new Token(Token::PUNCTUATION_TYPE, $expression[$cursor], $cursor + 1);
                 ++$cursor;

--- a/src/Symfony/Component/ExpressionLanguage/composer.json
+++ b/src/Symfony/Component/ExpressionLanguage/composer.json
@@ -18,7 +18,6 @@
     "require": {
         "php": ">=7.1.3",
         "symfony/cache": "^3.4|^4.0|^5.0",
-        "symfony/polyfill-php80": "^1.16",
         "symfony/service-contracts": "^1.1|^2"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 5.3
| Bug fix      | yes
| New feature  | no
| Deprecations | no
| Tickets       | Fix #42280 
| License       | MIT
| Doc PR        | N/A

This is a partial revert of #41576 and is a followup to #42296
