### PR TITLE
[Serializer] Add `SerializedPath` annotation to flatten nested attributes

### DIFF
--- a/src/Symfony/Component/Serializer/Annotation/SerializedName.php
+++ b/src/Symfony/Component/Serializer/Annotation/SerializedName.php
@@ -27,8 +27,8 @@ final class SerializedName
 {
     public function __construct(private string $serializedName)
     {
-        if (empty($serializedName)) {
-            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a non-empty string.', static::class));
+        if ('' === $serializedName) {
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a non-empty string.', self::class));
         }
     }
 

--- a/src/Symfony/Component/Serializer/Annotation/SerializedPath.php
+++ b/src/Symfony/Component/Serializer/Annotation/SerializedPath.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Annotation;
+
+use Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException;
+use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * Annotation class for @SerializedPath().
+ *
+ * @Annotation
+ * @NamedArgumentConstructor
+ * @Target({"PROPERTY", "METHOD"})
+ *
+ * @author Tobias Bönner <tobi@boenner.family>
+ */
+#[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+final class SerializedPath
+{
+    private PropertyPath $serializedPath;
+
+    public function __construct(string $serializedPath)
+    {
+        try {
+            $this->serializedPath = new PropertyPath($serializedPath);
+        } catch (InvalidPropertyPathException $pathException) {
+            throw new InvalidArgumentException(sprintf('Parameter of annotation "%s" must be a valid property path.', self::class));
+        }
+    }
+
+    public function getSerializedPath(): PropertyPath
+    {
+        return $this->serializedPath;
+    }
+}

--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Change the signature of `AttributeMetadataInterface::setSerializedName()` to `setSerializedName(?string)`
  * Change the signature of `ClassMetadataInterface::setClassDiscriminatorMapping()` to `setClassDiscriminatorMapping(?ClassDiscriminatorMapping)`
  * Add option YamlEncoder::YAML_INDENTATION to YamlEncoder constructor options to configure additional indentation for each level of nesting. This allows configuring indentation in the service configuration.
+ * Add `SerializedPath` annotation to flatten nested attributes
 
 6.1
 ---

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadata.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Serializer\Mapping;
 
+use Symfony\Component\PropertyAccess\PropertyPath;
+
 /**
  * @author Kévin Dunglas <dunglas@gmail.com>
  */
@@ -47,6 +49,13 @@ class AttributeMetadata implements AttributeMetadataInterface
      *           {@link getSerializedName()} instead.
      */
     public $serializedName;
+
+    /**
+     * @internal This property is public in order to reduce the size of the
+     *           class' serialized representation. Do not access it. Use
+     *           {@link getSerializedPath()} instead.
+     */
+    public ?PropertyPath $serializedPath = null;
 
     /**
      * @var bool
@@ -121,6 +130,16 @@ class AttributeMetadata implements AttributeMetadataInterface
         return $this->serializedName;
     }
 
+    public function setSerializedPath(PropertyPath $serializedPath = null): void
+    {
+        $this->serializedPath = $serializedPath;
+    }
+
+    public function getSerializedPath(): ?PropertyPath
+    {
+        return $this->serializedPath;
+    }
+
     public function setIgnore(bool $ignore)
     {
         $this->ignore = $ignore;
@@ -190,14 +209,9 @@ class AttributeMetadata implements AttributeMetadataInterface
         }
 
         // Overwrite only if not defined
-        if (null === $this->maxDepth) {
-            $this->maxDepth = $attributeMetadata->getMaxDepth();
-        }
-
-        // Overwrite only if not defined
-        if (null === $this->serializedName) {
-            $this->serializedName = $attributeMetadata->getSerializedName();
-        }
+        $this->maxDepth ??= $attributeMetadata->getMaxDepth();
+        $this->serializedName ??= $attributeMetadata->getSerializedName();
+        $this->serializedPath ??= $attributeMetadata->getSerializedPath();
 
         // Overwrite only if both contexts are empty
         if (!$this->normalizationContexts && !$this->denormalizationContexts) {
@@ -217,6 +231,6 @@ class AttributeMetadata implements AttributeMetadataInterface
      */
     public function __sleep(): array
     {
-        return ['name', 'groups', 'maxDepth', 'serializedName', 'ignore', 'normalizationContexts', 'denormalizationContexts'];
+        return ['name', 'groups', 'maxDepth', 'serializedName', 'serializedPath', 'ignore', 'normalizationContexts', 'denormalizationContexts'];
     }
 }

--- a/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
+++ b/src/Symfony/Component/Serializer/Mapping/AttributeMetadataInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Serializer\Mapping;
 
+use Symfony\Component\PropertyAccess\PropertyPath;
+
 /**
  * Stores metadata needed for serializing and deserializing attributes.
  *
@@ -58,6 +60,10 @@ interface AttributeMetadataInterface
      * Gets the serialization name for this attribute.
      */
     public function getSerializedName(): ?string;
+
+    public function setSerializedPath(?PropertyPath $serializedPath): void;
+
+    public function getSerializedPath(): ?PropertyPath;
 
     /**
      * Sets if this attribute must be ignored or not.

--- a/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactoryCompiler.php
+++ b/src/Symfony/Component/Serializer/Mapping/Factory/ClassMetadataFactoryCompiler.php
@@ -48,6 +48,7 @@ EOF;
                     $attributeMetadata->getGroups(),
                     $attributeMetadata->getMaxDepth(),
                     $attributeMetadata->getSerializedName(),
+                    $attributeMetadata->getSerializedPath(),
                 ];
             }
 

--- a/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/AnnotationLoader.php
@@ -18,6 +18,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\Ignore;
 use Symfony\Component\Serializer\Annotation\MaxDepth;
 use Symfony\Component\Serializer\Annotation\SerializedName;
+use Symfony\Component\Serializer\Annotation\SerializedPath;
 use Symfony\Component\Serializer\Exception\MappingException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
@@ -38,6 +39,7 @@ class AnnotationLoader implements LoaderInterface
         Ignore::class,
         MaxDepth::class,
         SerializedName::class,
+        SerializedPath::class,
         Context::class,
     ];
 
@@ -81,6 +83,8 @@ class AnnotationLoader implements LoaderInterface
                         $attributesMetadata[$property->name]->setMaxDepth($annotation->getMaxDepth());
                     } elseif ($annotation instanceof SerializedName) {
                         $attributesMetadata[$property->name]->setSerializedName($annotation->getSerializedName());
+                    } elseif ($annotation instanceof SerializedPath) {
+                        $attributesMetadata[$property->name]->setSerializedPath($annotation->getSerializedPath());
                     } elseif ($annotation instanceof Ignore) {
                         $attributesMetadata[$property->name]->setIgnore(true);
                     } elseif ($annotation instanceof Context) {
@@ -134,6 +138,12 @@ class AnnotationLoader implements LoaderInterface
                     }
 
                     $attributeMetadata->setSerializedName($annotation->getSerializedName());
+                } elseif ($annotation instanceof SerializedPath) {
+                    if (!$accessorOrMutator) {
+                        throw new MappingException(sprintf('SerializedPath on "%s::%s()" cannot be added. SerializedPath can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));
+                    }
+
+                    $attributeMetadata->setSerializedPath($annotation->getSerializedPath());
                 } elseif ($annotation instanceof Ignore) {
                     if (!$accessorOrMutator) {
                         throw new MappingException(sprintf('Ignore on "%s::%s()" cannot be added. Ignore can only be added on methods beginning with "get", "is", "has" or "set".', $className, $method->name));

--- a/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/XmlFileLoader.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Serializer\Mapping\Loader;
 
 use Symfony\Component\Config\Util\XmlUtils;
+use Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException;
+use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Serializer\Exception\MappingException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
@@ -66,6 +68,14 @@ class XmlFileLoader extends FileLoader
 
                 if (isset($attribute['serialized-name'])) {
                     $attributeMetadata->setSerializedName((string) $attribute['serialized-name']);
+                }
+
+                if (isset($attribute['serialized-path'])) {
+                    try {
+                        $attributeMetadata->setSerializedPath(new PropertyPath((string) $attribute['serialized-path']));
+                    } catch (InvalidPropertyPathException) {
+                        throw new MappingException(sprintf('The "serialized-path" value must be a valid property path for the attribute "%s" of the class "%s".', $attributeName, $classMetadata->getName()));
+                    }
                 }
 
                 if (isset($attribute['ignore'])) {

--- a/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/YamlFileLoader.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Serializer\Mapping\Loader;
 
+use Symfony\Component\PropertyAccess\Exception\InvalidPropertyPathException;
+use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Serializer\Exception\MappingException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
@@ -84,11 +86,19 @@ class YamlFileLoader extends FileLoader
                 }
 
                 if (isset($data['serialized_name'])) {
-                    if (!\is_string($data['serialized_name']) || empty($data['serialized_name'])) {
+                    if (!\is_string($data['serialized_name']) || '' === $data['serialized_name']) {
                         throw new MappingException(sprintf('The "serialized_name" value must be a non-empty string in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
                     }
 
                     $attributeMetadata->setSerializedName($data['serialized_name']);
+                }
+
+                if (isset($data['serialized_path'])) {
+                    try {
+                        $attributeMetadata->setSerializedPath(new PropertyPath((string) $data['serialized_path']));
+                    } catch (InvalidPropertyPathException) {
+                        throw new MappingException(sprintf('The "serialized_path" value must be a valid property path in "%s" for the attribute "%s" of the class "%s".', $this->file, $attribute, $classMetadata->getName()));
+                    }
                 }
 
                 if (isset($data['ignore'])) {

--- a/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
+++ b/src/Symfony/Component/Serializer/Mapping/Loader/schema/dic/serializer-mapping/serializer-mapping-1.0.xsd
@@ -81,6 +81,13 @@
                 </xsd:restriction>
             </xsd:simpleType>
         </xsd:attribute>
+        <xsd:attribute name="serialized-path">
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                    <xsd:minLength value="1" />
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
         <xsd:attribute name="ignore" type="xsd:boolean" />
     </xsd:complexType>
 

--- a/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
+++ b/src/Symfony/Component/Serializer/NameConverter/MetadataAwareNameConverter.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\NameConverter;
 
+use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 
@@ -76,6 +77,10 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
             return null;
         }
 
+        if (null !== $attributesMetadata[$propertyName]->getSerializedName() && null !== $attributesMetadata[$propertyName]->getSerializedPath()) {
+            throw new LogicException(sprintf('Found SerializedName and SerializedPath annotations on property "%s" of class "%s".', $propertyName, $class));
+        }
+
         return $attributesMetadata[$propertyName]->getSerializedName() ?? null;
     }
 
@@ -111,6 +116,10 @@ final class MetadataAwareNameConverter implements AdvancedNameConverterInterface
         foreach ($classMetadata->getAttributesMetadata() as $name => $metadata) {
             if (null === $metadata->getSerializedName()) {
                 continue;
+            }
+
+            if (null !== $metadata->getSerializedName() && null !== $metadata->getSerializedPath()) {
+                throw new LogicException(sprintf('Found SerializedName and SerializedPath annotations on property "%s" of class "%s".', $name, $class));
             }
 
             $groups = $metadata->getGroups();

--- a/src/Symfony/Component/Serializer/Tests/Annotation/SerializedNameTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/SerializedNameTest.php
@@ -20,16 +20,12 @@ use Symfony\Component\Serializer\Exception\InvalidArgumentException;
  */
 class SerializedNameTest extends TestCase
 {
-    /**
-     * @testWith    [""]
-     *              [0]
-     */
-    public function testNotAStringSerializedNameParameter($value)
+    public function testNotAStringSerializedNameParameter()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Parameter of annotation "Symfony\Component\Serializer\Annotation\SerializedName" must be a non-empty string.');
 
-        new SerializedName($value);
+        new SerializedName('');
     }
 
     public function testSerializedNameParameters()

--- a/src/Symfony/Component/Serializer/Tests/Annotation/SerializedPathTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Annotation/SerializedPathTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Annotation;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyAccess\PropertyPath;
+use Symfony\Component\Serializer\Annotation\SerializedPath;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+
+/**
+ * @author Tobias Bönner <tobi@boenner.family>
+ */
+class SerializedPathTest extends TestCase
+{
+    public function testEmptyStringSerializedPathParameter()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Parameter of annotation "Symfony\Component\Serializer\Annotation\SerializedPath" must be a valid property path.');
+
+        new SerializedPath('');
+    }
+
+    public function testSerializedPath()
+    {
+        $path = '[one][two]';
+        $serializedPath = new SerializedPath($path);
+        $propertyPath = new PropertyPath($path);
+        $this->assertEquals($propertyPath, $serializedPath->getSerializedPath());
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/SerializedPathDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Annotations/SerializedPathDummy.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Annotations;
+
+use Symfony\Component\Serializer\Annotation\SerializedPath;
+
+/**
+ * @author Tobias Bönner <tobi@boenner.family>
+ */
+class SerializedPathDummy
+{
+    /**
+     * @SerializedPath("[one][two]")
+     */
+    public $three;
+
+    public $seven;
+
+    /**
+     * @SerializedPath("[three][four]")
+     */
+    public function getSeven()
+    {
+        return $this->seven;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/SerializedPathDummy.php
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/Attributes/SerializedPathDummy.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Fixtures\Attributes;
+
+use Symfony\Component\Serializer\Annotation\SerializedPath;
+
+/**
+ * @author Tobias Bönner <tobi@boenner.family>
+ */
+class SerializedPathDummy
+{
+    #[SerializedPath('[one][two]')]
+    public $three;
+
+    public $seven;
+
+    #[SerializedPath('[three][four]')]
+    public function getSeven()
+    {
+        return $this->seven;
+    }
+}

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.xml
@@ -25,6 +25,11 @@
         <attribute name="bar" serialized-name="qux" />
     </class>
 
+    <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy">
+        <attribute name="three" serialized-path="[one][two]" />
+        <attribute name="seven" serialized-path="[three][four]" />
+    </class>
+
     <class name="Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummy">
         <discriminator-map type-property="type">
             <mapping type="first" class="Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummyFirstChild" />

--- a/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
+++ b/src/Symfony/Component/Serializer/Tests/Fixtures/serialization.yml
@@ -16,6 +16,12 @@
       serialized_name: 'baz'
     bar:
       serialized_name: 'qux'
+'Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy':
+  attributes:
+    three:
+      serialized_path: '[one][two]'
+    seven:
+      serialized_path: '[three][four]'
 'Symfony\Component\Serializer\Tests\Fixtures\Annotations\AbstractDummy':
   discriminator_map:
     type_property: type

--- a/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/AttributeMetadataTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Mapping;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\AttributeMetadataInterface;
 
@@ -56,6 +57,15 @@ class AttributeMetadataTest extends TestCase
         $attributeMetadata->setSerializedName('serialized_name');
 
         $this->assertEquals('serialized_name', $attributeMetadata->getSerializedName());
+    }
+
+    public function testSerializedPath()
+    {
+        $attributeMetadata = new AttributeMetadata('path');
+        $serializedPath = new PropertyPath('[serialized][path]');
+        $attributeMetadata->setSerializedPath($serializedPath);
+
+        $this->assertEquals($serializedPath, $attributeMetadata->getSerializedPath());
     }
 
     public function testIgnore()
@@ -119,6 +129,7 @@ class AttributeMetadataTest extends TestCase
 
     public function testMerge()
     {
+        $serializedPath = new PropertyPath('[a4][a5]');
         $attributeMetadata1 = new AttributeMetadata('a1');
         $attributeMetadata1->addGroup('a');
         $attributeMetadata1->addGroup('b');
@@ -128,6 +139,7 @@ class AttributeMetadataTest extends TestCase
         $attributeMetadata2->addGroup('c');
         $attributeMetadata2->setMaxDepth(2);
         $attributeMetadata2->setSerializedName('a3');
+        $attributeMetadata2->setSerializedPath($serializedPath);
         $attributeMetadata2->setNormalizationContextForGroups(['foo' => 'bar'], ['a']);
         $attributeMetadata2->setDenormalizationContextForGroups(['baz' => 'qux'], ['c']);
 
@@ -138,6 +150,7 @@ class AttributeMetadataTest extends TestCase
         $this->assertEquals(['a', 'b', 'c'], $attributeMetadata1->getGroups());
         $this->assertEquals(2, $attributeMetadata1->getMaxDepth());
         $this->assertEquals('a3', $attributeMetadata1->getSerializedName());
+        $this->assertEquals($serializedPath, $attributeMetadata1->getSerializedPath());
         $this->assertSame(['a' => ['foo' => 'bar']], $attributeMetadata1->getNormalizationContexts());
         $this->assertSame(['c' => ['baz' => 'qux']], $attributeMetadata1->getDenormalizationContexts());
         $this->assertTrue($attributeMetadata1->isIgnored());
@@ -166,6 +179,8 @@ class AttributeMetadataTest extends TestCase
         $attributeMetadata->addGroup('b');
         $attributeMetadata->setMaxDepth(3);
         $attributeMetadata->setSerializedName('serialized_name');
+        $serializedPath = new PropertyPath('[serialized][path]');
+        $attributeMetadata->setSerializedPath($serializedPath);
 
         $serialized = serialize($attributeMetadata);
         $this->assertEquals($attributeMetadata, unserialize($serialized));

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Factory/ClassMetadataFactoryCompilerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryCompiler;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Serializer\Tests\Fixtures\Annotations\MaxDepthDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedNameDummy;
+use Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\Dummy;
 
 final class ClassMetadataFactoryCompilerTest extends TestCase
@@ -44,25 +45,27 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
         $dummyMetadata = $classMetatadataFactory->getMetadataFor(Dummy::class);
         $maxDepthDummyMetadata = $classMetatadataFactory->getMetadataFor(MaxDepthDummy::class);
         $serializedNameDummyMetadata = $classMetatadataFactory->getMetadataFor(SerializedNameDummy::class);
+        $serializedPathDummyMetadata = $classMetatadataFactory->getMetadataFor(SerializedPathDummy::class);
 
         $code = (new ClassMetadataFactoryCompiler())->compile([
             $dummyMetadata,
             $maxDepthDummyMetadata,
             $serializedNameDummyMetadata,
+            $serializedPathDummyMetadata,
         ]);
 
         file_put_contents($this->dumpPath, $code);
         $compiledMetadata = require $this->dumpPath;
 
-        $this->assertCount(3, $compiledMetadata);
+        $this->assertCount(4, $compiledMetadata);
 
         $this->assertArrayHasKey(Dummy::class, $compiledMetadata);
         $this->assertEquals([
             [
-                'foo' => [[], null, null],
-                'bar' => [[], null, null],
-                'baz' => [[], null, null],
-                'qux' => [[], null, null],
+                'foo' => [[], null, null, null],
+                'bar' => [[], null, null, null],
+                'baz' => [[], null, null, null],
+                'qux' => [[], null, null, null],
             ],
             null,
         ], $compiledMetadata[Dummy::class]);
@@ -70,9 +73,9 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
         $this->assertArrayHasKey(MaxDepthDummy::class, $compiledMetadata);
         $this->assertEquals([
             [
-                'foo' => [[], 2, null],
-                'bar' => [[], 3, null],
-                'child' => [[], null, null],
+                'foo' => [[], 2, null, null],
+                'bar' => [[], 3, null, null],
+                'child' => [[], null, null, null],
             ],
             null,
         ], $compiledMetadata[MaxDepthDummy::class]);
@@ -80,12 +83,21 @@ final class ClassMetadataFactoryCompilerTest extends TestCase
         $this->assertArrayHasKey(SerializedNameDummy::class, $compiledMetadata);
         $this->assertEquals([
             [
-                'foo' => [[], null, 'baz'],
-                'bar' => [[], null, 'qux'],
-                'quux' => [[], null, null],
-                'child' => [[], null, null],
+                'foo' => [[], null, 'baz', null],
+                'bar' => [[], null, 'qux', null],
+                'quux' => [[], null, null, null],
+                'child' => [[], null, null, null],
             ],
             null,
         ], $compiledMetadata[SerializedNameDummy::class]);
+
+        $this->assertArrayHasKey(SerializedPathDummy::class, $compiledMetadata);
+        $this->assertEquals([
+            [
+                'three' => [[], null, null, '[one][two]'],
+                'seven' => [[], null, null, '[three][four]'],
+            ],
+            null,
+        ], $compiledMetadata[SerializedPathDummy::class]);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/AnnotationLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Mapping\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Serializer\Exception\MappingException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
@@ -90,6 +91,16 @@ abstract class AnnotationLoaderTest extends TestCase
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertEquals('baz', $attributesMetadata['foo']->getSerializedName());
         $this->assertEquals('qux', $attributesMetadata['bar']->getSerializedName());
+    }
+
+    public function testLoadSerializedPath()
+    {
+        $classMetadata = new ClassMetadata($this->getNamespace().'\SerializedPathDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertEquals(new PropertyPath('[one][two]'), $attributesMetadata['three']->getSerializedPath());
+        $this->assertEquals(new PropertyPath('[three][four]'), $attributesMetadata['seven']->getSerializedPath());
     }
 
     public function testLoadClassMetadataAndMerge()

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/XmlFileLoaderTest.php
@@ -84,6 +84,16 @@ class XmlFileLoaderTest extends TestCase
         $this->assertEquals('qux', $attributesMetadata['bar']->getSerializedName());
     }
 
+    public function testSerializedPath()
+    {
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertEquals('[one][two]', $attributesMetadata['three']->getSerializedPath());
+        $this->assertEquals('[three][four]', $attributesMetadata['seven']->getSerializedPath());
+    }
+
     public function testLoadDiscriminatorMap()
     {
         $classMetadata = new ClassMetadata(AbstractDummy::class);

--- a/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Mapping/Loader/YamlFileLoaderTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Serializer\Tests\Mapping\Loader;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Serializer\Exception\MappingException;
 use Symfony\Component\Serializer\Mapping\AttributeMetadata;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorMapping;
@@ -95,6 +96,16 @@ class YamlFileLoaderTest extends TestCase
         $attributesMetadata = $classMetadata->getAttributesMetadata();
         $this->assertEquals('baz', $attributesMetadata['foo']->getSerializedName());
         $this->assertEquals('qux', $attributesMetadata['bar']->getSerializedName());
+    }
+
+    public function testSerializedPath()
+    {
+        $classMetadata = new ClassMetadata('Symfony\Component\Serializer\Tests\Fixtures\Annotations\SerializedPathDummy');
+        $this->loader->loadClassMetadata($classMetadata);
+
+        $attributesMetadata = $classMetadata->getAttributesMetadata();
+        $this->assertEquals(new PropertyPath('[one][two]'), $attributesMetadata['three']->getSerializedPath());
+        $this->assertEquals(new PropertyPath('[three][four]'), $attributesMetadata['seven']->getSerializedPath());
     }
 
     public function testLoadDiscriminatorMap()

--- a/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
+++ b/src/Symfony/Component/Serializer/Tests/NameConverter/MetadataAwareNameConverterTest.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Serializer\Tests\NameConverter;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Annotation\SerializedName;
+use Symfony\Component\Serializer\Annotation\SerializedPath;
+use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
@@ -163,4 +166,31 @@ final class MetadataAwareNameConverterTest extends TestCase
         $this->assertEquals('buzForExport', $nameConverter->denormalize('buz', OtherSerializedNameDummy::class, null, ['groups' => ['b']]));
         $this->assertEquals('buz', $nameConverter->denormalize('buz', OtherSerializedNameDummy::class));
     }
+
+    public function testDenormalizeWithNestedPathAndName()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Found SerializedName and SerializedPath annotations on property "foo" of class "Symfony\Component\Serializer\Tests\NameConverter\NestedPathAndName".');
+        $nameConverter->denormalize('foo', NestedPathAndName::class);
+    }
+
+    public function testNormalizeWithNestedPathAndName()
+    {
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $nameConverter = new MetadataAwareNameConverter($classMetadataFactory);
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Found SerializedName and SerializedPath annotations on property "foo" of class "Symfony\Component\Serializer\Tests\NameConverter\NestedPathAndName".');
+        $nameConverter->normalize('foo', NestedPathAndName::class);
+    }
+}
+
+class NestedPathAndName
+{
+    /**
+     * @SerializedName("five")
+     * @SerializedPath("[one][two][three]")
+     */
+    public $foo;
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/AbstractObjectNormalizerTest.php
@@ -16,6 +16,8 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\Extractor\ReflectionExtractor;
 use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer\Annotation\SerializedName;
+use Symfony\Component\Serializer\Annotation\SerializedPath;
 use Symfony\Component\Serializer\Exception\ExtraAttributesException;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\LogicException;
@@ -28,6 +30,7 @@ use Symfony\Component\Serializer\Mapping\ClassMetadataInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -101,6 +104,132 @@ class AbstractObjectNormalizerTest extends TestCase
             'any',
             ['allow_extra_attributes' => false]
         );
