### PR TITLE
[Security] Remove sorting of security listeners at runtime from Firewall

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -360,6 +360,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                 'csrf_token_id' => $firewall['logout']['csrf_token_id'],
                 'logout_path' => $firewall['logout']['path'],
             ]);
+            $listeners[] = new Reference($logoutListenerId);
 
             $logoutSuccessListenerId = 'security.logout.listener.default.'.$id;
             $container->setDefinition($logoutSuccessListenerId, new ChildDefinition('security.logout.listener.default'))

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -204,6 +204,7 @@ abstract class CompleteConfigurationTest extends TestCase
                 'security.channel_listener',
                 'security.firewall.authenticator.secure',
                 'security.authentication.switchuser_listener.secure',
+                'security.logout_listener.secure',
                 'security.access_listener',
             ],
             [

--- a/src/Symfony/Component/Security/Http/Firewall.php
+++ b/src/Symfony/Component/Security/Http/Firewall.php
@@ -52,38 +52,13 @@ class Firewall implements EventSubscriberInterface
 
         $authenticationListeners = $listeners[0];
         $exceptionListener = $listeners[1];
-        $logoutListener = $listeners[2];
 
         if (null !== $exceptionListener) {
             $this->exceptionListeners[$event->getRequest()] = $exceptionListener;
             $exceptionListener->register($this->dispatcher);
         }
 
-        // Authentication listeners are pre-sorted by SortFirewallListenersPass
-        $authenticationListeners = function () use ($authenticationListeners, $logoutListener) {
-            if (null !== $logoutListener) {
-                $logoutListenerPriority = $this->getListenerPriority($logoutListener);
-            }
-
-            foreach ($authenticationListeners as $listener) {
-                $listenerPriority = $this->getListenerPriority($listener);
-
-                // Yielding the LogoutListener at the correct position
-                if (null !== $logoutListener && $listenerPriority < $logoutListenerPriority) {
-                    yield $logoutListener;
-                    $logoutListener = null;
-                }
-
-                yield $listener;
-            }
-
-            // When LogoutListener has the lowest priority of all listeners
-            if (null !== $logoutListener) {
-                yield $logoutListener;
-            }
-        };
-
-        $this->callListeners($event, $authenticationListeners());
+        $this->callListeners($event, $authenticationListeners);
     }
 
     public function onKernelFinishRequest(FinishRequestEvent $event)

--- a/src/Symfony/Component/Security/Http/composer.json
+++ b/src/Symfony/Component/Security/Http/composer.json
@@ -33,7 +33,7 @@
     },
     "conflict": {
         "symfony/event-dispatcher": "<5.4",
-        "symfony/security-bundle": "<5.4",
+        "symfony/security-bundle": "<6.0",
         "symfony/security-csrf": "<5.4"
     },
     "suggest": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| License       | MIT

This is follow-up of introducing the ability to sort security listeners, which was introduced in #37337. Part of the discussion at that time was whether we'd still need to hardcoded sorting algorithm in the `Firewall` class, which was previously needed to sort in the `LogoutListener` at the correct position. With the ability to sort by a priority that was actually no longer needed.

I had this change temporarily implemented in https://github.com/symfony/symfony/commit/19727865a12e5529a430aed4f95cd8b46f78f979, though in the discussion it was decided against and instead keep the code for backwards compatibility reasons. Otherwise we'd need to declare a conflict with `security-bundle` in the `composer.json` and it was argued by @chalasr against making the `security` component aware of `security-bundle` (see https://github.com/symfony/symfony/pull/37337#discussion_r444511366).

Though I've recognized, things have changed in the meantime, and `security` component is now declaring conflict for `security-bundle` (introduced by @nicolas-grekas in https://github.com/symfony/symfony/commit/314ef9fb886b7c2d2c331052b744e0bca68d484a)

So I want to give this another shot and clean up the `Firewall` class, targeting potentially the 5.4 branch, definitely for the 6.0 branch.

**Considerations**
To make the clean-up work, the `LogoutListener` service needs to be added to the list of listeners generated by `SecurityExtension`. Until now, it's intentionally (?) left out. In the 5.4 branch this _could_ be considered a breaking change. Let me know what you think, if this is in fact considered as breaking, I'm happy to change the target to 6.0.