### PR TITLE
[Lock] Fix incorrect return type in PostgreSqlStore

### DIFF
--- a/src/Symfony/Component/Lock/Store/PostgreSqlStore.php
+++ b/src/Symfony/Component/Lock/Store/PostgreSqlStore.php
@@ -18,7 +18,7 @@ use Symfony\Component\Lock\BlockingStoreInterface;
 use Symfony\Component\Lock\Exception\InvalidArgumentException;
 use Symfony\Component\Lock\Exception\LockConflictedException;
 use Symfony\Component\Lock\Key;
-use Symfony\Component\Lock\PersistingStoreInterface;
+use Symfony\Component\Lock\SharedLockStoreInterface;
 
 /**
  * PostgreSqlStore is a PersistingStoreInterface implementation using
@@ -276,7 +276,7 @@ class PostgreSqlStore implements BlockingSharedLockStoreInterface, BlockingStore
         }
     }
 
-    private function getInternalStore(): PersistingStoreInterface
+    private function getInternalStore(): SharedLockStoreInterface
     {
         $namespace = spl_object_hash($this->getConnection());
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | no
| License       | MIT
| Doc PR        | no

[Reported by Psalm](https://github.com/symfony/symfony/pull/43587/checks?check_run_id=3939988273):
```
ERROR: UndefinedInterfaceMethod - src/Symfony/Component/Lock/Store/PostgreSqlStore.php:235:36 - Method Symfony\Component\Lock\PersistingStoreInterface::saveRead does not exist (see https://psalm.dev/181)
        $this->getInternalStore()->saveRead($key);
```