### PR TITLE
[Form] Remove deprecated code from FormErrorIterator

### DIFF
--- a/src/Symfony/Component/Form/FormErrorIterator.php
+++ b/src/Symfony/Component/Form/FormErrorIterator.php
@@ -190,8 +190,7 @@ class FormErrorIterator implements \RecursiveIterator, \SeekableIterator, \Array
     public function getChildren(): self
     {
         if (!$this->hasChildren()) {
-            trigger_deprecation('symfony/form', '5.4', 'Calling "%s()" if the current element is not iterable is deprecated, call "%s" to get the current element.', __METHOD__, self::class.'::current()');
-            // throw new LogicException(sprintf('The current element is not iterable. Use "%s" to get the current element.', self::class.'::current()'));
+            throw new LogicException(sprintf('The current element is not iterable. Use "%s" to get the current element.', self::class.'::current()'));
         }
 
         return current($this->errors);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Follow-up of https://github.com/symfony/symfony/pull/42387
| License       | MIT
| Doc PR        | 

Remove deprecated code from `FormErrorIterator::children()`
