### PR TITLE
[HttpKernel] fix ErrorException in CacheWarmerAggregate

### DIFF
--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
@@ -102,7 +102,9 @@ class CacheWarmerAggregate implements CacheWarmerInterface
 
                 if (file_exists($this->deprecationLogsFilepath)) {
                     $previousLogs = unserialize(file_get_contents($this->deprecationLogsFilepath));
-                    $collectedLogs = array_merge($previousLogs, $collectedLogs);
+                    if (\is_array($previousLogs)) {
+                        $collectedLogs = array_merge($previousLogs, $collectedLogs);
+                    }
                 }
 
                 file_put_contents($this->deprecationLogsFilepath, serialize(array_values($collectedLogs)));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets      |
| License       | MIT
| Doc PR        | 


I ran into an `ErrorException` reloading after some changes. I suppose this triggered a cache warmup call. This didn't go as expected, because `$previousLogs = unserialize(file_get_contents($this->deprecationLogsFilepath));` set `$previousLogs` to `false` instead of the expected array. I think it makes sense to only call `array_merge` if `$previousLogs` was successfully instantiated as an array.

My IDE also pointed out that `$collectedLogs` was possible undefined, so moving its declaration outside of the if block resolved that.

Stacktrace:
```
ErrorException:
Warning: array_merge(): Expected parameter 1 to be an array, bool given

  at /srv/vendor/symfony/http-kernel/CacheWarmer/CacheWarmerAggregate.php:106
  at Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate->warmUp('/srv/var/cache/local')
     (/srv/vendor/symfony/http-kernel/Kernel.php:584)
  at Symfony\Component\HttpKernel\Kernel->initializeContainer()
     (/srv/vendor/symfony/http-kernel/Kernel.php:786)
  at Symfony\Component\HttpKernel\Kernel->preBoot()
     (/srv/vendor/symfony/http-kernel/Kernel.php:187)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (/srv/public/index.php:44)                
```