### PR TITLE
[Dotenv] Duplicate $_SERVER values in $_ENV if they don't exist

### DIFF
--- a/src/Symfony/Component/Dotenv/Dotenv.php
+++ b/src/Symfony/Component/Dotenv/Dotenv.php
@@ -136,8 +136,12 @@ final class Dotenv
 
         foreach ($values as $name => $value) {
             $notHttpName = 0 !== strpos($name, 'HTTP_');
+            if (isset($_SERVER[$name]) && $notHttpName && !isset($_ENV[$name])) {
+                $_ENV[$name] = $_SERVER[$name];
+            }
+
             // don't check existence with getenv() because of thread safety issues
-            if (!isset($loadedVars[$name]) && (!$overrideExistingVars && (isset($_ENV[$name]) || (isset($_SERVER[$name]) && $notHttpName)))) {
+            if (!isset($loadedVars[$name]) && !$overrideExistingVars && isset($_ENV[$name])) {
                 continue;
             }
 

--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -493,4 +493,14 @@ class DotenvTest extends TestCase
         $this->assertSame('no', $_ENV['TEST_USE_PUTENV']);
         $this->assertFalse(getenv('TEST_USE_PUTENV'));
     }
+
+    public function testSERVERVarsDuplicationInENV()
+    {
+        unset($_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS'], $_ENV['FOO']);
+        $_SERVER['FOO'] = 'CCC';
+
+        (new Dotenv(false))->populate(['FOO' => 'BAR']);
+
+        $this->assertSame('CCC', $_ENV['FOO']);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

Ref https://github.com/symfony/recipes/pull/1014

@nicolas-grekas found the right approach and the patch. `$_SERVER` values that don't exist in `$_ENV` should be duplicated in `$_ENV` so both superglobals are coherent.