### PR TITLE
[ErrorHandler] Fix wrong path to autoloader, and exclude vendor classes in patch-type script

### DIFF
--- a/src/Symfony/Component/ErrorHandler/Resources/bin/patch-type-declarations
+++ b/src/Symfony/Component/ErrorHandler/Resources/bin/patch-type-declarations
@@ -42,9 +42,9 @@ if (false === getenv('SYMFONY_PATCH_TYPE_DECLARATIONS')) {
     echo 'No SYMFONY_PATCH_TYPE_DECLARATIONS env var set, patching type declarations in all methods (run the command with "-h" for more information).'.PHP_EOL;
 }
 
-if (is_file($autoload = __DIR__.'/../../../autoload.php')) {
+if (is_file($autoload = __DIR__.'/../../../../autoload.php')) {
     // noop
-} elseif (is_file($autoload = __DIR__.'/../../../../../autoload.php')) {
+} elseif (is_file($autoload = __DIR__.'/../../../../../../../autoload.php')) {
     // noop
 } else {
     echo PHP_EOL.'  /!\ Cannot find the Composer autoloader, did you forget to run "composer install"?'.PHP_EOL;
@@ -71,7 +71,11 @@ set_error_handler(function ($type, $msg, $file, $line, $context = []) use (&$dep
 
 $exclude = getenv('SYMFONY_PATCH_TYPE_EXCLUDE') ?: null;
 foreach ($loader->getClassMap() as $class => $file) {
-    if ($exclude && preg_match($exclude, realpath($file))) {
+    if (false !== strpos($file = realpath($file), '/vendor/')) {
+        continue;
+    }
+
+    if ($exclude && preg_match($exclude, $file)) {
         continue;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I was testing the tool properly after the merge (without having to copy paste the script), and discovered I got the path wrong :/ This PR fixes it.

I also discovered that we need to not load vendor classes - I got an "undefined class" error when loading all classes (and it also saves some performance).