### PR TITLE
[Console] add suggestions for debug commands: firewall, form, messenger, router

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -13,6 +13,8 @@ namespace Symfony\Bundle\FrameworkBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Console\Helper\DescriptorHelper;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -130,5 +132,19 @@ EOF
         }
 
         return $foundRoutesNames;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('name')) {
+            $suggestions->suggestValues(array_keys($this->router->getRouteCollection()->all()));
+
+            return;
+        }
+
+        if ($input->mustSuggestOptionValuesFor('format')) {
+            $helper = new DescriptorHelper();
+            $suggestions->suggestValues($helper->getFormats());
+        }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/RouterDebugCommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -67,6 +68,37 @@ class RouterDebugCommandTest extends AbstractWebTestCase
         $this->expectExceptionMessage('The route "gerard" does not exist.');
         $tester = $this->createCommandTester();
         $tester->execute(['name' => 'gerard'], ['interactive' => true]);
+    }
+
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testComplete(array $input, array $expectedSuggestions)
+    {
+        if (!class_exists(CommandCompletionTester::class)) {
+            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+        }
+
+        $tester = new CommandCompletionTester($this->application->get('debug:router'));
+        $this->assertSame($expectedSuggestions, $tester->complete($input));
+    }
+
+    public function provideCompletionSuggestions()
+    {
+        yield 'option --format' => [
+            ['--format', ''],
+            ['txt', 'xml', 'json', 'md'],
+        ];
+
+        yield 'route_name' => [
+            [''],
+            [
+                'routerdebug_session_welcome',
+                'routerdebug_session_welcome_name',
+                'routerdebug_session_logout',
+                'routerdebug_test',
+            ],
+        ];
     }
 
     private function createCommandTester(): CommandTester

--- a/src/Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/DebugFirewallCommand.php
@@ -15,6 +15,8 @@ use Psr\Container\ContainerInterface;
 use Symfony\Bundle\SecurityBundle\Security\FirewallContext;
 use Symfony\Bundle\SecurityBundle\Security\LazyFirewallContext;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -276,5 +278,12 @@ EOF
         }
 
         return $name;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('name')) {
+            $suggestions->suggestValues($this->firewallNames);
+        }
     }
 }

--- a/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Form/Tests/Command/DebugCommandTest.php
@@ -14,11 +14,14 @@ namespace Symfony\Component\Form\Tests\Command;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Command\DebugCommand;
+use Symfony\Component\Form\Extension\Core\CoreExtension;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormRegistry;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\ResolvedFormTypeFactory;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -184,6 +187,96 @@ Symfony\Component\Form\Tests\Command\FooType (foo)
 
 TXT
             , $tester->getDisplay(true));
+    }
+
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testComplete(array $input, array $expectedSuggestions)
+    {
+        if (!class_exists(CommandCompletionTester::class)) {
+            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+        }
+
+        $formRegistry = new FormRegistry([], new ResolvedFormTypeFactory());
+        $command = new DebugCommand($formRegistry);
+        $application = new Application();
+        $application->add($command);
+        $tester = new CommandCompletionTester($application->get('debug:form'));
+        $this->assertSame($expectedSuggestions, $tester->complete($input));
+    }
+
+    public function provideCompletionSuggestions(): iterable
+    {
+        yield 'option --format' => [
+            ['--format', ''],
+            ['txt', 'json'],
+        ];
+
+        yield 'form_type' => [
+            [''],
+            $this->getCoreTypes(),
+        ];
+
+        yield 'option for FQCN' => [
+            ['Symfony\\Component\\Form\\Extension\\Core\\Type\\ButtonType', ''],
+            [
+                'block_name',
+                'block_prefix',
+                'disabled',
+                'label',
+                'label_format',
+                'row_attr',
+                'label_html',
+                'label_translation_parameters',
+                'attr_translation_parameters',
+                'attr',
+                'translation_domain',
+                'auto_initialize',
+                'priority',
+            ],
+        ];
+
+        yield 'option for short name' => [
+            ['ButtonType', ''],
+            [
+                'block_name',
+                'block_prefix',
+                'disabled',
+                'label',
+                'label_format',
+                'row_attr',
+                'label_html',
+                'label_translation_parameters',
+                'attr_translation_parameters',
+                'attr',
+                'translation_domain',
+                'auto_initialize',
+                'priority',
+            ],
+        ];
+
+        yield 'option for ambiguous form type' => [
+            ['Type', ''],
+            [],
+        ];
+
+        yield 'option for invalid form type' => [
+            ['NotExistingFormType', ''],
+            [],
+        ];
+    }
+
+    private function getCoreTypes(): array
+    {
+        $coreExtension = new CoreExtension();
+        $loadTypesRefMethod = (new \ReflectionObject($coreExtension))->getMethod('loadTypes');
+        $loadTypesRefMethod->setAccessible(true);
+        $coreTypes = $loadTypesRefMethod->invoke($coreExtension);
+        $coreTypes = array_map(function (FormTypeInterface $type) { return \get_class($type); }, $coreTypes);
+        sort($coreTypes);
+
+        return $coreTypes;
     }
 
     private function createCommandTester(array $namespaces = ['Symfony\Component\Form\Extension\Core\Type'], array $types = [])

--- a/src/Symfony/Component/Messenger/Command/DebugCommand.php
+++ b/src/Symfony/Component/Messenger/Command/DebugCommand.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Messenger\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -137,5 +139,12 @@ EOF
         }
 
         return '';
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('bus')) {
+            $suggestions->suggestValues(array_keys($this->mapping));
+        }
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/DebugCommandTest.php
@@ -12,7 +12,9 @@
 namespace Symfony\Component\Messenger\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Messenger\Command\DebugCommand;
 use Symfony\Component\Messenger\Tests\Fixtures\DummyCommand;
@@ -165,5 +167,29 @@ TXT
 
         $tester = new CommandTester($command);
         $tester->execute(['bus' => 'unknown_bus'], ['decorated' => false]);
+    }
+
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testComplete(array $input, array $expectedSuggestions)
+    {
+        if (!class_exists(CommandCompletionTester::class)) {
+            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+        }
+
+        $command = new DebugCommand(['command_bus' => [], 'query_bus' => []]);
+        $application = new Application();
+        $application->add($command);
+        $tester = new CommandCompletionTester($application->get('debug:messenger'));
+        $this->assertSame($expectedSuggestions, $tester->complete($input));
+    }
+
+    public function provideCompletionSuggestions(): iterable
+    {
+        yield 'bus' => [
+            [''],
+            ['command_bus', 'query_bus'],
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #43594
| License       | MIT
| Doc PR        | -

Adding Bash completion for following commands:

- `debug:firewall`
- `debug:form`
- `debug:messenger`
- `debug:router`

~Waiting for #43596 to be merged first as it adds testing utilities and `DescriptorHelper::getFormats()`.~