### PR TITLE
[Console] Add exact command used to trigger invocation to the completion debug log

### DIFF
--- a/src/Symfony/Component/Console/Command/CompleteCommand.php
+++ b/src/Symfony/Component/Console/Command/CompleteCommand.php
@@ -83,6 +83,8 @@ final class CompleteCommand extends Command
                 '<comment>'.date('Y-m-d H:i:s').'</>',
                 '<info>Input:</> <comment>("|" indicates the cursor position)</>',
                 '  '.(string) $completionInput,
+                '<info>Command:</>',
+                '  '.(string) implode(' ', $_SERVER['argv']),
                 '<info>Messages:</>',
             ]);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

![Screenshot from 2021-10-20 11-26-31](https://user-images.githubusercontent.com/209225/138067036-9be62255-948f-4b8a-94f0-ec626e747646.png)

Gives you the exact command which was used to generate the completion in the completion debug log. Can use it to directly invoke and debug further without going through the completion script.