### PR TITLE
[HttpFoundation] Remove possibility to pass null as $requestIp in IpUtils

### DIFF
--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -123,6 +123,7 @@ HttpFoundation
  * Retrieving non-scalar values using `InputBag::get()` will throw `BadRequestException` (use `InputBad::all()` instead to retrieve an array)
  * Passing non-scalar default value as the second argument `InputBag::get()` will throw `\InvalidArgumentException`
  * Passing non-scalar, non-array value as the second argument `InputBag::set()` will throw `\InvalidArgumentException`
+ * Passing `null` as `$requestIp` to `IpUtils::__checkIp()`, `IpUtils::__checkIp4()` or `IpUtils::__checkIp6()` is not supported anymore.
 
 HttpKernel
 ----------

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * Retrieving non-scalar values using `InputBag::get()` will throw `BadRequestException` (use `InputBad::all()` instead to retrieve an array)
  * Passing non-scalar default value as the second argument `InputBag::get()` will throw `\InvalidArgumentException`
  * Passing non-scalar, non-array value as the second argument `InputBag::set()` will throw `\InvalidArgumentException`
+ * Passing `null` as `$requestIp` to `IpUtils::__checkIp()`, `IpUtils::__checkIp4()` or `IpUtils::__checkIp6()` is not supported anymore.
 
 5.4
 ---

--- a/src/Symfony/Component/HttpFoundation/IpUtils.php
+++ b/src/Symfony/Component/HttpFoundation/IpUtils.php
@@ -32,14 +32,8 @@ class IpUtils
      *
      * @param string|array $ips List of IPs or subnets (can be a string if only a single one)
      */
-    public static function checkIp(?string $requestIp, string|array $ips): bool
+    public static function checkIp(string $requestIp, string|array $ips): bool
     {
-        if (null === $requestIp) {
-            trigger_deprecation('symfony/http-foundation', '5.4', 'Passing null as $requestIp to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
-
-            return false;
-        }
-
         if (!\is_array($ips)) {
             $ips = [$ips];
         }
@@ -63,14 +57,8 @@ class IpUtils
      *
      * @return bool Whether the request IP matches the IP, or whether the request IP is within the CIDR subnet
      */
-    public static function checkIp4(?string $requestIp, string $ip): bool
+    public static function checkIp4(string $requestIp, string $ip): bool
     {
-        if (null === $requestIp) {
-            trigger_deprecation('symfony/http-foundation', '5.4', 'Passing null as $requestIp to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
-
-            return false;
-        }
-
         $cacheKey = $requestIp.'-'.$ip;
         if (isset(self::$checkedIps[$cacheKey])) {
             return self::$checkedIps[$cacheKey];
@@ -114,14 +102,8 @@ class IpUtils
      *
      * @throws \RuntimeException When IPV6 support is not enabled
      */
-    public static function checkIp6(?string $requestIp, string $ip): bool
+    public static function checkIp6(string $requestIp, string $ip): bool
     {
-        if (null === $requestIp) {
-            trigger_deprecation('symfony/http-foundation', '5.4', 'Passing null as $requestIp to "%s()" is deprecated, pass an empty string instead.', __METHOD__);
-
-            return false;
-        }
-
         $cacheKey = $requestIp.'-'.$ip;
         if (isset(self::$checkedIps[$cacheKey])) {
             return self::$checkedIps[$cacheKey];

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -78,33 +78,6 @@ class IpUtilsTest extends TestCase
     }
 
     /**
-     * @group legacy
-     */
-    public function testIpTriggersDeprecationOnNull()
-    {
-        $this->expectDeprecation('Since symfony/http-foundation 5.4: Passing null as $requestIp to "Symfony\Component\HttpFoundation\IpUtils::checkIp()" is deprecated, pass an empty string instead.');
-        $this->assertFalse(IpUtils::checkIp(null, '192.168.1.1'));
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testIp4TriggersDeprecationOnNull()
-    {
-        $this->expectDeprecation('Since symfony/http-foundation 5.4: Passing null as $requestIp to "Symfony\Component\HttpFoundation\IpUtils::checkIp4()" is deprecated, pass an empty string instead.');
-        $this->assertFalse(IpUtils::checkIp4(null, '192.168.1.1'));
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testIp6TriggersDeprecationOnNull()
-    {
-        $this->expectDeprecation('Since symfony/http-foundation 5.4: Passing null as $requestIp to "Symfony\Component\HttpFoundation\IpUtils::checkIp6()" is deprecated, pass an empty string instead.');
-        $this->assertFalse(IpUtils::checkIp6(null, '2a01:198:603:0::/65'));
-    }
-
-    /**
      * @requires extension sockets
      */
     public function testAnIpv6WithOptionDisabledIpv6()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/issues/43350#issuecomment-936951604
| License       | MIT
| Doc PR        | 

Removes the code which was deprecated in https://github.com/symfony/symfony/pull/43411
