### PR TITLE
Fix framework configuration when messenger uses without console

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -45,6 +45,7 @@ Messenger
 
  * Deprecate not setting the `delete_after_ack` config option (or DSN parameter) using the Redis transport,
    its default value will change to `true` in 6.0
+ * Deprecate not setting the `reset_on_message` config option, its default value will change to `true` in 6.0
 
 SecurityBundle
 --------------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -157,6 +157,7 @@ Messenger
  * Removed the `prefetch_count` parameter in the AMQP bridge.
  * Removed the use of TLS option for Redis Bridge, use `rediss://127.0.0.1` instead of `redis://127.0.0.1?tls=1`
  * The `delete_after_ack` config option of the Redis transport now defaults to `true`
+ * The `reset_on_message` config option now defaults to `true`
 
 Mime
 ----

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/messenger.php
@@ -201,7 +201,6 @@ return static function (ContainerConfigurator $container) {
         ->set('messenger.listener.reset_services', ResetServicesListener::class)
             ->args([
                 service('services_resetter'),
-                abstract_arg('receivers names'),
             ])
 
         ->set('messenger.routable_message_bus', RoutableMessageBus::class)

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * Add support for resetting container services after each messenger message.
  * Added `WorkerMetadata` class which allows you to access the configuration details of a worker, like `queueNames` and `transportNames` it consumes from.
  * New method `getMetadata()` was added to `Worker` class which returns the `WorkerMetadata` object.
+ * Deprecate not setting the `reset_on_message` config option, its default value will change to `true` in 6.0
 
 5.3
 ---


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix https://github.com/symfony/symfony/pull/43133#pullrequestreview-764470022
| License       | MIT
| Doc PR        |  later

We hurried, an addition to #43133

It fixes https://github.com/symfony/symfony/pull/43133#pullrequestreview-764470022
It adds the forgotten CHANGELOG & UPGRADE

I'm not sure about the CHANGELOG format. I've done as people do but... [it says](https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry) "New entries must be added on top of the list." However, nobody does it :shrug: 

~I don't know how to test the fix, because of `class_exists()` call that cannot be easily mocked.~

`src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php:245`:
```php
if (class_exists(Application::class)) {
    $loader->load('console.php');
    /* ... */
}

```