### PR TITLE
[Serializer] Save missing arguments in MissingConstructorArgumentsException

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add support for serializing empty array as object
  * Return empty collections as `ArrayObject` from `Serializer::normalize()` when `PRESERVE_EMPTY_OBJECTS` is set
  * Add support for collecting type errors during denormalization
+ * Add missing arguments in `MissingConstructorArgumentsException`
 
 5.3
 ---

--- a/src/Symfony/Component/Serializer/Exception/MissingConstructorArgumentsException.php
+++ b/src/Symfony/Component/Serializer/Exception/MissingConstructorArgumentsException.php
@@ -16,4 +16,23 @@ namespace Symfony\Component\Serializer\Exception;
  */
 class MissingConstructorArgumentsException extends RuntimeException
 {
+    /**
+     * @var string[]
+     */
+    private $missingArguments;
+
+    public function __construct(string $message, int $code = 0, \Throwable $previous = null, array $missingArguments = [])
+    {
+        $this->missingArguments = $missingArguments;
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getMissingConstructorArguments(): array
+    {
+        return $this->missingArguments;
+    }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php
@@ -401,7 +401,7 @@ abstract class AbstractNormalizer implements NormalizerInterface, DenormalizerIn
                     $params[] = null;
                 } else {
                     if (!isset($context['not_normalizable_value_exceptions'])) {
-                        throw new MissingConstructorArgumentsException(sprintf('Cannot create an instance of "%s" from serialized data because its constructor requires parameter "%s" to be present.', $class, $constructorParameter->name));
+                        throw new MissingConstructorArgumentsException(sprintf('Cannot create an instance of "%s" from serialized data because its constructor requires parameter "%s" to be present.', $class, $constructorParameter->name), 0, null, [$constructorParameter->name]);
                     }
 
                     $exception = NotNormalizableValueException::createForUnexpectedDataType(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | not really
| Deprecations? | no
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

It's currently not possible to get the information about which constructor argument is missing (except by doing regex in the exception message string). Having this information is useful when we want to have an input transformer without the need to set every fields to nullable.

For example with this flow: `[request payload] -> [normalizer/unserializer] -> [dto] -> [validation]`, each field must be nullable to not have exception during the normalization and then we still need to validate, instead we could catch `MissingConstructorArgumentsException`, handle it and make a nice http exception.

Edit: related to https://github.com/symfony/symfony/pull/42502