### PR TITLE
[Validator] Deprecated email validation mode `loose`

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -151,3 +151,8 @@ Security
        }
    }
    ```
+
+Validator
+---------
+
+   * Deprecated email validation mode `loose`; will be removed in Symfony 6 in favor of `html5` (= new default)

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -497,6 +497,8 @@ Validator
   $builder->enableAnnotationMapping(true)
       ->addDefaultDoctrineAnnotationReader();
   ```
+  
+  * Removed email validation mode `loose`; default is now `html5`.
 
 Workflow
 --------

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -498,7 +498,7 @@ Validator
       ->addDefaultDoctrineAnnotationReader();
   ```
   
-  * Removed email validation mode `loose`; default is now `html5`.
+  * Removed email validation mode `loose`; default is now `html5`
 
 Workflow
 --------

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -7,7 +7,7 @@ CHANGELOG
  * Add a `CssColor` constraint to validate CSS colors
  * Add support for `ConstraintViolationList::createFromMessage()`
  * Add error's uid to `Count` and `Length` constraints with "exactly" option enabled
- * Deprecated email validation mode `loose`; will be removed in Symfony 6 in favor of `html5` (= new default)
+ * Deprecate email validation mode `loose`, use `html5` instead
 
 5.3
 ---

--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add a `CssColor` constraint to validate CSS colors
  * Add support for `ConstraintViolationList::createFromMessage()`
  * Add error's uid to `Count` and `Length` constraints with "exactly" option enabled
+ * Deprecated email validation mode `loose`; will be removed in Symfony 6 in favor of `html5` (= new default)
 
 5.3
 ---

--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -27,6 +27,7 @@ class Email extends Constraint
 {
     public const VALIDATION_MODE_HTML5 = 'html5';
     public const VALIDATION_MODE_STRICT = 'strict';
+    /** @deprecated since Symfony 5.4; will be removed in Symfony 6.0; use email validation mode "html" instead */
     public const VALIDATION_MODE_LOOSE = 'loose';
 
     public const INVALID_FORMAT_ERROR = 'bd79c0ab-ddba-46cc-a703-a7a4b08de310';

--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -27,7 +27,7 @@ class Email extends Constraint
 {
     public const VALIDATION_MODE_HTML5 = 'html5';
     public const VALIDATION_MODE_STRICT = 'strict';
-    /** @deprecated since Symfony 5.4; will be removed in Symfony 6.0; use email validation mode "html" instead */
+    /** @deprecated since Symfony 5.4; will be removed in Symfony 6.0; use email validation mode "html5" instead */
     public const VALIDATION_MODE_LOOSE = 'loose';
 
     public const INVALID_FORMAT_ERROR = 'bd79c0ab-ddba-46cc-a703-a7a4b08de310';

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -78,7 +78,7 @@ class EmailValidator extends ConstraintValidator
         }
 
         if (Email::VALIDATION_MODE_LOOSE === $constraint->mode) {
-            trigger_deprecation('symfony/validator', '5.4', 'The email validation mode `loose` is deprecated since Symfony 5.4, and will be removed in Symfony 6.0 in favor of `html5` (= new default)');
+            trigger_deprecation('symfony/validator', '5.4', 'The "loose" email validation mode is deprecated, use "html5" instead');
         }
 
         if (!\in_array($constraint->mode, Email::$validationModes, true)) {

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -40,7 +40,7 @@ class EmailValidator extends ConstraintValidator
             throw new \InvalidArgumentException('The "defaultMode" parameter value is not valid.');
         }
         
-        if ($defaultMode === Email::VALIDATION_MODE_LOOSE) {
+        if (Email::VALIDATION_MODE_LOOSE === $defaultMode) {
             trigger_deprecation('symfony/validator', '5.4', 'The email validation mode "loose" is deprecated; in Symfony 6.0 the default mode will be "html5".');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -77,6 +77,10 @@ class EmailValidator extends ConstraintValidator
             $constraint->mode = $this->defaultMode;
         }
 
+        if (Email::VALIDATION_MODE_LOOSE === $constraint->mode) {
+            trigger_deprecation('symfony/validator', '5.4', 'The email validation mode `loose` is deprecated since Symfony 5.4, and will be removed in Symfony 6.0 in favor of `html5` (= new default)');
+        }
+
         if (!\in_array($constraint->mode, Email::$validationModes, true)) {
             throw new \InvalidArgumentException(sprintf('The "%s::$mode" parameter value is not valid.', get_debug_type($constraint)));
         }

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -39,6 +39,10 @@ class EmailValidator extends ConstraintValidator
         if (!\in_array($defaultMode, Email::$validationModes, true)) {
             throw new \InvalidArgumentException('The "defaultMode" parameter value is not valid.');
         }
+        
+        if ($defaultMode === Email::VALIDATION_MODE_LOOSE) {
+            trigger_deprecation('symfony/validator', '5.4', 'The email validation mode "loose" is deprecated; in Symfony 6.0 the default mode will be "html5".');
+        }
 
         $this->defaultMode = $defaultMode;
     }

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -73,12 +73,12 @@ class EmailValidator extends ConstraintValidator
             $value = ($constraint->normalizer)($value);
         }
 
-        if (null === $constraint->mode) {
-            $constraint->mode = $this->defaultMode;
-        }
-
         if (Email::VALIDATION_MODE_LOOSE === $constraint->mode) {
             trigger_deprecation('symfony/validator', '5.4', 'The "loose" email validation mode is deprecated, use "html5" instead');
+        }
+
+        if (null === $constraint->mode) {
+            $constraint->mode = $this->defaultMode;
         }
 
         if (!\in_array($constraint->mode, Email::$validationModes, true)) {

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -41,7 +41,7 @@ class EmailValidator extends ConstraintValidator
         }
         
         if (Email::VALIDATION_MODE_LOOSE === $defaultMode) {
-            trigger_deprecation('symfony/validator', '5.4', 'The email validation mode "loose" is deprecated; in Symfony 6.0 the default mode will be "html5".');
+            trigger_deprecation('symfony/validator', '5.4', 'The "loose" email validation mode is deprecated, use "html5" instead');
         }
 
         $this->defaultMode = $defaultMode;

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -39,7 +39,7 @@ class EmailValidator extends ConstraintValidator
         if (!\in_array($defaultMode, Email::$validationModes, true)) {
             throw new \InvalidArgumentException('The "defaultMode" parameter value is not valid.');
         }
-        
+
         if (Email::VALIDATION_MODE_LOOSE === $defaultMode) {
             trigger_deprecation('symfony/validator', '5.4', 'The "loose" email validation mode is deprecated, use "html5" instead');
         }

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -64,16 +64,18 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider getValidEmails
      */
-    public function testValidEmails($email)
+    public function testValidEmailsLoose($email)
     {
-        $this->validator->validate($email, new Email());
+        $this->validator->validate($email, new Email(['mode' => Email::VALIDATION_MODE_LOOSE]));
 
+        $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
         $this->assertNoViolation();
     }
 
-    public function getValidEmails()
+    public function getValidEmailsLoose()
     {
         return [
             ['fabien@symfony.com'],

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -23,7 +23,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
 {
     protected function createValidator()
     {
-        return new EmailValidator(Email::VALIDATION_MODE_HTML5);
+        return new EmailValidator(Email::VALIDATION_MODE_LOOSE);
     }
 
     public function testUnknownDefaultModeTriggerException()

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -65,7 +65,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
 
     /**
      * @group legacy
-     * @dataProvider getValidEmails
+     * @dataProvider getValidEmailsLoose
      */
     public function testValidEmailsLoose($email)
     {

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -223,6 +223,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
 
         $this->validator->validate('example@example..com', $constraint);
 
+        $this->expectDeprecation();
         $this->assertNoViolation();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -36,14 +36,10 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
         new EmailValidator('Unknown Mode');
     }
 
-    /**
-     * @group legacy
-     */
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Email());
 
-        $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
         $this->assertNoViolation();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -223,7 +223,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
 
         $this->validator->validate('example@example..com', $constraint);
 
-        $this->expectDeprecation();
+        // $this->expectDeprecation();
         $this->assertNoViolation();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -23,7 +23,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
 {
     protected function createValidator()
     {
-        return new EmailValidator(Email::VALIDATION_MODE_LOOSE);
+        return new EmailValidator(Email::VALIDATION_MODE_HTML5);
     }
 
     public function testUnknownDefaultModeTriggerException()
@@ -214,6 +214,9 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
              ->assertRaised();
     }
 
+    /** 
+     * @group legacy
+     */
     public function testModeLoose()
     {
         $constraint = new Email(['mode' => Email::VALIDATION_MODE_LOOSE]);

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -24,12 +24,8 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
 {
     use ExpectDeprecationTrait;
 
-    /**
-     * @group legacy
-     */
     protected function createValidator()
     {
-        $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
         return new EmailValidator(Email::VALIDATION_MODE_LOOSE);
     }
 
@@ -40,10 +36,14 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
         new EmailValidator('Unknown Mode');
     }
 
+    /**
+     * @group legacy
+     */
     public function testNullIsValid()
     {
         $this->validator->validate(null, new Email());
 
+        $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
         $this->assertNoViolation();
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -26,6 +26,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
 
     protected function createValidator()
     {
+        $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
         return new EmailValidator(Email::VALIDATION_MODE_LOOSE);
     }
 
@@ -217,9 +218,6 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
              ->assertRaised();
     }
 
-    /**
-     * @group legacy
-     */
     public function testModeLoose()
     {
         $constraint = new Email(['mode' => Email::VALIDATION_MODE_LOOSE]);

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -24,6 +24,9 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
 {
     use ExpectDeprecationTrait;
 
+    /**
+     * @group legacy
+     */
     protected function createValidator()
     {
         $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
@@ -218,6 +221,9 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
              ->assertRaised();
     }
 
+    /**
+     * @group legacy
+     */
     public function testModeLoose()
     {
         $constraint = new Email(['mode' => Email::VALIDATION_MODE_LOOSE]);

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -26,7 +26,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
 
     protected function createValidator()
     {
-        return new EmailValidator(Email::VALIDATION_MODE_LOOSE);
+        return new EmailValidator(Email::VALIDATION_MODE_HTML5);
     }
 
     public function testUnknownDefaultModeTriggerException()

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -214,7 +214,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
              ->assertRaised();
     }
 
-    /** 
+    /**
      * @group legacy
      */
     public function testModeLoose()

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Validator\Tests\Constraints;
 
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\EmailValidator;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
@@ -21,6 +22,8 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 class EmailValidatorTest extends ConstraintValidatorTestCase
 {
+    use ExpectDeprecationTrait;
+
     protected function createValidator()
     {
         return new EmailValidator(Email::VALIDATION_MODE_LOOSE);
@@ -223,7 +226,7 @@ class EmailValidatorTest extends ConstraintValidatorTestCase
 
         $this->validator->validate('example@example..com', $constraint);
 
-        // $this->expectDeprecation();
+        $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
         $this->assertNoViolation();
     }
 

--- a/src/Symfony/Component/Validator/Tests/ValidationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidationTest.php
@@ -26,13 +26,13 @@ class ValidationTest extends TestCase
 
     public function testCreateCallableValid()
     {
-        $validator = Validation::createCallable(new Email(Email::VALIDATION_MODE_HTML5));
+        $validator = Validation::createCallable(new Email('mode' => Email::VALIDATION_MODE_HTML5));
         $this->assertEquals('test@example.com', $validator('test@example.com'));
     }
 
     public function testCreateCallableInvalid()
     {
-        $validator = Validation::createCallable(new Email(Email::VALIDATION_MODE_HTML5));
+        $validator = Validation::createCallable(new Email('mode' => Email::VALIDATION_MODE_HTML5));
         try {
             $validator('test');
             $this->fail('No ValidationFailedException thrown');
@@ -47,13 +47,13 @@ class ValidationTest extends TestCase
 
     public function testCreateIsValidCallableValid()
     {
-        $validator = Validation::createIsValidCallable(new Email(Email::VALIDATION_MODE_HTML5));
+        $validator = Validation::createIsValidCallable(new Email('mode' => Email::VALIDATION_MODE_HTML5));
         $this->assertTrue($validator('test@example.com'));
     }
 
     public function testCreateIsValidCallableInvalid()
     {
-        $validator = Validation::createIsValidCallable(new Email(Email::VALIDATION_MODE_HTML5));
+        $validator = Validation::createIsValidCallable(new Email('mode' => Email::VALIDATION_MODE_HTML5));
         $this->assertFalse($validator('test', $violations));
         $this->assertCount(1, $violations);
         $this->assertEquals('This value is not a valid email address.', $violations->get(0)->getMessage());

--- a/src/Symfony/Component/Validator/Tests/ValidationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidationTest.php
@@ -24,6 +24,9 @@ class ValidationTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
+    /**
+     * @group legacy
+     */
     public function testCreateCallableValid()
     {
         $validator = Validation::createCallable(new Email());
@@ -31,6 +34,9 @@ class ValidationTest extends TestCase
         $this->assertEquals('test@example.com', $validator('test@example.com'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testCreateCallableInvalid()
     {
         $validator = Validation::createCallable(new Email());
@@ -47,6 +53,9 @@ class ValidationTest extends TestCase
         }
     }
 
+    /**
+     * @group legacy
+     */
     public function testCreateIsValidCallableValid()
     {
         $validator = Validation::createIsValidCallable(new Email());
@@ -54,6 +63,9 @@ class ValidationTest extends TestCase
         $this->assertTrue($validator('test@example.com'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testCreateIsValidCallableInvalid()
     {
         $validator = Validation::createIsValidCallable(new Email());

--- a/src/Symfony/Component/Validator/Tests/ValidationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidationTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Validator\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Exception\ValidationFailedException;
 use Symfony\Component\Validator\Validation;
@@ -22,8 +21,6 @@ use Symfony\Component\Validator\Validation;
  */
 class ValidationTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     public function testCreateCallableValid()
     {
         $validator = Validation::createCallable(new Email(['mode' => Email::VALIDATION_MODE_HTML5]));

--- a/src/Symfony/Component/Validator/Tests/ValidationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidationTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Exception\ValidationFailedException;
 use Symfony\Component\Validator\Validation;
@@ -21,9 +22,12 @@ use Symfony\Component\Validator\Validation;
  */
 class ValidationTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testCreateCallableValid()
     {
         $validator = Validation::createCallable(new Email());
+        $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
         $this->assertEquals('test@example.com', $validator('test@example.com'));
     }
 

--- a/src/Symfony/Component/Validator/Tests/ValidationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidationTest.php
@@ -26,13 +26,13 @@ class ValidationTest extends TestCase
 
     public function testCreateCallableValid()
     {
-        $validator = Validation::createCallable(new Email('mode' => Email::VALIDATION_MODE_HTML5));
+        $validator = Validation::createCallable(new Email(['mode' => Email::VALIDATION_MODE_HTML5]));
         $this->assertEquals('test@example.com', $validator('test@example.com'));
     }
 
     public function testCreateCallableInvalid()
     {
-        $validator = Validation::createCallable(new Email('mode' => Email::VALIDATION_MODE_HTML5));
+        $validator = Validation::createCallable(new Email(['mode' => Email::VALIDATION_MODE_HTML5]));
         try {
             $validator('test');
             $this->fail('No ValidationFailedException thrown');
@@ -47,13 +47,13 @@ class ValidationTest extends TestCase
 
     public function testCreateIsValidCallableValid()
     {
-        $validator = Validation::createIsValidCallable(new Email('mode' => Email::VALIDATION_MODE_HTML5));
+        $validator = Validation::createIsValidCallable(new Email(['mode' => Email::VALIDATION_MODE_HTML5]));
         $this->assertTrue($validator('test@example.com'));
     }
 
     public function testCreateIsValidCallableInvalid()
     {
-        $validator = Validation::createIsValidCallable(new Email('mode' => Email::VALIDATION_MODE_HTML5));
+        $validator = Validation::createIsValidCallable(new Email(['mode' => Email::VALIDATION_MODE_HTML5]));
         $this->assertFalse($validator('test', $violations));
         $this->assertCount(1, $violations);
         $this->assertEquals('This value is not a valid email address.', $violations->get(0)->getMessage());

--- a/src/Symfony/Component/Validator/Tests/ValidationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidationTest.php
@@ -34,6 +34,7 @@ class ValidationTest extends TestCase
     public function testCreateCallableInvalid()
     {
         $validator = Validation::createCallable(new Email());
+        $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
         try {
             $validator('test');
             $this->fail('No ValidationFailedException thrown');
@@ -49,12 +50,14 @@ class ValidationTest extends TestCase
     public function testCreateIsValidCallableValid()
     {
         $validator = Validation::createIsValidCallable(new Email());
+        $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
         $this->assertTrue($validator('test@example.com'));
     }
 
     public function testCreateIsValidCallableInvalid()
     {
         $validator = Validation::createIsValidCallable(new Email());
+        $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
         $this->assertFalse($validator('test', $violations));
         $this->assertCount(1, $violations);
         $this->assertEquals('This value is not a valid email address.', $violations->get(0)->getMessage());

--- a/src/Symfony/Component/Validator/Tests/ValidationTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidationTest.php
@@ -24,23 +24,15 @@ class ValidationTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
-    /**
-     * @group legacy
-     */
     public function testCreateCallableValid()
     {
-        $validator = Validation::createCallable(new Email());
-        $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
+        $validator = Validation::createCallable(new Email(Email::VALIDATION_MODE_HTML5));
         $this->assertEquals('test@example.com', $validator('test@example.com'));
     }
 
-    /**
-     * @group legacy
-     */
     public function testCreateCallableInvalid()
     {
-        $validator = Validation::createCallable(new Email());
-        $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
+        $validator = Validation::createCallable(new Email(Email::VALIDATION_MODE_HTML5));
         try {
             $validator('test');
             $this->fail('No ValidationFailedException thrown');
@@ -53,23 +45,15 @@ class ValidationTest extends TestCase
         }
     }
 
-    /**
-     * @group legacy
-     */
     public function testCreateIsValidCallableValid()
     {
-        $validator = Validation::createIsValidCallable(new Email());
-        $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
+        $validator = Validation::createIsValidCallable(new Email(Email::VALIDATION_MODE_HTML5));
         $this->assertTrue($validator('test@example.com'));
     }
 
-    /**
-     * @group legacy
-     */
     public function testCreateIsValidCallableInvalid()
     {
-        $validator = Validation::createIsValidCallable(new Email());
-        $this->expectDeprecation('Since symfony/validator 5.4: The "loose" email validation mode is deprecated, use "html5" instead');
+        $validator = Validation::createIsValidCallable(new Email(Email::VALIDATION_MODE_HTML5));
         $this->assertFalse($validator('test', $violations));
         $this->assertCount(1, $violations);
         $this->assertEquals('This value is not a valid email address.', $violations->get(0)->getMessage());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #41855
| License       | MIT
| Doc PR        | TODO

Closes https://github.com/symfony/symfony/issues/41855

Don't know what else needs to be done... ;-)