### PR TITLE
[Cache] Make sure PdoAdapter::prune() always returns a bool

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/AdapterTestCase.php
@@ -217,7 +217,7 @@ abstract class AdapterTestCase extends CachePoolTest
         $doSet('qux', 'qux-val', new \DateInterval('PT20S'));
 
         sleep(30);
-        $cache->prune();
+        $this->assertTrue($cache->prune());
         $this->assertTrue($this->isPruned($cache, 'foo'));
         $this->assertTrue($this->isPruned($cache, 'bar'));
         $this->assertTrue($this->isPruned($cache, 'baz'));
@@ -228,27 +228,27 @@ abstract class AdapterTestCase extends CachePoolTest
         $doSet('baz', 'baz-val', new \DateInterval('PT40S'));
         $doSet('qux', 'qux-val', new \DateInterval('PT80S'));
 
-        $cache->prune();
+        $this->assertTrue($cache->prune());
         $this->assertFalse($this->isPruned($cache, 'foo'));
         $this->assertFalse($this->isPruned($cache, 'bar'));
         $this->assertFalse($this->isPruned($cache, 'baz'));
         $this->assertFalse($this->isPruned($cache, 'qux'));
 
         sleep(30);
-        $cache->prune();
+        $this->assertTrue($cache->prune());
         $this->assertFalse($this->isPruned($cache, 'foo'));
         $this->assertTrue($this->isPruned($cache, 'bar'));
         $this->assertFalse($this->isPruned($cache, 'baz'));
         $this->assertFalse($this->isPruned($cache, 'qux'));
 
         sleep(30);
-        $cache->prune();
+        $this->assertTrue($cache->prune());
         $this->assertFalse($this->isPruned($cache, 'foo'));
         $this->assertTrue($this->isPruned($cache, 'baz'));
         $this->assertFalse($this->isPruned($cache, 'qux'));
 
         sleep(30);
-        $cache->prune();
+        $this->assertTrue($cache->prune());
         $this->assertFalse($this->isPruned($cache, 'foo'));
         $this->assertTrue($this->isPruned($cache, 'qux'));
     }

--- a/src/Symfony/Component/Cache/Traits/PdoTrait.php
+++ b/src/Symfony/Component/Cache/Traits/PdoTrait.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Statement;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
 use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
 use Symfony\Component\Cache\Marshaller\MarshallerInterface;
@@ -183,6 +184,13 @@ trait PdoTrait
             $delete->bindValue(':namespace', sprintf('%s%%', $this->namespace), $useDbalConstants ? ParameterType::STRING : \PDO::PARAM_STR);
         }
         try {
+            // Doctrine DBAL ^2.13 || >= 3.1
+            if ($delete instanceof Statement && method_exists($delete, 'executeStatement')) {
+                $delete->executeStatement();
+
+                return true;
+            }
+
             return $delete->execute();
         } catch (TableNotFoundException $e) {
             return true;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This fixes a failing test on the 6.0 branch. ~~I wasn't sure if I should backport this change to 4.4/5.3 since the behavior of returning a DBAL result has always been wrong, kinda.~~ Backported!