### PR TITLE
[HttpKernel] Fix timestamp_rfc3339 in LoggerDataCollector

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/LoggerDataCollector.php
@@ -208,7 +208,8 @@ class LoggerDataCollector extends DataCollector implements LateDataCollectorInte
         $logs = [];
         foreach (unserialize($logContent) as $log) {
             $log['context'] = ['exception' => new SilencedErrorContext($log['type'], $log['file'], $log['line'], $log['trace'], $log['count'])];
-            $log['timestamp'] = (new \DateTimeImmutable())->setTimestamp($bootTime)->format(\DateTimeInterface::RFC3339_EXTENDED);
+            $log['timestamp'] = $bootTime;
+            $log['timestamp_rfc3339'] = (new \DateTimeImmutable())->setTimestamp($bootTime)->format(\DateTimeInterface::RFC3339_EXTENDED);
             $log['priority'] = 100;
             $log['priorityName'] = 'DEBUG';
             $log['channel'] = null;

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/LoggerDataCollectorTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\LoggerDataCollector;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
+use Symfony\Component\VarDumper\Cloner\Data;
 
 class LoggerDataCollectorTest extends TestCase
 {
@@ -43,6 +44,52 @@ class LoggerDataCollectorTest extends TestCase
             ['message' => 'Some custom logging message'],
             ['message' => 'With ending :'],
         ], $compilerLogs['Unknown Compiler Pass']);
+    }
+
+    public function testCollectFromDeprecationsLog()
+    {
+        $containerPathPrefix = __DIR__.'/';
+        $path = $containerPathPrefix.'Deprecations.log';
+        touch($path);
+        file_put_contents($path, serialize([[
+            'type' => 16384,
+            'message' => 'The "Symfony\Bundle\FrameworkBundle\Controller\Controller" class is deprecated since Symfony 4.2, use Symfony\Bundle\FrameworkBundle\Controller\AbstractController instead.',
+            'file' => '/home/hamza/projet/contrib/sf/vendor/symfony/framework-bundle/Controller/Controller.php',
+            'line' => 17,
+            'trace' => [[
+                'file' => '/home/hamza/projet/contrib/sf/src/Controller/DefaultController.php',
+                'line' => 9,
+                'function' => 'spl_autoload_call',
+            ]],
+            'count' => 1,
+        ]]));
+
+        $logger = $this
+            ->getMockBuilder(DebugLoggerInterface::class)
+            ->setMethods(['countErrors', 'getLogs', 'clear'])
+            ->getMock();
+
+        $logger->expects($this->once())->method('countErrors')->willReturn(0);
+        $logger->expects($this->exactly(2))->method('getLogs')->willReturn([]);
+
+        $c = new LoggerDataCollector($logger, $containerPathPrefix);
+        $c->lateCollect();
+
+        $processedLogs = $c->getProcessedLogs();
+
+        $this->assertCount(1, $processedLogs);
+
+        $this->assertEquals($processedLogs[0]['type'], 'deprecation');
+        $this->assertEquals($processedLogs[0]['errorCounter'], 1);
+        $this->assertEquals($processedLogs[0]['timestamp'], (new \DateTimeImmutable())->setTimestamp(filemtime($path))->format(\DateTimeInterface::RFC3339_EXTENDED));
+        $this->assertEquals($processedLogs[0]['priority'], 100);
+        $this->assertEquals($processedLogs[0]['priorityName'], 'DEBUG');
+        $this->assertNull($processedLogs[0]['channel']);
+
+        $this->assertInstanceOf(Data::class, $processedLogs[0]['message']);
+        $this->assertInstanceOf(Data::class, $processedLogs[0]['context']);
+
+        @unlink($path);
     }
 
     public function testWithMainRequest()


### PR DESCRIPTION
Found that this was still needed for some log items to avoid an error in Profiler

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Ticket | Fixes https://github.com/symfony/symfony/issues/42622
| License       | MIT

Fix for the following error on Web Profiler when looking at error logs

```
[2021-08-17T10:30:06.093284+00:00] request.CRITICAL: Uncaught PHP Exception Twig\Error\RuntimeError: "An exception has been thrown during the rendering of a template ("Warning: Undefined array key "timestamp_rfc3339"")." at /app/vendor/symfony/web-profiler-bundle/Resources/views/Collector/logger.html.twig line 49 {"exception":"[object] (Twig\\Error\\RuntimeError(code: 0): An exception has been thrown during the rendering of a template (\"Warning: Undefined array key \"timestamp_rfc3339\"\"). at /app/vendor/symfony/web-profiler-bundle/Resources/views/Collector/logger.html.twig:49)\n[previous exception] [object] (ErrorException(code: 0): Warning: Undefined array key \"timestamp_rfc3339\" at /app/vendor/symfony/http-kernel/DataCollector/LoggerDataCollector.php:112)"} []
```

Found this issue on a new 5.4 project build today

Expected data shape is 
```
array:7 [▼
  "timestamp" => Symfony\Component\VarDumper\Cloner\Data {#2810 ▶}
  "timestamp_rfc3339" => Symfony\Component\VarDumper\Cloner\Data {#2622 ▶}
  "message" => Symfony\Component\VarDumper\Cloner\Data {#2811 ▶}
  "priority" => Symfony\Component\VarDumper\Cloner\Data {#2812 ▶}
  "priorityName" => Symfony\Component\VarDumper\Cloner\Data {#2813 ▶}
  "context" => Symfony\Component\VarDumper\Cloner\Data {#2814 ▶}
  "channel" => Symfony\Component\VarDumper\Cloner\Data {#2815 ▶}
]
```

However I'm seeing this shape for `Please install the "intl" PHP extension for best performance.`
```
array:8 [▼
  "message" => Symfony\Component\VarDumper\Cloner\Data {#2905 ▶}
  "context" => Symfony\Component\VarDumper\Cloner\Data {#2717 ▶}
  "timestamp" => Symfony\Component\VarDumper\Cloner\Data {#2906 ▶}
  "priority" => Symfony\Component\VarDumper\Cloner\Data {#2907 ▶}
  "priorityName" => Symfony\Component\VarDumper\Cloner\Data {#2908 ▶}
  "channel" => Symfony\Component\VarDumper\Cloner\Data {#2909 ▶}
  "scream" => Symfony\Component\VarDumper\Cloner\Data {#2910 ▶}
  "errorCount" => Symfony\Component\VarDumper\Cloner\Data {#2911 ▶}
]
```
![image](https://user-images.githubusercontent.com/1097038/129744965-3cb18a81-5083-446d-af7e-d1209dde9eb5.png)
