### PR TITLE
[Security] make TokenInterface::getUser() nullable to tell about unauthenticated tokens

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -112,8 +112,8 @@ Security
    behavior when using `enable_authenticator_manager: true`)
  * Deprecate not setting the `$exceptionOnNoToken` argument of `AccessListener` to `false`
    (this is the default behavior when using `enable_authenticator_manager: true`)
- * Deprecate `TokenInterface:isAuthenticated()` and `setAuthenticated()` methods without replacement.
-   Security tokens won't have an "authenticated" flag anymore, so they will always be considered authenticated
+ * Deprecate `TokenInterface:isAuthenticated()` and `setAuthenticated()` methods,
+   return `null` from `getUser()` instead when a token is not authenticated
  * Deprecate `DeauthenticatedEvent`, use `TokenDeauthenticatedEvent` instead
  * Deprecate `CookieClearingLogoutHandler`, `SessionLogoutHandler` and `CsrfTokenClearingLogoutHandler`.
    Use `CookieClearingLogoutListener`, `SessionLogoutListener` and `CsrfTokenClearingLogoutListener` instead

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -359,8 +359,8 @@ Security
    `UsernamePasswordFormAuthenticationListener`, `UsernamePasswordJsonAuthenticationListener` and `X509AuthenticationListener`
    from security-http, use the new authenticator system instead
  * Remove the Guard component, use the new authenticator system instead
- * Remove `TokenInterface:isAuthenticated()` and `setAuthenticated()` methods without replacement.
-   Security tokens won't have an "authenticated" flag anymore, so they will always be considered authenticated
+ * Remove `TokenInterface:isAuthenticated()` and `setAuthenticated()`,
+   return `null` from `getUser()` instead when a token is not authenticated
  * Remove `DeauthenticatedEvent`, use `TokenDeauthenticatedEvent` instead
  * Remove `CookieClearingLogoutHandler`, `SessionLogoutHandler` and `CsrfTokenClearingLogoutHandler`.
    Use `CookieClearingLogoutListener`, `SessionLogoutListener` and `CsrfTokenClearingLogoutListener` instead

