### PR TITLE
[Serializer] Return an ArrayObject for empty collection objects when PRESERVE_EMPTY_OBJECTS is set

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
  * Add support of PHP backed enumerations
  * Add support for serializing empty array as object
- * Deprecate support for returning empty, iterable, countable, raw object when normalizing
+ * Return empty collections as `ArrayObject` from `Serializer::normalize()` when `PRESERVE_EMPTY_OBJECTS` is set
 
 5.3
 ---

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -164,18 +164,13 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
             return $data;
         }
 
-        if (is_iterable($data)) {
-            if (is_countable($data) && 0 === \count($data)) {
-                switch (true) {
-                    case ($context[AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS] ?? false) && \is_object($data):
-                        if (!$data instanceof \ArrayObject) {
-                            trigger_deprecation('symfony/serializer', '5.4', 'Returning empty object of class "%s" from "%s()" is deprecated. This class should extend "ArrayObject".', get_debug_type($data), __METHOD__);
-                        }
+        if (\is_array($data) && !$data && ($context[self::EMPTY_ARRAY_AS_OBJECT] ?? false)) {
+            return new \ArrayObject();
+        }
 
-                        return $data;
-                    case ($context[self::EMPTY_ARRAY_AS_OBJECT] ?? false) && \is_array($data):
-                        return new \ArrayObject();
-                }
+        if (is_iterable($data)) {
+            if ($data instanceof \Countable && ($context[AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS] ?? false) && !\count($data)) {
+                return new \ArrayObject();
             }
 
             $normalized = [];

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -581,7 +581,7 @@ class SerializerTest extends TestCase
     /** @dataProvider provideObjectOrCollectionTests */
     public function testNormalizePreserveEmptyArrayObject(Serializer $serializer, array $data)
     {
-        $expected = '{"a1":{},"a2":{"k":"v"},"b1":[],"b2":{"k":"v"},"c1":{"nested":{}},"c2":{"nested":{"k":"v"}},"d1":{"nested":[]},"d2":{"nested":{"k":"v"}},"e1":{"map":[]},"e2":{"map":{"k":"v"}},"f1":{"map":{}},"f2":{"map":{"k":"v"}},"g1":{"list":{"list":[]},"settings":[]},"g2":{"list":["greg"],"settings":[]}}';
+        $expected = '{"a1":{},"a2":{"k":"v"},"b1":[],"b2":{"k":"v"},"c1":{"nested":{}},"c2":{"nested":{"k":"v"}},"d1":{"nested":[]},"d2":{"nested":{"k":"v"}},"e1":{"map":[]},"e2":{"map":{"k":"v"}},"f1":{"map":{}},"f2":{"map":{"k":"v"}},"g1":{"list":{},"settings":[]},"g2":{"list":["greg"],"settings":[]}}';
         $this->assertSame($expected, $serializer->serialize($data, 'json', [
             AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true,
         ]));
@@ -599,62 +599,7 @@ class SerializerTest extends TestCase
     /** @dataProvider provideObjectOrCollectionTests */
     public function testNormalizeEmptyArrayAsObjectAndPreserveEmptyArrayObject(Serializer $serializer, array $data)
     {
-        $expected = '{"a1":{},"a2":{"k":"v"},"b1":{},"b2":{"k":"v"},"c1":{"nested":{}},"c2":{"nested":{"k":"v"}},"d1":{"nested":{}},"d2":{"nested":{"k":"v"}},"e1":{"map":{}},"e2":{"map":{"k":"v"}},"f1":{"map":{}},"f2":{"map":{"k":"v"}},"g1":{"list":{"list":[]},"settings":{}},"g2":{"list":["greg"],"settings":{}}}';
-        $this->assertSame($expected, $serializer->serialize($data, 'json', [
-            Serializer::EMPTY_ARRAY_AS_OBJECT => true,
-            AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true,
-        ]));
-    }
-
-    /**
-     * @dataProvider provideObjectOrCollectionTests
-     * @group legacy
-     */
-    public function testNormalizeWithCollectionLegacy(Serializer $serializer, array $data)
-    {
-        $data['g1'] = new BazLegacy([]);
-        $data['g2'] = new BazLegacy(['greg']);
-        $expected = '{"a1":[],"a2":{"k":"v"},"b1":[],"b2":{"k":"v"},"c1":{"nested":[]},"c2":{"nested":{"k":"v"}},"d1":{"nested":[]},"d2":{"nested":{"k":"v"}},"e1":{"map":[]},"e2":{"map":{"k":"v"}},"f1":{"map":[]},"f2":{"map":{"k":"v"}},"g1":{"list":[],"settings":[]},"g2":{"list":["greg"],"settings":[]}}';
-        $this->assertSame($expected, $serializer->serialize($data, 'json'));
-    }
-
-    /**
-     * @dataProvider provideObjectOrCollectionTests
-     * @group legacy
-     */
-    public function testNormalizePreserveEmptyArrayObjectLegacy(Serializer $serializer, array $data)
-    {
-        $data['g1'] = new BazLegacy([]);
-        $data['g2'] = new BazLegacy(['greg']);
-        $expected = '{"a1":{},"a2":{"k":"v"},"b1":[],"b2":{"k":"v"},"c1":{"nested":{}},"c2":{"nested":{"k":"v"}},"d1":{"nested":[]},"d2":{"nested":{"k":"v"}},"e1":{"map":[]},"e2":{"map":{"k":"v"}},"f1":{"map":{}},"f2":{"map":{"k":"v"}},"g1":{"list":{"list":[]},"settings":[]},"g2":{"list":["greg"],"settings":[]}}';
-        $this->assertSame($expected, $serializer->serialize($data, 'json', [
-            AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true,
-        ]));
-    }
-
-    /**
-     * @dataProvider provideObjectOrCollectionTests
-     * @group legacy
-     */
-    public function testNormalizeEmptyArrayAsObjectLegacy(Serializer $serializer, array $data)
-    {
-        $data['g1'] = new BazLegacy([]);
-        $data['g2'] = new BazLegacy(['greg']);
-        $expected = '{"a1":[],"a2":{"k":"v"},"b1":{},"b2":{"k":"v"},"c1":{"nested":[]},"c2":{"nested":{"k":"v"}},"d1":{"nested":{}},"d2":{"nested":{"k":"v"}},"e1":{"map":{}},"e2":{"map":{"k":"v"}},"f1":{"map":[]},"f2":{"map":{"k":"v"}},"g1":{"list":[],"settings":{}},"g2":{"list":["greg"],"settings":{}}}';
-        $this->assertSame($expected, $serializer->serialize($data, 'json', [
-            Serializer::EMPTY_ARRAY_AS_OBJECT => true,
-        ]));
-    }
-
-    /**
-     * @dataProvider provideObjectOrCollectionTests
-     * @group legacy
-     */
-    public function testNormalizeEmptyArrayAsObjectAndPreserveEmptyArrayObjectLegacy(Serializer $serializer, array $data)
-    {
-        $data['g1'] = new BazLegacy([]);
-        $data['g2'] = new BazLegacy(['greg']);
-        $expected = '{"a1":{},"a2":{"k":"v"},"b1":{},"b2":{"k":"v"},"c1":{"nested":{}},"c2":{"nested":{"k":"v"}},"d1":{"nested":{}},"d2":{"nested":{"k":"v"}},"e1":{"map":{}},"e2":{"map":{"k":"v"}},"f1":{"map":{}},"f2":{"map":{"k":"v"}},"g1":{"list":{"list":[]},"settings":{}},"g2":{"list":["greg"],"settings":{}}}';
+        $expected = '{"a1":{},"a2":{"k":"v"},"b1":{},"b2":{"k":"v"},"c1":{"nested":{}},"c2":{"nested":{"k":"v"}},"d1":{"nested":{}},"d2":{"nested":{"k":"v"}},"e1":{"map":{}},"e2":{"map":{"k":"v"}},"f1":{"map":{}},"f2":{"map":{"k":"v"}},"g1":{"list":{},"settings":{}},"g2":{"list":["greg"],"settings":{}}}';
         $this->assertSame($expected, $serializer->serialize($data, 'json', [
             Serializer::EMPTY_ARRAY_AS_OBJECT => true,
             AbstractObjectNormalizer::PRESERVE_EMPTY_OBJECTS => true,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In #42619, we tried adding a BC layer for this behavior change, but when reviewing #42699, I figured out there is no possible BC layer: userland implementations (eg an entity returning an empty doctrine collection) won't extend ArrayObject because we ask them to do so.

I therefor propose to return an ArrayObject as of 5.4, relying on the intuition that this should not have much BC impact in practice.

/cc @lyrixx 