### PR TITLE
Small optimization/readability improvement

### DIFF
--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -472,20 +472,18 @@ class Email extends Message
 
         $attachmentParts = $inlineParts = [];
         foreach ($this->attachments as $attachment) {
-            foreach ($names as $name) {
+            foreach ($names as $i => $name) {
                 if (isset($attachment['part'])) {
                     continue;
                 }
                 if ($name !== $attachment['name']) {
                     continue;
                 }
-                if (isset($inlineParts[$name])) {
-                    continue 2;
-                }
                 $attachment['inline'] = true;
-                $inlineParts[$name] = $part = $this->createDataPart($attachment);
+                $inlineParts[] = $part = $this->createDataPart($attachment);
                 $html = str_replace('cid:'.$name, 'cid:'.$part->getContentId(), $html);
                 $part->setName($part->getContentId());
+                unset($names[$i]);
                 continue 2;
             }
             $attachmentParts[] = $this->createDataPart($attachment);
@@ -494,7 +492,7 @@ class Email extends Message
             $htmlPart = new TextPart($html, $this->htmlCharset, 'html');
         }
 
-        return [$htmlPart, $attachmentParts, array_values($inlineParts)];
+        return [$htmlPart, $attachmentParts, $inlineParts];
     }
 
     private function createDataPart(array $attachment): DataPart


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Instead of iterating over all the found names for each attachment and then filtering out the ones we already processed, we simply remove the processed ones from the list of candidates. So the inner loop gets shorter on each iteration, and we don't have to call `array_values` later on.

I realize that this is just a micro-optimization, so no hard feelings if you decide it's not worth it. But I also found this version a bit easier to read, so I figured I'd post it.
