### PR TITLE
[Security] Move `TraceableAuthenticator` to `security-http`

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Debug/TraceableFirewallListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/TraceableFirewallListener.php
@@ -11,11 +11,11 @@
 
 namespace Symfony\Bundle\SecurityBundle\Debug;
 
-use Symfony\Bundle\SecurityBundle\Debug\Authenticator\TraceableAuthenticatorManagerListener;
 use Symfony\Bundle\SecurityBundle\EventListener\FirewallListener;
 use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
 use Symfony\Bundle\SecurityBundle\Security\LazyFirewallContext;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticatorManagerListener;
 use Symfony\Component\Security\Http\Firewall\FirewallListenerInterface;
 
 /**

--- a/src/Symfony/Bundle/SecurityBundle/Debug/TraceableListenerTrait.php
+++ b/src/Symfony/Bundle/SecurityBundle/Debug/TraceableListenerTrait.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Debug;
 
-use Symfony\Bundle\SecurityBundle\Debug\Authenticator\TraceableAuthenticatorManagerListener;
+use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticatorManagerListener;
 use Symfony\Component\VarDumper\Caster\ClassStub;
 
 /**

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
 
 use Symfony\Bridge\Twig\Extension\LogoutUrlExtension;
-use Symfony\Bundle\SecurityBundle\Debug\Authenticator\TraceableAuthenticatorManagerListener;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FirewallListenerFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
@@ -45,6 +44,7 @@ use Symfony\Component\Security\Core\Encoder\SodiumPasswordEncoder;
 use Symfony\Component\Security\Core\User\ChainUserProvider;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticatorManagerListener;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 
 /**

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Debug/TraceableFirewallListenerTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Debug/TraceableFirewallListenerTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\Debug;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bundle\SecurityBundle\Debug\Authenticator\TraceableAuthenticatorManagerListener;
 use Symfony\Bundle\SecurityBundle\Debug\TraceableFirewallListener;
 use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -23,6 +22,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticatorManager;
+use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticatorManagerListener;
 use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\SecurityBundle\Debug\Authenticator;
+namespace Symfony\Component\Security\Http\Authenticator\Debug;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,9 +25,9 @@ use Symfony\Component\Security\Http\EntryPoint\Exception\NotAnEntryPointExceptio
 use Symfony\Component\VarDumper\Caster\ClassStub;
 
 /**
- * @author Robin Chalas <robin.chalas@gmail.com>
+ * Collects info about an authenticator for debugging purposes.
  *
- * @internal
+ * @author Robin Chalas <robin.chalas@gmail.com>
  */
 final class TraceableAuthenticator implements AuthenticatorInterface, InteractiveAuthenticatorInterface, AuthenticationEntryPointInterface
 {
@@ -43,11 +43,13 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
 
     public function getInfo(): array
     {
+        $class = \get_class($this->authenticator instanceof GuardBridgeAuthenticator ? $this->authenticator->getGuardAuthenticator() : $this->authenticator);
+
         return [
             'supports' => true,
             'passport' => $this->passport,
             'duration' => $this->duration,
-            'stub' => $this->stub ?? $this->stub = new ClassStub(\get_class($this->authenticator instanceof GuardBridgeAuthenticator ? $this->authenticator->getGuardAuthenticator() : $this->authenticator)),
+            'stub' => $this->stub ?? $this->stub = class_exists(ClassStub::class) ? new ClassStub($class) : $class,
         ];
     }
 

--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticatorManagerListener.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticatorManagerListener.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\SecurityBundle\Debug\Authenticator;
+namespace Symfony\Component\Security\Http\Authenticator\Debug;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -21,17 +21,17 @@ use Symfony\Component\VarDumper\Caster\ClassStub;
  * Decorates the AuthenticatorManagerListener to collect information about security authenticators.
  *
  * @author Robin Chalas <robin.chalas@gmail.com>
- *
- * @internal
  */
-class TraceableAuthenticatorManagerListener extends AbstractListener
+final class TraceableAuthenticatorManagerListener extends AbstractListener
 {
     private $authenticationManagerListener;
     private $authenticatorsInfo = [];
+    private $hasVardumper;
 
     public function __construct(AuthenticatorManagerListener $authenticationManagerListener)
     {
         $this->authenticationManagerListener = $authenticationManagerListener;
+        $this->hasVardumper = class_exists(ClassStub::class);
     }
 
     public function supports(Request $request): ?bool
@@ -50,7 +50,7 @@ class TraceableAuthenticatorManagerListener extends AbstractListener
         foreach ($request->attributes->get('_security_skipped_authenticators') as $skippedAuthenticator) {
             $this->authenticatorsInfo[] = [
                 'supports' => false,
-                'stub' => new ClassStub(\get_class($skippedAuthenticator)),
+                'stub' => $this->hasVardumper ? new ClassStub(\get_class($skippedAuthenticator)) : \get_class($skippedAuthenticator),
                 'passport' => null,
                 'duration' => 0,
             ];

--- a/src/Symfony/Component/Security/Http/Tests/Authenticator/Debug/TraceableAuthenticatorTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/Authenticator/Debug/TraceableAuthenticatorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Tests\Authenticator\Debug;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
+use Symfony\Component\Security\Http\Authenticator\Debug\TraceableAuthenticator;
+use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
+
+class TraceableAuthenticatorTest extends TestCase
+{
+    public function testGetInfo()
+    {
+        $request = new Request();
+        $passport = new SelfValidatingPassport(new UserBadge('robin', function () {}));
+
+        $authenticator = $this->createMock(AuthenticatorInterface::class);
+        $authenticator
+            ->expects($this->once())
+            ->method('authenticate')
+            ->with($request)
+            ->willReturn($passport);
+
+        $traceable = new TraceableAuthenticator($authenticator);
+        $this->assertSame($passport, $traceable->authenticate($request));
+        $this->assertSame($passport, $traceable->getInfo()['passport']);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Necessary to fix tests on branch 6.0 https://github.com/symfony/symfony/runs/3861906767. 

There is an incompatible signature for `AuthenticatorInterface::createAuthenticatedToken()` between security-bundle 6.0 and security-http 5.4 because of the deprecated `PassportInterface` type.
Moving `TraceableAuthenticator` and `TraceableAuthenticatorManagerListener` to `security-http` fixes the issue and it's looking good to me.