### PR TITLE
[DependencyInjection] Fix AutowiringFailedException::getMessageCallback() when the message is not a closure

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Exception/AutowiringFailedException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/AutowiringFailedException.php
@@ -17,7 +17,7 @@ namespace Symfony\Component\DependencyInjection\Exception;
 class AutowiringFailedException extends RuntimeException
 {
     private string $serviceId;
-    private ?\Closure $messageCallback;
+    private ?\Closure $messageCallback = null;
 
     public function __construct(string $serviceId, string|\Closure $message = '', int $code = 0, \Throwable $previous = null)
     {

--- a/src/Symfony/Component/DependencyInjection/Tests/Exception/AutowiringFailedExceptionTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Exception/AutowiringFailedExceptionTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Exception;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Exception\AutowiringFailedException;
+
+final class AutowiringFailedExceptionTest extends TestCase
+{
+    public function testGetMessageCallbackWhenMessageIsNotANotClosure()
+    {
+        $exception = new AutowiringFailedException(
+            'App\DummyService',
+            'Cannot autowire service "App\DummyService": argument "$email" of method "__construct()" is type-hinted "string", you should configure its value explicitly.'
+        );
+
+        self::assertNull($exception->getMessageCallback());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

In the `AutowiringFailedException` class, if the message is not a closure, the property `$messageCallback` is [not set](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/DependencyInjection/Exception/AutowiringFailedException.php#L32) but since 6.0, this property has been type hinted which results to an `Error` when `getMessageCallback()` is called : `Error: Typed property Symfony\Component\DependencyInjection\Exception\AutowiringFailedException::$messageCallback must not be accessed before initialization.`.  
This PR tries to fix it.