### PR TITLE
[ErrorHandler] Turn return-type annotations into deprecations by default + add mode to turn them into native types

### DIFF
--- a/.github/patch-types.php
+++ b/.github/patch-types.php
@@ -15,7 +15,6 @@ foreach ($loader->getClassMap() as $class => $file) {
     switch (true) {
         case false !== strpos($file = realpath($file), '/vendor/'):
         case false !== strpos($file, '/src/Symfony/Bridge/PhpUnit/'):
-        case false !== strpos($file, '/Attribute/'):
         case false !== strpos($file, '/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/Validation/Article.php'):
         case false !== strpos($file, '/src/Symfony/Component/Cache/Tests/Fixtures/DriverWrapper.php'):
         case false !== strpos($file, '/src/Symfony/Component/Config/Tests/Fixtures/BadFileName.php'):

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -139,9 +139,11 @@ jobs:
         if: "${{ matrix.php == '8.0' && ! matrix.mode }}"
         run: |
           sed -i 's/"\*\*\/Tests\/"//' composer.json
+          git add .
           composer install -q --optimize-autoloader
           SYMFONY_PATCH_TYPE_DECLARATIONS='force=1&php=7.2' php .github/patch-types.php
           SYMFONY_PATCH_TYPE_DECLARATIONS='force=1&php=7.2' php .github/patch-types.php # ensure the script is idempotent
+          git diff --exit-code
           echo PHPUNIT="$PHPUNIT,legacy" >> $GITHUB_ENV
 
       - name: Run tests

--- a/src/Symfony/Component/ErrorHandler/CHANGELOG.md
+++ b/src/Symfony/Component/ErrorHandler/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Make `DebugClassLoader` trigger deprecation notices on missing return types
+ * Add `SYMFONY_PATCH_TYPE_DECLARATIONS='force=2'` mode to `DebugClassLoader` to turn annotations into native return types
+
 5.2.0
 -----
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Leverages #42149

We need extensive doc on the topic for sure, a whole new chapter.

DebugClassLoader allows patching an app or a lib by going through these steps:

- require `symfony/error-handler` if not already there
- run `composer install -q --optimize-autoloader`
- copy/paste the below script to the root of the app/lib, in `patch-types.php`
- run the script with `SYMFONY_PATCH_TYPE_DECLARATIONS='force=phpdoc' php patch-types.php`

`SYMFONY_PATCH_TYPE_DECLARATIONS` can be set to:
- `'force=phpdoc'` to copy `@return` annotations from parent classes, to express that the next major version of that lib is going to add a native return types;
- `'force=1'` to turn `@return` annotations into native return types, but only on tests/private/final/internal methods;
- `'force=2'` to turn `@return` annotations into native return types, for all possible methods.

```php
<?php

if (false === getenv('SYMFONY_PATCH_TYPE_DECLARATIONS')) {
    echo "Please define the SYMFONY_PATCH_TYPE_DECLARATIONS env var when running this script.\n";
    exit(1);
}

$loader = require __DIR__.'/vendor/autoload.php';

Symfony\Component\ErrorHandler\DebugClassLoader::enable();

foreach ($loader->getClassMap() as $class => $file) {
    switch (true) {
        case false !== strpos($file = realpath($file), '/vendor/'):
        case false !== strpos($file, '/src/path-to-exclude/'): // add as many as required
            continue 2;
    }

    class_exists($class);
}

Symfony\Component\ErrorHandler\DebugClassLoader::checkClasses();
```