### PR TITLE
[Meta] Use GitHub issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.yaml
@@ -1,0 +1,38 @@
+name: 🐛 Bug Report
+description: ⚠️ See below for security reports
+labels: Bug
+
+body:
+    - type: input
+      id: affected-versions
+      attributes:
+          label: Symfony version(s) affected
+          placeholder: x.y.z
+      validations:
+          required: true
+    - type: textarea
+      id: description
+      attributes:
+          label: Description
+          description: A clear and consise description of the problem
+      validations:
+          required: true
+    - type: textarea
+      id: how-to-reproduce
+      attributes:
+          label: How to reproduce
+          description: |
+              Code and/or config needed to reproduce the problem.
+              If it's a complex bug, create a "bug reproducer" as explained in https://symfony.com/doc/current/contributing/code/reproducer.html
+      validations:
+          required: true
+    - type: textarea
+      id: possible-solution
+      attributes:
+          label: Possible Solution
+          description: "Optional: only if you have suggestions on a fix/reason for the bug"
+    - type: textarea
+      id: additional-context
+      attributes:
+          label: Additional Context
+          description: "Optional: any other context about the problem: log messages, screenshots, etc."

--- a/.github/ISSUE_TEMPLATE/2_Feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/2_Feature_request.yaml
@@ -1,0 +1,17 @@
+name: 🚀 Feature Request
+description: RFC and ideas for new features and improvements
+body:
+    - type: textarea
+      id: description
+      attributes:
+          label: Description
+          description: A clear and concise description of the new feature
+      validations:
+          required: true
+    - type: textarea
+      id: example
+      attributes:
+          label: Example
+          description: |
+              A simple example of the new feature in action (include PHP code, YAML config, etc.)
+              If the new feature changes an existing feature, include a simple before/after comparison.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | n/a
| License       | MIT
| Doc PR        | n/a

[GitHub Issue Forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) are now in open beta for all public repositories.  These provide a more structured way for contributors to create new issues with defined fields and basic validation.  When submitted, the forms are converted into Markdown and can be edited just like any other issue.

This PR converts the Bug Report and Feature Request issue templates into Issue Forms.  The other types were not converted because those are not intended to be submitted and Issue Forms [currently require at least one submittable field](https://gh-community.github.io/issue-template-feedback/structured/#body-must-contain-at-least-one-non-markdown-field).

You can preview these forms on my fork: https://github.com/colinodell/symfony/issues/new/choose

If you are not interested in this, please feel free to close this PR - I won't be offended :)