### PR TITLE
[Security] Deprecate LogoutListener being returned as 3rd element by FirewallMapInterface::getListeners

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -18,6 +18,7 @@ CHANGELOG
  * Display the roles of the logged-in user in the Web Debug Toolbar
  * Add the `security.access_decision_manager.strategy_service` option
  * Deprecate not configuring explicitly a provider for custom_authenticators when there is more than one registered provider
+ * Deprecate `FirewallContext::getListeners`, use `FirewallContext::getFirewallListeners` and `FirewallContext::getExceptionListener` instead
 
 5.3
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -320,7 +320,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
             $configId = 'security.firewall.map.config.'.$name;
 
-            [$matcher, $listeners, $exceptionListener, $logoutListener] = $this->createFirewall($container, $name, $firewall, $authenticationProviders, $providerIds, $configId);
+            [$matcher, $listeners, $exceptionListener] = $this->createFirewall($container, $name, $firewall, $authenticationProviders, $providerIds, $configId);
 
             $contextId = 'security.firewall.map.context.'.$name;
             $isLazy = !$firewall['stateless'] && (!empty($firewall['anonymous']['lazy']) || $firewall['lazy']);
@@ -329,8 +329,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
             $context
                 ->replaceArgument(0, new IteratorArgument($listeners))
                 ->replaceArgument(1, $exceptionListener)
-                ->replaceArgument(2, $logoutListener)
-                ->replaceArgument(3, new Reference($configId))
+                ->replaceArgument(2, new Reference($configId))
             ;
 
             $contextRefs[$contextId] = new Reference($contextId);
@@ -450,6 +449,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
                 'csrf_token_id' => $firewall['logout']['csrf_token_id'],
                 'logout_path' => $firewall['logout']['path'],
             ]);
+            $listeners[] = new Reference($logoutListenerId);
 
             // add default logout listener
             if (isset($firewall['logout']['success_handler'])) {
@@ -599,7 +599,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         $config->replaceArgument(10, $listenerKeys);
         $config->replaceArgument(11, $firewall['switch_user'] ?? null);
 
-        return [$matcher, $listeners, $exceptionListener, null !== $logoutListenerId ? new Reference($logoutListenerId) : null];
+        return [$matcher, $listeners, $exceptionListener];
     }
 
     private function createContextListener(ContainerBuilder $container, string $contextKey, ?string $firewallEventDispatcherId)

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.php
@@ -196,7 +196,6 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 [],
                 service('security.exception_listener'),
-                abstract_arg('LogoutListener'),
                 abstract_arg('FirewallConfig'),
             ])
 
@@ -205,7 +204,6 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 [],
                 service('security.exception_listener'),
