### PR TITLE
[Cache] Decrease the probability of invalidation loss on tag eviction

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -412,8 +412,6 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
             return $tagVersions;
         }
 
-        $tod = gettimeofday();
-        $newVersion = $tod['sec'] * 1000000 + $tod['usec'];
         $updatedTags = [];
         foreach ($this->tags->getItems(array_keys($tags)) as $tag => $version) {
             $tag = $tags[$tag];
@@ -421,12 +419,12 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
             if ($version->isHit()) {
                 $tagVersions[$tag] = $version->get();
             } else {
-                $tagVersions[$tag] = $newVersion;
-                $updatedTags[$tag] = $version->set($newVersion);
+                $tagVersions[$tag] = mt_rand(0, \PHP_INT_MAX);
+                $updatedTags[$tag] = $version->set($tagVersions[$tag]);
             }
 
-            if (isset($invalidatedTags[$tag])) {
-                $updatedTags[$tag] = $version->set(++$tagVersions[$tag]);
+            if (isset($invalidatedTags[$tag]) && !isset($updatedTags[$tag])) {
+                $updatedTags[$tag] = $version->set(\PHP_INT_MAX === $tagVersions[$tag] ? 0 : ++$tagVersions[$tag]);
             }
             $this->knownTagVersions[$tag] = [$now, $tagVersions[$tag]];
         }

--- a/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/TagAwareAdapterTest.php
@@ -83,6 +83,7 @@ class TagAwareAdapterTest extends AdapterTestCase
         $item->expiresAfter(100);
 
         $tag = $this->createMock(CacheItemInterface::class);
+        $tag->expects(self::exactly(2))->method('isHit')->willReturn(true);
         $tag->expects(self::exactly(2))->method('get')->willReturn(10);
 
         $tagsPool->expects(self::exactly(2))->method('getItems')->willReturn([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

When using TagAwareAdapter with volatile caches such as Memcached and Redis with 'alkeys-lru' eviction policy, eviction of _any_ key may happen.

Currently, tag-based invalidation is achieved by incrementing tag version numbers starting from 0. The 0th version is assumed by default and is not even stored in the cache, only non-zero versions are stored. Because of that, when a tag version key is evicted from cache, version counter is "reset" to 0, and if there are items still stored with tag version 0 (had not been accessed/updated by the moment of tag eviction), such items become valid again while must be deemed invalidated. Similarly invalifation may be lost when tag is invalidated particular number of times after its eviction (for items with non-zero tag version).

This scenario is more likely for item-tag pairs which are accessed and invalidated less frequently than others (due to LRU policy and lower version numbers) but this measure is quite relative. LRU caches implement different algorithms (e.g. https://redis.io/topics/lru-cache, https://memcached.org/blog/modern-lru/) and free to evict any key of their choice so even a tag which is accessed or invalidated pretty frequently can be evicted when LRU cache is full and under havy loads.

In order to prevent invalidation losses, any non-repetative numbers can be used as initial value for tag versions.