### PR TITLE
[VarDumper] fix dumping typed references from properties

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Cloner/VarClonerTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Cloner/VarClonerTest.php
@@ -499,12 +499,55 @@ Symfony\Component\VarDumper\Cloner\Data Object
                     [p1] => 123
                     [p2] => Symfony\Component\VarDumper\Cloner\Stub Object
                         (
-                            [type] => 4
-                            [class] => stdClass
-                            [value] => 
+                            [type] => 1
+                            [class] => 
+                            [value] => Symfony\Component\VarDumper\Cloner\Stub Object
+                                (
+                                    [type] => 4
+                                    [class] => stdClass
+                                    [value] => 
+                                    [cut] => 0
+                                    [handle] => %i
+                                    [refCount] => 1
+                                    [position] => 0
+                                    [attr] => Array
+                                        (
+                                        )
+
+                                )
+
                             [cut] => 0
-                            [handle] => %i
-                            [refCount] => 0
+                            [handle] => 1
+                            [refCount] => 1
+                            [position] => 0
+                            [attr] => Array
+                                (
+                                )
+
+                        )
+
+                    [p3] => Symfony\Component\VarDumper\Cloner\Stub Object
+                        (
+                            [type] => 1
+                            [class] => 
+                            [value] => Symfony\Component\VarDumper\Cloner\Stub Object
+                                (
+                                    [type] => 4
+                                    [class] => stdClass
+                                    [value] => 
+                                    [cut] => 0
+                                    [handle] => %i
+                                    [refCount] => 1
+                                    [position] => 0
+                                    [attr] => Array
+                                        (
+                                        )
+
+                                )
+
+                            [cut] => 0
+                            [handle] => 1
+                            [refCount] => 1
                             [position] => 0
                             [attr] => Array
                                 (

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/Php74.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/Php74.php
@@ -6,9 +6,11 @@ class Php74
 {
     public $p1 = 123;
     public \stdClass $p2;
+    public \stdClass $p3;
 
     public function __construct()
     {
         $this->p2 = new \stdClass();
+        $this->p3 = &$this->p2;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As spotted by SecurityBundle's tests on 6.0