### PR TITLE
[Mime] Allow array as input for RawMessage

### DIFF
--- a/src/Symfony/Component/Mime/RawMessage.php
+++ b/src/Symfony/Component/Mime/RawMessage.php
@@ -33,8 +33,11 @@ class RawMessage implements \Serializable
         if (\is_string($this->message)) {
             return $this->message;
         }
+        if ($this->message instanceof \Traversable) {
+            $this->message = iterator_to_array($this->message, false);
+        }
 
-        return $this->message = implode('', iterator_to_array($this->message, false));
+        return $this->message = implode('', $this->message);
     }
 
     public function toIterable(): iterable

--- a/src/Symfony/Component/Mime/Tests/RawMessageTest.php
+++ b/src/Symfony/Component/Mime/Tests/RawMessageTest.php
@@ -16,21 +16,26 @@ use Symfony\Component\Mime\RawMessage;
 
 class RawMessageTest extends TestCase
 {
-    public function testToString()
+    /**
+     * @dataProvider provideMessages
+     */
+    public function testToString($messageParameter)
     {
-        $message = new RawMessage('string');
-        $this->assertEquals('string', $message->toString());
-        $this->assertEquals('string', implode('', iterator_to_array($message->toIterable())));
+        $message = new RawMessage($messageParameter);
+        $this->assertEquals('some string', $message->toString());
+        $this->assertEquals('some string', implode('', iterator_to_array($message->toIterable())));
         // calling methods more than once work
-        $this->assertEquals('string', $message->toString());
-        $this->assertEquals('string', implode('', iterator_to_array($message->toIterable())));
+        $this->assertEquals('some string', $message->toString());
+        $this->assertEquals('some string', implode('', iterator_to_array($message->toIterable())));
+    }
 
-        $message = new RawMessage(new \ArrayObject(['some', ' ', 'string']));
-        $this->assertEquals('some string', $message->toString());
-        $this->assertEquals('some string', implode('', iterator_to_array($message->toIterable())));
-        // calling methods more than once work
-        $this->assertEquals('some string', $message->toString());
-        $this->assertEquals('some string', implode('', iterator_to_array($message->toIterable())));
+    public function provideMessages(): array
+    {
+        return [
+            'string' => ['some string'],
+            'traversable' => [new \ArrayObject(['some', ' ', 'string'])],
+            'array' => [['some', ' ', 'string']],
+        ];
     }
 
     public function testSerialization()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`RawMessage` according to its documentation allows `iterable|string` as input. However, if I pass an array (which counts as an `iterable`), the instance would error when calling `toString()`.

This PR fixes this problem.

An alternative solution would be to change the documentation to `\Traversable|string`.