### PR TITLE
[Dotenv] Add $overrideExistingVars to bootEnv() and  loadEnv() and dotenv_overload to SymfonyRuntime

### DIFF
--- a/src/Symfony/Component/Dotenv/CHANGELOG.md
+++ b/src/Symfony/Component/Dotenv/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * Add `dotenv:dump` command to compile the contents of the .env files into a PHP-optimized file called `.env.local.php`
  * Add `debug:dotenv` command to list all dotenv files with variables and values
+ * Add `$overrideExistingVars` on `Dotenv::bootEnv()` and `Dotenv::loadEnv()`
 
 5.1.0
 -----

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -236,6 +236,9 @@ class DotenvTest extends TestCase
             putenv('SYMFONY_DOTENV_VARS');
             putenv('FOO');
             putenv('TEST_APP_ENV');
+
+            $_ENV['EXISTING_KEY'] = $_SERVER['EXISTING_KEY'] = 'EXISTING_VALUE';
+            putenv('EXISTING_KEY=EXISTING_VALUE');
         };
 
         @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
@@ -243,54 +246,107 @@ class DotenvTest extends TestCase
         $path = tempnam($tmpdir, 'sf-');
 
         // .env
-        file_put_contents($path, 'FOO=BAR');
+        file_put_contents($path, "FOO=BAR\nEXISTING_KEY=NEW_VALUE");
 
         $resetContext();
         (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('BAR', getenv('FOO'));
         $this->assertSame('dev', getenv('TEST_APP_ENV'));
+        $this->assertSame('EXISTING_VALUE', getenv('EXISTING_KEY'));
+        $this->assertSame('EXISTING_VALUE', $_ENV['EXISTING_KEY']);
+
+        $resetContext();
+        (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV', 'dev', ['test'], true);
+        $this->assertSame('BAR', getenv('FOO'));
+        $this->assertSame('dev', getenv('TEST_APP_ENV'));
+        $this->assertSame('NEW_VALUE', getenv('EXISTING_KEY'));
+        $this->assertSame('NEW_VALUE', $_ENV['EXISTING_KEY']);
 
         // .env.local
-        file_put_contents("$path.local", 'FOO=localBAR');
+        file_put_contents("$path.local", "FOO=localBAR\nEXISTING_KEY=localNEW_VALUE");
 
         $resetContext();
         $_SERVER['TEST_APP_ENV'] = 'local';
         (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('localBAR', getenv('FOO'));
+        $this->assertSame('EXISTING_VALUE', getenv('EXISTING_KEY'));
+        $this->assertSame('EXISTING_VALUE', $_ENV['EXISTING_KEY']);
+
+        $resetContext();
+        $_SERVER['TEST_APP_ENV'] = 'local';
+        (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV', 'dev', ['test'], true);
+        $this->assertSame('localBAR', getenv('FOO'));
+        $this->assertSame('localNEW_VALUE', getenv('EXISTING_KEY'));
+        $this->assertSame('localNEW_VALUE', $_ENV['EXISTING_KEY']);
 
         // special case for test
         $resetContext();
         $_SERVER['TEST_APP_ENV'] = 'test';
         (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('BAR', getenv('FOO'));
+        $this->assertSame('EXISTING_VALUE', getenv('EXISTING_KEY'));
+        $this->assertSame('EXISTING_VALUE', $_ENV['EXISTING_KEY']);
+
+        $resetContext();
+        $_SERVER['TEST_APP_ENV'] = 'test';
+        (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV', 'dev', ['test'], true);
+        $this->assertSame('BAR', getenv('FOO'));
+        $this->assertSame('NEW_VALUE', getenv('EXISTING_KEY'));
+        $this->assertSame('NEW_VALUE', $_ENV['EXISTING_KEY']);
 
         // .env.dev
-        file_put_contents("$path.dev", 'FOO=devBAR');
+        file_put_contents("$path.dev", "FOO=devBAR\nEXISTING_KEY=devNEW_VALUE");
 
         $resetContext();
         (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('devBAR', getenv('FOO'));
+        $this->assertSame('EXISTING_VALUE', getenv('EXISTING_KEY'));
+        $this->assertSame('EXISTING_VALUE', $_ENV['EXISTING_KEY']);
+
+        $resetContext();
+        (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV', 'dev', ['test'], true);
+        $this->assertSame('devBAR', getenv('FOO'));
+        $this->assertSame('devNEW_VALUE', getenv('EXISTING_KEY'));
+        $this->assertSame('devNEW_VALUE', $_ENV['EXISTING_KEY']);
 
         // .env.dev.local
-        file_put_contents("$path.dev.local", 'FOO=devlocalBAR');
+        file_put_contents("$path.dev.local", "FOO=devlocalBAR\nEXISTING_KEY=devlocalNEW_VALUE");
 
         $resetContext();
         (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('devlocalBAR', getenv('FOO'));
+        $this->assertSame('EXISTING_VALUE', getenv('EXISTING_KEY'));
+        $this->assertSame('EXISTING_VALUE', $_ENV['EXISTING_KEY']);
+
+        $resetContext();
+        (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV', 'dev', ['test'], true);
+        $this->assertSame('devlocalBAR', getenv('FOO'));
+        $this->assertSame('devlocalNEW_VALUE', getenv('EXISTING_KEY'));
+        $this->assertSame('devlocalNEW_VALUE', $_ENV['EXISTING_KEY']);
         unlink("$path.local");
         unlink("$path.dev");
         unlink("$path.dev.local");
 
         // .env.dist
-        file_put_contents("$path.dist", 'FOO=distBAR');
+        file_put_contents("$path.dist", "FOO=distBAR\nEXISTING_KEY=distNEW_VALUE");
 
         $resetContext();
         unlink($path);
         (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV');
         $this->assertSame('distBAR', getenv('FOO'));
+        $this->assertSame('EXISTING_VALUE', getenv('EXISTING_KEY'));
+        $this->assertSame('EXISTING_VALUE', $_ENV['EXISTING_KEY']);
+
+        $resetContext();
+        (new Dotenv())->usePutenv()->loadEnv($path, 'TEST_APP_ENV', 'dev', ['test'], true);
+        $this->assertSame('distBAR', getenv('FOO'));
+        $this->assertSame('distNEW_VALUE', getenv('EXISTING_KEY'));
+        $this->assertSame('distNEW_VALUE', $_ENV['EXISTING_KEY']);
         unlink("$path.dist");
 
         $resetContext();
+        unset($_ENV['EXISTING_KEY'], $_SERVER['EXISTING_KEY']);
+        putenv('EXISTING_KEY');
         rmdir($tmpdir);
     }
 
@@ -490,22 +546,37 @@ class DotenvTest extends TestCase
             unset($_SERVER['TEST_APP_ENV'], $_ENV['TEST_APP_ENV']);
             unset($_SERVER['TEST_APP_DEBUG'], $_ENV['TEST_APP_DEBUG']);
             unset($_SERVER['FOO'], $_ENV['FOO']);
+
+            $_ENV['EXISTING_KEY'] = $_SERVER['EXISTING_KEY'] = 'EXISTING_VALUE';
         };
 
         @mkdir($tmpdir = sys_get_temp_dir().'/dotenv');
         $path = tempnam($tmpdir, 'sf-');
 
-        file_put_contents($path, 'FOO=BAR');
+        file_put_contents($path, "FOO=BAR\nEXISTING_KEY=NEW_VALUE");
         $resetContext();
         (new Dotenv('TEST_APP_ENV', 'TEST_APP_DEBUG'))->bootEnv($path);
         $this->assertSame('BAR', $_SERVER['FOO']);
+        $this->assertSame('EXISTING_VALUE', $_SERVER['EXISTING_KEY']);
+
+        $resetContext();
+        (new Dotenv('TEST_APP_ENV', 'TEST_APP_DEBUG'))->bootEnv($path, 'dev', ['test'], true);
+        $this->assertSame('BAR', $_SERVER['FOO']);
+        $this->assertSame('NEW_VALUE', $_SERVER['EXISTING_KEY']);
         unlink($path);
 
-        file_put_contents($path.'.local.php', '<?php return ["TEST_APP_ENV" => "dev", "FOO" => "BAR"];');
+        file_put_contents($path.'.local.php', '<?php return ["TEST_APP_ENV" => "dev", "FOO" => "BAR", "EXISTING_KEY" => "localphpNEW_VALUE"];');
         $resetContext();
         (new Dotenv('TEST_APP_ENV', 'TEST_APP_DEBUG'))->bootEnv($path);
         $this->assertSame('BAR', $_SERVER['FOO']);
         $this->assertSame('1', $_SERVER['TEST_APP_DEBUG']);
+        $this->assertSame('EXISTING_VALUE', $_SERVER['EXISTING_KEY']);
+
+        $resetContext();
+        (new Dotenv('TEST_APP_ENV', 'TEST_APP_DEBUG'))->bootEnv($path, 'dev', ['test'], true);
+        $this->assertSame('BAR', $_SERVER['FOO']);
+        $this->assertSame('1', $_SERVER['TEST_APP_DEBUG']);
+        $this->assertSame('localphpNEW_VALUE', $_SERVER['EXISTING_KEY']);
         unlink($path.'.local.php');
 
         $resetContext();

--- a/src/Symfony/Component/Runtime/CHANGELOG.md
+++ b/src/Symfony/Component/Runtime/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * The component is not experimental anymore
  * Add options "env_var_name" and "debug_var_name" to `GenericRuntime` and `SymfonyRuntime`
+ * Add option "dotenv_overload" to `SymfonyRuntime`
 
 5.3.0
 -----

--- a/src/Symfony/Component/Runtime/SymfonyRuntime.php
+++ b/src/Symfony/Component/Runtime/SymfonyRuntime.php
@@ -40,6 +40,7 @@ class_exists(MissingDotenv::class, false) || class_exists(Dotenv::class) || clas
  *  - "prod_envs" to define the names of the production envs - defaults to ["prod"];
  *  - "test_envs" to define the names of the test envs - defaults to ["test"];
  *  - "use_putenv" to tell Dotenv to set env vars using putenv() (NOT RECOMMENDED.)
+ *  - "dotenv_overload" to tell Dotenv to override existing vars
  *
  * When the "debug" / "env" options are not defined, they will fallback to the
  * "APP_DEBUG" / "APP_ENV" environment variables, and to the "--env|-e" / "--no-debug"
@@ -84,6 +85,7 @@ class SymfonyRuntime extends GenericRuntime
      *   error_handler?: string|false,
      *   env_var_name?: string,
      *   debug_var_name?: string,
+     *   dotenv_overload?: ?bool,
      * } $options
      */
     public function __construct(array $options = [])
@@ -102,7 +104,7 @@ class SymfonyRuntime extends GenericRuntime
             (new Dotenv($envKey, $debugKey))
                 ->setProdEnvs((array) ($options['prod_envs'] ?? ['prod']))
                 ->usePutenv($options['use_putenv'] ?? false)
-                ->bootEnv($options['project_dir'].'/'.($options['dotenv_path'] ?? '.env'), 'dev', (array) ($options['test_envs'] ?? ['test']));
+                ->bootEnv($options['project_dir'].'/'.($options['dotenv_path'] ?? '.env'), 'dev', (array) ($options['test_envs'] ?? ['test']), $options['dotenv_overload'] ?? false);
             $options['debug'] ?? $options['debug'] = '1' === $_SERVER[$debugKey];
             $options['disable_dotenv'] = true;
         } else {

--- a/src/Symfony/Component/Runtime/Tests/phpt/autoload.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/autoload.php
@@ -2,7 +2,8 @@
 
 use Symfony\Component\Runtime\SymfonyRuntime;
 
-$_SERVER['APP_RUNTIME_OPTIONS'] = [
+$_SERVER['APP_RUNTIME_OPTIONS'] = $_SERVER['APP_RUNTIME_OPTIONS'] ?? [];
+$_SERVER['APP_RUNTIME_OPTIONS'] += [
     'project_dir' => __DIR__,
 ] + ($_SERVER['APP_RUNTIME_OPTIONS'] ?? []);
 

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload.php
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload.php
@@ -1,0 +1,15 @@
+<?php
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+$_SERVER['SOME_VAR'] = 'ccc';
+$_SERVER['APP_RUNTIME_OPTIONS'] = [
+    'dotenv_overload' => true,
+];
+
+require __DIR__.'/autoload.php';
+
+return function (Request $request, array $context) {
+    return new Response('OK Request '.$context['SOME_VAR']);
+};

--- a/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload.phpt
+++ b/src/Symfony/Component/Runtime/Tests/phpt/dotenv_overload.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test Dotenv overload
+--SKIPIF--
+<?php require dirname(__DIR__, 6).'/vendor/autoload.php'; if (4 > (new \ReflectionMethod(\Symfony\Component\Dotenv\Dotenv::class, 'bootEnv'))->getNumberOfParameters()) die('Skip because Dotenv version is too low');
+--INI--
+display_errors=1
+--FILE--
+<?php
+
+require $_SERVER['SCRIPT_FILENAME'] = __DIR__.'/dotenv_overload.php';
+
+?>
+--EXPECTF--
+OK Request foo_bar


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | https://github.com/symfony/symfony/pull/41681#discussion_r696655398
| License       | MIT
| Doc PR        | -

The goal is to be able to use `bootEnv()` and `loadEnv()` and override existing vars directly instead of having to call `overload()` in a second time.