### PR TITLE
[Workflow] Add missing audit-trail settings in framework workflow con…

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -310,6 +310,7 @@
 
     <xsd:complexType name="workflow">
         <xsd:sequence>
+            <xsd:element name="audit-trail" type="audit_trail" minOccurs="0" maxOccurs="1" />
             <xsd:element name="initial-marking" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="marking-store" type="marking_store" minOccurs="0" maxOccurs="1" />
             <xsd:element name="support" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
@@ -338,6 +339,19 @@
         <xsd:attribute name="type" type="xsd:string" use="required" />
         <xsd:attribute name="logLevel" type="xsd:string" />
     </xsd:complexType>
+
+    <xsd:complexType name="audit_trail">
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+    </xsd:complexType>
+
+    <xsd:simpleType name="audit_trail_enabled">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="true" />
+            <xsd:enumeration value="false" />
+            <xsd:enumeration value="1" />
+            <xsd:enumeration value="0" />
+        </xsd:restriction>
+    </xsd:simpleType>
 
     <xsd:complexType name="marking_store">
         <xsd:sequence>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/workflows.xml
@@ -8,6 +8,7 @@
 
     <framework:config>
         <framework:workflow name="article" type="workflow">
+            <framework:audit-trail enabled="true"/>
             <framework:initial-marking>draft</framework:initial-marking>
             <framework:marking-store type="method" property="state" />
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
@@ -42,6 +43,7 @@
         </framework:workflow>
 
         <framework:workflow name="pull_request">
+            <framework:audit-trail enabled="false"/>
             <framework:initial-marking>start</framework:initial-marking>
             <framework:support>Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\FrameworkExtensionTest</framework:support>
             <framework:place name="start">


### PR DESCRIPTION
audit-trail config was missing in xsd. Example from symfony.com did not work as expected due to this.

| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43194
| License       | MIT
| Doc PR        |  N/A

Commit adds audit-trail in xsd