### PR TITLE
[VarDumper] Fix `Cannot instantiate abstract class on (...)`

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lv.xlf
@@ -340,15 +340,15 @@
             </trans-unit>
             <trans-unit id="88">
                 <source>This value should be positive.</source>
-                <target>Šai vērtībāi jābūt pozitīvai.</target>
+                <target>Šai vērtībai jābūt pozitīvai.</target>
             </trans-unit>
             <trans-unit id="89">
                 <source>This value should be either positive or zero.</source>
-                <target>Šai vērtībāi jābūt pozitīvai vai vienādai ar nulli.</target>
+                <target>Šai vērtībai jābūt pozitīvai vai vienādai ar nulli.</target>
             </trans-unit>
             <trans-unit id="90">
                 <source>This value should be negative.</source>
-                <target>Šai vērtībāi jābūt negatīvai.</target>
+                <target>Šai vērtībai jābūt negatīvai.</target>
             </trans-unit>
             <trans-unit id="91">
                 <source>This value should be either negative or zero.</source>

--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -214,18 +214,24 @@ class ExceptionCaster
 
                 if (file_exists($f['file']) && 0 <= self::$srcContext) {
                     if (!empty($f['class']) && (is_subclass_of($f['class'], 'Twig\Template') || is_subclass_of($f['class'], 'Twig_Template')) && method_exists($f['class'], 'getDebugInfo')) {
-                        $template = $f['object'] ?? unserialize(sprintf('O:%d:"%s":0:{}', \strlen($f['class']), $f['class']));
-
-                        $ellipsis = 0;
-                        $templateSrc = method_exists($template, 'getSourceContext') ? $template->getSourceContext()->getCode() : (method_exists($template, 'getSource') ? $template->getSource() : '');
-                        $templateInfo = $template->getDebugInfo();
-                        if (isset($templateInfo[$f['line']])) {
+                        $template = null;
+                        if (isset($f['object'])) {
+                            $template = $f['object'];
+                        } elseif ((new \ReflectionClass($f['class']))->isInstantiable()) {
+                            $template = unserialize(sprintf('O:%d:"%s":0:{}', strlen($f['class']), $f['class']));
+                        }
+                        if (isset($template)) {
+                            $ellipsis = 0;
+                            $templateSrc = method_exists($template, 'getSourceContext') ? $template->getSourceContext()->getCode() : (method_exists($template, 'getSource') ? $template->getSource() : '');
+                            $templateInfo = $template->getDebugInfo();
+                            if (isset($templateInfo[$f['line']])) {
                             if (!method_exists($template, 'getSourceContext') || !file_exists($templatePath = $template->getSourceContext()->getPath())) {
-                                $templatePath = null;
-                            }
-                            if ($templateSrc) {
-                                $src = self::extractSource($templateSrc, $templateInfo[$f['line']], self::$srcContext, 'twig', $templatePath, $f);
-                                $srcKey = ($templatePath ?: $template->getTemplateName()).':'.$templateInfo[$f['line']];
+                                    $templatePath = null;
+                                }
+                                if ($templateSrc) {
+                                    $src = self::extractSource($templateSrc, $templateInfo[$f['line']], self::$srcContext, 'twig', $templatePath, $f);
+                                    $srcKey = ($templatePath ?: $template->getTemplateName()) . ':' . $templateInfo[$f['line']];
+                                }
                             }
                         }
                     }

--- a/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php
@@ -218,19 +218,19 @@ class ExceptionCaster
                         if (isset($f['object'])) {
                             $template = $f['object'];
                         } elseif ((new \ReflectionClass($f['class']))->isInstantiable()) {
-                            $template = unserialize(sprintf('O:%d:"%s":0:{}', strlen($f['class']), $f['class']));
+                            $template = unserialize(sprintf('O:%d:"%s":0:{}', \strlen($f['class']), $f['class']));
                         }
                         if (isset($template)) {
                             $ellipsis = 0;
                             $templateSrc = method_exists($template, 'getSourceContext') ? $template->getSourceContext()->getCode() : (method_exists($template, 'getSource') ? $template->getSource() : '');
                             $templateInfo = $template->getDebugInfo();
                             if (isset($templateInfo[$f['line']])) {
-                            if (!method_exists($template, 'getSourceContext') || !file_exists($templatePath = $template->getSourceContext()->getPath())) {
+                                if (!method_exists($template, 'getSourceContext') || !file_exists($templatePath = $template->getSourceContext()->getPath())) {
                                     $templatePath = null;
                                 }
                                 if ($templateSrc) {
                                     $src = self::extractSource($templateSrc, $templateInfo[$f['line']], self::$srcContext, 'twig', $templatePath, $f);
-                                    $srcKey = ($templatePath ?: $template->getTemplateName()) . ':' . $templateInfo[$f['line']];
+                                    $srcKey = ($templatePath ?: $template->getTemplateName()).':'.$templateInfo[$f['line']];
                                 }
                             }
                         }

--- a/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Caster/ExceptionCasterTest.php
@@ -149,7 +149,7 @@ EODUMP;
     %sExceptionCasterTest.php:%d { …}
 %A
 EODUMP;
-        
+
         $this->assertStringMatchesFormat($expectedDump, $dump);
     }
 
@@ -215,7 +215,7 @@ array:2 [
     class: "__TwigTemplate_VarDumperFixture_u75a09"
     src: {
       %sTwig.php:1 {
-        › 
+        ›%s
         › foo bar
         ›   twig source
       }
@@ -230,7 +230,7 @@ array:2 [
       %sExceptionCasterTest.php:2 {
         › foo bar
         ›   twig source
-        › 
+        ›%s
       }
     }
   }

--- a/src/Symfony/Component/VarDumper/Tests/Fixtures/ConcreteBug.php
+++ b/src/Symfony/Component/VarDumper/Tests/Fixtures/ConcreteBug.php
@@ -1,0 +1,57 @@
+<?php
+
+abstract class __TwigTemplate_VarDumperFixture_abstractBug extends \Twig\Template
+{
+    private function createError()
+    {
+        return new \RuntimeException('Manually triggered error.');
+    }
+
+    public function provideError()
+    {
+        return $this->createError();
+    }
+}
+
+/* foo_abstract.twig */
+class __TwigTemplate_VarDumperFixture_concreteBug extends __TwigTemplate_VarDumperFixture_abstractBug
+{
+    public function __construct(Twig\Environment $env = null, $path = null)
+    {
+        if (null !== $env) {
+            parent::__construct($env);
+        }
+        $this->parent = false;
+        $this->blocks = [];
+        $this->path = $path;
+    }
+    
+    /**
+     * @inheritDoc
+     */
+    public function getTemplateName()
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDebugInfo()
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSourceContext()
+    {
+        return new Twig\Source("   foo bar\n     twig source\n\n", 'foo_abstract.twig', $this->path ?: __FILE__);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function doDisplay(array $context, array $blocks = [])
+    {
+    }
+}


### PR DESCRIPTION
Fix for `Cannot instantiate abstract class on (...)` in `ExceptionCaster` in VarDumper.
| Q             | A
| ------------- | ---
| Branch?       | 4.4 (and olders?)
| Bug fix?      | yes
| New feature?  |no
| Deprecations? | no
| Tickets       | Fix #27921
| License       | MIT

In this issue #27921 @nicolas-grekas said that this affects very old versions - even 2.8. I created a branch from 4.4 according to the CONTRIBBUTING guide.