### PR TITLE
[Validator] Add error's uid to `Count` and `Length` constraints with "exactly" option enabled

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add support for `ConstraintViolationList::createFromMessage()`
+ * Add error's uid to `Count` and `Length` constraints with "exactly" option enabled
 
 5.3
 ---

--- a/src/Symfony/Component/Validator/Constraints/Count.php
+++ b/src/Symfony/Component/Validator/Constraints/Count.php
@@ -25,11 +25,13 @@ class Count extends Constraint
 {
     public const TOO_FEW_ERROR = 'bef8e338-6ae5-4caf-b8e2-50e7b0579e69';
     public const TOO_MANY_ERROR = '756b1212-697c-468d-a9ad-50dd783bb169';
+    public const NOT_EQUAL_COUNT_ERROR = '9fe5d43f-3784-4ece-a0e1-473fc02dadbc';
     public const NOT_DIVISIBLE_BY_ERROR = DivisibleBy::NOT_DIVISIBLE_BY;
 
     protected static $errorNames = [
         self::TOO_FEW_ERROR => 'TOO_FEW_ERROR',
         self::TOO_MANY_ERROR => 'TOO_MANY_ERROR',
+        self::NOT_EQUAL_COUNT_ERROR => 'NOT_EQUAL_COUNT_ERROR',
         self::NOT_DIVISIBLE_BY_ERROR => 'NOT_DIVISIBLE_BY_ERROR',
     ];
 

--- a/src/Symfony/Component/Validator/Constraints/CountValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountValidator.php
@@ -41,24 +41,28 @@ class CountValidator extends ConstraintValidator
         $count = \count($value);
 
         if (null !== $constraint->max && $count > $constraint->max) {
-            $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->maxMessage)
+            $exactlyOptionEnabled = $constraint->min == $constraint->max;
+
+            $this->context->buildViolation($exactlyOptionEnabled ? $constraint->exactMessage : $constraint->maxMessage)
                 ->setParameter('{{ count }}', $count)
                 ->setParameter('{{ limit }}', $constraint->max)
                 ->setInvalidValue($value)
                 ->setPlural((int) $constraint->max)
-                ->setCode(Count::TOO_MANY_ERROR)
+                ->setCode($exactlyOptionEnabled ? Count::NOT_EQUAL_COUNT_ERROR : Count::TOO_MANY_ERROR)
                 ->addViolation();
 
             return;
         }
 
         if (null !== $constraint->min && $count < $constraint->min) {
-            $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->minMessage)
+            $exactlyOptionEnabled = $constraint->min == $constraint->max;
+
+            $this->context->buildViolation($exactlyOptionEnabled ? $constraint->exactMessage : $constraint->minMessage)
                 ->setParameter('{{ count }}', $count)
                 ->setParameter('{{ limit }}', $constraint->min)
                 ->setInvalidValue($value)
                 ->setPlural((int) $constraint->min)
-                ->setCode(Count::TOO_FEW_ERROR)
+                ->setCode($exactlyOptionEnabled ? Count::NOT_EQUAL_COUNT_ERROR : Count::TOO_FEW_ERROR)
                 ->addViolation();
 
             return;

