### PR TITLE
Add a warning in WDT when using symfony/symfony

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\WebProfilerBundle\Controller;
 
+use Symfony\Bundle\FullStack;
 use Symfony\Bundle\WebProfilerBundle\Csp\ContentSecurityPolicyHandler;
 use Symfony\Bundle\WebProfilerBundle\Profiler\TemplateManager;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -152,6 +153,7 @@ class ProfilerController
         }
 
         return $this->renderWithCspNonces($request, '@WebProfiler/Profiler/toolbar.html.twig', [
+            'full_stack' => class_exists(FullStack::class),
             'request' => $request,
             'profile' => $profile,
             'templates' => $this->getTemplateManager()->getNames($profile),

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -545,6 +545,11 @@ div.sf-toolbar .sf-toolbar-block a:hover {
     margin-right: 10px;
 }
 
+.sf-full-stack {
+    left: 0px;
+    font-size: 12px;
+}
+
 /***** Media query print: Do not print the Toolbar. *****/
 @media print {
     .sf-toolbar {

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -22,6 +22,22 @@
             {% endwith %}
         {% endif %}
     {% endfor %}
+    {% if full_stack %}
+        <div class="sf-full-stack sf-toolbar-block sf-toolbar-block-full-stack sf-toolbar-status-red sf-toolbar-block-right">
+            <div class="sf-toolbar-icon">
+                <span class="sf-toolbar-value">Using symfony/symfony is NOT supported</span>
+            </div>
+            <div class="sf-toolbar-info sf-toolbar-status-red">
+                <p>This project is using Symfony via the "symfony/symfony" package.</p>
+                <p>This is NOT supported anymore since Symfony 4.0.</p>
+                <p>Even if it seems to work well, it has some important limitations with no workarounds.</p>
+                <p>Using this package also makes your project slower.</p>
+
+                <strong>Please, stop using this package and replace it with individual packages instead.</strong>
+            </div>
+            <div></div>
+        </div>
+    {% endif %}
 
     <button class="hide-button" type="button" id="sfToolbarHideButton-{{ token }}" title="Close Toolbar" accesskey="D" aria-expanded="true" aria-controls="sfToolbarMainContent-{{ token }}">
         {{ include('@WebProfiler/Icon/close.svg') }}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a

Even if using the `symfony/symfony` package is still possible, it is highly discouraged. It comes with limitations that cannot be fixed (when you are using Mailer/Notifier/Messenger bridges for instance). It also makes the code slower for no good reasons and makes you download all possible Symfony packages even if you are not using them.

This has been the case since 4.0, it's time to warn people that they should upgrade ASAP.

We are adding a warning as we will still be tagging `symfony/symfony` for the next major versions as these tags help the maintainers.

![image](https://user-images.githubusercontent.com/47313/137490986-1c0070ca-48f8-4f93-95b5-7e9961110bdb.png)


![image](https://user-images.githubusercontent.com/47313/137490901-93b6e287-59dc-46d8-9ee3-e0aff1e92002.png)
