### PR TITLE
[SecurityBundle] Remove invalid template variable for Debug Collector

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -7,8 +7,6 @@
         {% if collector.token %}
             {% set is_authenticated = collector.enabled and collector.authenticated  %}
             {% set color_code = not is_authenticated ? 'yellow' %}
-        {% elseif collector.enabled %}
-            {% set color_code = collector.authenticatorManagerEnabled ? 'yellow' : 'red' %}
         {% else %}
             {% set color_code = '' %}
         {% endif %}


### PR DESCRIPTION
`collector.authenticatorManagerEnabled` is no longer available because `SecurityDataCollector::isAuthenticatorManagerEnabled()` was removed in a previous commit as it was deprecated. Removing this line fixes the debug bar on 6.0.x code and fixes https://github.com/symfony/symfony/issues/42652

Was introduced in a recent cleanup / refactor
https://github.com/symfony/security-bundle/commit/bb7140455045241764e4a032d55ad22bb9bc85ba

| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/42652
| License       | MIT

Fixes this error

![image](https://user-images.githubusercontent.com/1097038/131046409-13c61542-fc5c-4578-af08-501e37c72601.png)

![image](https://user-images.githubusercontent.com/1097038/131046331-b7a88124-11f6-4245-a6ab-35dd4bb85467.png)

