### PR TITLE
[Validator] optimise performance of `ExecutionContext::getPropertyPath()`

### DIFF
--- a/src/Symfony/Component/Validator/Context/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/Context/ExecutionContext.php
@@ -294,7 +294,7 @@ class ExecutionContext implements ExecutionContextInterface
      */
     public function getPropertyPath(string $subPath = ''): string
     {
-        return PropertyPath::append($this->propertyPath, $subPath);
+        return '' === $subPath ? $this->propertyPath : PropertyPath::append($this->propertyPath, $subPath);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #42767
| License       | MIT
| Doc PR        | 

Hello! My first deprecation here!

In order to improve performance lets deprecate use of `$subPath` argument  `ExecutionContextInterface::getPropertyPath()` and refactor usage of the code to make sure that no other class will call it with argument. 