### PR TITLE
[Validator] Add intl-icu polyfill as dependency due deprecated polyfill in intl

### DIFF
--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -19,6 +19,7 @@
         "php": ">=7.2.5",
         "symfony/deprecation-contracts": "^2.1",
         "symfony/polyfill-ctype": "~1.8",
+        "symfony/polyfill-intl-icu": "^1.21",
         "symfony/polyfill-mbstring": "~1.0",
         "symfony/polyfill-php73": "~1.0",
         "symfony/polyfill-php80": "^1.16",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

[This commit](https://github.com/symfony/symfony/commit/6ad0169c4feea4881b64dd5cb00acf5e9ecd11dd) from @nicolas-grekas deprecated _intl_'s built-in polyfills.

But _validator_ relies on either having intl-extension or polyfills available, for example in `Symfony\Component\Intl\Countries::exists()`. So I think _validator_ should require _polyfill-intl-icu_.
