### PR TITLE
[Notifier] [Twilio] Ensure from/sender is valid via regex

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Clickatell/Tests/ClickatellTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Clickatell/Tests/ClickatellTransportTest.php
@@ -2,39 +2,51 @@
 
 namespace Symfony\Component\Notifier\Bridge\Clickatell\Tests;
 
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\Clickatell\ClickatellTransport;
 use Symfony\Component\Notifier\Exception\LogicException;
 use Symfony\Component\Notifier\Exception\TransportException;
+use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
+use Symfony\Component\Notifier\Test\TransportTestCase;
+use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-class ClickatellTransportTest extends TestCase
+final class ClickatellTransportTest extends TransportTestCase
 {
-    public function testToString()
+    /**
+     * @return ClickatellTransport
+     */
+    public function createTransport(HttpClientInterface $client = null, string $from = null): TransportInterface
     {
-        $transport = new ClickatellTransport('authToken', 'fromValue', $this->createMock(HttpClientInterface::class));
-        $transport->setHost('clickatellHost');
-
-        $this->assertSame('clickatell://clickatellHost?from=fromValue', (string) $transport);
+        return new ClickatellTransport('authToken', $from, $client ?? $this->createMock(HttpClientInterface::class));
     }
 
-    public function testSupports()
+    public function toStringProvider(): iterable
     {
-        $transport = new ClickatellTransport('authToken', 'fromValue', $this->createMock(HttpClientInterface::class));
+        yield ['clickatell://api.clickatell.com', $this->createTransport()];
+        yield ['clickatell://api.clickatell.com?from=TEST', $this->createTransport(null, 'TEST')];
+    }
 
-        $this->assertTrue($transport->supports(new SmsMessage('+33612345678', 'testSmsMessage')));
-        $this->assertFalse($transport->supports($this->createMock(MessageInterface::class)));
+    public function supportedMessagesProvider(): iterable
+    {
+        yield [new SmsMessage('+33612345678', 'Hello!')];
+    }
+
+    public function unsupportedMessagesProvider(): iterable
+    {
+        yield [new ChatMessage('Hello!')];
+        yield [$this->createMock(MessageInterface::class)];
     }
 
     public function testExceptionIsThrownWhenNonMessageIsSend()
     {
-        $transport = new ClickatellTransport('authToken', 'fromValue', $this->createMock(HttpClientInterface::class));
+        $transport = $this->createTransport();
 
         $this->expectException(LogicException::class);
+
         $transport->send($this->createMock(MessageInterface::class));
     }
 
@@ -56,10 +68,11 @@ class ClickatellTransportTest extends TestCase
 
         $client = new MockHttpClient($response);
 
-        $transport = new ClickatellTransport('authToken', 'fromValue', $client);
+        $transport = $this->createTransport($client);
+
         $this->expectException(TransportException::class);
         $this->expectExceptionMessage('Unable to send SMS with Clickatell: Error code 105 with message "Invalid Account Reference EX0000000" (https://documentation-page).');
 
-        $transport->send(new SmsMessage('+33612345678', 'testSmsMessage'));
+        $transport->send(new SmsMessage('+33612345678', 'Hello!'));
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/CHANGELOG.md
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+* Ensure sender/from is valid via regex
+
 5.3
 ---
 

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportTest.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/Tests/TwilioTransportTest.php
@@ -11,22 +11,25 @@
 
 namespace Symfony\Component\Notifier\Bridge\Twilio\Tests;
 
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransport;
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Message\ChatMessage;
 use Symfony\Component\Notifier\Message\MessageInterface;
 use Symfony\Component\Notifier\Message\SmsMessage;
 use Symfony\Component\Notifier\Test\TransportTestCase;
 use Symfony\Component\Notifier\Transport\TransportInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class TwilioTransportTest extends TransportTestCase
 {
     /**
      * @return TwilioTransport
      */
-    public function createTransport(HttpClientInterface $client = null): TransportInterface
+    public function createTransport(HttpClientInterface $client = null, string $from = 'from'): TransportInterface
     {
-        return new TwilioTransport('accountSid', 'authToken', 'from', $client ?? $this->createMock(HttpClientInterface::class));
+        return new TwilioTransport('accountSid', 'authToken', $from, $client ?? $this->createMock(HttpClientInterface::class));
     }
 
     public function toStringProvider(): iterable
@@ -43,5 +46,96 @@ final class TwilioTransportTest extends TransportTestCase
     {
         yield [new ChatMessage('Hello!')];
         yield [$this->createMock(MessageInterface::class)];
+    }
+
+    /**
+     * @dataProvider invalidFromProvider
+     */
+    public function testInvalidArgumentExceptionIsThrownIfFromIsInvalid(string $from)
+    {
+        $transport = $this->createTransport(null, $from);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('The "From" number "%s" is not a valid phone number, shortcode, or alphanumeric sender ID.', $from));
+
+        $transport->send(new SmsMessage('+33612345678', 'Hello!'));
+    }
+
+    public function invalidFromProvider(): iterable
+    {
+        // alphanumeric sender ids
+        yield 'too short' => ['a'];
+        yield 'too long' => ['abcdefghijkl'];
+
+        // phone numbers
+        yield 'no zero at start if phone number' => ['+0'];
+        yield 'phone number to short' => ['+1'];
+    }
+
+    /**
+     * @dataProvider validFromProvider
+     */
+    public function testNoInvalidArgumentExceptionIsThrownIfFromIsValid(string $from)
+    {
+        $message = new SmsMessage('+33612345678', 'Hello!');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects($this->exactly(2))
+            ->method('getStatusCode')
+            ->willReturn(201);
+        $response->expects($this->once())
+            ->method('getContent')
+            ->willReturn(json_encode([
+                'sid' => '123',
+                'message' => 'foo',
+                'more_info' => 'bar',
+            ]));
+
+        $client = new MockHttpClient(function (string $method, string $url, array $options = []) use ($response): ResponseInterface {
+            $this->assertSame('POST', $method);
+            $this->assertSame('https://api.twilio.com/2010-04-01/Accounts/accountSid/Messages.json', $url);
+
+            return $response;
+        });
+
+        $transport = $this->createTransport($client, $from);
+
+        $sentMessage = $transport->send($message);
+
+        $this->assertSame('123', $sentMessage->getMessageId());
+    }
+
+    public function validFromProvider(): iterable
+    {
+        // alphanumeric sender ids
+        yield ['ab'];
+        yield ['abc'];
+        yield ['abcd'];
+        yield ['abcde'];
+        yield ['abcdef'];
+        yield ['abcdefg'];
+        yield ['abcdefgh'];
+        yield ['abcdefghi'];
+        yield ['abcdefghij'];
+        yield ['abcdefghijk'];
+        yield ['abcdef ghij'];
+        yield [' abcdefghij'];
+        yield ['abcdefghij '];
+
+        // phone numbers
+        yield ['+11'];
+        yield ['+112'];
+        yield ['+1123'];
+        yield ['+11234'];
+        yield ['+112345'];
+        yield ['+1123456'];
+        yield ['+11234567'];
+        yield ['+112345678'];
+        yield ['+1123456789'];
+        yield ['+11234567891'];
+        yield ['+112345678912'];
+        yield ['+1123456789123'];
+        yield ['+11234567891234'];
+        yield ['+112345678912345'];
     }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Twilio/TwilioTransport.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Notifier\Bridge\Twilio;
 
+use Symfony\Component\Notifier\Exception\InvalidArgumentException;
 use Symfony\Component\Notifier\Exception\TransportException;
 use Symfony\Component\Notifier\Exception\UnsupportedMessageTypeException;
 use Symfony\Component\Notifier\Message\MessageInterface;
@@ -55,6 +56,10 @@ final class TwilioTransport extends AbstractTransport
     {
         if (!$message instanceof SmsMessage) {
             throw new UnsupportedMessageTypeException(__CLASS__, SmsMessage::class, $message);
+        }
+
+        if (!preg_match('/^[a-zA-Z0-9\s]{2,11}$/', $this->from) && !preg_match('/^\+[1-9]\d{1,14}$/', $this->from)) {
+            throw new InvalidArgumentException(sprintf('The "From" number "%s" is not a valid phone number, shortcode, or alphanumeric sender ID.', $this->from));
         }
 
         $endpoint = sprintf('https://%s/2010-04-01/Accounts/%s/Messages.json', $this->getEndpoint(), $this->accountSid);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

I also spotted some missing tests for `ClickatellTransport`, so I added them to this PR.