### PR TITLE
[Console] add is_enabled option to console.command tag

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `TesterTrait::assertCommandIsSuccessful()` to test command
  * Deprecate `HelperSet::setCommand()` and `getCommand()` without replacement
+ * Add `is_enabled` option to the `console.command` tag
 
 5.3
 ---

--- a/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
+++ b/src/Symfony/Component/Console/DependencyInjection/AddConsoleCommandPass.php
@@ -77,6 +77,8 @@ class AddConsoleCommandPass implements CompilerPassInterface
                 $commandName = array_shift($aliases);
             }
 
+            $isEnabled = \array_key_exists('is_enabled', $tags[0]) ? $tags[0]['is_enabled'] : true;
+
             if (null === $commandName) {
                 if (!$definition->isPublic() || $definition->isPrivate() || $definition->hasTag($this->privateTagName)) {
                     $commandId = 'console.command.public_alias.'.$id;
@@ -131,7 +133,7 @@ class AddConsoleCommandPass implements CompilerPassInterface
                 $definition->addMethodCall('setDescription', [$description]);
 
                 $container->register('.'.$id.'.lazy', LazyCommand::class)
-                    ->setArguments([$commandName, $aliases, $description, $isHidden, new ServiceClosureArgument($lazyCommandRefs[$id])]);
+                    ->setArguments([$commandName, $aliases, $description, $isHidden, new ServiceClosureArgument($lazyCommandRefs[$id]), $isEnabled]);
 
                 $lazyCommandRefs[$id] = new Reference('.'.$id.'.lazy');
             }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | TODO

until now it was not possible to override the `$isEnabled = true` of the `LazyCommand`

was originally part of https://github.com/symfony/symfony/pull/42580