### PR TITLE
feat: #43086 add blacklisting of reserved shortcuts for InputOptions in commands

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -10,6 +10,7 @@ Console
 -------
 
  * Deprecate `HelperSet::setCommand()` and `getCommand()` without replacement
+ * Add blacklisting of reserved shortcuts for `InputOptions` in commands. See `getDefaultInputDefinition()` in `Symfony\Component\Console\Application`
 
 Finder
 ------

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.4
 ---
 
+ * Add blacklisting of reserved shortcuts for InputOptions in commands
  * Add `TesterTrait::assertCommandIsSuccessful()` to test command
  * Deprecate `HelperSet::setCommand()` and `getCommand()` without replacement
 

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -52,6 +52,11 @@ class InputOption
     private $default;
     private $description;
 
+    /* @see Symfony\Component\Console\Application->getDefaultInputDefinition() */
+    public const RESERVED_NAMES = ["help", "quiet", "version", "ansi", "no-ansi", "no-interaction", "env", "no-debug", "verbose"];
+    public const RESERVED_COMMANDS = ["about", "help", "list"];
+    public const RESERVED_SHORTCUTS = ["h", "q", "V", "n", "e", "v", "vv", "vvv"];
+
     /**
      * @param string|array|null                $shortcut The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
      * @param int|null                         $mode     The option mode: One of the VALUE_* constants
@@ -79,6 +84,10 @@ class InputOption
             }
             $shortcuts = preg_split('{(\|)-?}', ltrim($shortcut, '-'));
             $shortcuts = array_filter($shortcuts);
+            $used_reserved_shortcuts = array_intersect($shortcuts, self::RESERVED_SHORTCUTS);
+            if($used_reserved_shortcuts && !in_array($name, array_merge(self::RESERVED_NAMES, self::RESERVED_COMMANDS))) {
+                throw new InvalidArgumentException(sprintf('An option shortcut cannot include a reserved shortcut (%s).', implode('|', $used_reserved_shortcuts)));
+            }
             $shortcut = implode('|', $shortcuts);
 
             if (empty($shortcut)) {
@@ -226,6 +235,6 @@ class InputOption
             && $option->isArray() === $this->isArray()
             && $option->isValueRequired() === $this->isValueRequired()
             && $option->isValueOptional() === $this->isValueOptional()
-        ;
+            ;
     }
 }

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -52,7 +52,6 @@ class InputOption
     private $default;
     private $description;
 
-    /* @see Symfony\Component\Console\Application->getDefaultInputDefinition() */
     public const RESERVED_NAMES = ["help", "quiet", "version", "ansi", "no-ansi", "no-interaction", "env", "no-debug", "verbose"];
     public const RESERVED_COMMANDS = ["about", "help", "list"];
     public const RESERVED_SHORTCUTS = ["h", "q", "V", "n", "e", "v", "vv", "vvv"];
@@ -235,6 +234,6 @@ class InputOption
             && $option->isArray() === $this->isArray()
             && $option->isValueRequired() === $this->isValueRequired()
             && $option->isValueOptional() === $this->isValueOptional()
-            ;
+        ;
     }
 }

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -52,9 +52,9 @@ class InputOption
     private $default;
     private $description;
 
