### PR TITLE
[Ldap] Fix `resource` type checks & docblocks on PHP 8.1

### DIFF
--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Connection.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Ldap\Adapter\ExtLdap;
 
+use LDAP\Connection as LDAPConnection;
 use Symfony\Component\Ldap\Adapter\AbstractConnection;
 use Symfony\Component\Ldap\Exception\AlreadyExistsException;
 use Symfony\Component\Ldap\Exception\ConnectionException;
@@ -32,7 +33,7 @@ class Connection extends AbstractConnection
     /** @var bool */
     private $bound = false;
 
-    /** @var resource */
+    /** @var resource|LDAPConnection */
     private $connection;
 
     /**
@@ -89,9 +90,7 @@ class Connection extends AbstractConnection
     }
 
     /**
-     * Returns a link resource.
-     *
-     * @return resource
+     * @return resource|LDAPConnection
      *
      * @internal
      */
@@ -165,7 +164,7 @@ class Connection extends AbstractConnection
 
     private function disconnect()
     {
-        if ($this->connection && \is_resource($this->connection)) {
+        if ($this->connection) {
             ldap_unbind($this->connection);
         }
 

--- a/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
+++ b/src/Symfony/Component/Ldap/Adapter/ExtLdap/Query.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Ldap\Adapter\ExtLdap;
 
+use LDAP\Connection as LDAPConnection;
+use LDAP\Result;
 use Symfony\Component\Ldap\Adapter\AbstractQuery;
 use Symfony\Component\Ldap\Exception\LdapException;
 use Symfony\Component\Ldap\Exception\NotBoundException;
@@ -27,7 +29,7 @@ class Query extends AbstractQuery
     /** @var Connection */
     protected $connection;
 
-    /** @var resource[] */
+    /** @var resource[]|Result[] */
     private $results;
 
     /** @var array */
@@ -156,7 +158,7 @@ class Query extends AbstractQuery
      * Returns an LDAP search resource. If this query resulted in multiple searches, only the first
      * page will be returned.
      *
-     * @return resource
+     * @return resource|Result
      *
      * @internal
      */
@@ -172,7 +174,7 @@ class Query extends AbstractQuery
     /**
      * Returns all LDAP search resources.
      *
-     * @return resource[]
+     * @return resource[]|Result[]
      *
      * @internal
      */
@@ -215,7 +217,7 @@ class Query extends AbstractQuery
     /**
      * Sets LDAP pagination controls.
      *
-     * @param resource $con
+     * @param resource|LDAPConnection $con
      */
     private function controlPagedResult($con, int $pageSize, bool $critical, string $cookie): bool
     {
@@ -239,8 +241,8 @@ class Query extends AbstractQuery
     /**
      * Retrieve LDAP pagination cookie.
      *
-     * @param resource $con
-     * @param resource $result
+     * @param resource|LDAPConnection $con
+     * @param resource|Result         $result
      */
     private function controlPagedResultResponse($con, $result, string $cookie = ''): string
     {
@@ -257,9 +259,9 @@ class Query extends AbstractQuery
     /**
      * Calls actual LDAP search function with the prepared options and parameters.
      *
-     * @param resource $con
+     * @param resource|LDAPConnection $con
      *
-     * @return resource
+     * @return resource|Result
      */
     private function callSearchFunction($con, string $func, int $sizeLimit)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

From https://www.php.net/manual/en/migration81.incompatible.php:

> Several resources have been migrated to objects. Return value checks using is_resource() should be replaced with checks for false. 
The LDAP functions now accept and return, respectively, LDAP\ResultEntry objects instead of ldap result entry resources.
The LDAP functions now accept and return, respectively, LDAP\Connection objects instead of ldap link resources.
The LDAP functions now accept and return, respectively, LDAP\Result objects instead of ldap result resources.
The LDAP functions now accept and return, respectively, LDAP\ResultEntry objects instead of ldap result entry resources.

See also https://github.com/php/php-src/pull/6770 
