### PR TITLE
remove no longer needed PHP version requirements from tests

### DIFF
--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -420,9 +420,6 @@ class CommandTest extends TestCase
         $this->assertSame(['f'], $command->getAliases());
     }
 
-    /**
-     * @requires PHP 8
-     */
     public function testDefaultCommand()
     {
         $apl = new Application();

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/IntegrationTest.php
@@ -384,9 +384,6 @@ class IntegrationTest extends TestCase
         $this->assertSame(['bar_tab_class_with_defaultmethod' => $container->get(BarTagClass::class), 'foo' => $container->get(FooTagClass::class)], $param);
     }
 
-    /**
-     * @requires PHP 8
-     */
     public function testTaggedIteratorWithDefaultIndexMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -411,9 +408,6 @@ class IntegrationTest extends TestCase
         $this->assertSame(['bar_tag_class' => $container->get(BarTagClass::class), 'foo_tag_class' => $container->get(FooTagClass::class)], $param);
     }
 
-    /**
-     * @requires PHP 8
-     */
     public function testTaggedIteratorWithDefaultPriorityMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -438,9 +432,6 @@ class IntegrationTest extends TestCase
         $this->assertSame([0 => $container->get(FooTagClass::class), 1 => $container->get(BarTagClass::class)], $param);
     }
 
-    /**
-     * @requires PHP 8
-     */
     public function testTaggedIteratorWithDefaultIndexMethodAndWithDefaultPriorityMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -491,9 +482,6 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(FooTagClass::class), $locator->get('foo'));
     }
 
-    /**
-     * @requires PHP 8
-     */
     public function testTaggedLocatorConfiguredViaAttributeWithoutIndex()
     {
         $container = new ContainerBuilder();
@@ -520,9 +508,6 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(FooTagClass::class), $locator->get(FooTagClass::class));
     }
 
-    /**
-     * @requires PHP 8
-     */
     public function testTaggedLocatorWithDefaultIndexMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -549,9 +534,6 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(FooTagClass::class), $locator->get('foo_tag_class'));
     }
 
-    /**
-     * @requires PHP 8
-     */
     public function testTaggedLocatorWithDefaultPriorityMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -582,9 +564,6 @@ class IntegrationTest extends TestCase
         self::assertSame([FooTagClass::class, BarTagClass::class], array_keys($factories->getValue($locator)));
     }
 
-    /**
-     * @requires PHP 8
-     */
     public function testTaggedLocatorWithDefaultIndexMethodAndWithDefaultPriorityMethodConfiguredViaAttribute()
     {
         $container = new ContainerBuilder();
@@ -617,9 +596,6 @@ class IntegrationTest extends TestCase
         self::assertSame($container->get(FooTagClass::class), $locator->get('foo_tag_class'));
     }
 
-    /**
-     * @requires PHP 8
-     */
     public function testNestedDefinitionWithAutoconfiguredConstructorArgument()
     {
         $container = new ContainerBuilder();
@@ -904,9 +880,6 @@ class IntegrationTest extends TestCase
         ], $collector->collectedTags);
     }
 
-    /**
-     * @requires PHP 8
-     */
     public function testTagsViaAttributeOnPropertyMethodAndParameter()
     {
         $container = new ContainerBuilder();

--- a/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ControllerMetadata/ArgumentMetadataFactoryTest.php
@@ -134,9 +134,6 @@ class ArgumentMetadataFactoryTest extends TestCase
         $this->assertCount(1, $this->factory->createArgumentMetadata([new AttributeController(), 'multiAttributeArg'])[0]->getAttributes());
     }
 
-    /**
-     * @requires PHP 8
-     */
     public function testIssue41478()
     {
         $arguments = $this->factory->createArgumentMetadata([new AttributeController(), 'issue41478']);

--- a/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
+++ b/src/Symfony/Component/Messenger/Tests/DependencyInjection/MessengerPassTest.php
@@ -105,9 +105,6 @@ class MessengerPassTest extends TestCase
         $this->assertHandlerDescriptor($container, $handlerDescriptionMapping, DummyMessage::class, [DummyHandler::class], [['from_transport' => 'async']]);
     }
 
-    /**
-     * @requires PHP 8
-     */
     public function testTaggedMessageHandler()
     {
         $container = $this->getContainerBuilder($busId = 'message_bus');

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -997,7 +997,6 @@ class SerializerTest extends TestCase
         $this->assertSame($expected, $exceptionsAsArray);
     }
 
-    /** @requires PHP 8.0 */
     public function testCollectDenormalizationErrorsWithConstructor()
     {
         $json = '{"bool": "bool"}';

--- a/src/Symfony/Component/Validator/Tests/Constraints/CidrTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CidrTest.php
@@ -111,9 +111,6 @@ class CidrTest extends TestCase
         ];
     }
 
-    /**
-     * @requires PHP 8
-     */
     public function testAttributes()
     {
         $metadata = new ClassMetadata(CidrDummy::class);

--- a/src/Symfony/Component/Validator/Tests/Constraints/CssColorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CssColorTest.php
@@ -18,7 +18,6 @@ use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 
 /**
  * @author Mathieu Santostefano <msantostefano@protonmail.com>
- * @requires PHP 8
  */
 final class CssColorTest extends TestCase
 {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 6.0
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 
