### PR TITLE
Make test.session.listener compatible with SF 6.0 SessionListener

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.php
@@ -39,6 +39,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service_locator([
                     'session' => service('.session.do-not-use')->ignoreOnInvalid(),
+                    'session_factory' => service('session.factory')->ignoreOnInvalid(),
                 ]),
                 param('kernel.debug'),
                 param('session.storage.options'),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fix flipped tests for #41321 

In Symfony 6.0, the session_listener does not use `session` service anymore, it needs a `session_factory` instead.

note: the `session_listener` service is properly configured:
https://github.com/symfony/symfony/blob/0d61de7576d0d6807924fada3df508c5d05d8f2f/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.php#L146-L150