### PR TITLE
Silence Psalm errors about Enum classes

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -21,8 +21,10 @@
     <issueHandlers>
         <UndefinedClass>
             <errorLevel type="suppress">
-                <!-- Class has been added in PHP 8.1 -->
+                <!-- These classes have been added in PHP 8.1 -->
+                <referencedClass name="BackedEnum"/>
                 <referencedClass name="ReflectionIntersectionType"/>
+                <referencedClass name="UnitEnum"/>
             </errorLevel>
         </UndefinedClass>
     </issueHandlers>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

Psalm does not know about `BackedEnum` and `UnitEnum` yet. This PR should remove some distracting noise from PRs that work with PHP's native enum classes.