### PR TITLE
[Messenger] Provide a safe command bus strategy

### DIFF
--- a/src/Symfony/Bridge/Monolog/Tests/Messenger/ResetLoggersWorkerSubscriberTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Messenger/ResetLoggersWorkerSubscriberTest.php
@@ -27,6 +27,9 @@ use Symfony\Component\Messenger\Worker;
 
 class ResetLoggersWorkerSubscriberTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testLogsAreFlushed()
     {
         $loggerTestHandler = new TestHandler();

--- a/src/Symfony/Component/Messenger/Exception/MultipleHandlersForMessageException.php
+++ b/src/Symfony/Component/Messenger/Exception/MultipleHandlersForMessageException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Exception;
+
+class MultipleHandlersForMessageException extends LogicException
+{
+}

--- a/src/Symfony/Component/Messenger/Handler/AtLeastOneHandlerLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/AtLeastOneHandlerLocator.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Messenger\Handler;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
+
+final class AtLeastOneHandlerLocator extends HandlersLocator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getHandlers(Envelope $envelope): iterable
+    {
+        $count = $this->countHandlers($envelope);
+        if (0 === $count) {
+            throw new NoHandlerForMessageException(sprintf('No handler for message "%s".', \get_class($envelope->getMessage())));
+        }
+
+        yield from $this->doGetHandlers($envelope);
+    }
+}

--- a/src/Symfony/Component/Messenger/Handler/ExactlyOneHandlerLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/ExactlyOneHandlerLocator.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Messenger\Handler;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\MultipleHandlersForMessageException;
+use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
+
+final class ExactlyOneHandlerLocator extends HandlersLocator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getHandlers(Envelope $envelope): iterable
+    {
+        $count = $this->countHandlers($envelope);
+        if (0 === $count) {
+            throw new NoHandlerForMessageException(sprintf('No handler for message "%s".', \get_class($envelope->getMessage())));
+        }
+
+        if ($count > 1) {
+            throw new MultipleHandlersForMessageException(sprintf('Multiple handlers for message "%s".', \get_class($envelope->getMessage())));
+        }
+
+        yield from $this->doGetHandlers($envelope);
+    }
+}

--- a/src/Symfony/Component/Messenger/Handler/OptionalHandlerLocator.php
+++ b/src/Symfony/Component/Messenger/Handler/OptionalHandlerLocator.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Messenger\Handler;
+
+use Symfony\Component\Messenger\Envelope;
+
+final class OptionalHandlerLocator extends HandlersLocator
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getHandlers(Envelope $envelope): iterable
+    {
+        yield from $this->doGetHandlers($envelope);
+    }
+}

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -18,6 +18,7 @@ use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
 use Symfony\Component\Messenger\Handler\HandlerDescriptor;
 use Symfony\Component\Messenger\Handler\HandlersLocatorInterface;
