### PR TITLE
[Validator] Add simple way to check if there constraint violations

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * Add a `CssColor` constraint to validate CSS colors
  * Add support for `ConstraintViolationList::createFromMessage()`
  * Add error's uid to `Count` and `Length` constraints with "exactly" option enabled
+ * Add `ConstraintViolationList::isEmpty` to check if there are constraint violations in the list
 
 5.3
 ---

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -198,4 +198,12 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
 
         return new static($violations);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEmpty(): bool
+    {
+        return [] === $this->violations;
+    }
 }

--- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
@@ -15,6 +15,8 @@ namespace Symfony\Component\Validator;
  * A list of constraint violations.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @method bool isEmpty() Returns whether the violation list is empty.
  */
 interface ConstraintViolationListInterface extends \Traversable, \Countable, \ArrayAccess
 {

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
@@ -164,6 +164,23 @@ EOF;
         $this->assertSame('my message', $list[0]->getMessage());
     }
 
+    public function testIsEmpty()
+    {
+        $this->list = new ConstraintViolationList([]);
+
+        $this->assertCount(0, $this->list);
+        $this->assertTrue($this->list->isEmpty());
+    }
+
+    public function testIsEmptyWithViolations()
+    {
+        $violation = $this->getViolation('Error');
+        $this->list = new ConstraintViolationList([$violation]);
+
+        $this->assertCount(1, $this->list);
+        $this->assertFalse($this->list->isEmpty());
+    }
+
     protected function getViolation($message, $root = null, $propertyPath = null, $code = null)
     {
         return new ConstraintViolation($message, $message, [], $root, $propertyPath, null, null, $code);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | https://github.com/symfony/symfony-docs/pull/15983

The `ConstraintViolationList` class cannot be used with PHP's built-in function `empty(...)` because it is an object, so we have to use the less simple `count($violationList) === 0` or `$violationList->count() === 0`. 

It would be better to have a more natural way to determine if any violations exist via an `isEmpty()` method.