### PR TITLE
Update NotNormalizableValueException with the attribute information

### DIFF
--- a/src/Symfony/Component/Serializer/Exception/NotNormalizableValueException.php
+++ b/src/Symfony/Component/Serializer/Exception/NotNormalizableValueException.php
@@ -16,4 +16,17 @@ namespace Symfony\Component\Serializer\Exception;
  */
 class NotNormalizableValueException extends UnexpectedValueException
 {
+    private ?string $attribute;
+
+    public function __construct(string $message, int $code = 0, \Throwable $previous = null, ?string $attribute = null)
+    {
+        $this->$attribute = $attribute;
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getAttribute(): ?string
+    {
+        return $this->attribute;
+    }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -335,7 +335,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             try {
                 $this->setAttributeValue($object, $attribute, $value, $format, $context);
             } catch (InvalidArgumentException $e) {
-                throw new NotNormalizableValueException(sprintf('Failed to denormalize attribute "%s" value for class "%s": '.$e->getMessage(), $attribute, $type), $e->getCode(), $e);
+                throw new NotNormalizableValueException(sprintf('Failed to denormalize attribute "%s" value for class "%s": '.$e->getMessage(), $attribute, $type), $e->getCode(), $e, $attribute);
             }
         }
 
@@ -397,14 +397,14 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                         } elseif ('true' === $data || '1' === $data) {
                             $data = true;
                         } else {
-                            throw new NotNormalizableValueException(sprintf('The type of the "%s" attribute for class "%s" must be bool ("%s" given).', $attribute, $currentClass, $data));
+                            throw new NotNormalizableValueException(sprintf('The type of the "%s" attribute for class "%s" must be bool ("%s" given).', $attribute, $currentClass, $data), 0, null, $attribute);
                         }
                         break;
                     case Type::BUILTIN_TYPE_INT:
                         if (ctype_digit($data) || '-' === $data[0] && ctype_digit(substr($data, 1))) {
                             $data = (int) $data;
                         } else {
-                            throw new NotNormalizableValueException(sprintf('The type of the "%s" attribute for class "%s" must be int ("%s" given).', $attribute, $currentClass, $data));
+                            throw new NotNormalizableValueException(sprintf('The type of the "%s" attribute for class "%s" must be int ("%s" given).', $attribute, $currentClass, $data), 0, null, $attribute);
                         }
                         break;
                     case Type::BUILTIN_TYPE_FLOAT:
@@ -420,7 +420,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                             case '-INF':
                                 return -\INF;
                             default:
-                                throw new NotNormalizableValueException(sprintf('The type of the "%s" attribute for class "%s" must be float ("%s" given).', $attribute, $currentClass, $data));
+                                throw new NotNormalizableValueException(sprintf('The type of the "%s" attribute for class "%s" must be float ("%s" given).', $attribute, $currentClass, $data), 0, null, $attribute);
                         }
 
                         break;
@@ -491,7 +491,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             return $data;
         }
 
-        throw new NotNormalizableValueException(sprintf('The type of the "%s" attribute for class "%s" must be one of "%s" ("%s" given).', $attribute, $currentClass, implode('", "', array_keys($expectedTypes)), get_debug_type($data)));
+        throw new NotNormalizableValueException(sprintf('The type of the "%s" attribute for class "%s" must be one of "%s" ("%s" given).', $attribute, $currentClass, implode('", "', array_keys($expectedTypes)), get_debug_type($data)), 0, null, $attribute);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

It's currently not possible to get the information about which attribute is raising the exception (except by doing regex in the exception message string). Having this information allows to handle the error effectively upstream.

It's similar to #42712 but for a different exception.
