### PR TITLE
[Security] Don't produce TypeErrors for non-string CSRF tokens

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -87,7 +87,7 @@ class LogoutListener extends AbstractListener implements ListenerInterface
         if (null !== $this->csrfTokenManager) {
             $csrfToken = ParameterBagUtils::getRequestParameterValue($request, $this->options['csrf_parameter']);
 
-            if (false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['csrf_token_id'], $csrfToken))) {
+            if (!\is_string($csrfToken) || false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['csrf_token_id'], $csrfToken))) {
                 throw new LogoutException('Invalid CSRF token.');
             }
         }

--- a/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SimpleFormAuthenticationListener.php
@@ -84,7 +84,7 @@ class SimpleFormAuthenticationListener extends AbstractAuthenticationListener
         if (null !== $this->csrfTokenManager) {
             $csrfToken = ParameterBagUtils::getRequestParameterValue($request, $this->options['csrf_parameter']);
 
-            if (false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['csrf_token_id'], $csrfToken))) {
+            if (!\is_string($csrfToken) || false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['csrf_token_id'], $csrfToken))) {
                 throw new InvalidCsrfTokenException('Invalid CSRF token.');
             }
         }

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -72,7 +72,7 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
         if (null !== $this->csrfTokenManager) {
             $csrfToken = ParameterBagUtils::getRequestParameterValue($request, $this->options['csrf_parameter']);
 
-            if (false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['csrf_token_id'], $csrfToken))) {
+            if (!\is_string($csrfToken) || false === $this->csrfTokenManager->isTokenValid(new CsrfToken($this->options['csrf_token_id'], $csrfToken))) {
                 throw new InvalidCsrfTokenException('Invalid CSRF token.');
             }
         }

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/LogoutListenerTest.php
@@ -152,7 +152,10 @@ class LogoutListenerTest extends TestCase
         $listener($event);
     }
 
-    public function testCsrfValidationFails()
+    /**
+     * @dataProvider provideInvalidCsrfTokens
+     */
+    public function testCsrfValidationFails($invalidToken)
     {
         $this->expectException(LogoutException::class);
         $tokenManager = $this->getTokenManager();
@@ -160,18 +163,29 @@ class LogoutListenerTest extends TestCase
         [$listener, , $httpUtils, $options] = $this->getListener(null, $tokenManager);
 
         $request = new Request();
-        $request->query->set('_csrf_token', 'token');
+        if (null !== $invalidToken) {
+            $request->query->set('_csrf_token', $invalidToken);
+        }
 
         $httpUtils->expects($this->once())
             ->method('checkRequestPath')
             ->with($request, $options['logout_path'])
             ->willReturn(true);
 
-        $tokenManager->expects($this->once())
+        $tokenManager
             ->method('isTokenValid')
             ->willReturn(false);
 
         $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MASTER_REQUEST));
+    }
+
+    public function provideInvalidCsrfTokens(): array
+    {
+        return [
+            ['invalid'],
+            [['in' => 'valid']],
+            [null],
+        ];
     }
 
     private function getTokenManager()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42614
| License       | MIT
| Doc PR        | N/A