### PR TITLE
[Dotenv] Fix testLoadEnv() .env.dist isolation

### DIFF
--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -229,15 +229,12 @@ class DotenvTest extends TestCase
         $resetContext = static function (): void {
             unset($_ENV['SYMFONY_DOTENV_VARS']);
             unset($_ENV['FOO']);
-            unset($_ENV['BAR']);
             unset($_ENV['TEST_APP_ENV']);
             unset($_SERVER['SYMFONY_DOTENV_VARS']);
             unset($_SERVER['FOO']);
-            unset($_SERVER['BAR']);
             unset($_SERVER['TEST_APP_ENV']);
             putenv('SYMFONY_DOTENV_VARS');
             putenv('FOO');
-            putenv('BAR');
             putenv('TEST_APP_ENV');
         };
 
@@ -246,55 +243,54 @@ class DotenvTest extends TestCase
         $path = tempnam($tmpdir, 'sf-');
 
         // .env
+        file_put_contents($path, 'FOO=BAR');
 
         $resetContext();
-        file_put_contents($path, 'FOO=BAR');
         (new Dotenv(true))->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('BAR', getenv('FOO'));
         $this->assertSame('dev', getenv('TEST_APP_ENV'));
 
         // .env.local
+        file_put_contents("$path.local", 'FOO=localBAR');
 
         $resetContext();
         $_SERVER['TEST_APP_ENV'] = 'local';
-        file_put_contents("$path.local", 'FOO=localBAR');
         (new Dotenv(true))->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('localBAR', getenv('FOO'));
 
         // special case for test
-
         $resetContext();
         $_SERVER['TEST_APP_ENV'] = 'test';
         (new Dotenv(true))->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('BAR', getenv('FOO'));
 
         // .env.dev
+        file_put_contents("$path.dev", 'FOO=devBAR');
 
         $resetContext();
-        file_put_contents("$path.dev", 'FOO=devBAR');
         (new Dotenv(true))->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('devBAR', getenv('FOO'));
 
         // .env.dev.local
+        file_put_contents("$path.dev.local", 'FOO=devlocalBAR');
 
         $resetContext();
-        file_put_contents("$path.dev.local", 'FOO=devlocalBAR');
         (new Dotenv(true))->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('devlocalBAR', getenv('FOO'));
-
-        // .env.dist
-
-        $resetContext();
-        unlink($path);
-        file_put_contents("$path.dist", 'BAR=distBAR');
-        (new Dotenv(true))->loadEnv($path, 'TEST_APP_ENV');
-        $this->assertSame('distBAR', getenv('BAR'));
-
-        $resetContext();
-        unlink("$path.dist");
         unlink("$path.local");
         unlink("$path.dev");
         unlink("$path.dev.local");
+
+        // .env.dist
+        file_put_contents("$path.dist", 'FOO=distBAR');
+
+        $resetContext();
+        unlink($path);
+        (new Dotenv(true))->loadEnv($path, 'TEST_APP_ENV');
+        $this->assertSame('distBAR', getenv('FOO'));
+        unlink("$path.dist");
+
+        $resetContext();
         rmdir($tmpdir);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

Sorry but I did not catch everything in the first one.

When `.env.dist` is tested, `.env.local` , `.env.dev` and `.env.dev.local` still exists and "override" defined vars in `.env.dist`. I guess that's why you used another var (`BAR`). It makes more sense to me to actually test it "in isolation" since we don't test anything about the override right now.

Also, I applied some minor changes to minimize the diff on changes I'm working on for adding `$overrideExistingVars` to `loadEnv()` and `bootEnv()`.