### PR TITLE
[RateLimiter] bug #42194 fix: sliding window policy to use microtime - fix test

### DIFF
--- a/src/Symfony/Component/RateLimiter/Tests/RateLimitTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/RateLimitTest.php
@@ -48,10 +48,10 @@ class RateLimitTest extends TestCase
     public function testWaitUsesMicrotime()
     {
         ClockMock::register(RateLimit::class);
-        $rateLimit = new RateLimit(10, new \DateTimeImmutable('+2500 ms'), true, 10);
+        $retryAfter = time() + 2.5; // get timestamp in the middle of a second (xxx.5)
+        $rateLimit = new RateLimit(10, \DateTimeImmutable::createFromFormat('U.u', $retryAfter), true, 10);
 
-        $start = microtime(true);
-        $rateLimit->wait(); // wait 2.5 seconds
-        $this->assertEqualsWithDelta($start + 2.5, microtime(true), 0.1);
+        $rateLimit->wait(); // wait until $retryAfter (~2.5 seconds)
+        $this->assertEqualsWithDelta($retryAfter, microtime(true), 0.49);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tickets       | Fix #42194 <!-- prefix each issue number with "Fix #", no need to create an issue if none exist, explain below instead -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

As pointed out in the comment https://github.com/symfony/symfony/pull/43677#issuecomment-950410904, `RateLimitTest::testWaitUsesMicrotime()` fails intermittently.
I have looked at all `PHPUnit` actions since the test was introduced and interestingly, the fails only occurred during `7.2` test, and the time difference was always ~1.3s.