### PR TITLE
[Console] Fix backslash escaping in bash completion

### DIFF
--- a/src/Symfony/Component/Console/Command/CompleteCommand.php
+++ b/src/Symfony/Component/Console/Command/CompleteCommand.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Console\Command;
 use Symfony\Component\Console\Completion\CompletionInput;
 use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Completion\Output\BashCompletionOutput;
+use Symfony\Component\Console\Completion\Output\CompletionOutputInterface;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Symfony\Component\Console\Exception\ExceptionInterface;
 use Symfony\Component\Console\Input\InputInterface;
@@ -121,6 +122,7 @@ final class CompleteCommand extends Command
                 }
             }
 
+            /** @var CompletionOutputInterface $completionOutput */
             $completionOutput = new $completionOutput();
 
             $this->log('<info>Suggestions:</>');
@@ -156,10 +158,7 @@ final class CompleteCommand extends Command
             throw new \RuntimeException('The "--current" option must be set and it must be an integer.');
         }
 
-        $completionInput = CompletionInput::fromTokens(array_map(
-            function (string $i): string { return trim($i, "'"); },
-            $input->getOption('input')
-        ), (int) $currentIndex);
+        $completionInput = CompletionInput::fromTokens($input->getOption('input'), (int) $currentIndex);
 
         try {
             $completionInput->bind($this->getApplication()->getDefinition());

--- a/src/Symfony/Component/Console/Completion/Output/BashCompletionOutput.php
+++ b/src/Symfony/Component/Console/Completion/Output/BashCompletionOutput.php
@@ -21,12 +21,10 @@ class BashCompletionOutput implements CompletionOutputInterface
 {
     public function write(CompletionSuggestions $suggestions, OutputInterface $output): void
     {
-        $options = [];
+        $options = $suggestions->getValueSuggestions();
         foreach ($suggestions->getOptionSuggestions() as $option) {
             $options[] = '--'.$option->getName();
         }
-        $output->write(implode(' ', $options));
-
-        $output->writeln(implode(' ', $suggestions->getValueSuggestions()));
+        $output->writeln(implode("\n", $options));
     }
 }

--- a/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
@@ -79,32 +79,32 @@ class CompleteCommandTest extends TestCase
     /**
      * @dataProvider provideCompleteCommandNameInputs
      */
-    public function testCompleteCommandName(array $input, string $suggestions = 'help list completion hello'.\PHP_EOL)
+    public function testCompleteCommandName(array $input, array $suggestions)
     {
         $this->execute(['--current' => '1', '--input' => $input]);
-        $this->assertEquals($suggestions, $this->tester->getDisplay());
+        $this->assertEquals(implode("\n", $suggestions)."\n", $this->tester->getDisplay());
     }
 
     public function provideCompleteCommandNameInputs()
     {
-        yield 'empty' => [['bin/console']];
-        yield 'partial' => [['bin/console', 'he']];
-        yield 'complete-shortcut-name' => [['bin/console', 'hell'], 'hello'.\PHP_EOL];
+        yield 'empty' => [['bin/console'], ['help', 'list', 'completion', 'hello']];
+        yield 'partial' => [['bin/console', 'he'], ['help', 'list', 'completion', 'hello']];
+        yield 'complete-shortcut-name' => [['bin/console', 'hell'], ['hello']];
     }
 
     /**
      * @dataProvider provideCompleteCommandInputDefinitionInputs
      */
-    public function testCompleteCommandInputDefinition(array $input, string $suggestions)
+    public function testCompleteCommandInputDefinition(array $input, array $suggestions)
     {
         $this->execute(['--current' => '2', '--input' => $input]);
-        $this->assertEquals($suggestions, $this->tester->getDisplay());
+        $this->assertEquals(implode("\n", $suggestions)."\n", $this->tester->getDisplay());
     }
 
     public function provideCompleteCommandInputDefinitionInputs()
     {
-        yield 'definition' => [['bin/console', 'hello', '-'], '--help --quiet --verbose --version --ansi --no-interaction'.\PHP_EOL];
-        yield 'custom' => [['bin/console', 'hello'], 'Fabien Robin Wouter'.\PHP_EOL];
+        yield 'definition' => [['bin/console', 'hello', '-'], ['--help', '--quiet', '--verbose', '--version', '--ansi', '--no-interaction']];
+        yield 'custom' => [['bin/console', 'hello'], ['Fabien', 'Robin', 'Wouter']];
     }
 
     private function execute(array $input)

--- a/src/Symfony/Component/Console/Tests/Completion/CompletionInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Completion/CompletionInputTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Console\Tests\Command;
+namespace Symfony\Component\Console\Tests\Completion;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Completion\CompletionInput;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | #43664 
| License       | MIT
| Doc PR        | -

Fully tested code with #43598

- `printf` options `%b` and `%q` are handy to escape string using in shell input.
- Backslashes must to be escaped (doubled) in normal input (`bin/console debug:form App\\Form\\CommentType`). Otherwise they are dropped when PHP receive the argument (`App\Form\CommentType` become `AppFormCommentType` in `$SERVER['argv']`). This is not necessary for quoted arguments (`bin/console debug:form "App\Form\CommentType"` is OK). In the context of a command stored in a variable, like in the bash script, escaping is not interpreted: we must replace `\\` by `\` using `printf '%b'`.
- Completion does not process escaping. If `App\\Form\\` is typed, the suggestions must contain a `\\` to match. Since these values are provided to shell, double backslash must be escaped: `\` becomes `\\\\` in suggestion output.
- I choose to detect when quotes are typed to allow them in completion and add quotes to suggestions.
- Suggestion with spaces are still not properly working.

https://user-images.githubusercontent.com/400034/138536102-e282ee75-56c8-414b-8b16-7c3c290276d7.mov



