### PR TITLE
[Security] Fix AuthenticationTrustResolver::isAnonymous()

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolver.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolver.php
@@ -38,7 +38,7 @@ class AuthenticationTrustResolver implements AuthenticationTrustResolverInterfac
             trigger_deprecation('symfony/security-core', '5.4', 'The "%s()" method is deprecated, use "isAuthenticated()" or "isFullFledged()" if you want to check if the request is (fully) authenticated.', __METHOD__);
         }
 
-        return $token && !$this->isAuthenticated($token);
+        return $token instanceof AnonymousToken || ($token && !$token->getUser());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #42726 
| License       | MIT
| Doc PR        | -

This method wasn't checking if a token is null nor `$token->isAuthenticated()` until https://github.com/symfony/symfony/pull/42650. 
Reverting that behavior change fixes tests on both 5.3 and 5.4