### PR TITLE
[SecurityBundle] Deprecate not configuring explicitly a provider for custom_authenticators when there is more than one registered provider

### DIFF
--- a/UPGRADE-5.4.md
+++ b/UPGRADE-5.4.md
@@ -139,6 +139,7 @@ Security
  * Deprecate `AuthenticatorInterface::createAuthenticatedToken()`, use `AuthenticatorInterface::createToken()` instead
  * Deprecate `PassportInterface`, `UserPassportInterface` and `PassportTrait`, use `Passport` instead.
    As such, the return type declaration of `AuthenticatorInterface::authenticate()` will change to `Passport` in 6.0
+ * Deprecate not configuring explicitly a provider for custom_authenticators when there is more than one registered provider
 
    Before:
    ```php

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -430,6 +430,7 @@ SecurityBundle
  * Remove the `security.authentication.provider.*` services, use the new authenticator system instead
  * Remove the `security.authentication.listener.*` services, use the new authenticator system instead
  * Remove the Guard component integration, use the new authenticator system instead
+ * Remove the default provider for custom_authenticators when there is more than one registered provider
 
 Serializer
 ----------

--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
  * Deprecate the `always_authenticate_before_granting` option
  * Display the roles of the logged-in user in the Web Debug Toolbar
  * Add the `security.access_decision_manager.strategy_service` option
+ * Deprecate not configuring explicitly a provider for custom_authenticators when there is more than one registered provider
 
 5.3
 ---

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -703,6 +703,10 @@ class SecurityExtension extends Extension implements PrependExtensionInterface
         }
 
         if ('remember_me' === $factoryKey || 'anonymous' === $factoryKey || 'custom_authenticators' === $factoryKey) {
+            if ('custom_authenticators' === $factoryKey) {
+                trigger_deprecation('symfony/security-bundle', '5.4', 'Not configuring explicitly the provider for the "%s" listener on "%s" firewall is deprecated because it\'s ambiguous as there is more than one registered provider.', $factoryKey, $id);
+            }
+
             return 'security.user_providers';
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       |
| License       | MIT
| Doc PR        | not needed I guess

