### PR TITLE
Use try/finally to restore error handlers

### DIFF
--- a/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
+++ b/src/Symfony/Bridge/PhpUnit/DeprecationErrorHandler/Deprecation.php
@@ -102,8 +102,11 @@ class Deprecation
         }
 
         set_error_handler(function () {});
-        $parsedMsg = unserialize($this->message);
-        restore_error_handler();
+        try {
+            $parsedMsg = unserialize($this->message);
+        } finally {
+            restore_error_handler();
+        }
         if ($parsedMsg && isset($parsedMsg['deprecation'])) {
             $this->message = $parsedMsg['deprecation'];
             $this->originClass = $parsedMsg['class'];

--- a/src/Symfony/Component/Cache/Traits/RedisTrait.php
+++ b/src/Symfony/Component/Cache/Traits/RedisTrait.php
@@ -205,8 +205,11 @@ trait RedisTrait
                     @$redis->{$connect}($host, $port, $params['timeout'], (string) $params['persistent_id'], $params['retry_interval'], $params['read_timeout'], ...\defined('Redis::SCAN_PREFIX') ? [['stream' => $params['ssl'] ?? null]] : []);
 
                     set_error_handler(function ($type, $msg) use (&$error) { $error = $msg; });
-                    $isConnected = $redis->isConnected();
-                    restore_error_handler();
+                    try {
+                        $isConnected = $redis->isConnected();
+                    } finally {
+                        restore_error_handler();
+                    }
                     if (!$isConnected) {
                         $error = preg_match('/^Redis::p?connect\(\): (.*)/', $error, $error) ? sprintf(' (%s)', $error[1]) : '';
                         throw new InvalidArgumentException(sprintf('Redis connection "%s" failed: ', $dsn).$error.'.');

--- a/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ArrayNodeTest.php
@@ -254,14 +254,19 @@ class ArrayNodeTest extends TestCase
         };
 
         $prevErrorHandler = set_error_handler($deprecationHandler);
-        $node->finalize([]);
-        restore_error_handler();
-
+        try {
+            $node->finalize([]);
+        } finally {
+            restore_error_handler();
+        }
         $this->assertFalse($deprecationTriggered, '->finalize() should not trigger if the deprecated node is not set');
 
         $prevErrorHandler = set_error_handler($deprecationHandler);
-        $node->finalize(['foo' => []]);
-        restore_error_handler();
+        try {
+            $node->finalize(['foo' => []]);
+        } finally {
+            restore_error_handler();
+        }
         $this->assertTrue($deprecationTriggered, '->finalize() should trigger if the deprecated node is set');
     }
 

--- a/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
@@ -67,13 +67,19 @@ class ScalarNodeTest extends TestCase
         };
 
         $prevErrorHandler = set_error_handler($deprecationHandler);
-        $node->finalize([]);
-        restore_error_handler();
+        try {
+            $node->finalize([]);
+        } finally {
+            restore_error_handler();
+        }
         $this->assertSame(0, $deprecationTriggered, '->finalize() should not trigger if the deprecated node is not set');
 
         $prevErrorHandler = set_error_handler($deprecationHandler);
-        $node->finalize(['foo' => '']);
-        restore_error_handler();
+        try {
+            $node->finalize(['foo' => '']);
+        } finally {
+            restore_error_handler();
+        }
         $this->assertSame(1, $deprecationTriggered, '->finalize() should trigger if the deprecated node is set');
     }
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -737,15 +737,10 @@ class Filesystem
         self::$lastError = null;
         set_error_handler(__CLASS__.'::handleError');
         try {
-            $result = $func(...$args);
+            return $func(...$args);
+        } finally {
             restore_error_handler();
-
-            return $result;
-        } catch (\Throwable $e) {
         }
