### PR TITLE
[WebProfileBundle] Remove pre-2.8 web profiler variable

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -114,7 +114,6 @@ class ProfilerController
             'request' => $request,
             'templates' => $this->getTemplateManager()->getNames($profile),
             'is_ajax' => $request->isXmlHttpRequest(),
-            'profiler_markup_version' => 2, // 1 = original profiler, 2 = Symfony 2.8+ profiler
         ]), 200, ['Content-Type' => 'text/html']);
     }
 
@@ -157,7 +156,6 @@ class ProfilerController
             'templates' => $this->getTemplateManager()->getNames($profile),
             'profiler_url' => $url,
             'token' => $token,
-            'profiler_markup_version' => 2, // 1 = original toolbar, 2 = Symfony 2.8+ toolbar
         ]);
     }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -117,7 +117,7 @@
                         {% for name, template in templates %}
                             {% set menu -%}
                                 {%- if block('menu', template) is defined -%}
-                                    {% with { collector: profile.getcollector(name), profiler_markup_version: profiler_markup_version } %}
+                                    {% with { collector: profile.getcollector(name) } %}
                                         {{- block('menu', template) -}}
                                     {% endwith %}
                                 {%- endif -%}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -14,7 +14,6 @@
                 profiler_url: profiler_url,
                 token: profile.token,
                 name: name,
-                profiler_markup_version: profiler_markup_version,
                 csp_script_nonce: csp_script_nonce,
                 csp_style_nonce: csp_style_nonce
               } %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | n/a <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | n/a

This is a left-over from 2.8 where we changed the markup of the WDT. It's time to remove it now.
