### PR TITLE
[Security] prevent issues with timezones and DST by using only UNIX timestamps

### DIFF
--- a/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
+++ b/src/Symfony/Component/Security/Http/Tests/RememberMe/PersistentRememberMeHandlerTest.php
@@ -124,7 +124,7 @@ class PersistentRememberMeHandlerTest extends TestCase
         $this->tokenProvider->expects($this->any())
             ->method('loadTokenBySeries')
             ->with('series1')
-            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTime('-'.(31536000 + 1).' seconds')));
+            ->willReturn(new PersistentToken(InMemoryUser::class, 'wouter', 'series1', 'tokenvalue', new \DateTime('@'.(time() - (31536000 + 1)))));
 
         $this->tokenProvider->expects($this->never())->method('updateToken')->with('series1');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 