### PR TITLE
[Messenger] Allow retries to be logged as warnings

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add support for resetting container services after each messenger message.
  * Added `WorkerMetadata` class which allows you to access the configuration details of a worker, like `queueNames` and `transportNames` it consumes from.
  * New method `getMetadata()` was added to `Worker` class which returns the `WorkerMetadata` object.
+ * Add the `LogRetryAsWarningInterface` for exceptions to log retries as warnings instead of errors allowing the same behaviour as RecoverableExceptionInterface while still using the retry strategy
 
 5.3
 ---

--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
@@ -18,6 +18,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\Event\WorkerMessageRetriedEvent;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\LogRetryAsWarningInterface;
 use Symfony\Component\Messenger\Exception\RecoverableExceptionInterface;
 use Symfony\Component\Messenger\Exception\RuntimeException;
 use Symfony\Component\Messenger\Exception\UnrecoverableExceptionInterface;
@@ -72,11 +73,11 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
 
             if (null !== $this->logger) {
                 $logLevel = LogLevel::ERROR;
-                if ($throwable instanceof RecoverableExceptionInterface) {
+                if ($throwable instanceof LogRetryAsWarningInterface) {
                     $logLevel = LogLevel::WARNING;
                 } elseif ($throwable instanceof HandlerFailedException) {
                     foreach ($throwable->getNestedExceptions() as $nestedException) {
-                        if ($nestedException instanceof RecoverableExceptionInterface) {
+                        if ($nestedException instanceof LogRetryAsWarningInterface) {
                             $logLevel = LogLevel::WARNING;
                             break;
                         }

--- a/src/Symfony/Component/Messenger/Exception/LogRetryAsWarningInterface.php
+++ b/src/Symfony/Component/Messenger/Exception/LogRetryAsWarningInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+/**
+ * Marker interface for exceptions to indicate a retry should be logged as warning instead of error.
+ *
+ * @author Joris Steyn <j.steyn@hoffelijk.nl>
+ */
+interface LogRetryAsWarningInterface extends \Throwable
+{
+}

--- a/src/Symfony/Component/Messenger/Exception/RecoverableExceptionInterface.php
+++ b/src/Symfony/Component/Messenger/Exception/RecoverableExceptionInterface.php
@@ -19,6 +19,6 @@ namespace Symfony\Component\Messenger\Exception;
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-interface RecoverableExceptionInterface extends \Throwable
+interface RecoverableExceptionInterface extends LogRetryAsWarningInterface
 {
 }

--- a/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageForRetryListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/SendFailedMessageForRetryListenerTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Messenger\Tests\EventListener;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
 use Symfony\Component\Messenger\EventListener\SendFailedMessageForRetryListener;
@@ -20,6 +22,7 @@ use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Retry\RetryStrategyInterface;
 use Symfony\Component\Messenger\Stamp\DelayStamp;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Symfony\Component\Messenger\Tests\Fixtures\RetryWithWarningException;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -104,6 +107,60 @@ class SendFailedMessageForRetryListenerTest extends TestCase
         $retryStategy = $this->createMock(RetryStrategyInterface::class);
         $retryStategy->expects($this->once())->method('isRetryable')->willReturn(true);
         $retryStategy->expects($this->once())->method('getWaitingTime')->willReturn(1000);
+        $retryStrategyLocator = $this->createMock(ContainerInterface::class);
+        $retryStrategyLocator->expects($this->once())->method('has')->willReturn(true);
+        $retryStrategyLocator->expects($this->once())->method('get')->willReturn($retryStategy);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('log')->with(LogLevel::ERROR);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects($this->once())->method('dispatch');
+
+        $listener = new SendFailedMessageForRetryListener($senderLocator, $retryStrategyLocator, $logger, $eventDispatcher);
+
+        $event = new WorkerMessageFailedEvent($envelope, 'my_receiver', $exception);
+
+        $listener->onMessageFailed($event);
+    }
+
+    public function exceptionLogSeverityProvider()
+    {
+        return [
+            [new \Exception('test'), LogLevel::ERROR],
+            [new RecoverableMessageHandlingException('test'), LogLevel::WARNING],
+            [new RetryWithWarningException(), LogLevel::WARNING],
+        ];
+    }
+
+    /**
+     * @dataProvider exceptionLogSeverityProvider
+     */
+    public function testRetriesAreLoggedWithAppropriateLogSeverity(\Exception $exception, string $expectedSeverity)
+    {
+        $envelope = new Envelope(new \stdClass());
+
+        $sender = $this->createMock(SenderInterface::class);
+        $sender->expects($this->once())->method('send')->willReturnCallback(function (Envelope $envelope) {
+            /** @var DelayStamp $delayStamp */
+            $delayStamp = $envelope->last(DelayStamp::class);
+            /** @var RedeliveryStamp $redeliveryStamp */
+            $redeliveryStamp = $envelope->last(RedeliveryStamp::class);
+
+            $this->assertInstanceOf(DelayStamp::class, $delayStamp);
+            $this->assertSame(1000, $delayStamp->getDelay());
+
+            $this->assertInstanceOf(RedeliveryStamp::class, $redeliveryStamp);
+            $this->assertSame(1, $redeliveryStamp->getRetryCount());
+
+            return $envelope;
+        });
+        $senderLocator = $this->createMock(ContainerInterface::class);
+        $senderLocator->expects($this->once())->method('has')->willReturn(true);
+        $senderLocator->expects($this->once())->method('get')->willReturn($sender);
+        $retryStategy = $this->createMock(RetryStrategyInterface::class);
+        $retryStategy->expects($this->any())->method('isRetryable')->willReturn(true);
+        $retryStategy->expects($this->any())->method('getWaitingTime')->willReturn(1000);
         $retryStrategyLocator = $this->createMock(ContainerInterface::class);
         $retryStrategyLocator->expects($this->once())->method('has')->willReturn(true);
         $retryStrategyLocator->expects($this->once())->method('get')->willReturn($retryStategy);

--- a/src/Symfony/Component/Messenger/Tests/Fixtures/RetryWithWarningException.php
+++ b/src/Symfony/Component/Messenger/Tests/Fixtures/RetryWithWarningException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\Fixtures;
+
+use Exception;
+use Symfony\Component\Messenger\Exception\LogRetryAsWarningInterface;
+
+class RetryWithWarningException extends Exception implements LogRetryAsWarningInterface
+{
+}


### PR DESCRIPTION
This commit introduces a marker interface for exceptions to allow retries to be logged as warnings instead of the default error severity.

This behaviour is already implemented for recoverable exceptions, but those are retried ad infinitum regardless of the retry strategy. With the new marker interface, it's possible to log exceptions as warnings while still using the retry strategy.

The RecoverableExceptionInterface now extends this interface to achieve the existing behaviour using the new more flexible approach.

```
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Related to problem described in comments of https://github.com/symfony/messenger/pull/15
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/15844
```