### PR TITLE
fix PDO SQLSRV throws for method_exists()

### DIFF
--- a/src/Symfony/Component/Lock/Store/PdoStore.php
+++ b/src/Symfony/Component/Lock/Store/PdoStore.php
@@ -268,7 +268,7 @@ class PdoStore implements StoreInterface
             $table->setPrimaryKey([$this->idCol]);
 
             foreach ($schema->toSql($conn->getDatabasePlatform()) as $sql) {
-                if (method_exists($conn, 'executeStatement')) {
+                if (!$conn instanceof \PDO && method_exists($conn, 'executeStatement')) {
                     $conn->executeStatement($sql);
                 } else {
                     $conn->exec($sql);
@@ -298,7 +298,7 @@ class PdoStore implements StoreInterface
                 throw new \DomainException(sprintf('Creating the lock table is currently not implemented for PDO driver "%s".', $driver));
         }
 
-        if (method_exists($conn, 'executeStatement')) {
+        if (!$conn instanceof \PDO && method_exists($conn, 'executeStatement')) {
             $conn->executeStatement($sql);
         } else {
             $conn->exec($sql);
@@ -313,7 +313,7 @@ class PdoStore implements StoreInterface
         $sql = "DELETE FROM $this->table WHERE $this->expirationCol <= {$this->getCurrentTimestampStatement()}";
 
         $conn = $this->getConnection();
-        if (method_exists($conn, 'executeStatement')) {
+        if (!$conn instanceof \PDO && method_exists($conn, 'executeStatement')) {
             $conn->executeStatement($sql);
         } else {
             $conn->exec($sql);


### PR DESCRIPTION
pdo_sqlsrv driver 5.9.0 (on mac) always throws an exception for any call on method_exists().
(see microsoft/msphpsql/issues/1306)

```executeStatement()``` is a DBAL-method, and ```exec()``` is PDO.
fix by excluding method_exists() check for PDO type of connections

| Q             | A
| ------------- | ---
| Branch?       |  4.4 or 5.3 for bug fixes 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT
