### PR TITLE
[Messenger] Decouple DelayStamp from timezone settings

### DIFF
--- a/src/Symfony/Component/Messenger/Stamp/DelayStamp.php
+++ b/src/Symfony/Component/Messenger/Stamp/DelayStamp.php
@@ -33,7 +33,7 @@ final class DelayStamp implements StampInterface
 
     public static function delayFor(\DateInterval $interval): self
     {
-        $now = new \DateTimeImmutable();
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
         $end = $now->add($interval);
 
         return new self(($end->getTimestamp() - $now->getTimestamp()) * 1000);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

See CI failure: https://github.com/symfony/symfony/runs/4054884692?check_suite_focus=true#step:8:1557

The reason for this failure seems to be that DST ends in Europe tonight. Tinkering with `date.timezone` settings locally revealed that the test passes with `UTC` but fails with `Europe/Berlin`. If I'm right, the test will turn green again tomorrow without any intervention.

However, I believe that a developer would expect that calling `DelayStamp::delayFor(\DateInterval::createFromDateString('30 hours'))` like we do in the failing test would always result in the same delay. I've fixed this by using a UTC date for the delay calculation.