### PR TITLE
Suppress duplicate cookies

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -157,7 +157,7 @@ class NativeSessionStorage implements SessionStorageInterface
         // Subsequent calls to session_start() cause PHP to unconditionally
         // [re-]set the cookie header, which may be undesirable.
         // @see https://bugs.php.net/bug.php?id=38104#1491877141
-        if (true === $this->closed) {
+        if ($this->closed) {
             $options['use_cookies'] = 0;
         }
         if (!session_start($options)) {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -160,6 +160,7 @@ class NativeSessionStorage implements SessionStorageInterface
         if ($this->closed) {
             $options['use_cookies'] = 0;
         }
+
         if (!session_start($options)) {
             throw new \RuntimeException('Failed to start the session.');
         }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -153,7 +153,14 @@ class NativeSessionStorage implements SessionStorageInterface
         }
 
         // ok to try and start the session
-        if (!session_start()) {
+        $options = [];
+        // Subsequent calls to session_start() cause PHP to unconditionally
+        // [re-]set the cookie header, which may be undesirable.
+        // @see https://bugs.php.net/bug.php?id=38104#1491877141
+        if (true === $this->closed) {
+            $options['use_cookies'] = 0;
+        }
+        if (!session_start($options)) {
             throw new \RuntimeException('Failed to start the session.');
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -243,6 +243,22 @@ class NativeSessionStorageTest extends TestCase
         $storage->start();
     }
 
+    public function testSessionCookieOnlySentOnce()
+    {
+        if (!function_exists('xdebug_get_headers')) {
+            $this->markTestSkipped('Test utilizes missing xdebug_get_headers() function.');
+        }
+        $storage = $this->getStorage();
+        $storage->start();
+        $storage->getBag('attributes')->set('attribute', 1);
+        $storage->save();
+        $regex = '/^Set\-Cookie\: .*/';
+        $this->assertCount(1, preg_grep($regex, xdebug_get_headers()));
+        $storage->start();
+        $storage->save();
+        $this->assertCount(1, preg_grep($regex, xdebug_get_headers()));
+    }
+
     public function testRestart()
     {
         $storage = $this->getStorage();

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -245,7 +245,7 @@ class NativeSessionStorageTest extends TestCase
 
     public function testSessionCookieOnlySentOnce()
     {
-        if (!function_exists('xdebug_get_headers')) {
+        if (!\function_exists('xdebug_get_headers')) {
             $this->markTestSkipped('Test utilizes missing xdebug_get_headers() function.');
         }
         $storage = $this->getStorage();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42633
| License       | MIT
| Doc PR        | 

Suppresses PHP from sending duplicate session cookies on subsequent calls to the session storage start method.