### PR TITLE
[HttpClient] Don't pass float to `usleep()`

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -353,7 +353,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
         }
 
         if ($multi->pauseExpiries && 0 < $timeout -= microtime(true) - $now) {
-            usleep(1E6 * $timeout);
+            usleep((int) (1E6 * $timeout));
         }
 
         return 0;

--- a/src/Symfony/Component/HttpClient/Response/NativeResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/NativeResponse.php
@@ -366,7 +366,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
         }
 
         if (!$handles) {
-            usleep(1E6 * $timeout);
+            usleep((int) (1E6 * $timeout));
 
             return 0;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #41552
| License       | MIT
| Doc PR        | N/A

When we pass a float value to `usleep()`, PHP 8.1 will trigger a deprecation warning:

> Implicit conversion from float 999967.098236084 to int loses precision

This PR makes the cast explicit and fixes the failing test.