### PR TITLE
[Translation] [Bridge] [Lokalise] do not export empty strings

### DIFF
--- a/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/LokaliseProvider.php
@@ -148,6 +148,7 @@ final class LokaliseProvider implements ProviderInterface
                 'directory_prefix' => '%LANG_ISO%',
                 'filter_langs' => array_values($locales),
                 'filter_filenames' => array_map([$this, 'getLokaliseFilenameFromDomain'], $domains),
+                'export_empty_as' => 'skip',
             ],
         ]);
 

--- a/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
+++ b/src/Symfony/Component/Translation/Bridge/Lokalise/Tests/LokaliseProviderTest.php
@@ -246,6 +246,7 @@ class LokaliseProviderTest extends ProviderTestCase
                 'directory_prefix' => '%LANG_ISO%',
                 'filter_langs' => [$locale],
                 'filter_filenames' => [$domain.'.xliff'],
+                'export_empty_as' => 'skip',
             ]);
 
             $this->assertSame('POST', $method);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

This change excludes the possibility of receiving strings without translation. At the moment, all keys that have no translation in the Lokalise panel are empty strings after export.
Link to documentation describing the added parameter: https://app.lokalise.com/api2docs/curl/#transition-download-files-post

example w/o changes:
<img width="1556" alt="Screenshot 2021-10-04 at 16 59 04" src="https://user-images.githubusercontent.com/16158349/135877543-6a108f57-0bed-4a44-9902-b535451925f6.png">
`validators.es.xlf`
<img width="475" alt="Screenshot 2021-10-04 at 17 15 09" src="https://user-images.githubusercontent.com/16158349/135877509-ec08f4f7-814d-42bc-8764-dcc0b689b6e5.png">

**TODO:**
- [ ] Changelog