### PR TITLE
[WIP] Allow AbstractDoctrineExtension implementations to support the newer bundle structure

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -1,6 +1,11 @@
 UPGRADE FROM 5.3 to 5.4
 =======================
 
+DoctrineBridge
+--------------
+
+* Deprecate `AbstractDoctrineExtension::getMappingDriverBundleConfigDefaults()` in favor of `AbstractDoctrineExtension::getBundleMappingDriverDefaultConfig()`
+
 Cache
 -----
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -10,6 +10,7 @@ DoctrineBridge
 --------------
 
  * Remove `UserLoaderInterface::loadUserByUsername()` in favor of `UserLoaderInterface::loadUserByIdentifier()`
+ * Remove `AbstractDoctrineExtension::getMappingDriverBundleConfigDefaults()` in favor of `AbstractDoctrineExtension::getBundleMappingDriverDefaultConfig()`
 
 Cache
 -----

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Add support for the newer bundle structure to `AbstractDoctrineExtension::loadMappingInformation()`
+ * Deprecate `AbstractDoctrineExtension::getMappingDriverBundleConfigDefaults()` in favor of `AbstractDoctrineExtension::getBundleMappingDriverDefaultConfig()`
+
 5.3
 ---
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | TBD

Container extensions inheriting from `Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension` (i.e. the extensions in all Doctrine bundles) currently cannot smoothly support the newer bundle directory structure because the existing API relies on information being gleaned from Reflection for the bundle class.  This PR is an attempt to allow these extensions to support the newer structure.  The notable changes here are:

- The `loadMappingInformation()` method will start using the info from the `kernel.bundles_metadata` container parameter which holds the relevant bits of information about the bundle (its namespace and its root path, which can be different from the bundle classpath)
- The `getMappingDriverBundleConfigDefaults()` method is deprecated in favor of `getBundleMappingDriverDefaultConfig()`, this is needed to replace the `\ReflectionClass $bundle` argument with the preferred `array $bundleMetadata`
- The abstract `getMappingResourceConfigDirectory()` method adds a `string $bundleDir` argument, this is needed for the concrete implementations to have conditional paths supporting both structures (similar to other checks in the framework like the `is_dir($bundleDir.'/Resources/views') ? $bundleDir.'/Resources/views' : $bundleDir.'/templates'` check for the templates path)

### TODO

- [ ] Change the call to the deprecated `getMappingDriverBundleConfigDefaults()` method to the newer `getBundleMappingDriverDefaultConfig()` method