### PR TITLE
[Form] Add hash_password option to PasswordType

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordHasherExtension;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TransformationFailureExtension;
 use Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension;
@@ -112,6 +113,13 @@ return static function (ContainerConfigurator $container) {
         ->set('form.type.color', ColorType::class)
             ->args([service('translator')->ignoreOnInvalid()])
             ->tag('form.type')
+
+        ->set('form.type_extension.form.password_hasher', PasswordHasherExtension::class)
+            ->args([
+                service('security.password_hasher')->ignoreOnInvalid(),
+                service('form.property_accessor'),
+            ])
+            ->tag('form.type_extension', ['extended-type' => FormType::class])
 
         ->set('form.type_extension.form.transformation_failure_handling', TransformationFailureExtension::class)
             ->args([service('translator')->ignoreOnInvalid()])

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate calling `FormErrorIterator::children()` if the current element is not iterable.
  * Allow to pass `TranslatableMessage` objects to the `help` option
+ * Added a `hash_password` option to `PasswordType`
 
 5.3
 ---

--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -16,7 +16,9 @@ use Symfony\Component\Form\ChoiceList\Factory\CachingFactoryDecorator;
 use Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface;
 use Symfony\Component\Form\ChoiceList\Factory\DefaultChoiceListFactory;
 use Symfony\Component\Form\ChoiceList\Factory\PropertyAccessDecorator;
+use Symfony\Component\Form\Extension\Core\Type\PasswordHasherExtension;
 use Symfony\Component\Form\Extension\Core\Type\TransformationFailureExtension;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -31,12 +33,14 @@ class CoreExtension extends AbstractExtension
     private $propertyAccessor;
     private $choiceListFactory;
     private $translator;
+    private $passwordHasher;
 
-    public function __construct(PropertyAccessorInterface $propertyAccessor = null, ChoiceListFactoryInterface $choiceListFactory = null, TranslatorInterface $translator = null)
+    public function __construct(PropertyAccessorInterface $propertyAccessor = null, ChoiceListFactoryInterface $choiceListFactory = null, TranslatorInterface $translator = null, UserPasswordHasherInterface $passwordHasher = null)
     {
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
         $this->choiceListFactory = $choiceListFactory ?? new CachingFactoryDecorator(new PropertyAccessDecorator(new DefaultChoiceListFactory(), $this->propertyAccessor));
         $this->translator = $translator;
+        $this->passwordHasher = $passwordHasher;
     }
 
     protected function loadTypes()
@@ -83,6 +87,7 @@ class CoreExtension extends AbstractExtension
     protected function loadTypeExtensions()
     {
         return [
+            new PasswordHasherExtension($this->passwordHasher, $this->propertyAccessor),
             new TransformationFailureExtension($this->translator),
         ];
     }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
@@ -38,7 +38,7 @@ class PasswordHasherListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents()
     {
-        return [FormEvents::POST_SUBMIT => ['postSubmit', -256]];
+        return [FormEvents::POST_SUBMIT => ['postSubmit', -2048]];
     }
 
     public function postSubmit(FormEvent $event)

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
@@ -68,7 +68,9 @@ class PasswordHasherListener implements EventSubscriberInterface
                 if ($field->count()) {
                     $subData = $this->propertyAccessor->getValue($data, $field->getPropertyPath());
                     $this->hashPasswords($field, $subData);
-                    $this->propertyAccessor->setValue($data, $field->getPropertyPath(), $subData);
+                    if ($this->propertyAccessor->isWritable($data, $field->getPropertyPath())) {
+                        $this->propertyAccessor->setValue($data, $field->getPropertyPath(), $subData);
+                    }
                 }
                 continue;
             }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
@@ -12,11 +12,11 @@
 namespace Symfony\Component\Form\Extension\Core\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -30,7 +30,7 @@ class PasswordHasherListener implements EventSubscriberInterface
     private $passwordHasher;
     private $propertyAccessor;
 
-    /** @var FormType[] */
+    /** @var FormInterface[] */
     private static $passwordForms = [];
 
     public function __construct(UserPasswordHasherInterface $passwordHasher = null, PropertyAccessorInterface $propertyAccessor = null)

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
@@ -51,6 +51,10 @@ class PasswordHasherListener implements EventSubscriberInterface
         $parentForm = $form->getParent();
         $rootName = $form->getRoot()->getName();
 
