### PR TITLE
[Console] Fix broken docblock

### DIFF
--- a/src/Symfony/Component/Console/Completion/CompletionInput.php
+++ b/src/Symfony/Component/Console/Completion/CompletionInput.php
@@ -141,7 +141,7 @@ final class CompletionInput extends ArgvInput
      * TYPE_OPTION_NAME    when completing the name of an input option
      * TYPE_NONE           when nothing should be completed
      *
-     * @return self::TYPE_* TYPE_OPTION_NAME and TYPE_NONE are already implemented by the Console component
+     * @return string One of self::TYPE_* constants. TYPE_OPTION_NAME and TYPE_NONE are already implemented by the Console component
      */
     public function getCompletionType(): string
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | np
| Tickets       | -
| License       | MIT
| Doc PR        | -

Currently breaks the patch-return-types script on 6.0.