### PR TITLE
[DependencyInjection] autowire union and intersection types

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `service_closure()` to the PHP-DSL
  * Add support for autoconfigurable attributes on methods, properties and parameters
  * Make auto-aliases private by default
+ * Add support for autowiring union and intersection types
 
 5.3
 ---

--- a/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AutowirePass.php
@@ -45,6 +45,7 @@ class AutowirePass extends AbstractRecursivePass
     private $decoratedMethodIndex;
     private $decoratedMethodArgumentIndex;
     private $typesClone;
+    private $combinedAliases;
 
     public function __construct(bool $throwOnAutowireException = true)
     {
@@ -60,6 +61,8 @@ class AutowirePass extends AbstractRecursivePass
      */
     public function process(ContainerBuilder $container)
     {
+        $this->populateCombinedAliases($container);
+
         try {
             $this->typesClone = clone $this;
             parent::process($container);
@@ -72,6 +75,7 @@ class AutowirePass extends AbstractRecursivePass
             $this->decoratedMethodIndex = null;
             $this->decoratedMethodArgumentIndex = null;
             $this->typesClone = null;
+            $this->combinedAliases = [];
         }
     }
 
@@ -223,8 +227,6 @@ class AutowirePass extends AbstractRecursivePass
     /**
      * Autowires the constructor or a method.
      *
-     * @return array
-     *
      * @throws AutowiringFailedException
      */
     private function autowireMethod(\ReflectionFunctionAbstract $reflectionMethod, array $arguments, bool $checkAttributes, int $methodIndex): array
@@ -363,8 +365,12 @@ class AutowirePass extends AbstractRecursivePass
                 return new TypedReference($alias, $type, $reference->getInvalidBehavior());
             }
 
+            if (null !== ($alias = $this->combinedAliases[$alias] ?? null) && !$this->container->findDefinition($alias)->isAbstract()) {
+                return new TypedReference($alias, $type, $reference->getInvalidBehavior());
+            }
+
             if ($this->container->has($name) && !$this->container->findDefinition($name)->isAbstract()) {
-                foreach ($this->container->getAliases() as $id => $alias) {
+                foreach ($this->container->getAliases() + $this->combinedAliases as $id => $alias) {
                     if ($name === (string) $alias && str_starts_with($id, $type.' $')) {
                         return new TypedReference($name, $type, $reference->getInvalidBehavior());
                     }
@@ -374,6 +380,10 @@ class AutowirePass extends AbstractRecursivePass
 
         if ($this->container->has($type) && !$this->container->findDefinition($type)->isAbstract()) {
             return new TypedReference($type, $type, $reference->getInvalidBehavior());
+        }
+
+        if (null !== ($alias = $this->combinedAliases[$type] ?? null) && !$this->container->findDefinition($alias)->isAbstract()) {
+            return new TypedReference($alias, $type, $reference->getInvalidBehavior());
         }
 
         return null;
@@ -563,6 +573,47 @@ class AutowirePass extends AbstractRecursivePass
 
         if (class_exists($type, false) || interface_exists($type, false)) {
             $this->autowiringAliases[$type][$name] = $name;
+        }
+    }
+
+    private function populateCombinedAliases(ContainerBuilder $container): void
+    {
+        $this->combinedAliases = [];
+        $reverseAliases = [];
+
+        foreach ($container->getAliases() as $id => $alias) {
+            if (!preg_match('/(?(DEFINE)(?<V>[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*+))^((?&V)(?:\\\\(?&V))*+)(?: \$((?&V)))?$/', $id, $m)) {
+                continue;
+            }
+
+            $type = $m[2];
+            $name = $m[3] ?? '';
+            $reverseAliases[(string) $alias][$name][] = $type;
+        }
+
+        foreach ($reverseAliases as $alias => $names) {
+            foreach ($names as $name => $types) {
+                if (2 > $count = \count($types)) {
+                    continue;
+                }
+                sort($types);
+                $i = 1 << $count;
+
+                // compute the powerset of the list of types
+                while ($i--) {
+                    $set = [];
+                    for ($j = 0; $j < $count; ++$j) {
+                        if ($i & (1 << $j)) {
+                            $set[] = $types[$j];
+                        }
+                    }
+
+                    if (2 <= \count($set)) {
+                        $this->combinedAliases[implode('&', $set).('' === $name ? '' : ' $'.$name)] = $alias;
+                        $this->combinedAliases[implode('|', $set).('' === $name ? '' : ' $'.$name)] = $alias;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/LazyProxy/ProxyHelper.php
+++ b/src/Symfony/Component/DependencyInjection/LazyProxy/ProxyHelper.php
@@ -70,6 +70,8 @@ class ProxyHelper
             }
         }
 
+        sort($types);
+
         return $types ? implode($glue, $types) : null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #43325
| License       | MIT
| Doc PR        | -

This PR allows autowiring an argument of type `NormalizerInterface&DenormalizerInterface` if both individual types have a corresponding autowiring alias, and if both aliases point to the very same service.

This works the same with union types.