### PR TITLE
[Notifier] Fix 'Undefined array key' error in FirebaseTransport

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Firebase/Tests/FirebaseTransportTest.php
@@ -11,13 +11,18 @@
 
 namespace Symfony\Component\Notifier\Bridge\Firebase\Tests;
 
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\Notifier\Bridge\Firebase\FirebaseOptions;
 use Symfony\Component\Notifier\Bridge\Firebase\FirebaseTransport;
+use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * @author Oskar Stark <oskarstark@googlemail.com>
@@ -46,5 +51,35 @@ final class FirebaseTransportTest extends TransportTestCase
     {
         yield [new SmsMessage('0611223344', 'Hello!')];
         yield [$this->createMock(MessageInterface::class)];
+    }
+
+    /**
+     * @dataProvider sendWithErrorThrowsExceptionProvider
+     */
+    public function testSendWithErrorThrowsTransportException(ResponseInterface $response)
+    {
+        $this->expectException(TransportException::class);
+
+        $client = new MockHttpClient(static function () use ($response): ResponseInterface {
+            return $response;
+        });
+        $options = new class('recipient-id', []) extends FirebaseOptions {};
+
+        $transport = $this->createTransport($client);
+
+        $transport->send(new ChatMessage('Hello!', $options));
+    }
+
+    public function sendWithErrorThrowsExceptionProvider(): iterable
+    {
+        yield [new MockResponse(
+            json_encode(['results' => [['error' => 'testErrorCode']]]),
+            ['response_headers' => ['content-type' => ['application/json']], 'http_code' => 200]
+        )];
+
+        yield [new MockResponse(
+            json_encode(['results' => [['error' => 'testErrorCode']]]),
+            ['response_headers' => ['content-type' => ['application/json']], 'http_code' => 400]
+        )];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42841
| License       | MIT
| Doc PR        | n/a

This modification fixes a remaining `Undefined array key` error in *FirebaseTransport*.
It also add a test to cover #42690.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