+use Symfony\Component\Messenger\Handler\OptionalHandlerLocator;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
 
 /**
@@ -32,6 +33,9 @@ class HandleMessageMiddleware implements MiddlewareInterface
 
     public function __construct(HandlersLocatorInterface $handlersLocator, bool $allowNoHandlers = false)
     {
+        if (1 < \func_num_args()) {
+            trigger_deprecation('symfony/messenger', '5.4', 'Passing the allowNoHandlers argument is deprecated, inject an instance of the "%s" instead.', OptionalHandlerLocator::class);
+        }
         $this->handlersLocator = $handlersLocator;
         $this->allowNoHandlers = $allowNoHandlers;
         $this->logger = new NullLogger();

--- a/src/Symfony/Component/Messenger/Tests/FailureIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Tests/FailureIntegrationTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Messenger\EventListener\SendFailedMessageToFailureTranspor
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
 use Symfony\Component\Messenger\Handler\HandlerDescriptor;
-use Symfony\Component\Messenger\Handler\HandlersLocator;
+use Symfony\Component\Messenger\Handler\OptionalHandlerLocator;
 use Symfony\Component\Messenger\MessageBus;
 use Symfony\Component\Messenger\Middleware\FailedMessageProcessingMiddleware;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
@@ -80,7 +80,7 @@ class FailureIntegrationTest extends TestCase
         $transport1HandlerThatFails = new DummyTestHandler(true);
         $allTransportHandlerThatWorks = new DummyTestHandler(false);
         $transport2HandlerThatWorks = new DummyTestHandler(false);
-        $handlerLocator = new HandlersLocator([
+        $handlerLocator = new OptionalHandlerLocator([
             DummyMessage::class => [
                 new HandlerDescriptor($transport1HandlerThatFails, [
                     'from_transport' => 'transport1',
@@ -268,7 +268,7 @@ class FailureIntegrationTest extends TestCase
         $transport1HandlerThatFails = new DummyTestHandler(true);
         $allTransportHandlerThatWorks = new DummyTestHandler(false);
         $transport2HandlerThatWorks = new DummyTestHandler(false);
-        $handlerLocator = new HandlersLocator([
+        $handlerLocator = new OptionalHandlerLocator([
             DummyMessage::class => [
                 new HandlerDescriptor($transport1HandlerThatFails, [
                     'from_transport' => 'transport1',
@@ -460,7 +460,7 @@ class FailureIntegrationTest extends TestCase
         // using to so we can lazily get the bus later and avoid circular problem
         $transport1HandlerThatFails = new DummyTestHandler(true);
         $transport2HandlerThatFails = new DummyTestHandler(true);
-        $handlerLocator = new HandlersLocator([
+        $handlerLocator = new OptionalHandlerLocator([
             DummyMessage::class => [
                 new HandlerDescriptor($transport1HandlerThatFails, [
                     'from_transport' => 'transport1',

--- a/src/Symfony/Component/Messenger/Tests/Handler/AtLeastOneHandlerLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/AtLeastOneHandlerLocatorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Messenger\Tests\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
+use Symfony\Component\Messenger\Handler\AtLeastOneHandlerLocator;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Handler\HandlersLocatorInterface;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+
+final class AtLeastOneHandlerLocatorTest extends TestCase
+{
+    public function testItIsAHandlersLocator()
+    {
+        $this->assertInstanceOf(HandlersLocatorInterface::class, new AtLeastOneHandlerLocator([]));
+    }
+
+    public function testItYieldsHandlers()
+    {
+        $handler = $this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']);
+        $locator = new AtLeastOneHandlerLocator([
+            DummyMessage::class => [
+                $first = new HandlerDescriptor($handler, ['alias' => 'one']),
+                $second = new HandlerDescriptor($handler, ['alias' => 'two']),
+            ],
+        ]);
+
+        $this->assertSame([$first, $second], iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('a')))));
+    }
+
+    public function testItThrowsExceptionWhenNoHandlerIsDefined()
+    {
+        $this->expectException(NoHandlerForMessageException::class);
+
+        $locator = new AtLeastOneHandlerLocator([DummyMessage::class => []]);
+
+        iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('a'))));
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Handler/ExactlyOneHandlerLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/ExactlyOneHandlerLocatorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Messenger\Tests\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\MultipleHandlersForMessageException;
+use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
+use Symfony\Component\Messenger\Handler\ExactlyOneHandlerLocator;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Handler\HandlersLocatorInterface;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+
+final class ExactlyOneHandlerLocatorTest extends TestCase
+{
+    public function testItIsAHandlersLocator()
+    {
+        $this->assertInstanceOf(HandlersLocatorInterface::class, new ExactlyOneHandlerLocator([]));
+    }
+
+    public function testItYieldsExactlyOneHandler()
+    {
+        $handler = $this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']);
+        $locator = new ExactlyOneHandlerLocator([
+            DummyMessage::class => [$handler],
+        ]);
+
+        $this->assertEquals([new HandlerDescriptor($handler)], iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('a')))));
+    }
+
+    public function testItThrowsExceptionWhenNoHandlerIsDefined()
+    {
+        $this->expectException(NoHandlerForMessageException::class);
+
+        $locator = new ExactlyOneHandlerLocator([DummyMessage::class => []]);
+
+        iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('a'))));
+    }
+
+    public function testItThrowsExceptionWhenMultipleHandlersAreDefined()
+    {
+        $this->expectException(MultipleHandlersForMessageException::class);
+
+        $handler = $this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']);
+        $locator = new ExactlyOneHandlerLocator([
+            DummyMessage::class => [
+                new HandlerDescriptor($handler, ['alias' => 'one']),
+                new HandlerDescriptor($handler, ['alias' => 'two']),
+            ],
+        ]);
+
+        iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('a'))));
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
@@ -18,6 +18,9 @@ use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\Stamp\ReceivedStamp;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 
+/**
+ * @group legacy
+ */
 class HandlersLocatorTest extends TestCase
 {
     public function testItYieldsHandlerDescriptors()

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTestCallable.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTestCallable.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Messenger\Tests\Handler;
+
+class HandlersLocatorTestCallable
+{
+    public function __invoke()
+    {
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Handler/OptionalHandlerLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/OptionalHandlerLocatorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Symfony\Component\Messenger\Tests\Handler;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+use Symfony\Component\Messenger\Handler\HandlersLocatorInterface;
+use Symfony\Component\Messenger\Handler\OptionalHandlerLocator;
+use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
+
+final class OptionalHandlerLocatorTest extends TestCase
+{
+    public function testItIsAHandlersLocator()
+    {
+        $this->assertInstanceOf(HandlersLocatorInterface::class, new OptionalHandlerLocator([]));
+    }
+
+    public function testItYieldsHandlers()
+    {
+        $handler = $this->createPartialMock(HandlersLocatorTestCallable::class, ['__invoke']);
+        $locator = new OptionalHandlerLocator([
+            DummyMessage::class => [
+                $first = new HandlerDescriptor($handler, ['alias' => 'one']),
+                $second = new HandlerDescriptor($handler, ['alias' => 'two']),
+            ],
+        ]);
+
+        $this->assertSame([$first, $second], iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('a')))));
+    }
+
+    public function testItYieldsNothingWhenNoHandlerIsLocated()
+    {
+        $locator = new OptionalHandlerLocator([DummyMessage::class => []]);
+
+        $this->assertEmpty(iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('a')))));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Fix #36958 
| License       | MIT
| Doc PR        | pending...

# todo
- [ ] update CHANGELOG.md
- [ ] update UPGRADE.md
- [ ] write doc
- [ ] open related PR on FrameworkBundle (or provide changes in the same PR?)
- [x] ensure BC with 5.4 branch

In short, it is currently impossible to enforce that one, and only one, handler is registered for a given message (which is the strategy to use in a command bus).

This PR intends to resolve this issue.