### PR TITLE
Add Session Token to Amazon Mailer

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesApiAsyncAwsTransportTest.php
@@ -52,6 +52,22 @@ class SesApiAsyncAwsTransportTest extends TestCase
                 new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com:99']))),
                 'ses+api://ACCESS_KEY@example.com:99',
             ],
+            [
+                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'sessionToken' => 'SESSION_TOKEN']))),
+                'ses+api://ACCESS_KEY@us-east-1',
+            ],
+            [
+                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'region' => 'us-west-1', 'sessionToken' => 'SESSION_TOKEN']))),
+                'ses+api://ACCESS_KEY@us-west-1',
+            ],
+            [
+                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com', 'sessionToken' => 'SESSION_TOKEN']))),
+                'ses+api://ACCESS_KEY@example.com',
+            ],
+            [
+                new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com:99', 'sessionToken' => 'SESSION_TOKEN']))),
+                'ses+api://ACCESS_KEY@example.com:99',
+            ],
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesHttpAsyncAwsTransportTest.php
@@ -52,6 +52,22 @@ class SesHttpAsyncAwsTransportTest extends TestCase
                 new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com:99']))),
                 'ses+https://ACCESS_KEY@example.com:99',
             ],
+            [
+                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'sessionToken' => 'SESSION_TOKEN']))),
+                'ses+https://ACCESS_KEY@us-east-1',
+            ],
+            [
+                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'region' => 'us-west-1', 'sessionToken' => 'SESSION_TOKEN']))),
+                'ses+https://ACCESS_KEY@us-west-1',
+            ],
+            [
+                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com', 'sessionToken' => 'SESSION_TOKEN']))),
+                'ses+https://ACCESS_KEY@example.com',
+            ],
+            [
+                new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => 'ACCESS_KEY', 'accessKeySecret' => 'SECRET_KEY', 'endpoint' => 'https://example.com:99', 'sessionToken' => 'SESSION_TOKEN']))),
+                'ses+https://ACCESS_KEY@example.com:99',
+            ],
         ];
     }
 

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesTransportFactoryTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Tests/Transport/SesTransportFactoryTest.php
@@ -83,6 +83,21 @@ class SesTransportFactoryTest extends TransportFactoryTestCase
         ];
 
         yield [
+            new Dsn('ses+api', 'default', self::USER, self::PASSWORD, null, ['session_token' => 'se$sion']),
+            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'sessionToken' => 'se$sion']), null, $client, $logger), $dispatcher, $logger),
+        ];
+
+        yield [
+            new Dsn('ses+api', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu-west-2', 'session_token' => 'se$sion']),
+            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-2', 'sessionToken' => 'se$sion']), null, $client, $logger), $dispatcher, $logger),
+        ];
+
+        yield [
+            new Dsn('ses+api', 'example.com', self::USER, self::PASSWORD, 8080, ['session_token' => 'se$sion']),
+            new SesApiAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'endpoint' => 'https://example.com:8080', 'sessionToken' => 'se$sion']), null, $client, $logger), $dispatcher, $logger),
+        ];
+
+        yield [
             new Dsn('ses+https', 'default', self::USER, self::PASSWORD),
             new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1']), null, $client, $logger), $dispatcher, $logger),
         ];
@@ -100,6 +115,26 @@ class SesTransportFactoryTest extends TransportFactoryTestCase
         yield [
             new Dsn('ses+https', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu-west-2']),
             new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-2']), null, $client, $logger), $dispatcher, $logger),
+        ];
+
+        yield [
+            new Dsn('ses+https', 'default', self::USER, self::PASSWORD, null, ['session_token' => 'se$sion']),
+            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'sessionToken' => 'se$sion']), null, $client, $logger), $dispatcher, $logger),
+        ];
+
+        yield [
+            new Dsn('ses', 'default', self::USER, self::PASSWORD, null, ['session_token' => 'se$sion']),
+            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'sessionToken' => 'se$sion']), null, $client, $logger), $dispatcher, $logger),
+        ];
+
+        yield [
+            new Dsn('ses+https', 'example.com', self::USER, self::PASSWORD, 8080, ['session_token' => 'se$sion']),
+            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-1', 'endpoint' => 'https://example.com:8080', 'sessionToken' => 'se$sion']), null, $client, $logger), $dispatcher, $logger),
+        ];
+
+        yield [
+            new Dsn('ses+https', 'default', self::USER, self::PASSWORD, null, ['region' => 'eu-west-2', 'session_token' => 'se$sion']),
+            new SesHttpAsyncAwsTransport(new SesClient(Configuration::create(['accessKeyId' => self::USER, 'accessKeySecret' => self::PASSWORD, 'region' => 'eu-west-2', 'sessionToken' => 'se$sion']), null, $client, $logger), $dispatcher, $logger),
         ];
 
         yield [

--- a/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesTransportFactory.php
+++ b/src/Symfony/Component/Mailer/Bridge/Amazon/Transport/SesTransportFactory.php
@@ -52,6 +52,8 @@ final class SesTransportFactory extends AbstractTransportFactory
                     'accessKeySecret' => $dsn->getPassword(),
                 ] + (
                     'default' === $dsn->getHost() ? [] : ['endpoint' => 'https://'.$dsn->getHost().($dsn->getPort() ? ':'.$dsn->getPort() : '')]
+                ) + (
+                    null === $dsn->getOption('session_token') ? [] : ['sessionToken' => $dsn->getOption('session_token')]
                 );
 
                 return new $class(new SesClient(Configuration::create($options), null, $this->client, $this->logger), $this->dispatcher, $this->logger);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | There doesn't appear to be a Amazon/SES section in the docs right now <!-- required for new features -->

This PR provide's support for Amazons separate Session Token feature in both the API and HTTPS transports. I've added the ability to set the session token via a query parameter in the DSN.

Right now in Laravel users have the ability to use a Session Token together with temporary Access and Secret keys for sending emails. But unfortunately Symfony Mailer, which we're switching to for the upcoming Laravel v9 release doesn't has this feature yet. That's why I decided to send in this PR so both Symfony and Laravel users can enjoy this feature from SES / Amazon. This PR is needed for laravel/framework#38481

Documentation for the Session Token with temporary credentials can be found here: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
Documentation for creating `AsyncAws/Ses/SesClient` can be found here: https://async-aws.com/configuration.html#sessiontoken

Current setup through Laravel can be found here: https://github.com/laravel/framework/blob/8.x/src/Illuminate/Mail/MailManager.php#L258-L293
(It seems like Laravel has not documented this feature yet. I will be sending a PR to the Laravel docs and then update this PR accordingly)

@driesvints maybe you can also take a look at this PR.