### PR TITLE
GuardEvent::getTransition() cannot return null

### DIFF
--- a/src/Symfony/Component/Workflow/Event/GuardEvent.php
+++ b/src/Symfony/Component/Workflow/Event/GuardEvent.php
@@ -35,6 +35,11 @@ final class GuardEvent extends Event
         $this->transitionBlockerList = new TransitionBlockerList();
     }
 
+    public function getTransition(): Transition
+    {
+        return parent::getTransition();
+    }
+
     public function isBlocked(): bool
     {
         return !$this->transitionBlockerList->isEmpty();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4?
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a


Since $transition is required on the constructor, we can type thint that getTransition always return the `Transition`, rather than `Transition|null`.

This is a purely annotation change so no change to CHANGELOG or tests, but please let me know if this is desired, or I should target a different branch.

I'm also happy to update the other events that are only ever called with with a concrete Transition, if this is acceptable, however I need guidance on whether there's a change these could be called without the Transition in other uses, somehow, or not.