### PR TITLE
[Console] Add more context when CommandIsSuccessful fails

### DIFF
--- a/src/Symfony/Component/Console/Tester/Constraint/CommandIsSuccessful.php
+++ b/src/Symfony/Component/Console/Tester/Constraint/CommandIsSuccessful.php
@@ -39,4 +39,17 @@ final class CommandIsSuccessful extends Constraint
     {
         return 'the command '.$this->toString();
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function additionalFailureDescription($other): string
+    {
+        $mapping = [
+            Command::FAILURE => 'Command failed.',
+            Command::INVALID => 'Command was invalid.',
+        ];
+
+        return $mapping[$other] ?? sprintf('Command returned exit status %d.', $other);
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Tester/Constraint/CommandIsSuccessfulTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/Constraint/CommandIsSuccessfulTest.php
@@ -26,15 +26,31 @@ final class CommandIsSuccessfulTest extends TestCase
         $this->assertTrue($constraint->evaluate(Command::SUCCESS, '', true));
         $this->assertFalse($constraint->evaluate(Command::FAILURE, '', true));
         $this->assertFalse($constraint->evaluate(Command::INVALID, '', true));
+    }
+
+    /**
+     * @dataProvider providesUnsuccessful
+     */
+    public function testUnsuccessfulCommand(string $expectedException, int $exitCode)
+    {
+        $constraint = new CommandIsSuccessful();
 
         try {
-            $constraint->evaluate(Command::FAILURE);
+            $constraint->evaluate($exitCode);
         } catch (ExpectationFailedException $e) {
             $this->assertStringContainsString('Failed asserting that the command is successful.', TestFailure::exceptionToString($e));
+            $this->assertStringContainsString($expectedException, TestFailure::exceptionToString($e));
 
             return;
         }
 
         $this->fail();
+    }
+
+    public function providesUnsuccessful(): iterable
+    {
+        yield 'Failed' => ['Command failed.', Command::FAILURE];
+        yield 'Invalid' => ['Command was invalid.', Command::INVALID];
+        yield 'Exit code 3' => ['Command returned exit status 3.', 3];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Give some more context when CommandIsSuccessful::assertCommandIsSuccessful() fails