### PR TITLE
[SecurityBundle] Fix broken mock

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/MainConfigurationTest.php
@@ -122,6 +122,7 @@ class MainConfigurationTest extends TestCase
     {
         $factory = $this->createMock(AuthenticatorFactoryInterface::class);
         $factory->expects($this->once())->method('addConfiguration');
+        $factory->method('getKey')->willReturn('key');
 
         $configuration = new MainConfiguration(['stub' => $factory], []);
         $configuration->getConfigTreeBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #41552 
| License       | MIT
| Doc PR        | N/A

Implementations of `AuthenticatorFactoryInterface::getKey()` must not return `null`. Yet, the mock I'm fixing here does. This triggers deprecation warnings on PHP 8.1 (because we pass the return value to string functions).