### PR TITLE
[Cache] do not replace definition arguments that have not been configured

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/console.php
@@ -84,7 +84,6 @@ return static function (ContainerConfigurator $container) {
         ->set('console.command.cache_pool_clear', CachePoolClearCommand::class)
             ->args([
                 service('cache.global_clearer'),
-                null,
             ])
             ->tag('console.command')
 
@@ -97,7 +96,6 @@ return static function (ContainerConfigurator $container) {
         ->set('console.command.cache_pool_delete', CachePoolDeleteCommand::class)
             ->args([
                 service('cache.global_clearer'),
-                null,
             ])
             ->tag('console.command')
 

--- a/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
+++ b/src/Symfony/Component/Cache/DependencyInjection/CachePoolPass.php
@@ -237,11 +237,11 @@ class CachePoolPass implements CompilerPassInterface
         }
 
         if ($container->hasDefinition('console.command.cache_pool_clear')) {
-            $container->getDefinition('console.command.cache_pool_clear')->replaceArgument(1, $allPoolsKeys);
+            $container->getDefinition('console.command.cache_pool_clear')->addArgument($allPoolsKeys);
         }
 
         if ($container->hasDefinition('console.command.cache_pool_delete')) {
-            $container->getDefinition('console.command.cache_pool_delete')->replaceArgument(1, $allPoolsKeys);
+            $container->getDefinition('console.command.cache_pool_delete')->addArgument($allPoolsKeys);
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

see the failures for `deps=high` on the `4.4` branch
