### PR TITLE
[Runtime] Consider also $_ENV when resolving APP_RUNTIME and APP_RUNTIME_OPTIONS

### DIFF
--- a/src/Symfony/Component/Runtime/Internal/autoload_runtime.template
+++ b/src/Symfony/Component/Runtime/Internal/autoload_runtime.template
@@ -18,8 +18,8 @@ if (!is_object($app)) {
     throw new TypeError(sprintf('Invalid return value: callable object expected, "%s" returned from "%s".', get_debug_type($app), $_SERVER['SCRIPT_FILENAME']));
 }
 
-$runtime = $_SERVER['APP_RUNTIME'] ?? %runtime_class%;
-$runtime = new $runtime(($_SERVER['APP_RUNTIME_OPTIONS'] ?? []) + %runtime_options%);
+$runtime = $_SERVER['APP_RUNTIME'] ?? $_ENV['APP_RUNTIME'] ?? %runtime_class%;
+$runtime = new $runtime(($_SERVER['APP_RUNTIME_OPTIONS'] ?? $_ENV['APP_RUNTIME_OPTIONS'] ?? []) + %runtime_options%);
 
 [$app, $args] = $runtime
     ->getResolver($app)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #43832
| License       | MIT
| Doc PR        | symfony/symfony-docs#16038

Take also $_ENV into consideration when resolving APP_RUNTIME and APP_RUNTIME_OPTIONS.

On docker apache containers to get env variable into $_SERVER other configuration steps are needed. This is unnecessary since they are already available in $_ENV. Or maybe we can use getenv()? I'm preparing a PR for it (will be done in a bit)