### PR TITLE
[Notifier] Firebase error handling

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
@@ -89,8 +89,8 @@ final class FirebaseTransport extends AbstractTransport
 
             throw new TransportException('Unable to post the Firebase message: '.$errorMessage, $response);
         }
-        if ($jsonContents && isset($jsonContents['results']['error'])) {
-            throw new TransportException('Unable to post the Firebase message: '.$jsonContents['error'], $response);
+        if ($jsonContents && isset($jsonContents['results'][0]['error'])) {
+            throw new TransportException('Unable to post the Firebase message: '.$jsonContents['results'][0]['error'], $response);
         }
 
         $success = $response->toArray(false);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42211
| License       | MIT
| Doc PR        | symfony/symfony-docs

I found a bug in the Firebase error handling, resulting in a `Undefined index: message_id ` error.
It occurred when trying to send a notification to an unregistered device token. As I stated in my issue before.

Don't know if this (little) change should include any tests?
This is my first PR, so any feedback is welcome!