### PR TITLE
[Security] Add getter for attributes property

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/Passport/Passport.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Passport/Passport.php
@@ -103,4 +103,9 @@ class Passport implements UserPassportInterface
     {
         return $this->attributes[$name] ?? $default;
     }
+
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
 }


### PR DESCRIPTION
This addition prevents the need to overload the $attributes property when extending this class to get access to all attributes at once. Currently, there is no way to get all attributes out of the passport without knowing the names of each attribute. 

https://github.com/hslavich/OneloginSamlBundle/issues/181#issuecomment-937823962

| Q             | A
| ------------- | ---
| Branch?       | 5.4 for features
| Bug fix?      | no
| New feature?  | Enhancement
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#

Authenticators do not have access to all attributes in the passport at once, nor can they set them at once. The only way currently is to over-load the $attributes in an extended passport class.

Current code also stops a Subscriber/Listener (to for example CheckPassportEvent) from accessing all the current attributes without knowing their name.

Not having access or being able to set all attributes at once is particularly nasty when the attributes are set based on a SAML token. They can currently be set one at a time, but they can not be retrieved without knowing their names.