### PR TITLE
[HttpClient] Remove unused and redundant properties

### DIFF
--- a/src/Symfony/Component/HttpClient/Response/NativeResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/NativeResponse.php
@@ -36,8 +36,6 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
     private $remaining;
     private $buffer;
     private $multi;
-    private $debugBuffer;
-    private $shouldBuffer;
     private $pauseExpiry = 0;
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/43032#discussion_r710563195
| License       | MIT
| Doc PR        | N/A

* `$debugBuffer` is not used in this class.
* `$shouldBuffer` is already declared by `CommonResponseTrait`.