### PR TITLE
[Console] Relax return type on HelperInterface::getName()

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -212,6 +212,17 @@ index 761b31d0d2..bf4ff86dd5 100644
 +    protected function execute(InputInterface $input, OutputInterface $output): int
      {
          throw new LogicException('You must override the execute() method in the concrete command class.');
+diff --git a/src/Symfony/Component/Console/Helper/HelperInterface.php b/src/Symfony/Component/Console/Helper/HelperInterface.php
+index 1d2b7bf..cb1f661 100644
+--- a/src/Symfony/Component/Console/Helper/HelperInterface.php
++++ b/src/Symfony/Component/Console/Helper/HelperInterface.php
+@@ -33,5 +33,5 @@ interface HelperInterface
+      *
+      * @return string
+      */
+-    public function getName();
++    public function getName(): string;
+ }
 diff --git a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php b/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php
 index 1acec50de5..904e67a47b 100644
 --- a/src/Symfony/Component/DependencyInjection/Compiler/AbstractRecursivePass.php

--- a/src/Symfony/Component/Console/Helper/HelperInterface.php
+++ b/src/Symfony/Component/Console/Helper/HelperInterface.php
@@ -30,6 +30,8 @@ interface HelperInterface
 
     /**
      * Returns the canonical name of this helper.
+     *
+     * @return string
      */
-    public function getName(): string;
+    public function getName();
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #43021
| License       | MIT
| Doc PR        | N/A

Removing this one return type would allow Doctrine ORM 2.9 and DBAL 2.13 to work with Symfony 6.