### PR TITLE
[Serializer] serialize method return type can also be array

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/SerializerRuntime.php
+++ b/src/Symfony/Bridge/Twig/Extension/SerializerRuntime.php
@@ -26,7 +26,7 @@ final class SerializerRuntime implements RuntimeExtensionInterface
         $this->serializer = $serializer;
     }
 
-    public function serialize($data, string $format = 'json', array $context = []): string
+    public function serialize($data, string $format = 'json', array $context = [])
     {
         return $this->serializer->serialize($data, $format, $context);
     }

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -124,7 +124,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
     /**
      * {@inheritdoc}
      */
-    final public function serialize($data, string $format, array $context = []): string
+    final public function serialize($data, string $format, array $context = [])
     {
         if (!$this->supportsEncoding($format, $context)) {
             throw new NotEncodableValueException(sprintf('Serialization for the format "%s" is not supported.', $format));

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -23,7 +23,7 @@ interface SerializerInterface
      * @param string $format  Format name
      * @param array  $context Options normalizers/encoders have access to
      *
-     * @return string
+     * @return string|array
      */
     public function serialize($data, string $format, array $context = []);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The serialize method return type isn't string if format param is array. It can be both string and array


