### PR TITLE
Update README.md

### DIFF
--- a/src/Symfony/Component/Debug/README.md
+++ b/src/Symfony/Component/Debug/README.md
@@ -12,7 +12,7 @@ Getting Started
 ---------------
 
 ```
-$ composer install symfony/debug
+$ composer require symfony/debug
 ```
 
 ```php


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no<!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | (see below)
| License       | MIT
| Doc PR        | /

Replace `composer install` by `composer require` because composer uses the command `require` to add a dependancy
**cf :** https://github.com/symfony/debug/pull/9

symfony/debug does not exist for symfony 5 or above ?
