### PR TITLE
[HttpClient] fix missing kernel.reset tag on TraceableHttpClient services

### DIFF
--- a/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php
+++ b/src/Symfony/Component/HttpClient/DependencyInjection/HttpClientPass.php
@@ -37,6 +37,7 @@ final class HttpClientPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds($this->clientTag) as $id => $tags) {
             $container->register('.debug.'.$id, TraceableHttpClient::class)
                 ->setArguments([new Reference('.debug.'.$id.'.inner')])
+                ->addTag('kernel.reset', ['method' => 'reset'])
                 ->setDecoratedService($id);
             $container->getDefinition('data_collector.http_client')
                 ->addMethodCall('registerClient', [$id, new Reference('.debug.'.$id)]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Replaces #43287