### PR TITLE
[String] Add `trimSuffix()` and `trimPrefix()` methods

### DIFF
--- a/src/Symfony/Component/String/AbstractString.php
+++ b/src/Symfony/Component/String/AbstractString.php
@@ -617,9 +617,77 @@ abstract class AbstractString implements \Stringable, \JsonSerializable
     abstract public function trimEnd(string $chars = " \t\n\r\0\x0B\x0C\u{A0}\u{FEFF}"): self;
 
     /**
+     * @param string|string[] $prefix
+     *
+     * @return static
+     */
+    public function trimPrefix($prefix): self
+    {
+        if (\is_array($prefix) || $prefix instanceof \Traversable) {
+            foreach ($prefix as $s) {
+                $t = $this->trimPrefix($s);
+
+                if ($t->string !== $this->string) {
+                    return $t;
+                }
+            }
+
+            return clone $this;
+        }
+
+        $str = clone $this;
+
+        if ($prefix instanceof self) {
+            $prefix = $prefix->string;
+        } else {
+            $prefix = (string) $prefix;
+        }
+
+        if ('' !== $prefix && \strlen($this->string) >= \strlen($prefix) && 0 === substr_compare($this->string, $prefix, 0, \strlen($prefix), $this->ignoreCase)) {
+            $str->string = substr($this->string, \strlen($prefix));
+        }
+
+        return $str;
+    }
+
+    /**
      * @return static
      */
     abstract public function trimStart(string $chars = " \t\n\r\0\x0B\x0C\u{A0}\u{FEFF}"): self;
+
+    /**
+     * @param string|string[] $suffix
+     *
+     * @return static
+     */
+    public function trimSuffix($suffix): self
+    {
+        if (\is_array($suffix) || $suffix instanceof \Traversable) {
+            foreach ($suffix as $s) {
+                $t = $this->trimSuffix($s);
+
+                if ($t->string !== $this->string) {
+                    return $t;
+                }
+            }
+
+            return clone $this;
+        }
+
+        $str = clone $this;
+
+        if ($suffix instanceof self) {
+            $suffix = $suffix->string;
+        } else {
+            $suffix = (string) $suffix;
+        }
+
+        if ('' !== $suffix && \strlen($this->string) >= \strlen($suffix) && 0 === substr_compare($this->string, $suffix, -\strlen($suffix), null, $this->ignoreCase)) {
+            $str->string = substr($this->string, 0, -\strlen($suffix));
+        }
+
+        return $str;
+    }
 
     /**
      * @return static

--- a/src/Symfony/Component/String/AbstractUnicodeString.php
+++ b/src/Symfony/Component/String/AbstractUnicodeString.php
@@ -409,6 +409,26 @@ abstract class AbstractUnicodeString extends AbstractString
         return $str;
     }
 
+    public function trimPrefix($prefix): parent
+    {
+        if (!$this->ignoreCase) {
+            return parent::trimPrefix($prefix);
+        }
+
+        $str = clone $this;
+
+        if ($prefix instanceof \Traversable) {
+            $prefix = iterator_to_array($prefix, false);
+        } elseif ($prefix instanceof parent) {
+            $prefix = $prefix->string;
+        }
+
+        $prefix = implode('|', array_map('preg_quote', (array) $prefix));
+        $str->string = preg_replace("{^(?:$prefix)}iuD", '', $this->string);
+
+        return $str;
+    }
+
     public function trimStart(string $chars = " \t\n\r\0\x0B\x0C\u{A0}\u{FEFF}"): parent
     {
         if (" \t\n\r\0\x0B\x0C\u{A0}\u{FEFF}" !== $chars && !preg_match('//u', $chars)) {
@@ -418,6 +438,26 @@ abstract class AbstractUnicodeString extends AbstractString
 
         $str = clone $this;
         $str->string = preg_replace("{^[$chars]++}uD", '', $str->string);
+
+        return $str;
+    }
+
+    public function trimSuffix($suffix): parent
+    {
+        if (!$this->ignoreCase) {
+            return parent::trimSuffix($suffix);
+        }
+
+        $str = clone $this;
+
+        if ($suffix instanceof \Traversable) {
+            $suffix = iterator_to_array($suffix, false);
+        } elseif ($suffix instanceof parent) {
+            $suffix = $suffix->string;
+        }
+
+        $suffix = implode('|', array_map('preg_quote', (array) $suffix));
+        $str->string = preg_replace("{(?:$suffix)$}iuD", '', $this->string);
 
         return $str;
     }

--- a/src/Symfony/Component/String/CHANGELOG.md
+++ b/src/Symfony/Component/String/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Add `trimSuffix()` and `trimPrefix()` methods
+
 5.3
 ---
 

--- a/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
+++ b/src/Symfony/Component/String/Tests/AbstractAsciiTestCase.php
@@ -733,6 +733,15 @@ abstract class AbstractAsciiTestCase extends TestCase
         ];
     }
 
+    public function testTrimPrefix()
+    {
+        $str = static::createFromString('abc.def');
+
+        $this->assertEquals(static::createFromString('def'), $str->trimPrefix('abc.'));
+        $this->assertEquals(static::createFromString('def'), $str->trimPrefix(['abc.', 'def']));
+        $this->assertEquals(static::createFromString('def'), $str->ignoreCase()->trimPrefix('ABC.'));
+    }
+
     /**
      * @dataProvider provideTrimStart
      */
@@ -742,6 +751,15 @@ abstract class AbstractAsciiTestCase extends TestCase
         $result = null !== $chars ? $result->trimStart($chars) : $result->trimStart();
 
         $this->assertEquals(static::createFromString($expected), $result);
+    }
+
+    public function testTrimSuffix()
+    {
+        $str = static::createFromString('abc.def');
+
+        $this->assertEquals(static::createFromString('abc'), $str->trimSuffix('.def'));
+        $this->assertEquals(static::createFromString('abc'), $str->trimSuffix(['.def', 'abc']));
+        $this->assertEquals(static::createFromString('abc'), $str->ignoreCase()->trimSuffix('.DEF'));
     }
 
     public static function provideTrimStart()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Inspired by golang's string API.