### PR TITLE
[Messenger] Fix Redis Transport when username is empty

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/RedisExt/ConnectionTest.php
@@ -133,6 +133,9 @@ class ConnectionTest extends TestCase
     {
         yield 'Password only' => ['password', 'redis://password@localhost/queue'];
         yield 'User and password' => [['user', 'password'], 'redis://user:password@localhost/queue'];
+        yield 'User and colon' => ['user', 'redis://user:@localhost/queue'];
+        yield 'Colon and password' => ['password', 'redis://:password@localhost/queue'];
+        yield 'Colon and falsy password' => ['0', 'redis://:0@localhost/queue'];
     }
 
     public function testNoAuthWithEmptyPassword()

--- a/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
+++ b/src/Symfony/Component/Messenger/Transport/RedisExt/Connection.php
@@ -93,12 +93,14 @@ class Connection
         $stream = $pathParts[1] ?? $redisOptions['stream'] ?? null;
         $group = $pathParts[2] ?? $redisOptions['group'] ?? null;
         $consumer = $pathParts[3] ?? $redisOptions['consumer'] ?? null;
+        $pass = '' !== ($parsedUrl['pass'] ?? '') ? $parsedUrl['pass'] : null;
+        $user = '' !== ($parsedUrl['user'] ?? '') ? $parsedUrl['user'] : null;
 
         $connectionCredentials = [
             'host' => $parsedUrl['host'] ?? '127.0.0.1',
             'port' => $parsedUrl['port'] ?? 6379,
             // See: https://github.com/phpredis/phpredis/#auth
-            'auth' => isset($parsedUrl['pass']) && isset($parsedUrl['user']) ? [$parsedUrl['user'], $parsedUrl['pass']] : $parsedUrl['pass'] ?? $parsedUrl['user'] ?? null,
+            'auth' => null !== $pass && null !== $user ? [$user, $pass] : ($pass ?? $user),
         ];
 
         if (isset($parsedUrl['query'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43306
| License       | MIT
| Doc PR        | n/a

Checking the username and the password with `isset` is not enough. We also need to check they're not empty strings.
This fixes the BC break introduced by #43124.

See also https://3v4l.org/iASnE