-        restore_error_handler();
-
-        throw $e;
     }
 
     /**

--- a/src/Symfony/Component/Finder/SplFileInfo.php
+++ b/src/Symfony/Component/Finder/SplFileInfo.php
@@ -74,8 +74,11 @@ class SplFileInfo extends \SplFileInfo
     public function getContents()
     {
         set_error_handler(function ($type, $msg) use (&$error) { $error = $msg; });
-        $content = file_get_contents($this->getPathname());
-        restore_error_handler();
+        try {
+            $content = file_get_contents($this->getPathname());
+        } finally {
+            restore_error_handler();
+        }
         if (false === $content) {
             throw new \RuntimeException($error);
         }

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -93,8 +93,11 @@ class File extends \SplFileInfo
         $target = $this->getTargetFile($directory, $name);
 
         set_error_handler(function ($type, $msg) use (&$error) { $error = $msg; });
-        $renamed = rename($this->getPathname(), $target);
-        restore_error_handler();
+        try {
+            $renamed = rename($this->getPathname(), $target);
+        } finally {
+            restore_error_handler();
+        }
         if (!$renamed) {
             throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s).', $this->getPathname(), $target, strip_tags($error)));
         }

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -182,8 +182,11 @@ class UploadedFile extends File
             $target = $this->getTargetFile($directory, $name);
 
             set_error_handler(function ($type, $msg) use (&$error) { $error = $msg; });
-            $moved = move_uploaded_file($this->getPathname(), $target);
-            restore_error_handler();
+            try {
+                $moved = move_uploaded_file($this->getPathname(), $target);
+            } finally {
+                restore_error_handler();
+            }
             if (!$moved) {
                 throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s).', $this->getPathname(), $target, strip_tags($error)));
             }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/DebugHandlersListenerTest.php
@@ -50,9 +50,10 @@ class DebugHandlersListenerTest extends TestCase
         try {
             $listener->configure();
         } catch (\Exception $exception) {
+        } finally {
+            restore_exception_handler();
+            restore_error_handler();
         }
-        restore_exception_handler();
-        restore_error_handler();
 
         if (null !== $exception) {
             throw $exception;
@@ -116,9 +117,10 @@ class DebugHandlersListenerTest extends TestCase
         try {
             $dispatcher->dispatch($event, ConsoleEvents::COMMAND);
         } catch (\Exception $exception) {
+        } finally {
+            restore_exception_handler();
+            restore_error_handler();
         }
-        restore_exception_handler();
-        restore_error_handler();
 
         if (null !== $exception) {
             throw $exception;

--- a/src/Symfony/Component/Lock/Store/FlockStore.php
+++ b/src/Symfony/Component/Lock/Store/FlockStore.php
@@ -106,15 +106,18 @@ class FlockStore implements BlockingStoreInterface, SharedLockStoreInterface
 
             // Silence error reporting
             set_error_handler(function ($type, $msg) use (&$error) { $error = $msg; });
-            if (!$handle = fopen($fileName, 'r+') ?: fopen($fileName, 'r')) {
-                if ($handle = fopen($fileName, 'x')) {
-                    chmod($fileName, 0666);
-                } elseif (!$handle = fopen($fileName, 'r+') ?: fopen($fileName, 'r')) {
-                    usleep(100); // Give some time for chmod() to complete
-                    $handle = fopen($fileName, 'r+') ?: fopen($fileName, 'r');
+            try {
+                if (!$handle = fopen($fileName, 'r+') ?: fopen($fileName, 'r')) {
+                    if ($handle = fopen($fileName, 'x')) {
+                        chmod($fileName, 0666);
+                    } elseif (!$handle = fopen($fileName, 'r+') ?: fopen($fileName, 'r')) {
+                        usleep(100); // Give some time for chmod() to complete
+                        $handle = fopen($fileName, 'r+') ?: fopen($fileName, 'r');
+                    }
                 }
+            } finally {
+                restore_error_handler();
             }
-            restore_error_handler();
         }
 
         if (!$handle) {

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -537,11 +537,13 @@ class OptionsResolverTest extends TestCase
         });
         $e = error_reporting(0);
 
-        $configureOptions($this->resolver);
-        $this->resolver->resolve($options);
-
-        error_reporting($e);
-        restore_error_handler();
+        try {
+            $configureOptions($this->resolver);
+            $this->resolver->resolve($options);
+        } finally {
+            error_reporting($e);
+            restore_error_handler();
+        }
 
         $lastError = error_get_last();
         unset($lastError['file'], $lastError['line']);

--- a/src/Symfony/Component/Routing/Matcher/Dumper/StaticPrefixCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/StaticPrefixCollection.php
@@ -151,40 +151,43 @@ class StaticPrefixCollection
         $staticLength = null;
         set_error_handler([__CLASS__, 'handleError']);
 
-        for ($i = $baseLength; $i < $end && $prefix[$i] === $anotherPrefix[$i]; ++$i) {
-            if ('(' === $prefix[$i]) {
-                $staticLength = $staticLength ?? $i;
-                for ($j = 1 + $i, $n = 1; $j < $end && 0 < $n; ++$j) {
-                    if ($prefix[$j] !== $anotherPrefix[$j]) {
-                        break 2;
+        try {
+            for ($i = $baseLength; $i < $end && $prefix[$i] === $anotherPrefix[$i]; ++$i) {
+                if ('(' === $prefix[$i]) {
+                    $staticLength = $staticLength ?? $i;
+                    for ($j = 1 + $i, $n = 1; $j < $end && 0 < $n; ++$j) {
+                        if ($prefix[$j] !== $anotherPrefix[$j]) {
+                            break 2;
+                        }
+                        if ('(' === $prefix[$j]) {
+                            ++$n;
+                        } elseif (')' === $prefix[$j]) {
+                            --$n;
+                        } elseif ('\\' === $prefix[$j] && (++$j === $end || $prefix[$j] !== $anotherPrefix[$j])) {
+                            --$j;
+                            break;
+                        }
                     }
-                    if ('(' === $prefix[$j]) {
-                        ++$n;
-                    } elseif (')' === $prefix[$j]) {
-                        --$n;
-                    } elseif ('\\' === $prefix[$j] && (++$j === $end || $prefix[$j] !== $anotherPrefix[$j])) {
-                        --$j;
+                    if (0 < $n) {
                         break;
                     }
-                }
-                if (0 < $n) {
+                    if (('?' === ($prefix[$j] ?? '') || '?' === ($anotherPrefix[$j] ?? '')) && ($prefix[$j] ?? '') !== ($anotherPrefix[$j] ?? '')) {
+                        break;
+                    }
+                    $subPattern = substr($prefix, $i, $j - $i);
+                    if ($prefix !== $anotherPrefix && !preg_match('/^\(\[[^\]]++\]\+\+\)$/', $subPattern) && !preg_match('{(?<!'.$subPattern.')}', '')) {
+                        // sub-patterns of variable length are not considered as common prefixes because their greediness would break in-order matching
+                        break;
+                    }
+                    $i = $j - 1;
+                } elseif ('\\' === $prefix[$i] && (++$i === $end || $prefix[$i] !== $anotherPrefix[$i])) {
+                    --$i;
                     break;
                 }
-                if (('?' === ($prefix[$j] ?? '') || '?' === ($anotherPrefix[$j] ?? '')) && ($prefix[$j] ?? '') !== ($anotherPrefix[$j] ?? '')) {
-                    break;
-                }
-                $subPattern = substr($prefix, $i, $j - $i);
-                if ($prefix !== $anotherPrefix && !preg_match('/^\(\[[^\]]++\]\+\+\)$/', $subPattern) && !preg_match('{(?<!'.$subPattern.')}', '')) {
-                    // sub-patterns of variable length are not considered as common prefixes because their greediness would break in-order matching
-                    break;
-                }
-                $i = $j - 1;
-            } elseif ('\\' === $prefix[$i] && (++$i === $end || $prefix[$i] !== $anotherPrefix[$i])) {
-                --$i;
-                break;
             }
+        } finally {
+            restore_error_handler();
         }
-        restore_error_handler();
         if ($i < $end && 0b10 === (\ord($prefix[$i]) >> 6) && preg_match('//u', $prefix.' '.$anotherPrefix)) {
             do {
                 // Prevent cutting in the middle of an UTF-8 characters

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -298,11 +298,11 @@ class ContextListener extends AbstractListener
 
     private function safelyUnserialize(string $serializedToken)
     {
-        $e = $token = null;
+        $token = null;
         $prevUnserializeHandler = ini_set('unserialize_callback_func', __CLASS__.'::handleUnserializeCallback');
         $prevErrorHandler = set_error_handler(function ($type, $msg, $file, $line, $context = []) use (&$prevErrorHandler) {
             if (__FILE__ === $file) {
-                throw new \ErrorException($msg, 0x37313bc, $type, $file, $line);
+                throw new \ErrorException($msg, 0x37313BC, $type, $file, $line);
             }
 
             return $prevErrorHandler ? $prevErrorHandler($type, $msg, $file, $line, $context) : false;
@@ -310,17 +310,16 @@ class ContextListener extends AbstractListener
 
         try {
             $token = unserialize($serializedToken);
-        } catch (\Throwable $e) {
-        }
-        restore_error_handler();
-        ini_set('unserialize_callback_func', $prevUnserializeHandler);
-        if ($e) {
-            if (!$e instanceof \ErrorException || 0x37313bc !== $e->getCode()) {
+        } catch (\ErrorException $e) {
+            if (0x37313BC !== $e->getCode()) {
                 throw $e;
             }
             if ($this->logger) {
                 $this->logger->warning('Failed to unserialize the security token from the session.', ['key' => $this->sessionKey, 'received' => $serializedToken, 'exception' => $e]);
             }
+        } finally {
+            restore_error_handler();
+            ini_set('unserialize_callback_func', $prevUnserializeHandler);
         }
 
         return $token;
@@ -388,7 +387,7 @@ class ContextListener extends AbstractListener
      */
     public static function handleUnserializeCallback(string $class)
     {
-        throw new \ErrorException('Class not found: '.$class, 0x37313bc);
+        throw new \ErrorException('Class not found: '.$class, 0x37313BC);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

This PR attempts to make some code dealing with temporary error handlers a bit more robust by making sure the old error handler is always restored. A forgotten error handler is pretty hard to debug, so I'd like our code to be a it more defensive here.