### PR TITLE
[Translation] Throw exception if symfony/finder is not installed for PhpExtractor

### DIFF
--- a/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/PhpExtractor.php
@@ -329,6 +329,10 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
      */
     protected function extractFromDirectory($directory)
     {
+        if (!class_exists(Finder::class)) {
+            throw new \LogicException(sprintf('You cannot use "%s" as the "symfony/finder" package is not installed. Try running "composer require symfony/finder".', static::class));
+        }
+
         $finder = new Finder();
 
         return $finder->files()->name('*.php')->in($directory);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #42788 
| License       | MIT
| Doc PR        | N/A

Closes #42788