### PR TITLE
[HttpFoundation] Map `multipart/form-data` as `form` Content-Type

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1988,7 +1988,7 @@ class Request
             'rdf' => ['application/rdf+xml'],
             'atom' => ['application/atom+xml'],
             'rss' => ['application/rss+xml'],
-            'form' => ['application/x-www-form-urlencoded'],
+            'form' => ['application/x-www-form-urlencoded', 'multipart/form-data'],
         ];
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -501,6 +501,7 @@ class RequestTest extends TestCase
             ['xml', ['text/xml', 'application/xml', 'application/x-xml']],
             ['rdf', ['application/rdf+xml']],
             ['atom', ['application/atom+xml']],
+            ['form', ['application/x-www-form-urlencoded', 'multipart/form-data']],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  |yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? |no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | #34240 
| License       | MIT
| Doc PR        | –

As per RFC 2045 and RFC 2388 (see https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.2), the `multipart/form-data` Content-Type should be used when submitting a mixed forms containing files, binary data and non-ASCII data.
Currently, the same logic that would run in regular, non-mixed form scenarios can't run for mixed forms, as soon as it relies on the result of `Request::getContentType()` or anything else that might rely on `Request::$formats` without going low-level and avoiding the implemented abstraction. This PR fixes that.

Resolves #34240