### PR TITLE
Doctrine PropertyInfo Bridge handle anonymous classes

### DIFF
--- a/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
+++ b/src/Symfony/Bridge/Doctrine/PropertyInfo/DoctrineExtractor.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Doctrine\PropertyInfo;
 
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Exception\UnknownEntityNamespace;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\ORM\Mapping\MappingException as OrmMappingException;
@@ -208,7 +209,7 @@ class DoctrineExtractor implements PropertyListExtractorInterface, PropertyTypeE
     {
         try {
             return $this->entityManager ? $this->entityManager->getClassMetadata($class) : $this->classMetadataFactory->getMetadataFor($class);
-        } catch (MappingException | OrmMappingException $exception) {
+        } catch (MappingException | OrmMappingException | UnknownEntityNamespace $exception) {
             return null;
         }
     }

--- a/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/PropertyInfo/DoctrineExtractorTest.php
@@ -215,12 +215,16 @@ class DoctrineExtractorTest extends TestCase
 
     public function testGetPropertiesCatchException()
     {
-        $this->assertNull($this->createExtractor()->getProperties('Not\Exist'));
+        $extractor = $this->createExtractor();
+        $this->assertNull($extractor->getProperties(get_class(new class{})));
+        $this->assertNull($extractor->getProperties('Not\Exist'));
     }
 
     public function testGetTypesCatchException()
     {
-        $this->assertNull($this->createExtractor()->getTypes('Not\Exist', 'baz'));
+        $extractor = $this->createExtractor();
+        $this->assertNull($extractor->getProperties(get_class(new class{})));
+        $this->assertNull($extractor->getTypes('Not\Exist', 'baz'));
     }
 
     public function testGeneratedValueNotWritable()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

I'm unsure if this is a "feature" or bug fix, let me know if I should re-target to 5.4.

I've been facing an issue with the Symfony Serializer & Validator when normalizing an anonymous class, it would throw an exception due to the Doctrine property info extractor.

![Screenshot from 2021-08-18 02-41-27](https://user-images.githubusercontent.com/7744427/129766374-ca03f4d9-c214-44ce-b9c5-17d37a442e26.png)

The `getMetadata()` method lets Mapping exceptions gracefully return null, so I figured why not let `class@anoynmous` pass too