### PR TITLE
[PhpUnitBridge] Do not override correct triggering file for return type deprecations

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -87,7 +87,7 @@ class Deprecation
                     $this->getOriginalFilesStack();
                     array_splice($this->originalFilesStack, 0, $j, [$this->triggeringFile]);
 
-                    if (preg_match('/(?|"([^"]++)" that is deprecated|should implement method "(?:static )?([^:]++))/', $message, $m) || preg_match('/^(?:The|Method) "([^":]++)/', $message, $m)) {
+                    if (preg_match('/(?|"([^"]++)" that is deprecated|should implement method "(?:static )?([^:]++))/', $message, $m) || (false === strpos($message, 'native return type declaration') && preg_match('/^(?:The|Method) "([^":]++)/', $message, $m))) {
                         $this->triggeringFile = (new \ReflectionClass($m[1]))->getFileName();
                         array_unshift($this->originalFilesStack, $this->triggeringFile);
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Return type deprecations were sometimes incorrectly marked as direct/indirect, even when they occur on a vendor package. This is due to their special message, which starts with `Method "classFromVendor::method()" might add "type" [...] do the same in "affectedClass" [...]` (normal messages start with the affected class).

This means that the deprecation type checked whether the method causing the deprecation was inside the vendor directory, rather than the method affected by the deprecation. Even more, if the causing method was from PHP internals, `$this->triggeringFile` would become `false`, causing `realpath(false)` to return the current directory - meaning these were always marked as direct.