### PR TITLE
[Serializer] Throw NotNormalizableValueException when type is not known or not in body in discriminator map

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -22,7 +22,6 @@ use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Exception\ExtraAttributesException;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
-use Symfony\Component\Serializer\Exception\RuntimeException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
@@ -276,12 +275,12 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
     {
         if ($this->classDiscriminatorResolver && $mapping = $this->classDiscriminatorResolver->getMappingForClass($class)) {
             if (!isset($data[$mapping->getTypeProperty()])) {
-                throw new RuntimeException(sprintf('Type property "%s" not found for the abstract object "%s".', $mapping->getTypeProperty(), $class));
+                throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('Type property "%s" not found for the abstract object "%s".', $mapping->getTypeProperty(), $class), null, ['string'], isset($context['deserialization_path']) ? $context['deserialization_path'].'.'.$mapping->getTypeProperty() : $mapping->getTypeProperty(), false);
             }
 
             $type = $data[$mapping->getTypeProperty()];
             if (null === ($mappedClass = $mapping->getClassForType($type))) {
-                throw new RuntimeException(sprintf('The type "%s" has no mapped class for the abstract object "%s".', $type, $class));
+                throw NotNormalizableValueException::createForUnexpectedDataType(sprintf('The type "%s" is not a valid value.', $type), $type, ['string'], isset($context['deserialization_path']) ? $context['deserialization_path'].'.'.$mapping->getTypeProperty() : $mapping->getTypeProperty(), true);
             }
 
             if ($mappedClass !== $class) {

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Php74Full.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Php74Full.php
@@ -28,6 +28,7 @@ final class Php74Full
     /** @var Php74Full[] */
     public array $collection;
     public Php74FullWithConstructor $php74FullWithConstructor;
+    public DummyMessageInterface $dummyMessage;
 }
 
 

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -24,7 +24,6 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
 use Symfony\Component\Serializer\Exception\PartialDenormalizationException;
-use Symfony\Component\Serializer\Exception\RuntimeException;
 use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorFromClassMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
@@ -484,16 +483,34 @@ class SerializerTest extends TestCase
 
     public function testExceptionWhenTypeIsNotKnownInDiscriminator()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('The type "second" has no mapped class for the abstract object "Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface"');
-        $this->serializerWithClassDiscriminator()->deserialize('{"type":"second","one":1}', DummyMessageInterface::class, 'json');
+        try {
+            $this->serializerWithClassDiscriminator()->deserialize('{"type":"second","one":1}', DummyMessageInterface::class, 'json');
+
+            $this->fail();
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(NotNormalizableValueException::class, $e);
+            $this->assertSame('The type "second" is not a valid value.', $e->getMessage());
+            $this->assertSame('string', $e->getCurrentType());
+            $this->assertSame(['string'], $e->getExpectedTypes());
+            $this->assertSame('type', $e->getPath());
+            $this->assertTrue($e->canUseMessageForUser());
+        }
     }
 
     public function testExceptionWhenTypeIsNotInTheBodyToDeserialiaze()
     {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Type property "type" not found for the abstract object "Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface"');
-        $this->serializerWithClassDiscriminator()->deserialize('{"one":1}', DummyMessageInterface::class, 'json');
+        try {
+            $this->serializerWithClassDiscriminator()->deserialize('{"one":1}', DummyMessageInterface::class, 'json');
+
+            $this->fail();
+        } catch (\Throwable $e) {
+            $this->assertInstanceOf(NotNormalizableValueException::class, $e);
+            $this->assertSame('Type property "type" not found for the abstract object "Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface".', $e->getMessage());
+            $this->assertSame('null', $e->getCurrentType());
+            $this->assertSame(['string'], $e->getExpectedTypes());
+            $this->assertSame('type', $e->getPath());
+            $this->assertFalse($e->canUseMessageForUser());
+        }
     }
 
     public function testNotNormalizableValueExceptionMessageForAResource()
@@ -744,7 +761,9 @@ class SerializerTest extends TestCase
                     "string": null
                 }
             ],
-            "php74FullWithConstructor": {}
+            "php74FullWithConstructor": {},
+            "dummyMessage": {
+            }
         }';
 
         $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
@@ -892,6 +911,15 @@ class SerializerTest extends TestCase
                 'path' => 'php74FullWithConstructor',
                 'useMessageForUser' => true,
                 'message' => 'Failed to create object because the object miss the "constructorArgument" property.',
+            ],
+            [
+                'currentType' => 'null',
+                'expectedTypes' => [
+                    'string',
+                ],
+                'path' => 'dummyMessage.type',
+                'useMessageForUser' => false,
+                'message' => 'Type property "type" not found for the abstract object "Symfony\Component\Serializer\Tests\Fixtures\DummyMessageInterface".',
             ],
         ];
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |


I found another case where the API could leak internal and throw 500
when a user submit invalid values

Note: I have to tweak a bit an exception message