### PR TITLE
Possibility to configure directory for warmup (kernel.warmup_dir)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -122,7 +122,7 @@ EOF
 
         // the warmup cache dir name must have the same length as the real one
         // to avoid the many problems in serialized resources files
-        if($kernel->getContainer()->hasParameter('kernel.warmup_dir')) {
+        if ($kernel->getContainer()->hasParameter('kernel.warmup_dir')) {
             $warmupDir = $kernel->getContainer()->getParameter('kernel.warmup_dir');
         } else {
             $warmupDir = substr($realBuildDir, 0, -1).('_' === substr($realBuildDir, -1) ? '-' : '_');

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -122,7 +122,11 @@ EOF
 
         // the warmup cache dir name must have the same length as the real one
         // to avoid the many problems in serialized resources files
-        $warmupDir = substr($realBuildDir, 0, -1).('_' === substr($realBuildDir, -1) ? '-' : '_');
+        if($kernel->getContainer()->hasParameter('kernel.warmup_dir')) {
+            $warmupDir = $kernel->getContainer()->getParameter('kernel.warmup_dir');
+        } else {
+            $warmupDir = substr($realBuildDir, 0, -1).('_' === substr($realBuildDir, -1) ? '-' : '_');
+        }
 
         if ($output->isVerbose() && $fs->exists($warmupDir)) {
             $io->comment('Clearing outdated warmup directory...');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

This PR adds the possibility to optionally configure the location where the cache warmup should be done. 
#36515 introduced already the possibility to have a custom build location, but sometimes it would be also very handy to change the warmup directory as well, especially if you're on a network filesystem such as NFS. 
Then you could point the `kernel.warmup_dir` e.g. to `/tmp/symfony-warmup` where the build is much faster. 

