### PR TITLE
[HttpKernel] Fix broken mock

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/CacheClearer/Psr6CacheClearerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/CacheClearer/Psr6CacheClearerTest.php
@@ -32,9 +32,11 @@ class Psr6CacheClearerTest extends TestCase
         $pool = $this->createMock(CacheItemPoolInterface::class);
         $pool
             ->expects($this->once())
-            ->method('clear');
+            ->method('clear')
+            ->willReturn(true)
+        ;
 
-        (new Psr6CacheClearer(['pool' => $pool]))->clearPool('pool');
+        $this->assertTrue((new Psr6CacheClearer(['pool' => $pool]))->clearPool('pool'));
     }
 
     public function testClearPoolThrowsExceptionOnUnreferencedPool()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR fixes a test that fails on the 6.0 branch because of a broken mock: A correct implementation of `CacheItemPoolInterface::clear()` returns a `bool`, but this mock currently returns `null`.