### PR TITLE
[Cache] Fix comment in MemcachedAdapter

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/MemcachedAdapter.php
@@ -25,7 +25,6 @@ class MemcachedAdapter extends AbstractAdapter
     /**
      * We are replacing characters that are illegal in Memcached keys with reserved characters from
      * {@see \Symfony\Contracts\Cache\ItemInterface::RESERVED_CHARACTERS} that are legal in Memcached.
-This conversation was marked as resolved by lstrojny
      * Note: don’t use {@see \Symfony\Component\Cache\Adapter\AbstractAdapter::NS_SEPARATOR}.
      */
     private const RESERVED_MEMCACHED = " \n\r\t\v\f\0";


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3 
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | none

Just a small typo fix. Seems like a merge error or copy/paste from Github. Seems present since 5.1

Searched through the whole repo and this is the only location with this or similar sentences often seen on Github like "reviewed", "commented", etc.
