### PR TITLE
[Console] Issue 43602 : Add fish completion

### DIFF
--- a/src/Symfony/Component/Console/Command/CompleteCommand.php
+++ b/src/Symfony/Component/Console/Command/CompleteCommand.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Completion\Output\BashCompletionOutput;
 use Symfony\Component\Console\Completion\Output\CompletionOutputInterface;
+use Symfony\Component\Console\Completion\Output\FishCompletionOutput;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Input\InputInterface;
@@ -41,7 +42,10 @@ final class CompleteCommand extends Command
     public function __construct(array $completionOutputs = [])
     {
         // must be set before the parent constructor, as the property value is used in configure()
-        $this->completionOutputs = $completionOutputs + ['bash' => BashCompletionOutput::class];
+        $this->completionOutputs = $completionOutputs + [
+            'bash' => BashCompletionOutput::class,
+            'fish' => FishCompletionOutput::class,
+        ];
 
         parent::__construct();
     }

--- a/src/Symfony/Component/Console/Completion/Output/FishCompletionOutput.php
+++ b/src/Symfony/Component/Console/Completion/Output/FishCompletionOutput.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Completion\Output;
+
+use Symfony\Component\Console\Completion\CompletionSuggestions;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Guillaume Aveline <guillaume.aveline@pm.me>
+ */
+class FishCompletionOutput implements CompletionOutputInterface
+{
+    public function write(CompletionSuggestions $suggestions, OutputInterface $output): void
+    {
+        $values = $suggestions->getValueSuggestions();
+        foreach ($suggestions->getOptionSuggestions() as $option) {
+            $values[] = '--'.$option->getName();
+        }
+        $output->write(implode("\n", $values));
+    }
+}

--- a/src/Symfony/Component/Console/Resources/completion.fish
+++ b/src/Symfony/Component/Console/Resources/completion.fish
@@ -1,0 +1,29 @@
+# This file is part of the Symfony package.
+#
+# (c) Fabien Potencier <fabien@symfony.com>
+#
+# For the full copyright and license information, please view
+# https://symfony.com/doc/current/contributing/code/license.html
+
+function _sf_{{ COMMAND_NAME }}
+    set sf_cmd (commandline -o)
+    set c (math (count (commandline -oc))) - 1)
+
+    set completecmd "$sf_cmd[1]" "_complete" "-sfish" "-S{{ VERSION }}"
+
+    for i in $sf_cmd
+        if [ $i != "" ]
+            set completecmd $completecmd "-i$i"
+        end
+    end
+
+    set completecmd $completecmd "-c$c"
+
+    set sfcomplete ($completecmd)
+
+    for i in $sfcomplete
+        echo $i
+    end
+end
+
+complete -c '{{ COMMAND_NAME }}' -a '(_sf_{{ COMMAND_NAME }})' -f

--- a/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
@@ -47,7 +47,7 @@ class CompleteCommandTest extends TestCase
 
     public function testUnsupportedShellOption()
     {
-        $this->expectExceptionMessage('Shell completion is not supported for your shell: "unsupported" (supported: "bash").');
+        $this->expectExceptionMessage('Shell completion is not supported for your shell: "unsupported" (supported: "bash", "fish").');
         $this->execute(['--shell' => 'unsupported']);
     }
 

--- a/src/Symfony/Component/Console/Tests/Command/DumpCompletionCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/DumpCompletionCommandTest.php
@@ -23,7 +23,7 @@ class DumpCompletionCommandTest extends TestCase
     {
         yield 'shell' => [
             [''],
-            ['bash'],
+            ['bash', 'fish'],
         ];
     }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.json
@@ -89,7 +89,7 @@
                         "accept_value": true,
                         "is_value_required": true,
                         "is_multiple": false,
-                        "description": "The shell type (\"bash\")",
+                        "description": "The shell type (\"bash\", \"fish\")",
                         "default": null
                     },
                     "current": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_1.xml
@@ -10,7 +10,7 @@
       <arguments/>
       <options>
         <option name="--shell" shortcut="-s" accept_value="1" is_value_required="1" is_multiple="0">
-          <description>The shell type ("bash")</description>
+          <description>The shell type ("bash", "fish")</description>
           <defaults/>
         </option>
         <option name="--input" shortcut="-i" accept_value="1" is_value_required="1" is_multiple="1">

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.json
@@ -93,7 +93,7 @@
                         "accept_value": true,
                         "is_value_required": true,
                         "is_multiple": false,
-                        "description": "The shell type (\"bash\")",
+                        "description": "The shell type (\"bash\", \"fish\")",
                         "default": null
                     },
                     "current": {

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_2.xml
@@ -10,7 +10,7 @@
       <arguments/>
       <options>
         <option name="--shell" shortcut="-s" accept_value="1" is_value_required="1" is_multiple="0">
-          <description>The shell type ("bash")</description>
+          <description>The shell type ("bash", "fish")</description>
           <defaults/>
         </option>
         <option name="--input" shortcut="-i" accept_value="1" is_value_required="1" is_multiple="1">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43602
| License       | MIT

I tried to implement fish auto completion.
I hope it will work fine for you guys, let me know.

You can execute `bin/console completion fish >> ~/.config/fish/completions/sf_console.fish` and source the file
