### PR TITLE
[HttpKernel] Fix `TimeDataCollector`

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -41,7 +41,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
                 }
                 break;
             case KernelEvents::TERMINATE:
-                $sectionId = $event->getRequest()->attributes->get('_stopwatch_token');
+                $sectionId = $this->determineStopwatchToken($event);
                 if (null === $sectionId) {
                     break;
                 }
@@ -68,7 +68,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
                 $this->stopwatch->start('controller', 'section');
                 break;
             case KernelEvents::RESPONSE:
-                $sectionId = $event->getRequest()->attributes->get('_stopwatch_token');
+                $sectionId = $this->determineStopwatchToken($event);
                 if (null === $sectionId) {
                     break;
                 }
@@ -77,7 +77,7 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
             case KernelEvents::TERMINATE:
                 // In the special case described in the `preDispatch` method above, the `$token` section
                 // does not exist, then closing it throws an exception which must be caught.
-                $sectionId = $event->getRequest()->attributes->get('_stopwatch_token');
+                $sectionId = $this->determineStopwatchToken($event);
                 if (null === $sectionId) {
                     break;
                 }
@@ -87,5 +87,10 @@ class TraceableEventDispatcher extends BaseTraceableEventDispatcher
                 }
                 break;
         }
+    }
+
+    private function determineStopwatchToken($event)
+    {
+        return $event->getResponse()->headers->get('X-Debug-Token') ?? $event->getRequest()->attributes->get('_stopwatch_token');
     }
 }


### PR DESCRIPTION
In order for the `TimeDataCollector` to work properly the `X-Debug-Token` from the response header needs to be used which was removed in #42331 to fix #36623. Fixes #42804

| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #42804 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->

In order for the TimeDataCollector to work properly the X-Debug-Token from the response header needs to be used which was removed in #42331 to fix #36623.

Manually tested via profiler in a new app and via disabled profiler and command mentioned in https://github.com/symfony/symfony/issues/36623#issuecomment-880965006. I'm not a 100% sure if this is the best fix though.
