### PR TITLE
[HttpFoundation] Deprecate passing null as $requestIp in IpUtils

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -39,6 +39,7 @@ HttpKernel
 HttpFoundation
 --------------
 
+ * Deprecate passing `null` as `$requestIp` to `IpUtils::checkIp()`, `IpUtils::checkIp4()` or `IpUtils::checkIp6()`, pass an empty string instead.
  * Mark `Request::get()` internal, use explicit input sources instead
  * Deprecate `upload_progress.*` and `url_rewriter.tags` session options
 

--- a/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NoPrivateNetworkHttpClient.php
@@ -80,7 +80,7 @@ final class NoPrivateNetworkHttpClient implements HttpClientInterface, LoggerAwa
 
         $options['on_progress'] = function (int $dlNow, int $dlSize, array $info) use ($onProgress, $subnets, &$lastPrimaryIp): void {
             if ($info['primary_ip'] !== $lastPrimaryIp) {
-                if (IpUtils::checkIp($info['primary_ip'], $subnets ?? self::PRIVATE_SUBNETS)) {
+                if ($info['primary_ip'] && IpUtils::checkIp($info['primary_ip'], $subnets ?? self::PRIVATE_SUBNETS)) {
                     throw new TransportException(sprintf('IP "%s" is blocked for "%s".', $info['primary_ip'], $info['url']));
                 }
 

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 5.4
 ---
 
+ * Deprecate passing `null` as `$requestIp` to `IpUtils::__checkIp()`, `IpUtils::__checkIp4()` or `IpUtils::__checkIp6()`, pass an empty string instead.
  * Add the `litespeed_finish_request` method to work with Litespeed
  * Deprecate `upload_progress.*` and `url_rewriter.tags` session options
 

--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -37,6 +37,8 @@ class IpUtils
     public static function checkIp(?string $requestIp, $ips)
     {
         if (null === $requestIp) {
+            trigger_deprecation('symfony/http-foundation', '5.4', 'Passing null as $requestIp to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
             return false;
         }
 
@@ -65,6 +67,12 @@ class IpUtils
      */
     public static function checkIp4(?string $requestIp, string $ip)
     {
+        if (null === $requestIp) {
+            trigger_deprecation('symfony/http-foundation', '5.4', 'Passing null as $requestIp to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            return false;
+        }
+
         $cacheKey = $requestIp.'-'.$ip;
         if (isset(self::$checkedIps[$cacheKey])) {
             return self::$checkedIps[$cacheKey];
@@ -112,6 +120,12 @@ class IpUtils
      */
     public static function checkIp6(?string $requestIp, string $ip)
     {
+        if (null === $requestIp) {
+            trigger_deprecation('symfony/http-foundation', '5.4', 'Passing null as $requestIp to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
+
+            return false;
+        }
+
         $cacheKey = $requestIp.'-'.$ip;
         if (isset(self::$checkedIps[$cacheKey])) {
             return self::$checkedIps[$cacheKey];

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher.php
@@ -185,7 +185,7 @@ class RequestMatcher implements RequestMatcherInterface
             return false;
         }
 
-        if (IpUtils::checkIp($request->getClientIp(), $this->ips)) {
+        if (IpUtils::checkIp($request->getClientIp() ?? '', $this->ips)) {
             return true;
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -12,10 +12,13 @@
 namespace Symfony\Component\HttpFoundation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\HttpFoundation\IpUtils;
 
 class IpUtilsTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @dataProvider getIpv4Data
      */
@@ -40,7 +43,6 @@ class IpUtilsTest extends TestCase
             [false, '1.2.3.4', '256.256.256/0'], // invalid CIDR notation
             [false, 'an_invalid_ip', '192.168.1.0/24'],
             [false, '', '1.2.3.4/1'],
-            [false, null, '1.2.3.4/1'],
         ];
     }
 
@@ -72,8 +74,34 @@ class IpUtilsTest extends TestCase
             [false, '}__test|O:21:&quot;JDatabaseDriverMysqli&quot;:3:{s:2', '::1'],
             [false, '2a01:198:603:0:396e:4789:8e99:890f', 'unknown'],
             [false, '', '::1'],
-            [false, null, '::1'],
         ];
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testIpTriggersDeprecationOnNull()
+    {
+        $this->expectDeprecation('Since symfony/http-foundation 5.4: Passing null as $requestIp to "Symfony\Component\HttpFoundation\IpUtils::checkIp()" is deprecated, pass an empty string instead.');
+        $this->assertFalse(IpUtils::checkIp(null, '192.168.1.1'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testIp4TriggersDeprecationOnNull()
+    {
+        $this->expectDeprecation('Since symfony/http-foundation 5.4: Passing null as $requestIp to "Symfony\Component\HttpFoundation\IpUtils::checkIp4()" is deprecated, pass an empty string instead.');
+        $this->assertFalse(IpUtils::checkIp4(null, '192.168.1.1'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testIp6TriggersDeprecationOnNull()
+    {
+        $this->expectDeprecation('Since symfony/http-foundation 5.4: Passing null as $requestIp to "Symfony\Component\HttpFoundation\IpUtils::checkIp6()" is deprecated, pass an empty string instead.');
+        $this->assertFalse(IpUtils::checkIp6(null, '2a01:198:603:0::/65'));
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/HttpCache/SubRequestHandler.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/SubRequestHandler.php
@@ -31,7 +31,7 @@ class SubRequestHandler
 
         // remove untrusted values
         $remoteAddr = $request->server->get('REMOTE_ADDR');
-        if (!IpUtils::checkIp($remoteAddr, $trustedProxies)) {
+        if (!$remoteAddr || !IpUtils::checkIp($remoteAddr, $trustedProxies)) {
             $trustedHeaders = [
                 'FORWARDED' => $trustedHeaderSet & Request::HEADER_FORWARDED,
                 'X_FORWARDED_FOR' => $trustedHeaderSet & Request::HEADER_X_FORWARDED_FOR,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | https://github.com/symfony/symfony/issues/43350#issuecomment-936951604
| License       | MIT
| Doc PR        | 
