### PR TITLE
[Serializer] Add `NormalizedValueInterface` that can be returned by `NormalizerInterface::normalize` to enable receiving a value object for normalized values.

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Remove `ArrayDenormalizer::setSerializer()`, call `setDenormalizer()` instead
  * Remove the ability to create instances of the annotation classes by passing an array of parameters, use named arguments instead
+ * Add `NormalizedValueInterface` to enable normalizers to return a value object
 
 5.4
 ---

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizedValueInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizedValueInterface.php
@@ -13,5 +13,5 @@ namespace Symfony\Component\Serializer\Normalizer;
 
 interface NormalizedValueInterface
 {
-    public function getNormalization(): array|string|int|float|bool|\ArrayObject|null;
+    public function getValue(): array|string|int|float|bool|\ArrayObject|null;
 }

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizedValueInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizedValueInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+interface NormalizedValueInterface {
+
+    public function getNormalization(): array|string|int|float|bool|\ArrayObject|null;
+    
+}

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizedValueInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizedValueInterface.php
@@ -1,9 +1,17 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\Serializer\Normalizer;
 
-interface NormalizedValueInterface {
-
+interface NormalizedValueInterface
+{
     public function getNormalization(): array|string|int|float|bool|\ArrayObject|null;
-    
 }

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -28,7 +28,7 @@ interface NormalizerInterface
      * @param string $format  Format the normalization result will be encoded as
      * @param array  $context Context options for the normalizer
      *
-     * @return array|string|int|float|bool|\ArrayObject|null \ArrayObject is used to make sure an empty object is encoded as an object not an array
+     * @return array|string|int|float|bool|\ArrayObject|NormalizedValueInterface|null \ArrayObject is used to make sure an empty object is encoded as an object not an array
      *
      * @throws InvalidArgumentException   Occurs when the object given is not a supported type for the normalizer
      * @throws CircularReferenceException Occurs when the normalizer detects a circular reference when no circular
@@ -36,7 +36,7 @@ interface NormalizerInterface
      * @throws LogicException             Occurs when the normalizer is not called in an expected context
      * @throws ExceptionInterface         Occurs for all the other cases of errors
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|null;
+    public function normalize(mixed $object, string $format = null, array $context = []): array|string|int|float|bool|\ArrayObject|NormalizedValueInterface|null;
 
     /**
      * Checks whether the given class is supported for normalization by this normalizer.

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -28,6 +28,7 @@ use Symfony\Component\Serializer\Normalizer\ContextAwareDenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizedValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -159,6 +160,10 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
         // If a normalizer supports the given data, use it
         if ($normalizer = $this->getNormalizer($data, $format, $context)) {
             return $normalizer->normalize($data, $format, $context);
+        }
+
+        if ($data instanceof NormalizedValueInterface) {
+            $data = $data->getNormalization();
         }
 
         if (null === $data || is_scalar($data)) {

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -163,7 +163,7 @@ class Serializer implements SerializerInterface, ContextAwareNormalizerInterface
         }
 
         if ($data instanceof NormalizedValueInterface) {
-            $data = $data->getNormalization();
+            $data = $data->getValue();
         }
 
         if (null === $data || is_scalar($data)) {

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -41,6 +41,7 @@ use Symfony\Component\Serializer\Normalizer\DateTimeZoneNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
+use Symfony\Component\Serializer\Normalizer\NormalizedValueInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -209,6 +210,20 @@ class SerializerTest extends TestCase
         $data = ['foo', [5, 3]];
         $result = $serializer->serialize($data, 'json');
         $this->assertEquals(json_encode($data), $result);
+    }
+
+    public function testSerializeNormalizedValue()
+    {
+        $normalizedValue = 'normalizedValue';
+        $normalizedValueObject = $this->createMock(NormalizedValueInterface::class);
+        $normalizedValueObject->method('getNormalization')
+            ->willReturn($normalizedValue);
+
+        $serializer = new Serializer([], ['json' => new JsonEncoder()]);
+        $data = ['foo', [5, $normalizedValueObject]];
+        $expectedData = ['foo', [5, $normalizedValue]];
+        $result = $serializer->serialize($data, 'json');
+        $this->assertEquals(json_encode($expectedData), $result);
     }
 
     public function testSerializeEmpty()

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -216,7 +216,7 @@ class SerializerTest extends TestCase
     {
         $normalizedValue = 'normalizedValue';
         $normalizedValueObject = $this->createMock(NormalizedValueInterface::class);
-        $normalizedValueObject->method('getNormalization')
+        $normalizedValueObject->method('getValue')
             ->willReturn($normalizedValue);
 
         $serializer = new Serializer([], ['json' => new JsonEncoder()]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

I've built this PR to see if we can make the migration to Symfony 6 for Drupal a little less painfull. This also enables some new handy feature for the serializer where you could for example create a Cache dependency tree while serializing a tree of objects.

This PR is a result of the discussion in #43021.

## Drupal serialization
Drupal uses de serializer component for a few things. One of these things is serializing our entity objects to something that can be returned as json. The entity objects contain fields which can have one or more values, so we start high up and normalize all the way to the bottom of the stack, the field values.

## Creating sensible cache metadata using a value object
In order to get the combined cache tag information from every level of serialization we've chosen to track that in the normalizer. It knows what it did and we track this in a normalized value object (called CachableNormalization). This means we can consolidate the proper caching dependency tree information of the object without having to do some weird gymnastics to track this information somewhere else.

It would help us loads if we would have some sort of `NormalizedValueInterface` that can be returned by the normalize method. This would enable us to get things working as intented and keep a less complex cache-tracking system in place. An interface like this would work for us quite handily.