### PR TITLE
[HttpClient] Fix memory leak in TraceableHttpClient for environments with profiling

### DIFF
--- a/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
+++ b/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php
@@ -39,7 +39,7 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
      */
     public function collect(Request $request, Response $response/*, \Throwable $exception = null*/)
     {
-        $this->reset();
+        $this->resetData();
 
         foreach ($this->clients as $name => $client) {
             [$errorCount, $traces] = $this->collectOnClient($client);
@@ -85,6 +85,14 @@ final class HttpClientDataCollector extends DataCollector implements LateDataCol
     }
 
     public function reset()
+    {
+        $this->resetData();
+        foreach ($this->clients as $client) {
+            $client->reset();
+        }
+    }
+
+    private function resetData()
     {
         $this->data = [
             'clients' => [],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | See description in this PR
| License       | MIT

Each [`DataCollector`](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpKernel/DataCollector/DataCollectorInterface.php) implementation usually holds the Traceable versions of certain interfaces. 
These are used by the profiler to display the traces of calls. For long running processes, this can lead to increased memory usage over time. To prevent memory leakage, the `reset()` method can be called. For example on the [`profiler` service](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpKernel/Profiler/Profiler.php), which holds services tagged with `data_collector`. Which is used by the new [Messenger reset feature](https://github.com/symfony/symfony/pull/41163) as well.

On `reset`, each DataCollector removes it's data from memory, and that of the Traceable classes that it holds. See for example the [`EventDataCollector`](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php#L56). 

Now the [`HttpClientDataCollector`](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpClient/DataCollector/HttpClientDataCollector.php) seems to skip resetting the data of the [`TraceableHttpClient`(s)](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpClient/TraceableHttpClient.php) that it holds. This DataCollector only resets its own data. There doesn't seem to be any other class/service calling `reset` on the [`TraceableHttpClient`](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpClient/TraceableHttpClient.php). Therefor it should probably be done by this DataCollector? Unless there is a specific reason this is skipped, that I'm not aware about that.

I've tested this setup to confirm that without the reset on the clients, the memory keeps increasing, and _with_ the reset being called, the memory no longer increases.

Something else I found curious but might not be related:

```
bin/console debug:container http_client


 // This service is a private alias for the service .debug.http_client

Information for Service ".debug.http_client"
============================================

 ---------------- --------------------------------------------------
  Option           Value                                            
 ---------------- --------------------------------------------------
  Service ID       .debug.http_client
  Class            Symfony\Component\HttpClient\TraceableHttpClient
  Tags             monolog.logger (channel: http_client)
                   http_client.client
...
```

Note the tag `http_client.client` being present. 

Now listing services by that tags gives none:

```
bin/console debug:container --tag http_client.client

Symfony Container Services Tagged with "http_client.client" Tag
===============================================================

 ------------ ------------
  Service ID   Class name 
 ------------ ------------
```

Though the client is injected into [`data_collector.http_client`](https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php#L42), which searches services on that tag as well.