--- a/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/AbstractTokenProcessor.php
@@ -42,7 +42,7 @@ abstract class AbstractTokenProcessor
 
         if (null !== $token = $this->getToken()) {
             $record['extra'][$this->getKey()] = [
-                'authenticated' => method_exists($token, 'isAuthenticated') ? $token->isAuthenticated(false) : true, // @deprecated since Symfony 5.4, always true in 6.0
+                'authenticated' => method_exists($token, 'isAuthenticated') ? $token->isAuthenticated(false) : (bool) $token->getUser(),
                 'roles' => $token->getRoleNames(),
             ];
 

--- a/src/Symfony/Bridge/Twig/AppVariable.php
+++ b/src/Symfony/Bridge/Twig/AppVariable.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Exposes some Symfony parameters and services as an "app" global variable.
@@ -68,7 +69,7 @@ class AppVariable
     /**
      * Returns the current user.
      *
-     * @return object|null
+     * @return UserInterface|null
      *
      * @see TokenInterface::getUser()
      */
@@ -84,7 +85,7 @@ class AppVariable
 
         $user = $token->getUser();
 
-        // @deprecated since 5.4, $user will always be a UserInterface instance
+        // @deprecated since Symfony 5.4, $user will always be a UserInterface instance
         return \is_object($user) ? $user : null;
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -127,7 +127,7 @@ class SecurityDataCollector extends DataCollector implements LateDataCollectorIn
 
             $this->data = [
                 'enabled' => true,
-                'authenticated' => method_exists($token, 'isAuthenticated') ? $token->isAuthenticated(false) : true,
+                'authenticated' => method_exists($token, 'isAuthenticated') ? $token->isAuthenticated(false) : (bool) $token->getUser(),
                 'impersonated' => null !== $impersonatorUser,
                 'impersonator_user' => $impersonatorUser,
                 'impersonation_exit_path' => null,

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
@@ -111,7 +111,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
             }
 
             // @deprecated since Symfony 5.3
-            if ($user = $result->getUser() instanceof UserInterface && !method_exists($result->getUser(), 'getUserIdentifier')) {
+            if ($result->getUser() instanceof UserInterface && !method_exists($result->getUser(), 'getUserIdentifier')) {
                 trigger_deprecation('symfony/security-core', '5.3', 'Not implementing method "getUserIdentifier(): string" in user class "%s" is deprecated. This method will replace "getUsername()" in Symfony 6.0.', get_debug_type($result->getUser()));
             }
 

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -141,7 +141,7 @@ abstract class AbstractToken implements TokenInterface
     public function isAuthenticated()
     {
         if (1 > \func_num_args() || func_get_arg(0)) {
-            trigger_deprecation('symfony/security-core', '5.4', 'Method "%s()" is deprecated. In version 6.0, security tokens won\'t have an "authenticated" flag anymore and will always be considered authenticated.', __METHOD__);
+            trigger_deprecation('symfony/security-core', '5.4', 'Method "%s()" is deprecated, return null from "getUser()" instead when a token is not authenticated.', __METHOD__);
         }
 
         return $this->authenticated;
@@ -153,7 +153,7 @@ abstract class AbstractToken implements TokenInterface
     public function setAuthenticated(bool $authenticated)
     {
         if (2 > \func_num_args() || func_get_arg(1)) {
-            trigger_deprecation('symfony/security-core', '5.4', 'Method "%s()" is deprecated. In version 6.0, security tokens won\'t have an "authenticated" state anymore and will always be considered as authenticated.', __METHOD__);
+            trigger_deprecation('symfony/security-core', '5.4', 'Method "%s()" is deprecated', __METHOD__);
         }
 
         $this->authenticated = $authenticated;

--- a/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/NullToken.php
@@ -59,7 +59,7 @@ class NullToken implements TokenInterface
     public function isAuthenticated()
     {
         if (0 === \func_num_args() || func_get_arg(0)) {
-            trigger_deprecation('symfony/security-core', '5.4', 'Method "%s()" is deprecated. In version 6.0, security tokens won\'t have an "authenticated" flag anymore and will always be considered authenticated.', __METHOD__);
+            trigger_deprecation('symfony/security-core', '5.4', 'Method "%s()" is deprecated, return null from "getUser()" instead when a token is not authenticated.', __METHOD__);
         }
 
         return true;

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -51,7 +51,7 @@ interface TokenInterface extends \Serializable
     /**
      * Returns a user representation.
      *
-     * @return UserInterface
+     * @return UserInterface|null
      *
      * @see AbstractToken::setUser()
      */
@@ -71,14 +71,14 @@ interface TokenInterface extends \Serializable
      *
      * @return bool true if the token has been authenticated, false otherwise
      *
-     * @deprecated since Symfony 5.4. In 6.0, security tokens will always be considered authenticated
+     * @deprecated since Symfony 5.4, return null from "getUser()" instead when a token is not authenticated
      */
     public function isAuthenticated();
 
     /**
      * Sets the authenticated flag.
      *
-     * @deprecated since Symfony 5.4. In 6.0, security tokens will always be considered authenticated
+     * @deprecated since Symfony 5.4
      */
     public function setAuthenticated(bool $isAuthenticated);
 

--- a/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AuthorizationChecker.php
@@ -67,7 +67,9 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
      */
     final public function isGranted($attribute, $subject = null): bool
     {
-        if (null === ($token = $this->tokenStorage->getToken())) {
+        $token = $this->tokenStorage->getToken();
+
+        if (!$token || !$token->getUser()) {
             if ($this->exceptionOnNoToken) {
                 throw new AuthenticationCredentialsNotFoundException('The token storage contains no authentication token. One possible reason may be that there is no firewall configured for this URL.');
             }
@@ -78,7 +80,7 @@ class AuthorizationChecker implements AuthorizationCheckerInterface
             // @deprecated since Symfony 5.4
             if ($this->alwaysAuthenticate || !$authenticated = $token->isAuthenticated(false)) {
                 if (!($authenticated ?? true)) {
-                    trigger_deprecation('symfony/core', '5.4', 'Returning false from "%s()" is deprecated and won\'t have any effect in Symfony 6.0 as security tokens will always be considered authenticated.');
+                    trigger_deprecation('symfony/core', '5.4', 'Returning false from "%s()" is deprecated, return null from "getUser()" instead.');
                 }
                 $this->tokenStorage->setToken($token = $this->authenticationManager->authenticate($token));
             }

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Core\Authorization\Voter;
 
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
-use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -96,7 +95,7 @@ class AuthenticatedVoter implements VoterInterface
             if (self::IS_AUTHENTICATED === $attribute
                 && (method_exists($this->authenticationTrustResolver, 'isAuthenticated')
                     ? $this->authenticationTrustResolver->isAuthenticated($token)
-                    : (null !== $token && !$token instanceof NullToken))) {
+                    : ($token && $token->getUser()))) {
                 return VoterInterface::ACCESS_GRANTED;
             }
 

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -17,7 +17,7 @@ CHANGELOG
  * Deprecate setting the `$alwaysAuthenticate` argument to `true` and not setting the
    `$exceptionOnNoToken` argument to `false` of `AuthorizationChecker`
  * Deprecate methods `TokenInterface::isAuthenticated()` and `setAuthenticated`,
-   tokens will always be considered authenticated in 6.0
+   return null from "getUser()" instead when a token is not authenticated
 
 5.3
 ---

--- a/src/Symfony/Component/Security/Core/Security.php
+++ b/src/Symfony/Component/Security/Core/Security.php
@@ -42,12 +42,8 @@ class Security implements AuthorizationCheckerInterface
         }
 
         $user = $token->getUser();
-        // @deprecated since 5.4, $user will always be a UserInterface instance
-        if (!\is_object($user)) {
-            return null;
-        }
 
-        // @deprecated since 5.4, $user will always be a UserInterface instance
+        // @deprecated since Symfony 5.4, $user will always be a UserInterface instance
         if (!$user instanceof UserInterface) {
             return null;
         }

--- a/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authentication/AuthenticationTrustResolverTest.php
@@ -17,7 +17,6 @@ use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\InMemoryUser;
-use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class AuthenticationTrustResolverTest extends TestCase
@@ -29,7 +28,6 @@ class AuthenticationTrustResolverTest extends TestCase
     {
         $resolver = new AuthenticationTrustResolver();
         $this->assertFalse($resolver->isAnonymous(null));
-        $this->assertFalse($resolver->isAnonymous($this->getToken()));
         $this->assertFalse($resolver->isAnonymous($this->getRememberMeToken()));
         $this->assertFalse($resolver->isAnonymous(new FakeCustomToken()));
     }
@@ -39,7 +37,6 @@ class AuthenticationTrustResolverTest extends TestCase
         $resolver = new AuthenticationTrustResolver();
 
         $this->assertFalse($resolver->isRememberMe(null));
-        $this->assertFalse($resolver->isRememberMe($this->getToken()));
         $this->assertFalse($resolver->isRememberMe(new FakeCustomToken()));
         $this->assertTrue($resolver->isRememberMe(new RealCustomRememberMeToken()));
         $this->assertTrue($resolver->isRememberMe($this->getRememberMeToken()));
@@ -52,7 +49,6 @@ class AuthenticationTrustResolverTest extends TestCase
         $this->assertFalse($resolver->isFullFledged(null));
         $this->assertFalse($resolver->isFullFledged($this->getRememberMeToken()));
         $this->assertFalse($resolver->isFullFledged(new RealCustomRememberMeToken()));
-        $this->assertTrue($resolver->isFullFledged($this->getToken()));
         $this->assertTrue($resolver->isFullFledged(new FakeCustomToken()));
     }
 
@@ -72,7 +68,7 @@ class AuthenticationTrustResolverTest extends TestCase
         $resolver = $this->getResolver();
 
         $this->assertFalse($resolver->isAnonymous(null));
-        $this->assertFalse($resolver->isAnonymous($this->getToken()));
+        $this->assertFalse($resolver->isAnonymous(new FakeCustomToken()));
         $this->assertFalse($resolver->isAnonymous($this->getRememberMeToken()));
     }
 
@@ -81,7 +77,7 @@ class AuthenticationTrustResolverTest extends TestCase
         $resolver = $this->getResolver();
 
         $this->assertFalse($resolver->isRememberMe(null));
-        $this->assertFalse($resolver->isRememberMe($this->getToken()));
+        $this->assertFalse($resolver->isRememberMe(new FakeCustomToken()));
         $this->assertTrue($resolver->isRememberMe($this->getRememberMeToken()));
         $this->assertTrue($resolver->isRememberMe(new RealCustomRememberMeToken()));
     }
@@ -93,7 +89,7 @@ class AuthenticationTrustResolverTest extends TestCase
         $this->assertFalse($resolver->isFullFledged(null));
         $this->assertFalse($resolver->isFullFledged($this->getRememberMeToken()));
         $this->assertFalse($resolver->isFullFledged(new RealCustomRememberMeToken()));
-        $this->assertTrue($resolver->isFullFledged($this->getToken()));
+        $this->assertTrue($resolver->isFullFledged(new FakeCustomToken()));
     }
 
     /**
@@ -112,11 +108,6 @@ class AuthenticationTrustResolverTest extends TestCase
         $this->assertFalse($resolver->isFullFledged($this->getRealCustomAnonymousToken()));
     }
 
-    protected function getToken()
-    {
-        return $this->createMock(TokenInterface::class);
-    }
-
     protected function getAnonymousToken()
     {
         return new AnonymousToken('secret', 'anon.');
@@ -133,7 +124,7 @@ class AuthenticationTrustResolverTest extends TestCase
 
     protected function getRememberMeToken()
     {
-        $user = class_exists(InMemoryUser::class) ? new InMemoryUser('wouter', '', ['ROLE_USER']) : new User('wouter', '', ['ROLE_USER']);
+        $user = new InMemoryUser('wouter', '', ['ROLE_USER']);
 
         return new RememberMeToken($user, 'main', 'secret');
     }
@@ -179,6 +170,7 @@ class FakeCustomToken implements TokenInterface
 
     public function getUser(): UserInterface
     {
+        return new InMemoryUser('wouter', '', ['ROLE_USER']);
     }
 
     public function setUser($user)

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
@@ -13,12 +13,13 @@ namespace Symfony\Component\Security\Core\Tests\Authorization\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
-use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
+use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 
 class AuthenticatedVoterTest extends TestCase
 {
@@ -84,14 +85,28 @@ class AuthenticatedVoterTest extends TestCase
 
     protected function getToken($authenticated)
     {
+        $user = new InMemoryUser('wouter', '', ['ROLE_USER']);
+
         if ('fully' === $authenticated) {
-            return $this->createMock(TokenInterface::class);
-        } elseif ('remembered' === $authenticated) {
-            return $this->getMockBuilder(RememberMeToken::class)->setMethods(['setPersistent'])->disableOriginalConstructor()->getMock();
-        } elseif ('impersonated' === $authenticated) {
-            return $this->getMockBuilder(SwitchUserToken::class)->disableOriginalConstructor()->getMock();
-        } else {
-            return $this->getMockBuilder(AnonymousToken::class)->setConstructorArgs(['', ''])->getMock();
+            $token = new class() extends AbstractToken {
+                public function getCredentials()
+                {
+                }
+            };
+            $token->setUser($user);
+            $token->setAuthenticated(true, false);
+
+            return $token;
         }
+
+        if ('remembered' === $authenticated) {
+            return new RememberMeToken($user, 'foo', 'bar');
+        }
+
+        if ('impersonated' === $authenticated) {
+            return $this->getMockBuilder(SwitchUserToken::class)->disableOriginalConstructor()->getMock();
+        }
+
+        return new NullToken();
     }
 }

--- a/src/Symfony/Component/Security/Http/EventListener/UserCheckerListener.php
+++ b/src/Symfony/Component/Security/Http/EventListener/UserCheckerListener.php
@@ -46,7 +46,6 @@ class UserCheckerListener implements EventSubscriberInterface
     public function postCheckCredentials(AuthenticationSuccessEvent $event): void
     {
         $user = $event->getAuthenticationToken()->getUser();
-        // @deprecated since 5.4, $user will always be an UserInterface instance
         if (!$user instanceof UserInterface) {
             return;
         }

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -114,7 +114,7 @@ class AccessListener extends AbstractListener
 
         // @deprecated since Symfony 5.4
         if (method_exists($token, 'isAuthenticated') && !$token->isAuthenticated(false)) {
-            trigger_deprecation('symfony/core', '5.4', 'Returning false from "%s()" is deprecated and won\'t have any effect in Symfony 6.0 as security tokens will always be considered authenticated.');
+            trigger_deprecation('symfony/core', '5.4', 'Returning false from "%s()" is deprecated, return null from "getUser()" instead.');
 
             if ($this->authManager) {
                 $token = $this->authManager->authenticate($token);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As discussed in #42644
I think this might work well.