### PR TITLE
Fix tests failing with DBAL 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -123,7 +123,7 @@
         "doctrine/cache": "^1.6|^2.0",
         "doctrine/collections": "~1.0",
         "doctrine/data-fixtures": "^1.1",
-        "doctrine/dbal": "^2.6|^3.0",
+        "doctrine/dbal": "^2.7|^3.0",
         "doctrine/orm": "^2.6.3",
         "guzzlehttp/promises": "^1.4",
         "masterminds/html5": "^2.6",
@@ -143,6 +143,7 @@
         "twig/markdown-extra": "^2.12|^3"
     },
     "conflict": {
+        "doctrine/dbal": "<2.7",
         "egulias/email-validator": "~3.0.0",
         "masterminds/html5": "<2.6",
         "monolog/monolog": ">=2",

--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Doctrine\Security\RememberMe;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Result as DriverResult;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
@@ -63,7 +64,7 @@ class DoctrineTokenProvider implements TokenProviderInterface
         $sql = 'SELECT class, username, value, lastUsed AS last_used'
             .' FROM rememberme_token WHERE series=:series';
         $paramValues = ['series' => $series];
-        $paramTypes = ['series' => \PDO::PARAM_STR];
+        $paramTypes = ['series' => ParameterType::STRING];
         $stmt = $this->conn->executeQuery($sql, $paramValues, $paramTypes);
         $row = $stmt instanceof Result || $stmt instanceof DriverResult ? $stmt->fetchAssociative() : $stmt->fetch(\PDO::FETCH_ASSOC);
 
@@ -81,7 +82,7 @@ class DoctrineTokenProvider implements TokenProviderInterface
     {
         $sql = 'DELETE FROM rememberme_token WHERE series=:series';
         $paramValues = ['series' => $series];
-        $paramTypes = ['series' => \PDO::PARAM_STR];
+        $paramTypes = ['series' => ParameterType::STRING];
         if (method_exists($this->conn, 'executeStatement')) {
             $this->conn->executeStatement($sql, $paramValues, $paramTypes);
         } else {
@@ -102,9 +103,9 @@ class DoctrineTokenProvider implements TokenProviderInterface
             'series' => $series,
         ];
         $paramTypes = [
-            'value' => \PDO::PARAM_STR,
+            'value' => ParameterType::STRING,
             'lastUsed' => self::$useDeprecatedConstants ? Type::DATETIME : Types::DATETIME_MUTABLE,
-            'series' => \PDO::PARAM_STR,
+            'series' => ParameterType::STRING,
         ];
         if (method_exists($this->conn, 'executeStatement')) {
             $updated = $this->conn->executeStatement($sql, $paramValues, $paramTypes);
@@ -132,10 +133,10 @@ class DoctrineTokenProvider implements TokenProviderInterface
             'lastUsed' => $token->getLastUsed(),
         ];
         $paramTypes = [
-            'class' => \PDO::PARAM_STR,
-            'username' => \PDO::PARAM_STR,
-            'series' => \PDO::PARAM_STR,
-            'value' => \PDO::PARAM_STR,
+            'class' => ParameterType::STRING,
+            'username' => ParameterType::STRING,
+            'series' => ParameterType::STRING,
+            'value' => ParameterType::STRING,
             'lastUsed' => self::$useDeprecatedConstants ? Type::DATETIME : Types::DATETIME_MUTABLE,
         ];
         if (method_exists($this->conn, 'executeStatement')) {

--- a/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Messenger/DoctrinePingConnectionMiddlewareTest.php
@@ -103,9 +103,12 @@ class DoctrinePingConnectionMiddlewareTest extends MiddlewareTestCase
 
     public function testMiddlewareNoPingInNonWorkerContext()
     {
-        $this->connection->expects($this->never())
-            ->method('ping')
-            ->willReturn(false);
+        // This method has been removed in DBAL 3.0
+        if (method_exists(Connection::class, 'ping')) {
+            $this->connection->expects($this->never())
+                ->method('ping')
+                ->willReturn(false);
+        }
 
         $this->connection->expects($this->never())
             ->method('close')

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -43,10 +43,12 @@
         "doctrine/annotations": "^1.10.4",
         "doctrine/collections": "~1.0",
         "doctrine/data-fixtures": "^1.1",
-        "doctrine/dbal": "^2.6|^3.0",
+        "doctrine/dbal": "^2.7|^3.0",
         "doctrine/orm": "^2.6.3"
     },
     "conflict": {
+        "doctrine/dbal": "<2.7",
+        "doctrine/orm": "<2.6.3",
         "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
         "symfony/dependency-injection": "<3.4",
         "symfony/form": "<4.4",

--- a/src/Symfony/Component/Cache/composer.json
+++ b/src/Symfony/Component/Cache/composer.json
@@ -33,7 +33,7 @@
     "require-dev": {
         "cache/integration-tests": "dev-master",
         "doctrine/cache": "^1.6|^2.0",
-        "doctrine/dbal": "^2.6|^3.0",
+        "doctrine/dbal": "^2.7|^3.0",
         "predis/predis": "^1.1",
         "psr/simple-cache": "^1.0",
         "symfony/config": "^4.2|^5.0",
@@ -43,7 +43,7 @@
         "symfony/var-dumper": "^4.4|^5.0"
     },
     "conflict": {
-        "doctrine/dbal": "<2.6",
+        "doctrine/dbal": "<2.7",
         "symfony/dependency-injection": "<3.4",
         "symfony/http-kernel": "<4.4|>=5.0",
         "symfony/var-dumper": "<4.4"

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/ConnectionTest.php
@@ -140,7 +140,11 @@ class ConnectionTest extends TestCase
         $schemaConfig->method('getMaxIdentifierLength')->willReturn(63);
         $schemaConfig->method('getDefaultTableOptions')->willReturn([]);
         $schemaManager->method('createSchemaConfig')->willReturn($schemaConfig);
-        $driverConnection->method('getSchemaManager')->willReturn($schemaManager);
+        if (method_exists(DBALConnection::class, 'createSchemaManager')) {
+            $driverConnection->method('createSchemaManager')->willReturn($schemaManager);
+        } else {
+            $driverConnection->method('getSchemaManager')->willReturn($schemaManager);
+        }
 
         return $driverConnection;
     }
@@ -428,7 +432,11 @@ class ConnectionTest extends TestCase
             $expectedTable->addIndex($indexColumns);
         }
         $schemaManager->method('createSchema')->willReturn($schema);
-        $driverConnection->method('getSchemaManager')->willReturn($schemaManager);
+        if (method_exists(DBALConnection::class, 'createSchemaManager')) {
+            $driverConnection->method('createSchemaManager')->willReturn($schemaManager);
+        } else {
+            $driverConnection->method('getSchemaManager')->willReturn($schemaManager);
+        }
 
         $platformMock = $this->createMock($platformClass);
         $platformMock

--- a/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Doctrine/DoctrineIntegrationTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Messenger\Tests\Transport\Doctrine;
 use Doctrine\DBAL\Driver\Result as DriverResult;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 use Symfony\Component\Messenger\Transport\Doctrine\Connection;
@@ -175,7 +176,7 @@ class DoctrineIntegrationTest extends TestCase
 
     public function testTheTransportIsSetupOnGet()
     {
-        $this->assertFalse($this->driverConnection->getSchemaManager()->tablesExist('messenger_messages'));
+        $this->assertFalse($this->createSchemaManager()->tablesExist('messenger_messages'));
         $this->assertNull($this->connection->get());
 
         $this->connection->send('the body', ['my' => 'header']);
@@ -186,5 +187,12 @@ class DoctrineIntegrationTest extends TestCase
     private function formatDateTime(\DateTime $dateTime)
     {
         return $dateTime->format($this->driverConnection->getDatabasePlatform()->getDateTimeFormatString());
+    }
+
+    private function createSchemaManager(): AbstractSchemaManager
+    {
+        return method_exists($this->driverConnection, 'createSchemaManager')
+            ? $this->driverConnection->createSchemaManager()
+            : $this->driverConnection->getSchemaManager();
     }
 }

--- a/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/Doctrine/Connection.php
@@ -20,6 +20,7 @@ use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Comparator;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Synchronizer\SchemaSynchronizer;
@@ -377,7 +378,7 @@ class Connection
 
     private function getSchema(): Schema
     {
-        $schema = new Schema([], [], $this->driverConnection->getSchemaManager()->createSchemaConfig());
+        $schema = new Schema([], [], $this->createSchemaManager()->createSchemaConfig());
         $table = $schema->createTable($this->configuration['table_name']);
         $table->addColumn('id', self::$useDeprecatedConstants ? Type::BIGINT : Types::BIGINT)
             ->setAutoincrement(true)
@@ -421,7 +422,7 @@ class Connection
         }
 
         $comparator = new Comparator();
-        $schemaDiff = $comparator->compare($this->driverConnection->getSchemaManager()->createSchema(), $this->getSchema());
+        $schemaDiff = $comparator->compare($this->createSchemaManager()->createSchema(), $this->getSchema());
 
         foreach ($schemaDiff->toSaveSql($this->driverConnection->getDatabasePlatform()) as $sql) {
             if (method_exists($this->driverConnection, 'executeStatement')) {
@@ -430,5 +431,12 @@ class Connection
                 $this->driverConnection->exec($sql);
             }
         }
+    }
+
+    private function createSchemaManager(): AbstractSchemaManager
+    {
+        return method_exists($this->driverConnection, 'createSchemaManager')
+            ? $this->driverConnection->createSchemaManager()
+            : $this->driverConnection->getSchemaManager();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Doctrine ORM is not blocking the installation of DBAL 3 anymore. This has revealed a few tests that were not fully compatible with DBAL 3. This PR is an attempt to fix them.