### PR TITLE
[Messenger] Support rediss in transport bridge

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportFactoryTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/RedisTransportFactoryTest.php
@@ -27,6 +27,7 @@ class RedisTransportFactoryTest extends TestCase
         $factory = new RedisTransportFactory();
 
         $this->assertTrue($factory->supports('redis://localhost', []));
+        $this->assertTrue($factory->supports('rediss://localhost', []));
         $this->assertFalse($factory->supports('sqs://localhost', []));
         $this->assertFalse($factory->supports('invalid-dsn', []));
     }

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransportFactory.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/RedisTransportFactory.php
@@ -30,7 +30,7 @@ class RedisTransportFactory implements TransportFactoryInterface
 
     public function supports(string $dsn, array $options): bool
     {
-        return 0 === strpos($dsn, 'redis://');
+        return 0 === strpos($dsn, 'redis://') || 0 === strpos($dsn, 'rediss://');
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | 

Seems like support for `rediss` was added in the [main package](https://github.com/symfony/symfony/blob/e34cd7dd2c6d0b30d24cad443b8f964daa841d71/src/Symfony/Component/Messenger/Transport/TransportFactory.php#L46), but didn't propagate to the bridge

Followed a trail from here - https://github.com/symfony/symfony/pull/39607
