### PR TITLE
Fix non-existent parameter in test.session.listener

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -326,9 +326,8 @@ class FrameworkExtension extends Extension
 
             $this->sessionConfigEnabled = true;
             $this->registerSessionConfiguration($config['session'], $container, $loader);
-            if (!empty($config['test'])) {
-                $container->getDefinition('test.session.listener')->setArgument(2, '%session.storage.options%');
-            }
+        } elseif (!empty($config['test'])) {
+            $container->removeDefinition('test.session.listener');
         }
 
         if ($this->isConfigEnabled($container, $config['request'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The service `test.session.listener` declared in `test.php` uses the `session.storage.options` parameter.
But this parameter is defined in the `FrameworkExtension::registerSessionConfiguration` method which is called only when the `session` config is enabled.
Has a result, if someone run tests with `session: false` the user get the following exception: 
> Symfony\Component\DependencyInjection\Exception\RuntimeException: You have requested a non-existent parameter "session.storage.options". 

This PR remove the listener when the session is disabled.
It also removes the call to `setArgument` that is not needed because this is already the value defined by the service declaration