### PR TITLE
Fix tests when security-http 5.4 uses security-core 6.0

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Firewall/ContextListenerTest.php
@@ -546,7 +546,7 @@ class SupportingUserProvider implements UserProviderInterface
     }
 }
 
-class CustomToken implements TokenInterface
+abstract class BaseCustomToken implements TokenInterface
 {
     private $user;
     private $roles;
@@ -638,11 +638,24 @@ class CustomToken implements TokenInterface
         return false;
     }
 
-    public function getAttribute(string $name)
-    {
-    }
-
     public function setAttribute(string $name, $value)
     {
+    }
+}
+
+if (\PHP_VERSION_ID >= 80000) {
+    class CustomToken extends BaseCustomToken
+    {
+        public function getAttribute(string $name): mixed
+        {
+            return null;
+        }
+    }
+} else {
+    class CustomToken extends BaseCustomToken
+    {
+        public function getAttribute(string $name)
+        {
+        }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

see falling test in flipped tests for 6.0 branch: https://github.com/symfony/symfony/pull/41321/checks?check_run_id=3528227747#step:8:3572