### PR TITLE
[Security] Avoid extra warning when preloading file when EL is not installed

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguage.php
+++ b/src/Symfony/Component/Security/Core/Authorization/ExpressionLanguage.php
@@ -14,12 +14,12 @@ namespace Symfony\Component\Security\Core\Authorization;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage as BaseExpressionLanguage;
 
-// Help opcache.preload discover always-needed symbols
-class_exists(ExpressionLanguageProvider::class);
-
 if (!class_exists(BaseExpressionLanguage::class)) {
     throw new \LogicException(sprintf('The "%s" class requires the "ExpressionLanguage" component. Try running "composer require symfony/expression-language".', ExpressionLanguage::class));
 } else {
+    // Help opcache.preload discover always-needed symbols
+    class_exists(ExpressionLanguageProvider::class);
+
     /**
      * Adds some function to the default ExpressionLanguage.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

---

I checked on 5.4, this is the only occurence. 