### PR TITLE
Implement Message Stream for Postmark Mailer

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkApiTransportTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Mailer\Bridge\Postmark\Tests\Transport;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Mailer\Bridge\Postmark\Transport\MessageStreamHeader;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkApiTransport;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
@@ -123,12 +124,13 @@ class PostmarkApiTransportTest extends TestCase
         $transport->send($mail);
     }
 
-    public function testTagAndMetadataHeaders()
+    public function testTagAndMetadataAndMessageStreamHeaders()
     {
         $email = new Email();
         $email->getHeaders()->add(new TagHeader('password-reset'));
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
+        $email->getHeaders()->add(new MessageStreamHeader('broadcasts'));
         $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
 
         $transport = new PostmarkApiTransport('ACCESS_KEY');
@@ -139,8 +141,10 @@ class PostmarkApiTransportTest extends TestCase
         $this->assertArrayNotHasKey('Headers', $payload);
         $this->assertArrayHasKey('Tag', $payload);
         $this->assertArrayHasKey('Metadata', $payload);
+        $this->assertArrayHasKey('MessageStream', $payload);
 
         $this->assertSame('password-reset', $payload['Tag']);
         $this->assertSame(['Color' => 'blue', 'Client-ID' => '12345'], $payload['Metadata']);
+        $this->assertSame('broadcasts', $payload['MessageStream']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkSmtpTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkSmtpTransportTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Mailer\Bridge\Postmark\Tests\Transport;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\Bridge\Postmark\Transport\MessageStreamHeader;
 use Symfony\Component\Mailer\Bridge\Postmark\Transport\PostmarkSmtpTransport;
 use Symfony\Component\Mailer\Header\MetadataHeader;
 use Symfony\Component\Mailer\Header\TagHeader;
@@ -34,24 +35,26 @@ class PostmarkSmtpTransportTest extends TestCase
         $this->assertSame('foo: bar', $email->getHeaders()->get('FOO')->toString());
     }
 
-    public function testTagAndMetadataHeaders()
+    public function testTagAndMetadataAndMessageStreamHeaders()
     {
         $email = new Email();
         $email->getHeaders()->addTextHeader('foo', 'bar');
         $email->getHeaders()->add(new TagHeader('password-reset'));
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
         $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
+        $email->getHeaders()->add(new MessageStreamHeader('broadcasts'));
 
         $transport = new PostmarkSmtpTransport('ACCESS_KEY');
         $method = new \ReflectionMethod(PostmarkSmtpTransport::class, 'addPostmarkHeaders');
         $method->setAccessible(true);
         $method->invoke($transport, $email);
 
-        $this->assertCount(5, $email->getHeaders()->toArray());
+        $this->assertCount(6, $email->getHeaders()->toArray());
         $this->assertSame('foo: bar', $email->getHeaders()->get('FOO')->toString());
         $this->assertSame('X-PM-KeepID: true', $email->getHeaders()->get('X-PM-KeepID')->toString());
         $this->assertSame('X-PM-Tag: password-reset', $email->getHeaders()->get('X-PM-Tag')->toString());
         $this->assertSame('X-PM-Metadata-Color: blue', $email->getHeaders()->get('X-PM-Metadata-Color')->toString());
         $this->assertSame('X-PM-Metadata-Client-ID: 12345', $email->getHeaders()->get('X-PM-Metadata-Client-ID')->toString());
+        $this->assertSame('X-PM-Message-Stream: broadcasts', $email->getHeaders()->get('X-PM-Message-Stream')->toString());
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Tests/Transport/PostmarkTransportFactoryTest.php
@@ -69,6 +69,11 @@ class PostmarkTransportFactoryTest extends TransportFactoryTestCase
         ];
 
         yield [
+            new Dsn('postmark+api', 'example.com', self::USER, '', 8080, ['message_stream' => 'broadcasts']),
+            (new PostmarkApiTransport(self::USER, $this->getClient(), $dispatcher, $logger))->setHost('example.com')->setPort(8080)->setMessageStream('broadcasts'),
+        ];
+
+        yield [
             new Dsn('postmark', 'default', self::USER),
             new PostmarkSmtpTransport(self::USER, $dispatcher, $logger),
         ];
@@ -81,6 +86,11 @@ class PostmarkTransportFactoryTest extends TransportFactoryTestCase
         yield [
             new Dsn('postmark+smtps', 'default', self::USER),
             new PostmarkSmtpTransport(self::USER, $dispatcher, $logger),
+        ];
+
+        yield [
+            new Dsn('postmark+smtps', 'default', self::USER, null, null, ['message_stream' => 'broadcasts']),
+            (new PostmarkSmtpTransport(self::USER, $dispatcher, $logger))->setMessageStream('broadcasts'),
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/MessageStreamHeader.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/MessageStreamHeader.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Mailer\Bridge\Postmark\Transport;
+
+use Symfony\Component\Mime\Header\UnstructuredHeader;
+
+final class MessageStreamHeader extends UnstructuredHeader
+{
+    public function __construct(string $value)
+    {
+        parent::__construct('X-PM-Message-Stream', $value);
+    }
+}

--- a/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkSmtpTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Postmark/Transport/PostmarkSmtpTransport.php
@@ -26,6 +26,8 @@ use Symfony\Component\Mime\RawMessage;
  */
 class PostmarkSmtpTransport extends EsmtpTransport
 {
+    private $messageStream;
+
     public function __construct(string $id, EventDispatcherInterface $dispatcher = null, LoggerInterface $logger = null)
     {
         parent::__construct('smtp.postmarkapp.com', 587, false, $dispatcher, $logger);
@@ -60,5 +62,19 @@ class PostmarkSmtpTransport extends EsmtpTransport
                 $headers->remove($name);
             }
         }
+
+        if (null !== $this->messageStream && !$message->getHeaders()->has('X-PM-Message-Stream')) {
+            $headers->addTextHeader('X-PM-Message-Stream', $this->messageStream);
+        }
+    }
+
+    /**
+     * @return $this
+     */
+    public function setMessageStream(string $messageStream): self
+    {
+        $this->messageStream = $messageStream;
+
+        return $this;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes (I did not find a changelog for 5.4)
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | There doesn't appear to be a Postmark section in the docs right now <!-- required for new features -->

This PR provide's support for Postmark's separate Message Stream feature in both the API and SMTP transports. I've added the ability to both add a default Message Stream for the entire transport as well as specific message streams per email. 

Right now in Laravel users have the ability to define a default Message Stream per transport through the wildbit/swiftmailer-postmark package. But unfortunately Symfony Mailer, which we're switching to for the upcoming Laravel v9 release doesn't has this feature yet. That's why we decided to send in this PR so both Symfony and Laravel users can enjoy this feature from Postmark. This PR is needed for https://github.com/laravel/framework/pull/38481

I've added a new `MessageStreamHeader` specifically for Postmark because it's a Postmark specific feature.

Documentation for SMTP can be found here: https://postmarkapp.com/support/article/1207-how-to-create-and-send-through-message-streams
Documentation for API can be found here: https://postmarkapp.com/developer/api/email-api

Current setup through Laravel can be found here: https://laravel.com/docs/8.x/mail#postmark-driver
Another example is Mailcoach by Spatie: https://spatie.be/docs/laravel-mailcoach/v4/configuring-mail-providers/postmark#setting-the-message-stream-in-your-laravel-app

