### PR TITLE
[Cache] remove no longer valid test case

### DIFF
--- a/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
+++ b/src/Symfony/Component/Cache/Tests/Adapter/MemcachedAdapterTest.php
@@ -87,7 +87,6 @@ class MemcachedAdapterTest extends AdapterTestCase
     public function provideBadOptions(): array
     {
         return [
-            ['foo', 'bar'],
             ['hash', 'zyx'],
             ['serializer', 'zyx'],
             ['distribution', 'zyx'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

The Memcached adapter no longer should throw an exception when an unknown
option is passed.
