### PR TITLE
[Inflector] Fix inflector for "zombies"

### DIFF
--- a/src/Symfony/Component/Inflector/Inflector.php
+++ b/src/Symfony/Component/Inflector/Inflector.php
@@ -60,6 +60,9 @@ final class Inflector
         // indices (index), appendices (appendix), prices (price)
         ['seci', 4, false, true, ['ex', 'ix', 'ice']],
 
+        // zombies (zombie)
+        ['seibmoz', 7, true, true, 'zombie'],
+
         // selfies (selfie)
         ['seifles', 7, true, true, 'selfie'],
 

--- a/src/Symfony/Component/Inflector/Tests/InflectorTest.php
+++ b/src/Symfony/Component/Inflector/Tests/InflectorTest.php
@@ -151,6 +151,7 @@ class InflectorTest extends TestCase
             ['trees', 'tree'],
             ['waltzes', ['waltz', 'waltze']],
             ['wives', 'wife'],
+            ['zombies', 'zombie'],
 
             // test casing: if the first letter was uppercase, it should remain so
             ['Men', 'Man'],


### PR DESCRIPTION
The word "zombies" should be singularized to "zombie" (rather than
"zomby"). We provide a PLURAL_MAP for this case, as well as a test.

| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | See #43789 
| License       | MIT