### PR TITLE
[WebProfilerBundle] Fix displaying certain configs

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -116,14 +116,14 @@
             <span class="label">Symfony version</span>
         </div>
 
-        {% if 'n/a' != collector.env %}
+        {% if 'n/a' is not same as(collector.env) %}
             <div class="metric">
                 <span class="value">{{ collector.env }}</span>
                 <span class="label">Environment</span>
             </div>
         {% endif %}
 
-        {% if 'n/a' != collector.debug %}
+        {% if 'n/a' is not same as(collector.debug) %}
             <div class="metric">
                 <span class="value">{{ collector.debug ? 'enabled' : 'disabled' }}</span>
                 <span class="label">Debug</span>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I've noticed that the Debug info isn't always displayed:
![Screen1](https://user-images.githubusercontent.com/2445045/133604786-c5b8f083-72f4-4378-be3f-2642ef35f332.png)

This is because of type juggling:
![Screen2](https://user-images.githubusercontent.com/2445045/133605102-dae6c919-483a-4373-837f-f324d6550f31.png)

After the changes:
![Screen3](https://user-images.githubusercontent.com/2445045/133605231-d9756646-c2b7-4e20-90ae-1abbd8e74fc1.png)
