### PR TITLE
[Mailer] fix: don't leak dsn data when exceptions raises

### DIFF
--- a/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
+++ b/src/Symfony/Component/Mailer/Tests/Transport/DsnTest.php
@@ -76,7 +76,10 @@ class DsnTest extends TestCase
             'smtp://user1:pass2@example.com:99',
             new Dsn('smtp', 'example.com', 'user1', 'pass2', 99),
         ];
-
+        yield 'simple smtp with user and password between ()' => [
+            'smtp://(user1):(pass2)@example.com',
+            new Dsn('smtp', 'example.com', '(user1)', '(pass2)'),
+        ];
         yield 'gmail smtp with urlencoded user and pass' => [
             'smtp://u%24er:pa%24s@gmail',
             new Dsn('smtp', 'gmail', 'u$er', 'pa$s'),
@@ -92,17 +95,17 @@ class DsnTest extends TestCase
     {
         yield [
             'some://',
-            'The "some://" mailer DSN is invalid.',
+            'The mailer DSN is invalid.',
         ];
 
         yield [
             '//sendmail',
-            'The "//sendmail" mailer DSN must contain a scheme.',
+            'The mailer DSN must contain a scheme.',
         ];
 
         yield [
             'file:///some/path',
-            'The "file:///some/path" mailer DSN must contain a host (use "default" by default).',
+            'The mailer DSN must contain a host (use "default" by default).',
         ];
     }
 }

--- a/src/Symfony/Component/Mailer/Tests/TransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/TransportTest.php
@@ -90,11 +90,11 @@ class TransportTest extends TestCase
 
     public function fromWrongStringProvider(): iterable
     {
-        yield 'garbage at the end' => ['dummy://a some garbage here', 'The DSN has some garbage at the end: " some garbage here".'];
+        yield 'garbage at the end' => ['dummy://a some garbage here', 'The DSN has some garbage at the end.'];
 
-        yield 'not a valid DSN' => ['something not a dsn', 'The "something" mailer DSN must contain a scheme.'];
+        yield 'not a valid DSN' => ['something not a dsn', 'The DSN must contain a scheme.'];
 
-        yield 'failover not closed' => ['failover(dummy://a', 'The "(dummy://a" mailer DSN must contain a scheme.'];
+        yield 'failover not closed' => ['failover(dummy://a', 'The mailer DSN must contain a scheme.'];
 
         yield 'not a valid keyword' => ['foobar(dummy://a)', 'The "foobar" keyword is not valid (valid ones are "failover", "roundrobin")'];
     }

--- a/src/Symfony/Component/Mailer/Tests/TransportTest.php
+++ b/src/Symfony/Component/Mailer/Tests/TransportTest.php
@@ -92,7 +92,7 @@ class TransportTest extends TestCase
     {
         yield 'garbage at the end' => ['dummy://a some garbage here', 'The DSN has some garbage at the end.'];
 
-        yield 'not a valid DSN' => ['something not a dsn', 'The DSN must contain a scheme.'];
+        yield 'not a valid DSN' => ['something not a dsn', 'The mailer DSN must contain a scheme.'];
 
         yield 'failover not closed' => ['failover(dummy://a', 'The mailer DSN must contain a scheme.'];
 

--- a/src/Symfony/Component/Mailer/Transport.php
+++ b/src/Symfony/Component/Mailer/Transport.php
@@ -112,7 +112,7 @@ class Transport
     {
         [$transport, $offset] = $this->parseDsn($dsn);
         if ($offset !== \strlen($dsn)) {
-            throw new InvalidArgumentException(sprintf('The DSN has some garbage at the end: "%s".', substr($dsn, $offset)));
+            throw new InvalidArgumentException('The DSN has some garbage at the end.');
         }
 
         return $transport;

--- a/src/Symfony/Component/Mailer/Transport/Dsn.php
+++ b/src/Symfony/Component/Mailer/Transport/Dsn.php
@@ -38,15 +38,15 @@ final class Dsn
     public static function fromString(string $dsn): self
     {
         if (false === $parsedDsn = parse_url($dsn)) {
-            throw new InvalidArgumentException(sprintf('The "%s" mailer DSN is invalid.', $dsn));
+            throw new InvalidArgumentException('The mailer DSN is invalid.');
         }
 
         if (!isset($parsedDsn['scheme'])) {
-            throw new InvalidArgumentException(sprintf('The "%s" mailer DSN must contain a scheme.', $dsn));
+            throw new InvalidArgumentException('The mailer DSN must contain a scheme.');
         }
 
         if (!isset($parsedDsn['host'])) {
-            throw new InvalidArgumentException(sprintf('The "%s" mailer DSN must contain a host (use "default" by default).', $dsn));
+            throw new InvalidArgumentException('The mailer DSN must contain a host (use "default" by default).');
         }
 
         $user = '' !== ($parsedDsn['user'] ?? '') ? urldecode($parsedDsn['user']) : null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42750
| License       | MIT
| Doc PR        | symfony/symfony-docs

DSN sensitive data leaked when exception raised .

![issue](https://user-images.githubusercontent.com/3882551/131505995-7ec73a44-7c01-4ffa-9c33-467ec41a0362.png)

