### PR TITLE
[DebugClassLoader] Ignore __construct() when checking return types

### DIFF
--- a/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
+++ b/src/Symfony/Component/ErrorHandler/DebugClassLoader.php
@@ -750,6 +750,10 @@ class DebugClassLoader
 
     private function setReturnType(string $types, string $class, string $method, string $filename, ?string $parent, \ReflectionType $returnType = null): void
     {
+        if ('__construct' === $method) {
+            return;
+        }
+
         if ($nullable = 0 === strpos($types, 'null|')) {
             $types = substr($types, 5);
         } elseif ($nullable = '|null' === substr($types, -5)) {

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnType.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnType.php
@@ -7,6 +7,7 @@ use Symfony\Component\ErrorHandler\Tests\Fixtures\ReturnTypeInterface;
 
 class ReturnType extends ReturnTypeParent implements ReturnTypeInterface, Fixtures\OutsideInterface
 {
+    public function __construct() { }
     public function returnTypeGrandParent() { }
     public function returnTypeParentInterface() { }
     public function returnTypeInterface() { }

--- a/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeParent.php
+++ b/src/Symfony/Component/ErrorHandler/Tests/Fixtures/ReturnTypeParent.php
@@ -5,6 +5,13 @@ namespace Symfony\Component\ErrorHandler\Tests\Fixtures;
 abstract class ReturnTypeParent extends ReturnTypeGrandParent implements ReturnTypeParentInterface
 {
     /**
+     * @return void
+     */
+    public function __construct()
+    {
+    }
+
+    /**
      * No return declared here
      */
     public function returnTypeGrandParent()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Laravel annotates most of their constructors (104 of the 138 laravel constructors in my bundle's vendor dir) with `@return void`. It is not allowed to add return types to constructors (https://3v4l.org/IrqcG), so I propose to ignore `__construct()` when checking return types.