### PR TITLE
[Console] Add completion to messenger:setup-transports command

### DIFF
--- a/src/Symfony/Component/Messenger/Command/SetupTransportsCommand.php
+++ b/src/Symfony/Component/Messenger/Command/SetupTransportsCommand.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Messenger\Command;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -80,5 +82,14 @@ EOF
         }
 
         return 0;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('transport')) {
+            $suggestions->suggestValues($this->transportNames);
+
+            return;
+        }
     }
 }

--- a/src/Symfony/Component/Messenger/Tests/Command/SetupTransportsCommandTest.php
+++ b/src/Symfony/Component/Messenger/Tests/Command/SetupTransportsCommandTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Messenger\Tests\Command;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Messenger\Command\SetupTransportsCommand;
@@ -86,5 +87,22 @@ class SetupTransportsCommandTest extends TestCase
         $command = new SetupTransportsCommand($serviceLocator, ['amqp', 'other_transport']);
         $tester = new CommandTester($command);
         $tester->execute(['transport' => 'not_found']);
+    }
+
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testComplete(array $input, array $expectedSuggestions)
+    {
+        $serviceLocator = $this->createMock(ServiceLocator::class);
+        $command = new SetupTransportsCommand($serviceLocator, ['amqp', 'other_transport']);
+        $tester = new CommandCompletionTester($command);
+        $suggestions = $tester->complete($input);
+        $this->assertSame($expectedSuggestions, $suggestions);
+    }
+
+    public function provideCompletionSuggestions()
+    {
+        yield 'transport' => [[''], ['amqp', 'other_transport']];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4  <!-- see below -->
| Bug fix?      | no
| New feature?  | yes<!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       |  #43594 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        |  no <!-- required for new features -->

- Add completion for command messenger:setup-transports (transport)

