### PR TITLE
[FrameworkBundle][Validator] Prepare removing Doctrine Cache from remaining components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,7 +125,7 @@
         "async-aws/sns": "^1.0",
         "cache/integration-tests": "dev-master",
         "composer/package-versions-deprecated": "^1.8",
-        "doctrine/annotations": "^1.12",
+        "doctrine/annotations": "^1.13.1",
         "doctrine/cache": "^1.11|^2.0",
         "doctrine/collections": "~1.0",
         "doctrine/data-fixtures": "^1.1",
@@ -154,7 +154,7 @@
     "conflict": {
         "ext-psr": "<1.1|>=2",
         "async-aws/core": "<1.5",
-        "doctrine/annotations": "<1.12",
+        "doctrine/annotations": "<1.13.1",
         "doctrine/dbal": "<2.10",
         "egulias/email-validator": "~3.0.0",
         "masterminds/html5": "<2.6",

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/AnnotationsCacheWarmer.php
@@ -12,10 +12,8 @@
 namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
 
 use Doctrine\Common\Annotations\AnnotationException;
-use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Cache\Adapter\PhpArrayAdapter;
 
@@ -54,10 +52,7 @@ class AnnotationsCacheWarmer extends AbstractPhpFileCacheWarmer
         }
 
         $annotatedClasses = include $annotatedClassPatterns;
-        $reader = class_exists(PsrCachedReader::class)
-            ? new PsrCachedReader($this->annotationReader, $arrayAdapter, $this->debug)
-            : new CachedReader($this->annotationReader, DoctrineProvider::wrap($arrayAdapter), $this->debug)
-        ;
+        $reader = new PsrCachedReader($this->annotationReader, $arrayAdapter, $this->debug);
 
         foreach ($annotatedClasses as $class) {
             if (null !== $this->excludeRegexp && preg_match($this->excludeRegexp, $class)) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -1559,23 +1559,12 @@ class FrameworkExtension extends Extension
 
         if ('none' === $config['cache']) {
             $container->removeDefinition('annotations.cached_reader');
-            $container->removeDefinition('annotations.psr_cached_reader');
 
             return;
         }
 
         $cacheService = $config['cache'];
         if (\in_array($config['cache'], ['php_array', 'file'])) {
-            $isPsr6Service = $container->hasDefinition('annotations.psr_cached_reader');
-        } else {
-            $isPsr6Service = false;
-            trigger_deprecation('symfony/framework-bundle', '5.3', 'Using a custom service for "framework.annotation.cache" is deprecated, only values "none", "php_array" and "file" are valid in version 6.0.');
-        }
-
-        if ($isPsr6Service) {
-            $container->removeDefinition('annotations.cached_reader');
-            $container->setDefinition('annotations.cached_reader', $container->getDefinition('annotations.psr_cached_reader'));
-
             if ('php_array' === $config['cache']) {
                 $cacheService = 'annotations.cache_adapter';
 
@@ -1596,31 +1585,7 @@ class FrameworkExtension extends Extension
                 ;
             }
         } else {
-            // Legacy code for doctrine/annotations:<1.13
-            if (!class_exists(\Doctrine\Common\Cache\CacheProvider::class)) {
-                throw new LogicException('Annotations cannot be cached as the Doctrine Cache library is not installed. Try running "composer require doctrine/cache".');
-            }
-
-            if ('php_array' === $config['cache']) {
-                $cacheService = 'annotations.cache';
-
-                // Enable warmer only if PHP array is used for cache
-                $definition = $container->findDefinition('annotations.cache_warmer');
-                $definition->addTag('kernel.cache_warmer');
-            } elseif ('file' === $config['cache']) {
-                $cacheDir = $container->getParameterBag()->resolveValue($config['file_cache_dir']);
-
-                if (!is_dir($cacheDir) && false === @mkdir($cacheDir, 0777, true) && !is_dir($cacheDir)) {
-                    throw new \RuntimeException(sprintf('Could not create cache directory "%s".', $cacheDir));
-                }
-
-                $container
-                    ->getDefinition('annotations.filesystem_cache_adapter')
-                    ->replaceArgument(2, $cacheDir)
-                ;
-
-                $cacheService = 'annotations.filesystem_cache';
-            }
+            trigger_deprecation('symfony/framework-bundle', '5.3', 'Using a custom service for "framework.annotation.cache" is deprecated, only values "none", "php_array" and "file" are valid in version 6.0.');
         }
 
         $container

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
-use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\Psr6\DoctrineProvider;
@@ -33,14 +32,10 @@ return static function (ContainerConfigurator $container) {
         ->set('annotations.dummy_registry', AnnotationRegistry::class)
             ->call('registerUniqueLoader', ['class_exists'])
 
-        ->set('annotations.cached_reader', CachedReader::class)
+        ->set('annotations.cached_reader', PsrCachedReader::class)
             ->args([
                 service('annotations.reader'),
-                inline_service(DoctrineProvider::class)
-                    ->factory([DoctrineProvider::class, 'wrap'])
-                    ->args([
-                        inline_service(ArrayAdapter::class),
-                    ]),
+                inline_service(ArrayAdapter::class),
                 abstract_arg('Debug-Flag'),
             ])
 
@@ -56,6 +51,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('annotations.filesystem_cache_adapter'),
             ])
