### PR TITLE
[FrameworkBundle] Match 5.3 and 5.1 mailer configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer.php
@@ -73,5 +73,9 @@ return static function (ContainerConfigurator $container) {
             ->tag('kernel.event_subscriber')
             ->tag('kernel.reset', ['method' => 'reset'])
             ->deprecate('symfony/framework-bundle', '5.2', 'The "%service_id%" service is deprecated, use "mailer.message_logger_listener" instead.')
+
+        ->set('mailer.message_logger_listener', MessageLoggerListener::class)
+            ->tag('kernel.event_subscriber')
+            ->tag('kernel.reset', ['method' => 'reset'])
     ;
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_debug.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/mailer_debug.php
@@ -24,9 +24,5 @@ return static function (ContainerConfigurator $container) {
                 'template' => '@WebProfiler/Collector/mailer.html.twig',
                 'id' => 'mailer',
             ])
-
-        ->set('mailer.message_logger_listener', MessageLoggerListener::class)
-            ->tag('kernel.event_subscriber')
-            ->tag('kernel.reset', ['method' => 'reset'])
     ;
 };


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #39511
| License       | MIT
| Doc PR        | 

Looks like the listener has been in the main config file in 5.1 branch but has not been moved to 5.2 branch during the refactoring. 
