### PR TITLE
[Mailer] Adding support for TagHeader and MetadataHeader to the Sendgrid API transport

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Add support for `TagHeader` and `MetadataHeader` to the Sendgrid API transport
+
 4.4.0
 -----
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Mailer\Bridge\Sendgrid\Tests\Transport;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Bridge\Sendgrid\Transport\SendgridApiTransport;
 use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -221,5 +223,29 @@ class SendgridApiTransportTest extends TestCase
         $this->assertArrayHasKey('email', $payload['personalizations'][0]['to'][0]);
         $this->assertCount(1, $payload['personalizations'][0]['to']);
         $this->assertSame($envelopeTo, $payload['personalizations'][0]['to'][0]['email']);
+    }
+
+    public function testTagAndMetadataHeaders()
+    {
+        $email = new Email();
+        $email->getHeaders()->add(new TagHeader('category-one'));
+        $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));
+        $email->getHeaders()->add(new MetadataHeader('Client-ID', '12345'));
+        $envelope = new Envelope(new Address('alice@system.com'), [new Address('bob@system.com')]);
+
+        $transport = new SendgridApiTransport('ACCESS_KEY');
+        $method = new \ReflectionMethod(SendgridApiTransport::class, 'getPayload');
+        $method->setAccessible(true);
+        $payload = $method->invoke($transport, $email, $envelope);
+
+        $this->assertArrayHasKey('categories', $payload);
+        $this->assertArrayHasKey('custom_args', $payload['personalizations'][0]);
+
+        $this->assertCount(1, $payload['categories']);
+        $this->assertCount(2, $payload['personalizations'][0]['custom_args']);
+
+        $this->assertSame(['category-one'], $payload['categories']);
+        $this->assertSame('blue', $payload['personalizations'][0]['custom_args']['Color']);
+        $this->assertSame('12345', $payload['personalizations'][0]['custom_args']['Client-ID']);
     }
 }

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -15,6 +15,9 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Exception\HttpTransportException;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mailer\Header\MetadataHeader;
+use Symfony\Component\Mailer\Header\TagHeader;
 use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\AbstractApiTransport;
 use Symfony\Component\Mime\Address;
@@ -111,7 +114,8 @@ class SendgridApiTransport extends AbstractApiTransport
             $payload['reply_to'] = $emails[0];
         }
 
-        $payload['personalizations'][] = $personalization;
+        $customArguments = [];
+        $categories = [];
 
         // these headers can't be overwritten according to Sendgrid docs
         // see https://sendgrid.api-docs.io/v3.0/mail-send/mail-send-errors#-Headers-Errors
@@ -121,8 +125,27 @@ class SendgridApiTransport extends AbstractApiTransport
                 continue;
             }
 
-            $payload['headers'][$name] = $header->getBodyAsString();
+            if ($header instanceof TagHeader) {
+                if (10 === \count($categories)) {
+                    throw new TransportException(sprintf('Too many "%s" instances present in the email headers. Sendgrid does not accept more than 10 categories on an email.', TagHeader::class));
+                }
+                $categories[] = mb_substr($header->getValue(), 0, 255);
+            } elseif ($header instanceof MetadataHeader) {
+                $customArguments[$header->getKey()] = $header->getValue();
+            } else {
+                $payload['headers'][$name] = $header->getBodyAsString();
+            }
         }
+
+        if (\count($categories) > 0) {
+            $payload['categories'] = $categories;
+        }
+
+        if (\count($customArguments) > 0) {
+            $personalization['custom_args'] = $customArguments;
+        }
+
+        $payload['personalizations'][] = $personalization;
 
         return $payload;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | None
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/15816

I added support for tags and metadata to the Mailer Sendgrid API transport, in response to this discussion: https://github.com/symfony/symfony/discussions/42481

The relevant Sendgrid API documentation is located at:

- https://docs.sendgrid.com/for-developers/tracking-events/event#custom-arguments
- https://docs.sendgrid.com/api-reference/mail-send/mail-send