### PR TITLE
[Messenger] Fix broken Redis mocks

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: Ubuntu-20.04
 
     env:
-      extensions: amqp,apcu,igbinary,intl,mbstring,memcached,mongodb,redis
+      extensions: amqp,apcu,igbinary,intl,mbstring,memcached,mongodb,redis-5.3.4
 
     strategy:
       matrix:

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Tests/Transport/ConnectionTest.php
@@ -78,7 +78,7 @@ class ConnectionTest extends TestCase
         $redis->expects($this->once())
             ->method('connect')
             ->with('tls://127.0.0.1', 6379)
-            ->willReturn(null);
+            ->willReturn(true);
 
         Connection::fromDsn('redis://127.0.0.1?tls=1', [], $redis);
     }
@@ -92,7 +92,7 @@ class ConnectionTest extends TestCase
         $redis->expects($this->once())
             ->method('connect')
             ->with('tls://127.0.0.1', 6379)
-            ->willReturn(null);
+            ->willReturn(true);
 
         Connection::fromDsn('redis://127.0.0.1', ['tls' => true], $redis);
     }
@@ -103,7 +103,7 @@ class ConnectionTest extends TestCase
         $redis->expects($this->once())
             ->method('connect')
             ->with('tls://127.0.0.1', 6379)
-            ->willReturn(null);
+            ->willReturn(true);
 
         Connection::fromDsn('rediss://127.0.0.1', [], $redis);
     }
@@ -315,7 +315,7 @@ class ConnectionTest extends TestCase
 
         $redis->expects($this->exactly(1))->method('xadd')
             ->with('queue', '*', ['message' => '{"body":"1","headers":[]}'], 20000, true)
-            ->willReturn(1);
+            ->willReturn('1');
 
         $connection = Connection::fromDsn('redis://localhost/queue?stream_max_entries=20000', [], $redis); // 1 = always
         $connection->add('1', []);
@@ -355,7 +355,7 @@ class ConnectionTest extends TestCase
     {
         $redis = $this->createMock(\Redis::class);
 
-        $redis->expects($this->once())->method('xadd')->willReturn(0);
+        $redis->expects($this->once())->method('xadd')->willReturn('0');
         $redis->expects($this->once())->method('xack')->willReturn(0);
 
         $redis->method('getLastError')->willReturnOnConsecutiveCalls('xadd error', 'xack error');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Apparently, the PHP 8.1 CI runs a dev snapshot of ext-redis that has return types. This breaks some of our mock configurations.