### PR TITLE
Ignoring X-Transport header while signing email with DKIM

### DIFF
--- a/src/Symfony/Component/Mime/Crypto/DkimSigner.php
+++ b/src/Symfony/Component/Mime/Crypto/DkimSigner.php
@@ -68,6 +68,7 @@ final class DkimSigner
             throw new InvalidArgumentException('Invalid DKIM signing algorithm "%s".', $options['algorithm']);
         }
         $headersToIgnore['return-path'] = true;
+        $headersToIgnore['x-transport'] = true;
         foreach ($options['headers_to_ignore'] as $name) {
             $headersToIgnore[strtolower($name)] = true;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Related PR       | https://github.com/symfony/symfony-docs/pull/15603
| License       | MIT

Earlier @fabpot wrote in https://github.com/symfony/symfony-docs/issues/15603#issuecomment-895206311:

> Anyway, this should be fixed in the code, not in the docs.

**Original problem**

If we have multiple transports and use one of them, signature will contain X-Transport header by default. But email will not:
https://github.com/symfony/symfony/blob/810599d2f0fd19558d140c19bc50eb4dc0021a2e/src/Symfony/Component/Mailer/Transport/Transports.php#L56

And signature will be invalid.