### PR TITLE
[Form] Check the type of the constraints option

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormRendererInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -66,6 +67,7 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
             'allow_extra_fields' => false,
             'extra_fields_message' => 'This form should not contain extra fields.',
         ]);
+        $resolver->setAllowedTypes('constraints', [Constraint::class, Constraint::class.'[]']);
         $resolver->setAllowedTypes('legacy_error_messages', 'bool');
         $resolver->setDeprecated('legacy_error_messages', 'symfony/form', '5.2', function (Options $options, $value) {
             if (true === $value) {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
 use Symfony\Component\Form\Tests\Extension\Core\Type\FormTypeTest;
 use Symfony\Component\Form\Tests\Extension\Core\Type\TextTypeTest;
 use Symfony\Component\Form\Tests\Fixtures\Author;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -59,6 +60,19 @@ class FormTypeValidatorExtensionTest extends BaseValidatorExtensionTest
         $form = $this->createForm(['constraints' => $valid = new Valid()]);
 
         $this->assertSame([$valid], $form->getConfig()->getOption('constraints'));
+    }
+
+    public function testValidConstraintsArray()
+    {
+        $form = $this->createForm(['constraints' => [$valid = new Valid()]]);
+
+        $this->assertSame([$valid], $form->getConfig()->getOption('constraints'));
+    }
+
+    public function testInvalidConstraint()
+    {
+        $this->expectException(InvalidOptionsException::class);
+        $this->createForm(['constraints' => ['foo' => 'bar']]);
     }
 
     public function testGroupSequenceWithConstraintsOption()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40726
| License       | MIT
| Doc PR        | N/A

This PR adds a type check to the constraints passed to a form field. This should improve the error message the developer receives in cases like the one described in #40726.