### PR TITLE
[Validator] Add missing translations for Lithuanian (lt)

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.lt.xlf
@@ -394,6 +394,14 @@
                 <source>This value is not a valid CSS color.</source>
                 <target>Ši reikšmė nėra tinkama CSS spalva.</target>
             </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target>Ši vertė nėra tinkamas CIDR žymėjimas.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target>Tinklo kaukės reikšmė turi būti nuo {{ min }} iki {{ max }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43724
| License       | MIT
| Doc PR        |

Additionally (see https://symfony.com/releases):
 - Add missing translations for Lithuanian (lt)