### PR TITLE
[Console] [AppVeyor] Fix EOL in the tests

### DIFF
--- a/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CompleteCommandTest.php
@@ -82,7 +82,7 @@ class CompleteCommandTest extends TestCase
     public function testCompleteCommandName(array $input, array $suggestions)
     {
         $this->execute(['--current' => '1', '--input' => $input]);
-        $this->assertEquals(implode("\n", $suggestions)."\n", $this->tester->getDisplay());
+        $this->assertEquals(implode("\n", $suggestions).\PHP_EOL, $this->tester->getDisplay());
     }
 
     public function provideCompleteCommandNameInputs()
@@ -98,7 +98,7 @@ class CompleteCommandTest extends TestCase
     public function testCompleteCommandInputDefinition(array $input, array $suggestions)
     {
         $this->execute(['--current' => '2', '--input' => $input]);
-        $this->assertEquals(implode("\n", $suggestions)."\n", $this->tester->getDisplay());
+        $this->assertEquals(implode("\n", $suggestions).\PHP_EOL, $this->tester->getDisplay());
     }
 
     public function provideCompleteCommandInputDefinitionInputs()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4  <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

[Probably caused by this fix](https://github.com/symfony/symfony/pull/43665)

AppVeyor run tests on Windows and tests with EOL [failing](https://ci.appveyor.com/project/fabpot/symfony/builds/41346183#L1559)

![image](https://user-images.githubusercontent.com/57155526/139556426-38a1b371-8c23-4211-a0cd-c31dc26034a7.png)


@derrabus pls review

