### PR TITLE
[Translation]  Add more TranslatableMessageInterface classes for common use cases

### DIFF
--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add `github` format & autodetection to render errors as annotations when
    running the XLIFF linter command in a Github Actions environment.
  * Translation providers are not experimental anymore
+ * Add `FormattedTranslatableMessage`, `ImplodedTranslatableMessage` and `NotTranslatableMessage` classes and their helper functions `ft`, `it` and `nt`
 
 5.3
 ---

--- a/src/Symfony/Component/Translation/Message/FormattedTranslatableMessage.php
+++ b/src/Symfony/Component/Translation/Message/FormattedTranslatableMessage.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Message;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ */
+class FormattedTranslatableMessage implements TranslatableInterface
+{
+    use TranslatableParametersTrait;
+
+    private $format;
+
+    public function __construct(
+        string $format,
+        ...$parameters
+    ) {
+        $this->format = $format;
+        $this->parameters = $parameters;
+    }
+
+    public function __toString(): string
+    {
+        return $this->getFormat();
+    }
+
+    public function getFormat(): string
+    {
+        return $this->format;
+    }
+
+    public function trans(TranslatorInterface $translator, string $locale = null): string
+    {
+        return sprintf(
+            $this->getFormat(),
+            ...$this->getTranslatedParameters($translator, $locale)
+        );
+    }
+}

