### PR TITLE
Expand dumps

### DIFF
--- a/CHANGELOG-5.3.md
+++ b/CHANGELOG-5.3.md
@@ -7,6 +7,10 @@ in 5.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v5.3.0...v5.3.1
 
+* 5.3.11 (2021-10-30)
+
+ * feature #43799 [VarDumper] Support expanded dumps
+
 * 5.3.10 (2021-10-29)
 
  * bug #43798 [Dotenv] Duplicate $_SERVER values in $_ENV if they don't exist (fancyweb)

--- a/CHANGELOG-5.3.md
+++ b/CHANGELOG-5.3.md
@@ -9,7 +9,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 
 * 5.3.11 (2021-10-30)
 
- * feature #43799 [VarDumper] Support expanded dumps
+ * feature [VarDumper] Support expanded dumps
 
 * 5.3.10 (2021-10-29)
 

--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -59,7 +59,7 @@ if (!function_exists('edump')) {
 
         foreach ($moreVars as $v) {
             VarDumper::dump($v, null, [
-                'maxDepth' => 0
+                'maxDepth' => 0,
             ]);
         }
 
@@ -74,6 +74,7 @@ if (!function_exists('edump')) {
 if (!function_exists('edd')) {
     /**
      * @author Sebastian Hädrich <shaedrich@users.noreply.github.com>
+     *
      * @return never
      */
     function edd(...$vars)
@@ -84,7 +85,7 @@ if (!function_exists('edd')) {
 
         foreach ($vars as $v) {
             VarDumper::dump($v, null, [
-                'maxDepth' => 0
+                'maxDepth' => 0,
             ]);
         }
 

--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -48,3 +48,46 @@ if (!function_exists('dd')) {
         exit(1);
     }
 }
+
+if (!function_exists('edump')) {
+    /**
+     * @author Sebastian Hädrich <shaedrich@users.noreply.github.com>
+     */
+    function edump($var, ...$moreVars)
+    {
+        VarDumper::dump($var);
+
+        foreach ($moreVars as $v) {
+            VarDumper::dump($v, null, [
+                'maxDepth' => 0
+            ]);
+        }
+
+        if (1 < func_num_args()) {
+            return func_get_args();
+        }
+
+        return $var;
+    }
+}
+
+if (!function_exists('edd')) {
+    /**
+     * @author Sebastian Hädrich <shaedrich@users.noreply.github.com>
+     * @return never
+     */
+    function edd(...$vars)
+    {
+        if (!in_array(\PHP_SAPI, ['cli', 'phpdbg'], true) && !headers_sent()) {
+            header('HTTP/1.1 500 Internal Server Error');
+        }
+
+        foreach ($vars as $v) {
+            VarDumper::dump($v, null, [
+                'maxDepth' => 0
+            ]);
+        }
+
+        exit(1);
+    }
+}

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
@@ -45,6 +45,33 @@ class FunctionsTest extends TestCase
 
         $this->assertEquals([$var1, $var2, $var3], $return);
     }
+    public function testEDumpReturnsFirstArg()
+    {
+        $this->setupVarDumper();
+
+        $var1 = 'a';
+
+        ob_start();
+        $return = edump($var1);
+        ob_end_clean();
+
+        $this->assertEquals($var1, $return);
+    }
+
+    public function testEDumpReturnsAllArgsInArray()
+    {
+        $this->setupVarDumper();
+
+        $var1 = 'a';
+        $var2 = 'b';
+        $var3 = 'c';
+
+        ob_start();
+        $return = edump($var1, $var2, $var3);
+        ob_end_clean();
+
+        $this->assertEquals([$var1, $var2, $var3], $return);
+    }
 
     protected function setupVarDumper()
     {

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
@@ -45,6 +45,7 @@ class FunctionsTest extends TestCase
 
         $this->assertEquals([$var1, $var2, $var3], $return);
     }
+
     public function testEDumpReturnsFirstArg()
     {
         $this->setupVarDumper();

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -37,13 +37,13 @@ class VarDumper
      */
     private static $handler;
 
-    public static function dump($var)
+    public static function dump($var, $output = null, array $extraDisplayOptions = [])
     {
         if (null === self::$handler) {
             self::register();
         }
 
-        return (self::$handler)($var);
+        return (self::$handler)($var, $output, $extraDisplayOptions);
     }
 
     /**
@@ -90,8 +90,8 @@ class VarDumper
             $dumper = new ContextualizedDumper($dumper, [new SourceContextProvider()]);
         }
 
-        self::$handler = function ($var) use ($cloner, $dumper) {
-            $dumper->dump($cloner->cloneVar($var));
+        self::$handler = function ($var, $output, $extraDisplayOptions) use ($cloner, $dumper) {
+            $dumper->dump($cloner->cloneVar($var, $output, $extraDisplayOptions));
         };
     }
 


### PR DESCRIPTION
| Q             | A                                                           |
| ------------- | ----------------------------------------------------------- |
| Branch?       | [5.4](https://github.com/symfony/symfony/tree/5.4)          |
| Bug fix?      | no                                                          |
| New feature?  | yes                                                         |
| Deprecations? | no                                                          |
| Tickets       |                                                             |
| License       | MIT                                                         |
| Doc PR        | symfony/symfony-docs#16035 |

Lately, I came across [a blog post](https://laraveldaily.com/echoing-dd-vs-var_dump-vs-print_r/) mentioning that they didn't like that they have to expand three levels in a row often times, which makes it harder to use then native dumping methods. Therefore, I thought, since the `VarDumper` offers the very possibility to expand all entries by default if wanted, we could offer the opposite (default is currently collapsed state) state functionality to `dd()` and `dump()`. Unfortunately, since these two have variadic parameters (also mentioned in the blog post I mentioned at the beginning), we can't really pass any flags. That's why I decided to create two new, separate functions for this. If anyone has a better approach, be my guest.
