### PR TITLE
[Form] Do not trim unassigned unicode characters

### DIFF
--- a/src/Symfony/Component/Form/Tests/Util/StringUtilTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/StringUtilTest.php
@@ -16,11 +16,20 @@ use Symfony\Component\Form\Util\StringUtil;
 
 class StringUtilTest extends TestCase
 {
-    public function testTrim()
+    public function trimProvider()
     {
-        $data = ' Foo! ';
+        return [
+            [' Foo! ', 'Foo!'],
+            ["\u{1F92E}", "\u{1F92E}"], // unassigned character in PCRE versions of <PHP 7.3
+        ];
+    }
 
-        $this->assertEquals('Foo!', StringUtil::trim($data));
+    /**
+     * @dataProvider trimProvider
+     */
+    public function testTrim($data, $expectedData)
+    {
+        $this->assertSame($expectedData, StringUtil::trim($data));
     }
 
     /**

--- a/src/Symfony/Component/Form/Util/StringUtil.php
+++ b/src/Symfony/Component/Form/Util/StringUtil.php
@@ -33,7 +33,7 @@ class StringUtil
      */
     public static function trim($string)
     {
-        if (null !== $result = @preg_replace('/^[\pZ\pC]+|[\pZ\pC]+$/u', '', $string)) {
+        if (null !== $result = @preg_replace('/^[\pZ\p{Cc}\p{Cf}]+|[\pZ\p{Cc}\p{Cf}]+$/u', '', $string)) {
             return $result;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

I faced a problem with StringUtil::trim in PHP <7.3 and added a test only (for now).
I probably should have created an issue instead but I thought it is better to look at the result of a test and make sure it actually is a problem.

It is caused by `\pC` from the preg_replace.
I am no expert for UTF-8 whitespace and cannot suggest a good bugfix. Are you interested to work around the buggy behavior of the older PHP versions? Otherwise I'll close this.
