### PR TITLE
[Dotenv] do not pass a boolean to the constructor of the Dotenv class

### DIFF
--- a/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
+++ b/src/Symfony/Component/Dotenv/Tests/DotenvTest.php
@@ -488,7 +488,7 @@ class DotenvTest extends TestCase
         unset($_ENV['SYMFONY_DOTENV_VARS'], $_SERVER['SYMFONY_DOTENV_VARS'], $_ENV['FOO']);
         $_SERVER['FOO'] = 'CCC';
 
-        (new Dotenv(false))->populate(['FOO' => 'BAR']);
+        (new Dotenv())->populate(['FOO' => 'BAR']);
 
         $this->assertSame('CCC', $_ENV['FOO']);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | no
| New feature?  | no
| Deprecations? | no
| Tickets       | 
| License       | MIT
| Doc PR        | 