### PR TITLE
[HttpFoundation] Fix PHP 8.1 deprecation notice in IpUtils::checkIp()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -37,6 +37,10 @@ class IpUtils
      */
     public static function checkIp($requestIp, $ips)
     {
+        if (null === $requestIp) {
+            return false;
+        }
+
         if (!\is_array($ips)) {
             $ips = [$ips];
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -39,6 +39,8 @@ class IpUtilsTest extends TestCase
             [true, '1.2.3.4', '192.168.1.0/0'],
             [false, '1.2.3.4', '256.256.256/0'], // invalid CIDR notation
             [false, 'an_invalid_ip', '192.168.1.0/24'],
+            [false, '', '1.2.3.4/1'],
+            [false, null, '1.2.3.4/1'],
         ];
     }
 
@@ -69,6 +71,8 @@ class IpUtilsTest extends TestCase
             [false, '2a01:198:603:0:396e:4789:8e99:890f', ['::1', '1a01:198:603:0::/65']],
             [false, '}__test|O:21:&quot;JDatabaseDriverMysqli&quot;:3:{s:2', '::1'],
             [false, '2a01:198:603:0:396e:4789:8e99:890f', 'unknown'],
+            [false, '', '::1'],
+            [false, null, '::1'],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #43350
| License       | MIT
| Doc PR        | 

After this PR got merged I will create additional PRs to deprecate (5.4)/remove (6.0) passing `null` to various methods in `IpUtils` like suggested in https://github.com/symfony/symfony/issues/43350#issuecomment-936951604 