### PR TITLE
[VarDumper] Fix error with uninitialized XMLReader

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/XmlReaderCaster.php
@@ -44,6 +44,22 @@ class XmlReaderCaster
 
     public static function castXmlReader(\XMLReader $reader, array $a, Stub $stub, $isNested)
     {
+        try {
+            $properties = [
+                'LOADDTD' => @$reader->getParserProperty(\XMLReader::LOADDTD),
+                'DEFAULTATTRS' => @$reader->getParserProperty(\XMLReader::DEFAULTATTRS),
+                'VALIDATE' => @$reader->getParserProperty(\XMLReader::VALIDATE),
+                'SUBST_ENTITIES' => @$reader->getParserProperty(\XMLReader::SUBST_ENTITIES),
+            ];
+        } catch (\Error $e) {
+            $properties = [
+                'LOADDTD' => false,
+                'DEFAULTATTRS' => false,
+                'VALIDATE' => false,
+                'SUBST_ENTITIES' => false,
+            ];
+        }
+
         $props = Caster::PREFIX_VIRTUAL.'parserProperties';
         $info = [
             'localName' => $reader->localName,
@@ -57,12 +73,7 @@ class XmlReaderCaster
             'value' => $reader->value,
             'namespaceURI' => $reader->namespaceURI,
             'baseURI' => $reader->baseURI ? new LinkStub($reader->baseURI) : $reader->baseURI,
-            $props => [
-                'LOADDTD' => $reader->getParserProperty(\XMLReader::LOADDTD),
-                'DEFAULTATTRS' => $reader->getParserProperty(\XMLReader::DEFAULTATTRS),
-                'VALIDATE' => $reader->getParserProperty(\XMLReader::VALIDATE),
-                'SUBST_ENTITIES' => $reader->getParserProperty(\XMLReader::SUBST_ENTITIES),
-            ],
+            $props => $properties,
         ];
 
         if ($info[$props] = Caster::filter($info[$props], Caster::EXCLUDE_EMPTY, [], $count)) {

--- a/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/XmlReaderCasterTest.php
@@ -245,4 +245,18 @@ EODUMP
             ],
         ];
     }
+
+    public function testWithUninitializedXMLReader()
+    {
+        $this->reader = new \XmlReader();
+
+        $expectedDump = <<<'EODUMP'
+XMLReader {
+  +nodeType: NONE
+   …13
+}
+EODUMP;
+
+        $this->assertDumpMatchesFormat($expectedDump, $this->reader);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42581
| License       | MIT
| Doc PR        | n/a

When XMLReader is not initialized,  getParserProperty() throws an error (or emits a warning, depending on the PHP version).
Now the error is caught and the properties are set to false.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
