### PR TITLE
[ErrorHandler] Fix test `fatal_with_nested_handlers` for PHP 8.1

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Tests/phpt/fatal_with_nested_handlers_pre81.phpt
+++ b/src/Symfony/Component/ErrorHandler/Tests/phpt/fatal_with_nested_handlers_pre81.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test catching fatal errors when handlers are nested
 --SKIPIF--
-<?php if (\PHP_VERSION_ID < 80100) echo 'skip' ?>
+<?php if (\PHP_VERSION_ID >= 80100) echo 'skip' ?>
 --FILE--
 <?php
 
@@ -38,9 +38,6 @@ array(1) {
   string(37) "Error and exception handlers do match"
 }
 object(Symfony\Component\ErrorHandler\Error\FatalError)#%d (%d) {
-  ["message":protected]=>
-  string(186) "Error: Class Symfony\Component\ErrorHandler\Broken contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (JsonSerializable::jsonSerialize)"
-%a
   ["error":"Symfony\Component\ErrorHandler\Error\FatalError":private]=>
   array(4) {
     ["type"]=>
@@ -52,4 +49,7 @@ object(Symfony\Component\ErrorHandler\Error\FatalError)#%d (%d) {
     ["line"]=>
     int(%d)
   }
+  ["message":protected]=>
+  string(186) "Error: Class Symfony\Component\ErrorHandler\Broken contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (JsonSerializable::jsonSerialize)"
+%a
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #41552
| License       | MIT
| Doc PR        | Not needed.

PHP 8.1 changes the order in which `print_r()`, `var_dump()` and friends dump properties. This PR creates a new version of one of ErrorHandler's PHPT tests, adapting to this change.