### PR TITLE
Change count array comparison to empty array comparison to improve performance

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -55,7 +55,7 @@ class UniqueEntityValidator extends ConstraintValidator
 
         $fields = (array) $constraint->fields;
 
-        if (0 === \count($fields)) {
+        if ([] === $fields) {
             throw new ConstraintDefinitionException('At least one field has to be specified.');
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -236,7 +236,7 @@ EOF
             : new MergeOperation($currentCatalogue, $extractedCatalogue);
 
         // Exit if no messages found.
-        if (!\count($operation->getDomains())) {
+        if ($operation->getDomains() === []) {
             $errorIo->warning('No translation messages were found.');
 
             return 0;

--- a/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
+++ b/src/Symfony/Component/Asset/VersionStrategy/JsonManifestVersionStrategy.php
@@ -98,7 +98,7 @@ class JsonManifestVersionStrategy implements VersionStrategyInterface
         if ($this->strictMode) {
             $message = sprintf('Asset "%s" not found in manifest "%s".', $path, $this->manifestPath);
             $alternatives = $this->findAlternatives($path, $this->manifestData);
-            if (\count($alternatives) > 0) {
+            if ($alternatives !== []) {
                 $message .= sprintf(' Did you mean one of these? "%s".', implode('", "', $alternatives));
             }
 

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -312,7 +312,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
 
             $msg = sprintf('Unrecognized option%s "%s" under "%s"', 1 === \count($value) ? '' : 's', implode(', ', array_keys($value)), $this->getPath());
 
-            if (\count($guesses)) {
+            if ($guesses !== []) {
                 asort($guesses);
                 $msg .= sprintf('. Did you mean "%s"?', implode('", "', array_keys($guesses)));
             } else {

--- a/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/Dumper/XmlReferenceDumper.php
@@ -187,7 +187,7 @@ class XmlReferenceDumper
         }
 
         // attribute comments
-        if (\count($rootAttributeComments)) {
+        if ($rootAttributeComments !== []) {
             foreach ($rootAttributeComments as $attrName => $comment) {
                 $commentDepth = $depth + 4 + \strlen($attrName) + 2;
                 $commentLines = explode("\n", $comment);
@@ -206,7 +206,7 @@ class XmlReferenceDumper
 
         // render start tag + attributes
         $rootIsVariablePrototype = isset($prototypeValue);
-        $rootIsEmptyTag = (0 === \count($rootChildren) && !$rootIsVariablePrototype);
+        $rootIsEmptyTag = ([] === $rootChildren && !$rootIsVariablePrototype);
         $rootOpenTag = '<'.$rootName;
         if (1 >= ($attributesCount = \count($rootAttributes))) {
             if (1 === $attributesCount) {

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -210,7 +210,7 @@ class XmlUtils
 
         if (false !== $nodeValue) {
             $value = static::phpize($nodeValue);
-            if (\count($config)) {
+            if ($config !== []) {
                 $config['value'] = $value;
             } else {
                 $config = $value;

--- a/src/Symfony/Component/Console/Color.php
+++ b/src/Symfony/Component/Console/Color.php
@@ -84,7 +84,7 @@ final class Color
         foreach ($this->options as $option) {
             $setCodes[] = $option['set'];
         }
-        if (0 === \count($setCodes)) {
+        if ([] === $setCodes) {
             return '';
         }
 
@@ -103,7 +103,7 @@ final class Color
         foreach ($this->options as $option) {
             $unsetCodes[] = $option['unset'];
         }
-        if (0 === \count($unsetCodes)) {
+        if ([] === $unsetCodes) {
             return '';
         }
 

--- a/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
+++ b/src/Symfony/Component/Console/Descriptor/MarkdownDescriptor.php
@@ -92,7 +92,7 @@ class MarkdownDescriptor extends Descriptor
      */
     protected function describeInputDefinition(InputDefinition $definition, array $options = [])
     {
-        if ($showArguments = \count($definition->getArguments()) > 0) {
+        if ($showArguments = $definition->getArguments() !== []) {
             $this->write('### Arguments');
             foreach ($definition->getArguments() as $argument) {
                 $this->write("\n\n");
@@ -102,7 +102,7 @@ class MarkdownDescriptor extends Descriptor
             }
         }
 
-        if (\count($definition->getOptions()) > 0) {
+        if ($definition->getOptions() !== []) {
             if ($showArguments) {
                 $this->write("\n\n");
             }

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -72,7 +72,7 @@ abstract class Input implements InputInterface, StreamableInputInterface
             return !\array_key_exists($argument, $givenArguments) && $definition->getArgument($argument)->isRequired();
         });
 
-        if (\count($missingArguments) > 0) {
+        if ($missingArguments !== []) {
             throw new RuntimeException(sprintf('Not enough arguments (missing: "%s").', implode(', ', $missingArguments)));
         }
     }

--- a/src/Symfony/Component/Filesystem/Path.php
+++ b/src/Symfony/Component/Filesystem/Path.php
@@ -737,7 +737,7 @@ final class Path
 
             // Collapse ".." with the previous part, if one exists
             // Don't collapse ".." if the previous part is also ".."
-            if ('..' === $part && \count($canonicalParts) > 0 && '..' !== $canonicalParts[\count($canonicalParts) - 1]) {
+            if ('..' === $part && $canonicalParts !== [] && '..' !== $canonicalParts[\count($canonicalParts) - 1]) {
                 array_pop($canonicalParts);
 
                 continue;

--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -97,7 +97,7 @@ abstract class AbstractExtension implements FormExtensionInterface
             $this->initTypeExtensions();
         }
 
-        return isset($this->typeExtensions[$name]) && \count($this->typeExtensions[$name]) > 0;
+        return isset($this->typeExtensions[$name]) && $this->typeExtensions[$name] !== [];
     }
 
     /**

--- a/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
+++ b/src/Symfony/Component/Form/Console/Descriptor/TextDescriptor.php
@@ -167,7 +167,7 @@ class TextDescriptor extends Descriptor
                     unset($options[$group][$class]);
                 }
 
-                if (!\is_array($opt) || 0 === \count($opt)) {
+                if (!\is_array($opt) || [] === $opt) {
                     continue;
                 }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ArrayToPartsTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ArrayToPartsTransformer.php
@@ -70,7 +70,7 @@ class ArrayToPartsTransformer implements DataTransformerInterface
             }
         }
 
-        if (\count($emptyKeys) > 0) {
+        if ($emptyKeys !== []) {
             if (\count($emptyKeys) === \count($this->partMapping)) {
                 // All parts empty
                 return null;

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateIntervalToArrayTransformer.php
@@ -125,7 +125,7 @@ class DateIntervalToArrayTransformer implements DataTransformerInterface
                 $emptyFields[] = $field;
             }
         }
-        if (\count($emptyFields) > 0) {
+        if ($emptyFields !== []) {
             throw new TransformationFailedException(sprintf('The fields "%s" should not be empty.', implode('", "', $emptyFields)));
         }
         if (isset($value['invert']) && !\is_bool($value['invert'])) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -127,7 +127,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
             }
         }
 
-        if (\count($emptyFields) > 0) {
+        if ($emptyFields !== []) {
             throw new TransformationFailedException(sprintf('The fields "%s" should not be empty.', implode('", "', $emptyFields)));
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToDuplicatesTransformer.php
@@ -71,7 +71,7 @@ class ValueToDuplicatesTransformer implements DataTransformerInterface
             }
         }
 
-        if (\count($emptyKeys) > 0) {
+        if ($emptyKeys !== []) {
             if (\count($emptyKeys) == \count($this->keys)) {
                 // All keys empty
                 return null;

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -189,7 +189,7 @@ class FormValidator extends ConstraintValidator
         }
 
         // Mark the form with an error if it contains extra fields
-        if (!$config->getOption('allow_extra_fields') && \count($form->getExtraData()) > 0) {
+        if (!$config->getOption('allow_extra_fields') && $form->getExtraData() !== []) {
             $this->context->setConstraint($formConstraint);
             $this->context->buildViolation($config->getOption('extra_fields_message', ''))
                 ->setParameter('{{ extra_fields }}', '"'.implode('", "', array_keys($form->getExtraData())).'"')

--- a/src/Symfony/Component/Form/FormFactoryBuilder.php
+++ b/src/Symfony/Component/Form/FormFactoryBuilder.php
@@ -170,7 +170,7 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
             }
         }
 
-        if (\count($this->types) > 0 || \count($this->typeExtensions) > 0 || \count($this->typeGuessers) > 0) {
+        if ($this->types !== [] || $this->typeExtensions !== [] || $this->typeGuessers !== []) {
             if (\count($this->typeGuessers) > 1) {
                 $typeGuesser = new FormTypeGuesserChain($this->typeGuessers);
             } else {

--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -63,7 +63,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
      */
     public function isRendered()
     {
-        if (true === $this->rendered || 0 === \count($this->children)) {
+        if (true === $this->rendered || [] === $this->children) {
             return $this->rendered;
         }
 

--- a/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
+++ b/src/Symfony/Component/HttpFoundation/RateLimiter/AbstractRequestRateLimiter.php
@@ -27,7 +27,7 @@ abstract class AbstractRequestRateLimiter implements RequestRateLimiterInterface
     public function consume(Request $request): RateLimit
     {
         $limiters = $this->getLimiters($request);
-        if (0 === \count($limiters)) {
+        if ([] === $limiters) {
             $limiters = [new NoLimiter()];
         }
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1208,7 +1208,7 @@ class Request
             throw new SuspiciousOperationException(sprintf('Invalid Host "%s".', $host));
         }
 
-        if (\count(self::$trustedHostPatterns) > 0) {
+        if (self::$trustedHostPatterns !== []) {
             // to avoid host header injection attacks, you should provide a list of trusted host patterns
 
             if (\in_array($host, self::$trustedHosts)) {

--- a/src/Symfony/Component/HttpFoundation/RequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher.php
@@ -191,6 +191,6 @@ class RequestMatcher implements RequestMatcherInterface
 
         // Note to future implementors: add additional checks above the
         // foreach above or else your check might not be run!
-        return 0 === \count($this->ips);
+        return [] === $this->ips;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -200,7 +200,7 @@ class ControllerResolver implements ControllerResolverInterface
 
         $message = sprintf('Expected method "%s" on class "%s"', $method, $className);
 
-        if (\count($alternatives) > 0) {
+        if ($alternatives !== []) {
             $message .= sprintf(', did you mean "%s"?', implode('", "', $alternatives));
         } else {
             $message .= sprintf('. Available methods: "%s".', implode('", "', $collection));

--- a/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
@@ -80,7 +80,7 @@ class HIncludeFragmentRenderer extends RoutableFragmentRenderer
             $attributes['id'] = $options['id'];
         }
         $renderedAttributes = '';
-        if (\count($attributes) > 0) {
+        if ($attributes !== []) {
             $flags = \ENT_QUOTES | \ENT_SUBSTITUTE;
             foreach ($attributes as $attribute => $value) {
                 $renderedAttributes .= sprintf(

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -674,7 +674,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             $key = strtolower(str_replace('HTTP_', '', $key));
 
             if ('cookie' === $key) {
-                if (\count($request->cookies->all())) {
+                if ($request->cookies->all() !== []) {
                     return true;
                 }
             } elseif ($request->headers->has($key)) {

--- a/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Mailjet/Transport/MailjetApiTransport.php
@@ -79,7 +79,7 @@ class MailjetApiTransport extends AbstractApiTransport
         }
 
         // The response needs to contains a 'Messages' key that is an array
-        if (!\array_key_exists('Messages', $result) || !\is_array($result['Messages']) || 0 === \count($result['Messages'])) {
+        if (!\array_key_exists('Messages', $result) || !\is_array($result['Messages']) || [] === $result['Messages']) {
             throw new HttpTransportException(sprintf('Unable to send an email: "%s" malformed api response.', $response->getContent(false)), $response);
         }
 

--- a/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
+++ b/src/Symfony/Component/Mailer/Bridge/Sendgrid/Transport/SendgridApiTransport.php
@@ -137,11 +137,11 @@ class SendgridApiTransport extends AbstractApiTransport
             }
         }
 
-        if (\count($categories) > 0) {
+        if ($categories !== []) {
             $payload['categories'] = $categories;
         }
 
-        if (\count($customArguments) > 0) {
+        if ($customArguments !== []) {
             $personalization['custom_args'] = $customArguments;
         }
 

--- a/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/AmazonSqs/Transport/Connection.php
@@ -113,13 +113,13 @@ class Connection
 
         // check for extra keys in options
         $optionsExtraKeys = array_diff(array_keys($options), array_keys(self::DEFAULT_OPTIONS));
-        if (0 < \count($optionsExtraKeys)) {
+        if ([] !== $optionsExtraKeys) {
             throw new InvalidArgumentException(sprintf('Unknown option found: [%s]. Allowed options are [%s].', implode(', ', $optionsExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
         }
 
         // check for extra keys in options
         $queryExtraKeys = array_diff(array_keys($query), array_keys(self::DEFAULT_OPTIONS));
-        if (0 < \count($queryExtraKeys)) {
+        if ([] !== $queryExtraKeys) {
             throw new InvalidArgumentException(sprintf('Unknown option found in DSN: [%s]. Allowed options are [%s].', implode(', ', $queryExtraKeys), implode(', ', array_keys(self::DEFAULT_OPTIONS))));
         }
 

--- a/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Amqp/Transport/Connection.php
@@ -237,7 +237,7 @@ class Connection
 
     private static function validateOptions(array $options): void
     {
-        if (0 < \count($invalidOptions = array_diff(array_keys($options), self::AVAILABLE_OPTIONS))) {
+        if ([] !== ($invalidOptions = array_diff(array_keys($options), self::AVAILABLE_OPTIONS))) {
             trigger_deprecation('symfony/messenger', '5.1', 'Invalid option(s) "%s" passed to the AMQP Messenger transport. Passing invalid options is deprecated.', implode('", "', $invalidOptions));
         }
 
@@ -251,14 +251,14 @@ class Connection
                     continue;
                 }
 
-                if (0 < \count($invalidQueueOptions = array_diff(array_keys($queue), self::AVAILABLE_QUEUE_OPTIONS))) {
+                if ([] !== ($invalidQueueOptions = array_diff(array_keys($queue), self::AVAILABLE_QUEUE_OPTIONS))) {
                     trigger_deprecation('symfony/messenger', '5.1', 'Invalid queue option(s) "%s" passed to the AMQP Messenger transport. Passing invalid queue options is deprecated.', implode('", "', $invalidQueueOptions));
                 }
             }
         }
 
         if (\is_array($options['exchange'] ?? false)
-            && 0 < \count($invalidExchangeOptions = array_diff(array_keys($options['exchange']), self::AVAILABLE_EXCHANGE_OPTIONS))) {
+            && [] !== ($invalidExchangeOptions = array_diff(array_keys($options['exchange']), self::AVAILABLE_EXCHANGE_OPTIONS))) {
             trigger_deprecation('symfony/messenger', '5.1', 'Invalid exchange option(s) "%s" passed to the AMQP Messenger transport. Passing invalid exchange options is deprecated.', implode('", "', $invalidExchangeOptions));
         }
     }

--- a/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Doctrine/Transport/Connection.php
@@ -99,13 +99,13 @@ class Connection implements ResetInterface
 
         // check for extra keys in options
         $optionsExtraKeys = array_diff(array_keys($options), array_keys(static::DEFAULT_OPTIONS));
-        if (0 < \count($optionsExtraKeys)) {
+        if ([] !== $optionsExtraKeys) {
             throw new InvalidArgumentException(sprintf('Unknown option found: [%s]. Allowed options are [%s].', implode(', ', $optionsExtraKeys), implode(', ', array_keys(static::DEFAULT_OPTIONS))));
         }
 
         // check for extra keys in options
         $queryExtraKeys = array_diff(array_keys($query), array_keys(static::DEFAULT_OPTIONS));
-        if (0 < \count($queryExtraKeys)) {
+        if ([] !== $queryExtraKeys) {
             throw new InvalidArgumentException(sprintf('Unknown option found in DSN: [%s]. Allowed options are [%s].', implode(', ', $queryExtraKeys), implode(', ', array_keys(static::DEFAULT_OPTIONS))));
         }
 

--- a/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
+++ b/src/Symfony/Component/Messenger/Bridge/Redis/Transport/Connection.php
@@ -289,7 +289,7 @@ class Connection
     {
         $availableOptions = array_keys(self::DEFAULT_OPTIONS);
 
-        if (0 < \count($invalidOptions = array_diff(array_keys($options), $availableOptions))) {
+        if ([] !== ($invalidOptions = array_diff(array_keys($options), $availableOptions))) {
             trigger_deprecation('symfony/messenger', '5.1', 'Invalid option(s) "%s" passed to the Redis Messenger transport. Passing invalid options is deprecated.', implode('", "', $invalidOptions));
         }
     }
@@ -317,7 +317,7 @@ class Connection
             }
         }
 
-        if (\count($claimableIds) > 0) {
+        if ($claimableIds !== []) {
             try {
                 $this->connection->xclaim(
                     $this->stream,

--- a/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
+++ b/src/Symfony/Component/Messenger/Command/FailedMessagesShowCommand.php
@@ -120,7 +120,7 @@ EOF
             ];
         }
 
-        if (0 === \count($rows)) {
+        if ([] === $rows) {
             $io->success('No failed messages were found.');
 
             return;

--- a/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
+++ b/src/Symfony/Component/Messenger/Middleware/DispatchAfterCurrentBusMiddleware.php
@@ -96,7 +96,7 @@ class DispatchAfterCurrentBusMiddleware implements MiddlewareInterface
         }
 
         $this->isRootDispatchCallRunning = false;
-        if (\count($exceptions) > 0) {
+        if ($exceptions !== []) {
             throw new DelayedMessageHandlingException($exceptions);
         }
 

--- a/src/Symfony/Component/Mime/Header/Headers.php
+++ b/src/Symfony/Component/Mime/Header/Headers.php
@@ -169,7 +169,7 @@ final class Headers
         $header->setMaxLineLength($this->lineLength);
         $name = strtolower($header->getName());
 
-        if (\in_array($name, self::UNIQUE_HEADERS, true) && isset($this->headers[$name]) && \count($this->headers[$name]) > 0) {
+        if (\in_array($name, self::UNIQUE_HEADERS, true) && isset($this->headers[$name]) && $this->headers[$name] !== []) {
             throw new LogicException(sprintf('Impossible to set header "%s" as it\'s already defined and must be unique.', $header->getName()));
         }
 

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -892,7 +892,7 @@ class OptionsResolver implements Options
         // Make sure that no unknown options are passed
         $diff = array_diff_key($options, $clone->defined);
 
-        if (\count($diff) > 0) {
+        if ($diff !== []) {
             ksort($clone->defined);
             ksort($diff);
 
@@ -909,7 +909,7 @@ class OptionsResolver implements Options
         // Check whether any required option is missing
         $diff = array_diff_key($clone->required, $clone->defaults);
 
-        if (\count($diff) > 0) {
+        if ($diff !== []) {
             ksort($diff);
 
             throw new MissingOptionsException(sprintf(\count($diff) > 1 ? 'The required options "%s" are missing.' : 'The required option "%s" is missing.', $this->formatOptions(array_keys($diff))));
@@ -1092,7 +1092,7 @@ class OptionsResolver implements Options
                     $this->formatValue($value)
                 );
 
-                if (\count($printableAllowedValues) > 0) {
+                if ($printableAllowedValues !== []) {
                     $message .= sprintf(
                         ' Accepted values are: %s.',
                         $this->formatValues($printableAllowedValues)

--- a/src/Symfony/Component/PropertyInfo/Type.php
+++ b/src/Symfony/Component/PropertyInfo/Type.php
@@ -145,7 +145,7 @@ class Type
         trigger_deprecation('symfony/property-info', '5.3', 'The "%s()" method is deprecated, use "getCollectionKeyTypes()" instead.', __METHOD__);
 
         $type = $this->getCollectionKeyTypes();
-        if (0 === \count($type)) {
+        if ([] === $type) {
             return null;
         }
 

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -93,7 +93,7 @@ class UrlMatcher implements UrlMatcherInterface, RequestMatcherInterface
             throw new NoConfigurationException();
         }
 
-        throw 0 < \count($this->allow) ? new MethodNotAllowedException(array_unique($this->allow)) : new ResourceNotFoundException(sprintf('No routes found for "%s".', $pathinfo));
+        throw [] !== $this->allow ? new MethodNotAllowedException(array_unique($this->allow)) : new ResourceNotFoundException(sprintf('No routes found for "%s".', $pathinfo));
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -49,7 +49,7 @@ class UsernamePasswordToken extends AbstractToken
         $this->credentials = $credentials ?? null;
         $this->firewallName = $firewallName;
 
-        parent::setAuthenticated(\count($roles) > 0, false);
+        parent::setAuthenticated($roles !== [], false);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -265,7 +265,7 @@ class XmlEncoder implements EncoderInterface, DecoderInterface, NormalizationAwa
 
         $value = $this->parseXmlValue($node, $context);
 
-        if (!\count($data)) {
+        if ($data === []) {
             return $value;
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/AbstractObjectNormalizer.php
@@ -235,7 +235,7 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
             $data = $this->updateData($data, $attribute, $this->serializer->normalize($attributeValue, $format, $childContext), $class, $format, $attributeContext);
         }
 
-        if (isset($context[self::PRESERVE_EMPTY_OBJECTS]) && !\count($data)) {
+        if (isset($context[self::PRESERVE_EMPTY_OBJECTS]) && $data === []) {
             return new \ArrayObject();
         }
 
@@ -526,16 +526,16 @@ abstract class AbstractObjectNormalizer extends AbstractNormalizer
                 $builtinType = Type::BUILTIN_TYPE_OBJECT;
                 $class = $collectionValueType->getClassName().'[]';
 
-                if (\count($collectionKeyType = $type->getCollectionKeyTypes()) > 0) {
+                if (($collectionKeyType = $type->getCollectionKeyTypes()) !== []) {
                     [$context['key_type']] = $collectionKeyType;
                 }
-            } elseif ($type->isCollection() && \count($collectionValueType = $type->getCollectionValueTypes()) > 0 && Type::BUILTIN_TYPE_ARRAY === $collectionValueType[0]->getBuiltinType()) {
+            } elseif ($type->isCollection() && ($collectionValueType = $type->getCollectionValueTypes()) !== [] && Type::BUILTIN_TYPE_ARRAY === $collectionValueType[0]->getBuiltinType()) {
                 // get inner type for any nested array
                 [$innerType] = $collectionValueType;
 
                 // note that it will break for any other builtinType
                 $dimensions = '[]';
-                while (\count($innerType->getCollectionValueTypes()) > 0 && Type::BUILTIN_TYPE_ARRAY === $innerType->getBuiltinType()) {
+                while ($innerType->getCollectionValueTypes() !== [] && Type::BUILTIN_TYPE_ARRAY === $innerType->getBuiltinType()) {
                     $dimensions .= '[]';
                     [$innerType] = $innerType->getCollectionValueTypes();
                 }

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -105,7 +105,7 @@ class StopwatchEvent
      */
     public function stop()
     {
-        if (!\count($this->started)) {
+        if ($this->started === []) {
             throw new \LogicException('stop() called but start() has not been called before.');
         }
 

--- a/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
+++ b/src/Symfony/Component/Translation/Bridge/Crowdin/CrowdinProvider.php
@@ -64,7 +64,7 @@ final class CrowdinProvider implements ProviderInterface
 
         foreach ($translatorBag->getCatalogues() as $catalogue) {
             foreach ($catalogue->getDomains() as $domain) {
-                if (0 === \count($catalogue->all($domain))) {
+                if ([] === $catalogue->all($domain)) {
                     continue;
                 }
 
@@ -218,7 +218,7 @@ final class CrowdinProvider implements ProviderInterface
             }
 
             $offset += $limit;
-        } while (\count($strings) > 0);
+        } while ($strings !== []);
 
         return $result;
     }

--- a/src/Symfony/Component/Translation/Command/XliffLintCommand.php
+++ b/src/Symfony/Component/Translation/Command/XliffLintCommand.php
@@ -153,7 +153,7 @@ EOF
         libxml_clear_errors();
         libxml_use_internal_errors($internal);
 
-        return ['file' => $file, 'valid' => 0 === \count($errors), 'messages' => $errors];
+        return ['file' => $file, 'valid' => [] === $errors, 'messages' => $errors];
     }
 
     private function display(SymfonyStyle $io, array $files)

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -148,7 +148,7 @@ abstract class Constraint
                     $invalidOptions[] = $option;
                 }
             }
-        } elseif (null !== $options && !(\is_array($options) && 0 === \count($options))) {
+        } elseif (null !== $options && !(\is_array($options) && [] === $options)) {
             if (null === $defaultOption) {
                 throw new ConstraintDefinitionException(sprintf('No default option is configured for constraint "%s".', static::class));
             }
@@ -161,11 +161,11 @@ abstract class Constraint
             }
         }
 
-        if (\count($invalidOptions) > 0) {
+        if ($invalidOptions !== []) {
             throw new InvalidOptionsException(sprintf('The options "%s" do not exist in constraint "%s".', implode('", "', $invalidOptions), static::class), $invalidOptions);
         }
 
-        if (\count($missingOptions) > 0) {
+        if ($missingOptions !== []) {
             throw new MissingOptionsException(sprintf('The options "%s" must be set for constraint "%s".', implode('", "', array_keys($missingOptions)), static::class), array_keys($missingOptions));
         }
 

--- a/src/Symfony/Component/Validator/Constraints/Composite.php
+++ b/src/Symfony/Component/Validator/Constraints/Composite.php
@@ -99,7 +99,7 @@ abstract class Composite extends Constraint
             if (property_exists($constraint, 'groups')) {
                 $excessGroups = array_diff($constraint->groups, $this->groups);
 
-                if (\count($excessGroups) > 0) {
+                if ($excessGroups !== []) {
                     throw new ConstraintDefinitionException(sprintf('The group(s) "%s" passed to the constraint "%s" should also be passed to its containing constraint "%s".', implode('", "', $excessGroups), get_debug_type($constraint), static::class));
                 }
             } else {

--- a/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GenericMetadata.php
@@ -201,7 +201,7 @@ class GenericMetadata implements MetadataInterface
      */
     public function hasConstraints()
     {
-        return \count($this->constraints) > 0;
+        return $this->constraints !== [];
     }
 
     /**

--- a/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/PropertyInfoLoader.php
@@ -119,7 +119,7 @@ final class PropertyInfoLoader implements LoaderInterface
             }
             if (!$hasTypeConstraint) {
                 if (1 === \count($builtinTypes)) {
-                    if ($types[0]->isCollection() && \count($collectionValueType = $types[0]->getCollectionValueTypes()) > 0) {
+                    if ($types[0]->isCollection() && ($collectionValueType = $types[0]->getCollectionValueTypes()) !== []) {
                         [$collectionValueType] = $collectionValueType;
                         $this->handleAllConstraint($property, $allConstraint, $collectionValueType, $metadata);
                     }

--- a/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
+++ b/src/Symfony/Component/Validator/Validator/RecursiveContextualValidator.php
@@ -490,7 +490,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
 
         // If no more groups should be validated for the property nodes,
         // we can safely quit
-        if (0 === \count($groups)) {
+        if ([] === $groups) {
             return;
         }
 
@@ -602,7 +602,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
             $this->validateInGroup($value, $cacheKey, $metadata, $group, $context);
         }
 
-        if (0 === \count($groups)) {
+        if ([] === $groups) {
             return;
         }
 
@@ -626,7 +626,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface
         // The $cascadedGroups property is set, if the "Default" group is
         // overridden by a group sequence
         // See validateClassNode()
-        $cascadedGroups = null !== $cascadedGroups && \count($cascadedGroups) > 0 ? $cascadedGroups : $groups;
+        $cascadedGroups = null !== $cascadedGroups && $cascadedGroups !== [] ? $cascadedGroups : $groups;
 
         if ($value instanceof LazyProperty) {
             $value = $value->getPropertyValue();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | --
| License       | MIT
| Doc PR        | --

Everything is done automatically, I'm not sure it's good for readability, but I made this for someone interested in it.
```diff
-count($array) === 0;
-count($array) > 0;
-!count($array);
+$array === [];
+$array !== [];
+$array === [];
```