### PR TITLE
[Security] Fix `TraceableAuthenticator::createToken()` argument type

### DIFF
--- a/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
+++ b/src/Symfony/Component/Security/Http/Authenticator/Debug/TraceableAuthenticator.php
@@ -18,7 +18,6 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Guard\Authenticator\GuardBridgeAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface;
 use Symfony\Component\Security\Http\Authenticator\InteractiveAuthenticatorInterface;
-use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\EntryPoint\Exception\NotAnEntryPointException;
@@ -67,7 +66,7 @@ final class TraceableAuthenticator implements AuthenticatorInterface, Interactiv
         return $this->passport;
     }
 
-    public function createToken(Passport $passport, string $firewallName): TokenInterface
+    public function createToken(PassportInterface $passport, string $firewallName): TokenInterface
     {
         return method_exists($this->authenticator, 'createToken') ? $this->authenticator->createToken($passport, $firewallName) : $this->authenticator->createAuthenticatedToken($passport, $firewallName);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

The `$passport` argument in the `createToken()` method can be used as an argument for `createAuthenticatedToken()` and thus should be of type `PassportInterface`

Reported by @DesLynx  to @chalasr in https://github.com/symfony/security-http/commit/303edcd901f24bb9ea034d5beff71c7579c5ae30#r57936126