### PR TITLE
[Messenger] fix: TypeError in PhpSerializer::encode()

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Transport/Serialization/PhpSerializerTest.php
@@ -53,6 +53,18 @@ class PhpSerializerTest extends TestCase
         ]);
     }
 
+    public function testDecodingFailsWithBadBase64Body()
+    {
+        $this->expectException(MessageDecodingFailedException::class);
+        $this->expectExceptionMessageMatches('/Could not decode/');
+
+        $serializer = new PhpSerializer();
+
+        $serializer->decode([
+            'body' => 'x',
+        ]);
+    }
+
     public function testDecodingFailsWithBadClass()
     {
         $this->expectException(MessageDecodingFailedException::class);

--- a/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
+++ b/src/Symfony/Component/Messenger/Transport/Serialization/PhpSerializer.php
@@ -58,6 +58,10 @@ class PhpSerializer implements SerializerInterface
 
     private function safelyUnserialize(string $contents)
     {
+        if ('' === $contents) {
+            throw new MessageDecodingFailedException('Could not decode an empty message using PHP serialization.');
+        }
+
         $signalingException = new MessageDecodingFailedException(sprintf('Could not decode message using PHP serialization: %s.', $contents));
         $prevUnserializeHandler = ini_set('unserialize_callback_func', self::class.'::handleUnserializeCallback');
         $prevErrorHandler = set_error_handler(function ($type, $msg, $file, $line, $context = []) use (&$prevErrorHandler, $signalingException) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #43566 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        |<!-- required for new features -->

Messenger does not throw a `MessageDecodingFailedException` for some messages that have invalid bodies when using the native PHP serialize/deserialize format.
This happens because unserializing an empty string does not issue a PHP warning, and simply returns false.