-                abstract_arg('LogoutListener'),
                 abstract_arg('FirewallConfig'),
                 service('security.untracked_token_storage'),
             ])

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\SecurityBundle\Security;
 
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\Firewall\ExceptionListener;
 use Symfony\Component\Security\Http\FirewallMapInterface;
 
 /**
@@ -33,15 +34,44 @@ class FirewallMap implements FirewallMapInterface
         $this->map = $map;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getListeners(Request $request)
     {
+        if (2 > \func_num_args() || func_get_arg(1)) {
+            trigger_deprecation('symfony/security-bundle', '5.4', 'The %s() method is deprecated, use getFirewallListeners() or "getExceptionListener()" instead.', __METHOD__);
+        }
+
         $context = $this->getFirewallContext($request);
 
         if (null === $context) {
             return [[], null, null];
         }
 
-        return [$context->getListeners(), $context->getExceptionListener(), $context->getLogoutListener()];
+        return [$context->getListeners(false), $context->getExceptionListener(), $context->getLogoutListener(false)];
+    }
+
+    public function getFirewallListeners(Request $request): iterable
+    {
+        $context = $this->getFirewallContext($request);
+
+        if (null === $context) {
+            return [];
+        }
+
+        return $context->getFirewallListeners();
+    }
+
+    public function getExceptionListener(Request $request): ?ExceptionListener
+    {
+        $context = $this->getFirewallContext($request);
+
+        if (null === $context) {
+            return null;
+        }
+
+        return $context->getExceptionListener();
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/CompleteConfigurationTest.php
@@ -120,7 +120,7 @@ abstract class CompleteConfigurationTest extends TestCase
             $arguments = $contextDef->getArguments();
             $listeners[] = array_map('strval', $arguments[0]->getValues());
 
-            $configDef = $container->getDefinition((string) $arguments[3]);
+            $configDef = $container->getDefinition((string) $arguments[2]);
             $configs[] = array_values($configDef->getArguments());
         }
 
@@ -208,6 +208,7 @@ abstract class CompleteConfigurationTest extends TestCase
                 'security.channel_listener',
                 'security.firewall.authenticator.secure',
                 'security.authentication.switchuser_listener.secure',
+                'security.logout_listener.secure',
                 'security.access_listener',
             ],
             [
@@ -241,7 +242,7 @@ abstract class CompleteConfigurationTest extends TestCase
             $arguments = $contextDef->getArguments();
             $listeners[] = array_map('strval', $arguments[0]->getValues());
 
-            $configDef = $container->getDefinition((string) $arguments[3]);
+            $configDef = $container->getDefinition((string) $arguments[2]);
             $configs[] = array_values($configDef->getArguments());
         }
 
@@ -337,6 +338,7 @@ abstract class CompleteConfigurationTest extends TestCase
                 'security.authentication.listener.rememberme.secure',
                 'security.authentication.listener.anonymous.secure',
                 'security.authentication.switchuser_listener.secure',
+                'security.logout_listener.secure',
                 'security.access_listener',
             ],
             [

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallContextTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Security/FirewallContextTest.php
@@ -24,13 +24,15 @@ class FirewallContextTest extends TestCase
         $config = new FirewallConfig('main', 'user_checker', 'request_matcher');
         $exceptionListener = $this->getExceptionListenerMock();
         $logoutListener = $this->getLogoutListenerMock();
-        $listeners = [function () {}];
+        $listeners = [function () {}, $logoutListener];
+        $listenersMinusLogoutListener = [function () {}];
 
-        $context = new FirewallContext($listeners, $exceptionListener, $logoutListener, $config);
+        $context = new FirewallContext($listeners, $exceptionListener, $config);
 
-        $this->assertEquals($listeners, $context->getListeners());
+        $this->assertEquals($listenersMinusLogoutListener, iterator_to_array($context->getListeners(false)));
         $this->assertEquals($exceptionListener, $context->getExceptionListener());
-        $this->assertEquals($logoutListener, $context->getLogoutListener());
+        $this->assertEquals($logoutListener, $context->getLogoutListener(false));
+        $this->assertEquals($listeners, iterator_to_array($context->getFirewallListeners()));
         $this->assertEquals($config, $context->getConfig());
     }
 

--- a/src/Symfony/Component/Security/Http/CHANGELOG.md
+++ b/src/Symfony/Component/Security/Http/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
  * Deprecate `CookieClearingLogoutHandler`, `SessionLogoutHandler` and `CsrfTokenClearingLogoutHandler`.
    Use `CookieClearingLogoutListener`, `SessionLogoutListener` and `CsrfTokenClearingLogoutListener` instead
  * Deprecate `PassportInterface`, `UserPassportInterface` and `PassportTrait`, use `Passport` instead
+ * Deprecate `FirewallMapInterface::getListeners`, use `FirewallMapInterface::getFirewallListeners` and `FirewallMapInterface::getExceptionListener` instead
 
 5.3
 ---

--- a/src/Symfony/Component/Security/Http/Firewall.php
+++ b/src/Symfony/Component/Security/Http/Firewall.php
@@ -54,7 +54,7 @@ class Firewall implements EventSubscriberInterface
         }
 
         // register listeners for this firewall
-        $listeners = $this->map->getListeners($event->getRequest());
+        $listeners = $this->map->getListeners($event->getRequest(), false);
 
         $authenticationListeners = $listeners[0];
         $exceptionListener = $listeners[1];

--- a/src/Symfony/Component/Security/Http/FirewallMap.php
+++ b/src/Symfony/Component/Security/Http/FirewallMap.php
@@ -25,7 +25,7 @@ use Symfony\Component\Security\Http\Firewall\LogoutListener;
 class FirewallMap implements FirewallMapInterface
 {
     /**
-     * @var list<array{RequestMatcherInterface, list<callable>, ExceptionListener|null, LogoutListener|null}>
+     * @var list<array{RequestMatcherInterface, list<callable>, ExceptionListener|null, list<callable>, LogoutListener|null}>
      */
     private $map = [];
 

