### PR TITLE
[Translation] Add completion feature on translation pull and push commands

### DIFF
--- a/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPullCommand.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Translation\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -50,6 +52,36 @@ final class TranslationPullCommand extends Command
         $this->enabledLocales = $enabledLocales;
 
         parent::__construct();
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('provider')) {
+            $suggestions->suggestValues($this->providerCollection->keys());
+
+            return;
+        }
+
+        if ($input->mustSuggestOptionValuesFor('domains')) {
+            $provider = $this->providerCollection->get($input->getArgument('provider'));
+
+            if ($provider && method_exists($provider, 'getDomains')) {
+                $domains = $provider->getDomains();
+                $suggestions->suggestValues($domains);
+            }
+
+            return;
+        }
+
+        if ($input->mustSuggestOptionValuesFor('locales')) {
+            $suggestions->suggestValues($this->enabledLocales);
+
+            return;
+        }
+
+        if ($input->mustSuggestOptionValuesFor('format')) {
+            $suggestions->suggestValues(['php', 'xlf', 'xlf12', 'xlf20', 'po', 'mo', 'yml', 'yaml', 'ts', 'csv', 'json', 'ini', 'res']);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
+++ b/src/Symfony/Component/Translation/Command/TranslationPushCommand.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Translation\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -45,6 +47,30 @@ final class TranslationPushCommand extends Command
         $this->enabledLocales = $enabledLocales;
 
         parent::__construct();
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestArgumentValuesFor('provider')) {
+            $suggestions->suggestValues($this->providers->keys());
+
+            return;
+        }
+
+        if ($input->mustSuggestOptionValuesFor('domains')) {
+            $provider = $this->providers->get($input->getArgument('provider'));
+
+            if ($provider && method_exists($provider, 'getDomains')) {
+                $domains = $provider->getDomains();
+                $suggestions->suggestValues($domains);
+            }
+
+            return;
+        }
+
+        if ($input->mustSuggestOptionValuesFor('locales')) {
+            $suggestions->suggestValues($this->enabledLocales);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Translation/Tests/Command/TranslationProviderTestCase.php
+++ b/src/Symfony/Component/Translation/Tests/Command/TranslationProviderTestCase.php
@@ -44,11 +44,15 @@ abstract class TranslationProviderTestCase extends TestCase
         parent::tearDown();
     }
 
-    protected function getProviderCollection(ProviderInterface $provider, array $locales = ['en'], array $domains = ['messages']): TranslationProviderCollection
+    protected function getProviderCollection(ProviderInterface $provider, array $providerNames = ['loco'], array $locales = ['en'], array $domains = ['messages']): TranslationProviderCollection
     {
-        return new TranslationProviderCollection([
-            'loco' => new FilteringProvider($provider, $locales, $domains),
-        ]);
+        $collection = [];
+
+        foreach ($providerNames as $providerName) {
+            $collection[$providerName] = new FilteringProvider($provider, $locales, $domains);
+        }
+
+        return new TranslationProviderCollection($collection);
     }
 
     protected function createFile(array $messages = ['note' => 'NOTE'], $targetLanguage = 'en', $fileNamePattern = 'messages.%locale%.xlf', string $xlfVersion = 'xlf12'): string


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix (partially) https://github.com/symfony/symfony/issues/43594 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | 

This PR adds completion for arguments and options on `translation:pull` and `translation:push` commands.