### PR TITLE
[HttpKernel] Follow semantic versioning naming

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -132,6 +132,8 @@ HttpKernel
  * Remove support for returning a `ContainerBuilder` from `KernelInterface::registerContainerConfiguration()`
  * Rename `HttpKernelInterface::MASTER_REQUEST` to `MAIN_REQUEST`
  * Rename `KernelEvent::isMasterRequest()` to `isMainRequest()`
+ * Rename `Kernel::RELEASE_VERSION` to `Kernel::PATCH_VERSION`
+ * Add `Kernel::RELEASE_VERSION` that defaults to `Kernel::VERSION`
 
 Inflector
 ---------

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -76,10 +76,11 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
     private static $freshCache = [];
 
     public const VERSION = '6.0.0-DEV';
+    public const RELEASE_VERSION = self::VERSION;
     public const VERSION_ID = 60000;
     public const MAJOR_VERSION = 6;
     public const MINOR_VERSION = 0;
-    public const RELEASE_VERSION = 0;
+    public const PATCH_VERSION = 0;
     public const EXTRA_VERSION = 'DEV';
 
     public const END_OF_MAINTENANCE = '07/2022';


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | .
| Tickets       | .
| License       | MIT
| Doc PR        | .

Related to:

 - https://symfony.com/doc/current/contributing/community/releases.html
 - https://semver.org/spec/v2.0.0.html#semantic-versioning-200

imho a `release` version is more the full version than just the patch number of the version
of course feel free to close :)