-    public const RESERVED_NAMES = ["help", "quiet", "version", "ansi", "no-ansi", "no-interaction", "env", "no-debug", "verbose"];
-    public const RESERVED_COMMANDS = ["about", "help", "list"];
-    public const RESERVED_SHORTCUTS = ["h", "q", "V", "n", "e", "v", "vv", "vvv"];
+    public const RESERVED_NAMES = ['help', 'quiet', 'version', 'ansi', 'no-ansi', 'no-interaction', 'env', 'no-debug', 'verbose'];
+    public const RESERVED_COMMANDS = ['about', 'help', 'list'];
+    public const RESERVED_SHORTCUTS = ['h', 'q', 'V', 'n', 'e', 'v', 'vv', 'vvv'];
 
     /**
      * @param string|array|null                $shortcut The shortcuts, can be null, a string of shortcuts delimited by | or an array of shortcuts
@@ -84,7 +84,7 @@ class InputOption
             $shortcuts = preg_split('{(\|)-?}', ltrim($shortcut, '-'));
             $shortcuts = array_filter($shortcuts);
             $used_reserved_shortcuts = array_intersect($shortcuts, self::RESERVED_SHORTCUTS);
-            if($used_reserved_shortcuts && !in_array($name, array_merge(self::RESERVED_NAMES, self::RESERVED_COMMANDS))) {
+            if ($used_reserved_shortcuts && !\in_array($name, array_merge(self::RESERVED_NAMES, self::RESERVED_COMMANDS))) {
                 throw new InvalidArgumentException(sprintf('An option shortcut cannot include a reserved shortcut (%s).', implode('|', $used_reserved_shortcuts)));
             }
             $shortcut = implode('|', $shortcuts);

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -503,15 +503,10 @@ class ApplicationTest extends TestCase
         $application->setAutoExit(false);
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'foos:bar1'], ['decorated' => false]);
-        $this->assertSame('
-                                                          
-  There are no commands defined in the "foos" namespace.  
-                                                          
-  Did you mean this?                                      
-      foo                                                 
-                                                          
-
-', $tester->getDisplay(true));
+        $display = $tester->getDisplay(true);
+        $this->assertStringContainsString('There are no commands defined in the "foos" namespace.', $display);
+        $this->assertStringContainsString('Did you mean this?', $display);
+        $this->assertStringContainsString('foo', $display);
     }
 
     public function testCanRunAlternativeCommandName()

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -504,12 +504,12 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'foos:bar1'], ['decorated' => false]);
         $this->assertSame('
-                                                          
-  There are no commands defined in the "foos" namespace.  
-                                                          
-  Did you mean this?                                      
-      foo                                                 
-                                                          
+
+  There are no commands defined in the "foos" namespace.
+
+  Did you mean this?
+      foo
+
 
 ', $tester->getDisplay(true));
     }
@@ -1167,19 +1167,19 @@ class ApplicationTest extends TestCase
     public function testAddingOptionWithDuplicateShortcut()
     {
         $this->expectException(\LogicException::class);
-        $this->expectExceptionMessage('An option with shortcut "e" already exists.');
+        $this->expectExceptionMessage('An option with shortcut "t" already exists.');
         $dispatcher = new EventDispatcher();
         $application = new Application();
         $application->setAutoExit(false);
         $application->setCatchExceptions(false);
         $application->setDispatcher($dispatcher);
 
-        $application->getDefinition()->addOption(new InputOption('--env', '-e', InputOption::VALUE_REQUIRED, 'Environment'));
+        $application->getDefinition()->addOption(new InputOption('--test', '-t', InputOption::VALUE_REQUIRED, 'Test'));
 
         $application
             ->register('foo')
             ->setAliases(['f'])
-            ->setDefinition([new InputOption('survey', 'e', InputOption::VALUE_REQUIRED, 'My option with a shortcut.')])
+            ->setDefinition([new InputOption('survey', 't', InputOption::VALUE_REQUIRED, 'My option with a shortcut.')])
             ->setCode(function (InputInterface $input, OutputInterface $output) {})
         ;
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -504,12 +504,12 @@ class ApplicationTest extends TestCase
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'foos:bar1'], ['decorated' => false]);
         $this->assertSame('
-
-  There are no commands defined in the "foos" namespace.
-
-  Did you mean this?
-      foo
-
+                                                          
+  There are no commands defined in the "foos" namespace.  
+                                                          
+  Did you mean this?                                      
+      foo                                                 
+                                                          
 
 ', $tester->getDisplay(true));
     }
@@ -1198,6 +1198,7 @@ class ApplicationTest extends TestCase
         $application = new Application();
         $application->setAutoExit(false);
         $application->setCatchExceptions(false);
+
         $application
             ->register('foo')
             ->setDefinition([$def])
@@ -1214,7 +1215,7 @@ class ApplicationTest extends TestCase
         return [
             [new InputArgument('command', InputArgument::REQUIRED)],
             [new InputOption('quiet', '', InputOption::VALUE_NONE)],
-            [new InputOption('query', 'q', InputOption::VALUE_NONE)],
+            //[new InputOption('quiet', 'q', InputOption::VALUE_NONE)], \InvalidArgumentException::class);
         ];
     }
 

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -503,10 +503,15 @@ class ApplicationTest extends TestCase
         $application->setAutoExit(false);
         $tester = new ApplicationTester($application);
         $tester->run(['command' => 'foos:bar1'], ['decorated' => false]);
-        $display = $tester->getDisplay(true);
-        $this->assertStringContainsString('There are no commands defined in the "foos" namespace.', $display);
-        $this->assertStringContainsString('Did you mean this?', $display);
-        $this->assertStringContainsString('foo', $display);
+        $this->assertSame('
+                                                          
+  There are no commands defined in the "foos" namespace.  
+                                                          
+  Did you mean this?                                      
+      foo                                                 
+                                                          
+
+', $tester->getDisplay(true));
     }
 
     public function testCanRunAlternativeCommandName()

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -69,7 +69,7 @@ class InputOptionTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('An option shortcut cannot include a reserved shortcut (v).');
-        $option = new InputOption('foo', ['x'|'v'|'z']);
+        $option = new InputOption('foo', ['x' | 'v' | 'z']);
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('An option shortcut cannot include a reserved shortcut (V).');

--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -57,6 +57,41 @@ class InputOptionTest extends TestCase
         $this->assertNull($option->getShortcut(), '__construct() makes the shortcut null by default');
     }
 
+    public function testInvalidShortcut()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('An option shortcut cannot include a reserved shortcut (e).');
+        $option = new InputOption('foo', 'e');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('An option shortcut cannot include a reserved shortcut (v).');
+        $option = new InputOption('foo', 'x|v|z');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('An option shortcut cannot include a reserved shortcut (v).');
+        $option = new InputOption('foo', ['x'|'v'|'z']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('An option shortcut cannot include a reserved shortcut (V).');
+        $option = new InputOption('foo', 'V');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('An option shortcut cannot include a reserved shortcut (vvv).');
+        $option = new InputOption('foo', 'vvv');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('An option shortcut cannot include a reserved shortcut (help).');
+        $option = new InputOption('foo', 'help');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('An option shortcut cannot include a reserved shortcut (ansi).');
+        $option = new InputOption('foo', 'ansi');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('An option shortcut cannot include a reserved shortcut (no-ansi).');
+        $option = new InputOption('foo', 'no-ansi');
+    }
+
     public function testModes()
     {
         $option = new InputOption('foo', 'f');

--- a/src/Symfony/Component/Runtime/Tests/phpt/command.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/command.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 require __DIR__.'/autoload.php';
 
 return function (Command $command, InputInterface $input, OutputInterface $output, array $context) {
-    $command->addOption('hello', 'e', InputOption::VALUE_REQUIRED, 'How should I greet?', 'OK');
+    $command->addOption('hello', 'he', InputOption::VALUE_REQUIRED, 'How should I greet?', 'OK');
 
     return $command->setCode(function () use ($input, $output, $context) {
         $output->write($input->getOption('hello').' Command '.$context['SOME_VAR']);

--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -58,7 +58,7 @@ class LintCommand extends Command
             ->setDescription(self::$defaultDescription)
             ->addArgument('filename', InputArgument::IS_ARRAY, 'A file, a directory or "-" for reading from STDIN')
             ->addOption('format', null, InputOption::VALUE_REQUIRED, 'The output format')
-            ->addOption('exclude', 'e', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Path(s) to exclude')
+            ->addOption('exclude', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Path(s) to exclude')
             ->addOption('parse-tags', null, InputOption::VALUE_NEGATABLE, 'Parse custom tags', null)
             ->setHelp(<<<EOF
 The <info>%command.name%</info> command lints a YAML file and outputs to STDOUT


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #43086
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

This is an idea how to solve #43086
The blacklisting of reserved shortcuts for InputOptions in commands is done on initialisation and not at runtime.
I do not like the fact of the hardcodet arrays.
It would be better to read them from [getDefaultInputDefinition()](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Console/Application.php#L1035) in `Symfony\Component\Console\Application`. If possible.

There is space for more improvements. Please share your ideas.
