### PR TITLE
Fix ProgressBar to correctly clear multi-line formats

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressBar.php
+++ b/src/Symfony/Component/Console/Helper/ProgressBar.php
@@ -482,8 +482,10 @@ final class ProgressBar
                     }
                     $this->output->clear($lineCount);
                 } else {
-                    if ($this->formatLineCount > 0) {
-                        $this->cursor->moveUp($this->formatLineCount);
+                    for ($i = 0; $i < $this->formatLineCount; ++$i) {
+                        $this->cursor->moveToColumn(1);
+                        $this->cursor->clearLine();
+                        $this->cursor->moveUp();
                     }
 
                     $this->cursor->moveToColumn(1);

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressBarTest.php
@@ -812,7 +812,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         $this->assertEquals(
             ">---------------------------\nfoobar".
             $this->generateOutput("=========>------------------\nfoobar").
-            "\x1B[1A\x1B[1G\x1B[2K".
+            "\x1B[1G\x1B[2K\x1B[1A\x1B[1G\x1B[2K".
             $this->generateOutput("============================\nfoobar"),
             stream_get_contents($output->getStream())
         );
@@ -983,7 +983,7 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
     {
         $count = substr_count($expected, "\n");
 
-        return ($count ? sprintf("\x1B[%dA\x1B[1G\x1b[2K", $count) : "\x1B[1G\x1B[2K").$expected;
+        return ($count ? str_repeat("\x1B[1G\x1b[2K\x1B[1A", $count) : '')."\x1B[1G\x1B[2K".$expected;
     }
 
     public function testBarWidthWithMultilineFormat()
@@ -1092,6 +1092,35 @@ And, as in uffish thought he stood, The Jabberwock, with eyes of flame, Came whi
         $this->assertEquals(
             ' 0/2 [>---------------------------]   0%'.
             $this->generateOutput(' 1/2 [==============>-------------]  50%'),
+            stream_get_contents($output->getStream())
+        );
+    }
+
+    public function testMultiLineFormatIsFullyCleared()
+    {
+        $bar = new ProgressBar($output = $this->getOutputStream(), 3);
+        $bar->setFormat("%current%/%max%\n%message%\nFoo");
+
+        $bar->setMessage('1234567890');
+        $bar->start();
+        $bar->display();
+
+        $bar->setMessage('ABC');
+        $bar->advance();
+        $bar->display();
+
+        $bar->setMessage('A');
+        $bar->advance();
+        $bar->display();
+
+        $bar->finish();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            "0/3\n1234567890\nFoo".
+            $this->generateOutput("1/3\nABC\nFoo").
+            $this->generateOutput("2/3\nA\nFoo").
+            $this->generateOutput("3/3\nA\nFoo"),
             stream_get_contents($output->getStream())
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42684
| License       | MIT

This restores the functionality from 4.x where the progress bar will clear/overwrite all lines in the message format.

See https://github.com/symfony/symfony/commit/80d59d5c4ae45280bbe40fba91a158b1733df9e2#diff-cdbbf4d7e2335c831f7248edc7ba5168bf03a5cbe15d8d28f96e5c2f860cc8deL467 where the issue was introduced.
