### PR TITLE
[Translation] Use symfony default locale when pulling translations from providers

### DIFF
--- a/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
@@ -119,6 +119,7 @@ EOF
         $writeOptions = [
             'path' => end($this->transPaths),
             'xliff_version' => $xliffVersion,
+            'default_locale' => $this->defaultLocale,
         ];
 
         if (!$domains) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #43363 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | <!-- required for new features -->

When pulling translations from provider, locale source inside the Xll file is replaced with the \Locale::getDefault() instead of using the one configured in Symfony.

Inject the default_locale option from the translation pull command to the xlf writer.