### PR TITLE
[Messenger] Add a way to no ack message automatically

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Added `WorkerMetadata` class which allows you to access the configuration details of a worker, like `queueNames` and `transportNames` it consumes from.
  * New method `getMetadata()` was added to `Worker` class which returns the `WorkerMetadata` object.
  * Deprecate not setting the `reset_on_message` config option, its default value will change to `true` in 6.0
+ * Add `ConfigurableAutoAckInterface` and `DelayedAckStamp` to not automatically ACK message.
 
 5.3
 ---

--- a/src/Symfony/Component/Messenger/Handler/ConfigurableAutoAckInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/ConfigurableAutoAckInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+use Symfony\Component\Messenger\Envelope;
+
+/**
+ * Marker interface for message handlers to configure if auto ACK is disabled.
+ *
+ * @author Grégoire Pineau <lyrixx@lyrixx.info>
+ */
+interface ConfigurableAutoAckInterface
+{
+    public function isAutoAckDisabled(Envelope $envelope): bool;
+}

--- a/src/Symfony/Component/Messenger/Stamp/DelayedAckStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/DelayedAckStamp.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * Apply this stamp to delay ACK of your message on a transport.
+ */
+final class DelayedAckStamp implements StampInterface
+{
+}

--- a/src/Symfony/Component/Messenger/Worker.php
+++ b/src/Symfony/Component/Messenger/Worker.php
@@ -24,6 +24,7 @@ use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\RejectRedeliveredMessageException;
 use Symfony\Component\Messenger\Exception\RuntimeException;
 use Symfony\Component\Messenger\Stamp\ConsumedByWorkerStamp;
+use Symfony\Component\Messenger\Stamp\DelayedAckStamp;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Transport\Receiver\QueueReceiverInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
@@ -171,7 +172,9 @@ class Worker
             $this->logger->info('{class} was handled successfully (acknowledging to transport).', $context);
         }
 
-        $receiver->ack($envelope);
+        if (null === $envelope->last(DelayedAckStamp::class)) {
+            $receiver->ack($envelope);
+        }
     }
 
     public function stop(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #36910
| License       | MIT
| Doc PR        |

This PR add a way to manually controller auto ACK from the handler.
It open the door to buffering.

Here is the code one must write to buffer message, and process the buffer each 10s. No more code is needed!

```php
<?php

namespace App\MessageHandler;

use App\Message\HelloMessage;
use Psr\Container\ContainerInterface;
use Psr\Log\LoggerInterface;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;
use Symfony\Component\Messenger\Envelope;
use Symfony\Component\Messenger\Event\WorkerRunningEvent;
use Symfony\Component\Messenger\Event\WorkerStoppedEvent;
use Symfony\Component\Messenger\Handler\ConfigureAutoAckInterface;
use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
use Symfony\Component\Messenger\Stamp\ReceivedStamp;
use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;

final class HelloMessageHandler implements MessageHandlerInterface, ConfigureAutoAckInterface, EventSubscriberInterface
{
    private $buffer = [];
    private $lastFlushedAt = null;

    public function __construct(
        private ContainerInterface $receiverLocator,
        private LoggerInterface $logger,
    ) {
        $this->lastFlushedAt = time();
    }

    public function __invoke(HelloMessage $message, Envelope $envelope)
    {
        if ($this->isAutoAckDisabled($envelope)) {
            $this->logger->info('Add message to buffer.');
            $this->buffer[] = $envelope;
            $this->flushIfNeeded();

            return;
        }

        $this->logger->info('process message.');

        // Do regular processing
    }

    public function isAutoAckDisabled(Envelope $envelope): bool
    {
        // This handler could be used by many transports.
        // But only the async one should be manually controlled // bufferised 
        return $envelope->last(ReceivedStamp::class)->getTransportName() === 'async';
    }

    public function flushIfNeeded()
    {
        $this->logger->info('Flush buffer if needed.');
        if (time() < $this->lastFlushedAt + 10) {
            return;
        }
        $this->flush()
    }

    public function flush()
    {
        $this->logger->info('Flush buffer.');

        $this->lastFlushedAt = time();

        // Do your custom processing on the buffer

        try {
            foreach ($this->buffer as $envelope) {
                /** @var ReceiverInterface */
                $receiver = $this->receiverLocator->get($envelope->last(ReceivedStamp::class)->getTransportName());
                $receiver->ack($envelope);
            }
        } finally {
            $this->buffer = [];
        }
    }

    public static function getSubscribedEvents()
    {
        return [
            WorkerRunningEvent::class =>  'flushIfNeeded',
            WorkerStoppedEvent::class =>  'flush',
        ];
    }
}
```

```yaml
# services.yaml
services:
    App\MessageHandler\HelloMessageHandler:
        arguments:
            $receiverLocator: '@messenger.receiver_locator'
```

---

sponsored by [arte.tv](https://www.arte.tv/fr/)