### PR TITLE
added missing translations for Serbian (sr_Cyrl) #43733

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.sr_Cyrl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sr_Cyrl.xlf
@@ -394,6 +394,14 @@
                 <source>This value is not a valid CSS color.</source>
                 <target>Ова вредност није исправна CSS боја.</target>
             </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target>Ова вредност није исправна CIDR нотација.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target>Вредност мрежне маске треба бити између {{ min }} и {{ max }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43733 
| License       | MIT
| Doc PR        | 

Added Serbian Cyrillic translations for Ids 102 and 103
