### PR TITLE
[Console] Add support of HSL functional notation for output colors

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `TesterTrait::assertCommandIsSuccessful()` to test command
  * Deprecate `HelperSet::setCommand()` and `getCommand()` without replacement
  * Add `rgb(r, g, b)` notation support for output colors
+ * Add `hsl(h, s%, l%)` notation support for output colors
 
 5.3
 ---

--- a/src/Symfony/Component/Console/Tests/ColorTest.php
+++ b/src/Symfony/Component/Console/Tests/ColorTest.php
@@ -46,6 +46,9 @@ class ColorTest extends TestCase
 
         $color = new Color('rgb(255, 255, 255)', 'rgb(0, 0, 0)');
         $this->assertSame("\033[38;2;255;255;255;48;2;0;0;0m \033[39;49m", $color->apply(' '));
+
+        $color = new Color('hsl(0, 100%, 100%)', 'hsl(0, 0%, 0%)');
+        $this->assertSame("\033[38;2;255;255;255;48;2;0;0;0m \033[39;49m", $color->apply(' '));
     }
 
     public function testDegradedTrueColors()
@@ -58,6 +61,12 @@ class ColorTest extends TestCase
             $this->assertSame("\033[31;43m \033[39;49m", $color->apply(' '));
 
             $color = new Color('#c0392b', '#f1c40f');
+            $this->assertSame("\033[31;43m \033[39;49m", $color->apply(' '));
+
+            $color = new Color('rgb(192, 57, 43)', 'rgb(241, 196, 15)');
+            $this->assertSame("\033[31;43m \033[39;49m", $color->apply(' '));
+
+            $color = new Color('hsl(6, 63%, 46%)', 'hsl(48, 89%, 50%)');
             $this->assertSame("\033[31;43m \033[39;49m", $color->apply(' '));
         } finally {
             putenv('COLORTERM='.$colorterm);
@@ -90,5 +99,37 @@ class ColorTest extends TestCase
         yield ['rgb(256, 0, 0)', 'Invalid color component; value should be between 0 and 255, got 256.'];
 
         yield ['rgb(0, 0, 0', 'Invalid RGB functional notation; should be of the form "rgb(r, g, b)", got "rgb(0, 0, 0".'];
+    }
+
+    /**
+     * @dataProvider provideMalformedHslStrings
+     */
+    public function testMalformedHslString(string $color, string $exceptionMessage)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($exceptionMessage);
+
+        new Color($color);
+    }
+
+    public function provideMalformedHslStrings(): \Generator
+    {
+        yield ['hsl()', 'Invalid HSL functional notation; should be of the form "hsl(h, s%, l%)", got "hsl()".'];
+
+        yield ['hsl(0, 0%)', 'Invalid HSL functional notation; should be of the form "hsl(h, s%, l%)", got "hsl(0, 0%)".'];
+
+        yield ['hsl(0, 0, 0)', 'Invalid HSL functional notation; should be of the form "hsl(h, s%, l%)", got "hsl(0, 0, 0)".'];
+
+        yield ['hsl(0, 0%, 0%, 0%)', 'Invalid HSL functional notation; should be of the form "hsl(h, s%, l%)", got "hsl(0, 0%, 0%, 0%)".'];
+
+        yield ['hsl(360, 0%, 0%)', 'Invalid hue; value should be between 0 and 359, got 360.'];
+
+        yield ['hsl(0, 101%, 0%)', 'Invalid saturation; value should be between 0 and 100, got 101.'];
+
+        yield ['hsl(0, 0%, 101%)', 'Invalid lightness; value should be between 0 and 100, got 101.'];
+
+        yield ['hsl(invalid, 0%, 0%)', 'Invalid HSL functional notation; should be of the form "hsl(h, s%, l%)", got "hsl(invalid, 0%, 0%)".'];
+
+        yield ['hsl(0, 0%, 0%', 'Invalid HSL functional notation; should be of the form "hsl(h, s%, l%)", got "hsl(0, 0%, 0%".'];
     }
 }


### PR DESCRIPTION
Also add a missing test for RGB functional notation

| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | _NA_
| License       | MIT
| Doc PR        | symfony/symfony-docs#15839

> Wait, another way to set colors in console? You already proposed RGB functional notation a few days ago!

Yes. But wait. That's not just "another way to set colors". Of course RGB notation suits most cases and is some kind of a "must" when it comes to colors. But HSL notation has some undeniable pros over RGB notation. There's a great (french) article speaking about it (https://iamvdo.me/blog/les-avantages-de-hsl-par-rapport-a-rgb). To make it simple, HSL is way more effective when it comes to manipulating color gradients in particular. By adding this feature, we're giving this possibility to developers using Console components to make even more gorgeous CLI applications.
I don't think we need to add (yet, at least) other variations like CMYK or HSV. I rarely came across them, and it seems they’re clearly not as popular as RGB and HSL.

About having to put `%` in the notation, I think it's a good choice for two reasons.
 * It *greatly* simplifies the regex and validation of input. Supporting saturation and lightness in an interval of `[0, 1]` means, if we want to be exhaustive, we need to check these values can be in multiple format: `0.5`, `.5`, maybe `1.`. Having the mandatory percent sign clearly tells the developer to use an integer in the interval `[0, 100]`.
 * Also, that's the way to use and write `hsl` method in CSS.