### PR TITLE
Add return types to HttpCache createSurrogate and createStore methods

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -83,11 +83,17 @@ class HttpCache extends BaseHttpCache
         return [];
     }
 
+    /**
+     * @return SurrogateInterface
+     */
     protected function createSurrogate()
     {
         return $this->surrogate ?? new Esi();
     }
 
+    /**
+     * @return StoreInterface
+     */
     protected function createStore()
     {
         return $this->store ?? new Store($this->cacheDir ?: $this->kernel->getCacheDir().'/http_cache');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Add missing return types for protected HttpCache methods.
