### PR TITLE
AppVeyor: Reduce upload_max_filesize below PHP_INT_MAX

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,8 +27,8 @@ install:
     - echo memory_limit=-1 >> php.ini-min
     - echo serialize_precision=14 >> php.ini-min
     - echo max_execution_time=1200 >> php.ini-min
-    - echo post_max_size=4G >> php.ini-min
-    - echo upload_max_filesize=4G >> php.ini-min
+    - echo post_max_size=1G >> php.ini-min
+    - echo upload_max_filesize=1G >> php.ini-min
     - echo date.timezone="America/Los_Angeles" >> php.ini-min
     - echo extension_dir=ext >> php.ini-min
     - echo extension=php_xsl.dll >> php.ini-min


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The changes from #42618 made the tests on AppVeyor fail. The reason is that the test depends on the php.ini setting `upload_max_filesize`. The test picks the highest integer value available (`PHP_INT_MAX`), assuming that this value is higher than `upload_max_filesize` in Bytes. On AppVeyor, we test with a 32bit build of PHP and a `upload_max_filesize` setting of `4G`. The fact that 4 Gigabytes in Bytes produce a number that cannot be represented with a 32bit integer contradicts with that assumption.

This PR lowers `upload_max_filesize` to `1G` so that we have a chance to test with integer values that are higher than this setting.