### PR TITLE
[VarDumper] declare that dd() never returns

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -32,6 +32,9 @@ if (!function_exists('dump')) {
 }
 
 if (!function_exists('dd')) {
+    /**
+     * @return never
+     */
     function dd(...$vars)
     {
         foreach ($vars as $v) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

This change helps IDEs and static analyzers to understand that code after a `dd()` call isn't executed.