### PR TITLE
[PropertyAccess] Fix Regression in PropertyAccessor::isWritable() 

### DIFF
--- a/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyAccessor.php
@@ -313,10 +313,8 @@ class PropertyAccessor implements PropertyAccessorInterface
                     if (!$zval[self::VALUE] instanceof \ArrayAccess && !\is_array($zval[self::VALUE])) {
                         return false;
                     }
-                } else {
-                    if (!$this->isPropertyWritable($zval[self::VALUE], $propertyPath->getElement($i))) {
-                        return false;
-                    }
+                } elseif (!\is_object($zval[self::VALUE]) || !$this->isPropertyWritable($zval[self::VALUE], $propertyPath->getElement($i))) {
+                    return false;
                 }
 
                 if (\is_object($zval[self::VALUE])) {
@@ -663,10 +661,6 @@ class PropertyAccessor implements PropertyAccessorInterface
      */
     private function isPropertyWritable(object $object, string $property): bool
     {
-        if (!\is_object($object)) {
-            return false;
-        }
-
         $mutatorForArray = $this->getWriteInfo(\get_class($object), $property, []);
 
         if (PropertyWriteInfo::TYPE_NONE !== $mutatorForArray->getType() || ($object instanceof \stdClass && property_exists($object, $property))) {

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorArrayAccessTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorArrayAccessTest.php
@@ -38,6 +38,14 @@ abstract class PropertyAccessorArrayAccessTest extends TestCase
         ];
     }
 
+    public function getInvalidPropertyPaths()
+    {
+        return [
+            [$this->getContainer(['firstName' => 'Bernhard']), 'firstName', 'Bernhard'],
+            [$this->getContainer(['person' => $this->getContainer(['firstName' => 'Bernhard'])]), 'person.firstName', 'Bernhard'],
+        ];
+    }
+
     /**
      * @dataProvider getValidPropertyPaths
      */
@@ -82,5 +90,13 @@ abstract class PropertyAccessorArrayAccessTest extends TestCase
     public function testIsWritable($collection, $path)
     {
         $this->assertTrue($this->propertyAccessor->isWritable($collection, $path));
+    }
+
+    /**
+     * @dataProvider getInvalidPropertyPaths
+     */
+    public function testIsNotWritable($collection, $path)
+    {
+        $this->assertFalse($this->propertyAccessor->isWritable($collection, $path));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

1. is_object() check was moved to the isWritable() method. 
2. adds test to check for false as return value of isWritable method

Since commit [6f6c1a16](https://github.com/symfony/symfony/commit/6f6c1a1661a3861a4f0dbd07ac03f62dcd153fba) a regression exists where calling `$propertyAccessor->isWritable()` threw an `TypeError` when passing an array while using dot notation.

`$propertyAccessor->isWritable(["name" => "Bernard"], "name");`
> TypeError: Argument 1 passed to Symfony\Component\PropertyAccess\PropertyAccessor::isPropertyWritable() must be an object, array given
