### PR TITLE
Add back `@return $this` annotations

### DIFF
--- a/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
+++ b/src/Symfony/Bridge/Twig/Mime/WrappedTemplatedEmail.php
@@ -57,6 +57,9 @@ final class WrappedTemplatedEmail
         }
     }
 
+    /**
+     * @return $this
+     */
     public function setSubject(string $subject): static
     {
         $this->message->subject($subject);
@@ -69,6 +72,9 @@ final class WrappedTemplatedEmail
         return $this->message->getSubject();
     }
 
+    /**
+     * @return $this
+     */
     public function setReturnPath(string $address): static
     {
         $this->message->returnPath($address);
@@ -81,6 +87,9 @@ final class WrappedTemplatedEmail
         return $this->message->getReturnPath();
     }
 
+    /**
+     * @return $this
+     */
     public function addFrom(string $address, string $name = ''): static
     {
         $this->message->addFrom(new Address($address, $name));
@@ -96,6 +105,9 @@ final class WrappedTemplatedEmail
         return $this->message->getFrom();
     }
 
+    /**
+     * @return $this
+     */
     public function addReplyTo(string $address): static
     {
         $this->message->addReplyTo($address);
@@ -111,6 +123,9 @@ final class WrappedTemplatedEmail
         return $this->message->getReplyTo();
     }
 
+    /**
+     * @return $this
+     */
     public function addTo(string $address, string $name = ''): static
     {
         $this->message->addTo(new Address($address, $name));
@@ -126,6 +141,9 @@ final class WrappedTemplatedEmail
         return $this->message->getTo();
     }
 
+    /**
+     * @return $this
+     */
     public function addCc(string $address, string $name = ''): static
     {
         $this->message->addCc(new Address($address, $name));
@@ -141,6 +159,9 @@ final class WrappedTemplatedEmail
         return $this->message->getCc();
     }
 
+    /**
+     * @return $this
+     */
     public function addBcc(string $address, string $name = ''): static
     {
         $this->message->addBcc(new Address($address, $name));
@@ -156,6 +177,9 @@ final class WrappedTemplatedEmail
         return $this->message->getBcc();
     }
 
+    /**
+     * @return $this
+     */
     public function setPriority(int $priority): static
     {
         $this->message->priority($priority);

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/DefaultsConfigurator.php
@@ -38,6 +38,8 @@ class DefaultsConfigurator extends AbstractServiceConfigurator
     /**
      * Adds a tag for this definition.
      *
+     * @return $this
+     *
      * @throws InvalidArgumentException when an invalid tag name or attribute is provided
      */
     final public function tag(string $name, array $attributes = []): static

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ParametersConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ParametersConfigurator.php
@@ -27,6 +27,9 @@ class ParametersConfigurator extends AbstractConfigurator
         $this->container = $container;
     }
 
