### PR TITLE
[WebProfilerBundle] Add a "preview" tab in mailer profiler for HTML email

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/WebProfilerBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+5.4
+---
+
+ * Add a "preview" tab in mailer profiler for HTML email
+
 5.2.0
 -----
 
@@ -33,7 +38,7 @@ CHANGELOG
 -----
 
  * added information about orphaned events
- * made the toolbar auto-update with info from ajax reponses when they set the 
+ * made the toolbar auto-update with info from ajax reponses when they set the
    `Symfony-Debug-Toolbar-Replace header` to `1`
 
 4.0.0

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/mailer.html.twig
@@ -142,6 +142,18 @@
                                             {% if message.htmlBody is defined %}
                                                 {# Email instance #}
                                                 <div class="tab">
+                                                    <h3 class="tab-title">HTML preview</h3>
+                                                    <div class="tab-content">
+                                                        <pre class="prewrap" style="max-height: 600px">
+                                                            <iframe
+                                                                src="data:text/html;base64;charset=utf-8,{{ collector.base64Encode(message.htmlBody()) }}"
+                                                                style="height: 80vh;width: 100%;"
+                                                            >
+                                                            </iframe>
+                                                        </pre>
+                                                    </div>
+                                                </div>
+                                                <div class="tab">
                                                     <h3 class="tab-title">HTML Content</h3>
                                                     <div class="tab-content">
                                                         <pre class="prewrap" style="max-height: 600px">

--- a/src/Symfony/Component/Mailer/DataCollector/MessageDataCollector.php
+++ b/src/Symfony/Component/Mailer/DataCollector/MessageDataCollector.php
@@ -43,6 +43,14 @@ final class MessageDataCollector extends DataCollector
     }
 
     /**
+     * @internal
+     */
+    public function base64Encode(string $data): string
+    {
+        return base64_encode($data);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function reset()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       |
| License       | MIT
| Doc PR        | no need

I did not work with mail for a long time, and I just discover the new entry in the profile. This is very nice 👏🏼 
But I miss a preview rendering, so here we go

![image](https://user-images.githubusercontent.com/408368/138895761-7a6f49a4-d670-44e6-b59b-093eb59b924b.png)
