### PR TITLE
[FrameworkBundle] Fix cache pool configuration with one adapter and one provider

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1012,13 +1012,14 @@ class Configuration implements ConfigurationInterface
                             ->prototype('array')
                                 ->fixXmlConfig('adapter')
                                 ->beforeNormalization()
-                                    ->ifTrue(function ($v) { return (isset($v['adapters']) || \is_array($v['adapter'] ?? null)) && isset($v['provider']); })
-                                    ->thenInvalid('Pool cannot have a "provider" while "adapter" is set to a map')
+                                    ->ifTrue(function ($v) { return isset($v['provider']) && \is_array($v['adapters'] ?? $v['adapter'] ?? null) && 1 < \count($v['adapters'] ?? $v['adapter']); })
+                                    ->thenInvalid('Pool cannot have a "provider" while more than one adapter is defined')
                                 ->end()
                                 ->children()
                                     ->arrayNode('adapters')
                                         ->performNoDeepMerging()
                                         ->info('One or more adapters to chain for creating the pool, defaults to "cache.app".')
+                                        ->beforeNormalization()->castToArray()->end()
                                         ->beforeNormalization()
                                             ->always()->then(function ($values) {
                                                 if ([0] === array_keys($values) && \is_array($values[0])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

My current YAML config is:
```yaml
framework:
    cache:
        pools:
            app.cache.redis:
                adapter: "cache.adapter.redis"
                provider: "%env(REDIS_URL)%/4"
                default_lifetime: 86400
```

I'm trying to migrate it to PHP with the new config builder system. The problem is that `->adapter('cache.adapter.redis')` does not exist in the generated config class since `adapter` is just a shortcut in the first place. So I have to use `->adapters(['cache.adapter.redis'])` but the configuration doesn't allow it.

The difference with this patch is that we allow the case where `adapters` is a map that contains only one item and `provider` is set. The result is exactly the same and it becomes compatible with the config class.

I added an extra check for DX to avoid an `\ErrorException` if `adapters` is not an array.