### PR TITLE
[HttpFoundation] Deprecate upload_progress.* and url_rewriter.tags session options

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -40,6 +40,7 @@ HttpFoundation
 --------------
 
  * Mark `Request::get()` internal, use explicit input sources instead
+ * Deprecate `upload_progress.*` and `url_rewriter.tags` session options
 
 Messenger
 ---------

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 ---
 
  * Add the `litespeed_finish_request` method to work with Litespeed
+ * Deprecate `upload_progress.*` and `url_rewriter.tags` session options
 
 5.3
 ---

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -90,13 +90,6 @@ class NativeSessionStorage implements SessionStorageInterface
      * use_cookies, "1"
      * use_only_cookies, "1"
      * use_trans_sid, "0"
-     * upload_progress.enabled, "1"
-     * upload_progress.cleanup, "1"
-     * upload_progress.prefix, "upload_progress_"
-     * upload_progress.name, "PHP_SESSION_UPLOAD_PROGRESS"
-     * upload_progress.freq, "1%"
-     * upload_progress.min-freq, "1"
-     * url_rewriter.tags, "a=href,area=href,frame=src,form=,fieldset="
      * sid_length, "32"
      * sid_bits_per_character, "5"
      * trans_sid_hosts, $_SERVER['HTTP_HOST']
@@ -383,6 +376,13 @@ class NativeSessionStorage implements SessionStorageInterface
 
         foreach ($options as $key => $value) {
             if (isset($validOptions[$key])) {
+                if (str_starts_with($key, 'upload_progress.')) {
+                    trigger_deprecation('symfony/http-foundation', '5.4', 'Support for the "%s" session option is deprecated. The settings prefixed with "session.upload_progress." can not be changed at runtime.', $key);
+                    continue;
+                }
+                if ('url_rewriter.tags' === $key) {
+                    trigger_deprecation('symfony/http-foundation', '5.4', 'Support for the "%s" session option is deprecated. Use "trans_sid_tags" instead.', $key);
+                }
                 if ('cookie_samesite' === $key && \PHP_VERSION_ID < 70300) {
                     // PHP < 7.3 does not support same_site cookies. We will emulate it in
                     // the start() method instead.

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/NativeSessionStorageTest.php
@@ -195,13 +195,13 @@ class NativeSessionStorageTest extends TestCase
     public function testSessionOptions()
     {
         $options = [
-            'url_rewriter.tags' => 'a=href',
+            'trans_sid_tags' => 'a=href',
             'cache_expire' => '200',
         ];
 
         $this->getStorage($options);
 
-        $this->assertSame('a=href', ini_get('url_rewriter.tags'));
+        $this->assertSame('a=href', ini_get('session.trans_sid_tags'));
         $this->assertSame('200', ini_get('session.cache_expire'));
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #43284
| License       | MIT

Related to [issue #43284](https://github.com/symfony/symfony/issues/43284).

Deprecate support for configuring session.upload_progress.* - these options are `PHP_INI_PERDIR` options and can not be configured at runtime via `ini_set`.

Deprecate support for configuring `url_rewriter.tags` - as of PHP 7.1.0, this option is no longer used for session configuration and that setting is now `session.trans_sid_tags`. `url_rewriter.tags` is used only by `output_add_rewrite_var`.

---

I wasn't sure about writing a test for this. I couldn't find any other places that deprecation notices were being tested. However the existing HttpFoundation test uses `url_rewriter.tags` and I can see the new deprecation notice when running `php ./phpunit src/Symfony/Component/HttpFoundation/` -- it may be appropriate to update that to use a new option.
