### PR TITLE
[VarDumper] Make dumping DateInterval instances timezone-independent

### DIFF
--- a/src/Symfony/Component/VarDumper/Caster/DateCaster.php
+++ b/src/Symfony/Component/VarDumper/Caster/DateCaster.php
@@ -49,7 +49,7 @@ class DateCaster
 
     public static function castInterval(\DateInterval $interval, array $a, Stub $stub, $isNested, $filter)
     {
-        $now = new \DateTimeImmutable();
+        $now = new \DateTimeImmutable('@0', new \DateTimeZone('UTC'));
         $numberOfSeconds = $now->add($interval)->getTimestamp() - $now->getTimestamp();
         $title = number_format($numberOfSeconds, 0, '.', ' ').'s';
 
@@ -63,7 +63,8 @@ class DateCaster
         $format = '%R ';
 
         if (0 === $i->y && 0 === $i->m && ($i->h >= 24 || $i->i >= 60 || $i->s >= 60)) {
-            $i = date_diff($d = new \DateTime(), date_add(clone $d, $i)); // recalculate carry over points
+            $d = new \DateTimeImmutable('@0', new \DateTimeZone('UTC'));
+            $i = $d->diff($d->add($i)); // recalculate carry over points
             $format .= 0 < $i->days ? '%ad ' : '';
         } else {
             $format .= ($i->y ? '%yy ' : '').($i->m ? '%mm ' : '').($i->d ? '%dd ' : '');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | N/A
| License       | MIT
| Doc PR        | N/A

In our CI, we currently see failing VarDumper tests because the tests have been executed close to the end of DST in Europe. This PR attempts to make dumping `DateInterval` instances more robust by decoupling the dumper from global timezone settings and the current date.