### PR TITLE
[Notifier] Add sms77 Notifier Bridge

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -140,6 +140,7 @@ use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
 use Symfony\Component\Notifier\Bridge\Sendinblue\SendinblueTransportFactory as SendinblueNotifierTransportFactory;
 use Symfony\Component\Notifier\Bridge\Sinch\SinchTransportFactory;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
+use Symfony\Component\Notifier\Bridge\Sms77\Sms77TransportFactory;
 use Symfony\Component\Notifier\Bridge\Smsapi\SmsapiTransportFactory;
 use Symfony\Component\Notifier\Bridge\SmsBiuras\SmsBiurasTransportFactory;
 use Symfony\Component\Notifier\Bridge\Smsc\SmscTransportFactory;
@@ -2452,6 +2453,7 @@ class FrameworkExtension extends Extension
             SendinblueNotifierTransportFactory::class => 'notifier.transport_factory.sendinblue',
             SinchTransportFactory::class => 'notifier.transport_factory.sinch',
             SlackTransportFactory::class => 'notifier.transport_factory.slack',
+            Sms77TransportFactory::class => 'notifier.transport_factory.sms77',
             SmsapiTransportFactory::class => 'notifier.transport_factory.smsapi',
             SmsBiurasTransportFactory::class => 'notifier.transport_factory.smsbiuras',
             SmscTransportFactory::class => 'notifier.transport_factory.smsc',

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/notifier_transports.php
@@ -41,6 +41,7 @@ use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
 use Symfony\Component\Notifier\Bridge\Sendinblue\SendinblueTransportFactory;
 use Symfony\Component\Notifier\Bridge\Sinch\SinchTransportFactory;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
+use Symfony\Component\Notifier\Bridge\Sms77\Sms77TransportFactory;
 use Symfony\Component\Notifier\Bridge\Smsapi\SmsapiTransportFactory;
 use Symfony\Component\Notifier\Bridge\SmsBiuras\SmsBiurasTransportFactory;
 use Symfony\Component\Notifier\Bridge\Smsc\SmscTransportFactory;
