### PR TITLE
[Serializer] Fix denormalizing XML array with empty body (5.x)

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -422,11 +422,17 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             // if a value is meant to be a string, float, int or a boolean value from the serialized representation.
             // That's why we have to transform the values, if one of these non-string basic datatypes is expected.
             if (\is_string($data) && (XmlEncoder::FORMAT === $format || CsvEncoder::FORMAT === $format)) {
-                if ('' === $data && $type->isNullable() && \in_array($type->getBuiltinType(), [Type::BUILTIN_TYPE_BOOL, Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_FLOAT], true)) {
-                    return null;
+                if ('' === $data) {
+                    if (Type::BUILTIN_TYPE_ARRAY === $builtinType = $type->getBuiltinType()) {
+                        return [];
+                    }
+
+                    if ($type->isNullable() && \in_array($builtinType, [Type::BUILTIN_TYPE_BOOL, Type::BUILTIN_TYPE_INT, Type::BUILTIN_TYPE_FLOAT], true)) {
+                        return null;
+                    }
                 }
 
-                switch ($type->getBuiltinType()) {
+                switch ($builtinType ?? $type->getBuiltinType()) {
                     case Type::BUILTIN_TYPE_BOOL:
                         // according to https://www.w3.org/TR/xmlschema-2/#boolean, valid representations are "false", "true", "0" and "1"
                         if ('false' === $data || '0' === $data) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ObjectDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ObjectDummy.php
@@ -5,6 +5,9 @@ namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
 class ObjectDummy
 {
     protected $foo;
+    /**
+     * @var array
+     */
     public $bar;
     private $baz;
     protected $camelCase;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -164,6 +164,19 @@ class ObjectNormalizerTest extends TestCase
         $this->assertTrue($obj->isBaz());
     }
 
+    public function testDenormalizeEmptyXmlArray()
+    {
+        $normalizer = $this->getDenormalizerForObjectToPopulate();
+        $obj = $normalizer->denormalize(
+            ['bar' => ''],
+            ObjectDummy::class,
+            'xml'
+        );
+
+        $this->assertIsArray($obj->bar);
+        $this->assertEmpty($obj->bar);
+    }
+
     public function testDenormalizeWithObject()
     {
         $data = new \stdClass();


### PR DESCRIPTION
This happens for example with XML empty tags denormalizing to an object array attribute.

| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43193 on Symfony 5.x
| License       | MIT
| Doc PR        | _NA_

Fix for 4.4 can be found in #43205