### PR TITLE
[HttpKernel] Fix return types in `EventDataCollector`

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/EventDataCollector.php
@@ -15,6 +15,7 @@ use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -80,8 +81,10 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
 
     /**
      * @see TraceableEventDispatcher
+     *
+     * @return array|Data
      */
-    public function getCalledListeners(): array
+    public function getCalledListeners()
     {
         return $this->data['called_listeners'];
     }
@@ -96,8 +99,10 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
 
     /**
      * @see TraceableEventDispatcher
+     *
+     * @return array|Data
      */
-    public function getNotCalledListeners(): array
+    public function getNotCalledListeners()
     {
         return $this->data['not_called_listeners'];
     }
@@ -114,8 +119,10 @@ class EventDataCollector extends DataCollector implements LateDataCollectorInter
 
     /**
      * @see TraceableEventDispatcher
+     *
+     * @return array|Data
      */
-    public function getOrphanedEvents(): array
+    public function getOrphanedEvents()
     {
         return $this->data['orphaned_events'];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

DataCollectors' getters return `array|Data` when `lateCollect()` transforms the collected data using VarDumper.

Before:
<img width="1102" alt="Screenshot 2021-10-09 at 17 56 36" src="https://user-images.githubusercontent.com/7502063/136665739-c3cd2c9f-e6c3-4441-bb27-a3d8480a1b11.png">

After:
<img width="957" alt="Screenshot 2021-10-09 at 17 57 03" src="https://user-images.githubusercontent.com/7502063/136665743-99056576-ead3-4b0d-a58b-03b5cb594aa7.png">

