### PR TITLE
[DependencyInjection][HttpKernel] Throw a nice error if `Kernel::build()` compiles the container builder

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -738,9 +738,15 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *                                     env vars or be replaced by uniquely identifiable placeholders.
      *                                     Set to "true" when you want to use the current ContainerBuilder
      *                                     directly, keep to "false" when the container is dumped instead.
+     *
+     * @throws BadMethodCallException if the container has been compiled already
      */
     public function compile(bool $resolveEnvPlaceholders = false)
     {
+        if ($this->isCompiled()) {
+            throw new BadMethodCallException('Compiling an already compiled container is not allowed.');
+        }
+
         $compiler = $this->getCompiler();
 
         if ($this->trackResources) {

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\BadMethodCallException;
 use Symfony\Component\DependencyInjection\Exception\EnvNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\ParameterCircularReferenceException;
@@ -1752,6 +1753,17 @@ class ContainerBuilderTest extends TestCase
         $container->get(B::class);
 
         $this->addToAssertionCount(1);
+    }
+
+    public function testCompileTwice()
+    {
+        $container = new ContainerBuilder();
+        $container->compile();
+
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('Compiling an already compiled container is not allowed.');
+
+        $container->compile();
     }
 }
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -674,11 +674,13 @@ abstract class Kernel implements KernelInterface, RebootableInterface, Terminabl
             }
         }
 
-        foreach ($this->bundles as $bundle) {
+        foreach ($this->bundles + [$this] as $bundle) {
             $bundle->build($container);
-        }
 
-        $this->build($container);
+            if ($container->isCompiled()) {
+                throw new \LogicException(sprintf('The kernel\'s container has been compiled by the "build()" method of "%s". Please remove the call to "ContainerBuilder::compile()" from that method.', get_debug_type($bundle)));
+            }
+        }
 
         foreach ($container->getExtensions() as $extension) {
             $extensions[] = $extension->getAlias();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42977
| License       | MIT
| Doc PR        | N/A