### PR TITLE
Event listener from attribute should not have a default priority

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Attribute/AsEventListener.php
+++ b/src/Symfony/Component/EventDispatcher/Attribute/AsEventListener.php
@@ -22,7 +22,7 @@ class AsEventListener
     public function __construct(
         public ?string $event = null,
         public ?string $method = null,
-        public int $priority = 0,
+        public ?int $priority = null,
         public ?string $dispatcher = null,
     ) {
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | ~
| License       | MIT
| Doc PR        | ~

There is a difference between a service not having a priority and a priority of being `0`. If there is no priority (or it is `null`), the event listener/service can provide a method to return the priority. This would be disabled by a default value of `0`.

see https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/DependencyInjection/Compiler/PriorityTaggedServiceTrait.php#L68-L72
