### PR TITLE
[Security] Relax return type on VoterInterface

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -708,6 +708,16 @@ index eda4730004..00cfc5b9c7 100644
 +    public function loadTokenBySeries(string $series): PersistentTokenInterface;
  
      /**
+diff --git a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
+index 7e401c3ff3..6b446ff376 100644
+--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
++++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
+@@ -36,4 +36,4 @@ interface VoterInterface
+      * @return int either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
+      */
+-    public function vote(TokenInterface $token, mixed $subject, array $attributes);
++    public function vote(TokenInterface $token, mixed $subject, array $attributes): int;
+ }
 diff --git a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
 index 606c812fad..040c641bd7 100644
 --- a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
@@ -35,5 +35,5 @@ interface VoterInterface
      *
      * @return int either ACCESS_GRANTED, ACCESS_ABSTAIN, or ACCESS_DENIED
      */
-    public function vote(TokenInterface $token, mixed $subject, array $attributes): int;
+    public function vote(TokenInterface $token, mixed $subject, array $attributes);
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/security-acl/pull/97#issuecomment-913774242
| License       | MIT
| Doc PR        | N/A