### PR TITLE
[DependencyInjection][FrameworkBundle][SecurityBundle][TwigBundle] Deprecate Composer 1

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -126,7 +126,7 @@ class Configuration implements ConfigurationInterface
             $parentPackages = (array) $parentPackage;
             $parentPackages[] = 'symfony/framework-bundle';
 
-            return ContainerBuilder::willBeAvailable($package, $class, $parentPackages);
+            return ContainerBuilder::willBeAvailable($package, $class, $parentPackages, true);
         };
 
         $enableIfStandalone = static function (string $package, string $class) use ($willBeAvailable) {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
 
+use Composer\InstalledVersions;
 use Symfony\Bridge\Twig\Extension\LogoutUrlExtension;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\FirewallListenerFactoryInterface;
@@ -78,6 +79,10 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
 
     public function load(array $configs, ContainerBuilder $container)
     {
+        if (!class_exists(InstalledVersions::class)) {
+            trigger_deprecation('symfony/security-bundle', '5.4', 'Configuring Symfony without the Composer Runtime API is deprecated. Consider upgrading to Composer 2.');
+        }
+
         if (!array_filter($configs)) {
             return;
         }
@@ -120,7 +125,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
             $loader->load('security_legacy.php');
         }
 
-        if ($container::willBeAvailable('symfony/twig-bridge', LogoutUrlExtension::class, ['symfony/security-bundle'])) {
+        if ($container::willBeAvailable('symfony/twig-bridge', LogoutUrlExtension::class, ['symfony/security-bundle'], true)) {
             $loader->load('templating_twig.php');
         }
 
@@ -133,7 +138,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
             $loader->load('security_debug.php');
         }
 
-        if (!$container::willBeAvailable('symfony/expression-language', ExpressionLanguage::class, ['symfony/security-bundle'])) {
+        if (!$container::willBeAvailable('symfony/expression-language', ExpressionLanguage::class, ['symfony/security-bundle'], true)) {
             $container->removeDefinition('security.expression_language');
             $container->removeDefinition('security.access.expression_voter');
         }
@@ -1005,7 +1010,7 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
             return $this->expressions[$id];
         }
 
-        if (!$container::willBeAvailable('symfony/expression-language', ExpressionLanguage::class, ['symfony/security-bundle'])) {
+        if (!$container::willBeAvailable('symfony/expression-language', ExpressionLanguage::class, ['symfony/security-bundle'], true)) {
             throw new \RuntimeException('Unable to use expressions as the Symfony ExpressionLanguage component is not installed. Try running "composer require symfony/expression-language".');
         }
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExtensionPass.php
@@ -27,19 +27,19 @@ class ExtensionPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!$container::willBeAvailable('symfony/asset', Packages::class, ['symfony/twig-bundle'])) {
+        if (!$container::willBeAvailable('symfony/asset', Packages::class, ['symfony/twig-bundle'], true)) {
             $container->removeDefinition('twig.extension.assets');
         }
 
-        if (!$container::willBeAvailable('symfony/expression-language', Expression::class, ['symfony/twig-bundle'])) {
+        if (!$container::willBeAvailable('symfony/expression-language', Expression::class, ['symfony/twig-bundle'], true)) {
             $container->removeDefinition('twig.extension.expression');
         }
 
-        if (!$container::willBeAvailable('symfony/routing', UrlGeneratorInterface::class, ['symfony/twig-bundle'])) {
+        if (!$container::willBeAvailable('symfony/routing', UrlGeneratorInterface::class, ['symfony/twig-bundle'], true)) {
             $container->removeDefinition('twig.extension.routing');
         }
 
-        if (!$container::willBeAvailable('symfony/yaml', Yaml::class, ['symfony/twig-bundle'])) {
+        if (!$container::willBeAvailable('symfony/yaml', Yaml::class, ['symfony/twig-bundle'], true)) {
             $container->removeDefinition('twig.extension.yaml');
         }
 
@@ -115,7 +115,7 @@ class ExtensionPass implements CompilerPassInterface
             $container->getDefinition('twig.extension.expression')->addTag('twig.extension');
         }
 
-        if (!$container::willBeAvailable('symfony/workflow', Workflow::class, ['symfony/twig-bundle']) || !$container->has('workflow.registry')) {
+        if (!$container::willBeAvailable('symfony/workflow', Workflow::class, ['symfony/twig-bundle'], true) || !$container->has('workflow.registry')) {
             $container->removeDefinition('workflow.twig_extension');
         } else {
             $container->getDefinition('workflow.twig_extension')->addTag('twig.extension');

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\TwigBundle\DependencyInjection;
 
+use Composer\InstalledVersions;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileExistenceResource;
 use Symfony\Component\Console\Application;
@@ -35,22 +36,26 @@ class TwigExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container)
     {
+        if (!class_exists(InstalledVersions::class)) {
+            trigger_deprecation('symfony/twig-bundle', '5.4', 'Configuring Symfony without the Composer Runtime API is deprecated. Consider upgrading to Composer 2.');
+        }
+
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('twig.php');
 
-        if ($container::willBeAvailable('symfony/form', Form::class, ['symfony/twig-bundle'])) {
+        if ($container::willBeAvailable('symfony/form', Form::class, ['symfony/twig-bundle'], true)) {
             $loader->load('form.php');
         }
 
-        if ($container::willBeAvailable('symfony/console', Application::class, ['symfony/twig-bundle'])) {
+        if ($container::willBeAvailable('symfony/console', Application::class, ['symfony/twig-bundle'], true)) {
             $loader->load('console.php');
         }
 
-        if ($container::willBeAvailable('symfony/mailer', Mailer::class, ['symfony/twig-bundle'])) {
+        if ($container::willBeAvailable('symfony/mailer', Mailer::class, ['symfony/twig-bundle'], true)) {
             $loader->load('mailer.php');
         }
 
-        if (!$container::willBeAvailable('symfony/translation', Translator::class, ['symfony/twig-bundle'])) {
+        if (!$container::willBeAvailable('symfony/translation', Translator::class, ['symfony/twig-bundle'], true)) {
             $container->removeDefinition('twig.translation.extractor');
         }
 

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -1484,11 +1484,18 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     final public static function willBeAvailable(string $package, string $class, array $parentPackages): bool
     {
+        $skipDeprecation = 3 < \func_num_args() && func_get_arg(3);
+        $hasRuntimeApi = class_exists(InstalledVersions::class);
+
+        if (!$hasRuntimeApi && !$skipDeprecation) {
+            trigger_deprecation('symfony/dependency-injection', '5.4', 'Calling "%s" when dependencies have been installed with Composer 1 is deprecated. Consider upgrading to Composer 2.', __METHOD__);
+        }
+
         if (!class_exists($class) && !interface_exists($class, false) && !trait_exists($class, false)) {
             return false;
         }
 
-        if (!class_exists(InstalledVersions::class) || !InstalledVersions::isInstalled($package) || InstalledVersions::isInstalled($package, false)) {
+        if (!$hasRuntimeApi || !InstalledVersions::isInstalled($package) || InstalledVersions::isInstalled($package, false)) {
             return true;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | yes
| Tickets       | Prepares #43788
| License       | MIT
| Doc PR        | N/A

This PR deprecates configuring one of those core bundles that make use of `ContainerBuilder::willBeAvailable()` if dependencies have been installed with Composer 1. `ContainerBuilder::willBeAvailable()` also triggers a deprecation now that will be suppressed in all calls coming from our core bundles' extensions.