### PR TITLE
UniqueEntityValidator: Retrieve at max two entities to check uniqueness.

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `DoctrineOpenTransactionLoggerMiddleware` to log when a transaction has been left open
  * Deprecate `PdoCacheAdapterDoctrineSchemaSubscriber` and add `DoctrineDbalCacheAdapterSchemaSubscriber` instead
+ * `UniqueEntity` constraint retrieves a maximum of two entities if the default repository method is used.
 
 5.3
 ---

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -134,7 +134,18 @@ class UniqueEntityValidator extends ConstraintValidator
             $repository = $em->getRepository(\get_class($entity));
         }
 
-        $result = $repository->{$constraint->repositoryMethod}($criteria);
+        $arguments = [$criteria];
+
+        /* If the default repository method is used, it is always enough to retrieve at most two entities because:
+         * - No entity returned, the current entity is definitely unique.
+         * - More than one entity returned, the current entity cannot be unique.
+         * - One entity returned the uniqueness depends on the current entity.
+         */
+        if ('findBy' === $constraint->repositoryMethod) {
+            $arguments = [$criteria, null, 2];
+        }
+
+        $result = $repository->{$constraint->repositoryMethod}(...$arguments);
 
         if ($result instanceof \IteratorAggregate) {
             $result = $result->getIterator();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43254
| License       | MIT
| Doc PR        | symfony/symfony-docs#15965

It is enough to retrieve two entities to check for uniqueness.

- No entity returned, it is definitely unique.
- Two or more entities returned and it cannot be unique.
- One entity returned, it depends on the entity if it is unique or not.

By providing a limit it avoids potential performance and memory issues in case the entity uniqueness check is not done on a unique field.
