### PR TITLE
[Notifier] [GoogleChat] remove support for deprecated "threadKey" parameter

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatTransportFactory.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\GoogleChat;
 
-use Symfony\Component\Notifier\Exception\IncompleteDsnException;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
 use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
 use Symfony\Component\Notifier\Transport\Dsn;
@@ -38,16 +37,7 @@ final class GoogleChatTransportFactory extends AbstractTransportFactory
         $space = explode('/', $dsn->getPath())[1];
         $accessKey = $this->getUser($dsn);
         $accessToken = $this->getPassword($dsn);
-
         $threadKey = $dsn->getOption('thread_key');
-
-        /*
-         * Remove this check for 5.4
-         */
-        if (null === $threadKey && null !== $dsn->getOption('threadKey')) {
-            throw new IncompleteDsnException('GoogleChat DSN has changed since 5.3, use "thread_key" instead of "threadKey" parameter.');
-        }
-
         $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
         $port = $dsn->getPort();
 

--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/Tests/GoogleChatTransportFactoryTest.php
@@ -47,7 +47,6 @@ final class GoogleChatTransportFactoryTest extends TransportFactoryTestCase
     public function incompleteDsnProvider(): iterable
     {
         yield 'missing credentials' => ['googlechat://chat.googleapis.com/v1/spaces/AAAAA_YYYYY/messages'];
-        yield 'using old option: threadKey' => ['googlechat://abcde-fghij:kl_mnopqrstwxyz%3D@chat.googleapis.com/AAAAA_YYYYY?threadKey=abcdefg', 'GoogleChat DSN has changed since 5.3, use "thread_key" instead of "threadKey" parameter.']; // can be removed in Symfony 5.4
     }
 
     public function unsupportedSchemeProvider(): iterable


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Removing the deprecation error introduced when renaming `threadKey` to `thread_key` in #39579