### PR TITLE
[VarDumper] returns a 500 when dd() is executed

### DIFF
--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -37,6 +37,10 @@ if (!function_exists('dd')) {
      */
     function dd(...$vars)
     {
+        if (!in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && !headers_sent()) {
+            header('HTTP/1.1 500 Internal Server Error');
+        }
+
         foreach ($vars as $v) {
             VarDumper::dump($v);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        |

* It's more semantic
* It avoids reverse proxy to cache the page (of course this code should not be deployed to production!)
* It's easier to spot error in test when a dd() is left