### PR TITLE
[Serializer] symfony#36594 attributes cache breaks normalization

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -123,6 +123,10 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
 
         $this->defaultContext[self::EXCLUDE_FROM_CACHE_KEY] = array_merge($this->defaultContext[self::EXCLUDE_FROM_CACHE_KEY] ?? [], [self::CIRCULAR_REFERENCE_LIMIT_COUNTERS]);
 
+        if (\PHP_VERSION_ID >= 70400) {
+            $this->defaultContext[self::SKIP_UNINITIALIZED_VALUES] = true;
+        }
+
         $this->propertyTypeExtractor = $propertyTypeExtractor;
 
         if (null === $classDiscriminatorResolver && null !== $classMetadataFactory) {
@@ -190,7 +194,12 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             try {
                 $attributeValue = $this->getAttributeValue($object, $attribute, $format, $attributeContext);
             } catch (UninitializedPropertyException $e) {
-                if ($context[self::SKIP_UNINITIALIZED_VALUES] ?? $this->defaultContext[self::SKIP_UNINITIALIZED_VALUES] ?? false) {
+                if ($this->shouldSkipUninitializedValues($context)) {
+                    continue;
+                }
+                throw $e;
+            } catch (\Error $e) {
+                if ($this->shouldSkipUninitializedValues($context) && $this->isUninitializedValueError($e)) {
                     continue;
                 }
                 throw $e;
@@ -723,5 +732,23 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             // The context cannot be serialized, skip the cache
             return false;
         }
+    }
+
+    private function shouldSkipUninitializedValues(array $context): bool
+    {
+        return $context[self::SKIP_UNINITIALIZED_VALUES]
+            ?? $this->defaultContext[self::SKIP_UNINITIALIZED_VALUES]
+            ?? false;
+    }
+
+    /**
+     * This error may occur when specific object normalizer implementation gets attribute value
+     * by accessing a public uninitialized property or by calling a method accessing such property.
+     */
+    private function isUninitializedValueError(\Error $e): bool
+    {
+        return \PHP_VERSION_ID >= 70400
+            && str_starts_with($e->getMessage(), 'Typed property')
+            && str_ends_with($e->getMessage(), 'must not be accessed before initialization');
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -107,23 +107,9 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             }
         }
 