+    }
+
+    public function testDenormalizeWithDuplicateNestedAttributes()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Duplicate serialized path: "one,two,three" used for properties "foo" and "bar".');
+        $normalizer = new AbstractObjectNormalizerWithMetadata();
+        $normalizer->denormalize([], DuplicateValueNestedDummy::class, 'any');
+    }
+
+    public function testDenormalizeWithNestedAttributesWithoutMetadata()
+    {
+        $normalizer = new AbstractObjectNormalizerDummy();
+        $data = [
+            'one' => [
+                'two' => [
+                    'three' => 'foo',
+                ],
+                'four' => 'quux',
+            ],
+            'foo' => 'notfoo',
+            'baz' => 'baz',
+        ];
+        $test = $normalizer->denormalize($data, NestedDummy::class, 'any');
+        $this->assertSame('notfoo', $test->foo);
+        $this->assertSame('baz', $test->baz);
+        $this->assertNull($test->notfoo);
+    }
+
+    public function testDenormalizeWithNestedAttributes()
+    {
+        $normalizer = new AbstractObjectNormalizerWithMetadata();
+        $data = [
+            'one' => [
+                'two' => [
+                    'three' => 'foo',
+                ],
+                'four' => 'quux',
+            ],
+            'foo' => 'notfoo',
+            'baz' => 'baz',
+        ];
+        $test = $normalizer->denormalize($data, NestedDummy::class, 'any');
+        $this->assertSame('baz', $test->baz);
+        $this->assertSame('foo', $test->foo);
+        $this->assertSame('quux', $test->quux);
+        $this->assertSame('notfoo', $test->notfoo);
+    }
+
+    public function testDenormalizeWithNestedAttributesDuplicateKeys()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Duplicate values for key "quux" found. One value is set via the SerializedPath annotation: "one->four", the other one is set via the SerializedName annotation: "notquux".');
+        $normalizer = new AbstractObjectNormalizerWithMetadata();
+        $data = [
+            'one' => [
+                'four' => 'quux',
+            ],
+            'quux' => 'notquux',
+        ];
+        $normalizer->denormalize($data, DuplicateKeyNestedDummy::class, 'any');
+    }
+
+    public function testNormalizeWithNestedAttributesMixingArrayTypes()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The element you are trying to set is already populated: "[one][two]"');
+        $foobar = new AlreadyPopulatedNestedDummy();
+        $foobar->foo = 'foo';
+        $foobar->bar = 'bar';
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
+        $normalizer->normalize($foobar, 'any');
+    }
+
+    public function testNormalizeWithNestedAttributesElementAlreadySet()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The element you are trying to set is already populated: "[one][two][three]"');
+        $foobar = new DuplicateValueNestedDummy();
+        $foobar->foo = 'foo';
+        $foobar->bar = 'bar';
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
+        $normalizer->normalize($foobar, 'any');
+    }
+
+    public function testNormalizeWithNestedAttributes()
+    {
+        $foobar = new NestedDummy();
+        $foobar->foo = 'foo';
+        $foobar->quux = 'quux';
+        $foobar->baz = 'baz';
+        $foobar->notfoo = 'notfoo';
+        $data = [
+            'one' => [
+                'two' => [
+                    'three' => 'foo',
+                ],
+                'four' => 'quux',
+            ],
+            'foo' => 'notfoo',
+            'baz' => 'baz',
+        ];
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $normalizer = new ObjectNormalizer($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
+        $test = $normalizer->normalize($foobar, 'any');
+        $this->assertSame($data, $test);
+    }
+
+    public function testNormalizeWithNestedAttributesWithoutMetadata()
+    {
+        $foobar = new NestedDummy();
+        $foobar->foo = 'foo';
+        $foobar->quux = 'quux';
+        $foobar->baz = 'baz';
+        $foobar->notfoo = 'notfoo';
+        $data = [
+            'foo' => 'foo',
+            'quux' => 'quux',
+            'notfoo' => 'notfoo',
+            'baz' => 'baz',
+        ];
+        $normalizer = new ObjectNormalizer();
+        $test = $normalizer->normalize($foobar, 'any');
+        $this->assertSame($data, $test);
     }
 
     public function testDenormalizeCollectionDecodedFromXmlWithOneChild()
@@ -436,11 +565,73 @@ class EmptyDummy
 {
 }
 
+class AlreadyPopulatedNestedDummy
+{
+    /**
+     * @SerializedPath("[one][two][three]")
+     */
+    public $foo;
+
+    /**
+     * @SerializedPath("[one][two]")
+     */
+    public $bar;
+}
+
+class DuplicateValueNestedDummy
+{
+    /**
+     * @SerializedPath("[one][two][three]")
+     */
+    public $foo;
+
+    /**
+     * @SerializedPath("[one][two][three]")
+     */
+    public $bar;
+
+    public $baz;
+}
+
+class NestedDummy
+{
+    /**
+     * @SerializedPath("[one][two][three]")
+     */
+    public $foo;
+
+    /**
+     * @SerializedPath("[one][four]")
+     */
+    public $quux;
+
+    /**
+     * @SerializedPath("[foo]")
+     */
+    public $notfoo;
+
+    public $baz;
+}
+
+class DuplicateKeyNestedDummy
+{
+    /**
+     * @SerializedPath("[one][four]")
+     */
+    public $quux;
+
+    /**
+     * @SerializedName("quux")
+     */
+    public $notquux;
+}
+
 class AbstractObjectNormalizerWithMetadata extends AbstractObjectNormalizer
 {
     public function __construct()
     {
-        parent::__construct(new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader())));
+        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        parent::__construct($classMetadataFactory, new MetadataAwareNameConverter($classMetadataFactory));
     }
 
     protected function extractAttributes(object $object, string $format = null, array $context = []): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.2
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | Fix #32080
| License       | MIT
| Doc PR        | #17396

As suggested by @derrabus in #32080, I'm creating a PR for this. 

In order to normalize/denormalize nested attributes, the `@SerializedPath` annotation can be used:

```php
class NestedDummy
{
    /**
     * @SerializedPath("[one][two][three]")
     */
    public $foo;

    /**
     * @SerializedPath("[one][four]") 
     */
    public $bar;
}
```

with

```php
$data = [
    'one' => [
        'two' => [
            'three' => 'foo',
        ],
        'four' => 'bar',
    ],
];
$normalizer = new AbstractObjectNormalizerWithMetadata();
$normalizer->denormalize(
    $data,
    NestedDummy::class,
    'any'
);
```

The annotations needs to be used with a valid `PropertyPath` string for this to work. 

Open todos:
- [x] tests for new feature
- [x] update documentation