### PR TITLE
[Cache] Throw ValueError in debug mode when serialization fails

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/cache.php
@@ -217,6 +217,7 @@ return static function (ContainerConfigurator $container) {
         ->set('cache.default_marshaller', DefaultMarshaller::class)
             ->args([
                 null, // use igbinary_serialize() when available
+                '%kernel.debug%',
             ])
 
         ->set('cache.early_expiration_handler', EarlyExpirationHandler::class)

--- a/src/Symfony/Component/Cache/Tests/Marshaller/DefaultMarshallerTest.php
+++ b/src/Symfony/Component/Cache/Tests/Marshaller/DefaultMarshallerTest.php
@@ -109,4 +109,15 @@ class DefaultMarshallerTest extends TestCase
             restore_error_handler();
         }
     }
+
+    public function testSerializeDebug()
+    {
+        $marshaller = new DefaultMarshaller(false, true);
+        $values = [
+            'a' => function () {},
+        ];
+
+        $this->expectException(\ValueError::class);
+        $marshaller->marshall($values, $failed);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | -
| Tickets       | Fix #41685
| License       | MIT
| Doc PR        | -

This feature allows spotting mistakes at the dev stage when trying to store unserializable objects (typically a closure) into a cache.

This PR replaces #42241 with a simpler and more focused approach: here we fail via a simple `ValueError`, which won't get caught by any try/catch into the Cache component, and we fail only when serialization fails - not on any failures of cache pool methods.