### PR TITLE
[Validator] Add the missing translations for Russian (ru)

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
@@ -394,6 +394,14 @@
                 <source>This value is not a valid CSS color.</source>
                 <target>Значение не является корректным CSS цветом.</target>
             </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target>Значение не соответствует нотации CIDR.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target>Значение маски подсети должно быть от {{ min }} до {{ max }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43727
| License       | MIT
| Doc PR        | N/A

Additionally (see https://symfony.com/releases):
 - [Validator] Add the missing translations for Russian (ru)