--- a/src/Symfony/Component/Translation/Message/ImplodedTranslatableMessage.php
+++ b/src/Symfony/Component/Translation/Message/ImplodedTranslatableMessage.php
@@ -25,7 +25,7 @@ class ImplodedTranslatableMessage implements TranslatableInterface
 
     public function __construct(
         string $glue = '',
-        array $parameters = []
+        ...$parameters
     ) {
         $this->glue = $glue;
         $this->parameters = $parameters;

--- a/src/Symfony/Component/Translation/Message/ImplodedTranslatableMessage.php
+++ b/src/Symfony/Component/Translation/Message/ImplodedTranslatableMessage.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Message;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ */
+class ImplodedTranslatableMessage implements TranslatableInterface
+{
+    use TranslatableParametersTrait;
+
+    private $glue;
+
+    public function __construct(
+        string $glue = '',
+        array $parameters = []
+    ) {
+        $this->glue = $glue;
+        $this->parameters = $parameters;
+    }
+
+    public function getGlue(): string
+    {
+        return $this->glue;
+    }
+
+    public function trans(TranslatorInterface $translator, string $locale = null): string
+    {
+        return implode(
+            $this->getGlue(),
+            $this->getTranslatedParameters($translator, $locale)
+        );
+    }
+}

--- a/src/Symfony/Component/Translation/Message/NonTranslatableMessage.php
+++ b/src/Symfony/Component/Translation/Message/NonTranslatableMessage.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Message;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ */
+class NonTranslatableMessage implements TranslatableInterface
+{
+    use TranslatableParametersTrait;
+
+    private $message;
+
+    public function __construct(string $message)
+    {
+        $this->message = $message;
+    }
+
+    public function __toString(): string
+    {
+        return $this->getMessage();
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function trans(TranslatorInterface $translator, string $locale = null): string
+    {
+        return $this->getMessage();
+    }
+}

--- a/src/Symfony/Component/Translation/Message/TranslatableParametersTrait.php
+++ b/src/Symfony/Component/Translation/Message/TranslatableParametersTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Message;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ */
+trait TranslatableParametersTrait
+{
+    private $parameters = [];
+
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    public function getTranslatedParameters(
+        TranslatorInterface $translator,
+        ?string $locale
+    ): array
+    {
+        return array_map(
+            static function ($parameter) use ($translator, $locale) {
+                return $parameter instanceof TranslatableInterface ? $parameter->trans($translator, $locale) : $parameter;
+            },
+            $this->getParameters()
+        );
+    }
+}

--- a/src/Symfony/Component/Translation/Message/TranslatableParametersTrait.php
+++ b/src/Symfony/Component/Translation/Message/TranslatableParametersTrait.php
@@ -29,8 +29,7 @@ trait TranslatableParametersTrait
     public function getTranslatedParameters(
         TranslatorInterface $translator,
         ?string $locale
-    ): array
-    {
+    ): array {
         return array_map(
             static function ($parameter) use ($translator, $locale) {
                 return $parameter instanceof TranslatableInterface ? $parameter->trans($translator, $locale) : $parameter;

--- a/src/Symfony/Component/Translation/Resources/functions.php
+++ b/src/Symfony/Component/Translation/Resources/functions.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Component\Translation;
 
+use Symfony\Component\Translation\Message\FormattedTranslatableMessage;
+use Symfony\Component\Translation\Message\ImplodedTranslatableMessage;
+use Symfony\Component\Translation\Message\NonTranslatableMessage;
+
 if (!\function_exists(t::class)) {
     /**
      * @author Nate Wiebe <nate@northern.co>
@@ -18,5 +22,35 @@ if (!\function_exists(t::class)) {
     function t(string $message, array $parameters = [], string $domain = null): TranslatableMessage
     {
         return new TranslatableMessage($message, $parameters, $domain);
+    }
+}
+
+if (!\function_exists(ft::class)) {
+    /**
+     * @author Jakub Caban <kuba.iluvatar@gmail.com>
+     */
+    function ft(string $format, ...$parameters): FormattedTranslatableMessage
+    {
+        return new FormattedTranslatableMessage($format, $parameters);
+    }
+}
+
+if (!\function_exists(it::class)) {
+    /**
+     * @author Jakub Caban <kuba.iluvatar@gmail.com>
+     */
+    function it(string $glue, ...$parameters): ImplodedTranslatableMessage
+    {
+        return new ImplodedTranslatableMessage($glue, $parameters);
+    }
+}
+
+if (!\function_exists(nt::class)) {
+    /**
+     * @author Jakub Caban <kuba.iluvatar@gmail.com>
+     */
+    function nt(string $message): NonTranslatableMessage
+    {
+        return new NonTranslatableMessage($message);
     }
 }

--- a/src/Symfony/Component/Translation/Resources/functions.php
+++ b/src/Symfony/Component/Translation/Resources/functions.php
@@ -15,7 +15,7 @@ use Symfony\Component\Translation\Message\FormattedTranslatableMessage;
 use Symfony\Component\Translation\Message\ImplodedTranslatableMessage;
 use Symfony\Component\Translation\Message\NonTranslatableMessage;
 
-if (!\function_exists(t::class)) {
+if (!\function_exists('Symfony\Component\Translation\t')) {
     /**
      * @author Nate Wiebe <nate@northern.co>
      */
@@ -25,7 +25,7 @@ if (!\function_exists(t::class)) {
     }
 }
 
-if (!\function_exists(ft::class)) {
+if (!\function_exists('Symfony\Component\Translation\ft')) {
     /**
      * @author Jakub Caban <kuba.iluvatar@gmail.com>
      */
@@ -35,7 +35,7 @@ if (!\function_exists(ft::class)) {
     }
 }
 
-if (!\function_exists(it::class)) {
+if (!\function_exists('Symfony\Component\Translation\it')) {
     /**
      * @author Jakub Caban <kuba.iluvatar@gmail.com>
      */
@@ -45,7 +45,7 @@ if (!\function_exists(it::class)) {
     }
 }
 
-if (!\function_exists(nt::class)) {
+if (!\function_exists('Symfony\Component\Translation\nt')) {
     /**
      * @author Jakub Caban <kuba.iluvatar@gmail.com>
      */

--- a/src/Symfony/Component/Translation/Tests/TranslatableTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatableTest.php
@@ -14,20 +14,22 @@ namespace Symfony\Component\Translation\Tests;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Message\FormattedTranslatableMessage;
+use Symfony\Component\Translation\Message\ImplodedTranslatableMessage;
 use Symfony\Component\Translation\Message\NonTranslatableMessage;
 use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Component\Translation\Translator;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 class TranslatableTest extends TestCase
 {
     /**
      * @dataProvider getTransTests
      */
-    public function testTrans(string $expected, TranslatableMessage $translatable, array $translation, string $locale)
+    public function testTrans(string $expected, TranslatableInterface $translatable, array $translation, string $locale)
     {
         $translator = new Translator('en');
         $translator->addLoader('array', new ArrayLoader());
-        $translator->addResource('array', $translation, $locale, $translatable->getDomain());
+        $translator->addResource('array', $translation, $locale, '');
 
         $this->assertSame($expected, $translatable->trans($translator, $locale));
     }
@@ -64,6 +66,16 @@ class TranslatableTest extends TestCase
                 'Symfony is %what%!' => 'Symfony est %what% !',
                 'awesome' => 'superbe',
             ], 'fr'],
+            ['Symfony est super ! 100 times !', new FormattedTranslatableMessage('%s %d times !', new TranslatableMessage('Symfony is great!', [], ''), 100), [
+                'Symfony is great!' => 'Symfony est super !',
+            ], 'fr'],
+            ['Symfony est superbe', new ImplodedTranslatableMessage(' ', 'Symfony', new TranslatableMessage('is', [] ,''), new TranslatableMessage('super', [] ,'')), [
+                'is' => 'est',
+                'super' => 'superbe'
+            ], 'fr'],
+            ['Symfony is great!', new NonTranslatableMessage('Symfony is great!'), [
+                'Symfony is great!' => 'Symfony est super !',
+            ], 'fr']
         ];
     }
 

--- a/src/Symfony/Component/Translation/Tests/TranslatableTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatableTest.php
@@ -99,6 +99,9 @@ class TranslatableTest extends TestCase
             ['Symfony est super!', $messages, new TranslatableMessage('symfony.is.great', [], '')],
             ['Foo Bar Baz', $messages, new TranslatableMessage('foo.bar.baz', [], '')],
             ['Foo Baz', $messages, new TranslatableMessage('foo.baz', [], '')],
+            ['Result: Foo Baz', $messages, new FormattedTranslatableMessage('Result: %s', new TranslatableMessage('foo.baz', [], ''))],
+            ['Foo Baz ~ Foo Bar Baz', $messages, new ImplodedTranslatableMessage(' ~ ', new TranslatableMessage('foo.baz', [], ''), new TranslatableMessage('foo.bar.baz', [] , ''))],
+            ['foo.bar.baz', $messages, new NonTranslatableMessage('foo.bar.baz')]
         ];
     }
 }

--- a/src/Symfony/Component/Translation/Tests/TranslatableTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatableTest.php
@@ -69,13 +69,13 @@ class TranslatableTest extends TestCase
             ['Symfony est super ! 100 times !', new FormattedTranslatableMessage('%s %d times !', new TranslatableMessage('Symfony is great!', [], ''), 100), [
                 'Symfony is great!' => 'Symfony est super !',
             ], 'fr'],
-            ['Symfony est superbe', new ImplodedTranslatableMessage(' ', 'Symfony', new TranslatableMessage('is', [] ,''), new TranslatableMessage('super', [] ,'')), [
+            ['Symfony est superbe', new ImplodedTranslatableMessage(' ', 'Symfony', new TranslatableMessage('is', [], ''), new TranslatableMessage('super', [], '')), [
                 'is' => 'est',
-                'super' => 'superbe'
+                'super' => 'superbe',
             ], 'fr'],
             ['Symfony is great!', new NonTranslatableMessage('Symfony is great!'), [
                 'Symfony is great!' => 'Symfony est super !',
-            ], 'fr']
+            ], 'fr'],
         ];
     }
 
@@ -100,8 +100,8 @@ class TranslatableTest extends TestCase
             ['Foo Bar Baz', $messages, new TranslatableMessage('foo.bar.baz', [], '')],
             ['Foo Baz', $messages, new TranslatableMessage('foo.baz', [], '')],
             ['Result: Foo Baz', $messages, new FormattedTranslatableMessage('Result: %s', new TranslatableMessage('foo.baz', [], ''))],
-            ['Foo Baz ~ Foo Bar Baz', $messages, new ImplodedTranslatableMessage(' ~ ', new TranslatableMessage('foo.baz', [], ''), new TranslatableMessage('foo.bar.baz', [] , ''))],
-            ['foo.bar.baz', $messages, new NonTranslatableMessage('foo.bar.baz')]
+            ['Foo Baz ~ Foo Bar Baz', $messages, new ImplodedTranslatableMessage(' ~ ', new TranslatableMessage('foo.baz', [], ''), new TranslatableMessage('foo.bar.baz', [], ''))],
+            ['foo.bar.baz', $messages, new NonTranslatableMessage('foo.bar.baz')],
         ];
     }
 }

