### PR TITLE
[Messenger] allow processing messages in batches

### DIFF
--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Tests/Transport/AmqpExtIntegrationTest.php
@@ -215,7 +215,8 @@ Get envelope with message: Symfony\Component\Messenger\Bridge\Amqp\Tests\Fixture
 with stamps: [
     "Symfony\\Component\\Messenger\\Bridge\\Amqp\\Transport\\AmqpReceivedStamp",
     "Symfony\\Component\\Messenger\\Stamp\\ReceivedStamp",
-    "Symfony\\Component\\Messenger\\Stamp\\ConsumedByWorkerStamp"
+    "Symfony\\Component\\Messenger\\Stamp\\ConsumedByWorkerStamp",
+    "Symfony\\Component\\Messenger\\Stamp\\AckStamp"
 ]
 Done.
 

--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add `AsMessageHandler` attribute for declaring message handlers on PHP 8.
+ * Add support for handling messages in batches with `BatchHandlerInterface` and corresponding trait
  * Add `StopWorkerExceptionInterface` and its implementation `StopWorkerException` to stop the worker.
  * Add support for resetting container services after each messenger message.
  * Added `WorkerMetadata` class which allows you to access the configuration details of a worker, like `queueNames` and `transportNames` it consumes from.

--- a/src/Symfony/Component/Messenger/Handler/Acknowledger.php
+++ b/src/Symfony/Component/Messenger/Handler/Acknowledger.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+use Symfony\Component\Messenger\Exception\LogicException;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class Acknowledger
+{
+    private $handlerClass;
+    private $ack;
+    private $error = null;
+    private $result = null;
+
+    /**
+     * @param null|\Closure(\Throwable|null, mixed):void $ack
+     */
+    public function __construct(string $handlerClass, \Closure $ack = null)
+    {
+        $this->handlerClass = $handlerClass;
+        $this->ack = $ack ?? static function () {};
+    }
+
+    /**
+     * @param mixed $result
+     */
+    public function ack($result = null): void
+    {
+        $this->doAck(null, $result);
+    }
+
+    public function nack(\Throwable $error): void
+    {
+        $this->doAck($error);
+    }
+
+    public function getError(): ?\Throwable
+    {
+        return $this->error;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getResult()
+    {
+        return $this->result;
+    }
+
+    public function isAcknowledged(): bool
+    {
+        return null === $this->ack;
+    }
+
+    public function __destruct()
+    {
+        if ($this->ack instanceof \Closure) {
+            throw new LogicException(sprintf('The acknowledger was not called by the "%s" batch handler.', $this->handlerClass));
+        }
+    }
+
+    private function doAck(\Throwable $e = null, $result = null): void
+    {
+        if (!$ack = $this->ack) {
+            throw new LogicException(sprintf('The acknowledger cannot be called twice by the "%s" batch handler.', $this->handlerClass));
+        }
+        $this->ack = null;
+        $this->error = $e;
+        $this->result = $result;
+        $ack($e, $result);
+    }
+}

--- a/src/Symfony/Component/Messenger/Handler/BatchHandlerInterface.php
+++ b/src/Symfony/Component/Messenger/Handler/BatchHandlerInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+interface BatchHandlerInterface
+{
+    /**
+     * @param Acknowledger|null $ack The function to call to ack/nack the $message.
+     *                               The message should be handled synchronously when null.
+     *
+     * @return mixed The number of pending messages in the batch if $ack is not null,
+     *               the result from handling the message otherwise
+     */
+    //public function __invoke(object $message, Acknowledger $ack = null): mixed;
+
+    /**
+     * Flushes any pending buffers.
+     *
+     * @param bool $force Whether flushing is required; it can be skipped if not
+     */
+    public function flush(bool $force): void;
+}

--- a/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
+++ b/src/Symfony/Component/Messenger/Handler/BatchHandlerTrait.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Handler;
+
+use Symfony\Component\Messenger\Exception\LogicException;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+trait BatchHandlerTrait
+{
+    private $jobs = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function flush(bool $force): void
+    {
+        if ($jobs = $this->jobs) {
+            $this->jobs = [];
+            $this->process($jobs);
+        }
+    }
+
+    /**
+     * @param Acknowledger|null $ack The function to call to ack/nack the $message.
+     *                               The message should be handled synchronously when null.
+     *
+     * @return mixed The number of pending messages in the batch if $ack is not null,
+     *               the result from handling the message otherwise
+     */
+    private function handle(object $message, ?Acknowledger $ack)
+    {
+        if (null === $ack) {
+            $ack = new Acknowledger(get_debug_type($this));
+            $this->jobs[] = [$message, $ack];
+            $this->flush(true);
+
+            return $ack->getResult();
+        }
+
+        $this->jobs[] = [$message, $ack];
+        if (!$this->shouldFlush()) {
+            return \count($this->jobs);
+        }
+
+        $this->flush(true);
+
+        return 0;
+    }
+
+    private function shouldFlush(): bool
+    {
+        return 10 <= \count($this->jobs);
+    }
+
+    /**
+     * Completes the jobs in the list.
+     *
+     * @list<array{0: object, 1: Acknowledger}> $jobs A list of pairs of messages and their corresponding acknowledgers
+     */
+    private function process(array $jobs): void
+    {
+        throw new LogicException(sprintf('"%s" should implement abstract method "process()".', get_debug_type($this)));
+    }
+}

--- a/src/Symfony/Component/Messenger/Handler/HandlerDescriptor.php
+++ b/src/Symfony/Component/Messenger/Handler/HandlerDescriptor.php
@@ -19,12 +19,34 @@ namespace Symfony\Component\Messenger\Handler;
 final class HandlerDescriptor
 {
     private $handler;
+    private $name;
+    private $batchHandler;
     private $options;
 
     public function __construct(callable $handler, array $options = [])
     {
+        if (!$handler instanceof \Closure) {
+            $handler = \Closure::fromCallable($handler);
+        }
+
         $this->handler = $handler;
         $this->options = $options;
+
+        $r = new \ReflectionFunction($handler);
+
+        if (str_contains($r->name, '{closure}')) {
+            $this->name = 'Closure';
+        } elseif (!$handler = $r->getClosureThis()) {
+            $class = $r->getClosureScopeClass();
+
+            $this->name = ($class ? $class->name.'::' : '').$r->name;
+        } else {
+            if ($handler instanceof BatchHandlerInterface) {
+                $this->batchHandler = $handler;
+            }
+
+            $this->name = \get_class($handler).'::'.$r->name;
+        }
     }
 
     public function getHandler(): callable
@@ -34,7 +56,7 @@ final class HandlerDescriptor
 
     public function getName(): string
     {
-        $name = $this->callableName($this->handler);
+        $name = $this->name;
         $alias = $this->options['alias'] ?? null;
 
         if (null !== $alias) {
@@ -44,37 +66,13 @@ final class HandlerDescriptor
         return $name;
     }
 
+    public function getBatchHandler(): ?BatchHandlerInterface
+    {
+        return $this->batchHandler;
+    }
+
     public function getOption(string $option)
     {
         return $this->options[$option] ?? null;
-    }
-
-    private function callableName(callable $handler): string
-    {
-        if (\is_array($handler)) {
-            if (\is_object($handler[0])) {
-                return \get_class($handler[0]).'::'.$handler[1];
-            }
-
-            return $handler[0].'::'.$handler[1];
-        }
-
-        if (\is_string($handler)) {
-            return $handler;
-        }
-
-        if ($handler instanceof \Closure) {
-            $r = new \ReflectionFunction($handler);
-            if (str_contains($r->name, '{closure}')) {
-                return 'Closure';
-            }
-            if ($class = $r->getClosureScopeClass()) {
-                return $class->name.'::'.$r->name;
-            }
-
-            return $r->name;
-        }
-
-        return \get_class($handler).'::__invoke';
     }
 }

--- a/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/HandleMessageMiddleware.php
@@ -15,10 +15,15 @@ use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
+use Symfony\Component\Messenger\Handler\Acknowledger;
 use Symfony\Component\Messenger\Handler\HandlerDescriptor;
 use Symfony\Component\Messenger\Handler\HandlersLocatorInterface;
+use Symfony\Component\Messenger\Stamp\AckStamp;
+use Symfony\Component\Messenger\Stamp\FlushBatchHandlersStamp;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
 
 /**
  * @author Samuel Roze <samuel.roze@gmail.com>
@@ -60,11 +65,55 @@ class HandleMessageMiddleware implements MiddlewareInterface
 
             try {
                 $handler = $handlerDescriptor->getHandler();
-                $handledStamp = HandledStamp::fromDescriptor($handlerDescriptor, $handler($message));
+                $batchHandler = $handlerDescriptor->getBatchHandler();
+
+                /** @var AckStamp $ackStamp */
+                if ($batchHandler && $ackStamp = $envelope->last(AckStamp::class)) {
+                    $ack = new Acknowledger(get_debug_type($batchHandler), static function (\Throwable $e = null, $result = null) use ($envelope, $ackStamp, $handlerDescriptor) {
+                        if (null !== $e) {
+                            $e = new HandlerFailedException($envelope, [$e]);
+                        } else {
+                            $envelope = $envelope->with(HandledStamp::fromDescriptor($handlerDescriptor, $result));
+                        }
+
+                        $ackStamp->ack($envelope, $e);
+                    });
+
+                    $result = $handler($message, $ack);
+
+                    if (!\is_int($result) || 0 > $result) {
+                        throw new LogicException(sprintf('A handler implementing BatchHandlerInterface must return the size of the current batch as a positive integer, "%s" returned from "%s".', \is_int($result) ? $result : get_debug_type($result), get_debug_type($batchHandler)));
+                    }
+
+                    if (!$ack->isAcknowledged()) {
+                        $envelope = $envelope->with(new NoAutoAckStamp($handlerDescriptor));
+                    } elseif ($ack->getError()) {
+                        throw $ack->getError();
+                    } else {
+                        $result = $ack->getResult();
+                    }
+                } else {
+                    $result = $handler($message);
+                }
+
+                $handledStamp = HandledStamp::fromDescriptor($handlerDescriptor, $result);
                 $envelope = $envelope->with($handledStamp);
                 $this->logger->info('Message {class} handled by {handler}', $context + ['handler' => $handledStamp->getHandlerName()]);
             } catch (\Throwable $e) {
                 $exceptions[] = $e;
+            }
+        }
+
+        /** @var FlushBatchHandlersStamp $flushStamp */
+        if ($flushStamp = $envelope->last(FlushBatchHandlersStamp::class)) {
+            /** @var NoAutoAckStamp $stamp */
+            foreach ($envelope->all(NoAutoAckStamp::class) as $stamp) {
+                try {
+                    $handler = $stamp->getHandlerDescriptor()->getBatchHandler();
+                    $handler->flush($flushStamp->force());
+                } catch (\Throwable $e) {
+                    $exceptions[] = $e;
+                }
             }
         }
 
