### PR TITLE
[Messenger] Log when worker should stop and when `SIGTERM` is received

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -193,6 +193,9 @@ return static function (ContainerConfigurator $container) {
             ->tag('monolog.logger', ['channel' => 'messenger'])
 
         ->set('messenger.listener.stop_worker_on_sigterm_signal_listener', StopWorkerOnSigtermSignalListener::class)
+            ->args([
+                service('logger')->ignoreOnInvalid(),
+            ])
             ->tag('kernel.event_subscriber')
 
         ->set('messenger.listener.stop_worker_on_stop_exception_listener', StopWorkerOnCustomStopExceptionListener::class)

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -9,6 +9,8 @@ CHANGELOG
  * Added `WorkerMetadata` class which allows you to access the configuration details of a worker, like `queueNames` and `transportNames` it consumes from.
  * New method `getMetadata()` was added to `Worker` class which returns the `WorkerMetadata` object.
  * Deprecate not setting the `reset_on_message` config option, its default value will change to `true` in 6.0
+ * Add log when worker should stop.
+ * Add log when `SIGTERM` is received.
 
 5.3
 ---

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSigtermSignalListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnSigtermSignalListener.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Messenger\EventListener;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\Event\WorkerStartedEvent;
 
@@ -19,9 +20,20 @@ use Symfony\Component\Messenger\Event\WorkerStartedEvent;
  */
 class StopWorkerOnSigtermSignalListener implements EventSubscriberInterface
 {
+    private $logger;
+
+    public function __construct(LoggerInterface $logger = null)
+    {
+        $this->logger = $logger;
+    }
+
     public function onWorkerStarted(WorkerStartedEvent $event): void
     {
-        pcntl_signal(\SIGTERM, static function () use ($event) {
+        pcntl_signal(\SIGTERM, function () use ($event) {
+            if (null !== $this->logger) {
+                $this->logger->info('Received SIGTERM signal.');
+            }
+
             $event->getWorker()->stop();
         });
     }

--- a/src/Symfony/Component/Messenger/Tests/WorkerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/WorkerTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Messenger\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
@@ -328,6 +329,16 @@ class WorkerTest extends TestCase
 
         $envelope = current($receiver->getAcknowledgedEnvelopes());
         $this->assertCount(1, $envelope->all(\get_class($stamp)));
+    }
+
+    public function testWorkerShouldLogOnStop()
+    {
+        $bus = $this->createMock(MessageBusInterface::class);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('info')->with('Stopping worker.');
+        $worker = new Worker([], $bus, new EventDispatcher(), $logger);
+
+        $worker->stop();
     }
 }
 

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -176,6 +176,10 @@ class Worker
 
     public function stop(): void
     {
+        if (null !== $this->logger) {
+            $this->logger->info('Stopping worker.');
+        }
+
         $this->shouldStop = true;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

These two small log lines can help debugging crashing workers. Sometimes it's hard to tell if the worker crashed or is shutting down. Also, when working on gracefully shutdown problems, it's helpful to know when a `SIGTERM` was received and the worker is about to stop.