### PR TITLE
[Console] Add completion to help & list commands

### DIFF
--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\Console\Command;
 
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionInterface;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Descriptor\ApplicationDescription;
 use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,7 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class HelpCommand extends Command
+class HelpCommand extends Command implements CompletionInterface
 {
     private $command;
 
@@ -79,5 +83,20 @@ EOF
         $this->command = null;
 
         return 0;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('command_name')) {
+            $descriptor = new ApplicationDescription($this->getApplication());
+            $suggestions->suggestValues(array_keys($descriptor->getCommands()));
+
+            return;
+        }
+
+        if ($input->mustSuggestOptionValuesFor('format')) {
+            $helper = new DescriptorHelper();
+            $suggestions->suggestValues($helper->getFormats());
+        }
     }
 }

--- a/src/Symfony/Component/Console/Command/ListCommand.php
+++ b/src/Symfony/Component/Console/Command/ListCommand.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\Console\Command;
 
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionInterface;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Descriptor\ApplicationDescription;
 use Symfony\Component\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,7 +26,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class ListCommand extends Command
+class ListCommand extends Command implements CompletionInterface
 {
     /**
      * {@inheritdoc}
@@ -73,5 +77,20 @@ EOF
         ]);
 
         return 0;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('namespace')) {
+            $descriptor = new ApplicationDescription($this->getApplication());
+            $suggestions->suggestValues(array_keys($descriptor->getNamespaces()));
+
+            return;
+        }
+
+        if ($input->mustSuggestOptionValuesFor('format')) {
+            $helper = new DescriptorHelper();
+            $suggestions->suggestValues($helper->getFormats());
+        }
     }
 }

--- a/src/Symfony/Component/Console/Helper/DescriptorHelper.php
+++ b/src/Symfony/Component/Console/Helper/DescriptorHelper.php
@@ -84,4 +84,9 @@ class DescriptorHelper extends Helper
     {
         return 'descriptor';
     }
+
+    public function getFormats(): array
+    {
+        return array_keys($this->descriptors);
+    }
 }

--- a/src/Symfony/Component/Console/Tester/CommandCompletionTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandCompletionTester.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tester;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionInterface;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+
+/**
+ * Eases the testing of command completion.
+ *
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ */
+class CommandCompletionTester
+{
+    private $command;
+
+    public function __construct(Command $command)
+    {
+        $this->command = $command;
+    }
+
+    /**
+     * Create completion suggestions from input tokens.
+     */
+    public function complete(array $input): array
+    {
+        if (!$this->command instanceof CompletionInterface) {
+            throw new \LogicException(sprintf('Command "%s" must implement "%s" to support completion.', \get_class($this->command), CompletionInput::class));
+        }
+
+        $currentIndex = \count($input);
+        if ('' === end($input)) {
+            array_pop($input);
+        }
+        array_unshift($input, $this->command->getName());
+
+        $completionInput = CompletionInput::fromTokens($input, $currentIndex);
+        $completionInput->bind($this->command->getDefinition());
+        $suggestions = new CompletionSuggestions();
+
+        $this->command->complete($completionInput, $suggestions);
+
+        $options = [];
+        foreach ($suggestions->getOptionSuggestions() as $option) {
+            $options[] = '--'.$option->getName();
+        }
+
+        return array_merge($options, $suggestions->getValueSuggestions());
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\ListCommand;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class HelpCommandTest extends TestCase
@@ -67,5 +68,36 @@ class HelpCommandTest extends TestCase
         $commandTester->execute(['command_name' => 'list', '--format' => 'xml']);
         $this->assertStringContainsString('list [--raw] [--format FORMAT] [--short] [--] [&lt;namespace&gt;]', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
         $this->assertStringContainsString('<command', $commandTester->getDisplay(), '->execute() returns an XML help text if --format=xml is passed');
+    }
+
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testComplete(array $input, array $expectedSuggestions)
+    {
+        require_once realpath(__DIR__.'/../Fixtures/FooCommand.php');
+        $application = new Application();
+        $application->add(new \FooCommand());
+        $tester = new CommandCompletionTester($application->get('help'));
+        $suggestions = $tester->complete($input, 2);
+        $this->assertSame($expectedSuggestions, $suggestions);
+    }
+
+    public function provideCompletionSuggestions()
+    {
+        yield 'option --format' => [
+            ['--format', ''],
+            ['txt', 'xml', 'json', 'md'],
+        ];
+
+        yield 'nothing' => [
+            [''],
+            [],
+        ];
+
+        yield 'command_name' => [
+            ['f'],
+            ['completion', 'help', 'list', 'foo:bar'],
+        ];
     }
 }

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Console\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class ListCommandTest extends TestCase
@@ -111,5 +112,36 @@ list         List commands
 EOF;
 
         $this->assertEquals($output, trim($commandTester->getDisplay(true)));
+    }
+
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testComplete(array $input, array $expectedSuggestions)
+    {
+        require_once realpath(__DIR__.'/../Fixtures/FooCommand.php');
+        $application = new Application();
+        $application->add(new \FooCommand());
+        $tester = new CommandCompletionTester($application->get('list'));
+        $suggestions = $tester->complete($input, 2);
+        $this->assertSame($expectedSuggestions, $suggestions);
+    }
+
+    public function provideCompletionSuggestions()
+    {
+        yield 'option --format' => [
+            ['--format', ''],
+            ['txt', 'xml', 'json', 'md'],
+        ];
+
+        yield 'namespace' => [
+            [''],
+            ['_global', 'foo'],
+        ];
+
+        yield 'namespace started' => [
+            ['f'],
+            ['_global', 'foo'],
+        ];
     }
 }

--- a/src/Symfony/Component/Console/Tests/Helper/DescriptorHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DescriptorHelperTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Helper;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Helper\DescriptorHelper;
+
+class DescriptorHelperTest extends TestCase
+{
+    public function testGetFormats()
+    {
+        $helper = new DescriptorHelper();
+        $expectedFormats = [
+            'txt',
+            'xml',
+            'json',
+            'md',
+        ];
+        $this->assertSame($expectedFormats, $helper->getFormats());
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #43594
| License       | MIT
| Doc PR        | no

- Add completion for commands `help` and `list`
- Create a tester class to wrap completion code in tests
- To autocomplete option `--format`, supported formats are exposed by `DescriptorHelper`

