### PR TITLE
[HttpKernel] Make test more robust

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelBrowserTest.php
@@ -143,6 +143,10 @@ class HttpKernelBrowserTest extends TestCase
 
     public function testUploadedFileWhenSizeExceedsUploadMaxFileSize()
     {
+        if (UploadedFile::getMaxFilesize() >= \PHP_INT_MAX) {
+            $this->markTestSkipped('Cannot test when post_max_size or upload_max_filesize are not configured in php.ini');
+        }
+
         $source = tempnam(sys_get_temp_dir(), 'source');
 
         $kernel = new TestHttpKernel();
@@ -157,11 +161,11 @@ class HttpKernelBrowserTest extends TestCase
         /* should be modified when the getClientSize will be removed */
         $file->expects($this->any())
             ->method('getSize')
-            ->willReturn(\PHP_INT_MAX)
+            ->willReturn(UploadedFile::getMaxFilesize() + 1)
         ;
         $file->expects($this->any())
             ->method('getClientSize')
-            ->willReturn(\PHP_INT_MAX)
+            ->willReturn(UploadedFile::getMaxFilesize() + 1)
         ;
 
         $client->request('POST', '/', [], [$file]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
This change should make `testUploadedFileWhenSizeExceedsUploadMaxFileSize()` more robust (it failed on AppVeyor before).