### PR TITLE
Display the roles of the logged-in user in the Web Debug Toolbar

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -14,6 +14,7 @@ CHANGELOG
  * Deprecate passing an array of arrays as 1st argument to `MainConfiguration`, pass a sorted flat array of
    factories instead.
  * Deprecate the `always_authenticate_before_granting` option
+ * Display the roles of the logged-in user in the Web Debug Toolbar
 
 5.3
 ---

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -42,6 +42,20 @@
                         </div>
 
                         <div class="sf-toolbar-info-piece">
+                            <b>Roles</b>
+                            <span>
+                                {% set remainingRoles = collector.roles|slice(1) %}
+                                {{ collector.roles|first }}
+                                {% if remainingRoles|length > 1 %}
+                                    +
+                                    <abbr title="{{ remainingRoles|join(', ') }}">
+                                        {{ remainingRoles|length }} more
+                                    </abbr>
+                                {% endif %}
+                            </span>
+                        </div>
+
+                        <div class="sf-toolbar-info-piece">
                             <b>Token class</b>
                             <span>{{ collector.tokenClass|abbr_class }}</span>
                         </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 for features
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #42763
| License       | MIT
| Doc PR        | -

This PR adds the roles of the logged-in user to the WDT