--- a/src/Symfony/Component/Security/Http/FirewallMap.php
+++ b/src/Symfony/Component/Security/Http/FirewallMap.php
@@ -34,7 +34,26 @@ class FirewallMap implements FirewallMapInterface
      */
     public function add(RequestMatcherInterface $requestMatcher = null, array $listeners = [], ExceptionListener $exceptionListener = null, LogoutListener $logoutListener = null)
     {
-        $this->map[] = [$requestMatcher, $listeners, $exceptionListener, $logoutListener];
+        $allListeners = $listeners;
+
+        if (null !== $logoutListener) {
+            trigger_deprecation('symfony/security', '5.4', 'Passing the LogoutListener as forth argument is deprecated, add it to $listeners instead.', __METHOD__);
+
+            // Ensure LogoutListener is contained in all listeners list
+            if (!\in_array($logoutListener, $allListeners)) {
+                $allListeners[] = $logoutListener;
+            }
+        } else {
+            // Take LogoutListeners from all listeners list
+            foreach ($listeners as $listener) {
+                if ($listener instanceof LogoutListener) {
+                    $logoutListener = $listener;
+                    break;
+                }
+            }
+        }
+
+        $this->map[] = [$requestMatcher, $allListeners, $exceptionListener, $listeners, $logoutListener];
     }
 
     /**
@@ -42,12 +61,38 @@ class FirewallMap implements FirewallMapInterface
      */
     public function getListeners(Request $request)
     {
+        if (2 > \func_num_args() || func_get_arg(1)) {
+            trigger_deprecation('symfony/security', '5.4', 'The %s() method is deprecated, use getFirewallListeners() or "getExceptionListener()" instead.', __METHOD__);
+        }
+
         foreach ($this->map as $elements) {
             if (null === $elements[0] || $elements[0]->matches($request)) {
-                return [$elements[1], $elements[2], $elements[3]];
+                return [$elements[3], $elements[2], $elements[4]];
             }
         }
 
         return [[], null, null];
+    }
+
+    public function getFirewallListeners(Request $request): iterable
+    {
+        foreach ($this->map as $elements) {
+            if (null === $elements[0] || $elements[0]->matches($request)) {
+                return $elements[1];
+            }
+        }
+
+        return [];
+    }
+
+    public function getExceptionListener(Request $request): ?ExceptionListener
+    {
+        foreach ($this->map as $elements) {
+            if (null === $elements[0] || $elements[0]->matches($request)) {
+                return $elements[2];
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Symfony/Component/Security/Http/FirewallMapInterface.php
+++ b/src/Symfony/Component/Security/Http/FirewallMapInterface.php
@@ -18,6 +18,9 @@ use Symfony\Component\Security\Http\Firewall\LogoutListener;
 /**
  * This interface must be implemented by firewall maps.
  *
+ * @method iterable               getFirewallListeners(Request $request) returns the sorted list of firewall listeners
+ * @method ExceptionListener|null getExceptionListener(Request $request) returns the firewall's exception listener
+ *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 interface FirewallMapInterface
@@ -36,6 +39,8 @@ interface FirewallMapInterface
      * must be null.
      *
      * @return array{iterable<mixed, callable>, ExceptionListener, LogoutListener}
+     *
+     * @deprecated since Symfony 5.4, use "getFirewallListeners()" instead
      */
     public function getListeners(Request $request);
 }

--- a/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallMapTest.php
@@ -55,7 +55,7 @@ class FirewallMapTest extends TestCase
 
         $map->add($tooLateMatcher, [function () {}]);
 
-        [$listeners, $exception] = $map->getListeners($request);
+        [$listeners, $exception] = $map->getListeners($request, false);
 
         $this->assertEquals([$theListener], $listeners);
         $this->assertEquals($theException, $exception);
@@ -90,7 +90,7 @@ class FirewallMapTest extends TestCase
 
         $map->add($tooLateMatcher, [function () {}]);
 
-        [$listeners, $exception] = $map->getListeners($request);
+        [$listeners, $exception] = $map->getListeners($request, false);
 
         $this->assertEquals([$theListener], $listeners);
         $this->assertEquals($theException, $exception);
@@ -112,7 +112,7 @@ class FirewallMapTest extends TestCase
 
         $map->add($notMatchingMatcher, [function () {}]);
 
-        [$listeners, $exception] = $map->getListeners($request);
+        [$listeners, $exception] = $map->getListeners($request, false);
 
         $this->assertEquals([], $listeners);
         $this->assertNull($exception);

--- a/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/FirewallTest.php
@@ -23,6 +23,9 @@ use Symfony\Component\Security\Http\FirewallMapInterface;
 
 class FirewallTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testOnKernelRequestRegistersExceptionListener()
     {
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
@@ -50,6 +53,9 @@ class FirewallTest extends TestCase
         $firewall->onKernelRequest($event);
     }
 
+    /**
+     * @group legacy
+     */
     public function testOnKernelRequestStopsWhenThereIsAResponse()
     {
         $called = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| License       | MIT

[As discussed](https://github.com/symfony/symfony/pull/43548#issuecomment-945187951) with @chalasr, I'm adding these deprecations in preparation for #43548, which is targeting Symfony 6.0.

---

**What's this PR about?**

The 3rd element in the array returned by `FirewallMapInterface::getListeners()` containing the `LogoutListener` will be deprecated. Instead, in Symfony 6.0 the logout listener will be included in the first element, which is then containing _all_ firewall listeners and removing some unnecessary complexity (-> #43548).

This change is a follow-up of introducing the ability to sort security listeners, which was introduced in #37337. There is no longer the need for treating the `LogoutListener` as a special case to get its execution order right.