### PR TITLE
Update of the docblock of the get function of the inputbag class

### DIFF
--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -23,9 +23,9 @@ final class InputBag extends ParameterBag
     /**
      * Returns a scalar input value by name.
      *
-     * @param string|int|float|bool|null $default The default value if the input key does not exist
+     * @param string|int|float|bool|array|null $default The default value if the input key does not exist
      *
-     * @return string|int|float|bool|null
+     * @return string|int|float|bool|array|null
      */
     public function get(string $key, $default = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch       | 5.4
| Bug fix?     | no
| New feature  | no
| Deprecations? | no 
| License       | MIT

Simply update the docblock of the get function of the inputbag class. This problem is related to the use of phpstan