### PR TITLE
Allow AbstractDoctrineExtension implementations to support the newer bundle structure

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -12,6 +12,12 @@ Console
 
  * Deprecate `HelperSet::setCommand()` and `getCommand()` without replacement
 
+DoctrineBridge
+--------------
+
+ * Add argument `$bundleDir` to `AbstractDoctrineExtension::getMappingDriverBundleConfigDefaults()`
+ * Add argument `$bundleDir` to `AbstractDoctrineExtension::getMappingResourceConfigDirectory()`
+
 Finder
 ------
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -10,6 +10,8 @@ DoctrineBridge
 --------------
 
  * Remove `UserLoaderInterface::loadUserByUsername()` in favor of `UserLoaderInterface::loadUserByIdentifier()`
+ * Add argument `$bundleDir` to `AbstractDoctrineExtension::getMappingDriverBundleConfigDefaults()`
+ * Add argument `$bundleDir` to `AbstractDoctrineExtension::getMappingResourceConfigDirectory()`
 
 Cache
 -----

--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -7,6 +7,9 @@ CHANGELOG
  * Add `DoctrineOpenTransactionLoggerMiddleware` to log when a transaction has been left open
  * Deprecate `PdoCacheAdapterDoctrineSchemaSubscriber` and add `DoctrineDbalCacheAdapterSchemaSubscriber` instead
  * `UniqueEntity` constraint retrieves a maximum of two entities if the default repository method is used.
+ * Add support for the newer bundle structure to `AbstractDoctrineExtension::loadMappingInformation()`
+ * Add argument `$bundleDir` to `AbstractDoctrineExtension::getMappingDriverBundleConfigDefaults()`
+ * Add argument `$bundleDir` to `AbstractDoctrineExtension::getMappingResourceConfigDirectory()`
 
 5.3
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | N/A
| License       | MIT
| Doc PR        | TBD

Container extensions inheriting from `Symfony\Bridge\Doctrine\DependencyInjection\AbstractDoctrineExtension` (i.e. the extensions in all Doctrine bundles) currently cannot smoothly support the newer bundle directory structure because the existing API relies on information being gleaned from Reflection for the bundle class.  This PR is an attempt to allow these extensions to support the newer structure.  The notable changes here are:

- The `getMappingDriverBundleConfigDefaults()` method adds a `string $bundleDir` argument which replaces gleaning the bundle directory by reflecting on the Bundle class
- The abstract `getMappingResourceConfigDirectory()` method adds a `string $bundleDir` argument, this is needed for the concrete implementations to have conditional paths supporting both structures (similar to other checks in the framework like the `is_dir($bundleDir.'/Resources/views') ? $bundleDir.'/Resources/views' : $bundleDir.'/templates'` check for the templates path)