### PR TITLE
[Console] remove mixed return types from `InputInterface`

### DIFF
--- a/.github/expected-missing-return-types.diff
+++ b/.github/expected-missing-return-types.diff
@@ -848,3 +848,28 @@ index 012a483de2..6573ad7ec5 100644
 +    public function getTargets(): string|array
      {
          return self::PROPERTY_CONSTRAINT;
+diff --git a/src/Symfony/Component/Console/Input/InputInterface.php b/src/Symfony/Component/Console/Input/InputInterface.php
+index 024da1884e..943790e875 100644
+--- a/src/Symfony/Component/Console/Input/InputInterface.php
++++ b/src/Symfony/Component/Console/Input/InputInterface.php
+@@ -54,5 +54,5 @@ interface InputInterface
+      * @return mixed
+      */
+-    public function getParameterOption(string|array $values, string|bool|int|float|array|null $default = false, bool $onlyParams = false);
++    public function getParameterOption(string|array $values, string|bool|int|float|array|null $default = false, bool $onlyParams = false): mixed;
+ 
+     /**
+@@ -84,5 +84,5 @@ interface InputInterface
+      * @throws InvalidArgumentException When argument given doesn't exist
+      */
+-    public function getArgument(string $name);
++    public function getArgument(string $name): mixed;
+ 
+     /**
+@@ -112,5 +112,5 @@ interface InputInterface
+      * @throws InvalidArgumentException When option given doesn't exist
+      */
+-    public function getOption(string $name);
++    public function getOption(string $name): mixed;
+ 
+     /**

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -50,8 +50,10 @@ interface InputInterface
      * @param string|array                     $values     The value(s) to look for in the raw parameters (can be an array)
      * @param string|bool|int|float|array|null $default    The default value to return if no result is found
      * @param bool                             $onlyParams Only check real parameters, skip those following an end of options (--) signal
+     *
+     * @return mixed
      */
-    public function getParameterOption(string|array $values, string|bool|int|float|array|null $default = false, bool $onlyParams = false): mixed;
+    public function getParameterOption(string|array $values, string|bool|int|float|array|null $default = false, bool $onlyParams = false);
 
     /**
      * Binds the current Input instance with the given arguments and options.
@@ -77,9 +79,11 @@ interface InputInterface
     /**
      * Returns the argument value for a given argument name.
      *
+     * @return mixed
+     *
      * @throws InvalidArgumentException When argument given doesn't exist
      */
-    public function getArgument(string $name): mixed;
+    public function getArgument(string $name);
 
     /**
      * Sets an argument value by name.
@@ -103,9 +107,11 @@ interface InputInterface
     /**
      * Returns the option value for a given option name.
      *
+     * @return mixed
+     *
      * @throws InvalidArgumentException When option given doesn't exist
      */
-    public function getOption(string $name): mixed;
+    public function getOption(string $name);
 
     /**
      * Sets an option value by name.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Ref: https://github.com/symfony/symfony/issues/43021#issuecomment-942584170
| License       | MIT
| Doc PR        | n/a

As discussed in [this issue](https://github.com/symfony/symfony/issues/43021#issuecomment-942584170), I'm having some trouble supporting an `InputInterface` decorator in PHP 7.4/8.0 & Symfony >=6/<6.

The library where this is being used is not yet released and after discussing with @wouterj, I don't really have a great reason for not supporting PHP 8+ only. That being said, the console component is one of the most widely used so maybe this is too aggressive?