### PR TITLE
[DependencyInjection] fix support for "new" in initializers on PHP 8.1

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckArgumentsValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckArgumentsValidityPass.php
@@ -39,7 +39,13 @@ class CheckArgumentsValidityPass extends AbstractRecursivePass
         }
 
         $i = 0;
+        $hasNamedArgs = false;
         foreach ($value->getArguments() as $k => $v) {
+            if (\PHP_VERSION_ID >= 80000 && preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $k)) {
+                $hasNamedArgs = true;
+                continue;
+            }
+
             if ($k !== $i++) {
                 if (!\is_int($k)) {
                     $msg = sprintf('Invalid constructor argument for service "%s": integer expected but found string "%s". Check your service definition.', $this->currentId, $k);
@@ -57,11 +63,27 @@ class CheckArgumentsValidityPass extends AbstractRecursivePass
                     throw new RuntimeException($msg);
                 }
             }
+
+            if ($hasNamedArgs) {
+                $msg = sprintf('Invalid constructor argument for service "%s": cannot use positional argument after named argument. Check your service definition.', $this->currentId);
+                $value->addError($msg);
+                if ($this->throwExceptions) {
+                    throw new RuntimeException($msg);
+                }
+
+                break;
+            }
         }
 
         foreach ($value->getMethodCalls() as $methodCall) {
             $i = 0;
+            $hasNamedArgs = false;
             foreach ($methodCall[1] as $k => $v) {
+                if (\PHP_VERSION_ID >= 80000 && preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $k)) {
+                    $hasNamedArgs = true;
+                    continue;
+                }
+
                 if ($k !== $i++) {
                     if (!\is_int($k)) {
                         $msg = sprintf('Invalid argument for method call "%s" of service "%s": integer expected but found string "%s". Check your service definition.', $methodCall[0], $this->currentId, $k);
@@ -78,6 +100,16 @@ class CheckArgumentsValidityPass extends AbstractRecursivePass
                     if ($this->throwExceptions) {
                         throw new RuntimeException($msg);
                     }
+                }
+
+                if ($hasNamedArgs) {
+                    $msg = sprintf('Invalid argument for method call "%s" of service "%s": cannot use positional argument after named argument. Check your service definition.', $methodCall[0], $this->currentId);
+                    $value->addError($msg);
+                    if ($this->throwExceptions) {
+                        throw new RuntimeException($msg);
+                    }
+
+                    break;
                 }
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -124,7 +124,7 @@ class InlineServiceDefinitionsPass extends AbstractRecursivePass implements Repe
     protected function processValue($value, $isRoot = false)
     {
         if ($value instanceof ArgumentInterface) {
-            // Reference found in ArgumentInterface::getValues() are not inlineable
+            // References found in ArgumentInterface::getValues() are not inlineable
             return $value;
         }
 

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -714,8 +714,8 @@ EOF;
         $calls = '';
         foreach ($definition->getMethodCalls() as $k => $call) {
             $arguments = [];
-            foreach ($call[1] as $value) {
-                $arguments[] = $this->dumpValue($value);
+            foreach ($call[1] as $i => $value) {
+                $arguments[] = (\is_string($i) ? $i.': ' : '').$this->dumpValue($value);
             }
 
             $witherAssignation = '';
@@ -1080,8 +1080,8 @@ EOTXT
         }
 
         $arguments = [];
-        foreach ($definition->getArguments() as $value) {
-            $arguments[] = $this->dumpValue($value);
+        foreach ($definition->getArguments() as $i => $value) {
+            $arguments[] = (\is_string($i) ? $i.': ' : '').$this->dumpValue($value);
         }
 
         if (null !== $definition->getFactory()) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckArgumentsValidityPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckArgumentsValidityPassTest.php
@@ -46,22 +46,22 @@ class CheckArgumentsValidityPassTest extends TestCase
      */
     public function testException(array $arguments, array $methodCalls)
     {
-        $this->expectException(RuntimeException::class);
         $container = new ContainerBuilder();
         $definition = $container->register('foo');
         $definition->setArguments($arguments);
         $definition->setMethodCalls($methodCalls);
 
         $pass = new CheckArgumentsValidityPass();
+        $this->expectException(RuntimeException::class);
         $pass->process($container);
     }
 
     public function definitionProvider()
     {
         return [
-            [[null, 'a' => 'a'], []],
+            [['a' => 'a', null], []],
             [[1 => 1], []],
-            [[], [['baz', [null, 'a' => 'a']]]],
+            [[], [['baz', ['a' => 'a', null]]]],
             [[], [['baz', [1 => 1]]]],
         ];
     }
@@ -70,7 +70,7 @@ class CheckArgumentsValidityPassTest extends TestCase
     {
         $container = new ContainerBuilder();
         $definition = $container->register('foo');
-        $definition->setArguments([null, 'a' => 'a']);
+        $definition->setArguments(['a' => 'a', null]);
 
         $pass = new CheckArgumentsValidityPass(false);
         $pass->process($container);

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -42,6 +42,7 @@ use Symfony\Component\DependencyInjection\Tests\Compiler\Wither;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\CustomDefinition;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooClassWithEnumAttribute;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\FooUnitEnum;
+use Symfony\Component\DependencyInjection\Tests\Fixtures\NewInInitializer;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\ScalarFactory;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\StubbedTranslator;
 use Symfony\Component\DependencyInjection\Tests\Fixtures\TestDefinition1;
@@ -1185,6 +1186,24 @@ class PhpDumperTest extends TestCase
         $container = new \Symfony_DI_PhpDumper_Test_Object_Class_Name();
 
         $this->assertInstanceOf(\stdClass::class, $container->get('bar'));
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testNewInInitializer()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo', NewInInitializer::class)
+            ->setPublic(true)
+            ->setAutowired(true)
+            ->setArguments(['$bar' => 234]);
+
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        $this->assertStringEqualsFile(self::$fixturesPath.'/php/services_new_in_initializer.php', $dumper->dump());
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/NewInInitializer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/NewInInitializer.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Tests\Fixtures;
+
+class NewInInitializer
+{
+    public function __construct($foo = new \stdClass(), $bar = 123)
+    {
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_new_in_initializer.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services_new_in_initializer.php
@@ -1,0 +1,59 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+
+/**
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ *
+ * @final
+ */
+class ProjectServiceContainer extends Container
+{
+    private $parameters = [];
+
+    public function __construct()
+    {
+        $this->services = $this->privates = [];
+        $this->methodMap = [
+            'foo' => 'getFooService',
+        ];
+
+        $this->aliases = [];
+    }
+
+    public function compile(): void
+    {
+        throw new LogicException('You cannot compile a dumped container that was already compiled.');
+    }
+
+    public function isCompiled(): bool
+    {
+        return true;
+    }
+
+    public function getRemovedIds(): array
+    {
+        return [
+            'Psr\\Container\\ContainerInterface' => true,
+            'Symfony\\Component\\DependencyInjection\\ContainerInterface' => true,
+        ];
+    }
+
+    /**
+     * Gets the public 'foo' shared autowired service.
+     *
+     * @return \Symfony\Component\DependencyInjection\Tests\Fixtures\NewInInitializer
+     */
+    protected function getFooService()
+    {
+        return $this->services['foo'] = new \Symfony\Component\DependencyInjection\Tests\Fixtures\NewInInitializer(bar: 234);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Part of #41552
| License       | MIT
| Doc PR        | -