### PR TITLE
Fix missing type on http-foundation

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -208,7 +208,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
     /**
      * Adds a custom Cache-Control directive.
      *
-     * @param bool|string $value The Cache-Control directive value
+     * @param bool|int|string $value The Cache-Control directive value
      */
     public function addCacheControlDirective(string $key, $value = true)
     {

--- a/src/Symfony/Component/HttpFoundation/InputBag.php
+++ b/src/Symfony/Component/HttpFoundation/InputBag.php
@@ -23,9 +23,9 @@ final class InputBag extends ParameterBag
     /**
      * Returns a scalar input value by name.
      *
-     * @param string|int|float|bool|null $default The default value if the input key does not exist
+     * @param string|int|float|bool|array|null $default The default value if the input key does not exist
      *
-     * @return string|int|float|bool|null
+     * @return string|int|float|bool|array|null
      */
     public function get(string $key, $default = null)
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix missing type on http-foundation
| License       | MIT

Based on the `set` method on InputBag.php, as well as on Input BagTest.php, I think the return value and default value of the `get` method could be an array. I got psalm error when get request input like: `$inputBag->get('foo', ['a', 'b']);`

```
ERROR: InvalidArgument - EventsAction.php:143:84 - Argument 2 of Symfony\Component\HttpFoundation\InputBag::get expects null|scalar, array<empty, empty> provided (see https://psalm.dev/004)
                    'events' => $this->request->request->get('events', [])
```

Also on HeaderBag.php, I think I should be able to pass numeric values to cache-control. I got psalm error when run method like this: `$headerBag->addCacheControlDirective('max-age', 0);`

```
ERROR: InvalidScalarArgument - HttpSessionDirectives.php:12:69 - Argument 2 of Symfony\Component\HttpFoundation\ResponseHeaderBag::addCacheControlDirective expects bool|string, int(0) provided (see https://psalm.dev/012)
            $response->headers->addCacheControlDirective('max-age', 0);
```