### PR TITLE
[VarDumper]  skip command completion tests with older Symfony Console versions

### DIFF
--- a/src/Symfony/Component/VarDumper/Tests/Command/ServerDumpCommandTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Command/ServerDumpCommandTest.php
@@ -14,6 +14,10 @@ class ServerDumpCommandTest extends TestCase
      */
     public function testComplete(array $input, array $expectedSuggestions)
     {
+        if (!class_exists(CommandCompletionTester::class)) {
+            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+        }
+
         $tester = new CommandCompletionTester($this->createCommand());
 
         $this->assertSame($expectedSuggestions, $tester->complete($input));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 