### PR TITLE
[TwigBridge][Yaml] skip command completion tests with older Symfony Console versions

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Command/LintCommandTest.php
@@ -141,6 +141,10 @@ class LintCommandTest extends TestCase
      */
     public function testComplete(array $input, array $expectedSuggestions)
     {
+        if (!class_exists(CommandCompletionTester::class)) {
+            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+        }
+
         $tester = new CommandCompletionTester($this->createCommand());
 
         $this->assertSame($expectedSuggestions, $tester->complete($input));

--- a/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
+++ b/src/Symfony/Component/Yaml/Tests/Command/LintCommandTest.php
@@ -170,6 +170,10 @@ YAML;
      */
     public function testComplete(array $input, array $expectedSuggestions)
     {
+        if (!class_exists(CommandCompletionTester::class)) {
+            $this->markTestSkipped('Test command completion requires symfony/console 5.4+.');
+        }
+
         $tester = new CommandCompletionTester($this->createCommand());
 
         $this->assertSame($expectedSuggestions, $tester->complete($input));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 
