### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,8 +1,8 @@
 name: Integration
 
 on:
-  push:
-  pull_request:
+  ? push
+  ? pull_request
 
 defaults:
   run:
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.2', '8.0']
+        php: [ '7.2', '8.0' ]
 
     services:
       postgres:
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
 
       - name: Install system dependencies
         run: |
@@ -119,7 +119,7 @@ jobs:
           curl -s -u Administrator:111111 -X POST  http://localhost:8091/pools/default -d 'memoryQuota=256'
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@17ef667e04bd0c8836175514bc8ad08555a31106 # pin@v2
         with:
           coverage: "none"
           extensions: "json,couchbase,memcached,mongodb-1.10.0,redis,rdkafka,xsl,ldap"
@@ -136,7 +136,14 @@ jobs:
         uses: docker://bitnami/openldap
         with:
           entrypoint: /bin/bash
-          args: -c "(/opt/bitnami/openldap/bin/ldapwhoami -H ldap://ldap:3389 -D cn=admin,dc=symfony,dc=com -w symfony||sleep 5) && /opt/bitnami/openldap/bin/ldapadd -H ldap://ldap:3389 -D cn=admin,dc=symfony,dc=com -w symfony -f src/Symfony/Component/Ldap/Tests/Fixtures/data/fixtures.ldif && /opt/bitnami/openldap/bin/ldapdelete -H ldap://ldap:3389 -D cn=admin,dc=symfony,dc=com -w symfony cn=a,ou=users,dc=symfony,dc=com"
+          args: -c "(/opt/bitnami/openldap/bin/ldapwhoami -H ldap://ldap:3389 -D
+            cn=admin,dc=symfony,dc=com -w symfony||sleep 5) &&
+            /opt/bitnami/openldap/bin/ldapadd -H ldap://ldap:3389 -D
+            cn=admin,dc=symfony,dc=com -w symfony -f
+            src/Symfony/Component/Ldap/Tests/Fixtures/data/fixtures.ldif &&
+            /opt/bitnami/openldap/bin/ldapdelete -H ldap://ldap:3389 -D
+            cn=admin,dc=symfony,dc=com -w symfony
+            cn=a,ou=users,dc=symfony,dc=com"
 
       - name: Install dependencies
         run: |
@@ -158,13 +165,15 @@ jobs:
         run: ./phpunit --group integration -v
         env:
           REDIS_HOST: localhost
-          REDIS_CLUSTER_HOSTS: 'localhost:7000 localhost:7001 localhost:7002 localhost:7003 localhost:7004 localhost:7005'
+          REDIS_CLUSTER_HOSTS: 'localhost:7000 localhost:7001 localhost:7002
+            localhost:7003 localhost:7004 localhost:7005'
           REDIS_SENTINEL_HOSTS: 'localhost:26379'
           REDIS_SENTINEL_SERVICE: redis_sentinel
           MESSENGER_REDIS_DSN: redis://127.0.0.1:7006/messages
           MESSENGER_AMQP_DSN: amqp://localhost/%2f/messages
           MESSENGER_SQS_DSN: "sqs://localhost:9494/messages?sslmode=disable&poll_timeout=0.01"
-          MESSENGER_SQS_FIFO_QUEUE_DSN: "sqs://localhost:9494/messages.fifo?sslmode=disable&poll_timeout=0.01"
+          MESSENGER_SQS_FIFO_QUEUE_DSN: "sqs://localhost:9494/messages.fifo?sslmode=disab\
+            le&poll_timeout=0.01"
           MEMCACHED_HOST: localhost
           LDAP_HOST: localhost
           LDAP_PORT: 3389
@@ -180,8 +189,7 @@ jobs:
       #    docker run --rm -e COMPOSER_ROOT_VERSION -v $(pwd):/app -v $(which composer):/usr/local/bin/composer -v $(which vulcain):/usr/local/bin/vulcain -w /app php:8.0-alpine ./phpunit src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php --filter testHttp2Push
       #    sudo rm -rf .phpunit
       #    [ -d .phpunit.bak ] && mv .phpunit.bak .phpunit
