### PR TITLE
Work in progress - Allow signature generation when methods use new in initializers

### DIFF
--- a/src/Symfony/Component/Config/Tests/Resource/ReflectionClassResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ReflectionClassResourceTest.php
@@ -162,6 +162,10 @@ EOPHP;
             yield [false, 9, 'private string $priv;'];
         }
 
+        if (\PHP_VERSION_ID >= 80100) {
+            yield [true, 17, 'public function ccc($bar = new \stdClass()) {}'];
+        }
+
         yield [true, 17, 'public function ccc($bar = 187) {}'];
         yield [true, 17, 'public function ccc($bar = ANOTHER_ONE_THAT_WILL_NEVER_BE_DEFINED_CCCCCCCCC) {}'];
         yield [true, 17, 'public function ccc($bar = parent::BOOM) {}'];


### PR DESCRIPTION
This makes the tests running in PHP 8.1 fail because the strategy
to generate signatures won't work when used with the new in
initializers syntax.

| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/43260
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