+            ->deprecate('symfony/framework-bundle', '5.4', '"%service_id% is deprecated"')
 
         ->set('annotations.cache_warmer', AnnotationsCacheWarmer::class)
             ->args([
@@ -78,19 +74,8 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 service('annotations.cache_adapter'),
             ])
-            ->tag('container.hot_path')
+            ->deprecate('symfony/framework-bundle', '5.4', '"%service_id% is deprecated"')
 
         ->alias('annotation_reader', 'annotations.reader')
         ->alias(Reader::class, 'annotation_reader');
-
-    if (class_exists(PsrCachedReader::class)) {
-        $container->services()
-            ->set('annotations.psr_cached_reader', PsrCachedReader::class)
-                ->args([
-                    service('annotations.reader'),
-                    inline_service(ArrayAdapter::class),
-                    abstract_arg('Debug-Flag'),
-                ])
-        ;
-    }
 };

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/CacheWarmer/AnnotationsCacheWarmerTest.php
@@ -3,10 +3,8 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\CacheWarmer;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\FrameworkBundle\CacheWarmer\AnnotationsCacheWarmer;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
@@ -44,16 +42,10 @@ class AnnotationsCacheWarmerTest extends TestCase
         $this->assertFileExists($cacheFile);
 
         // Assert cache is valid
-        $reader = class_exists(PsrCachedReader::class)
-            ? new PsrCachedReader(
-                $this->getReadOnlyReader(),
-                new PhpArrayAdapter($cacheFile, new NullAdapter())
-            )
-            : new CachedReader(
-                $this->getReadOnlyReader(),
-                DoctrineProvider::wrap(new PhpArrayAdapter($cacheFile, new NullAdapter()))
-            )
-        ;
+        $reader = new PsrCachedReader(
+            $this->getReadOnlyReader(),
+            new PhpArrayAdapter($cacheFile, new NullAdapter())
+        );
         $refClass = new \ReflectionClass($this);
         $reader->getClassAnnotations($refClass);
         $reader->getMethodAnnotations($refClass->getMethod(__FUNCTION__));
@@ -71,18 +63,11 @@ class AnnotationsCacheWarmerTest extends TestCase
 
         // Assert cache is valid
         $phpArrayAdapter = new PhpArrayAdapter($cacheFile, new NullAdapter());
-        $reader = class_exists(PsrCachedReader::class)
-            ? new PsrCachedReader(
-                $this->getReadOnlyReader(),
-                $phpArrayAdapter,
-                true
-            )
-            : new CachedReader(
-                $this->getReadOnlyReader(),
-                DoctrineProvider::wrap($phpArrayAdapter),
-                true
-            )
-        ;
+        $reader = new PsrCachedReader(
+            $this->getReadOnlyReader(),
+            $phpArrayAdapter,
+            true
+        );
         $refClass = new \ReflectionClass($this);
         $reader->getClassAnnotations($refClass);
         $reader->getMethodAnnotations($refClass->getMethod(__FUNCTION__));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AutowiringTypesTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -34,11 +33,7 @@ class AutowiringTypesTest extends AbstractWebTestCase
         static::bootKernel();
 
         $annotationReader = self::getContainer()->get('test.autowiring_types.autowired_services')->getAnnotationReader();
