### PR TITLE
[BrowserKit][HttpClient][Routing] support building query strings with stringables

### DIFF
--- a/src/Symfony/Component/BrowserKit/HttpBrowser.php
+++ b/src/Symfony/Component/BrowserKit/HttpBrowser.php
@@ -91,7 +91,18 @@ class HttpBrowser extends AbstractBrowser
             return ['', []];
         }
 
-        return [http_build_query($fields, '', '&', \PHP_QUERY_RFC1738), ['Content-Type' => 'application/x-www-form-urlencoded']];
+        array_walk_recursive($fields, $caster = static function (&$v) use (&$caster) {
+            if (\is_object($v)) {
+                if ($vars = get_object_vars($v)) {
+                    array_walk_recursive($vars, $caster);
+                    $v = $vars;
+                } elseif (method_exists($v, '__toString')) {
+                    $v = (string) $v;
+                }
+            }
+        });
+
+        return [http_build_query($fields, '', '&'), ['Content-Type' => 'application/x-www-form-urlencoded']];
     }
 
     protected function getHeaders(Request $request): array

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -291,7 +291,18 @@ trait HttpClientTrait
     private static function normalizeBody($body)
     {
         if (\is_array($body)) {
-            return http_build_query($body, '', '&', \PHP_QUERY_RFC1738);
+            array_walk_recursive($body, $caster = static function (&$v) use (&$caster) {
+                if (\is_object($v)) {
+                    if ($vars = get_object_vars($v)) {
+                        array_walk_recursive($vars, $caster);
+                        $v = $vars;
+                    } elseif (method_exists($v, '__toString')) {
+                        $v = (string) $v;
+                    }
+                }
+            });
+
+            return http_build_query($body, '', '&');
         }
 
         if (\is_string($body)) {

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -400,4 +400,22 @@ class MockHttpClientTest extends HttpClientTestCase
 
         $this->assertSame($expectedBody, $response->getContent());
     }
+
+    public function testStringableBodyParam()
+    {
+        $client = new MockHttpClient();
+
+        $param = new class() {
+            public function __toString()
+            {
+                return 'bar';
+            }
+        };
+
+        $response = $client->request('GET', 'https://example.com', [
+            'body' => ['foo' => $param],
+        ]);
+
+        $this->assertSame('foo=bar', $response->getRequestOptions()['body']);
+    }
 }

--- a/src/Symfony/Component/Notifier/Bridge/Mercure/MercureTransport.php
+++ b/src/Symfony/Component/Notifier/Bridge/Mercure/MercureTransport.php
@@ -52,7 +52,7 @@ final class MercureTransport extends AbstractTransport
 
     public function __toString(): string
     {
-        return sprintf('mercure://%s?%s', $this->hubId, http_build_query(['topic' => $this->topics]));
+        return sprintf('mercure://%s?%s', $this->hubId, http_build_query(['topic' => $this->topics], '', '&'));
     }
 
     public function supports(MessageInterface $message): bool

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -295,6 +295,17 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
             return $a == $b ? 0 : 1;
         });
 
+        array_walk_recursive($extra, $caster = static function (&$v) use (&$caster) {
+            if (\is_object($v)) {
+                if ($vars = get_object_vars($v)) {
+                    array_walk_recursive($vars, $caster);
+                    $v = $vars;
+                } elseif (method_exists($v, '__toString')) {
+                    $v = (string) $v;
+                }
+            }
+        });
+
         // extract fragment
         $fragment = $defaults['_fragment'] ?? '';
 

--- a/src/Symfony/Component/Security/Http/Impersonate/ImpersonateUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Impersonate/ImpersonateUrlGenerator.php
@@ -69,7 +69,7 @@ class ImpersonateUrlGenerator
             $targetUri = $request->getRequestUri();
         }
 
-        $targetUri .= (parse_url($targetUri, \PHP_URL_QUERY) ? '&' : '?').http_build_query([$switchUserConfig['parameter'] => SwitchUserListener::EXIT_VALUE]);
+        $targetUri .= (parse_url($targetUri, \PHP_URL_QUERY) ? '&' : '?').http_build_query([$switchUserConfig['parameter'] => SwitchUserListener::EXIT_VALUE], '', '&');
 
         return $targetUri;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes (minor)
| Deprecations? | no
| Tickets       | Fix #26992
| License       | MIT
| Doc PR        | -

Allows using eg an instance of `Uid` as a route parameter.

Replaces #42057