### PR TITLE
[Form] Add the EnumType

### DIFF
--- a/.github/patch-types.php
+++ b/.github/patch-types.php
@@ -30,6 +30,9 @@ foreach ($loader->getClassMap() as $class => $file) {
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/Prototype/BadClasses/MissingParent.php'):
         case false !== strpos($file, '/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/'):
         case false !== strpos($file, '/src/Symfony/Component/ErrorHandler/Tests/Fixtures/'):
+        case false !== strpos($file, '/src/Symfony/Component/Form/Tests/Fixtures/Answer.php'):
+        case false !== strpos($file, '/src/Symfony/Component/Form/Tests/Fixtures/Number.php'):
+        case false !== strpos($file, '/src/Symfony/Component/Form/Tests/Fixtures/Suit.php'):
         case false !== strpos($file, '/src/Symfony/Component/PropertyInfo/Tests/Fixtures/'):
         case false !== strpos($file, '/src/Symfony/Component/PropertyInfo/Tests/Fixtures/Php81Dummy.php'):
         case false !== strpos($file, '/src/Symfony/Component/Runtime/Internal/ComposerPlugin.php'):

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php73": "^1.11",
         "symfony/polyfill-php80": "^1.16",
-        "symfony/polyfill-php81": "^1.22",
+        "symfony/polyfill-php81": "^1.23",
         "symfony/polyfill-uuid": "^1.15"
     },
     "replace": {

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Deprecate calling `FormErrorIterator::children()` if the current element is not iterable.
  * Allow to pass `TranslatableMessage` objects to the `help` option
+ * Add the `EnumType`
 
 5.3
 ---

--- a/src/Symfony/Component/Form/Extension/Core/Type/EnumType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/EnumType.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * A choice type for native PHP enums.
+ *
+ * @author Alexander M. Turek <me@derrabus.de>
+ */
+final class EnumType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver
+            ->setRequired(['class'])
+            ->setAllowedTypes('class', 'string')
+            ->setAllowedValues('class', \Closure::fromCallable('enum_exists'))
+            ->setDefault('choices', static function (Options $options): array {
+                return $options['class']::cases();
+            })
+            ->setDefault('choice_label', static function (\UnitEnum $choice): string {
+                return $choice->name;
+            })
+            ->setDefault('choice_value', static function (Options $options): ?\Closure {
+                if (!is_a($options['class'], \BackedEnum::class, true)) {
+                    return null;
+                }
+
+                return static function (?\BackedEnum $choice): ?string {
+                    if (null === $choice) {
+                        return null;
+                    }
+
+                    return (string) $choice->value;
+                };
+            })
+        ;
+    }
+
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -25,14 +25,14 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testPassDisabledAsOption()
     {
-        $form = $this->factory->create($this->getTestedType(), null, ['disabled' => true]);
+        $form = $this->factory->create($this->getTestedType(), null, array_merge($this->getTestOptions(), ['disabled' => true]));
 
         $this->assertTrue($form->isDisabled());
     }
 
     public function testPassIdAndNameToView()
     {
-        $view = $this->factory->createNamed('name', $this->getTestedType())
+        $view = $this->factory->createNamed('name', $this->getTestedType(), null, $this->getTestOptions())
             ->createView();
 
         $this->assertEquals('name', $view->vars['id']);
@@ -42,7 +42,7 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testStripLeadingUnderscoresAndDigitsFromId()
     {
-        $view = $this->factory->createNamed('_09name', $this->getTestedType())
+        $view = $this->factory->createNamed('_09name', $this->getTestedType(), null, $this->getTestOptions())
             ->createView();
 
         $this->assertEquals('name', $view->vars['id']);
@@ -53,7 +53,7 @@ abstract class BaseTypeTest extends TypeTestCase
     public function testPassIdAndNameToViewWithParent()
     {
         $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
-            ->add('child', $this->getTestedType())
+            ->add('child', $this->getTestedType(), $this->getTestOptions())
             ->getForm()
             ->createView();
 
@@ -66,7 +66,7 @@ abstract class BaseTypeTest extends TypeTestCase
     {
         $builder = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
             ->add('child', FormTypeTest::TESTED_TYPE);
-        $builder->get('child')->add('grand_child', $this->getTestedType());
+        $builder->get('child')->add('grand_child', $this->getTestedType(), $this->getTestOptions());
         $view = $builder->getForm()->createView();
 
         $this->assertEquals('parent_child_grand_child', $view['child']['grand_child']->vars['id']);
@@ -76,9 +76,9 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testPassTranslationDomainToView()
     {
-        $view = $this->factory->create($this->getTestedType(), null, [
+        $view = $this->factory->create($this->getTestedType(), null, array_merge($this->getTestOptions(), [
             'translation_domain' => 'domain',
-        ])
+        ]))
             ->createView();
 
         $this->assertSame('domain', $view->vars['translation_domain']);
@@ -90,7 +90,7 @@ abstract class BaseTypeTest extends TypeTestCase
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'translation_domain' => 'domain',
             ])
-            ->add('child', $this->getTestedType())
+            ->add('child', $this->getTestedType(), $this->getTestOptions())
             ->getForm()
             ->createView();
 
@@ -103,9 +103,9 @@ abstract class BaseTypeTest extends TypeTestCase
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'translation_domain' => 'parent_domain',
             ])
-            ->add('child', $this->getTestedType(), [
+            ->add('child', $this->getTestedType(), array_merge($this->getTestOptions(), [
                 'translation_domain' => 'domain',
-            ])
+            ]))
             ->getForm()
             ->createView();
 
@@ -115,7 +115,7 @@ abstract class BaseTypeTest extends TypeTestCase
     public function testDefaultTranslationDomain()
     {
         $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
-            ->add('child', $this->getTestedType())
+            ->add('child', $this->getTestedType(), $this->getTestOptions())
             ->getForm()
             ->createView();
 
@@ -126,9 +126,9 @@ abstract class BaseTypeTest extends TypeTestCase
     {
         $this->requiresFeatureSet(403);
 
-        $view = $this->factory->create($this->getTestedType(), null, [
+        $view = $this->factory->create($this->getTestedType(), null, array_merge($this->getTestOptions(), [
             'label_translation_parameters' => ['%param%' => 'value'],
-        ])
+        ]))
             ->createView();
 
         $this->assertSame(['%param%' => 'value'], $view->vars['label_translation_parameters']);
@@ -138,9 +138,9 @@ abstract class BaseTypeTest extends TypeTestCase
     {
         $this->requiresFeatureSet(403);
 
-        $view = $this->factory->create($this->getTestedType(), null, [
+        $view = $this->factory->create($this->getTestedType(), null, array_merge($this->getTestOptions(), [
             'attr_translation_parameters' => ['%param%' => 'value'],
-        ])
+        ]))
             ->createView();
 
         $this->assertSame(['%param%' => 'value'], $view->vars['attr_translation_parameters']);
@@ -154,7 +154,7 @@ abstract class BaseTypeTest extends TypeTestCase
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'label_translation_parameters' => ['%param%' => 'value'],
             ])
-            ->add('child', $this->getTestedType())
+            ->add('child', $this->getTestedType(), $this->getTestOptions())
             ->getForm()
             ->createView();
 
@@ -169,7 +169,7 @@ abstract class BaseTypeTest extends TypeTestCase
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'attr_translation_parameters' => ['%param%' => 'value'],
             ])
