### PR TITLE
[Console] [Framework] Add completion to secrets:set and fix secrets:remove

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsRemoveCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsRemoveCommand.php
@@ -89,8 +89,14 @@ EOF
             return;
         }
 
-        $vault = $input->getOption('local') ? $this->localVault : $this->vault;
         $vaultKeys = array_keys($this->vault->list(false));
-        $suggestions->suggestValues(array_intersect($vaultKeys, array_keys($vault->list(false))));
+        if ($input->getOption('local')) {
+            if (null === $this->localVault) {
+                return;
+            }
+            $vaultKeys = array_intersect($vaultKeys, array_keys($this->localVault->list(false)));
+        }
+
+        $suggestions->suggestValues($vaultKeys);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/SecretsSetCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/SecretsSetCommand.php
@@ -13,6 +13,8 @@ namespace Symfony\Bundle\FrameworkBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Secrets\AbstractVault;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -136,5 +138,12 @@ EOF
         }
 
         return 0;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('name')) {
+            $suggestions->suggestValues(array_keys($this->vault->list(false)));
+        }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsRemoveCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsRemoveCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Command\SecretsRemoveCommand;
+use Symfony\Bundle\FrameworkBundle\Secrets\AbstractVault;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
+
+class SecretsRemoveCommandTest extends TestCase
+{
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testComplete(bool $withLocalVault, array $input, array $expectedSuggestions)
+    {
+        $vault = $this->createMock(AbstractVault::class);
+        $vault->method('list')->willReturn(['SECRET' => null, 'OTHER_SECRET' => null]);
+        if ($withLocalVault) {
+            $localVault = $this->createMock(AbstractVault::class);
+            $localVault->method('list')->willReturn(['SECRET' => null]);
+        } else {
+            $localVault = null;
+        }
+        $command = new SecretsRemoveCommand($vault, $localVault);
+        $tester = new CommandCompletionTester($command);
+        $suggestions = $tester->complete($input);
+        $this->assertSame($expectedSuggestions, $suggestions);
+    }
+
+    public function provideCompletionSuggestions()
+    {
+        yield 'name' => [true, [''], ['SECRET', 'OTHER_SECRET']];
+        yield '--local name (with local vault)' => [true, ['--local', ''], ['SECRET']];
+        yield '--local name (without local vault)' => [false, ['--local', ''], []];
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsSetCommandTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Command/SecretsSetCommandTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Bundle\FrameworkBundle\Command\SecretsSetCommand;
+use Symfony\Bundle\FrameworkBundle\Secrets\AbstractVault;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
+
+class SecretsSetCommandTest extends TestCase
+{
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testComplete(array $input, array $expectedSuggestions)
+    {
+        $vault = $this->createMock(AbstractVault::class);
+        $vault->method('list')->willReturn(['SECRET' => null, 'OTHER_SECRET' => null]);
+        $localVault = $this->createMock(AbstractVault::class);
+        $command = new SecretsSetCommand($vault, $localVault);
+        $tester = new CommandCompletionTester($command);
+        $suggestions = $tester->complete($input);
+        $this->assertSame($expectedSuggestions, $suggestions);
+    }
+
+    public function provideCompletionSuggestions()
+    {
+        yield 'name' => [[''], ['SECRET', 'OTHER_SECRET']];
+        yield '--local name (with local vault)' => [['--local', ''], ['SECRET', 'OTHER_SECRET']];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #43594
| License       | MIT
| Doc PR        | no

- Add completion for command `secrets:set` (`name`)
- Fix completion for command `secrets:remove` when local vault is disabled and add tests.
- ~~Upgrade the required version of `symfony/console` since commands cannot implement an interface that does not exist in older versions #43620~~

