### PR TITLE
Display the roles of the logged-in user in the Web Debug Toolbar -- bugfix for two roles

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -46,7 +46,7 @@
                             <span>
                                 {% set remainingRoles = collector.roles|slice(1) %}
                                 {{ collector.roles|first }}
-                                {% if remainingRoles|length > 1 %}
+                                {% if remainingRoles is not empty %}
                                     +
                                     <abbr title="{{ remainingRoles|join(', ') }}">
                                         {{ remainingRoles|length }} more


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 for features
| Bug fix?      | yes
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Additional fix for #42763 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

The first commit from #42800 did not work properly if there are exactly two roles assigned to the logged in user (as then, the first would be shown, but not the "and n more" span). This PR fixes this issue
