### PR TITLE
[Framework] Clean "about" command help after Environment section was removed

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AboutCommand.php
@@ -44,9 +44,6 @@ The <info>%command.name%</info> command displays information about the current S
 
 The <info>PHP</info> section displays important configuration that could affect your application. The values might
 be different between web and CLI.
-
-The <info>Environment</info> section displays the current environment variables managed by Symfony Dotenv. It will not
-be shown if no variables were found. The values might be different between web and CLI.
 EOT
             )
         ;


### PR DESCRIPTION
In Symfony 5.1 the "Environment" section of "about" command was removed (see #34768). The help text needs to be updated as a consequence.

The sentence "It will not be shown if no variables were found." is particularly puzzling since the section is never shown.

| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #34768
| License       | MIT