### PR TITLE
[Serializer] Attributes that extend serializer`s annotations are not ignored by the serialization process

### DIFF
--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -33,12 +33,12 @@ use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
 class AnnotationLoader implements LoaderInterface
 {
     private const KNOWN_ANNOTATIONS = [
-        DiscriminatorMap::class => true,
-        Groups::class => true,
-        Ignore::class => true,
-        MaxDepth::class => true,
-        SerializedName::class => true,
-        Context::class => true,
+        DiscriminatorMap::class,
+        Groups::class,
+        Ignore::class,
+        MaxDepth::class,
+        SerializedName::class,
+        Context::class,
     ];
 
     private $reader;
@@ -157,7 +157,7 @@ class AnnotationLoader implements LoaderInterface
     {
         if (\PHP_VERSION_ID >= 80000) {
             foreach ($reflector->getAttributes() as $attribute) {
-                if (self::KNOWN_ANNOTATIONS[$attribute->getName()] ?? false) {
+                if ($this->isKnownAttribute($attribute->getName())) {
                     yield $attribute->newInstance();
                 }
             }
@@ -192,5 +192,16 @@ class AnnotationLoader implements LoaderInterface
         if ($annotation->getDenormalizationContext()) {
             $attributeMetadata->setDenormalizationContextForGroups($annotation->getDenormalizationContext(), $annotation->getGroups());
         }
+    }
+
+    private function isKnownAttribute(string $attributeName): bool
+    {
+        foreach (self::KNOWN_ANNOTATIONS as $knownAnnotation) {
+            if (is_a($attributeName, $knownAnnotation, true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/GroupDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/GroupDummy.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
 
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Tests\Fixtures\GroupDummyInterface;
+use Symfony\Component\Serializer\Tests\Fixtures\ChildOfGroupsAnnotationDummy;
 
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
@@ -27,6 +28,11 @@ class GroupDummy extends GroupDummyParent implements GroupDummyInterface
      * @Groups({"b", "c", "name_converter"})
      */
     protected $bar;
+    /**
+     * @ChildOfGroupsAnnotationDummy
+     */
+    protected $quux;
+
     private $fooBar;
     private $symfony;
 
@@ -77,5 +83,15 @@ class GroupDummy extends GroupDummyParent implements GroupDummyInterface
     public function getSymfony()
     {
         return $this->symfony;
+    }
+
+    public function getQuux()
+    {
+        return $this->quux;
+    }
+
+    public function setQuux($quux): void
+    {
+        $this->quux = $quux;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/GroupDummy.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
 
 use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Serializer\Tests\Fixtures\ChildOfGroupsAnnotationDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\GroupDummyInterface;
 
 /**
@@ -23,6 +24,8 @@ class GroupDummy extends GroupDummyParent implements GroupDummyInterface
     private $foo;
     #[Groups(["b", "c", "name_converter"])]
     protected $bar;
+    #[ChildOfGroupsAnnotationDummy]
+    protected $quux;
     private $fooBar;
     private $symfony;
 
@@ -67,5 +70,15 @@ class GroupDummy extends GroupDummyParent implements GroupDummyInterface
     public function getSymfony()
     {
         return $this->symfony;
+    }
+
+    public function getQuux()
+    {
+        return $this->quux;
+    }
+
+    public function setQuux($quux): void
+    {
+        $this->quux = $quux;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/ChildOfGroupsAnnotationDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/ChildOfGroupsAnnotationDummy.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Fixtures;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD"})
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+final class ChildOfGroupsAnnotationDummy extends Groups
+{
+    public function __construct()
+    {
+        parent::__construct(['d']);
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Mapping/TestClassMetadataFactory.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/TestClassMetadataFactory.php
@@ -33,6 +33,10 @@ class TestClassMetadataFactory
         $bar->addGroup('name_converter');
         $expected->addAttributeMetadata($bar);
 
+        $quux = new AttributeMetadata('quux');
+        $quux->addGroup('d');
+        $expected->addAttributeMetadata($quux);
+
         $fooBar = new AttributeMetadata('fooBar');
         $fooBar->addGroup('a');
         $fooBar->addGroup('b');

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/PropertyNormalizerTest.php
@@ -115,10 +115,11 @@ class PropertyNormalizerTest extends TestCase
         $group->setBaz('baz');
         $group->setFoo('foo');
         $group->setBar('bar');
+        $group->setQuux('quux');
         $group->setKevin('Kevin');
         $group->setCoopTilleuls('coop');
         $this->assertEquals(
-            ['foo' => 'foo', 'bar' => 'bar', 'kevin' => 'Kevin', 'coopTilleuls' => 'coop', 'fooBar' => null, 'symfony' => null, 'baz' => 'baz'],
+            ['foo' => 'foo', 'bar' => 'bar', 'quux' => 'quux', 'kevin' => 'Kevin', 'coopTilleuls' => 'coop', 'fooBar' => null, 'symfony' => null, 'baz' => 'baz'],
             $this->normalizer->normalize($group, 'any')
         );
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3 for bug fixes 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 
| Tickets       | Fix https://github.com/symfony/symfony/issues/43207
| License       | MIT
| Doc PR        | 