--- a/src/Symfony/Component/Validator/Constraints/Length.php
+++ b/src/Symfony/Component/Validator/Constraints/Length.php
@@ -26,11 +26,13 @@ class Length extends Constraint
 {
     public const TOO_SHORT_ERROR = '9ff3fdc4-b214-49db-8718-39c315e33d45';
     public const TOO_LONG_ERROR = 'd94b19cc-114f-4f44-9cc4-4138e80a87b9';
+    public const NOT_EQUAL_LENGTH_ERROR = '4b6f5c76-22b4-409d-af16-fbe823ba9332';
     public const INVALID_CHARACTERS_ERROR = '35e6a710-aa2e-4719-b58e-24b35749b767';
 
     protected static $errorNames = [
         self::TOO_SHORT_ERROR => 'TOO_SHORT_ERROR',
         self::TOO_LONG_ERROR => 'TOO_LONG_ERROR',
+        self::NOT_EQUAL_LENGTH_ERROR => 'NOT_EQUAL_LENGTH_ERROR',
         self::INVALID_CHARACTERS_ERROR => 'INVALID_CHARACTERS_ERROR',
     ];
 

--- a/src/Symfony/Component/Validator/Constraints/LengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LengthValidator.php
@@ -68,24 +68,28 @@ class LengthValidator extends ConstraintValidator
         $length = mb_strlen($stringValue, $constraint->charset);
 
         if (null !== $constraint->max && $length > $constraint->max) {
-            $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->maxMessage)
+            $exactlyOptionEnabled = $constraint->min == $constraint->max;
+
+            $this->context->buildViolation($exactlyOptionEnabled ? $constraint->exactMessage : $constraint->maxMessage)
                 ->setParameter('{{ value }}', $this->formatValue($stringValue))
                 ->setParameter('{{ limit }}', $constraint->max)
                 ->setInvalidValue($value)
                 ->setPlural((int) $constraint->max)
-                ->setCode(Length::TOO_LONG_ERROR)
+                ->setCode($exactlyOptionEnabled ? Length::NOT_EQUAL_LENGTH_ERROR : Length::TOO_LONG_ERROR)
                 ->addViolation();
 
             return;
         }
 
         if (null !== $constraint->min && $length < $constraint->min) {
-            $this->context->buildViolation($constraint->min == $constraint->max ? $constraint->exactMessage : $constraint->minMessage)
+            $exactlyOptionEnabled = $constraint->min == $constraint->max;
+
+            $this->context->buildViolation($exactlyOptionEnabled ? $constraint->exactMessage : $constraint->minMessage)
                 ->setParameter('{{ value }}', $this->formatValue($stringValue))
                 ->setParameter('{{ limit }}', $constraint->min)
                 ->setInvalidValue($value)
                 ->setPlural((int) $constraint->min)
-                ->setCode(Length::TOO_SHORT_ERROR)
+                ->setCode($exactlyOptionEnabled ? Length::NOT_EQUAL_LENGTH_ERROR : Length::TOO_SHORT_ERROR)
                 ->addViolation();
         }
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountValidatorTest.php
@@ -236,7 +236,7 @@ abstract class CountValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ limit }}', 4)
             ->setInvalidValue($value)
             ->setPlural(4)
-            ->setCode(Count::TOO_MANY_ERROR)
+            ->setCode(Count::NOT_EQUAL_COUNT_ERROR)
             ->assertRaised();
     }
 
@@ -255,7 +255,7 @@ abstract class CountValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ limit }}', 4)
             ->setInvalidValue($value)
             ->setPlural(4)
-            ->setCode(Count::TOO_MANY_ERROR)
+            ->setCode(Count::NOT_EQUAL_COUNT_ERROR)
             ->assertRaised();
     }
 
@@ -277,7 +277,7 @@ abstract class CountValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ limit }}', 4)
             ->setInvalidValue($value)
             ->setPlural(4)
-            ->setCode(Count::TOO_FEW_ERROR)
+            ->setCode(Count::NOT_EQUAL_COUNT_ERROR)
             ->assertRaised();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LengthValidatorTest.php
@@ -52,7 +52,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ limit }}', $limit)
             ->setInvalidValue('')
             ->setPlural($limit)
-            ->setCode(Length::TOO_SHORT_ERROR)
+            ->setCode(Length::NOT_EQUAL_LENGTH_ERROR)
             ->assertRaised();
     }
 
@@ -264,7 +264,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ limit }}', 4)
             ->setInvalidValue($value)
             ->setPlural(4)
-            ->setCode(Length::TOO_SHORT_ERROR)
+            ->setCode(Length::NOT_EQUAL_LENGTH_ERROR)
             ->assertRaised();
     }
 
@@ -283,7 +283,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ limit }}', 4)
             ->setInvalidValue($value)
             ->setPlural(4)
-            ->setCode(Length::TOO_SHORT_ERROR)
+            ->setCode(Length::NOT_EQUAL_LENGTH_ERROR)
             ->assertRaised();
     }
 
@@ -305,7 +305,7 @@ class LengthValidatorTest extends ConstraintValidatorTestCase
             ->setParameter('{{ limit }}', 4)
             ->setInvalidValue($value)
             ->setPlural(4)
-            ->setCode(Length::TOO_LONG_ERROR)
+            ->setCode(Length::NOT_EQUAL_LENGTH_ERROR)
             ->assertRaised();
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | TODO

This PR adds error's uui to `Count` and `Length` constraints with "exactly" option enabled. 
