### PR TITLE
added missing translations for Serbian Latin (sr_Latn) #43734

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.sr_Latn.xlf
@@ -394,6 +394,14 @@
                 <source>This value is not a valid CSS color.</source>
                 <target>Ova vrednost nije ispravna CSS boja.</target>
             </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target>Ova vrednost nije ispravna CIDR notacija.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target>Vrednost mrežne maske treba biti između {{ min }} i {{ max }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43734
| License       | MIT
| Doc PR        | 

Added missing translations 102 and 103 for Serbian Latin (sr_Latn) #43734