### PR TITLE
[DependencyInjection] Optimize PHP preloading

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -342,7 +342,7 @@ EOF;
 
                 $code[$options['class'].'.preload.php'] .= <<<'EOF'
 
-Preloader::preload($classes);
+$preloaded = Preloader::preload($classes);
 
 EOF;
             }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10_as_files.txt
@@ -140,7 +140,7 @@ $classes = [];
 $classes[] = 'FooClass';
 $classes[] = 'Symfony\Component\DependencyInjection\ContainerInterface';
 
-Preloader::preload($classes);
+$preloaded = Preloader::preload($classes);
 
     [ProjectServiceContainer.php] => <?php
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_as_files.txt
@@ -948,7 +948,7 @@ $classes[] = 'Some\Sidekick2';
 $classes[] = 'Request';
 $classes[] = 'Symfony\Component\DependencyInjection\ContainerInterface';
 
-Preloader::preload($classes);
+$preloaded = Preloader::preload($classes);
 
     [ProjectServiceContainer.php] => <?php
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_inlined_factories.txt
@@ -579,7 +579,7 @@ $classes[] = 'Some\Sidekick2';
 $classes[] = 'Request';
 $classes[] = 'Symfony\Component\DependencyInjection\ContainerInterface';
 
-Preloader::preload($classes);
+$preloaded = Preloader::preload($classes);
 
     [ProjectServiceContainer.php] => <?php
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services9_lazy_inlined_factories.txt
@@ -186,7 +186,7 @@ $classes[] = 'Bar\FooClass';
 $classes[] = 'Bar\FooLazyClass';
 $classes[] = 'Symfony\Component\DependencyInjection\ContainerInterface';
 
-Preloader::preload($classes);
+$preloaded = Preloader::preload($classes);
 
     [ProjectServiceContainer.php] => <?php
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_non_shared_lazy_as_files.txt
@@ -152,7 +152,7 @@ $classes = [];
 $classes[] = 'Bar\FooLazyClass';
 $classes[] = 'Symfony\Component\DependencyInjection\ContainerInterface';
 
-Preloader::preload($classes);
+$preloaded = Preloader::preload($classes);
 
     [ProjectServiceContainer.php] => <?php
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      |
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |


I'm trying to solve a warning when my app is booting:
```
[02-Sep-2021 10:02:59] NOTICE: PHP message: PHP Warning:  Can't preload unlinked class Symfony\Component\Security\Core\Authorization\ExpressionLanguageProvider: Unknown interface Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface in /app/vendor/symfony/security-core/Authorization/ExpressionLanguageProvider.php on line 22
```

It looks like it's not fixable since PHP parse all the file,
even if the class declaration is wrapped in an `if (false)` statement.

But anyway, I found some optimisations

* reuse the `$preloaded` var, to avoid parsing the same list many times
 (`Preloader::preload()`) is called many times in `var/cache/prod/App_KernelProdContainer.preload.php`
* call `class_exist` before using the reflection to avoid a useless throw / catch.