### PR TITLE
[Security] PreAuthenticatedAuthenticationProvider::authenticate(): don't load user via userProvider if the user was already supplied in the token

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProvider.php
@@ -16,6 +16,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**
@@ -54,7 +55,9 @@ class PreAuthenticatedAuthenticationProvider implements AuthenticationProviderIn
             throw new BadCredentialsException('No pre-authenticated principal found in request.');
         }
 
-        $user = $this->userProvider->loadUserByUsername($user);
+        if (!$user instanceof UserInterface) {
+            $user = $this->userProvider->loadUserByUsername($user);
+        }
 
         $this->userChecker->checkPostAuth($user);
 


### PR DESCRIPTION
Fixes #43374

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43374
| License       | MIT
| Doc PR        | N/A
