### PR TITLE
[Messenger] Fix `TraceableMessageBus` implementation so it can compute caller even when used within a callback

### DIFF
--- a/src/Symfony/Component/Messenger/Tests/TraceableMessageBusTest.php
+++ b/src/Symfony/Component/Messenger/Tests/TraceableMessageBusTest.php
@@ -156,4 +156,22 @@ class TraceableMessageBusTest extends TestCase
             ],
         ], $actualTracedMessage);
     }
+
+    public function testItTracesExceptionsWhenMessageBusIsFiredFromArrayCallback()
+    {
+        $message = new DummyMessage('Hello');
+        $exception = new \RuntimeException();
+
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->expects($this->once())
+            ->method('dispatch')
+            ->with($message)
+            ->willThrowException($exception);
+
+        $traceableBus = new TraceableMessageBus($bus);
+
+        $this->expectExceptionObject($exception);
+
+        array_map([$traceableBus, 'dispatch'], [$message]);
+    }
 }

--- a/src/Symfony/Component/Messenger/TraceableMessageBus.php
+++ b/src/Symfony/Component/Messenger/TraceableMessageBus.php
@@ -62,8 +62,8 @@ class TraceableMessageBus implements MessageBusInterface
     {
         $trace = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, 8);
 
-        $file = $trace[1]['file'];
-        $line = $trace[1]['line'];
+        $file = $trace[1]['file'] ?? null;
+        $line = $trace[1]['line'] ?? null;
 
         $handleTraitFile = (new \ReflectionClass(HandleTrait::class))->getFileName();
         $found = false;
@@ -97,9 +97,12 @@ class TraceableMessageBus implements MessageBusInterface
             }
         }
 
-        $name = str_replace('\\', '/', $file);
-        $name = substr($name, strrpos($name, '/') + 1);
+        $name = str_replace('\\', '/', (string) $file);
 
-        return compact('name', 'file', 'line');
+        return [
+            'name' => substr($name, strrpos($name, '/') + 1),
+            'file' => $file,
+            'line' => $line,
+        ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 

Quoting commits:

> 
>     This test shows that `array_map([new TraceableMessageBus(...), 'dispatch'], $messages)` does not work at all,
>     because `debug_backtrace()` is used in internals to compute the call-site, and it is not considering the fact
>     that the caller may be:
>     
>      * an internal PHP function
>      * a callback (this example test scenario)
>      * generated code (`eval()` result)
>     
>     The output of such a failure:
>     
>     ```
>     1) Symfony\Component\Messenger\Tests\TraceableMessageBusTest::testItTracesExceptionsWhenMessageBusIsFiredFromArrayCallback
>     Undefined array key "line"
>     
>     /app/src/Symfony/Component/Messenger/TraceableMessageBus.php:66
>     /app/src/Symfony/Component/Messenger/TraceableMessageBus.php:36
>     /app/src/Symfony/Component/Messenger/Tests/TraceableMessageBusTest.php:175
>     ```
>
>     To be on the safe side, also removed `compact()` usage, which was making everything
>     much muddier and harder to comprehend.