### PR TITLE
[PropertyInfo] Support for the `never` return type

### DIFF
--- a/.github/patch-types.php
+++ b/.github/patch-types.php
@@ -42,6 +42,7 @@ foreach ($loader->getClassMap() as $class => $file) {
         case false !== strpos($file, '/src/Symfony/Component/ErrorHandler/Tests/Fixtures/'):
         case false !== strpos($file, '/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Dummy.php'):
         case false !== strpos($file, '/src/Symfony/Component/PropertyInfo/Tests/Fixtures/ParentDummy.php'):
+        case false !== strpos($file, '/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php81Dummy.php'):
         case false !== strpos($file, '/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ObjectOuter.php'):
         case false !== strpos($file, '/src/Symfony/Component/VarDumper/Tests/Fixtures/NotLoadableClass.php'):
         case false !== strpos($file, '/src/Symfony/Component/VarDumper/Tests/Fixtures/ReflectionIntersectionTypeFixture.php'):

--- a/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
+++ b/src/Symfony/Component/PropertyInfo/Extractor/ReflectionExtractor.php
@@ -335,7 +335,7 @@ class ReflectionExtractor implements PropertyListExtractorInterface, PropertyTyp
 
         foreach ($reflectionType instanceof \ReflectionUnionType ? $reflectionType->getTypes() : [$reflectionType] as $type) {
             $phpTypeOrClass = $reflectionType instanceof \ReflectionNamedType ? $reflectionType->getName() : (string) $type;
-            if ('null' === $phpTypeOrClass || 'mixed' === $phpTypeOrClass) {
+            if ('null' === $phpTypeOrClass || 'mixed' === $phpTypeOrClass || 'never' === $phpTypeOrClass) {
                 continue;
             }
 

--- a/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Extractor/ReflectionExtractorTest.php
@@ -233,7 +233,7 @@ class ReflectionExtractorTest extends TestCase
     }
 
     /**
-     *     * @dataProvider php80TypesProvider
+     * @dataProvider php80TypesProvider
      * @requires PHP 8
      */
     public function testExtractPhp80Type($property, array $type = null)
@@ -253,6 +253,14 @@ class ReflectionExtractorTest extends TestCase
             ['data', null],
             ['mixedProperty', null],
         ];
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testExtractPhp81Type()
+    {
+        $this->assertNull($this->extractor->getTypes('Symfony\Component\PropertyInfo\Tests\Fixtures\Php81Dummy', 'nothing', []));
     }
 
     /**

--- a/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php81Dummy.php
+++ b/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php81Dummy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\PropertyInfo\Tests\Fixtures;
+
+class Php81Dummy
+{
+    public function getNothing(): never
+    {
+        throw new \Exception('Oops');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #41552
| License       | MIT
| Doc PR        | N/A

If the PropertyInfo component encounters the new `never` return type, it currently exits with an exception that isn't helpful. This PR proposes to skip that type because we cannot extract type information from it.