### PR TITLE
[DependencyInjection] Make auto-aliases private by default

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `service_closure()` to the PHP-DSL
  * Add support for autoconfigurable attributes on methods, properties and parameters
+ * Make auto-aliases private by default
 
 5.3
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutoAliasServicePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutoAliasServicePass.php
@@ -20,6 +20,8 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
  */
 class AutoAliasServicePass implements CompilerPassInterface
 {
+    private $privateAliases = [];
+
     /**
      * {@inheritdoc}
      */
@@ -33,9 +35,26 @@ class AutoAliasServicePass implements CompilerPassInterface
 
                 $aliasId = $container->getParameterBag()->resolveValue($tag['format']);
                 if ($container->hasDefinition($aliasId) || $container->hasAlias($aliasId)) {
-                    $container->setAlias($serviceId, new Alias($aliasId, true));
+                    $alias = new Alias($aliasId, $container->getDefinition($serviceId)->isPublic());
+                    $container->setAlias($serviceId, $alias);
+
+                    if (!$alias->isPublic()) {
+                        $alias->setPublic(true);
+                        $this->privateAliases[] = $alias;
+                    }
                 }
             }
         }
+    }
+
+    /**
+     * @internal to be removed in Symfony 6.0
+     */
+    public function getPrivateAliases(): array
+    {
+        $privateAliases = $this->privateAliases;
+        $this->privateAliases = [];
+
+        return $privateAliases;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -51,7 +51,7 @@ class PassConfig
         ];
 
         $this->optimizationPasses = [[
-            new AutoAliasServicePass(),
+            $autoAliasServicePass = new AutoAliasServicePass(),
             new ValidateEnvPlaceholdersPass(),
             new ResolveDecoratorStackPass(),
             new ResolveChildDefinitionsPass(),
@@ -78,7 +78,7 @@ class PassConfig
 
         $this->removingPasses = [[
             new RemovePrivateAliasesPass(),
-            new ReplaceAliasByActualDefinitionPass(),
+            (new ReplaceAliasByActualDefinitionPass())->setAutoAliasServicePass($autoAliasServicePass),
             new RemoveAbstractDefinitionsPass(),
             new RemoveUnusedDefinitionsPass(),
             new AnalyzeServiceReferencesPass(),

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ReplaceAliasByActualDefinitionPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ReplaceAliasByActualDefinitionPassTest.php
@@ -31,8 +31,8 @@ class ReplaceAliasByActualDefinitionPassTest extends TestCase
         $bDefinition = new Definition('\stdClass');
         $container->setDefinition('b', $bDefinition);
 
-        $container->setAlias('a_alias', 'a')->setPublic(true);
-        $container->setAlias('b_alias', 'b')->setPublic(true);
+        $container->setAlias('a_alias', 'a')->setPublic(true)->setDeprecated('foo/bar', '1.2', '%alias_id%');
+        $container->setAlias('b_alias', 'b')->setPublic(true)->setDeprecated('foo/bar', '1.2', '%alias_id%');
 
         $container->setAlias('container', 'service_container');
 
@@ -40,11 +40,13 @@ class ReplaceAliasByActualDefinitionPassTest extends TestCase
 
         $this->assertTrue($container->has('a'), '->process() does nothing to public definitions.');
         $this->assertTrue($container->hasAlias('a_alias'));
+        $this->assertTrue($container->getAlias('a_alias')->isDeprecated());
         $this->assertFalse($container->has('b'), '->process() removes non-public definitions.');
         $this->assertTrue(
             $container->has('b_alias') && !$container->hasAlias('b_alias'),
             '->process() replaces alias to actual.'
         );
+        $this->assertTrue($container->getDefinition('b_alias')->hasTag('container.private'));
 
         $this->assertTrue($container->has('container'));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | -
| License       | MIT
| Doc PR        | -

Replaces #41209

Before, this creates a public autoalias:
```yaml
    app.lock:
        tags:
            - { name: auto_alias, format: "app.%database_type%_lock" }
```

After, this creates a public autoalias:
```yaml
    app.lock:
        public: true
        tags:
            - { name: auto_alias, format: "app.%database_type%_lock" }
```

Omitting `public: true` will trigger a deprecation warning when the alias is accessed from `$container->get()`. In 6.0, the alias will be private by default if `public: true` is not set.