### PR TITLE
[Serializer] Fix denormalizing XML array with empty body (4.4)

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -16,6 +16,7 @@ use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Exception\ExtraAttributesException;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
@@ -409,6 +410,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             // This is special to xml format only
             if ('xml' === $format && null !== $collectionValueType && (!\is_array($data) || !\is_int(key($data)))) {
                 $data = [$data];
+            }
+
+            if (XmlEncoder::FORMAT === $format && '' === $data && Type::BUILTIN_TYPE_ARRAY === $type->getBuiltinType()) {
+                return [];
             }
 
             if (null !== $collectionValueType && Type::BUILTIN_TYPE_OBJECT === $collectionValueType->getBuiltinType()) {

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ObjectDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/ObjectDummy.php
@@ -5,6 +5,9 @@ namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
 class ObjectDummy
 {
     protected $foo;
+    /**
+     * @var array
+     */
     public $bar;
     private $baz;
     protected $camelCase;

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -165,6 +165,19 @@ class ObjectNormalizerTest extends TestCase
         $this->assertTrue($obj->isBaz());
     }
 
+    public function testDenormalizeEmptyXmlArray()
+    {
+        $normalizer = $this->getDenormalizerForObjectToPopulate();
+        $obj = $normalizer->denormalize(
+            ['bar' => ''],
+            ObjectDummy::class,
+            'xml'
+        );
+
+        $this->assertIsArray($obj->bar);
+        $this->assertEmpty($obj->bar);
+    }
+
     public function testDenormalizeWithObject()
     {
         $data = new \stdClass();


### PR DESCRIPTION
This happens for example with XML empty tags denormalizing to an object array attribute.

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43193 on Symfony 4.4
| License       | MIT
| Doc PR        | _NA_

Not sure how to deal with versions differences as they differ just a little bit. Anyway, here's the fix for 4.4 and you can find the fix for 5.x on #43204 :smile: 