### PR TITLE
[DependencyInjection] Allow injecting tagged iterator as service locator arguments

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/ServiceLocatorTagPassTest.php
@@ -147,6 +147,27 @@ class ServiceLocatorTagPassTest extends TestCase
         $this->assertInstanceOf(BoundArgument::class, $locator->getBindings()['foo']);
     }
 
+    public function testTaggedServices()
+    {
+        $container = new ContainerBuilder();
+
+        $container->register('bar', TestDefinition1::class)->addTag('test_tag');
+        $container->register('baz', TestDefinition2::class)->addTag('test_tag');
+
+        $container->register('foo', ServiceLocator::class)
+            ->setArguments([new TaggedIteratorArgument('test_tag', null, null, true)])
+            ->addTag('container.service_locator')
+        ;
+
+        (new ServiceLocatorTagPass())->process($container);
+
+        /** @var ServiceLocator $locator */
+        $locator = $container->get('foo');
+
+        $this->assertSame(TestDefinition1::class, \get_class($locator('bar')));
+        $this->assertSame(TestDefinition2::class, \get_class($locator('baz')));
+    }
+
     public function testIndexedByServiceIdWithDecoration()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#15821

Not sure if this is a feature or bug fix - kindly update the description and target branch and I will backport the changes for older version if needed.
This feature allows creating a named (reusable) service locator using tagged services:

```yml
services:
    _instanceof:
        App\Command\HandlerInterface:
            tags: ['app.command_handler']
    
    app.command_handlers:
        class: Symfony\Component\DependencyInjection\ServiceLocator
        arguments: [!tagged_iterator { tag: 'app.command_handler', default_index_method: 'getCommandName' }]
            
    App\CommandBus:
        arguments: ['@app.command_handlers']
            
    App\AnotherCommandBus:
        arguments: ['@app.command_handlers']
```

Prior to this change, following error would be thrown:
```
Invalid definition for service "app.command_handlers": an array of references is expected as first argument when the "container.service_locator" tag is set.
```