### PR TITLE
[Messenger] set ResetServicesListener as low priority

### DIFF
--- a/src/Symfony/Component/Messenger/EventListener/ResetServicesListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/ResetServicesListener.php
@@ -37,7 +37,7 @@ class ResetServicesListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            WorkerRunningEvent::class => ['resetServices'],
+            WorkerRunningEvent::class => ['resetServices', -1024],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

So that regular listeners don't start with resetted services and so that the profiler can collect info about regular listeners before being reset.