### PR TITLE
[Validator] Improve CssColorValidator regex to match colors with spac…

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CssColorValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CssColorValidator.php
@@ -32,10 +32,10 @@ class CssColorValidator extends ConstraintValidator
     // List comes from https://drafts.csswg.org/css-color/#css-system-colors
     private const PATTERN_SYSTEM_COLORS = '/^(Canvas|CanvasText|LinkText|VisitedText|ActiveText|ButtonFace|ButtonText|ButtonBorder|Field|FieldText|Highlight|HighlightText|SelectedItem|SelectedItemText|Mark|MarkText|GrayText)$/i';
     private const PATTERN_KEYWORDS = '/^(transparent|currentColor)$/i';
-    private const PATTERN_RGB = '/^rgb\((0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s?(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s?(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d)\)$/i';
-    private const PATTERN_RGBA = '/^rgba\((0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s?(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s?(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s?(0|0?\.\d|1(\.0)?)\)$/i';
-    private const PATTERN_HSL = '/^hsl\((0|360|35\d|3[0-4]\d|[12]\d\d|0?\d?\d),\s?(0|100|\d{1,2})%,\s?(0|100|\d{1,2})%\)$/i';
-    private const PATTERN_HSLA = '/^hsla\((0|360|35\d|3[0-4]\d|[12]\d\d|0?\d?\d),\s?(0|100|\d{1,2})%,\s?(0|100|\d{1,2})%,\s?(0?\.\d|1(\.0)?)\)$/i';
+    private const PATTERN_RGB = '/^rgb\(\s*(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d)\s*,\s*(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d)\s*,\s*(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d)\s*\)$/i';
+    private const PATTERN_RGBA = '/^rgba\(\s*(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d)\s*,\s*(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d)\s*,\s*(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d)\s*,\s*(0|0?\.\d|1(\.0)?)\s*\)$/i';
+    private const PATTERN_HSL = '/^hsl\(\s*(0|360|35\d|3[0-4]\d|[12]\d\d|0?\d?\d)\s*,\s*(0|100|\d{1,2})%\s*,\s*(0|100|\d{1,2})%\s*\)$/i';
+    private const PATTERN_HSLA = '/^hsla\(\s*(0|360|35\d|3[0-4]\d|[12]\d\d|0?\d?\d)\s*,\s*(0|100|\d{1,2})%\s*,\s*(0|100|\d{1,2})%\s*,\s*(0?\.\d|1(\.0)?)\s*\)$/i';
 
     private const COLOR_PATTERNS = [
         CssColor::HEX_LONG => self::PATTERN_HEX_LONG,

--- a/src/Symfony/Component/Validator/Tests/Constraints/CssColorValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CssColorValidatorTest.php
@@ -179,6 +179,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
         return [
             ['rgb(255, 255, 255)'], ['rgb(0, 0, 0)'], ['rgb(0, 0, 255)'], ['rgb(255, 0, 0)'], ['rgb(122, 122, 122)'], ['rgb(66, 66, 66)'],
             ['rgb(255,255,255)'], ['rgb(0,0,0)'], ['rgb(0,0,255)'], ['rgb(255,0,0)'], ['rgb(122,122,122)'], ['rgb(66,66,66)'],
+            ['rgb(       33   ,      34   ,    12      )'],
         ];
     }
 
@@ -196,6 +197,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
         return [
             ['rgba(255, 255, 255, 0.3)'], ['rgba(0, 0, 0, 0.3)'], ['rgba(0, 0, 255, 0.3)'], ['rgba(255, 0, 0, 0.3)'], ['rgba(122, 122, 122, 0.3)'], ['rgba(66, 66, 66, 0.3)'],
             ['rgba(255,255,255,0.3)'], ['rgba(0,0,0,0.3)'], ['rgba(0,0,255,0.3)'], ['rgba(255,0,0,0.3)'], ['rgba(122,122,122,0.3)'], ['rgba(66,66,66,0.3)'],
+            ['rgba(   23   ,   24   ,          24  ,        .3   )'],
         ];
     }
 
@@ -213,6 +215,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
         return [
             ['hsl(0, 0%, 20%)'], ['hsl(0, 100%, 50%)'], ['hsl(147, 50%, 47%)'], ['hsl(46, 100%, 0%)'],
             ['hsl(0,0%,20%)'], ['hsl(0,100%,50%)'], ['hsl(147,50%,47%)'], ['hsl(46,100%,0%)'],
+            ['hsl(    0    ,     15%     ,    3%   )'],
         ];
     }
 
@@ -230,6 +233,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
         return [
             ['hsla(0, 0%, 20%, 0.4)'], ['hsla(0, 100%, 50%, 0.4)'], ['hsla(147, 50%, 47%, 0.4)'], ['hsla(46, 100%, 0%, 0.4)'],
             ['hsla(0,0%,20%,0.4)'], ['hsla(0,100%,50%,0.4)'], ['hsla(147,50%,47%,0.4)'], ['hsla(46,100%,0%,0.4)'],
+            ['hsla(   0  ,     13%,      56%,    .4  )'],
         ];
     }
 
@@ -313,7 +317,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
 
     public function getInvalidRGB(): array
     {
-        return [['rgb(999,999,999)'], ['rgb(-99,-99,-99)'], ['rgb(a,b,c)']];
+        return [['rgb(999,999,999)'], ['rgb(-99,-99,-99)'], ['rgb(a,b,c)'], ['rgb(99 99, 9 99, 99 9)']];
     }
 
     /**
@@ -336,7 +340,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
 
     public function getInvalidRGBA(): array
     {
-        return [['rgba(999,999,999,999)'], ['rgba(-99,-99,-99,-99)'], ['rgba(a,b,c,d)']];
+        return [['rgba(999,999,999,999)'], ['rgba(-99,-99,-99,-99)'], ['rgba(a,b,c,d)'], ['rgba(99 99, 9 99, 99 9, . 9)']];
     }
 
     /**
@@ -359,7 +363,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
 
     public function getInvalidHSL(): array
     {
-        return [['hsl(1000, 1000%, 20000%)'], ['hsl(-100, -10%, -2%)'], ['hsl(a, b, c)'], ['hsl(a, b%, c%)']];
+        return [['hsl(1000, 1000%, 20000%)'], ['hsl(-100, -10%, -2%)'], ['hsl(a, b, c)'], ['hsl(a, b%, c%)'], ['hsl( 99 99% , 9 99% , 99 9%)']];
     }
 
     /**
@@ -382,7 +386,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
 
     public function getInvalidHSLA(): array
     {
-        return [['hsla(1000, 1000%, 20000%, 999)'], ['hsla(-100, -10%, -2%, 999)'], ['hsla(a, b, c, d)'], ['hsla(a, b%, c%, d)']];
+        return [['hsla(1000, 1000%, 20000%, 999)'], ['hsla(-100, -10%, -2%, 999)'], ['hsla(a, b, c, d)'], ['hsla(a, b%, c%, d)'], ['hsla( 9 99%  , 99 9% ,  9 %']];
     }
 
     public function testUnknownFormatsOnValidateTriggerException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT

Hi,

I just see a tweet about this new validator and spotted an edge case with colors like `rgb(  34  ,     35   ,    12   )`.
I know that this could be a rare case but still a case that can occur and should be valid.

I hope everything is correctly done to be able to merge this PR :-)

Thanks
