### PR TITLE
[FrameworkBundle] Avoid secrets:decrypt-to-local command to fail

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsDecryptToLocalCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsDecryptToLocalCommand.php
@@ -77,9 +77,8 @@ EOF
 
         foreach ($secrets as $k => $v) {
             if (null === $v) {
-                $io->error($this->vault->getLastMessage());
-
-                return 1;
+                $io->error($this->vault->getLastMessage() ?? sprintf('Secret "%s" has been skipped as there was an error reading it.', $k));
+                continue;
             }
 
             $this->localVault->seal($k, $v);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/42038
| License       | MIT
| Doc PR        | .

Small PR to fix this issue I encounter as well
For now I've not opted for solutions exposed in the issue, please discuss here

Also, I kept the vault continuing instead of stopping the command in case of null value

Thank you,