### PR TITLE
[PasswordHasher] Add autocompletion for security commands

### DIFF
--- a/src/Symfony/Component/PasswordHasher/Command/UserPasswordHashCommand.php
+++ b/src/Symfony/Component/PasswordHasher/Command/UserPasswordHashCommand.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\PasswordHasher\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -166,6 +168,15 @@ EOF
         $errorIo->success('Password hashing succeeded');
 
         return 0;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('user-class')) {
+            $suggestions->suggestValues($this->userClasses);
+
+            return;
+        }
     }
 
     /**

--- a/src/Symfony/Component/PasswordHasher/Tests/Command/UserPasswordHashCommandTest.php
+++ b/src/Symfony/Component/PasswordHasher/Tests/Command/UserPasswordHashCommandTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\PasswordHasher\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\PasswordHasher\Command\UserPasswordHashCommand;
 use Symfony\Component\PasswordHasher\Hasher\NativePasswordHasher;
@@ -284,6 +285,34 @@ EOTXT
         $tester->execute([
             'password' => 'password',
         ], ['interactive' => false]);
+    }
+
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testCompletionSuggestions(array $input, array $expectedSuggestions)
+    {
+        if (!class_exists(CommandCompletionTester::class)) {
+            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+        }
+
+        $command = new UserPasswordHashCommand($this->createMock(PasswordHasherFactoryInterface::class), ['App\Entity\User']);
+        $tester = new CommandCompletionTester($command);
+
+        $this->assertSame($expectedSuggestions, $tester->complete($input));
+    }
+
+    public function provideCompletionSuggestions()
+    {
+        yield 'user_class_empty' => [
+            [''],
+            ['App\Entity\User'],
+        ];
+
+        yield 'user_class_given' => [
+            ['App'],
+            ['App\Entity\User'],
+        ];
     }
 
     protected function setUp(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | Ref https://github.com/symfony/symfony/issues/43594
| License       | MIT
| Doc PR        | 

Related to https://github.com/symfony/symfony/issues/43594#issuecomment-949503331
I have a question regarding @wouterj 's comment on the issue
Also, the `password` is the first argument right now, should we swap it to be after `user-class`?

Still WIP, I am using `fish` and want to test as well https://github.com/symfony/symfony/pull/43641