### PR TITLE
[Cache] Fix invalidating tags on Redis <5

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/RedisTagAwareAdapter.php
@@ -15,6 +15,7 @@ use Predis\Connection\Aggregate\ClusterInterface;
 use Predis\Connection\Aggregate\PredisCluster;
 use Predis\Connection\Aggregate\ReplicationInterface;
 use Predis\Response\Status;
+use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Cache\Exception\InvalidArgumentException;
 use Symfony\Component\Cache\Exception\LogicException;
 use Symfony\Component\Cache\Marshaller\DeflateMarshaller;
@@ -159,6 +160,12 @@ EOLUA;
         });
 
         foreach ($results as $id => $result) {
+            if ($result instanceof \RedisException) {
+                CacheItem::log($this->logger, 'Failed to delete key "{key}": '.$result->getMessage(), ['key' => substr($id, \strlen($this->namespace)), 'exception' => $result]);
+
+                continue;
+            }
+
             try {
                 yield $id => !\is_string($result) || '' === $result ? [] : $this->marshaller->unmarshall($result);
             } catch (\Exception $e) {
@@ -197,6 +204,8 @@ EOLUA;
         // gargage collect that set from the client side.
 
         $lua = <<<'EOLUA'
+            redis.replicate_commands()
+
             local cursor = '0'
             local id = KEYS[1]
             repeat
@@ -234,6 +243,8 @@ EOLUA;
         });
 
         $lua = <<<'EOLUA'
+            redis.replicate_commands()
+
             local id = KEYS[1]
             local cursor = table.remove(ARGV)
             redis.call('SREM', '{'..id..'}'..id, unpack(ARGV))
@@ -241,7 +252,17 @@ EOLUA;
             return redis.call('SSCAN', '{'..id..'}'..id, cursor, 'COUNT', 5000)
 EOLUA;
 
-        foreach ($results as $id => [$cursor, $ids]) {
+        $success = true;
+        foreach ($results as $id => $values) {
+            if ($values instanceof \RedisException) {
+                CacheItem::log($this->logger, 'Failed to invalidate key "{key}": '.$values->getMessage(), ['key' => substr($id, \strlen($this->namespace)), 'exception' => $values]);
+                $success = false;
+
+                continue;
+            }
+
+            [$cursor, $ids] = $values;
+
             while ($ids || '0' !== $cursor) {
                 $this->doDelete($ids);
 
@@ -264,7 +285,7 @@ EOLUA;
             }
         }
 
-        return true;
+        return $success;
     }
 
     private function getRedisEvictionPolicy(): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42126
| License       | MIT
| Doc PR        | -

https://redis.io/commands/eval#replicating-commands-instead-of-scripts

> Note: starting with Redis 5, the replication method described in this section (scripts effects replication) is the default and does not need to be explicitly enabled.
> 
> Starting with Redis 3.2, it is possible to select an alternative replication method. Instead of replicating whole scripts, we can just replicate single write commands generated by the script. We call this script effects replication.
>
> To enable script effects replication you need to issue the following Lua command before the script performs a write:
>
> ```
> redis.replicate_commands()
> ```
