### PR TITLE
[Mime] Fix attached inline part not related

### DIFF
--- a/src/Symfony/Component/Mime/Email.php
+++ b/src/Symfony/Component/Mime/Email.php
@@ -480,6 +480,12 @@ class Email extends Message
         foreach ($this->attachments as $attachment) {
             foreach ($names as $name) {
                 if (isset($attachment['part'])) {
+                    if ('inline' === $attachment['part']->getPreparedHeaders()->getHeaderBody('Content-Disposition')) {
+                        $inlineParts[] = $attachment['part'];
+
+                        continue 2;
+                    }
+
                     continue;
                 }
                 if ($name !== $attachment['name']) {

--- a/src/Symfony/Component/Mime/Tests/EmailTest.php
+++ b/src/Symfony/Component/Mime/Tests/EmailTest.php
@@ -344,6 +344,12 @@ class EmailTest extends TestCase
         // 2 parts only, not 3 (text + embedded image once)
         $this->assertCount(2, $parts = $body->getParts());
         $this->assertStringMatchesFormat('html content <img src=3D"cid:%s@symfony">', $parts[0]->bodyToString());
+
+        $e = (new Email())->from('me@example.com')->to('you@example.com');
+        $e->html('html content <img src="cid:test.gif">');
+        $e->attachPart((new DataPart($image, 'test.gif'))->asInline());
+        $body = $e->getBody();
+        $this->assertInstanceOf(RelatedPart::class, $body);
     }
 
     public function testAttachments()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Closes #42921
| License       | MIT
| Doc PR        | -

Attaching an inline `DataPart` to email does not generate a `RelatedPart` when generating body, but only `MixedPart`.

The following code should work the same, but does not:
```php
$email = new Email();
$email->embed($image, 'test.gif');

// vs.

$email = new Email();
$email->attachPart((new DataPart($image, 'test.gif'))->asInline());
```

This PR fixes the behavior.