### PR TITLE
[Mailer] [Sendgrid] Fix test

### DIFF
--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Tests/Transport/SendgridApiTransportTest.php
@@ -227,6 +227,10 @@ class SendgridApiTransportTest extends TestCase
 
     public function testTagAndMetadataHeaders()
     {
+        if (!class_exists(TagHeader::class)) {
+            $this->markTestSkipped('This test requires symfony/mailer 5.1 or higher.');
+        }
+
         $email = new Email();
         $email->getHeaders()->add(new TagHeader('category-one'));
         $email->getHeaders()->add(new MetadataHeader('Color', 'blue'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

low-deps build is broken after https://github.com/symfony/symfony/pull/43018 because it uses symfony/mailer 4.4.x while `TagHeader` is 5.x only.