### PR TITLE
[Security] Do not deauthenticate token on user change if not an AbstractToken

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
 use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolverInterface;
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -237,7 +238,7 @@ class ContextListener extends AbstractListener
                 $newToken->setUser($refreshedUser, false);
 
                 // tokens can be deauthenticated if the user has been changed.
-                if ($this->hasUserChanged($user, $newToken)) {
+                if ($token instanceof AbstractToken && $this->hasUserChanged($user, $newToken)) {
                     $userDeauthenticated = true;
                     // @deprecated since Symfony 5.4
                     if (method_exists($newToken, 'setAuthenticated')) {

--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -29,6 +29,7 @@ use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\UsageTrackingTokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
@@ -231,6 +232,27 @@ class ContextListenerTest extends TestCase
         $tokenStorage = $this->handleEventWithPreviousSession([new NotSupportingUserProvider(true), new NotSupportingUserProvider(false), new SupportingUserProvider($refreshedUser)]);
 
         $this->assertNull($tokenStorage->getToken());
+    }
+
+    public function testTokenIsNotDeauthenticatedOnUserChangeIfNotAnInstanceOfAbstractToken()
+    {
+        $tokenStorage = new TokenStorage();
+        $refreshedUser = new InMemoryUser('changed', 'baz');
+
+        $token = new CustomToken(new InMemoryUser('original', 'foo'), ['ROLE_FOO']);
+
+        $session = new Session(new MockArraySessionStorage());
+        $session->set('_security_context_key', serialize($token));
+
+        $request = new Request();
+        $request->setSession($session);
+        $request->cookies->set('MOCKSESSID', true);
+
+        $listener = new ContextListener($tokenStorage, [new NotSupportingUserProvider(true), new NotSupportingUserProvider(false), new SupportingUserProvider($refreshedUser)], 'context_key');
+        $listener(new RequestEvent($this->createMock(HttpKernelInterface::class), $request, HttpKernelInterface::MAIN_REQUEST));
+
+        $this->assertInstanceOf(CustomToken::class, $tokenStorage->getToken());
+        $this->assertSame($refreshedUser, $tokenStorage->getToken()->getUser());
     }
 
     public function testIfTokenIsNotDeauthenticated()
@@ -521,5 +543,106 @@ class SupportingUserProvider implements UserProviderInterface
     public function supportsClass($class): bool
     {
         return InMemoryUser::class === $class;
+    }
+}
+
+class CustomToken implements TokenInterface
+{
+    private $user;
+    private $roles;
+
+    public function __construct(UserInterface $user, array $roles)
+    {
+        $this->user = $user;
+        $this->roles = $roles;
+    }
+
+    public function __serialize(): array
+    {
+        return [$this->user, $this->roles];
+    }
+
+    public function serialize(): string
+    {
+        return serialize($this->__serialize());
+    }
+
+    public function __unserialize(array $data): void
+    {
+        [$this->user, $this->roles] = $data;
+    }
+
+    public function unserialize($serialized)
+    {
+        $this->__unserialize(\is_array($serialized) ? $serialized : unserialize($serialized));
+    }
+
+    public function __toString(): string
+    {
+        return $this->user->getUserIdentifier();
+    }
+
+    public function getRoleNames(): array
+    {
+        return $this->roles;
+    }
+
+    public function getCredentials()
+    {
+    }
+
+    public function getUser(): UserInterface
+    {
+        return $this->user;
+    }
+
+    public function setUser($user)
+    {
+        $this->user = $user;
+    }
+
+    public function getUsername(): string
+    {
+        return $this->user->getUserIdentifier();
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->getUserIdentifier();
+    }
+
+    public function isAuthenticated(): bool
+    {
+        return true;
+    }
+
+    public function setAuthenticated(bool $isAuthenticated)
+    {
+    }
+
+    public function eraseCredentials()
+    {
+    }
+
+    public function getAttributes(): array
+    {
+        return [];
+    }
+
+    public function setAttributes(array $attributes)
+    {
+    }
+
+    public function hasAttribute(string $name): bool
+    {
+        return false;
+    }
+
+    public function getAttribute(string $name)
+    {
+    }
+
+    public function setAttribute(string $name, $value)
+    {
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

In #42050, we moved the `hasUserChanged()` logic used for deauthentication from AbstractToken to ContextListener.
Problem is that this check is now done against on all kind of tokens, whereas it was only for `AbstractToken` instances before. 
That breaks https://github.com/scheb/2fa, tokens get wrongly deauthenticated in the middle of the 2fa auth process.
This fixes it by skipping non-AbstractToken implementations. 
We may want to provide a way to opt-in/out the `hasUserChanged()` logic on a custom token with e.g.  a marker interface, but that's not necessarily worth it for now IMHO.