### PR TITLE
Silence warnings during tty detection

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -396,11 +396,11 @@ class DeprecationErrorHandler
         }
 
         if (\function_exists('stream_isatty')) {
-            return stream_isatty(\STDOUT);
+            return @stream_isatty(\STDOUT);
         }
 
         if (\function_exists('posix_isatty')) {
-            return posix_isatty(\STDOUT);
+            return @posix_isatty(\STDOUT);
         }
 
         $stat = fstat(\STDOUT);

--- a/src/Symfony/Component/Console/Helper/QuestionHelper.php
+++ b/src/Symfony/Component/Console/Helper/QuestionHelper.php
@@ -485,11 +485,11 @@ class QuestionHelper extends Helper
         }
 
         if (\function_exists('stream_isatty')) {
-            return self::$stdinIsInteractive = stream_isatty(fopen('php://stdin', 'r'));
+            return self::$stdinIsInteractive = @stream_isatty(fopen('php://stdin', 'r'));
         }
 
         if (\function_exists('posix_isatty')) {
-            return self::$stdinIsInteractive = posix_isatty(fopen('php://stdin', 'r'));
+            return self::$stdinIsInteractive = @posix_isatty(fopen('php://stdin', 'r'));
         }
 
         if (!\function_exists('exec')) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | 


When the DeprecationErrorHandler checks if it should colorize the output, in certain circumstances it can trigger the following warning:
```
 Warning: stream_isatty(): cannot cast a filtered stream on this system in /app/vendor/symfony/phpunit-bridge/DeprecationErrorHandler.php on line 411
```
This is triggered by some admittedly poor behavior inside of php. `stream_isatty` checks by doing a cast and looking for a failure and one of those failures logs a warning. You generally don't want to trigger warnings during a capabilities check(that's why I'm filing this) but PHP is doing just that.

This can lead to test suite failures since warnings are generally treated as failures by most test suites.

I think a test case to trigger the deprecation handler might be tricky but a simplified test case to trigger the warning in php looks like this.

```php
class strtoupper_filter extends php_user_filter {
  #[\ReturnTypeWillChange]
  function filter($in, $out, &$consumed, $closing)
  {
    while ($bucket = stream_bucket_make_writeable($in)) {
      $bucket->data = strtoupper($bucket->data);
      $consumed += $bucket->datalen;
      stream_bucket_append($out, $bucket);
    }
    return PSFS_PASS_ON;
  }
}

$stdout = fopen('php://stdout', 'wb');
stream_filter_register('capture', strtoupper_filter::class);
stream_filter_append($stdout, 'capture');
var_export(stream_isatty($stdout));
```
https://3v4l.org/0EHT4

A real world example of a test suite that is wrapping stdout with a stream wrapper during testing is Drupal. [Feature addition](https://www.drupal.org/node/2795567)

References:
[stream_isatty definition](https://github.com/php/php-src/blob/b732b6d06fab96c7875d31d94588b3b1057124b9/ext/standard/streamsfuncs.c#L1611)
[cast line that triggers warning](https://github.com/php/php-src/blob/ac34648cf6bf5493a8cd1a4c9a82406599f3f25c/main/streams/cast.c#L295)