### PR TITLE
[HttpClient] Add method to set response factory in mock client

### DIFF
--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Add `MockHttpClient::setResponseFactory()` method to be able to set response factory after client creating
+
 5.3
 ---
 

--- a/src/Symfony/Component/HttpClient/MockHttpClient.php
+++ b/src/Symfony/Component/HttpClient/MockHttpClient.php
@@ -36,6 +36,15 @@ class MockHttpClient implements HttpClientInterface
      */
     public function __construct($responseFactory = null, ?string $baseUri = 'https://example.com')
     {
+        $this->setResponseFactory($responseFactory);
+        $this->defaultOptions['base_uri'] = $baseUri;
+    }
+
+    /**
+     * @param callable|callable[]|ResponseInterface|ResponseInterface[]|iterable|null $responseFactory
+     */
+    public function setResponseFactory($responseFactory): void
+    {
         if ($responseFactory instanceof ResponseInterface) {
             $responseFactory = [$responseFactory];
         }
@@ -47,7 +56,6 @@ class MockHttpClient implements HttpClientInterface
         }
 
         $this->responseFactory = $responseFactory;
-        $this->defaultOptions['base_uri'] = $baseUri;
     }
 
     /**

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -291,6 +291,7 @@ class MockHttpClientTest extends HttpClientTestCase
             case 'testReentrantBufferCallback':
             case 'testThrowingBufferCallback':
             case 'testInfoOnCanceledResponse':
+            case 'testChangeResponseFactory':
                 $responses[] = new MockResponse($body, ['response_headers' => $headers]);
                 break;
 
@@ -386,5 +387,17 @@ class MockHttpClientTest extends HttpClientTestCase
     public function testHttp2PushVulcainWithUnusedResponse()
     {
         $this->markTestSkipped('MockHttpClient doesn\'t support HTTP/2 PUSH.');
+    }
+
+    public function testChangeResponseFactory()
+    {
+        /* @var MockHttpClient $client */
+        $client = $this->getHttpClient(__METHOD__);
+        $expectedBody = '{"foo": "bar"}';
+        $client->setResponseFactory(new MockResponse($expectedBody));
+
+        $response = $client->request('GET', 'http://localhost:8057');
+
+        $this->assertSame($expectedBody, $response->getContent());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #40620 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#15883 <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
