### PR TITLE
[RateLimiter][Runtime] Remove experimental from README.md

### DIFF
--- a/src/Symfony/Component/RateLimiter/README.md
+++ b/src/Symfony/Component/RateLimiter/README.md
@@ -4,11 +4,6 @@ Rate Limiter Component
 The Rate Limiter component provides a Token Bucket implementation to
 rate limit input and output in your application.
 
-**This Component is experimental**.
-[Experimental features](https://symfony.com/doc/current/contributing/code/experimental.html)
-are not covered by Symfony's
-[Backward Compatibility Promise](https://symfony.com/doc/current/contributing/code/bc.html).
-
 Getting Started
 ---------------
 

--- a/src/Symfony/Component/Runtime/README.md
+++ b/src/Symfony/Component/Runtime/README.md
@@ -3,11 +3,6 @@ Runtime Component
 
 Symfony Runtime enables decoupling applications from global state.
 
-**This Component is experimental**.
-[Experimental features](https://symfony.com/doc/current/contributing/code/experimental.html)
-are not covered by Symfony's
-[Backward Compatibility Promise](https://symfony.com/doc/current/contributing/code/bc.html).
-
 Resources
 ---------
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

Since https://github.com/symfony/symfony/pull/42957 is merged, experimental mentions in RateLimiter and Runtime README.md files can be removed.