### PR TITLE
[Security] Make `AuthenticationTrustResolverInterface::isAuthenticated()` non-virtual

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolverInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolverInterface.php
@@ -17,11 +17,14 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  * Interface for resolving the authentication status of a given token.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
- *
- * @method bool isAuthenticated(TokenInterface $token = null)
  */
 interface AuthenticationTrustResolverInterface
 {
+    /**
+     * Resolves whether the passed token implementation is authenticated.
+     */
+    public function isAuthenticated(TokenInterface $token = null): bool;
+
     /**
      * Resolves whether the passed token implementation is authenticated
      * using remember-me capabilities.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The method has been added in https://github.com/symfony/symfony/pull/42510 (5.4) as a replacement for `isAnonymous()`.