### PR TITLE
[Security] Fix wrong cache directive when using the new PUBLIC_ACCESS attribute

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/RememberMeBundle/Security/UserChangingUserProvider.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/RememberMeBundle/Security/UserChangingUserProvider.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\RememberMeBundle\Security;
 
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\InMemoryUserProvider;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -39,7 +40,7 @@ class UserChangingUserProvider implements UserProviderInterface
     {
         $user = $this->inner->refreshUser($user);
 
-        $alterUser = \Closure::bind(function (User $user) { $user->password = 'foo'; }, null, User::class);
+        $alterUser = \Closure::bind(function (InMemoryUser $user) { $user->password = 'foo'; }, null, class_exists(User::class) ? User::class : InMemoryUser::class);
         $alterUser($user);
 
         return $user;

--- a/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasher.php
+++ b/src/Symfony/Component/PasswordHasher/Hasher/UserPasswordHasher.php
@@ -50,7 +50,7 @@ class UserPasswordHasher implements UserPasswordHasherInterface
         } elseif ($user instanceof UserInterface) {
             $salt = $user->getSalt();
 
-            if (null !== $salt) {
+            if ($salt) {
                 trigger_deprecation('symfony/password-hasher', '5.3', 'Returning a string from "getSalt()" without implementing the "%s" interface is deprecated, the "%s" class should implement it.', LegacyPasswordAuthenticatedUserInterface::class, get_debug_type($user));
             }
         }

--- a/src/Symfony/Component/PasswordHasher/Tests/Hasher/UserPasswordHasherTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Hasher/UserPasswordHasherTest.php
@@ -158,7 +158,7 @@ class UserPasswordHasherTest extends TestCase
 
         $passwordHasher = new UserPasswordHasher($mockPasswordHasherFactory);
 
-        \Closure::bind(function () use ($passwordHasher) { $this->password = $passwordHasher->hashPassword($this, 'foo', 'salt'); }, $user, User::class)();
+        \Closure::bind(function () use ($passwordHasher) { $this->password = $passwordHasher->hashPassword($this, 'foo', 'salt'); }, $user, class_exists(User::class) ? User::class : InMemoryUser::class)();
         $this->assertFalse($passwordHasher->needsRehash($user));
         $this->assertTrue($passwordHasher->needsRehash($user));
         $this->assertFalse($passwordHasher->needsRehash($user));

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -75,7 +75,13 @@ class AccessListener extends AbstractListener
         $attributes = $request->attributes->get('_access_control_attributes');
         $request->attributes->remove('_access_control_attributes');
 
-        if (!$attributes || ([AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY] === $attributes && $event instanceof LazyResponseEvent)) {
+        if (
+            !$attributes
+            || (
+                ([AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY] === $attributes || [AuthenticatedVoter::PUBLIC_ACCESS] === $attributes)
+                && $event instanceof LazyResponseEvent
+            )
+        ) {
             return;
         }
 

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/AccessListenerTest.php
@@ -360,4 +360,41 @@ class AccessListenerTest extends TestCase
 
         $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
     }
+
+    public function testLazyPublicPagesShouldNotAccessTokenStorage()
+    {
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->expects($this->never())->method('getToken');
+
+        $request = new Request();
+        $accessMap = $this->createMock(AccessMapInterface::class);
+        $accessMap->expects($this->any())
+            ->method('getPatterns')
+            ->with($this->equalTo($request))
+            ->willReturn([[AuthenticatedVoter::PUBLIC_ACCESS], null])
+        ;
+
+        $listener = new AccessListener($tokenStorage, $this->createMock(AccessDecisionManagerInterface::class), $accessMap, $this->createMock(AuthenticationManagerInterface::class), false);
+        $listener(new LazyResponseEvent(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST)));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testLegacyLazyPublicPagesShouldNotAccessTokenStorage()
+    {
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->expects($this->never())->method('getToken');
+
+        $request = new Request();
+        $accessMap = $this->createMock(AccessMapInterface::class);
+        $accessMap->expects($this->any())
+            ->method('getPatterns')
+            ->with($this->equalTo($request))
+            ->willReturn([[AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY], null])
+        ;
+
+        $listener = new AccessListener($tokenStorage, $this->createMock(AccessDecisionManagerInterface::class), $accessMap, $this->createMock(AuthenticationManagerInterface::class), false);
+        $listener(new LazyResponseEvent(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST)));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Ref https://github.com/symfony/symfony/pull/41613#discussion_r647337747
| License       | MIT
| Doc PR        | -

`PUBLIC_ACCESS` is the new `IS_AUTHENTICATED_ANONYMOUSLY` since 5.2, but we didn't correctly check for this causing a private cache directive for a stateless page.

This PR also includes 2 changes from #42595 that could be backported to 5.3