### PR TITLE
[Console] Escape completion suggestions with special chars

### DIFF
--- a/src/Symfony/Component/Console/Completion/Output/BashCompletionOutput.php
+++ b/src/Symfony/Component/Console/Completion/Output/BashCompletionOutput.php
@@ -27,6 +27,24 @@ class BashCompletionOutput implements CompletionOutputInterface
         }
         $output->write(implode(' ', $options));
 
-        $output->writeln(implode(' ', $suggestions->getValueSuggestions()));
+        $output->writeln($this->normalizeSuggestions($suggestions->getValueSuggestions()));
+    }
+
+    /**
+     * Escapes special chars (e.g. backslash or space) and puts quotes around
+     * the suggestions whenever escaping was needed.
+     */
+    private function normalizeSuggestions(array $suggestions): string
+    {
+        $includesUnsafeChars = false;
+        $suggestions = array_map(function ($value) use (&$includesUnsafeChars) {
+            $newValue = str_replace('\\', '\\\\', $value);
+            $newValue = str_replace(' ', '\ ', $value);
+            $includesUnsafeChars = $includesUnsafeChars || $newValue !== $value;
+
+            return $newValue;
+        }, $suggestions);
+
+        return $includesUnsafeChars ? "\\'".implode("\\' \\'", $suggestions)."\\'" : implode(' ', $suggestions);
     }
 }

--- a/src/Symfony/Component/Console/Resources/completion.bash
+++ b/src/Symfony/Component/Console/Resources/completion.bash
@@ -21,7 +21,9 @@ _sf_{{ COMMAND_NAME }}() {
 
     local sfcomplete
     if sfcomplete=$(${completecmd[@]} 2>&1); then
-        COMPREPLY=($(compgen -W "$sfcomplete" -- "$cur"))
+        # $sfcomplete is escaped already, escape the input as well
+        local escapedcur=${cur//\\/\\\\}
+        COMPREPLY=($(compgen -W "${sfcomplete}" -- "${escapedcur//\'/\\\'}"))
         __ltrim_colon_completions "$cur"
     else
         if [[ "$sfcomplete" != *"Command \"_complete\" is not defined."* ]]; then


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

This fixes shell completion whenever a special char (backslash and whitespace at the moment) are present. In these cases, all suggestions are put in quotes (to avoid double-double escaping) and the special chars are escaped.

This bug was found in #43598