### PR TITLE
Lower log level in case of retry

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/SendFailedMessageForRetryListener.php
@@ -12,7 +12,6 @@ namespace Symfony\Component\Messenger\EventListener;
 
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Event\WorkerMessageFailedEvent;
@@ -71,18 +70,7 @@ class SendFailedMessageForRetryListener implements EventSubscriberInterface
             $delay = $retryStrategy->getWaitingTime($envelope, $throwable);
 
             if (null !== $this->logger) {
-                $logLevel = LogLevel::ERROR;
-                if ($throwable instanceof RecoverableExceptionInterface) {
-                    $logLevel = LogLevel::WARNING;
-                } elseif ($throwable instanceof HandlerFailedException) {
-                    foreach ($throwable->getNestedExceptions() as $nestedException) {
-                        if ($nestedException instanceof RecoverableExceptionInterface) {
-                            $logLevel = LogLevel::WARNING;
-                            break;
-                        }
-                    }
-                }
-                $this->logger->log($logLevel, 'Error thrown while handling message {class}. Sending for retry #{retryCount} using {delay} ms delay. Error: "{error}"', $context + ['retryCount' => $retryCount, 'delay' => $delay, 'error' => $throwable->getMessage(), 'exception' => $throwable]);
+                $this->logger->warning('Error thrown while handling message {class}. Sending for retry #{retryCount} using {delay} ms delay. Error: "{error}"', $context + ['retryCount' => $retryCount, 'delay' => $delay, 'error' => $throwable->getMessage(), 'exception' => $throwable]);
             }
 
             // add the delay and retry stamp info


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


When a message is retried, we currently log the failure with a `ERROR` level (or with a WARNING level in case of RecoverableExceptionInterface).

If the application has set up a retry mechanism, it means failure is expected and is part of the flow. Sending alert for something that will be retried is noise.

This PR reduces the verbosity of retried messages.

Should it be a bug for 4.4 :thinking: ?