### PR TITLE
[HttpFoundation] Update http response messages of statuses 413 and 422

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -138,7 +138,7 @@ class Response
      *
      * The list of codes is complete according to the
      * {@link https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml Hypertext Transfer Protocol (HTTP) Status Code Registry}
-     * (last updated 2018-09-21).
+     * (last updated 2021-10-01).
      *
      * Unless otherwise noted, the status code is defined in RFC2616.
      *
@@ -180,14 +180,14 @@ class Response
         410 => 'Gone',
         411 => 'Length Required',
         412 => 'Precondition Failed',
-        413 => 'Payload Too Large',
+        413 => 'Content Too Large',                                           // RFC-ietf-httpbis-semantics
         414 => 'URI Too Long',
         415 => 'Unsupported Media Type',
         416 => 'Range Not Satisfiable',
         417 => 'Expectation Failed',
         418 => 'I\'m a teapot',                                               // RFC2324
         421 => 'Misdirected Request',                                         // RFC7540
-        422 => 'Unprocessable Entity',                                        // RFC4918
+        422 => 'Unprocessable Content',                                       // RFC-ietf-httpbis-semantics
         423 => 'Locked',                                                      // RFC4918
         424 => 'Failed Dependency',                                           // RFC4918
         425 => 'Too Early',                                                   // RFC-ietf-httpbis-replay-04
@@ -1077,8 +1077,6 @@ class Response
      *
      * If the Response is not modified, it sets the status code to 304 and
      * removes the actual content by calling the setNotModified() method.
-     *
-     * @return bool
      *
      * @final
      */

--- a/src/Symfony/Component/HttpFoundation/Tests/Fixtures/xml/http-status-codes.xml
+++ b/src/Symfony/Component/HttpFoundation/Tests/Fixtures/xml/http-status-codes.xml
@@ -3,10 +3,10 @@
 <?xml-model href="http-status-codes.rng" schematypens="http://relaxng.org/ns/structure/1.0" ?>
 <registry xmlns="http://www.iana.org/assignments" id="http-status-codes">
     <title>Hypertext Transfer Protocol (HTTP) Status Code Registry</title>
-    <updated>2018-09-21</updated>
+    <updated>2021-10-01</updated>
     <registry id="http-status-codes-1">
         <title>HTTP Status Codes</title>
-        <xref type="rfc" data="rfc7231"/>
+        <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 16.2.1</xref>
         <registration_rule>IETF Review</registration_rule>
         <note>1xx: Informational - Request received, continuing process
             2xx: Success - The action was successfully received, understood, and accepted
@@ -14,15 +14,15 @@
             4xx: Client Error - The request contains bad syntax or cannot be fulfilled
             5xx: Server Error - The server failed to fulfill an apparently valid request
         </note>
-        <record>
+        <record updated="2021-10-01">
             <value>100</value>
             <description>Continue</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.2.1</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.2.1</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>101</value>
             <description>Switching Protocols</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.2.2</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.2.2</xref>
         </record>
         <record>
             <value>102</value>
@@ -38,40 +38,40 @@
             <value>104-199</value>
             <description>Unassigned</description>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>200</value>
             <description>OK</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.3.1</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.3.1</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>201</value>
             <description>Created</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.3.2</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.3.2</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>202</value>
             <description>Accepted</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.3.3</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.3.3</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>203</value>
             <description>Non-Authoritative Information</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.3.4</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.3.4</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>204</value>
             <description>No Content</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.3.5</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.3.5</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>205</value>
             <description>Reset Content</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.3.6</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.3.6</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>206</value>
             <description>Partial Content</description>
-            <xref type="rfc" data="rfc7233">RFC7233, Section 4.1</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.3.7</xref>
         </record>
         <record>
             <value>207</value>
@@ -96,160 +96,163 @@
             <value>227-299</value>
             <description>Unassigned</description>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>300</value>
             <description>Multiple Choices</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.4.1</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.4.1</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>301</value>
             <description>Moved Permanently</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.4.2</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.4.2</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>302</value>
             <description>Found</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.4.3</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.4.3</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>303</value>
             <description>See Other</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.4.4</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.4.4</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>304</value>
             <description>Not Modified</description>
-            <xref type="rfc" data="rfc7232">RFC7232, Section 4.1</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.4.5</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>305</value>
             <description>Use Proxy</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.4.5</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.4.6</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>306</value>
             <description>(Unused)</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.4.6</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.4.7</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>307</value>
             <description>Temporary Redirect</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.4.7</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.4.8</xref>
         </record>
