### PR TITLE
[Security] Cache voters that will always abstain

### DIFF
--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class AuthenticatedVoter implements VoterInterface
+class AuthenticatedVoter implements CacheableVoterInterface
 {
     public const IS_AUTHENTICATED_FULLY = 'IS_AUTHENTICATED_FULLY';
     public const IS_AUTHENTICATED_REMEMBERED = 'IS_AUTHENTICATED_REMEMBERED';
@@ -115,5 +115,24 @@ class AuthenticatedVoter implements VoterInterface
         }
 
         return $result;
+    }
+
+    public function supportsAttribute(string $attribute): bool
+    {
+        return \in_array($attribute, [
+            self::IS_AUTHENTICATED_FULLY,
+            self::IS_AUTHENTICATED_REMEMBERED,
+            self::IS_AUTHENTICATED_ANONYMOUSLY,
+            self::IS_AUTHENTICATED,
+            self::IS_ANONYMOUS,
+            self::IS_IMPERSONATOR,
+            self::IS_REMEMBERED,
+            self::PUBLIC_ACCESS,
+        ], true);
+    }
+
+    public function supportsType(string $subjectType): bool
+    {
+        return true;
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/CacheableVoterInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/CacheableVoterInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Authorization\Voter;
+
+/**
+ * Let voters expose the attributes and types they care about.
+ *
+ * By returning false to either `supportsAttribute` or `supportsType`, the
+ * voter will never be called for the specified attribute or subject.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+interface CacheableVoterInterface extends VoterInterface
+{
+    public function supportsAttribute(string $attribute): bool;
+
+    /**
+     * @param string $subjectType The type of the subject inferred by `get_class` or `get_debug_type`
+     */
+    public function supportsType(string $subjectType): bool;
+}

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class RoleVoter implements VoterInterface
+class RoleVoter implements CacheableVoterInterface
 {
     private $prefix;
 
@@ -53,6 +53,16 @@ class RoleVoter implements VoterInterface
         }
 
         return $result;
+    }
+
+    public function supportsAttribute(string $attribute): bool
+    {
+        return str_starts_with($attribute, $this->prefix);
+    }
+
+    public function supportsType(string $subjectType): bool
+    {
+        return true;
     }
 
     protected function extractRoles(TokenInterface $token)

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/TraceableVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/TraceableVoter.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  *
  * @internal
  */
-class TraceableVoter implements VoterInterface
+class TraceableVoter implements CacheableVoterInterface
 {
     private $voter;
     private $eventDispatcher;
@@ -45,5 +45,15 @@ class TraceableVoter implements VoterInterface
     public function getDecoratedVoter(): VoterInterface
     {
         return $this->voter;
+    }
+
+    public function supportsAttribute(string $attribute): bool
+    {
+        return !$this->voter instanceof CacheableVoterInterface || $this->voter->supportsAttribute($attribute);
+    }
+
+    public function supportsType(string $subjectType): bool
+    {
+        return !$this->voter instanceof CacheableVoterInterface || $this->voter->supportsType($subjectType);
     }
 }

--- a/src/Symfony/Component/Security/Core/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Core/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.4
 ---
 
+ * Add a `CacheableVoterInterface` for voters that vote only on identified attributes and subjects
  * Deprecate `AuthenticationEvents::AUTHENTICATION_FAILURE`, use the `LoginFailureEvent` instead
  * Deprecate `AnonymousToken`, as the related authenticator was deprecated in 5.3
  * Deprecate `Token::getCredentials()`, tokens should no longer contain credentials (as they represent authenticated sessions)

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/AuthenticatedVoterTest.php
@@ -83,6 +83,40 @@ class AuthenticatedVoterTest extends TestCase
         ];
     }
 
+    /**
+     * @dataProvider provideAttributes
+     */
+    public function testSupportsAttribute(string $attribute, bool $expected)
+    {
+        $voter = new AuthenticatedVoter(new AuthenticationTrustResolver());
+
+        $this->assertSame($expected, $voter->supportsAttribute($attribute));
+    }
+
+    public function provideAttributes()
+    {
+        yield [AuthenticatedVoter::IS_AUTHENTICATED_FULLY, true];
+        yield [AuthenticatedVoter::IS_AUTHENTICATED_REMEMBERED, true];
+        yield [AuthenticatedVoter::IS_AUTHENTICATED_ANONYMOUSLY, true];
+        yield [AuthenticatedVoter::IS_ANONYMOUS, true];
+        yield [AuthenticatedVoter::IS_AUTHENTICATED, true];
+        yield [AuthenticatedVoter::IS_IMPERSONATOR, true];
+        yield [AuthenticatedVoter::IS_REMEMBERED, true];
+        yield [AuthenticatedVoter::PUBLIC_ACCESS, true];
+
+        yield ['', false];
+        yield ['foo', false];
+    }
+
+    public function testSupportsType()
+    {
+        $voter = new AuthenticatedVoter(new AuthenticationTrustResolver());
+
+        $this->assertTrue($voter->supportsType(get_debug_type('foo')));
+        $this->assertTrue($voter->supportsType(get_debug_type(null)));
+        $this->assertTrue($voter->supportsType(get_debug_type(new \StdClass())));
+    }
+
     protected function getToken($authenticated)
     {
         $user = new InMemoryUser('wouter', '', ['ROLE_USER']);

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/RoleVoterTest.php
@@ -13,7 +13,9 @@ namespace Symfony\Component\Security\Core\Tests\Authorization\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Security\Core\Authentication\AuthenticationTrustResolver;
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\RoleVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
@@ -56,6 +58,35 @@ class RoleVoterTest extends TestCase
         $voter = new RoleVoter();
 
         $voter->vote($this->getTokenWithRoleNames(['ROLE_USER', 'ROLE_PREVIOUS_ADMIN']), null, ['ROLE_PREVIOUS_ADMIN']);
+    }
+
+    /**
+     * @dataProvider provideAttributes
+     */
+    public function testSupportsAttribute(string $prefix, string $attribute, bool $expected)
+    {
+        $voter = new RoleVoter($prefix);
+
+        $this->assertSame($expected, $voter->supportsAttribute($attribute));
+    }
+
+    public function provideAttributes()
+    {
+        yield ['ROLE_', 'ROLE_foo', true];
+        yield ['ROLE_', 'ROLE_', true];
+        yield ['FOO_', 'FOO_bar', true];
+
+        yield ['ROLE_', '', false];
+        yield ['ROLE_', 'foo', false];
+    }
+
+    public function testSupportsType()
+    {
+        $voter = new AuthenticatedVoter(new AuthenticationTrustResolver());
+
+        $this->assertTrue($voter->supportsType(get_debug_type('foo')));
+        $this->assertTrue($voter->supportsType(get_debug_type(null)));
+        $this->assertTrue($voter->supportsType(get_debug_type(new \StdClass())));
     }
 
     protected function getTokenWithRoleNames(array $roles)

