### PR TITLE
[Console] Remove `HelperSet::setCommand()` and `getCommand()`

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Remove `Helper::strlen()`, use `Helper::width()` instead
  * Remove `Helper::strlenWithoutDecoration()`, use `Helper::removeDecoration()` instead
  * `AddConsoleCommandPass` can not be configured anymore
+ * Remove `HelperSet::setCommand()` and `getCommand()` without replacement
 
 5.4
 ---

--- a/src/Symfony/Component/Console/Helper/HelperSet.php
+++ b/src/Symfony/Component/Console/Helper/HelperSet.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Console\Helper;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 
 /**
@@ -25,7 +24,6 @@ class HelperSet implements \IteratorAggregate
      * @var Helper[]
      */
     private $helpers = [];
-    private $command;
 
     /**
      * @param Helper[] $helpers An array of helper
@@ -67,28 +65,6 @@ class HelperSet implements \IteratorAggregate
         }
 
         return $this->helpers[$name];
-    }
-
-    /**
-     * @deprecated since Symfony 5.4
-     */
-    public function setCommand(Command $command = null)
-    {
-        trigger_deprecation('symfony/console', '5.4', 'Method "%s()" is deprecated.', __METHOD__);
-
-        $this->command = $command;
-    }
-
-    /**
-     * Gets the command associated with this helper set.
-     *
-     * @deprecated since Symfony 5.4
-     */
-    public function getCommand(): Command
-    {
-        trigger_deprecation('symfony/console', '5.4', 'Method "%s()" is deprecated.', __METHOD__);
-
-        return $this->command;
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Console\Tests\Helper;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Helper\HelperInterface;
 use Symfony\Component\Console\Helper\HelperSet;
@@ -72,35 +71,6 @@ class HelperSetTest extends TestCase
             $this->assertInstanceOf(ExceptionInterface::class, $e, '->get() throws domain specific exception when helper not found');
             $this->assertStringContainsString('The helper "foo" is not defined.', $e->getMessage(), '->get() throws InvalidArgumentException when helper not found');
         }
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testSetCommand()
-    {
-        $cmd_01 = new Command('foo');
-        $cmd_02 = new Command('bar');
-
-        $helperset = new HelperSet();
-        $helperset->setCommand($cmd_01);
-        $this->assertEquals($cmd_01, $helperset->getCommand(), '->setCommand() stores given command');
-
-        $helperset = new HelperSet();
-        $helperset->setCommand($cmd_01);
-        $helperset->setCommand($cmd_02);
-        $this->assertEquals($cmd_02, $helperset->getCommand(), '->setCommand() overwrites stored command with consecutive calls');
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testGetCommand()
-    {
-        $cmd = new Command('foo');
-        $helperset = new HelperSet();
-        $helperset->setCommand($cmd);
-        $this->assertEquals($cmd, $helperset->getCommand(), '->getCommand() retrieves stored command');
     }
 
     public function testIteration()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Follows #42632.