-            ->add('child', $this->getTestedType())
+            ->add('child', $this->getTestedType(), $this->getTestOptions())
             ->getForm()
             ->createView();
 
@@ -184,9 +184,9 @@ abstract class BaseTypeTest extends TypeTestCase
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'label_translation_parameters' => ['%parent_param%' => 'parent_value', '%override_param%' => 'parent_override_value'],
             ])
-            ->add('child', $this->getTestedType(), [
+            ->add('child', $this->getTestedType(), array_merge($this->getTestOptions(), [
                 'label_translation_parameters' => ['%override_param%' => 'child_value'],
-            ])
+            ]))
             ->getForm()
             ->createView();
 
@@ -201,9 +201,9 @@ abstract class BaseTypeTest extends TypeTestCase
             ->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE, null, [
                 'attr_translation_parameters' => ['%parent_param%' => 'parent_value', '%override_param%' => 'parent_override_value'],
             ])
-            ->add('child', $this->getTestedType(), [
+            ->add('child', $this->getTestedType(), array_merge($this->getTestOptions(), [
                 'attr_translation_parameters' => ['%override_param%' => 'child_value'],
-            ])
+            ]))
             ->getForm()
             ->createView();
 
@@ -215,7 +215,7 @@ abstract class BaseTypeTest extends TypeTestCase
         $this->requiresFeatureSet(403);
 
         $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
