### PR TITLE
[MonologBridge] Deprecate the Swiftmailer handler

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Test/DoctrineTestHelper.php
+++ b/src/Symfony/Bridge/Doctrine/Test/DoctrineTestHelper.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\TestCase;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated in 5.3, will be removed in 6.0.
+ * @deprecated since Symfony 5.3
  */
 class DoctrineTestHelper
 {

--- a/src/Symfony/Bridge/Doctrine/Test/TestRepositoryFactory.php
+++ b/src/Symfony/Bridge/Doctrine/Test/TestRepositoryFactory.php
@@ -19,7 +19,7 @@ use Doctrine\Persistence\ObjectRepository;
 /**
  * @author Andreas Braun <alcaeus@alcaeus.org>
  *
- * @deprecated in 5.3, will be removed in 6.0.
+ * @deprecated since Symfony 5.3
  */
 class TestRepositoryFactory implements RepositoryFactory
 {

--- a/src/Symfony/Bridge/Monolog/Handler/SwiftMailerHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/SwiftMailerHandler.php
@@ -15,12 +15,16 @@ use Monolog\Handler\SwiftMailerHandler as BaseSwiftMailerHandler;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
+trigger_deprecation('symfony/monolog-bridge', '5.4', '"%s" is deprecated and will be removed in 6.0.', SwiftMailerHandler::class);
+
 /**
  * Extended SwiftMailerHandler that flushes mail queue if necessary.
  *
  * @author Philipp Kräutli <pkraeutli@astina.ch>
  *
  * @final
+ *
+ * @deprecated since Symfony 5.4
  */
 class SwiftMailerHandler extends BaseSwiftMailerHandler
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a

As Swiftmailer is deprecated and won't be maintained anymore at the end of November, let's deprecate the Swiftmailer Monolog handler in 5.4.
