### PR TITLE
[Validator] Add missing translations for Bulgarian

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.bg.xlf
@@ -394,6 +394,14 @@
                 <source>This value is not a valid CSS color.</source>
                 <target>Стойността не е валиден CSS цвят.</target>
             </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target>Стойността не е валидна CIDR нотация.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target>Стойността на мрежовата маска трябва да бъде между {{ min }} и {{ max }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4 
| Bug fix?      | no 
| New feature?  | no 
| Deprecations? | no 
| Tickets       | #43710 
| License       | MIT

Adds missing Bulgarian Validator translations