### PR TITLE
[Security][Validator] Add missing translations for Gallician (gl)

### DIFF
--- a/src/Symfony/Component/Security/Core/Resources/translations/security.gl.xlf
+++ b/src/Symfony/Component/Security/Core/Resources/translations/security.gl.xlf
@@ -70,6 +70,14 @@
                 <source>Invalid or expired login link.</source>
                 <target>Ligazón de inicio de sesión non válida ou caducada.</target>
             </trans-unit>
+            <trans-unit id="19">
+                <source>Too many failed login attempts, please try again in %minutes% minute.</source>
+                <target>Demasiados intentos de inicio de sesión errados, por favor, ténteo de novo en %minutes% minuto.</target>
+            </trans-unit>
+            <trans-unit id="20">
+                <source>Too many failed login attempts, please try again in %minutes% minutes.</source>
+                <target>Demasiados intentos de inicio de sesión errados, por favor, ténteo de novo en %minutes% minutos.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.gl.xlf
@@ -386,6 +386,10 @@
                 <source>This value is not a valid International Securities Identification Number (ISIN).</source>
                 <target>Este valor non é un número de identificación de valores internacionais (ISIN) válido.</target>
             </trans-unit>
+            <trans-unit id="100">
+                <source>This value should be a valid expression.</source>
+                <target>Este valor debe ser unha expresión válida.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?      | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #41044 
| License       | MIT
| Doc PR        | symfony/symfony-docs#...
Added missing Gallician translation units for security and validators.
