### PR TITLE
[Serializer] Fix accessor-method false positive detection by ObjectNormalizer.

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -86,14 +86,14 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             $name = $reflMethod->name;
             $attributeName = null;
 
-            if (str_starts_with($name, 'get') || str_starts_with($name, 'has')) {
+            if ($this->strStartsWith($name, 'get') || $this->strStartsWith($name, 'has')) {
                 // getters and hassers
                 $attributeName = substr($name, 3);
 
                 if (!$reflClass->hasProperty($attributeName)) {
                     $attributeName = lcfirst($attributeName);
                 }
-            } elseif (str_starts_with($name, 'is')) {
+            } elseif ($this->strStartsWith($name, 'is')) {
                 // issers
                 $attributeName = substr($name, 2);
 
@@ -189,5 +189,12 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         }
 
         return $allowedAttributes;
+    }
+
+    private function strStartsWith(string $str, string $prefix): bool
+    {
+        $nextChar = $str[\strlen($prefix)] ?? '';
+
+        return \str_starts_with($str, $prefix) && \ctype_upper($nextChar);
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -287,6 +287,20 @@ class ObjectNormalizerTest extends TestCase
         $normalizer->denormalize($data, DummyWithConstructorInexistingObject::class);
     }
 
+    public function testAccessorLikeDistinction()
+    {
+        $obj = new DummyWithAccessorLikes();
+
+        $this->assertEquals(
+            [
+                'hasser' => true,
+                'getter' => true,
+                'isser' => true,
+            ],
+            $this->normalizer->normalize($obj, 'any')
+        );
+    }
+
     // attributes
 
     protected function getNormalizerForAttributes(): ObjectNormalizer
@@ -1018,5 +1032,38 @@ class DummyWithNullableConstructorObject
     public function getInner()
     {
         return $this->inner;
+    }
+}
+
+class DummyWithAccessorLikes
+{
+    public function hasHasser(): bool
+    {
+        return true;
+    }
+
+    public function hashasserLike(): bool
+    {
+        return true;
+    }
+
+    public function isIsser(): bool
+    {
+        return true;
+    }
+
+    public function isisserLike(): bool
+    {
+        return true;
+    }
+
+    public function getGetter(): bool
+    {
+        return true;
+    }
+
+    public function getgetterLike(): bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->


Fixes cases when methods like ```hashCode``` are treated as accessor methods by ObjectNormalizer.
