### PR TITLE
Support Uuid/Ulid as user identifier in hasUserChanged()

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -309,7 +309,13 @@ abstract class AbstractToken implements TokenInterface
         $userIdentifier = function ($user) {
             return method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername();
         };
-        if ($userIdentifier($this->user) !== $userIdentifier($user)) {
+        // if the username/identifier is an object with an eqials-method (like Uuid or Ulid), prefer that for a comparison
+        if (is_object($userIdentifier($this->user)) && method_exists($userIdentifier($this->user), 'equals')) {
+            if (!$userIdentifier($this->user)->equals($userIdentifier($user))){
+                return true;
+            }
+        }
+        elseif ($userIdentifier($this->user) !== $userIdentifier($user)) {
             return true;
         }
 

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -310,12 +310,11 @@ abstract class AbstractToken implements TokenInterface
             return method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername();
         };
         // if the username/identifier is an object with an eqials-method (like Uuid or Ulid), prefer that for a comparison
-        if (is_object($userIdentifier($this->user)) && method_exists($userIdentifier($this->user), 'equals')) {
+        if (\is_object($userIdentifier($this->user)) && method_exists($userIdentifier($this->user), 'equals')) {
             if (!$userIdentifier($this->user)->equals($userIdentifier($user))){
                 return true;
             }
-        }
-        elseif ($userIdentifier($this->user) !== $userIdentifier($user)) {
+        } elseif ($userIdentifier($this->user) !== $userIdentifier($user)) {
             return true;
         }
 

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -311,7 +311,7 @@ abstract class AbstractToken implements TokenInterface
         };
         // if the username/identifier is an object with an eqials-method (like Uuid or Ulid), prefer that for a comparison
         if (\is_object($userIdentifier($this->user)) && method_exists($userIdentifier($this->user), 'equals')) {
-            if (!$userIdentifier($this->user)->equals($userIdentifier($user))){
+            if (!$userIdentifier($this->user)->equals($userIdentifier($user))) {
                 return true;
             }
         } elseif ($userIdentifier($this->user) !== $userIdentifier($user)) {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -309,8 +309,8 @@ abstract class AbstractToken implements TokenInterface
         $userIdentifier = function ($user) {
             return method_exists($user, 'getUserIdentifier') ? $user->getUserIdentifier() : $user->getUsername();
         };
-        // if the username/identifier is an object with an eqials-method (like Uuid or Ulid), prefer that for a comparison
-        if (\is_object($userIdentifier($this->user)) && method_exists($userIdentifier($this->user), 'equals')) {
+        // if the username/identifier is a Uid (like Uuid or Ulid), prefer its eqials-method for a comparison
+        if ($userIdentifier($this->user) instanceof \Symfony\Component\Uid\AbstractUid) {
             if (!$userIdentifier($this->user)->equals($userIdentifier($user))) {
                 return true;
             }


### PR DESCRIPTION
Update: Revoked this PR, because implementing `UserInterface::getUserIdentifier()` the right way by returning a string instead of the `Uid`-object makes its change unnecessary.

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no (completes a new feature of Symfony 5.2)
| Deprecations? | no
| Tickets       | none
| License       | MIT
| Doc PR        | 

This was my problem: Uuid/Ulid are officially supported as Doctrine types since Symfony 5.2, but when a User Entity uses them as its identifier, the strict comparison of the identifier in `AbstractToken::hasUserChanged()` fails unless the User Entity implements `EquatableInterface` and does the whole comparison itself. In effect, the user is always assumed as changed and logged out. This little pitfall was driving me mad, when I implemented my first Uid-identified User entity. I was so close and read the documentation over and over again, until I found out that the comparison of my identifier went wrong.

This change had implemented a small check, if the `getUserIdentifier()` method of the User Entity returns an instance of a `AbstractUid` object and uses its equals-method for the comparison instead of the strict `!==` operator, that is always true for two different Uuid/Ulid objects, even if they contain the same Uid. Since the `UserInterface::getUserIdentifier()` method should return a string, this is not necessary at all.