### PR TITLE
[Translation] use intl domain when adding new key if intl domain exists

### DIFF
--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -167,7 +167,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
             $intlDomain .= self::INTL_DOMAIN_SUFFIX;
         }
         foreach ($messages as $id => $message) {
-            if (isset($this->messages[$intlDomain]) && \array_key_exists($id, $this->messages[$intlDomain])) {
+            if (isset($this->messages[$intlDomain])) {
                 $this->messages[$intlDomain][$id] = $message;
             } else {
                 $this->messages[$domain][$id] = $message;

--- a/src/Symfony/Component/Translation/Tests/Catalogue/MergeOperationTest.php
+++ b/src/Symfony/Component/Translation/Tests/Catalogue/MergeOperationTest.php
@@ -57,8 +57,8 @@ class MergeOperationTest extends AbstractOperationTest
     {
         $this->assertEquals(
             new MessageCatalogue('en', [
-                'messages' => ['a' => 'old_a', 'b' => 'old_b'],
-                'messages+intl-icu' => ['d' => 'old_d', 'c' => 'new_c'],
+                'messages' => [],
+                'messages+intl-icu' => ['a' => 'old_a', 'b' => 'old_b', 'd' => 'old_d', 'c' => 'new_c'],
             ]),
             $this->createOperation(
                 new MessageCatalogue('en', ['messages' => ['a' => 'old_a', 'b' => 'old_b'], 'messages+intl-icu' => ['d' => 'old_d']]),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42871
| License       | MIT
| Doc PR        | 

With no more informations on my questions in #42871 issue,  I assumed I was right when I said a merge operation between regular & int domain keys should result in only intl domain existing.
So I changed the test according to that but I'm not sure of any other impact this could have...

