### PR TITLE
[Cache] Deprecate support for Doctrine Cache

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -4,7 +4,7 @@ UPGRADE FROM 5.3 to 5.4
 Cache
 -----
 
- * Deprecate `DoctrineProvider` because this class has been added to the `doctrine/cache` package
+ * Deprecate `DoctrineProvider` and `DoctrineAdapter` because these classes have been added to the `doctrine/cache` package
 
 Console
 -------
@@ -28,6 +28,7 @@ FrameworkBundle
  * Deprecate the `AdapterInterface` autowiring alias, use `CacheItemPoolInterface` instead
  * Deprecate the public `profiler` service to private
  * Deprecate `get()`, `has()`, `getDoctrine()`, and `dispatchMessage()` in `AbstractController`, use method/constructor injection instead
+ * Deprecate the `cache.adapter.doctrine` service: The Doctrine Cache library is deprecated. Either switch to Symfony Cache or use the PSR-6 adapters provided by Doctrine Cache.
 
 HttpKernel
 ----------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -14,7 +14,7 @@ DoctrineBridge
 Cache
 -----
 
- * Remove `DoctrineProvider` because it has been added to the `doctrine/cache` package
+ * Remove `DoctrineProvider` and `DoctrineAdapter` because these classes have been added to the `doctrine/cache` package
 
 Config
 ------
@@ -104,6 +104,7 @@ FrameworkBundle
  * Remove option `--output-format` of the `translation:update` command, use e.g. `--output-format=xlf20` instead
  * Remove the `AdapterInterface` autowiring alias, use `CacheItemPoolInterface` instead
  * Remove `get()`, `has()`, `getDoctrine()`, and `dispatchMessage()` in `AbstractController`, use method/constructor injection instead
+ * Deprecate the `cache.adapter.doctrine` service: The Doctrine Cache library is deprecated. Either switch to Symfony Cache or use the PSR-6 adapters provided by Doctrine Cache.
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Deprecate the public `profiler` service to private
  * Deprecate `get()`, `has()`, `getDoctrine()`, and `dispatchMessage()` in `AbstractController`, use method/constructor injection instead
  * Add `MicroKernelTrait::getBundlesPath` method to get bundles config path
+ * Deprecate the `cache.adapter.doctrine` service
 
 5.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
