### PR TITLE
[Security][Validator] Add missing translations for Luxembourgish (lb)

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.lb.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.lb.xlf
@@ -70,6 +70,14 @@
                 <source>Invalid or expired login link.</source>
                 <target>Ongëltegen oder ofgelafene Login-Link.</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+                <target>Ze vill mësslonge Login-Versich, w.e.g. nach emol an %minutes% Minutt probéieren.</target>
+            </trans-unit>
+            <trans-unit id="20">
+                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+                <target>Ze vill mësslonge Login-Versich, w.e.g. nach emol a %minutes% Minutten probéieren.</target>
+            </trans-unit>            
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.lb.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lb.xlf
@@ -386,6 +386,10 @@
                 <source>This value is not a valid International Securities Identification Number (ISIN).</source>
                 <target>Dëse Wäert ass keng gëlteg International Wäertpabeiererkennnummer (ISIN).</target>
             </trans-unit>
+            <trans-unit id="100">
+                <source>This value should be a valid expression.</source>
+                <target>Dëse Wäert sollt gëlteg Ausdrock</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #41055  <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Added missing Luxembourgish translation units for security and validators.
