### PR TITLE
[Validator] Support enums in Choice constraints

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for `ConstraintViolationList::createFromMessage()`
+ * Add enum support (>= PHP 8.1) for the `Choice` constraint
 
 5.3
 ---

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -35,7 +35,7 @@ class ChoiceValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, Choice::class);
         }
 
-        if (!\is_array($constraint->choices) && !$constraint->callback) {
+        if (!\is_array($constraint->choices) && !is_a($constraint->choices, \BackedEnum::class, true) && !$constraint->callback) {
             throw new ConstraintDefinitionException('Either "choices" or "callback" must be specified on constraint Choice.');
         }
 
@@ -55,6 +55,13 @@ class ChoiceValidator extends ConstraintValidator
                 throw new ConstraintDefinitionException('The Choice constraint expects a valid callback.');
             }
             $choices = $choices();
+        } elseif (is_a($constraint->choices, \BackedEnum::class, true)) {
+            $choices = array_map(
+                function (\BackedEnum $enum) {
+                    return $enum->value;
+                },
+                $constraint->choices::cases()
+            );
         } else {
             $choices = $constraint->choices;
         }

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -35,7 +35,11 @@ class ChoiceValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, Choice::class);
         }
 
-        if (!\is_array($constraint->choices) && !is_a($constraint->choices, \BackedEnum::class, true) && !$constraint->callback) {
+        $valid = \is_array($constraint->choices)
+            || (\is_string($constraint->choices) && is_a($constraint->choices, \BackedEnum::class, true))
+            || isset($constraint->callback);
+
+        if (!$valid) {
             throw new ConstraintDefinitionException('Either "choices" or "callback" must be specified on constraint Choice.');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -60,12 +60,7 @@ class ChoiceValidator extends ConstraintValidator
             }
             $choices = $choices();
         } elseif (is_a($constraint->choices, \BackedEnum::class, true)) {
-            $choices = array_map(
-                function (\BackedEnum $enum) {
-                    return $enum->value;
-                },
-                $constraint->choices::cases()
-            );
+            $choices = \array_column($constraint->choices::cases(), 'value');
         } else {
             $choices = $constraint->choices;
         }

--- a/src/Symfony/Component/Validator/Test/SampleBackedEnum.php
+++ b/src/Symfony/Component/Validator/Test/SampleBackedEnum.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Validator\Test;
+
+enum SampleBackedEnum: string
+{
+    case FOO = 'foo';
+    case BAR = 'bar';
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraints\ChoiceValidator;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
-use Symfony\Component\Validator\Test\SampleBackedEnum;
+use Symfony\Component\Validator\Tests\SampleBackedEnum;
 
 function choice_callback()
 {

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\Constraints\ChoiceValidator;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+use Symfony\Component\Validator\Test\SampleBackedEnum;
 
 function choice_callback()
 {
@@ -92,6 +93,10 @@ class ChoiceValidatorTest extends ConstraintValidatorTestCase
 
         if (\PHP_VERSION_ID >= 80000) {
             yield 'named arguments' => [eval('return new \Symfony\Component\Validator\Constraints\Choice(choices: ["foo", "bar"]);')];
+        }
+
+        if (\PHP_VERSION_ID >= 80100) {
+            yield 'enums' => [new Choice(SampleBackedEnum::class)];
         }
     }
 

--- a/src/Symfony/Component/Validator/Tests/SampleBackedEnum.php
+++ b/src/Symfony/Component/Validator/Tests/SampleBackedEnum.php
@@ -9,9 +9,7 @@
  * file that was distributed with this source code.
  */
 
-declare(strict_types=1);
-
-namespace Symfony\Component\Validator\Test;
+namespace Symfony\Component\Validator\Tests;
 
 enum SampleBackedEnum: string
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      |no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | _TODO_

This PR allows using PHP 8.1 (backed) enums in `Choice` constraints.

Usage:

```php
enum Suit: string {
  case Hearts = 'H';
  case Diamonds = 'D';
  case Clubs = 'C';
  case Spades = 'S';
}
```

```php
class Card {
    public Suit $suit;
}
```

```php
class CardDTO {

    #[Choice(choices: Suit::class)]
    public string $suit;
}
```