+        if (!isset(self::$passwordTypes[$form->getName()])) {
+            self::$passwordTypes[$rootName] = [];
+        }
+
         if ($parentForm && $parentForm->getConfig()->getType()->getInnerType() instanceof RepeatedType) {
             if ('first' == $form->getName()) {
                 self::$passwordTypes[$rootName][] = $parentForm;

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
@@ -29,7 +29,7 @@ class PasswordHasherListener implements EventSubscriberInterface
     private $passwordHasher;
     private $propertyAccessor;
 
-    /** @var FormType[] */
+    /** @var FormType[][] */
     private static $passwordTypes = [];
 
     public function __construct(UserPasswordHasherInterface $passwordHasher = null, PropertyAccessorInterface $propertyAccessor = null)

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+
+/**
+ * @author Sébastien Alfaiate <s.alfaiate@webarea.fr>
+ */
+class PasswordHasherListener implements EventSubscriberInterface
+{
+    private $passwordHasher;
+    private $propertyAccessor;
+
+    public function __construct(UserPasswordHasherInterface $passwordHasher = null, PropertyAccessorInterface $propertyAccessor = null)
+    {
+        $this->passwordHasher = $passwordHasher;
+        $this->propertyAccessor = $propertyAccessor ?? PropertyAccess::createPropertyAccessor();
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [FormEvents::POST_SUBMIT => ['postSubmit', -256]];
+    }
+
+    public function postSubmit(FormEvent $event)
+    {
+        $form = $event->getForm();
+        $data = $event->getData();
+
+        if ($form->isRoot() && $form->isValid() && $data instanceof PasswordAuthenticatedUserInterface) {
+            foreach ($form->all() as $field) {
+                $passwordField = $field;
+
+                if (
+                    $field->getConfig()->getType()->getInnerType() instanceof RepeatedType
+                    && PasswordType::class == $field->getConfig()->getOption('type')
+                ) {
+                    $passwordField = $field->get('first');
+                }
+
+                if (!$passwordField->getConfig()->getType()->getInnerType() instanceof PasswordType) {
+                    continue;
+                }
+
+                if ($passwordField->getConfig()->getOption('hash_password')) {
+                    $this->propertyAccessor->setValue(
+                        $data,
+                        $field->getPropertyPath(),
+                        $this->passwordHasher->hashPassword($data, $field->getData())
+                    );
+                }
+            }
+
+            $event->setData($data);
+        }
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\Form\Extension\Core\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -29,7 +29,7 @@ class PasswordHasherListener implements EventSubscriberInterface
     private $passwordHasher;
     private $propertyAccessor;
 
-    /** @var FormType[][] */
+    /** @var FormInterface[][] */
     private static $passwordTypes = [];
 
     public function __construct(UserPasswordHasherInterface $passwordHasher = null, PropertyAccessorInterface $propertyAccessor = null)

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
@@ -65,7 +65,7 @@ class PasswordHasherListener implements EventSubscriberInterface
             }
 
             if (!$passwordField->getConfig()->getType()->getInnerType() instanceof PasswordType) {
-                if ($field->count()) {
+                if ($field->getConfig()->getOption('compound')) {
                     $subData = $this->propertyAccessor->getValue($data, $field->getPropertyPath());
                     $this->hashPasswords($field, $subData);
                     if ($this->propertyAccessor->isWritable($data, $field->getPropertyPath())) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordHasherExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordHasherExtension.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\EventListener\PasswordHasherListener;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+/**
+ * @author Sébastien Alfaiate <s.alfaiate@webarea.fr>
+ */
+class PasswordHasherExtension extends AbstractTypeExtension
+{
+    private $passwordHasher;
+    private $propertyAccessor;
+
+    public function __construct(UserPasswordHasherInterface $passwordHasher = null, PropertyAccessorInterface $propertyAccessor = null)
+    {
+        $this->passwordHasher = $passwordHasher;
+        $this->propertyAccessor = $propertyAccessor ?? PropertyAccess::createPropertyAccessor();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addEventSubscriber(new PasswordHasherListener($this->passwordHasher, $this->propertyAccessor));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getExtendedTypes(): iterable
+    {
+        return [FormType::class];
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -36,6 +36,7 @@ class PasswordType extends AbstractType
     {
         $resolver->setDefaults([
             'always_empty' => true,
+            'hash_password' => false,
             'trim' => false,
             'invalid_message' => function (Options $options, $previousValue) {
                 return ($options['legacy_error_messages'] ?? true)

--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -12,6 +12,9 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\EventListener\PasswordHasherListener;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
@@ -19,6 +22,16 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class PasswordType extends AbstractType
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        if ($options['hash_password']) {
+            $builder->addEventListener(FormEvents::POST_SUBMIT, [new PasswordHasherListener(), 'registerPasswordType']);
+        }
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/29066
| License       | MIT
| Doc PR        | TODO

This PR adds a new `hash_password` option to `PasswordType`.

When `hash_password` is set to `true` the form will return a hashed password (using the `security.yml` config) in place of the plain password.

The hash is generated on post submit AFTER form validation so that validators can validate constraints on the plain password.
And ONLY IF THE FORM IS VALID so that the password field can be filled with the plain password if the `always_empty` option is disabled when validation fails.

This option will make very easy to build registration & change password forms (No more unmapped plainPassword field or listener to setup on our projects).
For example, on EasyAdminBundle project, many developers are facing difficulties in setting up password hash:
https://github.com/EasyCorp/EasyAdminBundle/issues/3349

If the feedback is positive I can continue the work to add tests and documentation.

