### PR TITLE
[HttpKernel] Relax some transient tests

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -18,9 +18,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
 
-/**
- * @group time-sensitive
- */
 class FragmentHandlerTest extends TestCase
 {
     private $requestStack;
@@ -61,7 +58,20 @@ class FragmentHandlerTest extends TestCase
 
     public function testRender()
     {
-        $handler = $this->getHandler($this->returnValue(new Response('foo')), ['/', Request::create('/'), ['foo' => 'foo', 'ignore_errors' => true]]);
+        $expectedRequest = Request::create('/');
+        $handler = $this->getHandler(
+            $this->returnValue(new Response('foo')),
+            [
+                '/',
+                $this->callback(function (Request $request) use ($expectedRequest) {
+                    $expectedRequest->server->remove('REQUEST_TIME_FLOAT');
+                    $request->server->remove('REQUEST_TIME_FLOAT');
+
+                    return $expectedRequest == $request;
+                }),
+                ['foo' => 'foo', 'ignore_errors' => true],
+            ]
+        );
 
         $this->assertEquals('foo', $handler->render('/', 'foo', ['foo' => 'foo']));
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -261,13 +261,18 @@ class InlineFragmentRendererTest extends TestCase
     /**
      * Creates a Kernel expecting a request equals to $request.
      */
-    private function getKernelExpectingRequest(Request $request, $strict = false)
+    private function getKernelExpectingRequest(Request $expectedRequest)
     {
         $kernel = $this->createMock(HttpKernelInterface::class);
         $kernel
             ->expects($this->once())
             ->method('handle')
-            ->with($request)
+            ->with($this->callback(function (Request $request) use ($expectedRequest) {
+                $expectedRequest->server->remove('REQUEST_TIME_FLOAT');
+                $request->server->remove('REQUEST_TIME_FLOAT');
+
+                return $expectedRequest == $request;
+            }))
             ->willReturn(new Response('foo'));
 
         return $kernel;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

As observed in #42824 and more recently #43138, these tests randomly break for some reason.
Replaces #42824
