### PR TITLE
[Console] Runtime conflict for psr/log >= 3.0 instead of composer conflict

### DIFF
--- a/src/Symfony/Component/Console/Logger/ConsoleLogger.php
+++ b/src/Symfony/Component/Console/Logger/ConsoleLogger.php
@@ -17,6 +17,10 @@ use Psr\Log\LogLevel;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+if ((new \ReflectionMethod(AbstractLogger::class, 'log'))->hasReturnType()) {
+    throw new \RuntimeException(sprintf('The "%s" logger is not compatible with psr/log >= 3.0. Try running "composer require psr/log:^2.".', ConsoleLogger::class));
+}
+
 /**
  * PSR-3 compliant console logger.
  *

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -43,7 +43,6 @@
         "psr/log": "For using the console logger"
     },
     "conflict": {
-        "psr/log": ">=3",
         "symfony/dependency-injection": "<4.4",
         "symfony/dotenv": "<5.1",
         "symfony/event-dispatcher": "<4.4",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.3
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`ConsoleLogger` is not compatible with `psr/log >= 3.0` but it's an optional feature and `psr/log` is an optional dependency in the Console component. Yet, having a real "composer conflict", prevents `symfony/console` from being updated above the `5.3.2` version if a previous dependency has already installed `psr/log 3.0`. But I'd rather have an updated `symfony/console` version and `psr/log 2.0` since the `psr/log` changes are just about types.