-            ->add('child', $this->getTestedType())
+            ->add('child', $this->getTestedType(), $this->getTestOptions())
             ->getForm()
             ->createView();
 
@@ -227,7 +227,7 @@ abstract class BaseTypeTest extends TypeTestCase
         $this->requiresFeatureSet(403);
 
         $view = $this->factory->createNamedBuilder('parent', FormTypeTest::TESTED_TYPE)
-            ->add('child', $this->getTestedType())
+            ->add('child', $this->getTestedType(), $this->getTestOptions())
             ->getForm()
             ->createView();
 
@@ -236,7 +236,10 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testPassLabelToView()
     {
-        $view = $this->factory->createNamed('__test___field', $this->getTestedType(), null, ['label' => 'My label'])
+        $view = $this->factory->createNamed('__test___field', $this->getTestedType(), null, array_merge(
+            $this->getTestOptions(),
+            ['label' => 'My label']
+        ))
             ->createView();
 
         $this->assertSame('My label', $view->vars['label']);
@@ -244,7 +247,7 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testPassMultipartFalseToView()
     {
-        $view = $this->factory->create($this->getTestedType())
+        $view = $this->factory->create($this->getTestedType(), null, $this->getTestOptions())
             ->createView();
 
         $this->assertFalse($view->vars['multipart']);
@@ -252,7 +255,7 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testSubmitNull($expected = null, $norm = null, $view = null)
     {
-        $form = $this->factory->create($this->getTestedType());
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestOptions());
         $form->submit(null);
 
         $this->assertSame($expected, $form->getData());
@@ -262,7 +265,7 @@ abstract class BaseTypeTest extends TypeTestCase
 
     public function testSubmitNullUsesDefaultEmptyData($emptyData = 'empty', $expectedData = null)
     {
-        $builder = $this->factory->createBuilder($this->getTestedType());
+        $builder = $this->factory->createBuilder($this->getTestedType(), null, $this->getTestOptions());
 
         if ($builder->getCompound()) {
             $emptyData = [];
@@ -285,5 +288,10 @@ abstract class BaseTypeTest extends TypeTestCase
     protected function getTestedType()
     {
         return static::TESTED_TYPE;
+    }
+
+    protected function getTestOptions(): array
+    {
+        return [];
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/EnumTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/EnumTypeTest.php
@@ -1,0 +1,267 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Extension\Core\Type;
+
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\Form\Tests\Extension\Core\Type\BaseTypeTest;
+use Symfony\Component\Form\Tests\Fixtures\Answer;
+use Symfony\Component\Form\Tests\Fixtures\Number;
+use Symfony\Component\Form\Tests\Fixtures\Suit;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
+
+/**
+ * @requires PHP 8.1
+ */
+final class EnumTypeTest extends BaseTypeTest
+{
+    public const TESTED_TYPE = EnumType::class;
+
+    public function testClassOptionIsRequired()
+    {
+        $this->expectException(MissingOptionsException::class);
+        $this->factory->createNamed('name', $this->getTestedType());
+    }
+
+    public function testInvalidClassOption()
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->factory->createNamed('name', $this->getTestedType(), null, [
+            'class' => 'foo',
+        ]);
+    }
+
+    public function testInvalidClassOptionType()
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->factory->createNamed('name', $this->getTestedType(), null, [
+            'class' => new \stdClass(),
+        ]);
+    }
+
+    /**
+     * @dataProvider provideSingleSubmitData
+     */
+    public function testSubmitSingleNonExpanded(string $class, string $submittedData, \UnitEnum $expectedData)
+    {
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'multiple' => false,
+            'expanded' => false,
+            'class' => $class,
+        ]);
+
+        $form->submit($submittedData);
+
+        $this->assertEquals($expectedData, $form->getData());
+        $this->assertEquals($submittedData, $form->getViewData());
+        $this->assertTrue($form->isSynchronized());
+    }
+
+    /**
+     * @dataProvider provideSingleSubmitData
+     */
+    public function testSubmitSingleExpanded(string $class, string $submittedData, \UnitEnum $expectedData)
+    {
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'multiple' => false,
+            'expanded' => true,
+            'class' => $class,
+        ]);
+
+        $form->submit($submittedData);
+
+        $this->assertEquals($expectedData, $form->getData());
+        $this->assertEquals($submittedData, $form->getViewData());
+        $this->assertTrue($form->isSynchronized());
+    }
+
+    public function provideSingleSubmitData(): iterable
+    {
+        yield 'unbacked' => [
+            Answer::class,
+            '2',
+            Answer::FourtyTwo,
+        ];
+
+        yield 'string backed' => [
+            Suit::class,
+            (Suit::Spades)->value,
+            Suit::Spades,
+        ];
+
+        yield 'integer backed' => [
+            Number::class,
+            (string) (Number::Two)->value,
+            Number::Two,
+        ];
+    }
+
+    public function testSubmitSingleNonExpandedInvalidChoice()
+    {
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'multiple' => false,
+            'expanded' => false,
+            'class' => Suit::class,
+        ]);
+
+        $form->submit('foobar');
+
+        $this->assertNull($form->getData());
+        $this->assertEquals('foobar', $form->getViewData());
+        $this->assertFalse($form->isSynchronized());
+    }
+
+    public function testSubmitNull($expected = null, $norm = null, $view = null)
+    {
+        $form = $this->factory->create($this->getTestedType(), null, $this->getTestOptions());
+
+        $form->submit(null);
+
+        $this->assertNull($form->getData());
+        $this->assertNull($form->getNormData());
+        $this->assertSame('', $form->getViewData());
+        $this->assertTrue($form->isSynchronized());
+    }
+
+    public function testSubmitNullUsesDefaultEmptyData($emptyData = 'empty', $expectedData = null)
+    {
+        $emptyData = (Suit::Hearts)->value;
+
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'class' => Suit::class,
+            'empty_data' => $emptyData,
+        ]);
+
+        $form->submit(null);
+
+        $this->assertSame($emptyData, $form->getViewData());
+        $this->assertSame(Suit::Hearts, $form->getNormData());
+        $this->assertSame(Suit::Hearts, $form->getData());
+    }
+
+    public function testSubmitMultipleChoiceWithEmptyData()
+    {
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'multiple' => true,
+            'expanded' => false,
+            'class' => Suit::class,
+            'empty_data' => [(Suit::Diamonds)->value],
+        ]);
+
+        $form->submit(null);
+
+        $this->assertSame([Suit::Diamonds], $form->getData());
+    }
+
+    public function testSubmitSingleChoiceExpandedWithEmptyData()
+    {
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'multiple' => false,
+            'expanded' => true,
+            'class' => Suit::class,
+            'empty_data' => (Suit::Hearts)->value,
+        ]);
+
+        $form->submit(null);
+
+        $this->assertSame(Suit::Hearts, $form->getData());
+    }
+
+    public function testSubmitMultipleChoiceExpandedWithEmptyData()
+    {
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'multiple' => true,
+            'expanded' => true,
+            'class' => Suit::class,
+            'empty_data' => [(Suit::Spades)->value],
+        ]);
+
+        $form->submit(null);
+
+        $this->assertSame([Suit::Spades], $form->getData());
+    }
+
+    /**
+     * @dataProvider provideMultiSubmitData
+     */
+    public function testSubmitMultipleNonExpanded(string $class, array $submittedValues, array $expectedValues)
+    {
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'multiple' => true,
+            'expanded' => false,
+            'class' => $class,
+        ]);
+
+        $form->submit($submittedValues);
+
+        $this->assertSame($expectedValues, $form->getData());
+        $this->assertSame($submittedValues, $form->getViewData());
+        $this->assertTrue($form->isSynchronized());
+    }
+
+    /**
+     * @dataProvider provideMultiSubmitData
+     */
+    public function testSubmitMultipleExpanded(string $class, array $submittedValues, array $expectedValues)
+    {
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'multiple' => true,
+            'expanded' => true,
+            'class' => $class,
+        ]);
+
+        $form->submit($submittedValues);
+
+        $this->assertSame($expectedValues, $form->getData());
+        $this->assertSame($submittedValues, $form->getViewData());
+        $this->assertTrue($form->isSynchronized());
+    }
+
+    public function provideMultiSubmitData(): iterable
+    {
+        yield 'unbacked' => [
+            Answer::class,
+            ['0', '1'],
+            [Answer::Yes, Answer::No],
+        ];
+
+        yield 'string backed' => [
+            Suit::class,
+            [(Suit::Hearts)->value, (Suit::Spades)->value],
+            [Suit::Hearts, Suit::Spades],
+        ];
+
+        yield 'integer backed' => [
+            Number::class,
+            [(string) (Number::Two)->value, (string) (Number::Three)->value],
+            [Number::Two, Number::Three],
+        ];
+    }
+
+    public function testChoiceLabel()
+    {
+        $form = $this->factory->create($this->getTestedType(), null, [
+            'multiple' => false,
+            'expanded' => true,
+            'class' => Answer::class,
+        ]);
+
+        $view = $form->createView();
+
+        $this->assertSame('Yes', $view->children[0]->vars['label']);
+    }
+
+    protected function getTestOptions(): array
+    {
+        return ['class' => Suit::class];
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/Answer.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Answer.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+enum Answer
+{
+    case Yes;
+    case No;
+    case FourtyTwo;
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/Number.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Number.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+enum Number: int
+{
+    case One = 101;
+    case Two = 102;
+    case Three = 103;
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/Suit.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Suit.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -24,6 +24,7 @@
         "symfony/polyfill-intl-icu": "^1.21",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php80": "^1.16",
+        "symfony/polyfill-php81": "^1.23",
         "symfony/property-access": "^5.0.8|^6.0",
         "symfony/service-contracts": "^1.1|^2"
     },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | TODO

This PR adds a new `EnumType` that enables the form component to configure a `ChoiceType` for a native PHP enum.

Example:

```php
enum Suit: string
{
    case Hearts = 'H';
    case Diamonds = 'D';
    case Clubs = 'C';
    case Spades = 'S';
}

enum Rank: string
{
    case Ace = 'A';
    case King = 'K';
    case Queen = 'Q';
    case Jack = 'J';
    case Ten = 'X';
    case Nine = '9';
    case Eight = '8';
    case Seven = '7';
    case Six = '6';
    case Five = '5';
    case Four = '4';
    case Three = '3';
    case Two = '2';
}

final class Card
{
    public ?Suit $suit = null;
    public ?Rank $rank = null;
}
```

```php
$form = $this
    ->createFormBuilder(null, ['data_class' => Card::class])
    ->add('suit', EnumType::class, ['class' => Suit::class, 'required' => false, 'expanded' => true])
    ->add('rank', EnumType::class, ['class' => Rank::class, 'required' => false])
    ->add('submit', SubmitType::class)
    ->getForm()
    ->handleRequest($request)
;
```

<img width="768" alt="Bildschirmfoto 2021-09-19 um 18 06 39" src="https://user-images.githubusercontent.com/1506493/133934643-8dafc743-da5a-44a6-8ed7-3333e9a66317.png">