-        $checkPropertyInitialization = \PHP_VERSION_ID >= 70400;
-
         // properties
         foreach ($reflClass->getProperties() as $reflProperty) {
-            $isPublic = $reflProperty->isPublic();
-
-            if ($checkPropertyInitialization) {
-                if (!$isPublic) {
-                    $reflProperty->setAccessible(true);
-                }
-                if (!$reflProperty->isInitialized($object)) {
-                    unset($attributes[$reflProperty->name]);
-                    continue;
-                }
-            }
-
-            if (!$isPublic) {
+            if (!$reflProperty->isPublic()) {
                 continue;
             }
 

--- a/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/PropertyNormalizer.php
@@ -101,20 +101,9 @@ class PropertyNormalizer extends AbstractObjectNormalizer
     {
         $reflectionObject = new \ReflectionObject($object);
         $attributes = [];
-        $checkPropertyInitialization = \PHP_VERSION_ID >= 70400;
 
         do {
             foreach ($reflectionObject->getProperties() as $property) {
-                if ($checkPropertyInitialization) {
-                    if (!$property->isPublic()) {
-                        $property->setAccessible(true);
-                    }
-
-                    if (!$property->isInitialized($object)) {
-                        continue;
-                    }
-                }
-
                 if (!$this->isAllowedAttribute($reflectionObject->getName(), $property->name, $format, $context)) {
                     continue;
                 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CacheableObjectAttributesTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CacheableObjectAttributesTestTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
+
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
+
+/**
+ * This test ensures that attributes caching implemented in AbstractObjectNormalizer
+ * does not break normalization of multiple objects having different set of initialized/unInitialized properties.
+ *
+ * The attributes cache MUST NOT depend on a specific object state, so that cached attributes could be reused
+ * while normalizing any number of instances of the same class in any order.
+ */
+trait CacheableObjectAttributesTestTrait
+{
+    /**
+     * Returns a collection of objects to be normalized and compared with the expected array.
+     * It is a specific object normalizer test class responsibility to prepare testing data.
+     */
+    abstract protected function getObjectCollectionWithExpectedArray(): array;
+
+    abstract protected function getNormalizerForCacheableObjectAttributesTest(): AbstractObjectNormalizer;
+
+    /**
+     * The same normalizer instance normalizes two objects of the same class in a row:
+     *  1. an object having some uninitialized properties
+     *  2. an object with all properties being initialized.
+     *
+     * @requires PHP 7.4
+     */
+    public function testObjectCollectionNormalization()
+    {
+        [$collection, $expectedArray] = $this->getObjectCollectionWithExpectedArray();
+        $this->assertCollectionNormalizedProperly($collection, $expectedArray);
+    }
+
+    /**
+     * The same normalizer instance normalizes two objects of the same class in a row:
+     *  1. an object with all properties being initialized
+     *  2. an object having some uninitialized properties.
+     *
+     * @requires PHP 7.4
+     */
+    public function testReversedObjectCollectionNormalization()
+    {
+        [$collection, $expectedArray] = array_map('array_reverse', $this->getObjectCollectionWithExpectedArray());
+        $this->assertCollectionNormalizedProperly($collection, $expectedArray);
+    }
+
+    private function assertCollectionNormalizedProperly(array $collection, array $expectedArray): void
+    {
+        self::assertCount(\count($expectedArray), $collection);
+        $normalizer = $this->getNormalizerForCacheableObjectAttributesTest();
+        foreach ($collection as $i => $object) {
+            $result = $normalizer->normalize($object);
+            self::assertSame($expectedArray[$i], $result);
+        }
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/TypedPropertiesObjectWithGetters.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/TypedPropertiesObjectWithGetters.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Symfony\Component\Serializer\Tests\Normalizer\Features;
+
+class TypedPropertiesObjectWithGetters extends TypedPropertiesObject
+{
+    public function getUnInitialized(): string
+    {
+        return $this->unInitialized;
+    }
+
+    public function setUnInitialized(string $unInitialized): self
+    {
+        $this->unInitialized = $unInitialized;
+
+        return $this;
+    }
+
+    public function getInitialized(): string
+    {
+        return $this->initialized;
+    }
+
+    public function setInitialized(string $initialized): self
+    {
+        $this->initialized = $initialized;
+
+        return $this;
+    }
+
+    public function getInitialized2(): string
+    {
+        return $this->initialized2;
+    }
+
+    public function setInitialized2(string $initialized2): self
+    {
+        $this->initialized2 = $initialized2;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -31,6 +31,7 @@ use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Serializer\Tests\Fixtures\Annotations\GroupDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\CircularReferenceDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\SiblingHolder;
+use Symfony\Component\Serializer\Tests\Normalizer\Features\CacheableObjectAttributesTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CallbacksTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\CircularReferenceTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\ConstructorArgumentsTestTrait;
@@ -38,10 +39,13 @@ use Symfony\Component\Serializer\Tests\Normalizer\Features\GroupsTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\IgnoredAttributesTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\MaxDepthTestTrait;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\ObjectToPopulateTestTrait;
+use Symfony\Component\Serializer\Tests\Normalizer\Features\SkipUninitializedValuesTestTrait;
+use Symfony\Component\Serializer\Tests\Normalizer\Features\TypedPropertiesObjectWithGetters;
 use Symfony\Component\Serializer\Tests\Normalizer\Features\TypeEnforcementTestTrait;
 
 class GetSetMethodNormalizerTest extends TestCase
 {
+    use CacheableObjectAttributesTestTrait;
     use CallbacksTestTrait;
     use CircularReferenceTestTrait;
     use ConstructorArgumentsTestTrait;
@@ -49,6 +53,7 @@ class GetSetMethodNormalizerTest extends TestCase
     use IgnoredAttributesTestTrait;
     use MaxDepthTestTrait;
     use ObjectToPopulateTestTrait;
+    use SkipUninitializedValuesTestTrait;
     use TypeEnforcementTestTrait;
 
     /**
@@ -439,6 +444,27 @@ class GetSetMethodNormalizerTest extends TestCase
             ['foo' => true],
             $this->normalizer->normalize($obj, 'any')
         );
+    }
+
+    protected function getObjectCollectionWithExpectedArray(): array
+    {
+        return [[
+            new TypedPropertiesObjectWithGetters(),
+            (new TypedPropertiesObjectWithGetters())->setUninitialized('value2'),
+        ], [
+            ['initialized' => 'value', 'initialized2' => 'value'],
+            ['unInitialized' => 'value2', 'initialized' => 'value', 'initialized2' => 'value'],
+        ]];
+    }
+
+    protected function getNormalizerForCacheableObjectAttributesTest(): GetSetMethodNormalizer
+    {
+        return new GetSetMethodNormalizer();
+    }
+
+    protected function getNormalizerForSkipUninitializedValues(): NormalizerInterface
+    {
+        return new GetSetMethodNormalizer(new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader())));
     }
 }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no 
| Deprecations? | no
| Tickets       | Fix #36594 
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/15823

The bug itself is explained in the following (simplified) example:
```php
class Dummy
{
    public array $requiredData; // supposed to be set for any object
    public array $optionalData; // can be not initialized (and if so - ignored by serializer)
}

$object1 = new Dummy();
$object1->requiredData = ['username' => 'foo'];
$json1 = $serializer->serialize($object1, 'json'); // {"requiredData": {"username": "foo"}}
// at this point object normalizer has already cached attributes for Dummy::class and context,
// now it contains array ['requiredData'] - optionalData has been ignored as it's unitialized

// then, while the script is still running, we have another object of the same class with optionalData set
$object2 = new Dummy();
$object2->requiredData = ['username' => 'bar'];
$object2->optionalData = ['email' => 'bar@test.com'];
$json2 = $serializer->serialize($object2, 'json');
// expected: {"requiredData": {"username": "bar"}, "optionalData": {"email": "bar@test.com"}}
// actual: {"requiredData": {"username": "bar"}}
// here normalizer has no clue about optionalData attribute since it reuses attributes cached
// in \Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::$attributesCache
// while normalizing the first object
```

Though this PR created for 5.4 branch, it actually fixes a bug reproducible in 5.3. The reason why I use 5.4 for this fix is that 5.4 introduces a [new feature](https://github.com/symfony/symfony-docs/pull/15823) related to the same problem. If this PR gets approved and merged, I can potentially implement the same fix for 5.3, but `SKIP_UNINITIALIZED_VALUES` will cause some merge conflicts in the future..

As of v 5.3 symfony ignores uninitialized properties by default in `ObjectNormalizer::extractAttributes` and `PropertyNormalizer::extractAttributes` (implemented in https://github.com/symfony/symfony/pull/38900 and https://github.com/symfony/symfony/pull/34791) but this approach is wrong - **`extractAttributes` method MUST return the same attributes list for any instance of the same class**, otherwise cached attributes do not match actual attributes list for different instances having different set of initialized/uninitialized properties

So, this PR does a few things:

1. removes ignoring attributes from all built-in implementations of `\Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::extractAttributes` so that even uninitialized attributes will be cached by normalizer. Instead, we ignore uninitialized attributes when trying to access them while calling `\Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer::getAttributeValue`
2. sets `true` as the default value for `SKIP_UNINITIALIZED_VALUES` context setting as I believe this is the expected default behavior for any built-in object normalizer
3. makes `SKIP_UNINITIALIZED_VALUES` compatible with not just `ObjectNormalizer`, but with two other built-in normalizers `PropertyNormalizer` and `GetSetMethodNormalizer` as well