### PR TITLE
Show nice CLI output in Psalm action

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -52,4 +52,5 @@ jobs:
 
       - name: Psalm
         run: |
+          ./vendor/bin/psalm.phar --no-progress
           ./vendor/bin/psalm.phar --output-format=github --no-progress


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The GitHub format is cool, but rather useless on big PRs (especially when the Psalm comments are included in collapsed code blocks due to the size). It would be cool if GitHub improved this feature (e.g. by referencing the comments in the action output).

Until then, I propose to merge this PR: It runs Psalm twice, once using the human readable CLI output and once using the GitHub output. The job duration is not impacted here, as Psalm caches its errors and thus only runs once.