### PR TITLE
[FrameworkBundle][TwigBundle] Conflict with service-contracts >= 3

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -89,6 +89,7 @@
         "symfony/property-info": "<4.4",
         "symfony/property-access": "<5.3",
         "symfony/serializer": "<5.2",
+        "symfony/service-contracts": ">=3.0",
         "symfony/security-csrf": "<5.3",
         "symfony/stopwatch": "<4.4",
         "symfony/translation": "<5.3",

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -43,6 +43,7 @@
     "conflict": {
         "symfony/dependency-injection": "<5.3",
         "symfony/framework-bundle": "<5.0",
+        "symfony/service-contracts": ">=3.0",
         "symfony/translation": "<5.0"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Because some of their `getSubscribedServices()` are missing a return type in 5.4.