### PR TITLE
[RateLimiter] bug #42194  fix: sliding window policy to use microtime

### DIFF
--- a/src/Symfony/Component/RateLimiter/Policy/NoLimiter.php
+++ b/src/Symfony/Component/RateLimiter/Policy/NoLimiter.php
@@ -27,7 +27,7 @@ final class NoLimiter implements LimiterInterface
 {
     public function reserve(int $tokens = 1, float $maxTime = null): Reservation
     {
-        return new Reservation(time(), new RateLimit(\PHP_INT_MAX, new \DateTimeImmutable(), true, \PHP_INT_MAX));
+        return new Reservation(microtime(true), new RateLimit(\PHP_INT_MAX, new \DateTimeImmutable(), true, \PHP_INT_MAX));
     }
 
     public function consume(int $tokens = 1): RateLimit

--- a/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
+++ b/src/Symfony/Component/RateLimiter/Policy/SlidingWindow.php
@@ -39,7 +39,7 @@ final class SlidingWindow implements LimiterStateInterface
     private $intervalInSeconds;
 
     /**
-     * @var int the unix timestamp when the current window ends
+     * @var float the unix timestamp when the current window ends
      */
     private $windowEndAt;
 
@@ -55,7 +55,7 @@ final class SlidingWindow implements LimiterStateInterface
         }
         $this->id = $id;
         $this->intervalInSeconds = $intervalInSeconds;
-        $this->windowEndAt = time() + $intervalInSeconds;
+        $this->windowEndAt = microtime(true) + $intervalInSeconds;
         $this->cached = false;
     }
 
@@ -64,7 +64,7 @@ final class SlidingWindow implements LimiterStateInterface
         $new = new self($window->id, $intervalInSeconds);
         $windowEndAt = $window->windowEndAt + $intervalInSeconds;
 
-        if (time() < $windowEndAt) {
+        if (microtime(true) < $windowEndAt) {
             $new->hitCountForLastWindow = $window->hitCount;
             $new->windowEndAt = $windowEndAt;
         }
@@ -101,7 +101,7 @@ final class SlidingWindow implements LimiterStateInterface
 
     public function isExpired(): bool
     {
-        return time() > $this->windowEndAt;
+        return microtime(true) > $this->windowEndAt;
     }
 
     public function add(int $hits = 1)
@@ -115,13 +115,13 @@ final class SlidingWindow implements LimiterStateInterface
     public function getHitCount(): int
     {
         $startOfWindow = $this->windowEndAt - $this->intervalInSeconds;
-        $percentOfCurrentTimeFrame = min((time() - $startOfWindow) / $this->intervalInSeconds, 1);
+        $percentOfCurrentTimeFrame = min((microtime(true) - $startOfWindow) / $this->intervalInSeconds, 1);
 
         return (int) floor($this->hitCountForLastWindow * (1 - $percentOfCurrentTimeFrame) + $this->hitCount);
     }
 
     public function getRetryAfter(): \DateTimeImmutable
     {
-        return \DateTimeImmutable::createFromFormat('U', $this->windowEndAt);
+        return \DateTimeImmutable::createFromFormat('U.u', $this->windowEndAt);
     }
 }

--- a/src/Symfony/Component/RateLimiter/RateLimit.php
+++ b/src/Symfony/Component/RateLimiter/RateLimit.php
@@ -67,11 +67,11 @@ class RateLimit
 
     public function wait(): void
     {
-        $delta = $this->retryAfter->getTimestamp() - time();
+        $delta = $this->retryAfter->format('U.u') - microtime(true);
         if ($delta <= 0) {
             return;
         }
 
-        sleep($delta);
+        usleep($delta * 1e6);
     }
 }

--- a/src/Symfony/Component/RateLimiter/Tests/RateLimitTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/RateLimitTest.php
@@ -12,9 +12,13 @@
 namespace Symfony\Component\RateLimiter\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ClockMock;
 use Symfony\Component\RateLimiter\Exception\RateLimitExceededException;
 use Symfony\Component\RateLimiter\RateLimit;
 
+/**
+ * @group time-sensitive
+ */
 class RateLimitTest extends TestCase
 {
     public function testEnsureAcceptedDoesNotThrowExceptionIfAccepted()
@@ -39,5 +43,15 @@ class RateLimitTest extends TestCase
         }
 
         $this->fail('RateLimitExceededException not thrown.');
+    }
+
+    public function testWaitUsesMicrotime()
+    {
+        ClockMock::register(RateLimit::class);
+        $rateLimit = new RateLimit(10, new \DateTimeImmutable('+2500 ms'), true, 10);
+
+        $start = microtime(true);
+        $rateLimit->wait(); // wait 2.5 seconds
+        $this->assertEqualsWithDelta($start + 2.5, microtime(true), 0.1);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #42194
| License       | MIT
| Doc PR        | symfony/symfony-docs

Other parts of `RateLimiter` use `microtime()`, while  sliding window policy uses `time()` instead. That means the window may expire only up to 0.(9) seconds after the interval. Below an example that fails (window not expired) majority of the times (window is expired only if it starts e.g. at 1634992063.4999 and is checked at 1634992065.5000 - with `time()` rounding it would be 3 seconds).

```php
<?php

use Symfony\Component\RateLimiter\Policy\SlidingWindow;

require_once './vendor/autoload.php';

$window = new SlidingWindow('some_id', 2);
sleep(2); // mimic $limit->wait();
var_dump($window->isExpired()); // false - same second
```