+    /**
+     * @return $this
+     */
     final public function set(string $name, mixed $value): static
     {
         $this->container->setParameter($name, static::processValue($value, true));
@@ -34,6 +37,9 @@ class ParametersConfigurator extends AbstractConfigurator
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     final public function __invoke(string $name, mixed $value): static
     {
         return $this->set($name, $value);

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/PrototypeConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/PrototypeConfigurator.php
@@ -75,6 +75,8 @@ class PrototypeConfigurator extends AbstractServiceConfigurator
      * Excludes files from registration using glob patterns.
      *
      * @param string[]|string $excludes
+     *
+     * @return $this
      */
     final public function exclude(array|string $excludes): static
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/ReferenceConfigurator.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/ReferenceConfigurator.php
@@ -29,6 +29,9 @@ class ReferenceConfigurator extends AbstractConfigurator
         $this->id = $id;
     }
 
+    /**
+     * @return $this
+     */
     final public function ignoreOnInvalid(): static
     {
         $this->invalidBehavior = ContainerInterface::IGNORE_ON_INVALID_REFERENCE;
@@ -36,6 +39,9 @@ class ReferenceConfigurator extends AbstractConfigurator
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     final public function nullOnInvalid(): static
     {
         $this->invalidBehavior = ContainerInterface::NULL_ON_INVALID_REFERENCE;
@@ -43,6 +49,9 @@ class ReferenceConfigurator extends AbstractConfigurator
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     final public function ignoreOnUninitialized(): static
     {
         $this->invalidBehavior = ContainerInterface::IGNORE_ON_UNINITIALIZED_REFERENCE;

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AbstractTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AbstractTrait.php
@@ -16,6 +16,8 @@ trait AbstractTrait
     /**
      * Whether this definition is abstract, that means it merely serves as a
      * template for other definitions.
+     *
+     * @return $this
      */
     final public function abstract(bool $abstract = true): static
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ArgumentTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ArgumentTrait.php
@@ -15,6 +15,8 @@ trait ArgumentTrait
 {
     /**
      * Sets the arguments to pass to the service constructor/factory method.
+     *
+     * @return $this
      */
     final public function args(array $arguments): static
     {
@@ -25,6 +27,8 @@ trait ArgumentTrait
 
     /**
      * Sets one argument to pass to the service constructor/factory method.
+     *
+     * @return $this
      */
     final public function arg(string|int $key, mixed $value): static
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AutoconfigureTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AutoconfigureTrait.php
@@ -18,6 +18,8 @@ trait AutoconfigureTrait
     /**
      * Sets whether or not instanceof conditionals should be prepended with a global set.
      *
+     * @return $this
+     *
      * @throws InvalidArgumentException when a parent is already set
      */
     final public function autoconfigure(bool $autoconfigured = true): static

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AutowireTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/AutowireTrait.php
@@ -15,6 +15,8 @@ trait AutowireTrait
 {
     /**
      * Enables/disables autowiring.
+     *
+     * @return $this
      */
     final public function autowire(bool $autowired = true): static
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/BindTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/BindTrait.php
@@ -28,6 +28,8 @@ trait BindTrait
      *
      * @param string $nameOrFqcn A parameter name with its "$" prefix, or an FQCN
      * @param mixed  $valueOrRef The value or reference to bind
+     *
+     * @return $this
      */
     final public function bind(string $nameOrFqcn, mixed $valueOrRef): static
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/CallTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/CallTrait.php
@@ -22,6 +22,8 @@ trait CallTrait
      * @param array  $arguments    An array of arguments to pass to the method call
      * @param bool   $returnsClone Whether the call returns the service instance or not
      *
+     * @return $this
+     *
      * @throws InvalidArgumentException on empty $method param
      */
     final public function call(string $method, array $arguments = [], bool $returnsClone = false): static

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ClassTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ClassTrait.php
@@ -15,6 +15,8 @@ trait ClassTrait
 {
     /**
      * Sets the service class.
+     *
+     * @return $this
      */
     final public function class(?string $class): static
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ConfiguratorTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ConfiguratorTrait.php
@@ -17,6 +17,8 @@ trait ConfiguratorTrait
 {
     /**
      * Sets a configurator to call after the service is fully initialized.
+     *
+     * @return $this
      */
     final public function configurator(string|array|ReferenceConfigurator $configurator): static
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/DecorateTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/DecorateTrait.php
@@ -21,6 +21,8 @@ trait DecorateTrait
      *
      * @param string|null $id The decorated service id, use null to remove decoration
      *
+     * @return $this
+     *
      * @throws InvalidArgumentException in case the decorated service id and the new decorated service id are equals
      */
     final public function decorate(?string $id, string $renamedId = null, int $priority = 0, int $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE): static

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/DeprecateTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/DeprecateTrait.php
@@ -22,6 +22,8 @@ trait DeprecateTrait
      * @param string $version The version of the package that introduced the deprecation
      * @param string $message The deprecation message to use
      *
+     * @return $this
+     *
      * @throws InvalidArgumentException when the message template is invalid
      */
     final public function deprecate(string $package, string $version, string $message): static

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FactoryTrait.php
@@ -18,6 +18,8 @@ trait FactoryTrait
 {
     /**
      * Sets a factory.
+     *
+     * @return $this
      */
     final public function factory(string|array|ReferenceConfigurator $factory): static
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FileTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/FileTrait.php
@@ -15,6 +15,8 @@ trait FileTrait
 {
     /**
      * Sets a file to require before creating the service.
+     *
+     * @return $this
      */
     final public function file(string $file): static
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/LazyTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/LazyTrait.php
@@ -17,6 +17,8 @@ trait LazyTrait
      * Sets the lazy flag of this service.
      *
      * @param bool|string $lazy A FQCN to derivate the lazy proxy from or `true` to make it extend from the definition's class
+     *
+     * @return $this
      */
     final public function lazy(bool|string $lazy = true): static
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ParentTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ParentTrait.php
@@ -19,6 +19,8 @@ trait ParentTrait
     /**
      * Sets the Definition to inherit from.
      *
+     * @return $this
+     *
      * @throws InvalidArgumentException when parent cannot be set
      */
     final public function parent(string $parent): static

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/PropertyTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/PropertyTrait.php
@@ -15,6 +15,8 @@ trait PropertyTrait
 {
     /**
      * Sets a specific property.
+     *
+     * @return $this
      */
     final public function property(string $name, mixed $value): static
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/PublicTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/PublicTrait.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator\Traits;
 
 trait PublicTrait
 {
+    /**
+     * @return $this
+     */
     final public function public(): static
     {
         $this->definition->setPublic(true);
@@ -20,6 +23,9 @@ trait PublicTrait
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     final public function private(): static
     {
         $this->definition->setPublic(false);

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ShareTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/ShareTrait.php
@@ -15,6 +15,8 @@ trait ShareTrait
 {
     /**
      * Sets if the service must be shared or not.
+     *
+     * @return $this
      */
     final public function share(bool $shared = true): static
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/SyntheticTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/SyntheticTrait.php
@@ -16,6 +16,8 @@ trait SyntheticTrait
     /**
      * Sets whether this definition is synthetic, that is not constructed by the
      * container, but dynamically injected.
+     *
+     * @return $this
      */
     final public function synthetic(bool $synthetic = true): static
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/Configurator/Traits/TagTrait.php
@@ -17,6 +17,8 @@ trait TagTrait
 {
     /**
      * Adds a tag for this definition.
+     *
+     * @return $this
      */
     final public function tag(string $name, array $attributes = []): static
     {

--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -46,6 +46,9 @@ final class Dotenv
         $this->debugKey = $debugKey;
     }
 
+    /**
+     * @return $this
+     */
     public function setProdEnvs(array $prodEnvs): static
     {
         $this->prodEnvs = $prodEnvs;
@@ -56,6 +59,8 @@ final class Dotenv
     /**
      * @param bool $usePutenv If `putenv()` should be used to define environment variables or not.
      *                        Beware that `putenv()` is not thread safe, that's why this setting defaults to false
+     *
+     * @return $this
      */
     public function usePutenv(bool $usePutenv = true): static
     {

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -410,6 +410,8 @@ class Response
     /**
      * Sets the HTTP protocol version (1.0 or 1.1).
      *
+     * @return $this
+     *
      * @final
      */
     public function setProtocolVersion(string $version): static
@@ -434,6 +436,8 @@ class Response
      *
      * If the status text is null it will be automatically populated for the known
      * status codes and left empty otherwise.
+     *
+     * @return $this
      *
      * @throws \InvalidArgumentException When the HTTP status code is not valid
      *
@@ -475,6 +479,8 @@ class Response
 
     /**
      * Sets the response charset.
+     *
+     * @return $this
      *
      * @final
      */
@@ -555,6 +561,8 @@ class Response
      *
      * It makes the response ineligible for serving other clients.
      *
+     * @return $this
+     *
      * @final
      */
     public function setPrivate(): static
@@ -570,6 +578,8 @@ class Response
      *
      * It makes the response eligible for serving other clients.
      *
+     * @return $this
+     *
      * @final
      */
     public function setPublic(): static
@@ -582,6 +592,8 @@ class Response
 
     /**
      * Marks the response as "immutable".
+     *
+     * @return $this
      *
      * @final
      */
@@ -635,6 +647,8 @@ class Response
 
     /**
      * Sets the Date header.
+     *
+     * @return $this
      *
      * @final
      */
@@ -699,6 +713,8 @@ class Response
      *
      * Passing null as value will remove the header.
      *
+     * @return $this
+     *
      * @final
      */
     public function setExpires(\DateTimeInterface $date = null): static
@@ -750,6 +766,8 @@ class Response
      *
      * This methods sets the Cache-Control max-age directive.
      *
+     * @return $this
+     *
      * @final
      */
     public function setMaxAge(int $value): static
@@ -763,6 +781,8 @@ class Response
      * Sets the number of seconds after which the response should no longer be considered fresh by shared caches.
      *
      * This methods sets the Cache-Control s-maxage directive.
+     *
+     * @return $this
      *
      * @final
      */
@@ -796,6 +816,8 @@ class Response
      *
      * This method adjusts the Cache-Control/s-maxage directive.
      *
+     * @return $this
+     *
      * @final
      */
     public function setTtl(int $seconds): static
@@ -809,6 +831,8 @@ class Response
      * Sets the response's time-to-live for private/client caches in seconds.
      *
      * This method adjusts the Cache-Control/max-age directive.
+     *
+     * @return $this
      *
      * @final
      */
@@ -835,6 +859,8 @@ class Response
      * Sets the Last-Modified HTTP header with a DateTime instance.
      *
      * Passing null as value will remove the header.
+     *
+     * @return $this
      *
      * @final
      */
@@ -872,6 +898,8 @@ class Response
      * @param string|null $etag The ETag unique identifier or null to remove the header
      * @param bool        $weak Whether you want a weak ETag or not
      *
+     * @return $this
+     *
      * @final
      */
     public function setEtag(string $etag = null, bool $weak = false): static
@@ -893,6 +921,8 @@ class Response
      * Sets the response's cache headers (validation and/or expiration).
      *
      * Available options are: must_revalidate, no_cache, no_store, no_transform, public, private, proxy_revalidate, max_age, s_maxage, immutable, last_modified and etag.
+     *
+     * @return $this
      *
      * @throws \InvalidArgumentException
      *
@@ -955,6 +985,8 @@ class Response
      * This sets the status, removes the body, and discards any headers
      * that MUST NOT be included in 304 responses.
      *
+     * @return $this
+     *
      * @see https://tools.ietf.org/html/rfc2616#section-10.3.5
      *
      * @final
@@ -1005,6 +1037,8 @@ class Response
      * Sets the Vary header.
      *
      * @param bool $replace Whether to replace the actual value or not (true by default)
+     *
+     * @return $this
      *
      * @final
      */

--- a/src/Symfony/Component/Mime/Crypto/DkimOptions.php
+++ b/src/Symfony/Component/Mime/Crypto/DkimOptions.php
@@ -25,6 +25,9 @@ final class DkimOptions
         return $this->options;
     }
 
+    /**
+     * @return $this
+     */
     public function algorithm(int $algo): static
     {
         $this->options['algorithm'] = $algo;
@@ -32,6 +35,9 @@ final class DkimOptions
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function signatureExpirationDelay(int $show): static
     {
         $this->options['signature_expiration_delay'] = $show;
@@ -39,6 +45,9 @@ final class DkimOptions
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function bodyMaxLength(int $max): static
     {
         $this->options['body_max_length'] = $max;
@@ -46,6 +55,9 @@ final class DkimOptions
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function bodyShowLength(bool $show): static
     {
         $this->options['body_show_length'] = $show;
@@ -53,6 +65,9 @@ final class DkimOptions
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function headerCanon(string $canon): static
     {
         $this->options['header_canon'] = $canon;
@@ -60,6 +75,9 @@ final class DkimOptions
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function bodyCanon(string $canon): static
     {
         $this->options['body_canon'] = $canon;
@@ -67,6 +85,9 @@ final class DkimOptions
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function headersToIgnore(array $headers): static
     {
         $this->options['headers_to_ignore'] = $headers;

--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -491,6 +491,9 @@ class Email extends Message
         return $part;
     }
 
+    /**
+     * @return $this
+     */
     private function setHeaderBody(string $type, string $name, $body): static
     {
         $this->getHeaders()->setHeaderBody($type, $name, $body);

--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -76,42 +76,65 @@ final class Headers
 
     /**
      * @param array<Address|string> $addresses
+     *
+     * @return $this
      */
     public function addMailboxListHeader(string $name, array $addresses): static
     {
         return $this->add(new MailboxListHeader($name, Address::createArray($addresses)));
     }
 
+    /**
+     * @return $this
+     */
     public function addMailboxHeader(string $name, Address|string $address): static
     {
         return $this->add(new MailboxHeader($name, Address::create($address)));
     }
 
+    /**
+     * @return $this
+     */
     public function addIdHeader(string $name, string|array $ids): static
     {
         return $this->add(new IdentificationHeader($name, $ids));
     }
 
+    /**
+     * @return $this
+     */
     public function addPathHeader(string $name, Address|string $path): static
     {
         return $this->add(new PathHeader($name, $path instanceof Address ? $path : new Address($path)));
     }
 
+    /**
+     * @return $this
+     */
     public function addDateHeader(string $name, \DateTimeInterface $dateTime): static
     {
         return $this->add(new DateHeader($name, $dateTime));
     }
 
+    /**
+     * @return $this
+     */
     public function addTextHeader(string $name, string $value): static
     {
         return $this->add(new UnstructuredHeader($name, $value));
     }
 
+    /**
+     * @return $this
+     */
     public function addParameterizedHeader(string $name, string $value, array $params = []): static
     {
         return $this->add(new ParameterizedHeader($name, $value, $params));
     }
 
+    /**
+     * @return $this
+     */
     public function addHeader(string $name, mixed $argument, array $more = []): static
     {
         $parts = explode('\\', self::HEADER_CLASS_MAP[strtolower($name)] ?? UnstructuredHeader::class);
@@ -130,6 +153,9 @@ final class Headers
         return isset($this->headers[strtolower($name)]);
     }
 
+    /**
+     * @return $this
+     */
     public function add(HeaderInterface $header): static
     {
         self::checkHeaderClass($header);

--- a/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/AmazonSns/AmazonSnsOptions.php
@@ -41,6 +41,8 @@ final class AmazonSnsOptions implements MessageOptionsInterface
 
     /**
      * @param string $topic The Topic ARN for SNS message
+     *
+     * @return $this
      */
     public function recipient(string $topic): static
     {

--- a/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/RocketChat/RocketChatOptions.php
@@ -46,6 +46,9 @@ final class RocketChatOptions implements MessageOptionsInterface
         return $this->channel;
     }
 
+    /**
+     * @return $this
+     */
     public function channel(string $channel): static
     {
         $this->channel = $channel;

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackActionsBlock.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackActionsBlock.php
@@ -21,6 +21,9 @@ final class SlackActionsBlock extends AbstractSlackBlock
         $this->options['type'] = 'actions';
     }
 
+    /**
+     * @return $this
+     */
     public function button(string $text, string $url, string $style = null): static
     {
         if (25 === \count($this->options['elements'] ?? [])) {

--- a/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackSectionBlock.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/Block/SlackSectionBlock.php
@@ -21,6 +21,9 @@ final class SlackSectionBlock extends AbstractSlackBlock
         $this->options['type'] = 'section';
     }
 
+    /**
+     * @return $this
+     */
     public function text(string $text, bool $markdown = true): static
     {
         $this->options['text'] = [
@@ -31,6 +34,9 @@ final class SlackSectionBlock extends AbstractSlackBlock
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function field(string $text, bool $markdown = true): static
     {
         if (10 === \count($this->options['fields'] ?? [])) {
@@ -45,6 +51,9 @@ final class SlackSectionBlock extends AbstractSlackBlock
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function accessory(SlackBlockElementInterface $element): static
     {
         $this->options['accessory'] = $element->toArray();

--- a/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/Slack/SlackOptions.php
@@ -67,6 +67,8 @@ final class SlackOptions implements MessageOptionsInterface
 
     /**
      * @param string $id The hook id (anything after https://hooks.slack.com/services/)
+     *
+     * @return $this
      */
     public function recipient(string $id): static
     {
@@ -75,6 +77,9 @@ final class SlackOptions implements MessageOptionsInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function asUser(bool $bool): static
     {
         $this->options['as_user'] = $bool;
@@ -82,6 +87,9 @@ final class SlackOptions implements MessageOptionsInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function block(SlackBlockInterface $block): static
     {
         if (\count($this->options['blocks'] ?? []) >= self::MAX_BLOCKS) {
@@ -93,6 +101,9 @@ final class SlackOptions implements MessageOptionsInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function iconEmoji(string $emoji): static
     {
         $this->options['icon_emoji'] = $emoji;
@@ -100,6 +111,9 @@ final class SlackOptions implements MessageOptionsInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function iconUrl(string $url): static
     {
         $this->options['icon_url'] = $url;
@@ -107,6 +121,9 @@ final class SlackOptions implements MessageOptionsInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function linkNames(bool $bool): static
     {
         $this->options['link_names'] = $bool;
@@ -114,6 +131,9 @@ final class SlackOptions implements MessageOptionsInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function mrkdwn(bool $bool): static
     {
         $this->options['mrkdwn'] = $bool;
@@ -121,6 +141,9 @@ final class SlackOptions implements MessageOptionsInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function parse(string $parse): static
     {
         $this->options['parse'] = $parse;
@@ -128,6 +151,9 @@ final class SlackOptions implements MessageOptionsInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function unfurlLinks(bool $bool): static
     {
         $this->options['unfurl_links'] = $bool;
@@ -135,6 +161,9 @@ final class SlackOptions implements MessageOptionsInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function unfurlMedia(bool $bool): static
     {
         $this->options['unfurl_media'] = $bool;
@@ -142,6 +171,9 @@ final class SlackOptions implements MessageOptionsInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function username(string $username): static
     {
         $this->options['username'] = $username;
@@ -149,6 +181,9 @@ final class SlackOptions implements MessageOptionsInterface
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function threadTs(string $threadTs): static
     {
         $this->options['thread_ts'] = $threadTs;

--- a/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/ReplyKeyboardMarkup.php
+++ b/src/Symfony/Component/Notifier/Bridge/Telegram/Reply/Markup/ReplyKeyboardMarkup.php
@@ -27,6 +27,8 @@ final class ReplyKeyboardMarkup extends AbstractTelegramReplyMarkup
 
     /**
      * @param array|KeyboardButton[] $buttons
+     *
+     * @return $this
      */
     public function keyboard(array $buttons): static
     {

--- a/src/Symfony/Component/Notifier/Message/ChatMessage.php
+++ b/src/Symfony/Component/Notifier/Message/ChatMessage.php
@@ -37,6 +37,9 @@ final class ChatMessage implements MessageInterface
         return $message;
     }
 
+    /**
+     * @return $this
+     */
     public function subject(string $subject): static
     {
         $this->subject = $subject;
@@ -54,6 +57,9 @@ final class ChatMessage implements MessageInterface
         return $this->options ? $this->options->getRecipientId() : null;
     }
 
+    /**
+     * @return $this
+     */
     public function options(MessageOptionsInterface $options): static
     {
         $this->options = $options;
@@ -66,6 +72,9 @@ final class ChatMessage implements MessageInterface
         return $this->options;
     }
 
+    /**
+     * @return $this
+     */
     public function transport(?string $transport): static
     {
         $this->transport = $transport;

--- a/src/Symfony/Component/Notifier/Message/EmailMessage.php
+++ b/src/Symfony/Component/Notifier/Message/EmailMessage.php
@@ -72,6 +72,9 @@ final class EmailMessage implements MessageInterface
         return $this->envelope;
     }
 
+    /**
+     * @return $this
+     */
     public function envelope(Envelope $envelope): static
     {
         $this->envelope = $envelope;
@@ -94,6 +97,9 @@ final class EmailMessage implements MessageInterface
         return null;
     }
 
+    /**
+     * @return $this
+     */
     public function transport(?string $transport): static
     {
         if (!$this->message instanceof Email) {

--- a/src/Symfony/Component/Notifier/Message/SmsMessage.php
+++ b/src/Symfony/Component/Notifier/Message/SmsMessage.php
@@ -39,6 +39,9 @@ final class SmsMessage implements MessageInterface
         return new self($recipient->getPhone(), $notification->getSubject());
     }
 
+    /**
+     * @return $this
+     */
     public function phone(string $phone): static
     {
         if ('' === $phone) {
@@ -60,6 +63,9 @@ final class SmsMessage implements MessageInterface
         return $this->phone;
     }
 
+    /**
+     * @return $this
+     */
     public function subject(string $subject): static
     {
         $this->subject = $subject;
@@ -72,6 +78,9 @@ final class SmsMessage implements MessageInterface
         return $this->subject;
     }
 
+    /**
+     * @return $this
+     */
     public function transport(?string $transport): static
     {
         $this->transport = $transport;

--- a/src/Symfony/Component/OptionsResolver/OptionConfigurator.php
+++ b/src/Symfony/Component/OptionsResolver/OptionConfigurator.php
@@ -28,6 +28,8 @@ final class OptionConfigurator
     /**
      * Adds allowed types for this option.
      *
+     * @return $this
+     *
      * @throws AccessException If called from a lazy option or normalizer
      */
     public function allowedTypes(string ...$types): static
@@ -42,6 +44,8 @@ final class OptionConfigurator
      *
      * @param mixed ...$values One or more acceptable values/closures
      *
+     * @return $this
+     *
      * @throws AccessException If called from a lazy option or normalizer
      */
     public function allowedValues(mixed ...$values): static
@@ -53,6 +57,8 @@ final class OptionConfigurator
 
     /**
      * Sets the default value for this option.
+     *
+     * @return $this
      *
      * @throws AccessException If called from a lazy option or normalizer
      */
@@ -77,6 +83,8 @@ final class OptionConfigurator
      * @param string          $package The name of the composer package that is triggering the deprecation
      * @param string          $version The version of the package that introduced the deprecation
      * @param string|\Closure $message The deprecation message to use
+     *
+     * @return $this
      */
     public function deprecated(string $package, string $version, string|\Closure $message = 'The option "%name%" is deprecated.'): static
     {
@@ -87,6 +95,8 @@ final class OptionConfigurator
 
     /**
      * Sets the normalizer for this option.
+     *
+     * @return $this
      *
      * @throws AccessException If called from a lazy option or normalizer
      */
@@ -100,6 +110,8 @@ final class OptionConfigurator
     /**
      * Marks this option as required.
      *
+     * @return $this
+     *
      * @throws AccessException If called from a lazy option or normalizer
      */
     public function required(): static
@@ -111,6 +123,8 @@ final class OptionConfigurator
 
     /**
      * Sets an info message for an option.
+     *
+     * @return $this
      *
      * @throws AccessException If called from a lazy option or normalizer
      */

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -253,6 +253,8 @@ class Process implements \IteratorAggregate
      * This is identical to run() except that an exception is thrown if the process
      * exits with a non-zero exit code.
      *
+     * @return $this
+     *
      * @throws ProcessFailedException if the process didn't terminate successfully
      *
      * @final

--- a/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/CollectionConfigurator.php
@@ -72,6 +72,8 @@ class CollectionConfigurator
      * Sets the prefix to add to the path of all child routes.
      *
      * @param string|array $prefix the prefix, or the localized prefixes
+     *
+     * @return $this
      */
     final public function prefix(string|array $prefix): static
     {
@@ -103,6 +105,8 @@ class CollectionConfigurator
      * Sets the host to use for all child routes.
      *
      * @param string|array $host the host, or the localized hosts
+     *
+     * @return $this
      */
     final public function host(string|array $host): static
     {

--- a/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/ImportConfigurator.php
@@ -49,6 +49,8 @@ class ImportConfigurator
      * Sets the prefix to add to the path of all child routes.
      *
      * @param string|array $prefix the prefix, or the localized prefixes
+     *
+     * @return $this
      */
     final public function prefix(string|array $prefix, bool $trailingSlashOnRoot = true): static
     {
@@ -59,6 +61,8 @@ class ImportConfigurator
 
     /**
      * Sets the prefix to add to the name of all child routes.
+     *
+     * @return $this
      */
     final public function namePrefix(string $namePrefix): static
     {
@@ -71,6 +75,8 @@ class ImportConfigurator
      * Sets the host to use for all child routes.
      *
      * @param string|array $host the host, or the localized hosts
+     *
+     * @return $this
      */
     final public function host(string|array $host): static
     {

--- a/src/Symfony/Component/Routing/Loader/Configurator/RouteConfigurator.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/RouteConfigurator.php
@@ -37,6 +37,8 @@ class RouteConfigurator
      * Sets the host to use for all child routes.
      *
      * @param string|array $host the host, or the localized hosts
+     *
+     * @return $this
      */
     final public function host(string|array $host): static
     {

--- a/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
+++ b/src/Symfony/Component/Routing/Loader/Configurator/Traits/RouteTrait.php
@@ -23,6 +23,8 @@ trait RouteTrait
 
     /**
      * Adds defaults.
+     *
+     * @return $this
      */
     final public function defaults(array $defaults): static
     {
@@ -33,6 +35,8 @@ trait RouteTrait
 
     /**
      * Adds requirements.
+     *
+     * @return $this
      */
     final public function requirements(array $requirements): static
     {
@@ -43,6 +47,8 @@ trait RouteTrait
 
     /**
      * Adds options.
+     *
+     * @return $this
      */
     final public function options(array $options): static
     {
@@ -53,6 +59,8 @@ trait RouteTrait
 
     /**
      * Whether paths should accept utf8 encoding.
+     *
+     * @return $this
      */
     final public function utf8(bool $utf8 = true): static
     {
@@ -63,6 +71,8 @@ trait RouteTrait
 
     /**
      * Sets the condition.
+     *
+     * @return $this
      */
     final public function condition(string $condition): static
     {
@@ -73,6 +83,8 @@ trait RouteTrait
 
     /**
      * Sets the pattern for the host.
+     *
+     * @return $this
      */
     final public function host(string $pattern): static
     {
@@ -86,6 +98,8 @@ trait RouteTrait
      * So an empty array means that any scheme is allowed.
      *
      * @param string[] $schemes
+     *
+     * @return $this
      */
     final public function schemes(array $schemes): static
     {
@@ -99,6 +113,8 @@ trait RouteTrait
      * So an empty array means that any method is allowed.
      *
      * @param string[] $methods
+     *
+     * @return $this
      */
     final public function methods(array $methods): static
     {
@@ -111,6 +127,8 @@ trait RouteTrait
      * Adds the "_controller" entry to defaults.
      *
      * @param callable|string|array $controller a callable or parseable pseudo-callable
+     *
+     * @return $this
      */
     final public function controller(callable|string|array $controller): static
     {
@@ -121,6 +139,8 @@ trait RouteTrait
 
     /**
      * Adds the "_locale" entry to defaults.
+     *
+     * @return $this
      */
     final public function locale(string $locale): static
     {
@@ -131,6 +151,8 @@ trait RouteTrait
 
     /**
      * Adds the "_format" entry to defaults.
+     *
+     * @return $this
      */
     final public function format(string $format): static
     {
@@ -141,6 +163,8 @@ trait RouteTrait
 
     /**
      * Adds the "_stateless" entry to defaults.
+     *
+     * @return $this
      */
     final public function stateless(bool $stateless = true): static
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In #42213 I removed those annotations and tried to convinced myself and others that we could do so without loosing too much.

I was about to send a PR to remove all remaining similar annotations. When I reviewed the patch I created for that, I stopped on `ItemInterface::tag()` (which is just an example):
https://github.com/symfony/symfony/blob/444d43fa11990092c53ba54849bb1df36225adcf/src/Symfony/Contracts/Cache/ItemInterface.php#L52-L57

If we remove that annotation on the interface, all implementations will have to deal with the return value of the call to `tag()`. Whereas with `@return $this`, the contracts are clear: no need to, implementations are expected to mutate and return the current object. I don't think this would be appropriate in this example.

/cc @nikic as this might be some nice food for thoughts to consider adding `$this` as a possible native return type.