### PR TITLE
[DomCrawler] Don't pass `null` to `trim()`

### DIFF
--- a/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorAttributeValueSame.php
+++ b/src/Symfony/Component/DomCrawler/Test/Constraint/CrawlerSelectorAttributeValueSame.php
@@ -47,7 +47,7 @@ final class CrawlerSelectorAttributeValueSame extends Constraint
             return false;
         }
 
-        return $this->expectedText === trim($crawler->attr($this->attribute));
+        return $this->expectedText === trim($crawler->attr($this->attribute) ?? '');
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorAttributeValueSameTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Test/Constraint/CrawlerSelectorAttributeValueSameTest.php
@@ -23,6 +23,7 @@ class CrawlerSelectorAttributeValueSameTest extends TestCase
     {
         $constraint = new CrawlerSelectorAttributeValueSame('input[name="username"]', 'value', 'Fabien');
         $this->assertTrue($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username" value="Fabien">'), '', true));
+        $this->assertFalse($constraint->evaluate(new Crawler('<html><body><form><input type="text" name="username">'), '', true));
         $this->assertFalse($constraint->evaluate(new Crawler('<html><head><title>Bar'), '', true));
 
         try {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #41552
| License       | MIT
| Doc PR        | N/A

PHP 8.1 triggers a deprecation warning if we pass `null` to `trim()`.

A failing test of the FrameworkBundle test suite on the 5.3 branch uncovered that DomCrawler's `CrawlerSelectorAttributeValueSame` might do this if an attribute is queried that does not exist on a matched element. This PR adds a test case for that and fixes the behavior.