@@ -85,11 +134,13 @@ class HandleMessageMiddleware implements MiddlewareInterface
 
     private function messageHasAlreadyBeenHandled(Envelope $envelope, HandlerDescriptor $handlerDescriptor): bool
     {
-        $some = array_filter($envelope
-            ->all(HandledStamp::class), function (HandledStamp $stamp) use ($handlerDescriptor) {
-                return $stamp->getHandlerName() === $handlerDescriptor->getName();
-            });
+        /** @var HandledStamp $stamp */
+        foreach ($envelope->all(HandledStamp::class) as $stamp) {
+            if ($stamp->getHandlerName() === $handlerDescriptor->getName()) {
+                return true;
+            }
+        }
 
-        return \count($some) > 0;
+        return false;
     }
 }

--- a/src/Symfony/Component/Messenger/Stamp/AckStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/AckStamp.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+use Symfony\Component\Messenger\Envelope;
+
+/**
+ * Marker stamp for messages that can be ack/nack'ed.
+ */
+final class AckStamp implements NonSendableStampInterface
+{
+    private $ack;
+
+    /**
+     * @param \Closure(Envelope, \Throwable|null) $ack
+     */
+    public function __construct(\Closure $ack)
+    {
+        $this->ack = $ack;
+    }
+
+    public function ack(Envelope $envelope, \Throwable $e = null): void
+    {
+        ($this->ack)($envelope, $e);
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/FlushBatchHandlersStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/FlushBatchHandlersStamp.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+/**
+ * Marker telling that any batch handlers bound to the envelope should be flushed.
+ */
+final class FlushBatchHandlersStamp implements NonSendableStampInterface
+{
+    private $force;
+
+    public function __construct(bool $force)
+    {
+        $this->force = $force;
+    }
+
+    public function force(): bool
+    {
+        return $this->force;
+    }
+}

--- a/src/Symfony/Component/Messenger/Stamp/NoAutoAckStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/NoAutoAckStamp.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Stamp;
+
+use Symfony\Component\Messenger\Handler\HandlerDescriptor;
+
+/**
+ * Marker telling that ack should not be done automatically for this message.
+ */
+final class NoAutoAckStamp implements NonSendableStampInterface
+{
+    private $handlerDescriptor;
+
+    public function __construct(HandlerDescriptor $handlerDescriptor)
+    {
+        $this->handlerDescriptor = $handlerDescriptor;
+    }
+
+    public function getHandlerDescriptor(): HandlerDescriptor
+    {
+        return $this->handlerDescriptor;
+    }
+}

--- a/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Handler/HandlersLocatorTest.php
@@ -27,7 +27,10 @@ class HandlersLocatorTest extends TestCase
             DummyMessage::class => [$handler],
         ]);
 
