### PR TITLE
[Framework][Secrets] Fix service definition when local vault is disabled

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -298,7 +298,7 @@ return static function (ContainerConfigurator $container) {
         ->set('console.command.secrets_list', SecretsListCommand::class)
             ->args([
                 service('secrets.vault'),
-                service('secrets.local_vault'),
+                service('secrets.local_vault')->ignoreOnInvalid(),
             ])
             ->tag('console.command')
 
@@ -312,7 +312,7 @@ return static function (ContainerConfigurator $container) {
         ->set('console.command.secrets_encrypt_from_local', SecretsEncryptFromLocalCommand::class)
             ->args([
                 service('secrets.vault'),
-                service('secrets.local_vault'),
+                service('secrets.local_vault')->ignoreOnInvalid(),
             ])
             ->tag('console.command')
     ;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Local vault can be disabled with the following configuration:
```
framework:
    secrets:
        local_dotenv_file: ~
```
This removes the service `secrets.local_vault` ([code](https://github.com/symfony/symfony/blob/5.3/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L1669)). The `secrets:...` commands support this by having `$localVault` argument nullable.

When configuration was moved from XML to PHP in #37216, the attribute `on-invalid="ignore"` of some services was left.