### PR TITLE
[DependencyInjection] Move `array_merge` calls out of loops

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1280,10 +1280,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     {
         $tags = [];
         foreach ($this->getDefinitions() as $id => $definition) {
-            $tags = array_merge(array_keys($definition->getTags()), $tags);
+            $tags[] = array_keys($definition->getTags());
         }
 
-        return array_unique($tags);
+        return array_unique(array_merge([], ...$tags));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -130,23 +130,22 @@ class GraphvizDumper extends Dumper
                     $lazyEdge = $lazy || $this->container->getDefinition((string) $argument)->isLazy();
                 }
 
-                $edges[] = ['name' => $name, 'required' => $required, 'to' => $argument, 'lazy' => $lazyEdge];
+                $edges[] = [['name' => $name, 'required' => $required, 'to' => $argument, 'lazy' => $lazyEdge]];
             } elseif ($argument instanceof ArgumentInterface) {
-                $edges = array_merge($edges, $this->findEdges($id, $argument->getValues(), $required, $name, true));
+                $edges[] = $this->findEdges($id, $argument->getValues(), $required, $name, true);
             } elseif ($argument instanceof Definition) {
-                $edges = array_merge($edges,
-                    $this->findEdges($id, $argument->getArguments(), $required, ''),
-                    $this->findEdges($id, $argument->getProperties(), false, '')
-                );
+                $edges[] = $this->findEdges($id, $argument->getArguments(), $required, '');
+                $edges[] = $this->findEdges($id, $argument->getProperties(), false, '');
+
                 foreach ($argument->getMethodCalls() as $call) {
-                    $edges = array_merge($edges, $this->findEdges($id, $call[1], false, $call[0].'()'));
+                    $edges[] = $this->findEdges($id, $call[1], false, $call[0].'()');
                 }
             } elseif (\is_array($argument)) {
-                $edges = array_merge($edges, $this->findEdges($id, $argument, $required, $name, $lazy));
+                $edges[] = $this->findEdges($id, $argument, $required, $name, $lazy);
             }
         }
 
-        return $edges;
+        return array_merge([], ...$edges);
     }
 
     private function findNodes(): array

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -1753,6 +1753,18 @@ class ContainerBuilderTest extends TestCase
 
         $this->addToAssertionCount(1);
     }
+
+    public function testReferencingDeprecatedPublicService2()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register(A::class)
+            ->addTag('tag1')
+            ->addTag('tag2')
+            ->addTag('tag3');
+
+        $this->assertSame(['tag1', 'tag2', 'tag3'], $container->findTags());
+    }
 }
 
 class FooClass


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License | MIT

See https://github.com/symfony/symfony/pull/43268#issuecomment-932056954 for a small performance benchmark.