### PR TITLE
[Serializer] ensure ChainEncoder/ChainDecoder properly consider the context

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
@@ -59,7 +59,7 @@ class ChainDecoder implements ContextAwareDecoderInterface
      *
      * @throws RuntimeException if no decoder is found
      */
-    public function getDecoder(string $format, array $context): DecoderInterface
+    private function getDecoder(string $format, array $context): DecoderInterface
     {
         $hasContext = 0 < \count($context);
         if (

--- a/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
@@ -63,7 +63,7 @@ class ChainDecoder implements ContextAwareDecoderInterface
     {
         $hasContext = 0 < \count($context);
         if (
-            $hasContext
+            !$hasContext
             && isset($this->decoderByFormat[$format])
             && isset($this->decoders[$this->decoderByFormat[$format]])
         ) {
@@ -72,7 +72,7 @@ class ChainDecoder implements ContextAwareDecoderInterface
 
         foreach ($this->decoders as $i => $decoder) {
             if ($decoder->supportsDecoding($format, $context)) {
-                if ($hasContext) {
+                if (!$hasContext) {
                     // cache decoder if no dynamic context is given
                     $this->decoderByFormat[$format] = $i;
                 }

--- a/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
@@ -63,7 +63,7 @@ class ChainDecoder implements ContextAwareDecoderInterface
     {
         $hasContext = 0 < \count($context);
         if (
-            true !== $hasContext
+            $hasContext
             && isset($this->decoderByFormat[$format])
             && isset($this->decoders[$this->decoderByFormat[$format]])
         ) {
@@ -72,7 +72,7 @@ class ChainDecoder implements ContextAwareDecoderInterface
 
         foreach ($this->decoders as $i => $decoder) {
             if ($decoder->supportsDecoding($format, $context)) {
-                if (true !== $hasContext) {
+                if ($hasContext) {
                     // cache decoder if no dynamic context is given
                     $this->decoderByFormat[$format] = $i;
                 }

--- a/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainDecoder.php
@@ -25,7 +25,6 @@ use Symfony\Component\Serializer\Exception\RuntimeException;
 class ChainDecoder implements ContextAwareDecoderInterface
 {
     protected $decoders = [];
-    protected $decoderByFormat = [];
 
     public function __construct(array $decoders = [])
     {
@@ -59,18 +58,10 @@ class ChainDecoder implements ContextAwareDecoderInterface
      *
      * @throws RuntimeException if no decoder is found
      */
-    private function getDecoder(string $format, array $context): DecoderInterface
+    public function getDecoder(string $format, array $context): DecoderInterface
     {
-        if (isset($this->decoderByFormat[$format])
-            && isset($this->decoders[$this->decoderByFormat[$format]])
-        ) {
-            return $this->decoders[$this->decoderByFormat[$format]];
-        }
-
         foreach ($this->decoders as $i => $decoder) {
             if ($decoder->supportsDecoding($format, $context)) {
-                $this->decoderByFormat[$format] = $i;
-
                 return $decoder;
             }
         }

--- a/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
@@ -77,7 +77,7 @@ class ChainEncoder implements ContextAwareEncoderInterface
      *
      * @throws RuntimeException if no encoder is found
      */
-    public function getEncoder(string $format, array $context): EncoderInterface
+    private function getEncoder(string $format, array $context): EncoderInterface
     {
         $hasContext = 0 < \count($context);
         if (

--- a/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
@@ -81,7 +81,7 @@ class ChainEncoder implements ContextAwareEncoderInterface
     {
         $hasContext = 0 < \count($context);
         if (
-            true !== $hasContext
+            $hasContext
             && isset($this->encoderByFormat[$format])
             && isset($this->encoders[$this->encoderByFormat[$format]])
         ) {
@@ -90,7 +90,7 @@ class ChainEncoder implements ContextAwareEncoderInterface
 
         foreach ($this->encoders as $i => $encoder) {
             if ($encoder->supportsEncoding($format, $context)) {
-                if (true !== $hasContext) {
+                if ($hasContext) {
                     // cache encoder if no dynamic context is given
                     $this->encoderByFormat[$format] = $i;
                 }

--- a/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
@@ -81,7 +81,7 @@ class ChainEncoder implements ContextAwareEncoderInterface
     {
         $hasContext = 0 < \count($context);
         if (
-            $hasContext
+            !$hasContext
             && isset($this->encoderByFormat[$format])
             && isset($this->encoders[$this->encoderByFormat[$format]])
         ) {
@@ -90,7 +90,7 @@ class ChainEncoder implements ContextAwareEncoderInterface
 
         foreach ($this->encoders as $i => $encoder) {
             if ($encoder->supportsEncoding($format, $context)) {
-                if ($hasContext) {
+                if (!$hasContext) {
                     // cache encoder if no dynamic context is given
                     $this->encoderByFormat[$format] = $i;
                 }

--- a/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/ChainEncoder.php
@@ -25,7 +25,6 @@ use Symfony\Component\Serializer\Exception\RuntimeException;
 class ChainEncoder implements ContextAwareEncoderInterface
 {
     protected $encoders = [];
-    protected $encoderByFormat = [];
 
     public function __construct(array $encoders = [])
     {
@@ -77,18 +76,10 @@ class ChainEncoder implements ContextAwareEncoderInterface
      *
      * @throws RuntimeException if no encoder is found
      */
-    private function getEncoder(string $format, array $context): EncoderInterface
+    public function getEncoder(string $format, array $context): EncoderInterface
     {
-        if (isset($this->encoderByFormat[$format])
-            && isset($this->encoders[$this->encoderByFormat[$format]])
-        ) {
-            return $this->encoders[$this->encoderByFormat[$format]];
-        }
-
         foreach ($this->encoders as $i => $encoder) {
             if ($encoder->supportsEncoding($format, $context)) {
-                $this->encoderByFormat[$format] = $i;
-
                 return $encoder;
             }
         }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
@@ -36,6 +36,7 @@ class ChainDecoderTest extends TestCase
                 [self::FORMAT_2, [], false],
                 [self::FORMAT_3, [], false],
                 [self::FORMAT_3, ['foo' => 'bar'], true],
+                [self::FORMAT_3, ['foo' => 'bar2'], false],
             ]);
 
         $this->decoder2 = $this->createMock(DecoderInterface::class);
@@ -45,6 +46,8 @@ class ChainDecoderTest extends TestCase
                 [self::FORMAT_1, [], false],
                 [self::FORMAT_2, [], true],
                 [self::FORMAT_3, [], false],
+                [self::FORMAT_3, ['foo' => 'bar'], false],
+                [self::FORMAT_3, ['foo' => 'bar2'], true],
             ]);
 
         $this->chainDecoder = new ChainDecoder([$this->decoder1, $this->decoder2]);
@@ -53,9 +56,18 @@ class ChainDecoderTest extends TestCase
     public function testSupportsDecoding()
     {
         $this->assertTrue($this->chainDecoder->supportsDecoding(self::FORMAT_1));
+        $this->assertSame($this->decoder1, $this->chainDecoder->getDecoder(self::FORMAT_1, []));
+
         $this->assertTrue($this->chainDecoder->supportsDecoding(self::FORMAT_2));
+        $this->assertSame($this->decoder2, $this->chainDecoder->getDecoder(self::FORMAT_2, []));
+
         $this->assertFalse($this->chainDecoder->supportsDecoding(self::FORMAT_3));
+
         $this->assertTrue($this->chainDecoder->supportsDecoding(self::FORMAT_3, ['foo' => 'bar']));
+        $this->assertSame($this->decoder1, $this->chainDecoder->getDecoder(self::FORMAT_3, ['foo' => 'bar']));
+
+        $this->assertTrue($this->chainDecoder->supportsDecoding(self::FORMAT_3, ['foo' => 'bar2']));
+        $this->assertSame($this->decoder2, $this->chainDecoder->getDecoder(self::FORMAT_3, ['foo' => 'bar2']));
     }
 
     public function testDecode()

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainDecoderTest.php
@@ -55,19 +55,26 @@ class ChainDecoderTest extends TestCase
 
     public function testSupportsDecoding()
     {
+        $this->decoder1
+            ->method('decode')
+            ->willReturn('result1');
+        $this->decoder2
+            ->method('decode')
+            ->willReturn('result2');
+
         $this->assertTrue($this->chainDecoder->supportsDecoding(self::FORMAT_1));
-        $this->assertSame($this->decoder1, $this->chainDecoder->getDecoder(self::FORMAT_1, []));
+        $this->assertEquals('result1', $this->chainDecoder->decode('', self::FORMAT_1, []));
 
         $this->assertTrue($this->chainDecoder->supportsDecoding(self::FORMAT_2));
-        $this->assertSame($this->decoder2, $this->chainDecoder->getDecoder(self::FORMAT_2, []));
+        $this->assertEquals('result2', $this->chainDecoder->decode('', self::FORMAT_2, []));
 
         $this->assertFalse($this->chainDecoder->supportsDecoding(self::FORMAT_3));
 
         $this->assertTrue($this->chainDecoder->supportsDecoding(self::FORMAT_3, ['foo' => 'bar']));
-        $this->assertSame($this->decoder1, $this->chainDecoder->getDecoder(self::FORMAT_3, ['foo' => 'bar']));
+        $this->assertEquals('result1', $this->chainDecoder->decode('', self::FORMAT_3, ['foo' => 'bar']));
 
         $this->assertTrue($this->chainDecoder->supportsDecoding(self::FORMAT_3, ['foo' => 'bar2']));
-        $this->assertSame($this->decoder2, $this->chainDecoder->getDecoder(self::FORMAT_3, ['foo' => 'bar2']));
+        $this->assertEquals('result2', $this->chainDecoder->decode('', self::FORMAT_3, ['foo' => 'bar2']));
     }
 
     public function testDecode()

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
@@ -37,6 +37,7 @@ class ChainEncoderTest extends TestCase
                 [self::FORMAT_2, [], false],
                 [self::FORMAT_3, [], false],
                 [self::FORMAT_3, ['foo' => 'bar'], true],
+                [self::FORMAT_3, ['foo' => 'bar2'], false],
             ]);
 
         $this->encoder2 = $this->createMock(EncoderInterface::class);
@@ -46,6 +47,8 @@ class ChainEncoderTest extends TestCase
                 [self::FORMAT_1, [], false],
                 [self::FORMAT_2, [], true],
                 [self::FORMAT_3, [], false],
+                [self::FORMAT_3, ['foo' => 'bar'], false],
+                [self::FORMAT_3, ['foo' => 'bar2'], true],
             ]);
 
         $this->chainEncoder = new ChainEncoder([$this->encoder1, $this->encoder2]);
@@ -54,9 +57,18 @@ class ChainEncoderTest extends TestCase
     public function testSupportsEncoding()
     {
         $this->assertTrue($this->chainEncoder->supportsEncoding(self::FORMAT_1));
+        $this->assertSame($this->encoder1, $this->chainEncoder->getEncoder(self::FORMAT_1, []));
+
         $this->assertTrue($this->chainEncoder->supportsEncoding(self::FORMAT_2));
+        $this->assertSame($this->encoder2, $this->chainEncoder->getEncoder(self::FORMAT_2, []));
+
         $this->assertFalse($this->chainEncoder->supportsEncoding(self::FORMAT_3));
+
         $this->assertTrue($this->chainEncoder->supportsEncoding(self::FORMAT_3, ['foo' => 'bar']));
+        $this->assertSame($this->encoder1, $this->chainEncoder->getEncoder(self::FORMAT_3, ['foo' => 'bar']));
+
+        $this->assertTrue($this->chainEncoder->supportsEncoding(self::FORMAT_3, ['foo' => 'bar2']));
+        $this->assertSame($this->encoder2, $this->chainEncoder->getEncoder(self::FORMAT_3, ['foo' => 'bar2']));
     }
 
     public function testEncode()

--- a/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/ChainEncoderTest.php
@@ -56,19 +56,26 @@ class ChainEncoderTest extends TestCase
 
     public function testSupportsEncoding()
     {
+        $this->encoder1
+            ->method('encode')
+            ->willReturn('result1');
+        $this->encoder2
+            ->method('encode')
+            ->willReturn('result2');
+
         $this->assertTrue($this->chainEncoder->supportsEncoding(self::FORMAT_1));
-        $this->assertSame($this->encoder1, $this->chainEncoder->getEncoder(self::FORMAT_1, []));
+        $this->assertEquals('result1', $this->chainEncoder->encode('', self::FORMAT_1, []));
 
         $this->assertTrue($this->chainEncoder->supportsEncoding(self::FORMAT_2));
-        $this->assertSame($this->encoder2, $this->chainEncoder->getEncoder(self::FORMAT_2, []));
+        $this->assertEquals('result2', $this->chainEncoder->encode('', self::FORMAT_2, []));
 
         $this->assertFalse($this->chainEncoder->supportsEncoding(self::FORMAT_3));
 
         $this->assertTrue($this->chainEncoder->supportsEncoding(self::FORMAT_3, ['foo' => 'bar']));
-        $this->assertSame($this->encoder1, $this->chainEncoder->getEncoder(self::FORMAT_3, ['foo' => 'bar']));
+        $this->assertEquals('result1', $this->chainEncoder->encode('', self::FORMAT_3, ['foo' => 'bar']));
 
         $this->assertTrue($this->chainEncoder->supportsEncoding(self::FORMAT_3, ['foo' => 'bar2']));
-        $this->assertSame($this->encoder2, $this->chainEncoder->getEncoder(self::FORMAT_3, ['foo' => 'bar2']));
+        $this->assertEquals('result2', $this->chainEncoder->encode('', self::FORMAT_3, ['foo' => 'bar2']));
     }
 
     public function testEncode()


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #38270 
| License       | MIT
| Doc PR        | -

This PR removes the "caching" of encoder/decoder instances in a chain so they are re-evaluated for each single call.

The corresponding tests are extended to perform multiple calls with different context arrays. Also they now check not only if encoding/decoding is supported, but also that the responsible encoder/decoder instance is the correct (expected) one.

/cc @xabbuh 