--- a/src/Symfony/Component/Translation/Tests/TranslatableTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatableTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Translation\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Translation\Loader\ArrayLoader;
+use Symfony\Component\Translation\Message\FormattedTranslatableMessage;
+use Symfony\Component\Translation\Message\NonTranslatableMessage;
 use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Component\Translation\Translator;
 
@@ -45,6 +47,8 @@ class TranslatableTest extends TestCase
     public function testToString()
     {
         $this->assertSame('Symfony is great!', (string) new TranslatableMessage('Symfony is great!'));
+        $this->assertSame('Symfony is %s!', (string) new FormattedTranslatableMessage('Symfony is %s!', new TranslatableMessage('great')));
+        $this->assertSame('Symfony is great!', (string) new NonTranslatableMessage('Symfony is great!'));
     }
 
     public function getTransTests()

--- a/src/Symfony/Component/Translation/TranslatableMessage.php
+++ b/src/Symfony/Component/Translation/TranslatableMessage.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Translation;
 
+use Symfony\Component\Translation\Message\TranslatableParametersTrait;
 use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -19,8 +20,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class TranslatableMessage implements TranslatableInterface
 {
+    use TranslatableParametersTrait;
+
     private $message;
-    private $parameters;
     private $domain;
 
     public function __construct(string $message, array $parameters = [], string $domain = null)
@@ -40,11 +42,6 @@ class TranslatableMessage implements TranslatableInterface
         return $this->message;
     }
 
