### PR TITLE
[Cache] Commit items implicitly only when deferred keys are requested

### DIFF
--- a/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
+++ b/src/Symfony/Component/Cache/Adapter/TagAwareAdapter.php
@@ -158,9 +158,10 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
      */
     public function hasItem($key)
     {
-        if ($this->deferred) {
+        if (\is_string($key) && isset($this->deferred[$key])) {
             $this->commit();
         }
+
         if (!$this->pool->hasItem($key)) {
             return false;
         }
@@ -201,16 +202,19 @@ class TagAwareAdapter implements TagAwareAdapterInterface, TagAwareCacheInterfac
      */
     public function getItems(array $keys = [])
     {
-        if ($this->deferred) {
-            $this->commit();
-        }
         $tagKeys = [];
+        $commit = false;
 
         foreach ($keys as $key) {
             if ('' !== $key && \is_string($key)) {
+                $commit = $commit || isset($this->deferred[$key]);
                 $key = static::TAGS_PREFIX.$key;
                 $tagKeys[$key] = $key;
             }
+        }
+
+        if ($commit) {
+            $this->commit();
         }
 
         try {

--- a/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
+++ b/src/Symfony/Component/Cache/Traits/AbstractAdapterTrait.php
@@ -39,10 +39,11 @@ trait AbstractAdapterTrait
      */
     public function getItem($key)
     {
-        if ($this->deferred) {
+        $id = $this->getId($key);
+
+        if (isset($this->deferred[$key])) {
             $this->commit();
         }
-        $id = $this->getId($key);
 
         $f = $this->createCacheItem;
         $isHit = false;
@@ -66,14 +67,18 @@ trait AbstractAdapterTrait
      */
     public function getItems(array $keys = [])
     {
-        if ($this->deferred) {
-            $this->commit();
-        }
         $ids = [];
+        $commit = false;
 
         foreach ($keys as $key) {
             $ids[] = $this->getId($key);
+            $commit = $commit || isset($this->deferred[$key]);
         }
+
+        if ($commit) {
+            $this->commit();
+        }
+
         try {
             $items = $this->doFetch($ids);
         } catch (\Exception $e) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

Because of implicit commits before getting any item, deferred saves are useless.

```
for($r=0; $r<10; ++$r) {
    $item = $adapter->getItem('Key'.$r); // implicit commit
    $item->set('Value'.$r);
    $adapter->saveDeferred($item);
}
$adapter->commit(); // nothing to commit :-//
```
Let's commit deferred changes only when requested item was deferred previously. 