### PR TITLE
[Console] Deprecate `HelperSet::setCommand()` and `getCommand()`

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -6,6 +6,11 @@ Cache
 
  * Deprecate `DoctrineProvider` because this class has been added to the `doctrine/cache` package`
 
+Console
+-------
+
+ * Deprecate `HelperSet::setCommand()` and `getCommand()` without replacement
+
 Finder
 ------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -30,6 +30,7 @@ Console
  * `Command::setHidden()` has a default value (`true`) for `$hidden` parameter
  * Remove `Helper::strlen()`, use `Helper::width()` instead.
  * Remove `Helper::strlenWithoutDecoration()`, use `Helper::removeDecoration()` instead.
+ * Remove `HelperSet::setCommand()` and `getCommand()` without replacement
 
 DependencyInjection
 -------------------

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `TesterTrait::assertCommandIsSuccessful()` to test command
+ * Deprecate `HelperSet::setCommand()` and `getCommand()` without replacement
 
 5.3
 ---

--- a/src/Symfony/Component/Console/Helper/HelperSet.php
+++ b/src/Symfony/Component/Console/Helper/HelperSet.php
@@ -73,8 +73,13 @@ class HelperSet implements \IteratorAggregate
         return $this->helpers[$name];
     }
 
+    /**
+     * @deprecated since Symfony 5.4
+     */
     public function setCommand(Command $command = null)
     {
+        trigger_deprecation('symfony/console', '5.4', 'Method "%s()" is deprecated.', __METHOD__);
+
         $this->command = $command;
     }
 
@@ -82,9 +87,13 @@ class HelperSet implements \IteratorAggregate
      * Gets the command associated with this helper set.
      *
      * @return Command
+     *
+     * @deprecated since Symfony 5.4
      */
     public function getCommand()
     {
+        trigger_deprecation('symfony/console', '5.4', 'Method "%s()" is deprecated.', __METHOD__);
+
         return $this->command;
     }
 

--- a/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
@@ -74,6 +74,9 @@ class HelperSetTest extends TestCase
         }
     }
 
+    /**
+     * @group legacy
+     */
     public function testSetCommand()
     {
         $cmd_01 = new Command('foo');
@@ -89,6 +92,9 @@ class HelperSetTest extends TestCase
         $this->assertEquals($cmd_02, $helperset->getCommand(), '->setCommand() overwrites stored command with consecutive calls');
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetCommand()
     {
         $cmd = new Command('foo');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The `HelperSet` has a getter and setter for a `Command` property. But as far as I can tell, that property is neither populated nor queried anywhere and I fail to see what purpose that property serves. Because of that I'd like to remove it in Symfony 6.