### PR TITLE
[Validator] Add the missing translations for Bahasa Indonesia (id)

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.id.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.id.xlf
@@ -388,11 +388,19 @@
             </trans-unit>
             <trans-unit id="100">
                 <source>This value should be a valid expression.</source>
-                <target>Nilai ini harus berupa ekspresi yang valid.</target>
+                <target>Nilai ini harus berupa ekspresi yang sah.</target>
             </trans-unit>
             <trans-unit id="101">
                 <source>This value is not a valid CSS color.</source>
                 <target>Nilai ini bukan merupakan warna CSS yang sah.</target>
+            </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target>Nilai ini bukan merupakan notasi CIDR yang sah.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target>Nilai dari netmask harus berada diantara {{ min }} dan {{ max }}.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43721
| License       | MIT
| Doc PR        | N/A

Additionally (see https://symfony.com/releases):
 - [Validator] Add the missing translations for Bahasa Indonesia (id)