### PR TITLE
[Notifier] Add Esendex message ID to SentMessage object

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Esendex/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/CHANGELOG.md
@@ -1,6 +1,8 @@
 CHANGELOG
 =========
 
+ * Add returned message ID to `SentMessage`
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Esendex/Tests/EsendexTransportTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
+use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -87,5 +88,27 @@ final class EsendexTransportTest extends TransportTestCase
         $this->expectExceptionMessage('Unable to send the SMS: error 500. Details from Esendex: accountreference_invalid: "Invalid Account Reference EX0000000".');
 
         $transport->send(new SmsMessage('phone', 'testMessage'));
+    }
+
+    public function testSendWithSuccessfulResponseDispatchesMessageEvent()
+    {
+        $messageId = Uuid::v4()->toRfc4122();
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->exactly(2))
+            ->method('getStatusCode')
+            ->willReturn(200);
+        $response->expects($this->once())
+            ->method('getContent')
+            ->willReturn(json_encode(['batch' => ['messageheaders' => [['id' => $messageId]]]]));
+
+        $client = new MockHttpClient(static function () use ($response): ResponseInterface {
+            return $response;
+        });
+
+        $transport = $this->createTransport($client);
+
+        $sentMessage = $transport->send(new SmsMessage('phone', 'testMessage'));
+
+        $this->assertSame($messageId, $sentMessage->getMessageId());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The Esendex API request returns a unique message ID for each SMS sent.

This commit simply extracts the message ID and adds it to the returned SentMessage object.