### PR TITLE
[Minor] Fix missing and invalid imports

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatOptions.php
+++ b/src/Symfony/Component/Notifier/Bridge/GoogleChat/GoogleChatOptions.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Notifier\Bridge\GoogleChat;
 
-use Symfony\Component\Notifier\Bridge\GoogleChat\Component\Card;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageOptionsInterface;
 use Symfony\Component\Notifier\Notification\Notification;

--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/UserBadge.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/UserBadge.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Authenticator\Passport\Badge;
 
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\EventListener\UserProviderListener;

--- a/src/Symfony/Component/Semaphore/SemaphoreInterface.php
+++ b/src/Symfony/Component/Semaphore/SemaphoreInterface.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Semaphore;
 
 use Symfony\Component\Semaphore\Exception\SemaphoreAcquiringException;
+use Symfony\Component\Semaphore\Exception\SemaphoreExpiredException;
 use Symfony\Component\Semaphore\Exception\SemaphoreReleasingException;
 
 /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | -

Fixes invalid classes imports - mostly caused by renaming or moving the classes.
While the diff might be quite hard to understand, here are the reasons for changes:

- `Symfony\Component\Notifier\Bridge\GoogleChat\Component\Card` has been deleted and no longer used in this class
- `Symfony\Component\Security\Core\Exception\AuthenticationException` should be imported for `@throws` annotation: https://github.com/symfony/symfony/blob/c2182146479593682ac7c9347cde8e230b4e2708/src/Symfony/Component/Security/Http/Authenticator/Passport/Badge/UserBadge.php#L57-L60
- `Symfony\Component\Semaphore\Exception\SemaphoreExpiredException` should be imported for `@throws` annotation: https://github.com/symfony/symfony/blob/c2182146479593682ac7c9347cde8e230b4e2708/src/Symfony/Component/Semaphore/SemaphoreInterface.php#L38