@@ -223,6 +224,10 @@ return static function (ContainerConfigurator $container) {
             ->tag('texter.transport_factory')
 
         ->set('notifier.transport_factory.turbosms', TurboSmsTransportFactory::class)
+            ->parent('notifier.transport_factory.abstract')
+            ->tag('texter.transport_factory')
+
+        ->set('notifier.transport_factory.sms77', Sms77TransportFactory::class)
             ->parent('notifier.transport_factory.abstract')
             ->tag('texter.transport_factory')
     ;

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/.gitattributes
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/.gitattributes
@@ -1,0 +1,4 @@
+/Tests export-ignore
+/phpunit.xml.dist export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/.gitignore
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/.gitignore
@@ -1,0 +1,3 @@
+vendor/
+composer.lock
+phpunit.xml

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/CHANGELOG.md
@@ -1,0 +1,7 @@
+CHANGELOG
+=========
+
+5.4
+---
+
+ * Add the bridge

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/LICENSE
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2021 Fabien Potencier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/README.md
@@ -1,0 +1,23 @@
+sms77 Notifier
+=================
+
+Provides [sms77](https://www.sms77.io/) integration for Symfony Notifier.
+
+DSN example
+-----------
+
+```
+SMS//_DSN=sms77://APIKEY@default?from=FROM
+```
+
+where:
+ - `APIKEY` is your sms77 API key
+ - `FROM` is your sender (optional, default: SMS)
+
+Resources
+---------
+
+ * [Contributing](https://symfony.com/doc/current/contributing/index.html)
+ * [Report issues](https://github.com/symfony/symfony/issues) and
+   [send Pull Requests](https://github.com/symfony/symfony/pulls)
+   in the [main Symfony repository](https://github.com/symfony/symfony)

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/README.md
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/README.md
@@ -7,11 +7,11 @@ DSN example
 -----------
 
 ```
-SMS//_DSN=sms77://APIKEY@default?from=FROM
+SMS77_DSN=sms77://API_KEY@default?from=FROM
 ```
 
 where:
- - `APIKEY` is your sms77 API key
+ - `API_KEY` is your sms77 API key
  - `FROM` is your sender (optional, default: SMS)
 
 Resources

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77Transport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77Transport.php
@@ -88,12 +88,12 @@ final class Sms77Transport extends AbstractTransport
 
         $success = $response->toArray(false);
 
-        if (false === in_array($success['success'], [100, 101])) {
+        if (false === \in_array($success['success'], [100, 101])) {
             throw new TransportException(sprintf('Unable to send the SMS: "%s".', $success['success']), $response);
         }
 
         $sentMessage = new SentMessage($message, (string) $this);
-        $sentMessage->setMessageId((int)$success['messages'][0]['id']);
+        $sentMessage->setMessageId((int) $success['messages'][0]['id']);
 
         return $sentMessage;
     }

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77Transport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77Transport.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Sms77;
+
+use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SentMessage;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Transport\AbstractTransport;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author André Matthies <matthiez@gmail.com>
+ */
+final class Sms77Transport extends AbstractTransport
+{
+    protected const HOST = 'gateway.sms77.io';
+
+    private $apiKey;
+    private $from;
+
+    public function __construct(string $apiKey, string $from = null, HttpClientInterface $client = null, EventDispatcherInterface $dispatcher = null)
+    {
+        $this->apiKey = $apiKey;
+        $this->from = $from;
+
+        parent::__construct($client, $dispatcher);
+    }
+
+    public function __toString(): string
+    {
+        if (null === $this->from) {
+            return sprintf('sms77://%s', $this->getEndpoint());
+        }
+
+        return sprintf('sms77://%s?from=%s', $this->getEndpoint(), $this->from);
+    }
+
+    public function supports(MessageInterface $message): bool
+    {
+        return $message instanceof SmsMessage;
+    }
+
+    protected function doSend(MessageInterface $message): SentMessage
+    {
+        if (!$message instanceof SmsMessage) {
+            throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
+        }
+
+        $endpoint = sprintf('https://%s/api/sms', $this->getEndpoint());
+        $response = $this->client->request('POST', $endpoint, [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'SentWith' => 'Symfony Notifier',
+                'X-Api-Key' => $this->apiKey,
+            ],
+            'json' => [
+                'from' => $this->from,
+                'json' => 1,
+                'text' => $message->getSubject(),
+                'to' => $message->getPhone(),
+            ],
+        ]);
+
+        try {
+            $statusCode = $response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw new TransportException('Could not reach the remote Sms77 server.', $response, 0, $e);
+        }
+
+        if (200 !== $statusCode) {
+            $error = $response->toArray(false);
+
+            throw new TransportException(sprintf('Unable to send the SMS: "%s" (%s).', $error['description'], $error['code']), $response);
+        }
+
+        $success = $response->toArray(false);
+
+        if (false === in_array($success['success'], [100, 101])) {
+            throw new TransportException(sprintf('Unable to send the SMS: "%s".', $success['success']), $response);
+        }
+
+        $sentMessage = new SentMessage($message, (string) $this);
+        $sentMessage->setMessageId((int)$success['messages'][0]['id']);
+
+        return $sentMessage;
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77TransportFactory.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Sms77TransportFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Sms77;
+
+use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
+use Symfony\Component\Notifier\Transport\AbstractTransportFactory;
+use Symfony\Component\Notifier\Transport\Dsn;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+
+/**
+ * @author André Matthies <matthiez@gmail.com>
+ */
+final class Sms77TransportFactory extends AbstractTransportFactory
+{
+    /**
+     * @return Sms77Transport
+     */
+    public function create(Dsn $dsn): TransportInterface
+    {
+        $scheme = $dsn->getScheme();
+
+        if ('sms77' !== $scheme) {
+            throw new UnsupportedSchemeException($dsn, 'sms77', $this->getSupportedSchemes());
+        }
+
+        $apiKey = $this->getUser($dsn);
+        $from = $dsn->getOption('from');
+        $host = 'default' === $dsn->getHost() ? null : $dsn->getHost();
+        $port = $dsn->getPort();
+
+        return (new Sms77Transport($apiKey, $from, $this->client, $this->dispatcher))->setHost($host)->setPort($port);
+    }
+
+    protected function getSupportedSchemes(): array
+    {
+        return ['sms77'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportFactoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Sms77\Tests;
+
+use Symfony\Component\Notifier\Bridge\Sms77\Sms77TransportFactory;
+use Symfony\Component\Notifier\Test\TransportFactoryTestCase;
+use Symfony\Component\Notifier\Transport\TransportFactoryInterface;
+
+final class Sms77TransportFactoryTest extends TransportFactoryTestCase
+{
+    /**
+     * @return Sms77TransportFactory
+     */
+    public function createFactory(): TransportFactoryInterface
+    {
+        return new Sms77TransportFactory();
+    }
+
+    public function createProvider(): iterable
+    {
+        yield [
+            'sms77://host.test',
+            'sms77://apiKey@host.test',
+        ];
+
+        yield [
+            'sms77://host.test?from=TEST',
+            'sms77://apiKey@host.test?from=TEST',
+        ];
+    }
+
+    public function incompleteDsnProvider(): iterable
+    {
+        yield 'missing auth token' => ['sms77://host?from=TEST'];
+    }
+
+    public function supportsProvider(): iterable
+    {
+        yield [true, 'sms77://apiKey@default?from=TEST'];
+        yield [false, 'somethingElse://apiKey@default?from=TEST'];
+    }
+
+    public function unsupportedSchemeProvider(): iterable
+    {
+        yield ['somethingElse://apiKey@default?from=FROM'];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportFactoryTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportFactoryTest.php
@@ -40,7 +40,7 @@ final class Sms77TransportFactoryTest extends TransportFactoryTestCase
 
     public function incompleteDsnProvider(): iterable
     {
-        yield 'missing auth token' => ['sms77://host?from=TEST'];
+        yield 'missing api key' => ['sms77://host?from=TEST'];
     }
 
     public function supportsProvider(): iterable

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/Tests/Sms77TransportTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Notifier\Bridge\Sms77\Tests;
+
+use Symfony\Component\Notifier\Bridge\Sms77\Sms77Transport;
+use Symfony\Component\Notifier\Message\ChatMessage;
+use Symfony\Component\Notifier\Message\MessageInterface;
+use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Transport\TransportInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class Sms77TransportTest extends TransportTestCase
+{
+    /**
+     * @return Sms77Transport
+     */
+    public function createTransport(HttpClientInterface $client = null, string $from = null): TransportInterface
+    {
+        return new Sms77Transport('apiKey', $from, $client ?? $this->createMock(HttpClientInterface::class));
+    }
+
+    public function toStringProvider(): iterable
+    {
+        yield ['sms77://gateway.sms77.io', $this->createTransport()];
+        yield ['sms77://gateway.sms77.io?from=TEST', $this->createTransport(null, 'TEST')];
+    }
+
+    public function supportedMessagesProvider(): iterable
+    {
+        yield [new SmsMessage('0611223344', 'Hello!')];
+    }
+
+    public function unsupportedMessagesProvider(): iterable
+    {
+        yield [new ChatMessage('Hello!')];
+        yield [$this->createMock(MessageInterface::class)];
+    }
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "symfony/sms77-notifier",
+    "type": "symfony-bridge",
+    "description": "Symfony sms77 Notifier Bridge",
+    "keywords": ["sms", "sms77", "notifier"],
+    "homepage": "https://symfony.com",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "André Matthies",
+            "email": "matthiez@gmail.com"
+        },
+        {
+            "name": "Symfony Community",
+            "homepage": "https://symfony.com/contributors"
+        }
+    ],
+    "require": {
+        "php": ">=7.2.5",
+        "symfony/http-client": "^4.3|^5.0|^6.0",
+        "symfony/notifier": "^5.3|^6.0"
+    },
+    "autoload": {
+        "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Sms77\\": "" },
+        "exclude-from-classmap": [
+            "/Tests/"
+        ]
+    },
+    "minimum-stability": "dev"
+}

--- a/src/Symfony/Component/Notifier/Bridge/Sms77/phpunit.xml.dist
+++ b/src/Symfony/Component/Notifier/Bridge/Sms77/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Symfony Sms77 Notifier Bridge Test Suite">
+            <directory>./Tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
+++ b/src/Symfony/Component/Notifier/Exception/UnsupportedSchemeException.php
@@ -136,6 +136,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Slack\SlackTransportFactory::class,
             'package' => 'symfony/slack-notifier',
         ],
+        'sms77' => [
+            'class' => Bridge\Sms77\Sms77TransportFactory::class,
+            'package' => 'symfony/sms77-notifier',
+        ],
         'smsapi' => [
             'class' => Bridge\Smsapi\SmsapiTransportFactory::class,
             'package' => 'symfony/smsapi-notifier',

--- a/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
+++ b/src/Symfony/Component/Notifier/Tests/Exception/UnsupportedSchemeExceptionTest.php
@@ -43,6 +43,7 @@ use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
 use Symfony\Component\Notifier\Bridge\Sendinblue\SendinblueTransportFactory;
 use Symfony\Component\Notifier\Bridge\Sinch\SinchTransportFactory;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
+use Symfony\Component\Notifier\Bridge\Sms77\Sms77TransportFactory;
 use Symfony\Component\Notifier\Bridge\Smsapi\SmsapiTransportFactory;
 use Symfony\Component\Notifier\Bridge\SmsBiuras\SmsBiurasTransportFactory;
 use Symfony\Component\Notifier\Bridge\Smsc\SmscTransportFactory;
@@ -95,6 +96,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
             SendinblueTransportFactory::class => false,
             SinchTransportFactory::class => false,
             SlackTransportFactory::class => false,
+            Sms77TransportFactory::class => false,
             SmsapiTransportFactory::class => false,
             SmsBiurasTransportFactory::class => false,
             SmscTransportFactory::class => false,
@@ -153,6 +155,7 @@ final class UnsupportedSchemeExceptionTest extends TestCase
         yield ['sendinblue', 'symfony/sendinblue-notifier'];
         yield ['sinch', 'symfony/sinch-notifier'];
         yield ['slack', 'symfony/slack-notifier'];
+        yield ['sms77', 'symfony/sms77-notifier'];
         yield ['smsapi', 'symfony/smsapi-notifier'];
         yield ['smsbiuras', 'symfony/sms-biuras-notifier'];
         yield ['smsc', 'symfony/smsc-notifier'];

--- a/src/Symfony/Component/Notifier/Transport.php
+++ b/src/Symfony/Component/Notifier/Transport.php
@@ -36,6 +36,7 @@ use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
 use Symfony\Component\Notifier\Bridge\Sendinblue\SendinblueTransportFactory;
 use Symfony\Component\Notifier\Bridge\Sinch\SinchTransportFactory;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
+use Symfony\Component\Notifier\Bridge\Sms77\Sms77TransportFactory;
 use Symfony\Component\Notifier\Bridge\Smsapi\SmsapiTransportFactory;
 use Symfony\Component\Notifier\Bridge\SmsBiuras\SmsBiurasTransportFactory;
 use Symfony\Component\Notifier\Bridge\Smsc\SmscTransportFactory;
@@ -89,6 +90,7 @@ class Transport
         SendinblueTransportFactory::class,
         SinchTransportFactory::class,
         SlackTransportFactory::class,
+        Sms77TransportFactory::class,
         SmsapiTransportFactory::class,
         SmsBiurasTransportFactory::class,
         SmscTransportFactory::class,

--- a/src/Symfony/Component/Notifier/composer.json
+++ b/src/Symfony/Component/Notifier/composer.json
@@ -42,6 +42,7 @@
         "symfony/sendinblue-notifier": "<5.3",
         "symfony/sinch-notifier": "<5.3",
         "symfony/slack-notifier": "<5.3",
+        "symfony/sms77-notifier": "<5.3",
         "symfony/smsapi-notifier": "<5.3",
         "symfony/telegram-notifier": "<5.3",
         "symfony/twilio-notifier": "<5.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | [symfony/symfony-docs/pull/15840](https://github.com/symfony/symfony-docs/pull/15840)
| Recipe PR | [symfony/recipes/pull/1003](https://github.com/symfony/recipes/pull/1003)

Add sms77 bridge to Symfony Notifier.
A Germany based SMS provider established in 2003.