-        <record updated="2015-02-09">
+        <record updated="2021-10-01">
             <value>308</value>
             <description>Permanent Redirect</description>
-            <xref type="rfc" data="rfc7538"/>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.4.9</xref>
         </record>
         <record>
             <value>309-399</value>
             <description>Unassigned</description>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>400</value>
             <description>Bad Request</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.1</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.1</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>401</value>
             <description>Unauthorized</description>
-            <xref type="rfc" data="rfc7235">RFC7235, Section 3.1</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.2</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>402</value>
             <description>Payment Required</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.2</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.3</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>403</value>
             <description>Forbidden</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.3</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.4</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>404</value>
             <description>Not Found</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.4</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.5</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>405</value>
             <description>Method Not Allowed</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.5</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.6</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>406</value>
             <description>Not Acceptable</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.6</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.7</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>407</value>
             <description>Proxy Authentication Required</description>
-            <xref type="rfc" data="rfc7235">RFC7235, Section 3.2</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.8</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>408</value>
             <description>Request Timeout</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.7</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.9</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>409</value>
             <description>Conflict</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.8</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.10</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>410</value>
             <description>Gone</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.9</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.11</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>411</value>
             <description>Length Required</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.10</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.12</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>412</value>
             <description>Precondition Failed</description>
-            <xref type="rfc" data="rfc7232">RFC7232, Section 4.2</xref>
-            <xref type="rfc" data="rfc8144">RFC8144, Section 3.2</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.13</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>413</value>
-            <description>Payload Too Large</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.11</xref>
+            <description>Content Too Large</description>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.14</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>414</value>
             <description>URI Too Long</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.12</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.15</xref>
         </record>
-        <record updated="2015-09-20">
+        <record updated="2021-10-01">
             <value>415</value>
             <description>Unsupported Media Type</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.13</xref>
-            <xref type="rfc" data="rfc7694">RFC7694, Section 3</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.16</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>416</value>
             <description>Range Not Satisfiable</description>
-            <xref type="rfc" data="rfc7233">RFC7233, Section 4.4</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.17</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>417</value>
             <description>Expectation Failed</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.14</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.18</xref>
+        </record>
+        <record date="2021-10-01">
+            <value>418</value>
+            <description>(Unused)</description>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.19</xref>
         </record>
         <record>
-            <value>418-420</value>
+            <value>419-420</value>
             <description>Unassigned</description>
         </record>
-        <record date="2015-02-20">
+        <record date="2021-10-01">
             <value>421</value>
             <description>Misdirected Request</description>
-            <xref type="rfc" data="rfc7540">RFC7540, Section 9.1.2</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.20</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>422</value>
-            <description>Unprocessable Entity</description>
-            <xref type="rfc" data="rfc4918"/>
+            <description>Unprocessable Content</description>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.21</xref>
         </record>
         <record>
             <value>423</value>
@@ -266,10 +269,10 @@
             <description>Too Early</description>
             <xref type="rfc" data="rfc8470"/>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>426</value>
             <description>Upgrade Required</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.5.15</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.5.22</xref>
         </record>
         <record>
             <value>427</value>
@@ -307,35 +310,35 @@
             <value>452-499</value>
             <description>Unassigned</description>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>500</value>
             <description>Internal Server Error</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.6.1</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.6.1</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>501</value>
             <description>Not Implemented</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.6.2</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.6.2</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>502</value>
             <description>Bad Gateway</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.6.3</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.6.3</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>503</value>
             <description>Service Unavailable</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.6.4</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.6.4</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>504</value>
             <description>Gateway Timeout</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.6.5</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.6.5</xref>
         </record>
-        <record>
+        <record updated="2021-10-01">
             <value>505</value>
             <description>HTTP Version Not Supported</description>
-            <xref type="rfc" data="rfc7231">RFC7231, Section 6.6.6</xref>
+            <xref type="draft" data="RFC-ietf-httpbis-semantics">RFC-ietf-httpbis-semantics, Section 15.6.6</xref>
         </record>
         <record>
             <value>506</value>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

This introduces the response message changes described in https://github.com/symfony/symfony/issues/43292

Let me know if this needs a changelog entry or something else. As far as I saw these changes had been done as a bugfix previously which we did not continue to do here.