@@ -93,8 +93,10 @@ return static function (ContainerConfigurator $container) {
             ->call('setLogger', [service('logger')->ignoreOnInvalid()])
             ->tag('cache.pool', ['clearer' => 'cache.default_clearer', 'reset' => 'reset'])
             ->tag('monolog.logger', ['channel' => 'cache'])
+        ;
 
-        ->set('cache.adapter.doctrine', DoctrineAdapter::class)
+    if (class_exists(DoctrineAdapter::class)) {
+        $container->services()->set('cache.adapter.doctrine', DoctrineAdapter::class)
             ->abstract()
             ->args([
                 abstract_arg('Doctrine provider service'),
@@ -108,7 +110,11 @@ return static function (ContainerConfigurator $container) {
                 'reset' => 'reset',
             ])
             ->tag('monolog.logger', ['channel' => 'cache'])
+            ->deprecate('symfony/framework-bundle', '5.4', 'The abstract service "%service_id%" is deprecated.')
+        ;
+    }
 
+    $container->services()
         ->set('cache.adapter.filesystem', FilesystemAdapter::class)
             ->abstract()
             ->args([

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/cache.php
@@ -7,11 +7,6 @@ $container->loadFromExtension('framework', [
                 'adapter' => 'cache.adapter.apcu',
                 'default_lifetime' => 30,
             ],
-            'cache.bar' => [
-                'adapter' => 'cache.adapter.doctrine',
-                'default_lifetime' => 5,
-                'provider' => 'app.doctrine_cache_provider',
-            ],
             'cache.baz' => [
                 'adapter' => 'cache.adapter.filesystem',
                 'default_lifetime' => 7,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/doctrine_cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/doctrine_cache.php
@@ -1,0 +1,13 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'cache' => [
+        'pools' => [
+            'cache.bar' => [
+                'adapter' => 'cache.adapter.doctrine',
+                'default_lifetime' => 5,
+                'provider' => 'app.doctrine_cache_provider',
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/cache.xml
@@ -8,7 +8,6 @@
     <framework:config>
         <framework:cache>
             <framework:pool name="cache.foo" adapter="cache.adapter.apcu" default-lifetime="30" />
-            <framework:pool name="cache.bar" adapter="cache.adapter.doctrine" default-lifetime="5" provider="app.doctrine_cache_provider" />
             <framework:pool name="cache.baz" adapter="cache.adapter.filesystem" default-lifetime="7" />
             <framework:pool name="cache.foobar" adapter="cache.adapter.psr6" default-lifetime="10" provider="app.cache_pool" />
             <framework:pool name="cache.def" default-lifetime="PT11S" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/doctrine_cache.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/doctrine_cache.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:framework="http://symfony.com/schema/dic/symfony"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony https://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config>
+        <framework:cache>
+            <framework:pool name="cache.bar" adapter="cache.adapter.doctrine" default-lifetime="5" provider="app.doctrine_cache_provider" />
+        </framework:cache>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/cache.yml
@@ -4,10 +4,6 @@ framework:
             cache.foo:
                 adapter: cache.adapter.apcu
                 default_lifetime: 30
-            cache.bar:
-                adapter: cache.adapter.doctrine
-                default_lifetime: 5
-                provider: app.doctrine_cache_provider
             cache.baz:
                 adapter: cache.adapter.filesystem
                 default_lifetime: 7

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/doctrine_cache.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/doctrine_cache.yml
@@ -1,0 +1,7 @@
+framework:
+    cache:
+        pools:
+            cache.bar:
+                adapter: cache.adapter.doctrine
+                default_lifetime: 5
+                provider: app.doctrine_cache_provider

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -1519,7 +1519,6 @@ abstract class FrameworkExtensionTest extends TestCase
         $container->compile();
 
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.foo', 'cache.adapter.apcu', 30);
-        $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.bar', 'cache.adapter.doctrine', 5);
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.baz', 'cache.adapter.filesystem', 7);
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.foobar', 'cache.adapter.psr6', 10);
         $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.def', 'cache.app', 'PT11S');
@@ -1559,6 +1558,23 @@ abstract class FrameworkExtensionTest extends TestCase
                 ['setLogger', [new Reference('logger', ContainerInterface::IGNORE_ON_INVALID_REFERENCE)]],
             ], $tagAwareDefinition->getMethodCalls());
         }
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testDoctrineCache()
+    {
+        if (!class_exists(DoctrineAdapter::class)) {
+            self::markTestSkipped('This test requires symfony/cache 5.4 or lower.');
+        }
+
+        $container = $this->createContainerFromFile('doctrine_cache', [], true, false);
+        $container->setParameter('cache.prefix.seed', 'test');
+        $container->addCompilerPass(new CachePoolPass());
+        $container->compile();
+
+        $this->assertCachePoolServiceDefinitionIsCreated($container, 'cache.bar', 'cache.adapter.doctrine', 5);
     }
 
     public function testRedisTagAwareAdapter()

--- a/src/Symfony/Component/Cache/Adapter/DoctrineAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/DoctrineAdapter.php
@@ -12,9 +12,12 @@
 namespace Symfony\Component\Cache\Adapter;
 
 use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
+ *
+ * @deprecated Since Symfony 5.4, use Doctrine\Common\Cache\Psr6\CacheAdapter instead
  */
 class DoctrineAdapter extends AbstractAdapter
 {
@@ -22,6 +25,8 @@ class DoctrineAdapter extends AbstractAdapter
 
     public function __construct(CacheProvider $provider, string $namespace = '', int $defaultLifetime = 0)
     {
+        trigger_deprecation('symfony/cache', '5.4', '"%s" is deprecated, use "%s" instead.', __CLASS__, CacheAdapter::class);
+
         parent::__construct('', $defaultLifetime);
         $this->provider = $provider;
         $provider->setNamespace($namespace);

--- a/src/Symfony/Component/Cache/CHANGELOG.md
+++ b/src/Symfony/Component/Cache/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 ---
 
  * Make `LockRegistry` use semaphores when possible
- * Deprecate `DoctrineProvider` because this class has been added to the `doctrine/cache` package
+ * Deprecate `DoctrineProvider` and `DoctrineAdapter` because these classes have been added to the `doctrine/cache` package
 
 5.3
 ---

--- a/src/Symfony/Component/Cache/Tests/Adapter/DoctrineAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/DoctrineAdapterTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Cache\Adapter\DoctrineAdapter;
 use Symfony\Component\Cache\Tests\Fixtures\ArrayCache;
 
 /**
+ * @group legacy
  * @group time-sensitive
  */
 class DoctrineAdapterTest extends AdapterTestCase


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

The Doctrine Cache library is deprecated. I don't think we need to keep integration logic for Doctrine Cache in the 6.0 branch. Apps still relying on Doctrine Cache implementations can either:

* Find a suitable replacement among Symfony Cache's adapters.
* Wire their custom Doctrine Cache implementation into Doctrine's own PSR-6 adapter.