### PR TITLE
Update NativeSessionStorage docblock to match defaults

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -86,7 +86,7 @@ class NativeSessionStorage implements SessionStorageInterface
      * name, "PHPSESSID"
      * referer_check, ""
      * serialize_handler, "php"
-     * use_strict_mode, "0"
+     * use_strict_mode, "1"
      * use_cookies, "1"
      * use_only_cookies, "1"
      * use_trans_sid, "0"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Symfony overrides a number of PHP's default session INI values, including `use_strict_mode`. This was enabled by default in the HTTP framework bundle in 3.4 https://github.com/symfony/symfony/blob/8ac480a5eaa31595ca4f7c3e29106e9d4ba45527/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md#340 but the docblock was not updated to correspond with this change.