### PR TITLE
Run PHP 8.1 CI with all extensions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Configure for PHP 8.1
         if: "${{ matrix.php == '8.1' }}"
         run: |
-          echo "extensions=mbstring" >> $GITHUB_ENV
           composer config platform.php 8.0.99
 
       - name: Setup PHP


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #41552
| License       | MIT
| Doc PR        | N/A

Let's activate the same extensions for PHP 8.1 as we do for other PHP versions. The MongoDB extension is still not available, but that does not break the CI. All other extensions can be enabled by Setup PHP now.