-
-      - uses: marceloprado/has-changed-path@v1
+      - uses: marceloprado/has-changed-path@0ffbcfc95a9a2976ba454d8e8687bb49f989f721 # pin@v1
         id: changed-translation-files
         with:
           paths: src/**/Resources/translations/*.xlf

--- a/.github/workflows/intl-data-tests.yml
+++ b/.github/workflows/intl-data-tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
 
       - name: Install system dependencies
         run: |
@@ -37,7 +37,7 @@ jobs:
           echo "SYMFONY_ICU_VERSION=$SYMFONY_ICU_VERSION" >> $GITHUB_ENV
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@17ef667e04bd0c8836175514bc8ad08555a31106 # pin@v2
         with:
           coverage: "none"
           extensions: "zip,intl-${{env.SYMFONY_ICU_VERSION}}"

--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -11,14 +11,19 @@ jobs:
     runs-on: Ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
 
       - name: Fetch branch from where the PR started
-        run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+        run: git fetch --no-tags --prune --depth=1 origin
+          +refs/heads/*:refs/remotes/origin/*
 
       - name: Find packages
         id: find-packages
-        run: echo "::set-output name=packages::$(php .github/get-modified-packages.php $(find src/Symfony -mindepth 2 -type f -name composer.json -printf '%h\n' | jq -R -s -c 'split("\n")[:-1]') $(git diff --name-only origin/${{ github.base_ref }} HEAD | grep src/ | jq -R -s -c 'split("\n")[:-1]'))"
+        run: echo "::set-output name=packages::$(php .github/get-modified-packages.php
+          $(find src/Symfony -mindepth 2 -type f -name composer.json -printf
+          '%h\n' | jq -R -s -c 'split("\n")[:-1]') $(git diff --name-only
+          origin/${{ github.base_ref }} HEAD | grep src/ | jq -R -s -c
+          'split("\n")[:-1]'))"
 
       - name: Verify meta files are correct
         run: |

--- a/.github/workflows/phpunit-bridge.yml
+++ b/.github/workflows/phpunit-bridge.yml
@@ -19,13 +19,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@17ef667e04bd0c8836175514bc8ad08555a31106 # pin@v2
         with:
           coverage: "none"
           php-version: "7.1"
 
       - name: Lint
-        run: find ./src/Symfony/Bridge/PhpUnit -name '*.php' | grep -v -e /Tests/ -e ForV7 -e ForV8 -e ForV9 -e ConstraintLogicTrait | parallel -j 4 php -l {}
+        run: find ./src/Symfony/Bridge/PhpUnit -name '*.php' | grep -v -e /Tests/ -e
+          ForV7 -e ForV8 -e ForV9 -e ConstraintLogicTrait | parallel -j 4 php -l
+          {}

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,7 +1,7 @@
 name: Static analysis
 
 on:
-  pull_request: ~
+  ? pull_request
 
 defaults:
   run:
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@17ef667e04bd0c8836175514bc8ad08555a31106 # pin@v2
         with:
           php-version: '8.0'
           extensions: "json,couchbase,memcached,mongodb,redis,xsl,ldap,dom"
@@ -22,12 +22,12 @@ jobs:
           coverage: none
 
       - name: Checkout target branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
         with:
           ref: ${{ github.base_ref }}
 
       - name: Checkout PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,8 +1,8 @@
 name: PHPUnit
 
 on:
-  push:
-  pull_request:
+  ? push
+  ? pull_request
 
 defaults:
   run:
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
         with:
           fetch-depth: 2
 
@@ -42,7 +42,7 @@ jobs:
           composer config platform.php 8.1.99
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@17ef667e04bd0c8836175514bc8ad08555a31106 # pin@v2
         with:
           coverage: "none"
           ini-values: date.timezone=Europe/Paris,memory_limit=-1,default_socket_timeout=10,session.gc_probability=0,apc.enable_cli=1,zend.assertions=1


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no 

Pinning an action to a full length commit SHA is currently the only way to use an action as
an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a
backdoor to the action's repository, as they would need to generate a SHA-1 collision for
a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
