### PR TITLE
[HttpFoundation] Remove implicit float to int cast

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/CookieTest.php
@@ -117,17 +117,6 @@ class CookieTest extends TestCase
         $this->assertEquals($expire, $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date');
     }
 
-    public function testGetExpiresTimeIsCastToInt()
-    {
-        $cookie = Cookie::create('foo', 'bar', 3600.9);
-
-        $this->assertSame(3600, $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date as an integer');
-
-        $cookie = Cookie::create('foo')->withExpires(3600.6);
-
-        $this->assertSame(3600, $cookie->getExpiresTime(), '->getExpiresTime() returns the expire date as an integer');
-    }
-
     public function testConstructorWithDateTime()
     {
         $expire = new \DateTime();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #41552
| License       | MIT
| Doc PR        | N/A

This PR removes a test that triggers a deprecation warning on PHP 8.1. On 5.4 and below, the test made sure that if the caller passed a float value (despite the doc block demanding an integer) an explicit cast to int would be performed.

On the 6.0 branch, that cast has been removed because we've added a parameter type declaration that does not allow floats. Because the type cast is implicit now, PHP 8.1 triggers a deprecation when the case would mean a loss of precision. Since the test tested undocumented behavior anyway, I decided to remove it.