### PR TITLE
[FrameworkBundle][HttpKernel] Add the ability to enable the profiler using a parameter

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * Add `set_content_language_from_locale` config option to automatically set the `Content-Language` HTTP response header based on the Request locale
  * Deprecate the `framework.translator.enabled_locales`, use `framework.enabled_locales` instead
  * Add autowiring alias for `HttpCache\StoreInterface`
+ * Add the ability to enable the profiler using a request query parameter, body parameter or attribute
  * Deprecate the `AdapterInterface` autowiring alias, use `CacheItemPoolInterface` instead
  * Deprecate the public `profiler` service to private
  * Deprecate `get()`, `has()`, `getDoctrine()`, and `dispatchMessage()` in `AbstractController`, use method/constructor injection instead

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -315,6 +315,7 @@ class Configuration implements ConfigurationInterface
                     ->canBeEnabled()
                     ->children()
                         ->booleanNode('collect')->defaultTrue()->end()
+                        ->scalarNode('collect_parameter')->defaultNull()->info('The name of the parameter to use to enable or disable collection on a per request basis')->end()
                         ->booleanNode('only_exceptions')->defaultFalse()->end()
                         ->booleanNode('only_main_requests')->defaultFalse()->end()
                         ->booleanNode('only_master_requests')->setDeprecated('symfony/framework-bundle', '5.3', 'Option "%node%" at "%path%" is deprecated, use "only_main_requests" instead.')->defaultFalse()->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -770,6 +770,9 @@ class FrameworkExtension extends Extension
         $container->getDefinition('profiler')
             ->addArgument($config['collect'])
             ->addTag('kernel.reset', ['method' => 'reset']);
+
+        $container->getDefinition('profiler_listener')
+            ->addArgument($config['collect_parameter']);
     }
 
     private function registerWorkflowConfiguration(array $config, ContainerBuilder $container, PhpFileLoader $loader)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -91,6 +91,7 @@
 
     <xsd:complexType name="profiler">
         <xsd:attribute name="collect" type="xsd:string" />
+        <xsd:attribute name="collect-parameter" type="xsd:string" />
         <xsd:attribute name="only-exceptions" type="xsd:string" />
         <xsd:attribute name="only-main-requests" type="xsd:string" />
         <xsd:attribute name="only-master-requests" type="xsd:string" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -405,6 +405,7 @@ class ConfigurationTest extends TestCase
                 'only_main_requests' => false,
                 'dsn' => 'file:%kernel.cache_dir%/profiler',
                 'collect' => true,
+                'collect_parameter' => null,
             ],
             'translator' => [
                 'enabled' => !class_exists(FullStack::class),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerTest.php
@@ -36,6 +36,27 @@ class ProfilerTest extends AbstractWebTestCase
         $this->assertNull($client->getProfile());
     }
 
+    /**
+     * @dataProvider getConfigs
+     */
+    public function testProfilerCollectParameter($insulate)
+    {
+        $client = $this->createClient(['test_case' => 'ProfilerCollectParameter', 'root_config' => 'config.yml']);
+        if ($insulate) {
+            $client->insulate();
+        }
+
+        $client->request('GET', '/profiler');
+        $this->assertNull($client->getProfile());
+
+        // enable the profiler for the next request
+        $client->request('GET', '/profiler?profile=1');
+        $this->assertIsObject($client->getProfile());
+
+        $client->request('GET', '/profiler');
+        $this->assertNull($client->getProfile());
+    }
+
     public function getConfigs()
     {
         return [

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ProfilerCollectParameter/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ProfilerCollectParameter/bundles.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+
+return [
+    new FrameworkBundle(),
+    new TestBundle(),
+];

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ProfilerCollectParameter/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ProfilerCollectParameter/config.yml
@@ -1,0 +1,8 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    profiler:
+        enabled: true
+        collect: false
+        collect_parameter: profile

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ProfilerCollectParameter/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/ProfilerCollectParameter/routing.yml
@@ -1,0 +1,2 @@
+_sessiontest_bundle:
+    resource: '@TestBundle/Resources/config/routing.yml'

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.4
 ---
 
+ * Add the ability to enable the profiler using a request query parameter, body parameter or attribute
  * Deprecate `AbstractTestSessionListener::getSession` inject a session in the request instead
  * Deprecate the `fileLinkFormat` parameter of `DebugHandlersListener`
  * Add support for configuring log level, and status code by exception class

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -36,13 +36,14 @@ class ProfilerListener implements EventSubscriberInterface
     protected $exception;
     protected $profiles;
     protected $requestStack;
+    protected $collectParameter;
     protected $parents;
 
     /**
      * @param bool $onlyException    True if the profiler only collects data when an exception occurs, false otherwise
      * @param bool $onlyMainRequests True if the profiler only collects data when the request is the main request, false otherwise
      */
-    public function __construct(Profiler $profiler, RequestStack $requestStack, RequestMatcherInterface $matcher = null, bool $onlyException = false, bool $onlyMainRequests = false)
+    public function __construct(Profiler $profiler, RequestStack $requestStack, RequestMatcherInterface $matcher = null, bool $onlyException = false, bool $onlyMainRequests = false, string $collectParameter = null)
     {
         $this->profiler = $profiler;
         $this->matcher = $matcher;
@@ -51,6 +52,7 @@ class ProfilerListener implements EventSubscriberInterface
         $this->profiles = new \SplObjectStorage();
         $this->parents = new \SplObjectStorage();
         $this->requestStack = $requestStack;
+        $this->collectParameter = $collectParameter;
     }
 
     /**
@@ -79,6 +81,10 @@ class ProfilerListener implements EventSubscriberInterface
         }
 
         $request = $event->getRequest();
+        if (null !== $this->collectParameter && null !== $collectParameterValue = $request->get($this->collectParameter)) {
+            true === $collectParameterValue || filter_var($collectParameterValue, \FILTER_VALIDATE_BOOLEAN) ? $this->profiler->enable() : $this->profiler->disable();
+        }
+
         $exception = $this->exception;
         $this->exception = null;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | todo

The Symfony Profiler is a convenient development tool, however, in some cases, it has a huge overhead.
I used Blackfire to benchmark a development environment on a real-world project and noticed that the average response time was reduced by 30% just by disabling the profiler.

This PR adds a new configuration option allowing to enable and disable the profiler on a per request basis using a query parameter, a form field (for `POST` requests), or a request attribute. This PR allows keeping the benefit of this tool while improving the developer experience.

To enable it:

```yaml
framework:
    profiler:
        collect: false # Disable collection by default 
        collect_parameter: profile # Enable it if the parameter is set
```

Note: it's also possible to enable the collection by default and to disable it using the parameter

Then, to have the profiler, the user just has to add `?profile=1` to any URL.