### PR TITLE
[WebProfiler] fix AJAX request unit spacing

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -191,7 +191,7 @@ if (typeof Sfjs === 'undefined' || typeof Sfjs.loadToolbar === 'undefined') {
             row.appendChild(durationCell);
 
             request.liveDurationHandle = setInterval(function() {
-                durationCell.textContent = (new Date() - request.start) + 'ms';
+                durationCell.textContent = (new Date() - request.start) + ' ms';
             }, 100);
 
             row.className = 'sf-ajax-request sf-ajax-request-loading';
@@ -255,7 +255,7 @@ if (typeof Sfjs === 'undefined' || typeof Sfjs.loadToolbar === 'undefined') {
             }
 
             if (request.duration) {
-                durationCell.textContent = request.duration + 'ms';
+                durationCell.textContent = request.duration + ' ms';
             }
 
             if (request.profilerUrl) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -


This is simply adding space between request duration and unit (ms) to match with other profiler layout:
![image](https://user-images.githubusercontent.com/1985514/139429689-677bd394-a353-4bdb-b2a2-54ec186a9ae3.png)
