### PR TITLE
[RateLimiter] Increase delta in limiter tests

### DIFF
--- a/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/FixedWindowLimiterTest.php
@@ -78,7 +78,7 @@ class FixedWindowLimiterTest extends TestCase
 
         $start = microtime(true);
         $rateLimit->wait(); // wait 1 minute
-        $this->assertEqualsWithDelta($start + 60, microtime(true), 0.5);
+        $this->assertEqualsWithDelta($start + 60, microtime(true), 1);
     }
 
     public function testWrongWindowFromCache()

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/SlidingWindowLimiterTest.php
@@ -66,7 +66,7 @@ class SlidingWindowLimiterTest extends TestCase
 
         $start = microtime(true);
         $rateLimit->wait(); // wait 12 seconds
-        $this->assertEqualsWithDelta($start + 12, microtime(true), 0.5);
+        $this->assertEqualsWithDelta($start + 12, microtime(true), 1);
     }
 
     public function testReserve()

--- a/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
+++ b/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php
@@ -102,7 +102,7 @@ class TokenBucketLimiterTest extends TestCase
 
         $start = microtime(true);
         $rateLimit->wait(); // wait 1 second
-        $this->assertEqualsWithDelta($start + 1, microtime(true), 0.5);
+        $this->assertEqualsWithDelta($start + 1, microtime(true), 1);
     }
 
     public function testWrongWindowFromCache()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3 <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| License       | MIT

Tests from [PR](https://github.com/symfony/symfony/pull/42168) might randomly fail [1](https://ci.appveyor.com/project/fabpot/symfony/builds/41346868#L597) [2](https://ci.appveyor.com/project/fabpot/symfony/builds/41346183#L650)

I increased delta like in [this test](https://github.com/symfony/symfony/blob/5.3/src/Symfony/Component/RateLimiter/Tests/Policy/TokenBucketLimiterTest.php#L90).

![image](https://user-images.githubusercontent.com/57155526/139543405-e8e1b760-96b2-4aea-8ed2-15c6221cd387.png)

![image](https://user-images.githubusercontent.com/57155526/139543418-d9558c2e-9248-49dd-b941-ad917f5e23d2.png)

@fabpot @Nyholm please review


