### PR TITLE
Add suggestions for the option 'format' of lints commands: twig, yaml and xliff

### DIFF
--- a/src/Symfony/Bridge/Twig/Command/LintCommand.php
+++ b/src/Symfony/Bridge/Twig/Command/LintCommand.php
@@ -13,6 +13,8 @@ namespace Symfony\Bridge\Twig\Command;
 
 use Symfony\Component\Console\CI\GithubActionReporter;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -283,5 +285,12 @@ EOF
         }
 
         return $result;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestOptionValuesFor('format')) {
+            $suggestions->suggestValues(['txt', 'json', 'github']);
+        }
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -14,7 +14,9 @@ namespace Symfony\Bridge\Twig\Tests\Command;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Twig\Command\LintCommand;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
@@ -134,7 +136,27 @@ class LintCommandTest extends TestCase
         }
     }
 
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testComplete(array $input, array $expectedSuggestions)
+    {
+        $tester = new CommandCompletionTester($this->createCommand());
+
+        $this->assertSame($expectedSuggestions, $tester->complete($input));
+    }
+
+    public function provideCompletionSuggestions()
+    {
+        yield 'option' => [['--format', ''], ['txt', 'json', 'github']];
+    }
+
     private function createCommandTester(): CommandTester
+    {
+        return new CommandTester($this->createCommand());
+    }
+
+    private function createCommand(): Command
     {
         $environment = new Environment(new FilesystemLoader(\dirname(__DIR__).'/Fixtures/templates/'));
         $environment->addFilter(new TwigFilter('deprecated_filter', function ($v) {
@@ -145,9 +167,8 @@ class LintCommandTest extends TestCase
 
         $application = new Application();
         $application->add($command);
-        $command = $application->find('lint:twig');
 
-        return new CommandTester($command);
+        return $application->find('lint:twig');
     }
 
     private function createFile($content): string

--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Translation\Command;
 
 use Symfony\Component\Console\CI\GithubActionReporter;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -273,5 +275,12 @@ EOF
         }
 
         return null;
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestOptionValuesFor('format')) {
+            $suggestions->suggestValues(['txt', 'json', 'github']);
+        }
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
+++ b/src/Symfony/Component/Translation/Tests/Command/XliffLintCommandTest.php
@@ -13,7 +13,9 @@ namespace Symfony\Component\Translation\Tests\Command;
 
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Translation\Command\XliffLintCommand;
 
@@ -201,7 +203,7 @@ XLIFF;
         return $filename;
     }
 
-    private function createCommandTester($requireStrictFileNames = true, $application = null): CommandTester
+    private function createCommand($requireStrictFileNames = true, $application = null): Command
     {
         if (!$application) {
             $application = new Application();
@@ -214,7 +216,12 @@ XLIFF;
             $command->setApplication($application);
         }
 
-        return new CommandTester($command);
+        return $command;
+    }
+
+    private function createCommandTester($requireStrictFileNames = true, $application = null): CommandTester
+    {
+        return new CommandTester($this->createCommand($requireStrictFileNames, $application));
     }
 
     protected function setUp(): void
@@ -243,5 +250,20 @@ XLIFF;
         yield [true, 'messages.%locale%.xlf', 'es', true];
         yield [true, '%locale%.messages.xlf', 'en', true];
         yield [true, '%locale%.messages.xlf', 'es', true];
+    }
+
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testComplete(array $input, array $expectedSuggestions)
+    {
+        $tester = new CommandCompletionTester($this->createCommand());
+
+        $this->assertSame($expectedSuggestions, $tester->complete($input));
+    }
+
+    public function provideCompletionSuggestions()
+    {
+        yield 'option' => [['--format', ''], ['txt', 'json', 'github']];
     }
 }

--- a/src/Symfony/Component/Yaml/Command/LintCommand.php
+++ b/src/Symfony/Component/Yaml/Command/LintCommand.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Yaml\Command;
 
 use Symfony\Component\Console\CI\GithubActionReporter;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Completion\CompletionInput;
+use Symfony\Component\Console\Completion\CompletionSuggestions;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
@@ -276,5 +278,12 @@ EOF
         }
 
         return $default($fileOrDirectory);
+    }
+
+    public function complete(CompletionInput $input, CompletionSuggestions $suggestions): void
+    {
+        if ($input->mustSuggestOptionValuesFor('format')) {
+            $suggestions->suggestValues(['txt', 'json', 'github']);
+        }
     }
 }

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -14,7 +14,9 @@ namespace Symfony\Component\Yaml\Tests\Command;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\CI\GithubActionReporter;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Tester\CommandCompletionTester;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Yaml\Command\LintCommand;
 
@@ -163,6 +165,21 @@ YAML;
         $tester->execute(['filename' => $filename], ['decorated' => false]);
     }
 
+    /**
+     * @dataProvider provideCompletionSuggestions
+     */
+    public function testComplete(array $input, array $expectedSuggestions)
+    {
+        $tester = new CommandCompletionTester($this->createCommand());
+
+        $this->assertSame($expectedSuggestions, $tester->complete($input));
+    }
+
+    public function provideCompletionSuggestions()
+    {
+        yield 'option' => [['--format', ''], ['txt', 'json', 'github']];
+    }
+
     private function createFile($content): string
     {
         $filename = tempnam(sys_get_temp_dir().'/framework-yml-lint-test', 'sf-');
@@ -173,13 +190,17 @@ YAML;
         return $filename;
     }
 
-    protected function createCommandTester(): CommandTester
+    protected function createCommand(): Command
     {
         $application = new Application();
         $application->add(new LintCommand());
-        $command = $application->find('lint:yaml');
 
-        return new CommandTester($command);
+        return $application->find('lint:yaml');
+    }
+
+    protected function createCommandTester(): CommandTester
+    {
+        return new CommandTester($this->createCommand());
     }
 
     protected function setUp(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | #43594
| License       | MIT
| Doc PR        | -

Adding Bash completion for the following commands:

- lint:twig (--format)
- lint:xliff (--format)
- lint:yaml (--format)
