### PR TITLE
[Serializer] Fix accessor-method false positive detection.

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -95,7 +95,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             if ($prefix = $this->extractAccessorPrefix($name)) {
                 $attributeName = $this->extractAttributeName($name, $prefix);
 
-                if (!$reflClass->hasProperty($attributeName)) {
+                if ($attributeName && !$reflClass->hasProperty($attributeName)) {
                     $attributeName = lcfirst($attributeName);
                 }
             }

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -86,14 +86,14 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             $name = $reflMethod->name;
             $attributeName = null;
 
-            if (str_starts_with($name, 'get') || str_starts_with($name, 'has')) {
+            if ($this->strStartsWith($name, 'get') || $this->strStartsWith($name, 'has')) {
                 // getters and hassers
                 $attributeName = substr($name, 3);
 
                 if (!$reflClass->hasProperty($attributeName)) {
                     $attributeName = lcfirst($attributeName);
                 }
-            } elseif (str_starts_with($name, 'is')) {
+            } elseif ($this->strStartsWith($name, 'is')) {
                 // issers
                 $attributeName = substr($name, 2);
 
@@ -189,5 +189,12 @@ class ObjectNormalizer extends AbstractObjectNormalizer
         }
 
         return $allowedAttributes;
+    }
+
+    private function strStartsWith(string $str, string $prefix): bool
+    {
+        $nextChar = $str[\strlen($prefix)] ?? '';
+
+        return str_starts_with($str, $prefix) && ctype_upper($nextChar);
     }
 }

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -95,7 +95,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             if ($prefix = $this->extractAccessorPrefix($name)) {
                 $attributeName = $this->extractAttributeName($name, $prefix);
 
-                if ($attributeName && !$reflClass->hasProperty($attributeName)) {
+                if (!$reflClass->hasProperty($attributeName)) {
                     $attributeName = lcfirst($attributeName);
                 }
             }
@@ -197,7 +197,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
      */
     private function extractAccessorPrefix(string $methodName): ?string
     {
-        $prefix = null;
+        $prefix = '';
 
         foreach (self::ACCESSOR_PREFIXES as $accessor) {
             if (str_starts_with($methodName, $accessor)) {

--- a/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/ObjectNormalizer.php
@@ -190,7 +190,7 @@ class ObjectNormalizer extends AbstractObjectNormalizer
     }
 
     /**
-     * Extract accessor prefix from method name if possible
+     * Extract accessor prefix from method name if possible.
      *
      * @psalm-pure
      * @psalm-return (value-of<self::ACCESSOR_PREFIXES>)|null
@@ -206,19 +206,19 @@ class ObjectNormalizer extends AbstractObjectNormalizer
             }
         }
 
-        $nextChar = $methodName[strlen($prefix)] ?? '';
+        $nextChar = $methodName[\strlen($prefix)] ?? '';
 
         return $prefix && ctype_upper($nextChar) ? $prefix : null;
     }
 
     /**
-     * Extract attribute name from accessor method name if possible
+     * Extract attribute name from accessor method name if possible.
      *
      * @psalm-pure
      * @psalm-param (value-of<self::ACCESSOR_PREFIXES>) $accessorPrefix
      */
     private function extractAttributeName(string $accessorMethod, string $accessorPrefix): ?string
     {
-        return substr($accessorMethod, strlen($accessorPrefix)) ?: null;
+        return substr($accessorMethod, \strlen($accessorPrefix)) ?: null;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -306,11 +306,11 @@ class ObjectNormalizerTest extends TestCase
     {
         $obj = new DummyWithAccessorLikes();
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 'hasser' => true,
-                'getter' => true,
                 'isser' => true,
+                'getter' => true,
             ],
             $this->normalizer->normalize($obj, 'any')
         );
@@ -1059,7 +1059,7 @@ class DummyWithAccessorLikes
 
     public function hashasserLike(): bool
     {
-        return true;
+        return false;
     }
 
     public function isIsser(): bool
@@ -1069,7 +1069,7 @@ class DummyWithAccessorLikes
 
     public function isisserLike(): bool
     {
-        return true;
+        return false;
     }
 
     public function getGetter(): bool
@@ -1079,6 +1079,6 @@ class DummyWithAccessorLikes
 
     public function getgetterLike(): bool
     {
-        return true;
+        return false;
     }
 }

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/ObjectNormalizerTest.php
@@ -302,6 +302,20 @@ class ObjectNormalizerTest extends TestCase
         $normalizer->denormalize($data, DummyWithConstructorInexistingObject::class);
     }
 
+    public function testAccessorLikeDistinction()
+    {
+        $obj = new DummyWithAccessorLikes();
+
+        $this->assertEquals(
+            [
+                'hasser' => true,
+                'getter' => true,
+                'isser' => true,
+            ],
+            $this->normalizer->normalize($obj, 'any')
+        );
+    }
+
     // attributes
 
     protected function getNormalizerForAttributes(): ObjectNormalizer
@@ -1033,5 +1047,38 @@ class DummyWithNullableConstructorObject
     public function getInner()
     {
         return $this->inner;
+    }
+}
+
+class DummyWithAccessorLikes
+{
+    public function hasHasser(): bool
+    {
+        return true;
+    }
+
+    public function hashasserLike(): bool
+    {
+        return true;
+    }
+
+    public function isIsser(): bool
+    {
+        return true;
+    }
+
+    public function isisserLike(): bool
+    {
+        return true;
+    }
+
+    public function getGetter(): bool
+    {
+        return true;
+    }
+
+    public function getgetterLike(): bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | 


Fix for cases when methods like ```hashCode``` are treated as accessor methods by ObjectNormalizer.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->
