### PR TITLE
Use empty() instead of (bool)count()

### DIFF
--- a/src/Symfony/Component/Console/Question/Question.php
+++ b/src/Symfony/Component/Console/Question/Question.php
@@ -279,7 +279,7 @@ class Question
 
     protected function isAssoc(array $array)
     {
-        return (bool) \count(array_filter(array_keys($array), 'is_string'));
+        return !empty(array_filter(array_keys($array), 'is_string'));
     }
 
     public function isTrimmable(): bool


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

While the performance seems to be more or less the same, this is way easier to read in my opinion.
I am new to Symfony, so if there is any reason that this was coded the way it was, I am happy to hear about it.