### PR TITLE
[Runtime] Fix class validation of composer "extra.runtime.class"

### DIFF
--- a/src/Symfony/Component/Runtime/Internal/ComposerPlugin.php
+++ b/src/Symfony/Component/Runtime/Internal/ComposerPlugin.php
@@ -18,7 +18,6 @@ use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\ScriptEvents;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Runtime\RuntimeInterface;
 use Symfony\Component\Runtime\SymfonyRuntime;
 
 /**
@@ -97,10 +96,6 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
         }
 
         $runtimeClass = $extra['class'] ?? SymfonyRuntime::class;
-
-        if (SymfonyRuntime::class !== $runtimeClass && !is_subclass_of($runtimeClass, RuntimeInterface::class)) {
-            throw new \InvalidArgumentException(sprintf('Class "%s" listed under "extra.runtime.class" in your composer.json file '.(class_exists($runtimeClass) ? 'should implement "%s".' : 'not found.'), $runtimeClass, RuntimeInterface::class));
-        }
 
         unset($extra['class'], $extra['autoload_template']);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

This PR fixes a bug of validating a runtime class from the composer param `extra.runtime.class`. When provided, it always fails. Taking as an example the `Runtime\Swoole\Runtime` of the `runtime/swoole` package, when executing the `composer dump-autoload`, it ends with the following exception, even though the `runtime/swoole` package was installed.
```
 [InvalidArgumentException]
 Class "Runtime\Swoole\Runtime" listed under "extra.runtime.class" in your composer.json file not found.
```
When a composer plugin is executed, the composer autoloader for the project is not registered, thereby any reference to a class from installed packages won't work.
The fix drops this check to avoid it. I don't think it's worth checking here if a runtime class is valid or not. For instance, anything that comes from the `$_SERVER['APP_RUNTIME']` is accepted, nothing is validated.