### PR TITLE
[Form] Add hash_mapping option to PasswordType

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TransformationFailureExtension;
 use Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension;
@@ -111,6 +112,13 @@ return static function (ContainerConfigurator $container) {
 
         ->set('form.type.color', ColorType::class)
             ->args([service('translator')->ignoreOnInvalid()])
+            ->tag('form.type')
+
+        ->set('form.type.password', PasswordType::class)
+            ->args([
+                service('security.password_hasher')->ignoreOnInvalid(),
+                service('form.property_accessor'),
+            ])
             ->tag('form.type')
 
         ->set('form.type_extension.form.transformation_failure_handling', TransformationFailureExtension::class)

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate calling `FormErrorIterator::children()` if the current element is not iterable.
  * Allow to pass `TranslatableMessage` objects to the `help` option
+ * Add `hash_mapping` option to `PasswordType`
 
 5.3
 ---

--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\ChoiceList\Factory\ChoiceListFactoryInterface;
 use Symfony\Component\Form\ChoiceList\Factory\DefaultChoiceListFactory;
 use Symfony\Component\Form\ChoiceList\Factory\PropertyAccessDecorator;
 use Symfony\Component\Form\Extension\Core\Type\TransformationFailureExtension;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -31,12 +32,14 @@ class CoreExtension extends AbstractExtension
     private $propertyAccessor;
     private $choiceListFactory;
     private $translator;
+    private $passwordHasher;
 
-    public function __construct(PropertyAccessorInterface $propertyAccessor = null, ChoiceListFactoryInterface $choiceListFactory = null, TranslatorInterface $translator = null)
+    public function __construct(PropertyAccessorInterface $propertyAccessor = null, ChoiceListFactoryInterface $choiceListFactory = null, TranslatorInterface $translator = null, UserPasswordHasherInterface $passwordHasher = null)
     {
         $this->propertyAccessor = $propertyAccessor ?: PropertyAccess::createPropertyAccessor();
         $this->choiceListFactory = $choiceListFactory ?? new CachingFactoryDecorator(new PropertyAccessDecorator(new DefaultChoiceListFactory(), $this->propertyAccessor));
         $this->translator = $translator;
+        $this->passwordHasher = $passwordHasher;
     }
 
     protected function loadTypes()
@@ -58,7 +61,7 @@ class CoreExtension extends AbstractExtension
             new Type\LocaleType(),
             new Type\MoneyType(),
             new Type\NumberType(),
-            new Type\PasswordType(),
+            new Type\PasswordType($this->passwordHasher, $this->propertyAccessor),
             new Type\PercentType(),
             new Type\RadioType(),
             new Type\RangeType(),

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/PasswordHasherListener.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+
+/**
+ * @author Sébastien Alfaiate <s.alfaiate@webarea.fr>
+ */
+class PasswordHasherListener implements EventSubscriberInterface
+{
+    private $passwordHasher;
+    private $propertyAccessor;
+
+    public function __construct(UserPasswordHasherInterface $passwordHasher = null, PropertyAccessorInterface $propertyAccessor = null)
+    {
+        $this->passwordHasher = $passwordHasher;
+        $this->propertyAccessor = $propertyAccessor ?? PropertyAccess::createPropertyAccessor();
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            FormEvents::SUBMIT => ['hashPassword', -256],
+        ];
+    }
+
+    public function hashPassword(FormEvent $event)
+    {
+        $form = $event->getForm();
+        $parentForm = $form->getParent();
+
+        if ($parentForm && $parentForm->getConfig()->getType()->getInnerType() instanceof RepeatedType) {
+            $parentForm = $parentForm->getParent();
+        }
+
+        if ($parentForm && ($user = $parentForm->getData()) && ($user instanceof PasswordAuthenticatedUserInterface)) {
+            $this->propertyAccessor->setValue(
+                $user,
+                $form->getConfig()->getOption('hash_mapping'),
+                $this->passwordHasher->hashPassword($user, $event->getData())
+            );
+        }
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.1
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #29066
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/15872

Following https://github.com/symfony/symfony/pull/42807 with a different implementation.

This PR adds a new `hash_mapping` option to `PasswordType`.

The `hash_mapping` option can be set with a property path where we want to store the hashed password.

Some questions I have:
- Is it better to move this out from the `Core` to a dedicated `PasswordHasher` extension? (same as [Csrf](https://github.com/symfony/symfony/tree/5.4/src/Symfony/Component/Form/Extension/Csrf), [Validator](https://github.com/symfony/symfony/tree/5.4/src/Symfony/Component/Form/Extension/Validator), ...)
- Not sure if this can be made generic and not only for `PasswordAuthenticatedUserInterface` entities (is it possible with `PasswordHasher` component?) 
- Should we automatically generate a new salt if the entity is using a legacy algorithm?

I am submitting this PR to get feedback for now, and if they are positive, I will continue the work to add tests.