### PR TITLE
[PhpUnitBridge] wrong output when trying to quiet deprecations

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler.php
@@ -320,7 +320,7 @@ class DeprecationErrorHandler
                     fwrite($handle, "\n".self::colorize($deprecationGroupMessage, 'legacy' !== $group && 'indirect' !== $group)."\n");
                 }
 
-                if ('legacy' !== $group && !$configuration->verboseOutput($group) && !$isFailing) {
+                if ('legacy' !== $group && !$configuration->verboseOutput($group)) {
                     continue;
                 }
                 $notices = $this->deprecationGroups[$group]->notices();

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/partially_quiet2.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/partially_quiet2.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test DeprecationErrorHandler quiet on everything but self/direct deprecations
+--FILE--
+<?php
+
+$k = 'SYMFONY_DEPRECATIONS_HELPER';
+putenv($k.'='.$_SERVER[$k] = $_ENV[$k] = 'max[self]=0&max[direct]=0&quiet[]=unsilenced&quiet[]=indirect&quiet[]=other');
+putenv('ANSICON');
+putenv('ConEmuANSI');
+putenv('TERM');
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+define('PHPUNIT_COMPOSER_INSTALL', $vendor.'/vendor/autoload.php');
+require PHPUNIT_COMPOSER_INSTALL;
+require_once __DIR__.'/../../bootstrap.php';
+require __DIR__.'/fake_vendor/autoload.php';
+require __DIR__.'/fake_vendor/acme/lib/deprecation_riddled.php';
+require __DIR__.'/fake_vendor/acme/outdated-lib/outdated_file.php';
+
+?>
+--EXPECTF--
+Unsilenced deprecation notices (3)
+
+Remaining direct deprecation notices (2)
+
+  1x: root deprecation
+
+  1x: silenced bar deprecation
+    1x in FooTestCase::testNonLegacyBar
+
+Remaining indirect deprecation notices (1)
+
+Legacy deprecation notices (2)

--- a/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/quiet_but_failing.phpt
+++ b/src/Symfony/Bridge/PhpUnit/Tests/DeprecationErrorHandler/quiet_but_failing.phpt
@@ -34,6 +34,3 @@ require __DIR__.'/fake_vendor/acme/outdated-lib/outdated_file.php';
 ?>
 --EXPECTF--
 Remaining indirect deprecation notices (1)
-
-  1x: Since acme/lib 3.0: deprecatedApi is deprecated, use deprecatedApi_new instead.
-    1x in SomeService::deprecatedApi from acme\lib


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I've found what I suspect is a bug when trying to display verbose deprecation for some types and hide others. This is a failing test. When using `max[self]=0&max[direct]=0&quiet[]=unsilenced&quiet[]=indirect&quiet[]=other` I expect everything but self/direct depredations to be hidden. This is not the case.

The actual output of the failing test is as follows:

```
Unsilenced deprecation notices (3)

  2x: unsilenced foo deprecation
    2x in FooTestCase::testLegacyFoo

  1x: unsilenced bar deprecation
    1x in FooTestCase::testNonLegacyBar

Remaining direct deprecation notices (2)

  1x: root deprecation

  1x: silenced bar deprecation
    1x in FooTestCase::testNonLegacyBar

Remaining indirect deprecation notices (1)

  1x: Since acme/lib 3.0: deprecatedApi is deprecated, use deprecatedApi_new instead.
    1x in SomeService::deprecatedApi from acme\lib

Legacy deprecation notices (2)
```
