### PR TITLE
[Notifier] [Firebase] Only call setMessageId if valid message id

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/FirebaseTransport.php
@@ -96,7 +96,10 @@ final class FirebaseTransport extends AbstractTransport
         $success = $response->toArray(false);
 
         $sentMessage = new SentMessage($message, (string) $this);
-        $sentMessage->setMessageId($success['results'][0]['message_id'] ?? '');
+
+        if (null !== $success['results'][0]['message_id'] ?? null) {
+            $sentMessage->setMessageId($success['results'][0]['message_id']);
+        }
 
         return $sentMessage;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Follows https://github.com/symfony/symfony/pull/43073#issuecomment-922526653
| License       | MIT
| Doc PR        | ---