### PR TITLE
Remove untranslated translation for Afrikaans

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.af.xlf
@@ -358,10 +358,6 @@
                 <source>This value is not a valid timezone.</source>
                 <target>Hierdie waarde is nie 'n geldige tydsone nie.</target>
             </trans-unit>
-            <trans-unit id="93">
-                <source>This password has been leaked in a data breach, it must not be used. Please use another password.</source>
-                <target>This password has been leaked in a data breach, it must not be used. Please use another password.</target>
-            </trans-unit>
             <trans-unit id="94">
                 <source>This value should be between {{ min }} and {{ max }}.</source>
                 <target>Hierdie waarde moet tussen {{ min }} en {{ max }} wees.</target>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

If the translation is actually missing, this will be reported as missing by the translation tooling of carsonbot.
