### PR TITLE
[Validator] [CssColor] Fixed default behavior

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CssColor.php
+++ b/src/Symfony/Component/Validator/Constraints/CssColor.php
@@ -65,22 +65,22 @@ class CssColor extends Constraint
     /**
      * @param array|string $formats The types of CSS colors allowed (e.g. hexadecimal only, RGB and HSL only, etc.).
      */
-    public function __construct($formats, string $message = null, array $groups = null, $payload = null, array $options = null)
+    public function __construct($formats = [], string $message = null, array $groups = null, $payload = null, array $options = null)
     {
-        $validationModesAsString = array_reduce(self::$validationModes, function ($carry, $value) {
-            return $carry ? $carry.', '.$value : $value;
-        }, '');
+        $validationModesAsString = implode(', ', self::$validationModes);
 
-        if (\is_array($formats) && \is_string(key($formats))) {
+        if (!$formats) {
+            $options['value'] = self::$validationModes;
+        } elseif (\is_array($formats) && \is_string(key($formats))) {
             $options = array_merge($formats, $options);
         } elseif (\is_array($formats)) {
-            if ([] === array_intersect(static::$validationModes, $formats)) {
+            if ([] === array_intersect(self::$validationModes, $formats)) {
                 throw new InvalidArgumentException(sprintf('The "formats" parameter value is not valid. It must contain one or more of the following values: "%s".', $validationModesAsString));
             }
 
             $options['value'] = $formats;
         } elseif (\is_string($formats)) {
-            if (!\in_array($formats, static::$validationModes)) {
+            if (!\in_array($formats, self::$validationModes)) {
                 throw new InvalidArgumentException(sprintf('The "formats" parameter value is not valid. It must contain one or more of the following values: "%s".', $validationModesAsString));
             }
 

--- a/src/Symfony/Component/Validator/Constraints/CssColorValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CssColorValidator.php
@@ -32,10 +32,10 @@ class CssColorValidator extends ConstraintValidator
     // List comes from https://drafts.csswg.org/css-color/#css-system-colors
     private const PATTERN_SYSTEM_COLORS = '/^(Canvas|CanvasText|LinkText|VisitedText|ActiveText|ButtonFace|ButtonText|ButtonBorder|Field|FieldText|Highlight|HighlightText|SelectedItem|SelectedItemText|Mark|MarkText|GrayText)$/i';
     private const PATTERN_KEYWORDS = '/^(transparent|currentColor)$/i';
-    private const PATTERN_RGB = '/^rgb\((0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s?(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s?(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d)\)$/i';
-    private const PATTERN_RGBA = '/^rgba\((0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s?(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s?(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s?(0|0?\.\d|1(\.0)?)\)$/i';
-    private const PATTERN_HSL = '/^hsl\((0|360|35\d|3[0-4]\d|[12]\d\d|0?\d?\d),\s?(0|100|\d{1,2})%,\s?(0|100|\d{1,2})%\)$/i';
-    private const PATTERN_HSLA = '/^hsla\((0|360|35\d|3[0-4]\d|[12]\d\d|0?\d?\d),\s?(0|100|\d{1,2})%,\s?(0|100|\d{1,2})%,\s?(0?\.\d|1(\.0)?)\)$/i';
+    private const PATTERN_RGB = '/^rgb\(\s*(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s*(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s*(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d)\s*\)$/i';
+    private const PATTERN_RGBA = '/^rgba\(\s*(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s*(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s*(0|255|25[0-4]|2[0-4]\d|1\d\d|0?\d?\d),\s*(0|0?\.\d|1(\.0)?)\s*\)$/i';
+    private const PATTERN_HSL = '/^hsl\(\s*(0|360|35\d|3[0-4]\d|[12]\d\d|0?\d?\d),\s*(0|100|\d{1,2})%,\s*(0|100|\d{1,2})%\s*\)$/i';
+    private const PATTERN_HSLA = '/^hsla\(\s*(0|360|35\d|3[0-4]\d|[12]\d\d|0?\d?\d),\s*(0|100|\d{1,2})%,\s*(0|100|\d{1,2})%,\s*(0?\.\d|1(\.0)?)\s*\)$/i';
 
     private const COLOR_PATTERNS = [
         CssColor::HEX_LONG => self::PATTERN_HEX_LONG,

--- a/src/Symfony/Component/Validator/Tests/Constraints/CssColorValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CssColorValidatorTest.php
@@ -44,6 +44,33 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @dataProvider getValidAnyColor
+     */
+    public function testValidAnyColor($cssColor)
+    {
+        $this->validator->validate($cssColor, new CssColor());
+        $this->assertNoViolation();
+    }
+
+    public function getValidAnyColor(): array
+    {
+        return [
+            ['#ABCDEF'],
+            ['#ABCDEF00'],
+            ['#F4B'],
+            ['#F4B1'],
+            ['black'],
+            ['aliceblue'],
+            ['Canvas'],
+            ['transparent'],
+            ['rgb(255, 255, 255)'],
+            ['rgba(255, 255, 255, 0.3)'],
+            ['hsl(0, 0%, 20%)'],
+            ['hsla(0, 0%, 20%, 0.4)'],
+        ];
+    }
+
+    /**
      * @dataProvider getValidHexLongColors
      */
     public function testValidHexLongColors($cssColor)
@@ -177,6 +204,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     public function getValidRGB(): array
     {
         return [
+            ['rgb(0,      255,     243)'],
             ['rgb(255, 255, 255)'], ['rgb(0, 0, 0)'], ['rgb(0, 0, 255)'], ['rgb(255, 0, 0)'], ['rgb(122, 122, 122)'], ['rgb(66, 66, 66)'],
             ['rgb(255,255,255)'], ['rgb(0,0,0)'], ['rgb(0,0,255)'], ['rgb(255,0,0)'], ['rgb(122,122,122)'], ['rgb(66,66,66)'],
         ];
@@ -194,6 +222,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     public function getValidRGBA(): array
     {
         return [
+            ['rgba(   255,      255,     255,    0.3         )'], ['rgba(255,      255,     255,    0.3)'], ['rgba(255,      255,     255,    .3)'],
             ['rgba(255, 255, 255, 0.3)'], ['rgba(0, 0, 0, 0.3)'], ['rgba(0, 0, 255, 0.3)'], ['rgba(255, 0, 0, 0.3)'], ['rgba(122, 122, 122, 0.3)'], ['rgba(66, 66, 66, 0.3)'],
             ['rgba(255,255,255,0.3)'], ['rgba(0,0,0,0.3)'], ['rgba(0,0,255,0.3)'], ['rgba(255,0,0,0.3)'], ['rgba(122,122,122,0.3)'], ['rgba(66,66,66,0.3)'],
         ];
@@ -211,6 +240,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     public function getValidHSL(): array
     {
         return [
+            ['hsl(0,    0%,   20%)'], ['hsl(     0,    0%,   20%     )'],
             ['hsl(0, 0%, 20%)'], ['hsl(0, 100%, 50%)'], ['hsl(147, 50%, 47%)'], ['hsl(46, 100%, 0%)'],
             ['hsl(0,0%,20%)'], ['hsl(0,100%,50%)'], ['hsl(147,50%,47%)'], ['hsl(46,100%,0%)'],
         ];
@@ -228,6 +258,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
     public function getValidHSLA(): array
     {
         return [
+            ['hsla(   0,    0%,     20%,   0.4     )'], ['hsla(0,    0%,     20%,   0.4)'], ['hsla(0,    0%,     20%,   .4)'],
             ['hsla(0, 0%, 20%, 0.4)'], ['hsla(0, 100%, 50%, 0.4)'], ['hsla(147, 50%, 47%, 0.4)'], ['hsla(46, 100%, 0%, 0.4)'],
             ['hsla(0,0%,20%,0.4)'], ['hsla(0,100%,50%,0.4)'], ['hsla(147,50%,47%,0.4)'], ['hsla(46,100%,0%,0.4)'],
         ];
@@ -313,7 +344,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
 
     public function getInvalidRGB(): array
     {
-        return [['rgb(999,999,999)'], ['rgb(-99,-99,-99)'], ['rgb(a,b,c)']];
+        return [['rgb(999,999,999)'], ['rgb(-99,-99,-99)'], ['rgb(a,b,c)'], ['rgb(99 99, 9 99, 99 9)']];
     }
 
     /**
@@ -336,7 +367,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
 
     public function getInvalidRGBA(): array
     {
-        return [['rgba(999,999,999,999)'], ['rgba(-99,-99,-99,-99)'], ['rgba(a,b,c,d)']];
+        return [['rgba(999,999,999,999)'], ['rgba(-99,-99,-99,-99)'], ['rgba(a,b,c,d)'], ['rgba(99 99, 9 99, 99 9, . 9)']];
     }
 
     /**
@@ -359,7 +390,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
 
     public function getInvalidHSL(): array
     {
-        return [['hsl(1000, 1000%, 20000%)'], ['hsl(-100, -10%, -2%)'], ['hsl(a, b, c)'], ['hsl(a, b%, c%)']];
+        return [['hsl(1000, 1000%, 20000%)'], ['hsl(-100, -10%, -2%)'], ['hsl(a, b, c)'], ['hsl(a, b%, c%)'], ['hsl( 99 99% , 9 99% , 99 9%)']];
     }
 
     /**
@@ -382,7 +413,7 @@ final class CssColorValidatorTest extends ConstraintValidatorTestCase
 
     public function getInvalidHSLA(): array
     {
-        return [['hsla(1000, 1000%, 20000%, 999)'], ['hsla(-100, -10%, -2%, 999)'], ['hsla(a, b, c, d)'], ['hsla(a, b%, c%, d)']];
+        return [['hsla(1000, 1000%, 20000%, 999)'], ['hsla(-100, -10%, -2%, 999)'], ['hsla(a, b, c, d)'], ['hsla(a, b%, c%, d)'], ['hsla( 9 99% , 99 9% , 9 %']];
     }
 
     public function testUnknownFormatsOnValidateTriggerException()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Following the @javiereguiluz PR in docs (https://github.com/symfony/symfony-docs/pull/15906), I figured out I've missed the default behavior of the constraint, which is "all formats are valid if you pass no arguments". It's fixed.

I've also replaced an overengineered `array_reduce` with an `implode`.

Tests have been updated too.