### PR TITLE
[FrameworkBundle] Allow multiple loginUser calls

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php
@@ -128,10 +128,10 @@ class KernelBrowser extends HttpKernelBrowser
         $container = $this->getContainer();
         $container->get('security.untracked_token_storage')->setToken($token);
 
-        if ($container->has('session.factory')) {
-            $session = $container->get('session.factory')->createSession();
-        } elseif ($container->has('session')) {
+        if ($container->has('session')) {
             $session = $container->get('session');
+        } elseif ($container->has('session.factory')) {
+            $session = $container->get('session.factory')->createSession();
         } else {
             return $this;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SecurityTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/SecurityTest.php
@@ -70,4 +70,20 @@ class SecurityTest extends AbstractWebTestCase
         $client->request('GET', '/main/user_profile');
         $this->assertEquals('Welcome the-username!', $client->getResponse()->getContent());
     }
+
+    public function testLoginUserMultipleTimes()
+    {
+        $userFoo = new InMemoryUser('the-username', 'the-password', ['ROLE_FOO']);
+        $userBar = new InMemoryUser('no-role-username', 'the-password');
+        $client = $this->createClient(['test_case' => 'Security', 'root_config' => 'config.yml']);
+        $client->loginUser($userFoo);
+
+        $client->request('GET', '/main/user_profile');
+        $this->assertEquals('Welcome the-username!', $client->getResponse()->getContent());
+
+        $client->loginUser($userBar);
+
+        $client->request('GET', '/main/user_profile');
+        $this->assertEquals('Welcome no-role-username!', $client->getResponse()->getContent());
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  |no
| Deprecations? | no
| Tickets       | Fix #43266, #41590 
| License       | MIT

This [PR](https://github.com/symfony/symfony/pull/42979) introduced a regression when calling multiple times `loginUser` within the same test. 
@Philosoft provided a simple reproducer [here](https://github.com/symfony/symfony/issues/43266#issuecomment-942327177).
