### PR TITLE
[DoctrineBridge] Determine attribute or annotation type for directories

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -89,25 +89,8 @@ abstract class AbstractDoctrineExtension extends Extension
                 if (!$mappingConfig) {
                     continue;
                 }
-            } elseif (!$mappingConfig['type'] && \PHP_VERSION_ID < 80000) {
-                $mappingConfig['type'] = 'annotation';
             } elseif (!$mappingConfig['type']) {
-                $mappingConfig['type'] = 'attribute';
-
-                $glob = new GlobResource($mappingConfig['dir'], '*', true);
-                $container->addResource($glob);
-
-                foreach ($glob as $file) {
-                    $content = file_get_contents($file);
-
-                    if (preg_match('/^#\[.*Entity\b/m', $content)) {
-                        break;
-                    }
-                    if (preg_match('/^ \* @.*Entity\b/m', $content)) {
-                        $mappingConfig['type'] = 'annotation';
-                        break;
-                    }
-                }
+                $mappingConfig['type'] = $this->detectMappingType($mappingConfig['dir'], $container);
             }
 
             $this->assertValidMappingConfiguration($mappingConfig, $objectManager['name']);
@@ -259,7 +242,7 @@ abstract class AbstractDoctrineExtension extends Extension
     /**
      * Detects what metadata driver to use for the supplied directory.
      *
-     * @return string|null
+     * @return string|null A metadata driver short name, if one can be detected
      */
     protected function detectMetadataDriver(string $dir, ContainerBuilder $container)
     {
@@ -280,11 +263,46 @@ abstract class AbstractDoctrineExtension extends Extension
             }
             $container->fileExists($resource, false);
 
-            return $container->fileExists($dir.'/'.$this->getMappingObjectDefaultName(), false) ? 'annotation' : null;
+            if ($container->fileExists($dir.'/'.$this->getMappingObjectDefaultName(), false)) {
+                return $this->detectMappingType($dir, $container);
+            }
+
+            return null;
         }
         $container->fileExists($dir.'/'.$configPath, false);
 
         return $driver;
+    }
+
+    /**
+     * Detects what mapping type to use for the supplied directory.
+     *
+     * @return string A mapping type 'attribute' or 'annotation'
+     */
+    private function detectMappingType(string $directory, ContainerBuilder $container): string
+    {
+        if (\PHP_VERSION_ID < 80000) {
+            return 'annotation';
+        }
+
+        $type = 'attribute';
+
+        $glob = new GlobResource($directory, '*', true);
+        $container->addResource($glob);
+
+        foreach ($glob as $file) {
+            $content = file_get_contents($file);
+
+            if (preg_match('/^#\[.*Entity\b/m', $content)) {
+                break;
+            }
+            if (preg_match('/^ \* @.*Entity\b/m', $content)) {
+                $type = 'annotation';
+                break;
+            }
+        }
+
+        return $type;
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/DoctrineExtensionTest.php
@@ -171,6 +171,23 @@ class DoctrineExtensionTest extends TestCase
         ], $expectedEm2));
     }
 
+    public function testMappingTypeDetection()
+    {
+        $container = $this->createContainer();
+
+        $reflection = new \ReflectionClass(\get_class($this->extension));
+        $method = $reflection->getMethod('detectMappingType');
+        $method->setAccessible(true);
+
+        // The ordinary fixtures contain annotation
+        $mappingType = $method->invoke($this->extension, __DIR__.'/../Fixtures', $container);
+        $this->assertSame($mappingType, 'annotation');
+
+        // In the attribute folder, attributes are used
+        $mappingType = $method->invoke($this->extension, __DIR__.'/../Fixtures/Attribute', $container);
+        $this->assertSame($mappingType, \PHP_VERSION_ID < 80000 ? 'annotation' : 'attribute');
+    }
+
     public function providerBasicDrivers()
     {
         return [

--- a/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Attribute/UuidIdEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Fixtures/Attribute/UuidIdEntity.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Tests\Fixtures\Attribute;
+
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\Id;
+
+#[Entity]
+class UuidIdEntity
+{
+    #[Id]
+    #[Column("uuid")]
+    protected $id;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43753
| License       | MIT

When loading a bundle with a Doctrine entity, this entity is automatically recognized if auto_mapping: true is set in the Doctrine DBAL configuration. This currently only works if your entity class uses annotations, not attributes; this pull request adds that possibility.
