### PR TITLE
[Console] Show proxified command class in completion debug

### DIFF
--- a/src/Symfony/Component/Console/Command/CompleteCommand.php
+++ b/src/Symfony/Component/Console/Command/CompleteCommand.php
@@ -108,7 +108,7 @@ final class CompleteCommand extends Command
                     $suggestions->suggestOptions($command->getDefinition()->getOptions());
                 } else {
                     $this->log([
-                        '  Completing using the <comment>'.\get_class($command).'</> class.',
+                        '  Completing using the <comment>'.\get_class($command instanceof LazyCommand ? $command->getCommand() : $command).'</> class.',
                         '  Completing <comment>'.$completionInput->getCompletionType().'</> for <comment>'.$completionInput->getCompletionName().'</>',
                     ]);
                     if (null !== $compval = $completionInput->getCompletionValue()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Fix the class shown in completion debug when the command is wrapped in LazyCommand.

Before:
```
Input: ("|" indicates the cursor position)
  bin/console debug:form|
Messages:
  Completing using the Symfony\Component\Console\Command\LazyCommand class.
  Completing argument_value for class
  Current value: 
Suggestions:
```

After:
```
Input: ("|" indicates the cursor position)
  bin/console debug:form|
Messages:
  Completing using the Symfony\Component\Form\Command\DebugCommand class.
  Completing argument_value for command
  Current value: debug:form
Suggestions:
```