-    public function getParameters(): array
-    {
-        return $this->parameters;
-    }
-
     public function getDomain(): ?string
     {
         return $this->domain;
@@ -52,11 +49,11 @@ class TranslatableMessage implements TranslatableInterface
 
     public function trans(TranslatorInterface $translator, string $locale = null): string
     {
-        return $translator->trans($this->getMessage(), array_map(
-            static function ($parameter) use ($translator, $locale) {
-                return $parameter instanceof TranslatableInterface ? $parameter->trans($translator, $locale) : $parameter;
-            },
-            $this->getParameters()
-        ), $this->getDomain(), $locale);
+        return $translator->trans(
+            $this->getMessage(),
+            $this->getTranslatedParameters($translator, $locale),
+            $this->getDomain(),
+            $locale
+        );
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | symfony/symfony-docs#15966

`TranslatableInterface` is a great way to separate translation logic and application logic. Using it we can type-hint `TranslatableInterface|string` and only translate objects when necessary.

The aim of this PR is to provide helper classes for common use cases that occurred frequently in my projects and that allow most of it to be strictly type-hinted with `TranslatableInterface`. This makes app logic and DI simpler as `TranslatorInterface` is only needed when transforming data into response.

The classes in question are simple wrappers around `sprintf` and `implode` and one that forces message to not be translated at all. Usage examples:

`FormattedTranslatableMessage`:
```
$message = ft('%s (%d)', t('Review reports'), 20);
echo $message->trans($translator); // Prints "Review reports (20)" with "Review reports" part being translated
```

`ImplodedTranslatableMessage`:
```
$message = it('<br>', t("Incorrect address"), t("Wrong date format"));
echo $message->trans($translator); // Prints "Incorrect address<br>Wrong date format" where each line is translated independently
```

`NonTranslatableMessage`:
```
$message = nt('form.label.name');
echo $message->trans($translator); // Prints "form.label.name" no matter if it's in translation catalogue or not
```

TODO:
- [x] submit changes to the documentation