### PR TITLE
[HttpClient] Fix RetryableHttpClient yielding a null chunk

### DIFF
--- a/src/Symfony/Component/HttpClient/RetryableHttpClient.php
+++ b/src/Symfony/Component/HttpClient/RetryableHttpClient.php
@@ -117,7 +117,9 @@ class RetryableHttpClient implements HttpClientInterface
 
                 if (false === $shouldRetry) {
                     $context->passthru();
-                    yield $firstChunk;
+                    if (null !== $firstChunk) {
+                        yield $firstChunk;
+                    }
                     yield $context->createChunk($content);
                     $content = '';
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43390 
| License       | MIT
| Doc PR        | 



RetryableHttpClient was yield a null chuck to AsyncResponse throwing an LogicException ([AsyncResponse.php:361](https://github.com/symfony/symfony/blob/5.3/src/Symfony/Component/HttpClient/Response/AsyncResponse.php#L361)).

I wasn't able to create a unit test as it requires constant adjustments on the timeout to trigger this issue as described on #43390


_This is my first PR on symfony, so please do tell me if I did something wrong._
