### PR TITLE
[Notifier] Fix low-deps tests

### DIFF
--- a/src/Symfony/Component/Notifier/Bridge/Expo/composer.json
+++ b/src/Symfony/Component/Notifier/Bridge/Expo/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.2.5",
         "symfony/http-client": "^4.3|^5.0|^6.0",
-        "symfony/notifier": "^5.3|^6.0"
+        "symfony/notifier": "^5.4|^6.0"
     },
     "autoload": {
         "psr-4": { "Symfony\\Component\\Notifier\\Bridge\\Expo\\": "" },


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

`ExpoTransport` uses the new `PushMessage` introduced with Symfony 5.4.