### PR TITLE
[Messenger] Add back kernel.event_subscriber tag on StopWorkerOnCustomStopExceptionListener

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -196,6 +196,7 @@ return static function (ContainerConfigurator $container) {
             ->tag('kernel.event_subscriber')
 
         ->set('messenger.listener.stop_worker_on_stop_exception_listener', StopWorkerOnCustomStopExceptionListener::class)
+            ->tag('kernel.event_subscriber')
 
         ->set('messenger.listener.reset_services', ResetServicesListener::class)
             ->args([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes (but the bug was not released)
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |


refs:
https://github.com/symfony/symfony/pull/41163#discussion_r706804912