### PR TITLE
[RateLimiter] Add support for long intervals (months and years)

### DIFF
--- a/src/Symfony/Component/RateLimiter/CHANGELOG.md
+++ b/src/Symfony/Component/RateLimiter/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * The component is not experimental anymore
+ * Add support for long intervals (months and years)
 
 5.2.0
 -----

--- a/src/Symfony/Component/RateLimiter/Policy/Rate.php
+++ b/src/Symfony/Component/RateLimiter/Policy/Rate.php
@@ -49,6 +49,16 @@ final class Rate
         return new static(new \DateInterval('P1D'), $rate);
     }
 
+    public static function perMonth(int $rate = 1): self
+    {
+        return new static(new \DateInterval('P1M'), $rate);
+    }
+
+    public static function perYear(int $rate = 1): self
+    {
+        return new static(new \DateInterval('P1Y'), $rate);
+    }
+
     /**
      * @param string $string using the format: "%interval_spec%-%rate%", {@see DateInterval}
      */
@@ -91,6 +101,6 @@ final class Rate
 
     public function __toString(): string
     {
-        return $this->refillTime->format('P%dDT%HH%iM%sS').'-'.$this->refillAmount;
+        return $this->refillTime->format('P%y%m%dDT%HH%iM%sS').'-'.$this->refillAmount;
     }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
@@ -16,6 +16,7 @@ use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\RateLimiter\Policy\FixedWindowLimiter;
 use Symfony\Component\RateLimiter\Storage\InMemoryStorage;
 use Symfony\Component\RateLimiter\Tests\Resources\DummyWindow;
+use Symfony\Component\RateLimiter\Util\TimeUtil;
 
 /**
  * @group time-sensitive
@@ -49,16 +50,19 @@ class FixedWindowLimiterTest extends TestCase
         $this->assertSame(10, $rateLimit->getLimit());
     }
 
-    public function testConsumeOutsideInterval()
+    /**
+     * @dataProvider provideConsumeOutsideInterval
+     */
+    public function testConsumeOutsideInterval(string $dateIntervalString)
     {
-        $limiter = $this->createLimiter();
+        $limiter = $this->createLimiter($dateIntervalString);
 
         // start window...
         $limiter->consume();
-        // ...add a max burst at the end of the window...
-        sleep(55);
+        // ...add a max burst, 5 seconds before the end of the window...
+        sleep(TimeUtil::dateIntervalToSeconds(new \DateInterval($dateIntervalString)) - 5);
         $limiter->consume(9);
-        // ...try bursting again at the start of the next window
+        // ...try bursting again at the start of the next window, 10 seconds later
         sleep(10);
         $rateLimit = $limiter->consume(10);
         $this->assertEquals(0, $rateLimit->getRemainingTokens());
@@ -74,8 +78,21 @@ class FixedWindowLimiterTest extends TestCase
         $this->assertEquals(9, $rateLimit->getRemainingTokens());
     }
 
-    private function createLimiter(): FixedWindowLimiter
+    private function createLimiter(string $dateIntervalString = 'PT1M'): FixedWindowLimiter
     {
-        return new FixedWindowLimiter('test', 10, new \DateInterval('PT1M'), $this->storage);
+        return new FixedWindowLimiter('test', 10, new \DateInterval($dateIntervalString), $this->storage);
+    }
+
+    public function provideConsumeOutsideInterval(): \Generator
+    {
+        yield ['PT15S'];
+
+        yield ['PT1M'];
+
+        yield ['PT1H'];
+
+        yield ['P1M'];
+
+        yield ['P1Y'];
     }
 }

--- a/src/Symfony/Component/RateLimiter/Util/TimeUtil.php
+++ b/src/Symfony/Component/RateLimiter/Util/TimeUtil.php
@@ -20,10 +20,8 @@ final class TimeUtil
 {
     public static function dateIntervalToSeconds(\DateInterval $interval): int
     {
-        return (float) $interval->format('%s')      // seconds
-            + $interval->format('%i') * 60          // minutes
-            + $interval->format('%H') * 3600        // hours
-            + $interval->format('%d') * 3600 * 24   // days
-            ;
+        $now = new \DateTimeImmutable();
+
+        return ($now->add($interval))->getTimestamp() - $now->getTimestamp();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Fix #42784
| License       | MIT
| Doc PR        | _NA_

As mentioned in the issue and as found on Stackoverflow, we may use timestamps instead of converting `DateInterval` properties to seconds.