### PR TITLE
[Config] Fix signature generation with nested attributes on PHP 8.1

### DIFF
--- a/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
+++ b/src/Symfony/Component/Config/Resource/ReflectionClassResource.php
@@ -122,7 +122,7 @@ class ReflectionClassResource implements SelfCheckingResourceInterface
         if (\PHP_VERSION_ID >= 80000) {
             $attributes = [];
             foreach ($class->getAttributes() as $a) {
-                $attributes[] = [$a->getName(), $a->getArguments()];
+                $attributes[] = [$a->getName(), \PHP_VERSION_ID >= 80100 ? (string) $a : $a->getArguments()];
             }
             yield print_r($attributes, true);
             $attributes = [];
@@ -146,7 +146,7 @@ class ReflectionClassResource implements SelfCheckingResourceInterface
             foreach ($class->getProperties(\ReflectionProperty::IS_PUBLIC | \ReflectionProperty::IS_PROTECTED) as $p) {
                 if (\PHP_VERSION_ID >= 80000) {
                     foreach ($p->getAttributes() as $a) {
-                        $attributes[] = [$a->getName(), $a->getArguments()];
+                        $attributes[] = [$a->getName(), \PHP_VERSION_ID >= 80100 ? (string) $a : $a->getArguments()];
                     }
                     yield print_r($attributes, true);
                     $attributes = [];
@@ -166,7 +166,7 @@ class ReflectionClassResource implements SelfCheckingResourceInterface
         foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_PROTECTED) as $m) {
             if (\PHP_VERSION_ID >= 80000) {
                 foreach ($m->getAttributes() as $a) {
-                    $attributes[] = [$a->getName(), $a->getArguments()];
+                    $attributes[] = [$a->getName(), \PHP_VERSION_ID >= 80100 ? (string) $a : $a->getArguments()];
                 }
                 yield print_r($attributes, true);
                 $attributes = [];
@@ -177,7 +177,7 @@ class ReflectionClassResource implements SelfCheckingResourceInterface
             foreach ($m->getParameters() as $p) {
                 if (\PHP_VERSION_ID >= 80000) {
                     foreach ($p->getAttributes() as $a) {
-                        $attributes[] = [$a->getName(), $a->getArguments()];
+                        $attributes[] = [$a->getName(), \PHP_VERSION_ID >= 80100 ? (string) $a : $a->getArguments()];
                     }
                     yield print_r($attributes, true);
                     $attributes = [];
@@ -185,6 +185,12 @@ class ReflectionClassResource implements SelfCheckingResourceInterface
 
                 if (!$p->isDefaultValueAvailable()) {
                     $defaults[$p->name] = null;
+
+                    continue;
+                }
+
+                if (\PHP_VERSION_ID >= 80100) {
+                    $defaults[$p->name] = (string) $p;
 
                     continue;
                 }

--- a/src/Symfony/Component/Config/Tests/Resource/ReflectionClassResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/ReflectionClassResourceTest.php
@@ -126,6 +126,10 @@ EOPHP;
             yield [true, 0, '#[Foo]'];
         }
 
+        if (\PHP_VERSION_ID >= 80100) {
+            yield [true, 0, '#[Foo(new MissingClass)]'];
+        }
+
         yield [true, 1, 'abstract class %s'];
         yield [true, 1, 'final class %s'];
         yield [true, 1, 'class %s extends Exception'];
@@ -135,6 +139,11 @@ EOPHP;
         yield [true, 4, '/** pub docblock */'];
         yield [true, 5, 'protected $pub = [];'];
         yield [true, 5, 'public $pub = [123];'];
+
+        if (\PHP_VERSION_ID >= 80100) {
+            yield [true, 5, '#[Foo(new MissingClass)] public $pub = [];'];
+        }
+
         yield [true, 6, '/** prot docblock */'];
         yield [true, 7, 'private $prot;'];
         yield [false, 8, '/** priv docblock */'];
@@ -151,6 +160,11 @@ EOPHP;
             yield [true, 13, 'protected function prot(#[Foo] $a = []) {}'];
         }
 
+        if (\PHP_VERSION_ID >= 80100) {
+            yield [true, 13, '#[Foo(new MissingClass)] protected function prot($a = []) {}'];
+            yield [true, 13, 'protected function prot(#[Foo(new MissingClass)] $a = []) {}'];
+        }
+
         yield [false, 14, '/** priv docblock */'];
         yield [false, 15, ''];
 
@@ -162,10 +176,16 @@ EOPHP;
             yield [false, 9, 'private string $priv;'];
         }
 
+        if (\PHP_VERSION_ID >= 80100) {
+            yield [true, 17, 'public function __construct(private $bar = new \stdClass()) {}'];
+            yield [true, 17, 'public function ccc($bar = new \stdClass()) {}'];
+            yield [true, 17, 'public function ccc($bar = new MissingClass()) {}'];
+        }
+
         yield [true, 17, 'public function ccc($bar = 187) {}'];
         yield [true, 17, 'public function ccc($bar = ANOTHER_ONE_THAT_WILL_NEVER_BE_DEFINED_CCCCCCCCC) {}'];
         yield [true, 17, 'public function ccc($bar = parent::BOOM) {}'];
-        yield [true, 17, null, static function () { \define('A_CONSTANT_THAT_FOR_SURE_WILL_NEVER_BE_DEFINED_CCCCCC', 'foo'); }];
+        yield [\PHP_VERSION_ID < 80100, 17, null, static function () { \define('A_CONSTANT_THAT_FOR_SURE_WILL_NEVER_BE_DEFINED_CCCCCC', 'foo'); }];
     }
 
     public function testEventSubscriber()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix https://github.com/symfony/symfony/issues/43260, part of #41552
| License       | MIT
| Doc PR        | -

This fix allows the new PHP 8.1 syntax of [new in initializers](https://wiki.php.net/rfc/new_in_initializers)

It allows the method signature to be inferred from the object that is the default parameter value.
