### PR TITLE
Feature/sendgrid mailer settings

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * [BC BREAK] Renamed and moved `Symfony\Component\Mailer\Bridge\Sendgrid\Http\Api\SendgridTransport`
    to `Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridApiTransport`, `Symfony\Component\Mailer\Bridge\Sendgrid\Smtp\SendgridTransport`
    to `Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridSmtpTransport`.
+ * The "mail_settings" property can be set when using the SendgridApiTransport
 
 4.3.0
 -----

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -121,7 +121,12 @@ class SendgridApiTransport extends AbstractApiTransport
                 continue;
             }
 
-            $payload['headers'][$name] = $header->getBodyAsString();
+            if ('mail_settings' === $name) {
+                // https://docs.sendgrid.com/ui/sending-email/index-suppressions#bypass-filters-and-v3-mail-send
+                $payload['mail_settings'] = json_decode($header->getBodyAsString(), true);
+            } else {
+                $payload['headers'][$name] = $header->getBodyAsString();
+            }
         }
 
         return $payload;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #42854
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The Sendgrid API [allows filters](https://docs.sendgrid.com/ui/sending-email/index-suppressions#bypass-filters-and-v3-mail-send) to be sent via the `mail_settings` field when sending an email. This change allows users of the Sendgrid API mail transport to use this setting.