### PR TITLE
[Form] Remove broken test case

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -17,9 +17,9 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToStringTransf
 
 class DateTimeToStringTransformerTest extends TestCase
 {
-    public function dataProvider()
+    public function dataProvider(): array
     {
-        $data = [
+        return [
             ['Y-m-d H:i:s', '2010-02-03 16:05:06', '2010-02-03 16:05:06 UTC'],
             ['Y-m-d H:i:00', '2010-02-03 16:05:00', '2010-02-03 16:05:00 UTC'],
             ['Y-m-d H:i', '2010-02-03 16:05', '2010-02-03 16:05:00 UTC'],
@@ -36,7 +36,6 @@ class DateTimeToStringTransformerTest extends TestCase
 
             // different day representations
             ['Y-m-j', '2010-02-3', '2010-02-03 00:00:00 UTC'],
-            ['z', '33', '1970-02-03 00:00:00 UTC'],
 
             // not bijective
             // this will not work as PHP will use actual date to replace missing info
@@ -63,8 +62,6 @@ class DateTimeToStringTransformerTest extends TestCase
 
             ['Y-z', '2010-33', '2010-02-03 00:00:00 UTC'],
         ];
-
-        return $data;
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #41552 
| License       | MIT
| Doc PR        | N/A

If we try to parse a `DateTime` object solely from a day of year, like this…

```php
$date = \DateTime::createFromFormat('z', '33');
```

… PHP 8.1 will refuse to do that with the error message

> A 'day of year' can only come after a year has been found

The commit that caused this was https://github.com/php/php-src/commit/8426623521d0a7154fe6eced4406135bf995587a by @derickr.

Our `DateTimeToStringTransformerTest` tests if that kind of transformation works, but I doubt that this covers an actual use case. This is why I propose to simply remove the failing test case.