### PR TITLE
[String] Fix inflector for "zombies"

### DIFF
--- a/src/Symfony/Component/String/Inflector/EnglishInflector.php
+++ b/src/Symfony/Component/String/Inflector/EnglishInflector.php
@@ -58,6 +58,9 @@ final class EnglishInflector implements InflectorInterface
         // selfies (selfie)
         ['seifles', 7, true, true, 'selfie'],
 
+        // zombies (zombie)
+        ['seibmoz', 7, true, true, 'zombie'],
+
         // movies (movie)
         ['seivom', 6, true, true, 'movie'],
 

--- a/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
+++ b/src/Symfony/Component/String/Tests/Inflector/EnglishInflectorTest.php
@@ -152,6 +152,7 @@ class EnglishInflectorTest extends TestCase
             ['trees', 'tree'],
             ['waltzes', ['waltz', 'waltze']],
             ['wives', 'wife'],
+            ['zombies', 'zombie'],
 
             // test casing: if the first letter was uppercase, it should remain so
             ['Men', 'Man'],


### PR DESCRIPTION
The word "zombies" should be singularized to "zombie" (rather than
"zomby"). We provide a PLURAL_MAP for this case, as well as a test.

| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43789 
| License       | MIT
