### PR TITLE
Add completion for cache:pool:clear and cache:pool:delete commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolClearCommand.php
@@ -13,6 +13,8 @@ namespace Symfony\Bundle\FrameworkBundle\Command;
 
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -31,12 +33,14 @@ final class CachePoolClearCommand extends Command
     protected static $defaultDescription = 'Clear cache pools';
 
     private $poolClearer;
+    private $poolNames;
 
-    public function __construct(Psr6CacheClearer $poolClearer)
+    public function __construct(Psr6CacheClearer $poolClearer, array $poolNames = null)
     {
         parent::__construct();
 
         $this->poolClearer = $poolClearer;
+        $this->poolNames = $poolNames;
     }
 
     /**
@@ -113,5 +117,12 @@ EOF
         $io->success('Cache was successfully cleared.');
 
         return 0;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if (\is_array($this->poolNames) && $input->mustSuggestArgumentValuesFor('pools')) {
+            $suggestions->suggestValues($this->poolNames);
+        }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolDeleteCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CachePoolDeleteCommand.php
@@ -12,6 +12,8 @@
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -29,12 +31,14 @@ final class CachePoolDeleteCommand extends Command
     protected static $defaultDescription = 'Delete an item from a cache pool';
 
     private $poolClearer;
+    private $poolNames;
 
-    public function __construct(Psr6CacheClearer $poolClearer)
+    public function __construct(Psr6CacheClearer $poolClearer, array $poolNames = null)
     {
         parent::__construct();
 
         $this->poolClearer = $poolClearer;
+        $this->poolNames = $poolNames;
     }
 
     /**
@@ -80,5 +84,12 @@ EOF
         $io->success(sprintf('Cache item "%s" was successfully deleted.', $key));
 
         return 0;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if (\is_array($this->poolNames) && $input->mustSuggestArgumentValuesFor('pool')) {
+            $suggestions->suggestValues($this->poolNames);
+        }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -84,6 +84,7 @@ return static function (ContainerConfigurator $container) {
         ->set('console.command.cache_pool_clear', CachePoolClearCommand::class)
             ->args([
                 service('cache.global_clearer'),
+                null,
             ])
             ->tag('console.command')
 
@@ -96,6 +97,7 @@ return static function (ContainerConfigurator $container) {
         ->set('console.command.cache_pool_delete', CachePoolDeleteCommand::class)
             ->args([
                 service('cache.global_clearer'),
+                null,
             ])
             ->tag('console.command')
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolClearCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolClearCommandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bundle\FrameworkBundle\Command\CachePoolClearCommand;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class CachePoolClearCommandTest extends TestCase
+{
+    private $cachePool;
+
+    protected function setUp(): void
+    {
+        $this->cachePool = $this->createMock(CacheItemPoolInterface::class);
+    }
+
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testComplete(array $input, array $expectedSuggestions)
+    {
+        $application = new Application($this->getKernel());
+        $application->add(new CachePoolClearCommand(new Psr6CacheClearer(['foo' => $this->cachePool]), ['foo']));
+        $tester = new CommandCompletionTester($application->get('cache:pool:clear'));
+
+        $suggestions = $tester->complete($input);
+
+        $this->assertSame($expectedSuggestions, $suggestions);
+    }
+
+    public function provideCompletionSuggestions()
+    {
+        yield 'pool_name' => [
+            ['f'],
+            ['foo'],
+        ];
+    }
+
+    /**
+     * @return MockObject&KernelInterface
+     */
+    private function getKernel(): KernelInterface
+    {
+        $container = $this->createMock(ContainerInterface::class);
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel
+            ->expects($this->any())
+            ->method('getContainer')
+            ->willReturn($container);
+
+        $kernel
+            ->expects($this->once())
+            ->method('getBundles')
+            ->willReturn([]);
+
+        return $kernel;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolDeleteCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/CachePoolDeleteCommandTest.php
@@ -16,6 +16,7 @@ use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bundle\FrameworkBundle\Command\CachePoolDeleteCommand;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer;
@@ -81,6 +82,28 @@ class CachePoolDeleteCommandTest extends TestCase
 
         $tester = $this->getCommandTester($this->getKernel());
         $tester->execute(['pool' => 'foo', 'key' => 'bar']);
+    }
+
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testComplete(array $input, array $expectedSuggestions)
+    {
+        $application = new Application($this->getKernel());
+        $application->add(new CachePoolDeleteCommand(new Psr6CacheClearer(['foo' => $this->cachePool]), ['foo']));
+        $tester = new CommandCompletionTester($application->get('cache:pool:delete'));
+
+        $suggestions = $tester->complete($input);
+
+        $this->assertSame($expectedSuggestions, $suggestions);
+    }
+
+    public function provideCompletionSuggestions()
+    {
+        yield 'pool_name' => [
+            ['f'],
+            ['foo'],
+        ];
     }
 
     /**

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -230,8 +230,18 @@ class CachePoolPass implements CompilerPassInterface
             }
         }
 
+        $allPoolsKeys = array_keys($allPools);
+
         if ($container->hasDefinition('console.command.cache_pool_list')) {
-            $container->getDefinition('console.command.cache_pool_list')->replaceArgument(0, array_keys($allPools));
+            $container->getDefinition('console.command.cache_pool_list')->replaceArgument(0, $allPoolsKeys);
+        }
+
+        if ($container->hasDefinition('console.command.cache_pool_clear')) {
+            $container->getDefinition('console.command.cache_pool_clear')->replaceArgument(1, $allPoolsKeys);
+        }
+
+        if ($container->hasDefinition('console.command.cache_pool_delete')) {
+            $container->getDefinition('console.command.cache_pool_delete')->replaceArgument(1, $allPoolsKeys);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | #43594 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | No <!-- required for new features -->
<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against branch 5.x.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
-->

This PR adds completion to `cache:pool:clear` and `cache:pool:delete` commands.
