### PR TITLE
Add missing validators translation in Brazillian Portuguese

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt_BR.xlf
@@ -394,6 +394,14 @@
                 <source>This value is not a valid CSS color.</source>
                 <target>Este valor não é uma cor CSS válida.</target>
             </trans-unit>
+            <trans-unit id="102">
+                <source>This value is not a valid CIDR notation.</source>
+                <target>Este valor não é uma notação CIDR válida.</target>
+            </trans-unit>
+            <trans-unit id="103">
+                <source>The value of the netmask should be between {{ min }} and {{ max }}.</source>
+                <target>O valor da máscara de rede deve estar entre {{ min }} e {{ max }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | no
| Deprecations? |  no
| Tickets       | Fix #43709  
| License       | MIT
| Doc PR        | N/A

Additionally (see https://symfony.com/releases):
- [Validator]Add missing validators translation in Brazillian Portuguese