### PR TITLE
[Security] Add alias for FirewallMapInterface to @security.firewall.map

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -48,6 +48,7 @@ use Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Security\Http\Controller\UserValueResolver;
 use Symfony\Component\Security\Http\Firewall;
+use Symfony\Component\Security\Http\FirewallMapInterface;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\Impersonate\ImpersonateUrlGenerator;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
@@ -188,6 +189,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('Firewall context locator'),
                 abstract_arg('Request matchers'),
             ])
+        ->alias(FirewallMapInterface::class, 'security.firewall.map')
 
         ->set('security.firewall.context', FirewallContext::class)
             ->abstract()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

refs: https://symfony.com/blog/new-in-symfony-3-2-firewall-config-class-and-profiler