--- a/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/TraceableVoterTest.php
+++ b/src/Symfony/Component/Security/Core/Tests/Authorization/Voter/TraceableVoterTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Core\Tests\Authorization\Voter;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\CacheableVoterInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\TraceableVoter;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\Event\VoteEvent;
@@ -50,5 +51,57 @@ class TraceableVoterTest extends TestCase
         $result = $sut->vote($token, 'anysubject', ['attr1']);
 
         $this->assertSame(VoterInterface::ACCESS_DENIED, $result);
+    }
+
+    public function testSupportsAttributeOnCacheable()
+    {
+        $voter = $this->getMockBuilder(CacheableVoterInterface::class)->getMockForAbstractClass();
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMockForAbstractClass();
+
+        $voter
+            ->expects($this->once())
+            ->method('supportsAttribute')
+            ->with('foo')
+            ->willReturn(false);
+
+        $sut = new TraceableVoter($voter, $eventDispatcher);
+
+        $this->assertFalse($sut->supportsAttribute('foo'));
+    }
+
+    public function testSupportsTypeOnCacheable()
+    {
+        $voter = $this->getMockBuilder(CacheableVoterInterface::class)->getMockForAbstractClass();
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMockForAbstractClass();
+
+        $voter
+            ->expects($this->once())
+            ->method('supportsType')
+            ->with('foo')
+            ->willReturn(false);
+
+        $sut = new TraceableVoter($voter, $eventDispatcher);
+
+        $this->assertFalse($sut->supportsType('foo'));
+    }
+
+    public function testSupportsAttributeOnNonCacheable()
+    {
+        $voter = $this->getMockBuilder(VoterInterface::class)->getMockForAbstractClass();
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMockForAbstractClass();
+
+        $sut = new TraceableVoter($voter, $eventDispatcher);
+
+        $this->assertTrue($sut->supportsAttribute('foo'));
+    }
+
+    public function testSupportsTypeOnNonCacheable()
+    {
+        $voter = $this->getMockBuilder(VoterInterface::class)->getMockForAbstractClass();
+        $eventDispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMockForAbstractClass();
+
+        $sut = new TraceableVoter($voter, $eventDispatcher);
+
+        $this->assertTrue($sut->supportsType('foo'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | todo

The current implementation of the AccessDecisionManager is to iterate over all the Voters, and stops when the strategy is met.

When an application performs a lot of checks (ie. an Admin shows a list of "blog post" and shows buttons to users that are allowed to "edit", "delete", "publish", ... ie `{% if is_granted('blog_delete', item) %}DELETE{% endif %}`). In that case, the number of calls to the `VoterInterface::vote` methods grows exponentially. At some point, adding a new Voter to handle a new case (maybe not related to our blog posts) will have a performance impact

Moreover in most of the time, a voter looks like:
```php
protected function supports($attribute, $subject)
{
  return \in_array($attribute, ['BLOG_DELETE', 'BLOG_UPDATE'], true) && $subject instanceof BlogPost;
}
```
We could leverage this, to cache the list of voters that need to be called or can be ignored

In the same way `symfony/serializer` provides a `CacheableSupportsMethodInterface` I suggest to add a new `CacheableAbstainVotesInterface` that will remember voters that will always abstain vote on a given attribute or a given object's type
When the Voter does not implements the interface OR returns `false` will provide the current behavior: The voter is always called.

How to use this PR:
```php
class TokenVoter extends Voter implements CacheableAbstainVotesInterface
{
    public const ATTRIBUTES = [
        'UPDATE',
        'DELETE',
        'REGENERATE',
    ];

    public function willAlwaysAbstainOnAttribute(string $attribute): bool
    {
        return !\in_array($attribute, self::ATTRIBUTES, true);
    }

    public function willAlwaysAbstainOnObjectType(string $objectType): bool
    {
        return !is_a(Token::class, $objectType);
    }

    protected function supports($attribute, $subject)
    {
        return \in_array($attribute, self::ATTRIBUTES, true) && $subject instanceof Token;
    }

    protected function voteOnAttribute($attribute, $webhookToken, TokenInterface $token)
    {
...
    }
}
```

Results:
For 40 Voters and calling 500 times `isGranted(variousAttributes, variousObjects)` it get -40% perf gain !


Opinionated choices in that PR:
* Only for string attributes: handling all cases (resources, callable, ...) would add too much complexity
* Only for decision with a single attribute: handling mix of string/null/whatever would add too much complexity

TODO
 * [ ] tests (waiting for feedback on the global design of this feature)
 * [ ] Doc