### PR TITLE
[Messenger] add an "inactivity-limit" option to consume command

### DIFF
--- a/src/Symfony/Component/Messenger/CHANGELOG.md
+++ b/src/Symfony/Component/Messenger/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
  * Deprecate not setting the `reset_on_message` config option, its default value will change to `true` in 6.0
  * Add log when worker should stop.
  * Add log when `SIGTERM` is received.
+ * Add a new `inactivity-limit` option to the consume command.
 
 5.3
 ---

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnInactivityLimitListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnInactivityLimitListener.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\EventListener;
+
+use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+
+/**
+ * @author Gary PEGEOT <garypegeot@gmail.com>
+ */
+class StopWorkerOnInactivityLimitListener extends StopWorkerOnTimeLimitListener
+{
+    public function onWorkerRunning(WorkerRunningEvent $event): void
+    {
+        if (!$event->isWorkerIdle()) {
+            $this->endTime += $this->timeLimitInSeconds;
+        }
+
+        parent::onWorkerRunning($event);
+    }
+}

--- a/src/Symfony/Component/Messenger/EventListener/StopWorkerOnTimeLimitListener.php
+++ b/src/Symfony/Component/Messenger/EventListener/StopWorkerOnTimeLimitListener.php
@@ -22,9 +22,9 @@ use Symfony\Component\Messenger\Event\WorkerStartedEvent;
  */
 class StopWorkerOnTimeLimitListener implements EventSubscriberInterface
 {
-    private $timeLimitInSeconds;
+    protected $timeLimitInSeconds;
+    protected $endTime;
     private $logger;
-    private $endTime;
 
     public function __construct(int $timeLimitInSeconds, LoggerInterface $logger = null)
     {

--- a/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnInactivityLimitListenerTest.php
+++ b/src/Symfony/Component/Messenger/Tests/EventListener/StopWorkerOnInactivityLimitListenerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Messenger\Tests\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Messenger\Event\WorkerRunningEvent;
+use Symfony\Component\Messenger\EventListener\StopWorkerOnInactivityLimitListener;
+use Symfony\Component\Messenger\Worker;
+
+class StopWorkerOnInactivityLimitListenerTest extends TestCase
+{
+    /**
+     * @group time-sensitive
+     */
+    public function testWorkerStopsWhenTimeLimitIsReached()
+    {
+        $worker = $this->createMock(Worker::class);
+        $worker->expects($this->never())->method('stop');
+
+        $timeoutListener = new StopWorkerOnInactivityLimitListener(1, new NullLogger());
+        $timeoutListener->onWorkerStarted();
+        sleep(2);
+        $timeoutListener->onWorkerRunning(new WorkerRunningEvent($worker, false));
+
+        $worker = $this->createMock(Worker::class);
+        $worker->expects($this->once())->method('stop');
+        sleep(2);
+        $timeoutListener->onWorkerRunning(new WorkerRunningEvent($worker, true));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4 
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no 
| Tickets       | N/A
| License       | MIT
| Doc PR        |  TODO

Hi ! the use case for this PR is:

1. A cron job create a variable amount of messages
2. Some worker(s) consumes the messages until there's no more in the queue

The goal of this option to be able to stop workers once the queue is empty, instead of staying idle for one day. A "stop on idle" could fit too, but the time delay allow a little security buffer for late messages.