-        $this->assertEquals([new HandlerDescriptor($handler)], iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('a')))));
+        $descriptor = new HandlerDescriptor($handler);
+        $descriptor->getName();
+
+        $this->assertEquals([$descriptor], iterator_to_array($locator->getHandlers(new Envelope(new DummyMessage('a')))));
     }
 
     public function testItReturnsOnlyHandlersMatchingTransport()
@@ -42,6 +45,9 @@ class HandlersLocatorTest extends TestCase
                 $second = new HandlerDescriptor($secondHandler, ['from_transport' => 'transportName', 'alias' => 'three']),
             ],
         ]);
+
+        $first->getName();
+        $second->getName();
 
         $this->assertEquals([
             $first,

--- a/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Middleware/HandleMessageMiddlewareTest.php
@@ -13,12 +13,18 @@ namespace Symfony\Component\Messenger\Tests\Middleware;
 
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\HandlerFailedException;
+use Symfony\Component\Messenger\Exception\LogicException;
 use Symfony\Component\Messenger\Exception\NoHandlerForMessageException;
+use Symfony\Component\Messenger\Handler\Acknowledger;
+use Symfony\Component\Messenger\Handler\BatchHandlerInterface;
+use Symfony\Component\Messenger\Handler\BatchHandlerTrait;
 use Symfony\Component\Messenger\Handler\HandlerDescriptor;
 use Symfony\Component\Messenger\Handler\HandlersLocator;
 use Symfony\Component\Messenger\Middleware\HandleMessageMiddleware;
 use Symfony\Component\Messenger\Middleware\StackMiddleware;
+use Symfony\Component\Messenger\Stamp\AckStamp;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Stamp\NoAutoAckStamp;
 use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyMessage;
 
@@ -128,6 +134,132 @@ class HandleMessageMiddlewareTest extends MiddlewareTestCase
         $middleware = new HandleMessageMiddleware(new HandlersLocator([]), true);
 
         $this->assertInstanceOf(Envelope::class, $middleware->handle(new Envelope(new DummyMessage('Hey')), new StackMiddleware()));
+    }
+
+    public function testBatchHandler()
+    {
+        $handler = new class() implements BatchHandlerInterface {
+            public $processedMessages;
+
+            use BatchHandlerTrait;
+
+            public function __invoke(DummyMessage $message, Acknowledger $ack = null)
+            {
+                return $this->handle($message, $ack);
+            }
+
+            private function shouldFlush()
+            {
+                return 2 <= \count($this->jobs);
+            }
+
+            private function process(array $jobs): void
+            {
+                $this->processedMessages = array_column($jobs, 0);
+
+                foreach ($jobs as [$job, $ack]) {
+                    $ack->ack($job);
+                }
+            }
+        };
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler)],
+        ]));
+
+        $ackedMessages = [];
+        $ack = static function (Envelope $envelope, \Throwable $e = null) use (&$ackedMessages) {
+            if (null !== $e) {
+                throw $e;
+            }
+            $ackedMessages[] = $envelope->last(HandledStamp::class)->getResult();
+        };
+
+        $expectedMessages = [
+            new DummyMessage('Hey'),
+            new DummyMessage('Bob'),
+        ];
+
+        $envelopes = [];
+        foreach ($expectedMessages as $message) {
+            $envelopes[] = $middleware->handle(new Envelope($message, [new AckStamp($ack)]), new StackMiddleware());
+        }
+
+        $this->assertSame($expectedMessages, $handler->processedMessages);
+        $this->assertSame($expectedMessages, $ackedMessages);
+
+        $this->assertNotNull($envelopes[0]->last(NoAutoAckStamp::class));
+        $this->assertNull($envelopes[1]->last(NoAutoAckStamp::class));
+    }
+
+    public function testBatchHandlerNoAck()
+    {
+        $handler = new class() implements BatchHandlerInterface {
+            use BatchHandlerTrait;
+
+            public function __invoke(DummyMessage $message, Acknowledger $ack = null)
+            {
+                return $this->handle($message, $ack);
+            }
+
+            private function shouldFlush()
+            {
+                return true;
+            }
+
+            private function process(array $jobs): void
+            {
+            }
+        };
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler)],
+        ]));
+
+        $error = null;
+        $ack = static function (Envelope $envelope, \Throwable $e = null) use (&$error) {
+            $error = $e;
+        };
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The acknowledger was not called by the "Symfony\Component\Messenger\Handler\BatchHandlerInterface@anonymous" batch handler.');
+
+        $middleware->handle(new Envelope(new DummyMessage('Hey'), [new AckStamp($ack)]), new StackMiddleware());
+    }
+
+    public function testBatchHandlerNoBatch()
+    {
+        $handler = new class() implements BatchHandlerInterface {
+            public $processedMessages;
+
+            use BatchHandlerTrait;
+
+            public function __invoke(DummyMessage $message, Acknowledger $ack = null)
+            {
+                return $this->handle($message, $ack);
+            }
+
+            private function shouldFlush()
+            {
+                return false;
+            }
+
+            private function process(array $jobs): void
+            {
+                $this->processedMessages = array_column($jobs, 0);
+                [$job, $ack] = array_shift($jobs);
+                $ack->ack($job);
+            }
+        };
+
+        $middleware = new HandleMessageMiddleware(new HandlersLocator([
+            DummyMessage::class => [new HandlerDescriptor($handler)],
+        ]));
+
+        $message = new DummyMessage('Hey');
+        $middleware->handle(new Envelope($message), new StackMiddleware());
+
+        $this->assertSame([$message], $handler->processedMessages);
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #36910
| License       | MIT
| Doc PR        | -

This replaces #42873 as it proposes an alternative approach to handling messages in batch.

`BatchHandlerInterface` says it all: if a handler implements this interface, then it should expect a new `$ack` optional argument to be provided when `__invoke()` is called. When `$ack` is not provided, `__invoke()` is expected to handle the message synchronously as usual. But when `$ack` is provided, `__invoke()` is expected to buffer the message and its `$ack` function, and to return the number of pending messages in the batch.

Batch handlers are responsible for deciding when they flush their buffers, calling the `$ack` functions while doing so.

Best reviewed [ignoring whitespaces](https://github.com/symfony/symfony/pull/43354/files?w=1).


Here is what a batch handler might look like:

```php
class MyBatchHandler implements BatchHandlerInterface
{
    use BatchHandlerTrait;

    public function __invoke(MyMessage $message, Acknowledger $ack = null)
    {
        return $this->handle($message, $ack);
    }

    private function process(array $jobs): void
    {
        foreach ($jobs as [$message, $ack]) {
            try {
                // [...] compute $result from $message
                $ack->ack($result);
            } catch (\Throwable $e) {
                $ack->nack($e);
            }
        }
    }
}
```

The size of the batch is controlled by `BatchHandlerTrait::shouldFlush()` (defaults to 10).

The transport is acknowledged in batch, *after* the bus returned from dispatching (unlike what is done in #42873). This is especially important when considering transactions since we don't want to ack unless the transaction committed successfully.

By default, pending batches are flushed when the worker is idle and when it stops.