### PR TITLE
[Templating] Relax return type on HelperInterface::getName()

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -789,6 +789,17 @@ index 6704940153..ee0f2ed470 100644
 -    public function getListeners(Request $request);
 +    public function getListeners(Request $request): array;
  }
+diff --git a/src/Symfony/Component/Templating/Helper/HelperInterface.php b/src/Symfony/Component/Templating/Helper/HelperInterface.php
+index 5dade65db5..db0d0a00ea 100644
+--- a/src/Symfony/Component/Templating/Helper/HelperInterface.php
++++ b/src/Symfony/Component/Templating/Helper/HelperInterface.php
+@@ -24,5 +24,5 @@ interface HelperInterface
+      * @return string
+      */
+-    public function getName();
++    public function getName(): string;
+ 
+     /**
 diff --git a/src/Symfony/Component/Translation/Extractor/AbstractFileExtractor.php b/src/Symfony/Component/Translation/Extractor/AbstractFileExtractor.php
 index 4c088b94f9..86107a636d 100644
 --- a/src/Symfony/Component/Translation/Extractor/AbstractFileExtractor.php

--- a/src/Symfony/Component/Templating/Helper/HelperInterface.php
+++ b/src/Symfony/Component/Templating/Helper/HelperInterface.php
@@ -20,8 +20,10 @@ interface HelperInterface
 {
     /**
      * Returns the canonical name of this helper.
+     *
+     * @return string
      */
-    public function getName(): string;
+    public function getName();
 
     /**
      * Sets the default charset.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Part of #43021 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | N/A <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

Removing this one return type would allow KnpMenuBundle to work with Symfony 6. See: https://github.com/symfony/symfony/issues/43021#issuecomment-922668817