-        if (class_exists(PsrCachedReader::class)) {
-            $this->assertInstanceOf(PsrCachedReader::class, $annotationReader);
-        } else {
-            $this->assertInstanceOf(CachedReader::class, $annotationReader);
-        }
+        $this->assertInstanceOf(PsrCachedReader::class, $annotationReader);
     }
 
     public function testEventDispatcherAutowiring()

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -33,7 +33,7 @@
         "symfony/routing": "^5.3|^6.0"
     },
     "require-dev": {
-        "doctrine/annotations": "^1.10.4",
+        "doctrine/annotations": "^1.13.1",
         "doctrine/cache": "^1.11|^2.0",
         "doctrine/persistence": "^1.3|^2.0",
         "symfony/asset": "^5.3|^6.0",
@@ -70,6 +70,7 @@
         "symfony/phpunit-bridge": "^5.3|^6.0"
     },
     "conflict": {
+        "doctrine/annotations": "<1.13.1",
         "doctrine/cache": "<1.11",
         "doctrine/persistence": "<1.3",
         "phpdocumentor/reflection-docblock": "<3.2.2",

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -15,7 +15,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\Common\Annotations\CachedReader;
 use Doctrine\Common\Annotations\PsrCachedReader;
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Cache\Psr6\DoctrineProvider;
+use Doctrine\Common\Cache\ArrayCache;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Validator\Context\ExecutionContextFactory;
@@ -429,22 +429,16 @@ class ValidatorBuilder
             throw new LogicException('Enabling annotation based constraint mapping requires the packages doctrine/annotations and symfony/cache to be installed.');
         }
 
-        // Doctrine Annotation >= 1.13, Symfony Cache
-        if (class_exists(PsrCachedReader::class) && class_exists(ArrayAdapter::class)) {
+        if (class_exists(ArrayAdapter::class)) {
             return new PsrCachedReader(new AnnotationReader(), new ArrayAdapter());
         }
 
-        // Doctrine Annotations < 1.13, Doctrine Cache >= 1.11, Symfony Cache
-        if (class_exists(CachedReader::class) && class_exists(ArrayAdapter::class)) {
-            return new CachedReader(new AnnotationReader(), DoctrineProvider::wrap(new ArrayAdapter()));
+        if (class_exists(CachedReader::class) && class_exists(ArrayCache::class)) {
+            trigger_deprecation('symfony/validator', '5.4', 'Enabling annotation based constraint mapping without having symfony/cache installed is deprecated.');
+
+            return new CachedReader(new AnnotationReader(), new ArrayCache());
         }
 
-        // Doctrine Annotation >= 1.13, Doctrine Cache >= 2, no Symfony Cache
-        if (class_exists(PsrCachedReader::class)) {
-            throw new LogicException('Enabling annotation based constraint mapping requires the package symfony/cache to be installed.');
-        }
-
-        // Doctrine Annotation (<1.13 || >2), no Doctrine Cache, no Symfony Cache
-        throw new LogicException('Enabling annotation based constraint mapping requires the packages doctrine/annotations (>=1.13) and symfony/cache to be installed.');
+        throw new LogicException('Enabling annotation based constraint mapping requires the packages doctrine/annotations and symfony/cache to be installed.');
     }
 }

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -40,11 +40,12 @@
         "symfony/property-access": "^4.4|^5.0|^6.0",
         "symfony/property-info": "^5.3|^6.0",
         "symfony/translation": "^4.4|^5.0|^6.0",
-        "doctrine/annotations": "^1.10.4",
+        "doctrine/annotations": "^1.13",
         "doctrine/cache": "^1.11|^2.0",
         "egulias/email-validator": "^2.1.10|^3"
     },
     "conflict": {
+        "doctrine/annotations": "<1.13",
         "doctrine/cache": "<1.11",
         "doctrine/lexer": "<1.0.2",
         "phpunit/phpunit": "<5.4.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR removes and dreprecates logic that used Doctrine Cache to created a cached annotations reader. Thas should allow us to purge Doctrine Cache from the codebase in 6.0.